### PR TITLE
[Silabs]Set optimization to Os for the lighting-app thread

### DIFF
--- a/examples/lighting-app/silabs/openthread.gn
+++ b/examples/lighting-app/silabs/openthread.gn
@@ -24,6 +24,7 @@ default_args = {
   target_cpu = "arm"
   target_os = "freertos"
   chip_openthread_ftd = true
+  optimize_debug_level = "s"
 
   import("//openthread.gni")
 }


### PR DESCRIPTION
### Problem
Flash memory is getting tight with the lighting-app thread app on EFR32MG12. 
We saw an efr32 CI fail due to this.

### Solution
Enable optimization by size by default on the thread lighting app