### PR TITLE
Reduce ember attribute-storage API surface: remove emberAfIsCluster* methods

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1026,12 +1026,13 @@ uint8_t emberAfClusterCountByIndex(uint16_t endpointIndex, bool server)
 uint8_t emberAfClusterCountForEndpointType(const EmberAfEndpointType * type, bool server)
 {
     const EmberAfClusterMask cluster_mask = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
-    uint8_t c = 0;
-    const uint8_t clusterCount = type->clusterCount;
+    uint8_t c                             = 0;
+    const uint8_t clusterCount            = type->clusterCount;
 
     for (uint8_t i = 0; i < clusterCount; i++)
     {
-        if ((type->cluster[i].mask & cluster_mask) != 0) {
+        if ((type->cluster[i].mask & cluster_mask) != 0)
+        {
             c++;
         }
     }
@@ -1138,8 +1139,8 @@ const EmberAfCluster * emberAfGetNthCluster(EndpointId endpoint, uint8_t n, bool
     }
 
     const EmberAfEndpointType endpointType = emAfEndpoints[index].endpointType;
-    const EmberAfClusterMask cluster_mask = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
-    const uint8_t clusterCount = endpointType->clusterCount;
+    const EmberAfClusterMask cluster_mask  = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
+    const uint8_t clusterCount             = endpointType->clusterCount;
 
     uint8_t c = 0;
     for (uint8_t i = 0; i < clusterCount; i++)
@@ -1151,7 +1152,7 @@ const EmberAfCluster * emberAfGetNthCluster(EndpointId endpoint, uint8_t n, bool
 
         if (c == n)
         {
-           return cluster;
+            return cluster;
         }
 
         c++;

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1028,7 +1028,7 @@ uint8_t emberAfClusterCountForEndpointType(const EmberAfEndpointType * type, boo
     const EmberAfClusterMask cluster_mask = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
 
     return static_cast<uint8_t>(std::count_if(type->cluster, type->cluster + type->clusterCount,
-                                              [=](const EmberAfCluster &cluster) { return (cluster.mask & cluster_mask) != 0; }));
+                                              [=](const EmberAfCluster & cluster) { return (cluster.mask & cluster_mask) != 0; }));
 }
 
 uint8_t emberAfGetClusterCountForEndpoint(EndpointId endpoint)

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1138,14 +1138,16 @@ const EmberAfCluster * emberAfGetNthCluster(EndpointId endpoint, uint8_t n, bool
         return nullptr;
     }
 
-    const EmberAfEndpointType endpointType = emAfEndpoints[index].endpointType;
-    const EmberAfClusterMask cluster_mask  = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
-    const uint8_t clusterCount             = endpointType->clusterCount;
+    const EmberAfEndpointType *endpointType = emAfEndpoints[index].endpointType;
+    const EmberAfClusterMask cluster_mask   = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
+    const uint8_t clusterCount              = endpointType->clusterCount;
 
     uint8_t c = 0;
     for (uint8_t i = 0; i < clusterCount; i++)
     {
-        if ((endpointType->cluster[i].mask & cluster_mask) == 0)
+        const EmberAfCluster *cluster= &(endpointType->cluster[i]);
+
+        if ((cluster->mask & cluster_mask) == 0)
         {
             continue;
         }

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1138,14 +1138,14 @@ const EmberAfCluster * emberAfGetNthCluster(EndpointId endpoint, uint8_t n, bool
         return nullptr;
     }
 
-    const EmberAfEndpointType *endpointType = emAfEndpoints[index].endpointType;
-    const EmberAfClusterMask cluster_mask   = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
-    const uint8_t clusterCount              = endpointType->clusterCount;
+    const EmberAfEndpointType * endpointType = emAfEndpoints[index].endpointType;
+    const EmberAfClusterMask cluster_mask    = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
+    const uint8_t clusterCount               = endpointType->clusterCount;
 
     uint8_t c = 0;
     for (uint8_t i = 0; i < clusterCount; i++)
     {
-        const EmberAfCluster *cluster= &(endpointType->cluster[i]);
+        const EmberAfCluster * cluster = &(endpointType->cluster[i]);
 
         if ((cluster->mask & cluster_mask) == 0)
         {

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1028,7 +1028,7 @@ uint8_t emberAfClusterCountForEndpointType(const EmberAfEndpointType * type, boo
     const EmberAfClusterMask cluster_mask = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
 
     return static_cast<uint8_t>(std::count_if(type->cluster, type->cluster + type->clusterCount,
-                                              [=](auto cluster) { return (cluster.mask & cluster_mask) != 0; }));
+                                              [=](const EmberAfCluster &cluster) { return (cluster.mask & cluster_mask) != 0; }));
 }
 
 uint8_t emberAfGetClusterCountForEndpoint(EndpointId endpoint)

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1132,28 +1132,29 @@ CHIP_ERROR SetTagList(EndpointId endpoint, Span<const Clusters::Descriptor::Stru
 const EmberAfCluster * emberAfGetNthCluster(EndpointId endpoint, uint8_t n, bool server)
 {
     uint16_t index = emberAfIndexFromEndpoint(endpoint);
-    uint8_t c = 0;
-    const EmberAfCluster * cluster;
-
     if (index == kEmberInvalidEndpointIndex)
     {
         return nullptr;
     }
 
-    const EmberAfEndpointType *endpointType = emAfEndpoints[index].endpointType;
+    const EmberAfEndpointType endpointType = emAfEndpoints[index].endpointType;
     const EmberAfClusterMask cluster_mask = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
     const uint8_t clusterCount = endpointType->clusterCount;
 
+    uint8_t c = 0;
     for (uint8_t i = 0; i < clusterCount; i++)
     {
-        if ((endpointType->cluster[i].mask & cluster_mask) != 0)
+        if ((endpointType->cluster[i].mask & cluster_mask) == 0)
         {
-            if (c == n)
-            {
-                return cluster;
-            }
-            c++;
+            continue;
         }
+
+        if (c == n)
+        {
+           return cluster;
+        }
+
+        c++;
     }
     return nullptr;
 }

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -714,7 +714,7 @@ const EmberAfCluster * emberAfFindClusterInType(const EmberAfEndpointType * endp
     {
         const EmberAfCluster * cluster = &(endpointType->cluster[i]);
 
-        if ((mask == 0 || ((cluster->mask & mask) != 0)))
+        if (mask == 0 || ((cluster->mask & mask) != 0))
         {
             if (cluster->clusterId == clusterId)
             {

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1026,17 +1026,9 @@ uint8_t emberAfClusterCountByIndex(uint16_t endpointIndex, bool server)
 uint8_t emberAfClusterCountForEndpointType(const EmberAfEndpointType * type, bool server)
 {
     const EmberAfClusterMask cluster_mask = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
-    uint8_t c                             = 0;
-    const uint8_t clusterCount            = type->clusterCount;
 
-    for (uint8_t i = 0; i < clusterCount; i++)
-    {
-        if ((type->cluster[i].mask & cluster_mask) != 0)
-        {
-            c++;
-        }
-    }
-    return c;
+    return static_cast<uint8_t>(std::count_if(type->cluster, type->cluster + type->clusterCount,
+                                              [=](auto cluster) { return (cluster.mask & cluster_mask) != 0; }));
 }
 
 uint8_t emberAfGetClusterCountForEndpoint(EndpointId endpoint)

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -714,8 +714,7 @@ const EmberAfCluster * emberAfFindClusterInType(const EmberAfEndpointType * endp
     {
         const EmberAfCluster * cluster = &(endpointType->cluster[i]);
 
-        if ((mask == 0 || (mask == CLUSTER_MASK_CLIENT && emberAfClusterIsClient(cluster)) ||
-             (mask == CLUSTER_MASK_SERVER && emberAfClusterIsServer(cluster))))
+        if ((mask == 0 || ((cluster->mask & mask) != 0)))
         {
             if (cluster->clusterId == clusterId)
             {
@@ -1026,16 +1025,13 @@ uint8_t emberAfClusterCountByIndex(uint16_t endpointIndex, bool server)
 
 uint8_t emberAfClusterCountForEndpointType(const EmberAfEndpointType * type, bool server)
 {
+    const EmberAfClusterMask cluster_mask = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
     uint8_t c = 0;
-    for (uint8_t i = 0; i < type->clusterCount; i++)
+    const uint8_t clusterCount = type->clusterCount;
+
+    for (uint8_t i = 0; i < clusterCount; i++)
     {
-        auto * cluster = &(type->cluster[i]);
-        if (server && emberAfClusterIsServer(cluster))
-        {
-            c++;
-        }
-        if ((!server) && emberAfClusterIsClient(cluster))
-        {
+        if ((type->cluster[i].mask & cluster_mask) != 0) {
             c++;
         }
     }
@@ -1136,21 +1132,21 @@ CHIP_ERROR SetTagList(EndpointId endpoint, Span<const Clusters::Descriptor::Stru
 const EmberAfCluster * emberAfGetNthCluster(EndpointId endpoint, uint8_t n, bool server)
 {
     uint16_t index = emberAfIndexFromEndpoint(endpoint);
-    EmberAfDefinedEndpoint * de;
-    uint8_t i, c = 0;
+    uint8_t c = 0;
     const EmberAfCluster * cluster;
 
     if (index == kEmberInvalidEndpointIndex)
     {
         return nullptr;
     }
-    de = &(emAfEndpoints[index]);
 
-    for (i = 0; i < de->endpointType->clusterCount; i++)
+    const EmberAfEndpointType *endpointType = emAfEndpoints[index].endpointType;
+    const EmberAfClusterMask cluster_mask = server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT;
+    const uint8_t clusterCount = endpointType->clusterCount;
+
+    for (uint8_t i = 0; i < clusterCount; i++)
     {
-        cluster = &(de->endpointType->cluster[i]);
-
-        if ((server && emberAfClusterIsServer(cluster)) || ((!server) && emberAfClusterIsClient(cluster)))
+        if ((endpointType->cluster[i].mask & cluster_mask) != 0)
         {
             if (c == n)
             {

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -89,9 +89,6 @@ extern uint8_t attributeDefaults[]; // storage bucked for > 2b default values
 
 void emAfCallInits(void);
 
-#define emberAfClusterIsClient(cluster) ((bool) (((cluster)->mask & CLUSTER_MASK_CLIENT) != 0))
-#define emberAfClusterIsServer(cluster) ((bool) (((cluster)->mask & CLUSTER_MASK_SERVER) != 0))
-
 // Initial configuration
 void emberAfEndpointConfigure(void);
 


### PR DESCRIPTION
These methods seem to be internal only (since they reference AF structures that are generally inside the attribute-storage class only).

Removed the methods (macros named like methods actually) completely as they are basically one-line and the code seemingly could be made clearer by using correct masks instead.