### PR TITLE
[Tizen] Display human readable error messages instead of numbers

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -137,16 +137,18 @@ CHIP_ERROR BLEManagerImpl::_BleInitialize(void * userData)
     }
 
     ret = bt_initialize();
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_initialize() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_initialize() failed: %s", get_error_message(ret)));
 
     ret = bt_adapter_set_state_changed_cb(__AdapterStateChangedCb, nullptr);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_adapter_set_state_changed_cb() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_adapter_set_state_changed_cb() failed: %s", get_error_message(ret)));
 
     ret = bt_gatt_server_initialize();
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_initialize() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_initialize() failed: %s", get_error_message(ret)));
 
     ret = bt_gatt_set_connection_state_changed_cb(GattConnectionStateChangedCb, nullptr);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_adapter_set_state_changed_cb() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_adapter_set_state_changed_cb() failed: %s", get_error_message(ret)));
 
     // The hash table key is stored in the BLEConnection structure
     // and is freed by the __BLEConnectionFree() function.
@@ -196,12 +198,13 @@ void BLEManagerImpl::ReadValueRequestedCb(const char * remoteAddress, int reques
     ChipLogProgress(DeviceLayer, "Gatt read requested on %s: uuid=%s", __ConvertAttTypeToStr(type), StringOrNullMarker(uuid.get()));
 
     ret = bt_gatt_get_value(gattHandle, &MakeUniquePointerReceiver(value).Get(), &len);
-    VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_get_value() failed. ret: %d", ret));
+    VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_get_value() failed: %s", get_error_message(ret)));
 
     ChipLogByteSpan(DeviceLayer, ByteSpan(Uint8::from_const_char(value.get()), len));
 
     ret = bt_gatt_server_send_response(requestId, BT_GATT_REQUEST_TYPE_READ, offset, 0x00, value.get(), len);
-    VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_send_response() failed. ret: %d", ret));
+    VerifyOrReturn(ret == BT_ERROR_NONE,
+                   ChipLogError(DeviceLayer, "bt_gatt_server_send_response() failed: %s", get_error_message(ret)));
 }
 
 void BLEManagerImpl::WriteValueRequestedCb(const char * remoteAddress, int requestId, bt_gatt_server_h server, bt_gatt_h gattHandle,
@@ -222,15 +225,16 @@ void BLEManagerImpl::WriteValueRequestedCb(const char * remoteAddress, int reque
     ChipLogByteSpan(DeviceLayer, ByteSpan(Uint8::from_const_char(value), len));
 
     ret = bt_gatt_set_value(gattHandle, value, len);
-    VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_set_value() failed. ret: %d", ret));
+    VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_set_value() failed: %s", get_error_message(ret)));
 
     ret = bt_gatt_server_send_response(requestId, BT_GATT_REQUEST_TYPE_WRITE, offset, 0x00, nullptr, 0);
-    VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_send_response() failed. ret: %d", ret));
+    VerifyOrReturn(ret == BT_ERROR_NONE,
+                   ChipLogError(DeviceLayer, "bt_gatt_server_send_response() failed: %s", get_error_message(ret)));
 
     sInstance.HandleC1CharWriteEvent(conn, Uint8::from_const_char(value), len);
 }
 
-void BLEManagerImpl::NotificationStateChangedCb(bool notify, bt_gatt_server_h server, bt_gatt_h gattHandle, void * userData)
+void BLEManagerImpl::NotificationStateChangedCb(bool notify, bt_gatt_server_h server, bt_gatt_h charHandle, void * userData)
 {
     GAutoPtr<char> uuid;
     BLEConnection * conn = nullptr;
@@ -248,8 +252,10 @@ void BLEManagerImpl::NotificationStateChangedCb(bool notify, bt_gatt_server_h se
     }
 
     VerifyOrReturn(conn != nullptr, ChipLogError(DeviceLayer, "Failed to find connection info"));
-    VerifyOrReturn(__GetAttInfo(gattHandle, &MakeUniquePointerReceiver(uuid).Get(), &type) == BT_ERROR_NONE,
-                   ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from GATT handle"));
+
+    int ret = __GetAttInfo(charHandle, &MakeUniquePointerReceiver(uuid).Get(), &type);
+    VerifyOrReturn(ret == BT_ERROR_NONE,
+                   ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from CHAR handle: %s", get_error_message(ret)));
 
     ChipLogProgress(DeviceLayer, "Notification State Changed %d on %s: %s", notify, __ConvertAttTypeToStr(type),
                     StringOrNullMarker(uuid.get()));
@@ -461,11 +467,12 @@ CHIP_ERROR BLEManagerImpl::ConnectChipThing(const char * address)
     ChipLogProgress(DeviceLayer, "ConnectRequest: Addr [%s]", StringOrNullMarker(address));
 
     ret = bt_gatt_client_create(address, &sInstance.mGattClient);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Failed to create GATT client. ret [%d]", ret);
+    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Failed to create GATT client: %s", get_error_message(ret));
                  err = CHIP_ERROR_INTERNAL);
 
     ret = bt_gatt_connect(address, false);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Failed to issue GATT connect request. ret [%d]", ret);
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "Failed to issue GATT connect request: %s", get_error_message(ret));
                  err = CHIP_ERROR_INTERNAL);
 
     ChipLogProgress(DeviceLayer, "GATT Connect Issued");
@@ -552,11 +559,11 @@ int BLEManagerImpl::RegisterGATTServer()
 
     // Create Server
     ret = bt_gatt_server_create(&server);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_create() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_create() failed: %s", get_error_message(ret)));
 
     // Create Service (BTP Service)
     ret = bt_gatt_service_create(chip_ble_service_uuid, BT_GATT_SERVICE_TYPE_PRIMARY, &service);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_service_create() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_service_create() failed: %s", get_error_message(ret)));
 
     // Create 1st Characteristic (Client TX Buffer)
     ret = bt_gatt_characteristic_create(
@@ -565,44 +572,51 @@ int BLEManagerImpl::RegisterGATTServer()
                                 // consider to use WITHOUT_RESPONSE property in the future according to the CHIP Spec 4.16.3.2. BTP
                                 // GATT Service
         "CHIPoBLE_C1", strlen("CHIPoBLE_C1"), &char1);
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_gatt_characteristic_create() failed: %s", get_error_message(ret)));
 
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_characteristic_create() failed. ret: %d", ret));
     ret = bt_gatt_server_set_write_value_requested_cb(char1, WriteValueRequestedCb, nullptr);
     VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_gatt_server_set_write_value_requested_cb() failed. ret: %d", ret));
+                 ChipLogError(DeviceLayer, "bt_gatt_server_set_write_value_requested_cb() failed: %s", get_error_message(ret)));
+
     ret = bt_gatt_service_add_characteristic(service, char1);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_service_add_characteristic() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_gatt_service_add_characteristic() failed: %s", get_error_message(ret)));
 
     // Create 2nd Characteristic (Client RX Buffer)
     ret = bt_gatt_characteristic_create(chip_ble_char_c2_rx_uuid, BT_GATT_PERMISSION_READ,
                                         BT_GATT_PROPERTY_READ | BT_GATT_PROPERTY_INDICATE, "CHIPoBLE_C2", strlen("CHIPoBLE_C2"),
                                         &char2);
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_gatt_characteristic_create() failed: %s", get_error_message(ret)));
 
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_characteristic_create() failed. ret: %d", ret));
     ret = bt_gatt_server_set_read_value_requested_cb(char2, ReadValueRequestedCb, nullptr);
     VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_gatt_server_set_read_value_requested_cb() failed. ret: %d", ret));
+                 ChipLogError(DeviceLayer, "bt_gatt_server_set_read_value_requested_cb() failed: %s", get_error_message(ret)));
     ret = bt_gatt_server_set_characteristic_notification_state_change_cb(char2, NotificationStateChangedCb, nullptr);
-    VerifyOrExit(
-        ret == BT_ERROR_NONE,
-        ChipLogError(DeviceLayer, "bt_gatt_server_set_characteristic_notification_state_change_cb() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_gatt_server_set_characteristic_notification_state_change_cb() failed: %s",
+                              get_error_message(ret)));
 
     // Create CCC Descriptor
     ret = bt_gatt_descriptor_create(desc_uuid_short, BT_GATT_PERMISSION_READ | BT_GATT_PERMISSION_WRITE, desc_value,
                                     sizeof(desc_value), &desc);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_descriptor_create() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_descriptor_create() failed: %s", get_error_message(ret)));
     ret = bt_gatt_characteristic_add_descriptor(char2, desc);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_characteristic_add_descriptor() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_gatt_characteristic_add_descriptor() failed: %s", get_error_message(ret)));
     ret = bt_gatt_service_add_characteristic(service, char2);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_service_add_characteristic() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_gatt_service_add_characteristic() failed: %s", get_error_message(ret)));
 
     // Register Service to Server
     ret = bt_gatt_server_register_service(server, service);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_register_service() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_gatt_server_register_service() failed: %s", get_error_message(ret)));
 
     // Start Server
     ret = bt_gatt_server_start();
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_start() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_start() failed: %s", get_error_message(ret)));
 
     ChipLogDetail(DeviceLayer, "NotifyBLEPeripheralGATTServerRegisterComplete Success");
     BLEManagerImpl::NotifyBLEPeripheralGATTServerRegisterComplete(true, nullptr);
@@ -634,7 +648,7 @@ int BLEManagerImpl::StartBLEAdvertising()
     if (sInstance.mAdvReqInProgress)
     {
         ChipLogProgress(DeviceLayer, "Advertising Request In Progress");
-        return ret;
+        return BT_ERROR_NONE;
     }
 
     ChipLogProgress(DeviceLayer, "Start Advertising");
@@ -642,23 +656,25 @@ int BLEManagerImpl::StartBLEAdvertising()
     if (mAdvertiser == nullptr)
     {
         ret = bt_adapter_le_create_advertiser(&mAdvertiser);
-        VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_adapter_le_create_advertiser() failed. ret: %d", ret));
+        VerifyOrExit(ret == BT_ERROR_NONE,
+                     ChipLogError(DeviceLayer, "bt_adapter_le_create_advertiser() failed: %s", get_error_message(ret)));
     }
     else
     {
         ret = bt_adapter_le_clear_advertising_data(mAdvertiser, BT_ADAPTER_LE_PACKET_ADVERTISING);
         VerifyOrExit(ret == BT_ERROR_NONE,
-                     ChipLogError(DeviceLayer, "bt_adapter_le_clear_advertising_data() failed. ret: %d", ret));
+                     ChipLogError(DeviceLayer, "bt_adapter_le_clear_advertising_data() failed: %s", get_error_message(ret)));
 
         ret = bt_adapter_le_clear_advertising_data(mAdvertiser, BT_ADAPTER_LE_PACKET_SCAN_RESPONSE);
         VerifyOrExit(ret == BT_ERROR_NONE,
-                     ChipLogError(DeviceLayer, "bt_adapter_le_clear_advertising_data() failed. ret: %d", ret));
+                     ChipLogError(DeviceLayer, "bt_adapter_le_clear_advertising_data() failed: %s", get_error_message(ret)));
     }
 
     if (mFlags.Has(Flags::kFastAdvertisingEnabled))
     {
         ret = bt_adapter_le_set_advertising_mode(mAdvertiser, BT_ADAPTER_LE_ADVERTISING_MODE_LOW_LATENCY);
-        VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_adapter_le_set_advertising_mode() failed. ret: %d", ret));
+        VerifyOrExit(ret == BT_ERROR_NONE,
+                     ChipLogError(DeviceLayer, "bt_adapter_le_set_advertising_mode() failed: %s", get_error_message(ret)));
 
         // NOTE: Check specification for recommended Advertising Interval range for Fast Advertising
         // ret = bt_adapter_le_set_advertising_interval(mAdvertiser, BT_LE_ADV_INTERVAL_MIN, BT_LE_ADV_INTERVAL_MIN);
@@ -676,7 +692,7 @@ int BLEManagerImpl::StartBLEAdvertising()
     ret = bt_adapter_le_add_advertising_service_data(mAdvertiser, BT_ADAPTER_LE_PACKET_ADVERTISING, chip_ble_service_uuid_short,
                                                      service_data, sizeof(service_data));
     VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_adapter_le_add_advertising_service_data() failed. ret: %d", ret));
+                 ChipLogError(DeviceLayer, "bt_adapter_le_add_advertising_service_data() failed: %s", get_error_message(ret)));
 
     err = SystemInfo::GetPlatformVersion(version);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "GetPlatformVersion() failed. %s", ErrorStr(err)));
@@ -684,7 +700,8 @@ int BLEManagerImpl::StartBLEAdvertising()
     {
         ret = bt_adapter_le_set_advertising_flags(
             mAdvertiser, BT_ADAPTER_LE_ADVERTISING_FLAGS_GEN_DISC | BT_ADAPTER_LE_ADVERTISING_FLAGS_BREDR_UNSUP);
-        VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_adapter_le_set_advertising_flags() failed. ret: %d", ret));
+        VerifyOrExit(ret == BT_ERROR_NONE,
+                     ChipLogError(DeviceLayer, "bt_adapter_le_set_advertising_flags() failed: %s", get_error_message(ret)));
     }
     else
     {
@@ -693,12 +710,14 @@ int BLEManagerImpl::StartBLEAdvertising()
 
     ret = bt_adapter_le_set_advertising_device_name(mAdvertiser, BT_ADAPTER_LE_PACKET_ADVERTISING, true);
     VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_adapter_le_set_advertising_device_name() failed. ret: %d", ret));
+                 ChipLogError(DeviceLayer, "bt_adapter_le_set_advertising_device_name() failed: %s", get_error_message(ret)));
 
     BLEManagerImpl::NotifyBLEPeripheralAdvConfiguredComplete(true, nullptr);
 
     ret = bt_adapter_le_start_advertising_new(mAdvertiser, AdvertisingStateChangedCb, nullptr);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_adapter_le_start_advertising_new() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_adapter_le_start_advertising_new() failed: %s", get_error_message(ret)));
+
     sInstance.mAdvReqInProgress = true;
     return ret;
 
@@ -709,11 +728,12 @@ exit:
 
 int BLEManagerImpl::StopBLEAdvertising()
 {
-    int ret = BT_ERROR_NONE;
-
     ChipLogProgress(DeviceLayer, "Stop Advertising");
-    ret = bt_adapter_le_stop_advertising(mAdvertiser);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_adapter_le_stop_advertising() failed. ret: %d", ret));
+
+    int ret = bt_adapter_le_stop_advertising(mAdvertiser);
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_adapter_le_stop_advertising() failed: %s", get_error_message(ret)));
+
     sInstance.mAdvReqInProgress = true;
     return ret;
 
@@ -728,8 +748,9 @@ static bool __GattClientForeachCharCb(int total, int index, bt_gatt_h charHandle
     GAutoPtr<char> uuid;
     auto conn = static_cast<BLEConnection *>(data);
 
-    VerifyOrExit(__GetAttInfo(charHandle, &MakeUniquePointerReceiver(uuid).Get(), &type) == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from CHAR handle"));
+    int ret = __GetAttInfo(charHandle, &MakeUniquePointerReceiver(uuid).Get(), &type);
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from CHAR handle: %s", get_error_message(ret)));
 
     if (strcasecmp(uuid.get(), chip_ble_char_c1_tx_uuid) == 0)
     {
@@ -754,8 +775,9 @@ static bool __GattClientForeachServiceCb(int total, int index, bt_gatt_h svcHand
     auto conn = static_cast<BLEConnection *>(data);
     ChipLogProgress(DeviceLayer, "__GattClientForeachServiceCb");
 
-    VerifyOrExit(__GetAttInfo(svcHandle, &MakeUniquePointerReceiver(uuid).Get(), &type) == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from SVC handle"));
+    int ret = __GetAttInfo(svcHandle, &MakeUniquePointerReceiver(uuid).Get(), &type);
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from SVC handle: %s", get_error_message(ret)));
 
     if (strcasecmp(uuid.get(), chip_ble_service_uuid) == 0)
     {
@@ -776,9 +798,10 @@ exit:
 bool BLEManagerImpl::IsDeviceChipPeripheral(BLE_CONNECTION_OBJECT conId)
 {
     auto conn = static_cast<BLEConnection *>(conId);
+    int ret;
 
-    if (bt_gatt_client_foreach_services(sInstance.mGattClient, __GattClientForeachServiceCb, conn) != BT_ERROR_NONE)
-        ChipLogError(DeviceLayer, "Error Browsing GATT services");
+    if ((ret = bt_gatt_client_foreach_services(sInstance.mGattClient, __GattClientForeachServiceCb, conn)) != BT_ERROR_NONE)
+        ChipLogError(DeviceLayer, "Failed to browse GATT services: %s", get_error_message(ret));
 
     return (conn->isChipDevice ? true : false);
 }
@@ -907,7 +930,7 @@ void BLEManagerImpl::DriveBLEState()
     if (!mIsCentral && mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kAppRegistered))
     {
         ret = RegisterGATTServer();
-        VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Register GATT Server Failed. ret: %d", ret));
+        VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Register GATT Server failed: %s", get_error_message(ret)));
 
         ChipLogProgress(DeviceLayer, "GATT Service Registered");
         mFlags.Set(Flags::kAppRegistered);
@@ -919,13 +942,13 @@ void BLEManagerImpl::DriveBLEState()
         if (!mFlags.Has(Flags::kAdvertising))
         {
             ret = StartBLEAdvertising();
-            VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Start Advertising Failed. ret: %d", ret));
+            VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Start Advertising failed: %s", get_error_message(ret)));
         }
         else if (mFlags.Has(Flags::kAdvertisingRefreshNeeded))
         {
             ChipLogProgress(DeviceLayer, "Advertising Refreshed Needed. Stop Advertising");
             ret = StopBLEAdvertising();
-            VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Stop Advertising Failed. ret: %d", ret));
+            VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Stop Advertising failed: %s", get_error_message(ret)));
         }
     }
     else if (mFlags.Has(Flags::kAdvertising))
@@ -933,10 +956,11 @@ void BLEManagerImpl::DriveBLEState()
         ChipLogProgress(DeviceLayer, "Stop Advertising");
 
         ret = StopBLEAdvertising();
-        VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Stop Advertising Failed. ret: %d", ret));
+        VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Stop Advertising failed: %s", get_error_message(ret)));
 
         ret = bt_adapter_le_destroy_advertiser(mAdvertiser);
-        VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_adapter_le_destroy_advertiser() failed. ret: %d", ret));
+        VerifyOrExit(ret == BT_ERROR_NONE,
+                     ChipLogError(DeviceLayer, "bt_adapter_le_destroy_advertiser() failed: %s", get_error_message(ret)));
         mAdvertiser = nullptr;
     }
 
@@ -974,7 +998,7 @@ exit:
 void BLEManagerImpl::_Shutdown()
 {
     int ret = bt_deinitialize();
-    VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_deinitialize() failed. ret: %d", ret));
+    VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_deinitialize() failed: %s", get_error_message(ret)));
 }
 
 CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
@@ -1013,7 +1037,7 @@ CHIP_ERROR BLEManagerImpl::_GetDeviceName(char * buf, size_t bufSize)
     ret = bt_adapter_get_name(&deviceName);
     if (ret != BT_ERROR_NONE)
     {
-        ChipLogError(DeviceLayer, "bt_adapter_get_name() failed. ret: %d", ret);
+        ChipLogError(DeviceLayer, "bt_adapter_get_name() failed: %s", get_error_message(ret));
         return CHIP_ERROR_INTERNAL;
     }
 
@@ -1037,7 +1061,7 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
     ret = bt_adapter_set_name(deviceName);
     if (ret != BT_ERROR_NONE)
     {
-        ChipLogError(DeviceLayer, "bt_adapter_set_name() failed. ret: %d", ret);
+        ChipLogError(DeviceLayer, "bt_adapter_set_name() failed: %s", get_error_message(ret));
         return CHIP_ERROR_INTERNAL;
     }
 
@@ -1190,7 +1214,7 @@ bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const 
     Ble::ChipBleUUID service_uuid;
     Ble::ChipBleUUID char_notif_uuid;
     auto conn = static_cast<BLEConnection *>(conId);
-    int ret   = BT_ERROR_NONE;
+    int ret;
 
     ChipLogProgress(DeviceLayer, "SubscribeCharacteristic");
 
@@ -1204,13 +1228,16 @@ bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const 
                  ChipLogError(DeviceLayer, "SubscribeCharacteristic() called with invalid characteristic ID"));
     VerifyOrExit(conn->gattCharC2Handle != nullptr, ChipLogError(DeviceLayer, "Char C2 is null"));
 
-    ChipLogProgress(DeviceLayer, "Sending Notification Enable Request to CHIP Peripheral(con %s)", conn->peerAddr);
+    ChipLogProgress(DeviceLayer, "Sending Notification Enable Request to CHIP Peripheral: %s", conn->peerAddr);
 
     ret = bt_gatt_client_set_characteristic_value_changed_cb(conn->gattCharC2Handle, CharacteristicNotificationCb, conn);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_gatt_client_set_characteristic_value_changed_cb() failed. ret: %d", ret));
+    VerifyOrExit(
+        ret == BT_ERROR_NONE,
+        ChipLogError(DeviceLayer, "bt_gatt_client_set_characteristic_value_changed_cb() failed: %s", get_error_message(ret)));
+
     sInstance.NotifySubscribeOpComplete(conn, true);
     return true;
+
 exit:
     return false;
 }
@@ -1221,7 +1248,7 @@ bool BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, cons
     Ble::ChipBleUUID service_uuid;
     Ble::ChipBleUUID char_notif_uuid;
     auto conn = static_cast<BLEConnection *>(conId);
-    int ret   = BT_ERROR_NONE;
+    int ret;
 
     ChipLogProgress(DeviceLayer, "UnSubscribeCharacteristic");
 
@@ -1235,13 +1262,16 @@ bool BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, cons
                  ChipLogError(DeviceLayer, "UnSubscribeCharacteristic() called with invalid characteristic ID"));
     VerifyOrExit(conn->gattCharC2Handle != nullptr, ChipLogError(DeviceLayer, "Char C2 is null"));
 
-    ChipLogProgress(DeviceLayer, "Disable Notification Request to CHIP Peripheral(con %s)", conn->peerAddr);
+    ChipLogProgress(DeviceLayer, "Disable Notification Request to CHIP Peripheral: %s", conn->peerAddr);
 
     ret = bt_gatt_client_unset_characteristic_value_changed_cb(conn->gattCharC2Handle);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_gatt_client_unset_characteristic_value_changed_cb() failed. ret: %d", ret));
+    VerifyOrExit(
+        ret == BT_ERROR_NONE,
+        ChipLogError(DeviceLayer, "bt_gatt_client_unset_characteristic_value_changed_cb() failed: %s", get_error_message(ret)));
+
     sInstance.NotifySubscribeOpComplete(conn, false);
     return true;
+
 exit:
     return false;
 }
@@ -1249,7 +1279,7 @@ exit:
 bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
 {
     auto conn = static_cast<BLEConnection *>(conId);
-    int ret   = BT_ERROR_NONE;
+    int ret;
 
     ChipLogProgress(DeviceLayer, "Close BLE Connection");
 
@@ -1258,7 +1288,7 @@ bool BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
 
     ChipLogProgress(DeviceLayer, "Send GATT disconnect to [%s]", conn->peerAddr);
     ret = bt_gatt_disconnect(conn->peerAddr);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_disconnect() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_disconnect() failed: %s", get_error_message(ret)));
 
     RemoveConnectionData(conn->peerAddr);
     return true;
@@ -1271,7 +1301,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const Ble::Chip
                                     System::PacketBufferHandle pBuf)
 {
     auto conn = static_cast<BLEConnection *>(conId);
-    int ret   = BT_ERROR_NONE;
+    int ret;
 
     ChipLogProgress(DeviceLayer, "SendIndication");
 
@@ -1279,14 +1309,15 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const Ble::Chip
     VerifyOrExit(conn != nullptr, ChipLogError(DeviceLayer, "Failed to find connection info"));
 
     ret = bt_gatt_set_value(mGattCharC2Handle, Uint8::to_const_char(pBuf->Start()), pBuf->DataLength());
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_set_value() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_set_value() failed: %s", get_error_message(ret)));
 
     ChipLogProgress(DeviceLayer, "Sending indication for CHIPoBLE RX characteristic (con %s, len %u)", conn->peerAddr,
                     pBuf->DataLength());
 
     ret = bt_gatt_server_notify_characteristic_changed_value(mGattCharC2Handle, IndicationConfirmationCb, conn->peerAddr, nullptr);
-    VerifyOrExit(ret == BT_ERROR_NONE,
-                 ChipLogError(DeviceLayer, "bt_gatt_server_notify_characteristic_changed_value() failed. ret: %d", ret));
+    VerifyOrExit(
+        ret == BT_ERROR_NONE,
+        ChipLogError(DeviceLayer, "bt_gatt_server_notify_characteristic_changed_value() failed: %s", get_error_message(ret)));
     return true;
 
 exit:
@@ -1314,13 +1345,14 @@ bool BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const Ble::Ch
     VerifyOrExit(conn->gattCharC1Handle != nullptr, ChipLogError(DeviceLayer, "Char C1 is null"));
 
     ret = bt_gatt_set_value(conn->gattCharC1Handle, Uint8::to_const_char(pBuf->Start()), pBuf->DataLength());
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_set_value() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_set_value() failed: %s", get_error_message(ret)));
 
     ChipLogProgress(DeviceLayer, "Sending Write Request for CHIPoBLE TX characteristic (con %s, len %u)", conn->peerAddr,
                     pBuf->DataLength());
 
     ret = bt_gatt_client_write_value(conn->gattCharC1Handle, WriteCompletedCb, conn);
-    VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_client_write_value() failed. ret: %d", ret));
+    VerifyOrExit(ret == BT_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "bt_gatt_client_write_value() failed: %s", get_error_message(ret)));
     return true;
 exit:
     return false;

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -215,9 +215,9 @@ private:
     void NotifySubscribeOpComplete(BLE_CONNECTION_OBJECT conId, bool isSubscribed);
     void NotifyBLENotificationReceived(System::PacketBufferHandle & buf, BLE_CONNECTION_OBJECT conId);
 
-    int RegisterGATTServer();
-    int StartBLEAdvertising();
-    int StopBLEAdvertising();
+    CHIP_ERROR RegisterGATTServer();
+    CHIP_ERROR StartBLEAdvertising();
+    CHIP_ERROR StopBLEAdvertising();
     void CleanScanConfig();
 
     CHIPoBLEServiceMode mServiceMode;

--- a/src/platform/Tizen/BUILD.gn
+++ b/src/platform/Tizen/BUILD.gn
@@ -47,6 +47,8 @@ static_library("Tizen") {
     "DeviceInstanceInfoProviderImpl.h",
     "DiagnosticDataProviderImpl.cpp",
     "DiagnosticDataProviderImpl.h",
+    "ErrorUtils.cpp",
+    "ErrorUtils.h",
     "InetPlatformConfig.h",
     "KeyValueStoreManagerImpl.cpp",
     "KeyValueStoreManagerImpl.h",

--- a/src/platform/Tizen/ChipDeviceScanner.h
+++ b/src/platform/Tizen/ChipDeviceScanner.h
@@ -86,7 +86,7 @@ public:
     ~ChipDeviceScanner(void);
 
     /// Initiate a scan for devices, with the given timeout & scan filter data
-    CHIP_ERROR StartChipScan(System::Clock::Timeout timeout, ScanFilterType filterType, ScanFilterData & filterData);
+    CHIP_ERROR StartChipScan(System::Clock::Timeout timeout, ScanFilterType filterType, const ScanFilterData & filterData);
 
     /// Stop any currently running scan
     CHIP_ERROR StopChipScan(void);
@@ -99,10 +99,11 @@ private:
     static void LeScanResultCb(int result, bt_adapter_le_device_scan_result_info_s * info, void * userData);
     static gboolean TimerExpiredCb(gpointer user_data);
     static CHIP_ERROR TriggerScan(ChipDeviceScanner * userData);
-    void CheckScanFilter(ScanFilterType filterType, ScanFilterData & filterData);
-    int RegisterScanFilter(ScanFilterType filterType, ScanFilterData & filterData);
-    void UnRegisterScanFilter(void);
-    int CreateLEScanFilter(ScanFilterType filterType, ScanFilterData & filterData);
+
+    int CreateLEScanFilter(ScanFilterType filterType);
+    int RegisterScanFilter(ScanFilterType filterType, const ScanFilterData & filterData);
+    int SetupScanFilter(ScanFilterType filterType, const ScanFilterData & filterData);
+    void UnRegisterScanFilter();
 
     ChipDeviceScannerDelegate * mDelegate = nullptr;
     bool mIsScanning                      = false;

--- a/src/platform/Tizen/ConnectivityUtils.cpp
+++ b/src/platform/Tizen/ConnectivityUtils.cpp
@@ -633,29 +633,24 @@ double ConnectivityUtils::ConvertFrequencyToFloat(const iw_freq * in)
     return result;
 }
 
-CHIP_ERROR ConnectivityUtils::GetWiFiParameter(int skfd,            /* Socket to the kernel */
+CHIP_ERROR ConnectivityUtils::GetWiFiParameter(int sock,            /* Socket to the kernel */
                                                const char * ifname, /* Device name */
                                                int request,         /* WE ID */
                                                struct iwreq * pwrq) /* Fixed part of the request */
 {
     Platform::CopyString(pwrq->ifr_name, ifname);
-
-    if (ioctl(skfd, request, pwrq) < 0)
+    if (ioctl(sock, request, pwrq) < 0)
         return CHIP_ERROR_BAD_REQUEST;
-
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConnectivityUtils::GetWiFiStats(int skfd, const char * ifname, struct iw_statistics * stats)
+CHIP_ERROR ConnectivityUtils::GetWiFiStats(int sock, const char * ifname, struct iw_statistics * stats)
 {
-    struct iwreq wrq;
-
+    struct iwreq wrq   = {};
     wrq.u.data.pointer = (caddr_t) stats;
-    wrq.u.data.length  = sizeof(struct iw_statistics);
-    wrq.u.data.flags   = 1; /*Clear updated flag */
-    Platform::CopyString(wrq.ifr_name, ifname);
-
-    return GetWiFiParameter(skfd, ifname, SIOCGIWSTATS, &wrq);
+    wrq.u.data.length  = sizeof(*stats);
+    wrq.u.data.flags   = 1; /* Clear updated flag */
+    return GetWiFiParameter(sock, ifname, SIOCGIWSTATS, &wrq);
 }
 
 } // namespace Internal

--- a/src/platform/Tizen/ConnectivityUtils.cpp
+++ b/src/platform/Tizen/ConnectivityUtils.cpp
@@ -52,6 +52,17 @@ constexpr uint16_t Map2400MHz(const uint8_t inChannel)
     return 0;
 }
 
+constexpr uint8_t MapFrequencyToChannel(const uint16_t frequency)
+{
+    if (frequency < 2412)
+        return 0;
+    if (frequency < 2484)
+        return static_cast<uint8_t>((frequency - 2407) / 5);
+    if (frequency == 2484)
+        return 14;
+    return static_cast<uint8_t>(frequency / 5 - 1000);
+}
+
 constexpr uint16_t Map5000MHz(const uint8_t inChannel)
 {
     switch (inChannel)
@@ -176,36 +187,6 @@ CHIP_ERROR GetWiFiStats(int sock, const char * ifname, struct iw_statistics * st
 } // namespace
 
 namespace ConnectivityUtils {
-
-uint16_t MapChannelToFrequency(const uint16_t inBand, const uint8_t inChannel)
-{
-    uint16_t frequency = 0;
-
-    if (inBand == kWiFi_BAND_2_4_GHZ)
-    {
-        frequency = Map2400MHz(inChannel);
-    }
-    else if (inBand == kWiFi_BAND_5_0_GHZ)
-    {
-        frequency = Map5000MHz(inChannel);
-    }
-
-    return frequency;
-}
-
-uint8_t MapFrequencyToChannel(const uint16_t frequency)
-{
-    if (frequency < 2412)
-        return 0;
-
-    if (frequency < 2484)
-        return static_cast<uint8_t>((frequency - 2407) / 5);
-
-    if (frequency == 2484)
-        return 14;
-
-    return static_cast<uint8_t>(frequency / 5 - 1000);
-}
 
 InterfaceTypeEnum GetInterfaceConnectionType(const char * ifname)
 {

--- a/src/platform/Tizen/ConnectivityUtils.cpp
+++ b/src/platform/Tizen/ConnectivityUtils.cpp
@@ -166,8 +166,8 @@ CHIP_ERROR GetWiFiParameter(int sock,            /* Socket to the kernel */
                             struct iwreq * pwrq) /* Fixed part of the request */
 {
     chip::Platform::CopyString(pwrq->ifr_name, ifname);
-    if (ioctl(sock, request, pwrq) < 0)
-        return CHIP_ERROR_BAD_REQUEST;
+    if (ioctl(sock, request, pwrq) == -1)
+        return CHIP_ERROR_POSIX(errno);
     return CHIP_NO_ERROR;
 }
 
@@ -228,12 +228,12 @@ CHIP_ERROR GetInterfaceHardwareAddrs(const char * ifname, uint8_t * buf, size_t 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     int sock = socket(AF_INET, SOCK_DGRAM, 0);
-    VerifyOrReturnError(sock != -1, CHIP_ERROR_OPEN_FAILED,
+    VerifyOrReturnError(sock != -1, CHIP_ERROR_POSIX(errno),
                         ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno)));
 
     struct ifreq req;
     Platform::CopyString(req.ifr_name, ifname);
-    VerifyOrExit(ioctl(sock, SIOCGIFHWADDR, &req) != -1, err = CHIP_ERROR_READ_FAILED;
+    VerifyOrExit(ioctl(sock, SIOCGIFHWADDR, &req) != -1, err = CHIP_ERROR_POSIX(errno);
                  ChipLogError(DeviceLayer, "Failed to get hardware address: %s", strerror(errno)));
 
     // Copy 48-bit IEEE MAC Address
@@ -255,7 +255,7 @@ CHIP_ERROR GetInterfaceIPv4Addrs(const char * ifname, uint8_t & size, NetworkInt
     if (getifaddrs(&ifaddr) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
-        return err;
+        return CHIP_ERROR_POSIX(errno);
     }
 
     uint8_t index = 0;
@@ -297,7 +297,7 @@ CHIP_ERROR GetInterfaceIPv6Addrs(const char * ifname, uint8_t & size, NetworkInt
     if (getifaddrs(&ifaddr) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
-        return err;
+        return CHIP_ERROR_POSIX(errno);
     }
 
     uint8_t index = 0;
@@ -339,7 +339,7 @@ CHIP_ERROR GetWiFiInterfaceName(char * ifname, size_t bufSize)
     if (getifaddrs(&ifaddr) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
-        return err;
+        return CHIP_ERROR_POSIX(errno);
     }
 
     struct ifaddrs * ifa = nullptr;
@@ -364,7 +364,7 @@ CHIP_ERROR GetWiFiChannelNumber(const char * ifname, uint16_t & channelNumber)
     double freq;
 
     int sock = socket(AF_INET, SOCK_DGRAM, 0);
-    VerifyOrReturnError(sock != -1, CHIP_ERROR_OPEN_FAILED,
+    VerifyOrReturnError(sock != -1, CHIP_ERROR_POSIX(errno),
                         ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno)));
 
     err = GetWiFiParameter(sock, ifname, SIOCGIWFREQ, &wrq);
@@ -386,7 +386,7 @@ CHIP_ERROR GetWiFiRssi(const char * ifname, int8_t & rssi)
     struct iw_statistics stats;
 
     int sock = socket(AF_INET, SOCK_DGRAM, 0);
-    VerifyOrReturnError(sock != -1, CHIP_ERROR_OPEN_FAILED,
+    VerifyOrReturnError(sock != -1, CHIP_ERROR_POSIX(errno),
                         ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno)));
 
     err = GetWiFiStats(sock, ifname, &stats);
@@ -441,7 +441,7 @@ CHIP_ERROR GetWiFiBeaconLostCount(const char * ifname, uint32_t & beaconLostCoun
     struct iw_statistics stats;
 
     int sock = socket(AF_INET, SOCK_DGRAM, 0);
-    VerifyOrReturnError(sock != -1, CHIP_ERROR_OPEN_FAILED,
+    VerifyOrReturnError(sock != -1, CHIP_ERROR_POSIX(errno),
                         ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno)));
 
     err = GetWiFiStats(sock, ifname, &stats);
@@ -460,7 +460,7 @@ CHIP_ERROR GetWiFiCurrentMaxRate(const char * ifname, uint64_t & currentMaxRate)
     struct iwreq wrq;
 
     int sock = socket(AF_INET, SOCK_DGRAM, 0);
-    VerifyOrReturnError(sock != -1, CHIP_ERROR_OPEN_FAILED,
+    VerifyOrReturnError(sock != -1, CHIP_ERROR_POSIX(errno),
                         ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno)));
 
     err = GetWiFiParameter(sock, ifname, SIOCGIWRATE, &wrq);
@@ -482,7 +482,7 @@ CHIP_ERROR GetEthInterfaceName(char * ifname, size_t bufSize)
     if (getifaddrs(&ifaddr) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
-        return err;
+        return CHIP_ERROR_POSIX(errno);
     }
 
     struct ifaddrs * ifa = nullptr;
@@ -512,10 +512,10 @@ CHIP_ERROR GetEthPHYRate(const char * ifname, PHYRateEnum & pHYRate)
     Platform::CopyString(ifr.ifr_name, ifname);
 
     int sock = socket(AF_INET, SOCK_DGRAM, 0);
-    VerifyOrReturnError(sock != -1, CHIP_ERROR_OPEN_FAILED,
+    VerifyOrReturnError(sock != -1, CHIP_ERROR_POSIX(errno),
                         ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno)));
 
-    VerifyOrExit(ioctl(sock, SIOCETHTOOL, &ifr) != -1, err = CHIP_ERROR_READ_FAILED;
+    VerifyOrExit(ioctl(sock, SIOCETHTOOL, &ifr) != -1, err = CHIP_ERROR_POSIX(errno);
                  ChipLogError(DeviceLayer, "Cannot get device settings: %s", strerror(errno)));
 
     speed = (ecmd.speed_hi << 16) | ecmd.speed;
@@ -573,10 +573,10 @@ CHIP_ERROR GetEthFullDuplex(const char * ifname, bool & fullDuplex)
     Platform::CopyString(ifr.ifr_name, ifname);
 
     int sock = socket(AF_INET, SOCK_DGRAM, 0);
-    VerifyOrReturnError(sock != -1, CHIP_ERROR_OPEN_FAILED,
+    VerifyOrReturnError(sock != -1, CHIP_ERROR_POSIX(errno),
                         ChipLogError(DeviceLayer, "Failed to create INET socket: %s", strerror(errno)));
 
-    VerifyOrExit(ioctl(sock, SIOCETHTOOL, &ifr) != -1, err = CHIP_ERROR_READ_FAILED;
+    VerifyOrExit(ioctl(sock, SIOCETHTOOL, &ifr) != -1, err = CHIP_ERROR_POSIX(errno);
                  ChipLogError(DeviceLayer, "Cannot get device settings: %s", strerror(errno)));
 
     fullDuplex = ecmd.duplex == DUPLEX_FULL;

--- a/src/platform/Tizen/ConnectivityUtils.cpp
+++ b/src/platform/Tizen/ConnectivityUtils.cpp
@@ -37,10 +37,6 @@
 using namespace ::chip::app::Clusters::GeneralDiagnostics;
 using namespace ::chip::app::Clusters::EthernetNetworkDiagnostics;
 
-namespace chip {
-namespace DeviceLayer {
-namespace Internal {
-
 namespace {
 
 constexpr uint16_t Map2400MHz(const uint8_t inChannel)
@@ -169,7 +165,7 @@ CHIP_ERROR GetWiFiParameter(int sock,            /* Socket to the kernel */
                             int request,         /* WE ID */
                             struct iwreq * pwrq) /* Fixed part of the request */
 {
-    Platform::CopyString(pwrq->ifr_name, ifname);
+    chip::Platform::CopyString(pwrq->ifr_name, ifname);
     if (ioctl(sock, request, pwrq) < 0)
         return CHIP_ERROR_BAD_REQUEST;
     return CHIP_NO_ERROR;
@@ -186,6 +182,9 @@ CHIP_ERROR GetWiFiStats(int sock, const char * ifname, struct iw_statistics * st
 
 } // namespace
 
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
 namespace ConnectivityUtils {
 
 InterfaceTypeEnum GetInterfaceConnectionType(const char * ifname)

--- a/src/platform/Tizen/ConnectivityUtils.h
+++ b/src/platform/Tizen/ConnectivityUtils.h
@@ -59,7 +59,7 @@ public:
 private:
     static uint16_t Map2400MHz(const uint8_t inChannel);
     static uint16_t Map5000MHz(const uint8_t inChannel);
-    static double ConvertFrequenceToFloat(const iw_freq * in);
+    static double ConvertFrequencyToFloat(const iw_freq * in);
     static CHIP_ERROR GetWiFiParameter(int skfd, const char * ifname, int request, struct iwreq * pwrq);
     static CHIP_ERROR GetWiFiStats(int skfd, const char * ifname, struct iw_statistics * stats);
 };

--- a/src/platform/Tizen/ConnectivityUtils.h
+++ b/src/platform/Tizen/ConnectivityUtils.h
@@ -38,31 +38,24 @@ namespace Internal {
 static constexpr uint16_t kWiFi_BAND_2_4_GHZ = 2400;
 static constexpr uint16_t kWiFi_BAND_5_0_GHZ = 5000;
 
-class ConnectivityUtils
-{
-public:
-    static uint16_t MapChannelToFrequency(const uint16_t inBand, const uint8_t inChannel);
-    static uint8_t MapFrequencyToChannel(const uint16_t frequency);
-    static app::Clusters::GeneralDiagnostics::InterfaceTypeEnum GetInterfaceConnectionType(const char * ifname);
-    static CHIP_ERROR GetInterfaceHardwareAddrs(const char * ifname, uint8_t * buf, size_t bufSize);
-    static CHIP_ERROR GetInterfaceIPv4Addrs(const char * ifname, uint8_t & size, NetworkInterface * ifp);
-    static CHIP_ERROR GetInterfaceIPv6Addrs(const char * ifname, uint8_t & size, NetworkInterface * ifp);
-    static CHIP_ERROR GetWiFiInterfaceName(char * ifname, size_t bufSize);
-    static CHIP_ERROR GetWiFiChannelNumber(const char * ifname, uint16_t & channelNumber);
-    static CHIP_ERROR GetWiFiRssi(const char * ifname, int8_t & rssi);
-    static CHIP_ERROR GetWiFiBeaconLostCount(const char * ifname, uint32_t & beaconLostCount);
-    static CHIP_ERROR GetWiFiCurrentMaxRate(const char * ifname, uint64_t & currentMaxRate);
-    static CHIP_ERROR GetEthInterfaceName(char * ifname, size_t bufSize);
-    static CHIP_ERROR GetEthPHYRate(const char * ifname, app::Clusters::EthernetNetworkDiagnostics::PHYRateEnum & pHYRate);
-    static CHIP_ERROR GetEthFullDuplex(const char * ifname, bool & fullDuplex);
+namespace ConnectivityUtils {
 
-private:
-    static uint16_t Map2400MHz(const uint8_t inChannel);
-    static uint16_t Map5000MHz(const uint8_t inChannel);
-    static double ConvertFrequencyToFloat(const iw_freq * in);
-    static CHIP_ERROR GetWiFiParameter(int skfd, const char * ifname, int request, struct iwreq * pwrq);
-    static CHIP_ERROR GetWiFiStats(int skfd, const char * ifname, struct iw_statistics * stats);
-};
+uint16_t MapChannelToFrequency(const uint16_t inBand, const uint8_t inChannel);
+uint8_t MapFrequencyToChannel(const uint16_t frequency);
+app::Clusters::GeneralDiagnostics::InterfaceTypeEnum GetInterfaceConnectionType(const char * ifname);
+CHIP_ERROR GetInterfaceHardwareAddrs(const char * ifname, uint8_t * buf, size_t bufSize);
+CHIP_ERROR GetInterfaceIPv4Addrs(const char * ifname, uint8_t & size, NetworkInterface * ifp);
+CHIP_ERROR GetInterfaceIPv6Addrs(const char * ifname, uint8_t & size, NetworkInterface * ifp);
+CHIP_ERROR GetWiFiInterfaceName(char * ifname, size_t bufSize);
+CHIP_ERROR GetWiFiChannelNumber(const char * ifname, uint16_t & channelNumber);
+CHIP_ERROR GetWiFiRssi(const char * ifname, int8_t & rssi);
+CHIP_ERROR GetWiFiBeaconLostCount(const char * ifname, uint32_t & beaconLostCount);
+CHIP_ERROR GetWiFiCurrentMaxRate(const char * ifname, uint64_t & currentMaxRate);
+CHIP_ERROR GetEthInterfaceName(char * ifname, size_t bufSize);
+CHIP_ERROR GetEthPHYRate(const char * ifname, app::Clusters::EthernetNetworkDiagnostics::PHYRateEnum & pHYRate);
+CHIP_ERROR GetEthFullDuplex(const char * ifname, bool & fullDuplex);
+
+} // namespace ConnectivityUtils
 
 } // namespace Internal
 } // namespace DeviceLayer

--- a/src/platform/Tizen/ConnectivityUtils.h
+++ b/src/platform/Tizen/ConnectivityUtils.h
@@ -40,8 +40,6 @@ static constexpr uint16_t kWiFi_BAND_5_0_GHZ = 5000;
 
 namespace ConnectivityUtils {
 
-uint16_t MapChannelToFrequency(const uint16_t inBand, const uint8_t inChannel);
-uint8_t MapFrequencyToChannel(const uint16_t frequency);
 app::Clusters::GeneralDiagnostics::InterfaceTypeEnum GetInterfaceConnectionType(const char * ifname);
 CHIP_ERROR GetInterfaceHardwareAddrs(const char * ifname, uint8_t * buf, size_t bufSize);
 CHIP_ERROR GetInterfaceIPv4Addrs(const char * ifname, uint8_t & size, NetworkInterface * ifp);

--- a/src/platform/Tizen/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Tizen/DiagnosticDataProviderImpl.cpp
@@ -28,9 +28,11 @@
 #include <platform/Tizen/ConnectivityUtils.h>
 #include <platform/Tizen/DiagnosticDataProviderImpl.h>
 
+#include <errno.h>
 #include <ifaddrs.h>
 #include <linux/if_link.h>
 #include <malloc.h>
+#include <string.h>
 
 using namespace ::chip::app;
 using namespace ::chip::DeviceLayer::Internal;
@@ -63,7 +65,7 @@ CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
 
     if (getifaddrs(&ifaddr) == -1)
     {
-        ChipLogError(DeviceLayer, "Failed to get network interfaces");
+        ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
         return err;
     }
 
@@ -72,7 +74,7 @@ CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
     {
         if (ConnectivityUtils::GetInterfaceConnectionType(ifa->ifa_name) == InterfaceTypeEnum::kEthernet)
         {
-            ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface:%s", StringOrNullMarker(ifa->ifa_name));
+            ChipLogProgress(DeviceLayer, "Found the primary Ethernet interface: %s", StringOrNullMarker(ifa->ifa_name));
             break;
         }
     }
@@ -123,7 +125,7 @@ CHIP_ERROR GetWiFiStatsCount(WiFiStatsCountType type, uint64_t & count)
 
     if (getifaddrs(&ifaddr) == -1)
     {
-        ChipLogError(DeviceLayer, "Failed to get network interfaces");
+        ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
         return err;
     }
 
@@ -290,7 +292,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
 
     if (getifaddrs(&ifaddr) == -1)
     {
-        ChipLogError(DeviceLayer, "Failed to get network interfaces");
+        ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
         return err;
     }
 
@@ -341,11 +343,13 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         }
     }
 
-    *netifpp = head;
-    err      = CHIP_NO_ERROR;
+    if (head != nullptr)
+    {
+        *netifpp = head;
+        err      = CHIP_NO_ERROR;
+    }
 
     freeifaddrs(ifaddr);
-
     return err;
 }
 
@@ -451,7 +455,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
 
     if (getifaddrs(&ifaddr) == -1)
     {
-        ChipLogError(DeviceLayer, "Failed to get network interfaces");
+        ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
         return err;
     }
 
@@ -619,7 +623,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
 
     if (getifaddrs(&ifaddr) == -1)
     {
-        ChipLogError(DeviceLayer, "Failed to get network interfaces");
+        ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
         return err;
     }
 

--- a/src/platform/Tizen/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Tizen/DiagnosticDataProviderImpl.cpp
@@ -66,7 +66,7 @@ CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
     if (getifaddrs(&ifaddr) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
-        return err;
+        return CHIP_ERROR_POSIX(errno);
     }
 
     struct ifaddrs * ifa = nullptr;
@@ -126,7 +126,7 @@ CHIP_ERROR GetWiFiStatsCount(WiFiStatsCountType type, uint64_t & count)
     if (getifaddrs(&ifaddr) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
-        return err;
+        return CHIP_ERROR_POSIX(errno);
     }
 
     struct ifaddrs * ifa = nullptr;
@@ -293,7 +293,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     if (getifaddrs(&ifaddr) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
-        return err;
+        return CHIP_ERROR_POSIX(errno);
     }
 
     NetworkInterface * head = nullptr;
@@ -456,7 +456,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetEthNetworkDiagnosticsCounts()
     if (getifaddrs(&ifaddr) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
-        return err;
+        return CHIP_ERROR_POSIX(errno);
     }
 
     struct ifaddrs * ifa = nullptr;
@@ -624,7 +624,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
     if (getifaddrs(&ifaddr) == -1)
     {
         ChipLogError(DeviceLayer, "Failed to get network interfaces: %s", strerror(errno));
-        return err;
+        return CHIP_ERROR_POSIX(errno);
     }
 
     struct ifaddrs * ifa = nullptr;

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -88,7 +88,7 @@ void OnRegister(dnssd_error_e result, dnssd_service_h service, void * data)
 
     if (result != DNSSD_ERROR_NONE)
     {
-        ChipLogError(DeviceLayer, "DNSsd %s: Error: %d", __func__, result);
+        ChipLogError(DeviceLayer, "DNSsd %s: Error: %s", __func__, get_error_message(result));
         rCtx->mCallback(rCtx->mCbContext, nullptr, nullptr, TizenToChipError(result));
         // After this point, the context might be no longer valid
         rCtx->mInstance->RemoveContext(rCtx);
@@ -331,10 +331,10 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * userData)
     }
 #endif
 
-    ChipLogDetail(DeviceLayer, "DNSsd %s: IPv4: %s, IPv6: %s, ret: %d", __func__, StringOrNullMarker(ipv4.get()),
-                  StringOrNullMarker(ipv6.get()), ret);
-
-    VerifyOrExit(ret == DNSSD_ERROR_NONE, );
+    ChipLogDetail(DeviceLayer, "DNSsd %s: IPv4: %s, IPv6: %s", __func__, StringOrNullMarker(ipv4.get()),
+                  StringOrNullMarker(ipv6.get()));
+    VerifyOrExit(ret == DNSSD_ERROR_NONE,
+                 ChipLogError(DeviceLayer, "chip::Inet::IPAddress::FromString() failed: %s", get_error_message(ret)));
 
     ret = dnssd_service_get_port(service, &port);
     VerifyOrExit(ret == DNSSD_ERROR_NONE, ChipLogError(DeviceLayer, "dnssd_service_get_port() failed: %s", get_error_message(ret)));
@@ -489,7 +489,7 @@ void DnssdTizen::Shutdown()
 {
     int ret = dnssd_deinitialize();
     if (ret != DNSSD_ERROR_NONE)
-        ChipLogError(DeviceLayer, "DNSsd %s: Error: %d", __func__, ret);
+        ChipLogError(DeviceLayer, "dnssd_deinitialize() failed: %s", get_error_message(ret));
 }
 
 CHIP_ERROR DnssdTizen::RegisterService(const DnssdService & service, DnssdPublishCallback callback, void * context)

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -230,7 +230,7 @@ CHIP_ERROR BrowseAsync(chip::Dnssd::BrowseContext * bCtx)
     else
     {
         char iface[IF_NAMESIZE + 1] = "";
-        VerifyOrReturnValue(if_indextoname(interfaceId, iface) != nullptr, CHIP_ERROR_INTERNAL,
+        VerifyOrReturnValue(if_indextoname(interfaceId, iface) != nullptr, CHIP_ERROR_POSIX(errno),
                             ChipLogError(DeviceLayer, "if_indextoname() failed: %s", strerror(errno)));
         ret = dnssd_browse_service(bCtx->mType, iface, &bCtx->mBrowserHandle, OnBrowse, bCtx);
     }
@@ -554,7 +554,7 @@ CHIP_ERROR DnssdTizen::RegisterService(const DnssdService & service, DnssdPublis
         char iface[IF_NAMESIZE + 1] = "";
         VerifyOrExit(if_indextoname(interfaceId, iface) != nullptr,
                      ChipLogError(DeviceLayer, "if_indextoname() failed: %s", strerror(errno));
-                     err = CHIP_ERROR_INTERNAL);
+                     err = CHIP_ERROR_POSIX(errno));
         ret = dnssd_service_set_interface(serviceHandle, iface);
         VerifyOrExit(ret == DNSSD_ERROR_NONE,
                      ChipLogError(DeviceLayer, "dnssd_service_set_interface() failed: %s", get_error_message(ret));
@@ -644,7 +644,7 @@ CHIP_ERROR DnssdTizen::Resolve(const DnssdService & browseResult, chip::Inet::In
         char iface[IF_NAMESIZE + 1] = "";
         VerifyOrExit(if_indextoname(interfaceId, iface) != nullptr,
                      ChipLogError(DeviceLayer, "if_indextoname() failed: %s", strerror(errno));
-                     err = CHIP_ERROR_INTERNAL);
+                     err = CHIP_ERROR_POSIX(errno));
         ret = dnssd_create_remote_service(fullType.c_str(), browseResult.mName, iface, &resolveCtx->mServiceHandle);
     }
 

--- a/src/platform/Tizen/ErrorUtils.cpp
+++ b/src/platform/Tizen/ErrorUtils.cpp
@@ -17,6 +17,7 @@
 
 #include "ErrorUtils.h"
 
+#include <app_preference.h>
 #include <dns-sd.h>
 
 namespace chip {
@@ -27,14 +28,20 @@ CHIP_ERROR TizenToChipError(int tizenError)
 {
     switch (tizenError)
     {
-    case DNSSD_ERROR_NONE:
+    case TIZEN_ERROR_NONE:
         return CHIP_NO_ERROR;
-    case DNSSD_ERROR_NAME_CONFLICT:
-        return CHIP_ERROR_MDNS_COLLISION;
-    case DNSSD_ERROR_OUT_OF_MEMORY:
-        return CHIP_ERROR_NO_MEMORY;
+    case TIZEN_ERROR_OUT_OF_MEMORY:
+        return CHIP_NO_ERROR;
     default:
         return CHIP_ERROR_INTERNAL;
+
+    // Tizen DNSSD API errors
+    case DNSSD_ERROR_NAME_CONFLICT:
+        return CHIP_ERROR_MDNS_COLLISION;
+
+    // Tizen Preference API errors
+    case PREFERENCE_ERROR_NO_KEY:
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
 }
 

--- a/src/platform/Tizen/ErrorUtils.cpp
+++ b/src/platform/Tizen/ErrorUtils.cpp
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "ErrorUtils.h"
+
+#include <dns-sd.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+CHIP_ERROR TizenToChipError(int tizenError)
+{
+    switch (tizenError)
+    {
+    case DNSSD_ERROR_NONE:
+        return CHIP_NO_ERROR;
+    case DNSSD_ERROR_NAME_CONFLICT:
+        return CHIP_ERROR_MDNS_COLLISION;
+    case DNSSD_ERROR_OUT_OF_MEMORY:
+        return CHIP_ERROR_NO_MEMORY;
+    default:
+        return CHIP_ERROR_INTERNAL;
+    }
+}
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Tizen/ErrorUtils.h
+++ b/src/platform/Tizen/ErrorUtils.h
@@ -1,0 +1,30 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+CHIP_ERROR TizenToChipError(int tizenError);
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Tizen/Logging.cpp
+++ b/src/platform/Tizen/Logging.cpp
@@ -34,10 +34,9 @@ namespace Platform {
  */
 void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
-    static constexpr char kLogTag[]               = "CHIP";
-    char msgBuf[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = {
-        0,
-    };
+    static constexpr char kLogTag[] = "CHIP";
+
+    char msgBuf[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
     vsnprintf(msgBuf, sizeof(msgBuf), msg, v);
 
     switch (category)

--- a/src/platform/Tizen/SystemInfo.cpp
+++ b/src/platform/Tizen/SystemInfo.cpp
@@ -24,6 +24,8 @@
 
 #include <lib/support/logging/CHIPLogging.h>
 
+#include "ErrorUtils.h"
+
 using namespace std;
 
 namespace chip {
@@ -47,8 +49,8 @@ CHIP_ERROR SystemInfo::GetPlatformVersion(PlatformVersion & version)
     ret = system_info_get_platform_string("http://tizen.org/feature/platform.version", &platformVersion);
     if (ret != SYSTEM_INFO_ERROR_NONE)
     {
-        ChipLogError(DeviceLayer, "system_info_get_platform_string() failed. %s", get_error_message(ret));
-        return CHIP_ERROR_INTERNAL;
+        ChipLogError(DeviceLayer, "system_info_get_platform_string() failed: %s", get_error_message(ret));
+        return TizenToChipError(ret);
     }
 
     sInstance.mMajor = version.mMajor = (uint8_t) (platformVersion[0] - '0');

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -36,7 +36,8 @@
 using namespace ::chip::DeviceLayer::NetworkCommissioning;
 
 namespace {
-static constexpr const char * __WiFiDeviceStateToStr(wifi_manager_device_state_e state)
+
+constexpr const char * __WiFiDeviceStateToStr(wifi_manager_device_state_e state)
 {
     switch (state)
     {
@@ -49,7 +50,7 @@ static constexpr const char * __WiFiDeviceStateToStr(wifi_manager_device_state_e
     }
 }
 
-static constexpr const char * __WiFiScanStateToStr(wifi_manager_scan_state_e state)
+constexpr const char * __WiFiScanStateToStr(wifi_manager_scan_state_e state)
 {
     switch (state)
     {
@@ -62,7 +63,7 @@ static constexpr const char * __WiFiScanStateToStr(wifi_manager_scan_state_e sta
     }
 }
 
-static constexpr const char * __WiFiConnectionStateToStr(wifi_manager_connection_state_e state)
+constexpr const char * __WiFiConnectionStateToStr(wifi_manager_connection_state_e state)
 {
     switch (state)
     {
@@ -81,7 +82,7 @@ static constexpr const char * __WiFiConnectionStateToStr(wifi_manager_connection
     }
 }
 
-static constexpr const char * __WiFiIPConflictStateToStr(wifi_manager_ip_conflict_state_e state)
+constexpr const char * __WiFiIPConflictStateToStr(wifi_manager_ip_conflict_state_e state)
 {
     switch (state)
     {
@@ -94,7 +95,7 @@ static constexpr const char * __WiFiIPConflictStateToStr(wifi_manager_ip_conflic
     }
 }
 
-static constexpr const char * __WiFiModuleStateToStr(wifi_manager_module_state_e state)
+constexpr const char * __WiFiModuleStateToStr(wifi_manager_module_state_e state)
 {
     switch (state)
     {
@@ -107,7 +108,7 @@ static constexpr const char * __WiFiModuleStateToStr(wifi_manager_module_state_e
     }
 }
 
-static constexpr const char * __WiFiSecurityTypeToStr(wifi_manager_security_type_e type)
+constexpr const char * __WiFiSecurityTypeToStr(wifi_manager_security_type_e type)
 {
     switch (type)
     {
@@ -136,7 +137,7 @@ static constexpr const char * __WiFiSecurityTypeToStr(wifi_manager_security_type
 
 // wifi_manager's scan results don't contains the channel infomation, so we need this lookup table for resolving the band and
 // channel infomation.
-std::pair<WiFiBand, int> _GetBandAndChannelFromFrequency(int freq)
+constexpr std::pair<WiFiBand, int> _GetBandAndChannelFromFrequency(int freq)
 {
     std::pair<WiFiBand, int> ret = std::make_pair(WiFiBand::k2g4, 0);
     if (freq <= 931)
@@ -229,7 +230,7 @@ std::pair<WiFiBand, int> _GetBandAndChannelFromFrequency(int freq)
     return ret;
 }
 
-uint8_t _GetNetworkSecurityType(wifi_manager_security_type_e type)
+constexpr uint8_t _GetNetworkSecurityType(wifi_manager_security_type_e type)
 {
     switch (type)
     {
@@ -255,6 +256,7 @@ uint8_t _GetNetworkSecurityType(wifi_manager_security_type_e type)
         return 0x0;
     }
 }
+
 } // namespace
 
 namespace chip {


### PR DESCRIPTION
### Problem

In most places, in case of error, Tizen platform prints error code instead of human readable message, which is hard to decipher.

### Changes

- Replace error code with `get_error_message()` Tizen API
- Add utils which converts Tizen error codes to Matter error codes
- Make sure that INET socket is closed upon returning error (similar fix should be done in Linux platform)
- Convert ConnectivityUtils class with all static functions to namespace and keep helper functions in the *.cpp file only
- Wrap POSIX `errno` with `CHIP_ERROR_POSIX`

### Testing

Tested lighting-app commissioning with chip-tool.
CI will verify potential build breaks.