### PR TITLE
[ICD] Add Check-In message check when switching to idle mode

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -254,7 +254,6 @@ static_library("interaction-model") {
     ":message-def",
     ":paths",
     ":subscription-manager",
-    "${chip_root}/src/app/icd:configuration-data",
     "${chip_root}/src/app/icd:icd_config",
     "${chip_root}/src/app/icd:observer",
     "${chip_root}/src/lib/address_resolve",

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -114,6 +114,12 @@ source_set("pre-encoded-value") {
   ]
 }
 
+source_set("subscription-manager") {
+  sources = [ "SubscriptionManager.h" ]
+
+  public_deps = [ "${chip_root}/src/lib/core" ]
+}
+
 source_set("message-def") {
   sources = [
     "MessageDef/ArrayBuilder.cpp",
@@ -247,6 +253,8 @@ static_library("interaction-model") {
     ":app_config",
     ":message-def",
     ":paths",
+    ":subscription-manager",
+    "${chip_root}/src/app/icd:configuration-data",
     "${chip_root}/src/app/icd:icd_config",
     "${chip_root}/src/app/icd:observer",
     "${chip_root}/src/lib/address_resolve",

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -330,7 +330,7 @@ void InteractionModelEngine::ShutdownMatchingSubscriptions(const Optional<Fabric
 }
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
 
-bool InteractionModelEngine::SubjectHasActiveSubcription(const FabricIndex & aFabricIndex, const NodeId & subjectID)
+bool InteractionModelEngine::SubjectHasActiveSubscription(const FabricIndex & aFabricIndex, const NodeId & subjectID)
 {
     bool isActive = false;
     mReadHandlers.ForEachActiveObject([aFabricIndex, subjectID, &isActive](ReadHandler * handler) {

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -369,7 +369,7 @@ bool InteractionModelEngine::SubjectHasActiveSubcription(const FabricIndex & aFa
 
 bool InteractionModelEngine::SubjectHasPersistedSubscription(const FabricIndex & aFabricIndex, const NodeId & subject)
 {
-    // TODO : Implement persisted sub verification
+    // TODO(#30281) : Implement persisted sub check and verify how persistent subscriptions affects this at ICDManager::Init
     return false;
 }
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -330,7 +330,7 @@ void InteractionModelEngine::ShutdownMatchingSubscriptions(const Optional<Fabric
 }
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
 
-bool InteractionModelEngine::SubjectHasActiveSubscription(const FabricIndex aFabricIndex, const NodeId & subjectID)
+bool InteractionModelEngine::SubjectHasActiveSubcription(const FabricIndex & aFabricIndex, const NodeId & subjectID)
 {
     bool isActive = false;
     mReadHandlers.ForEachActiveObject([aFabricIndex, subjectID, &isActive](ReadHandler * handler) {
@@ -365,6 +365,12 @@ bool InteractionModelEngine::SubjectHasActiveSubscription(const FabricIndex aFab
     });
 
     return isActive;
+}
+
+bool InteractionModelEngine::SubjectHasPersistedSubscription(const FabricIndex & aFabricIndex, const NodeId & subject)
+{
+    // TODO : Implement persisted sub verification
+    return false;
 }
 
 void InteractionModelEngine::OnDone(CommandHandler & apCommandObj)

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -324,7 +324,7 @@ public:
 
     CHIP_ERROR ResumeSubscriptions();
 
-    bool SubjectHasActiveSubcription(const FabricIndex & aFabricIndex, const NodeId & subject) override;
+    bool SubjectHasActiveSubscription(const FabricIndex & aFabricIndex, const NodeId & subject) override;
 
     bool SubjectHasPersistedSubscription(const FabricIndex & aFabricIndex, const NodeId & subject) override;
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -27,9 +27,30 @@
 
 #include <access/AccessControl.h>
 #include <app/AppConfig.h>
+#include <app/AttributePathParams.h>
+#include <app/CommandHandler.h>
+#include <app/CommandHandlerInterface.h>
+#include <app/CommandSender.h>
+#include <app/ConcreteAttributePath.h>
+#include <app/ConcreteCommandPath.h>
+#include <app/ConcreteEventPath.h>
+#include <app/DataVersionFilter.h>
+#include <app/EventPathParams.h>
 #include <app/MessageDef/AttributeReportIBs.h>
 #include <app/MessageDef/ReportDataMessage.h>
+#include <app/ObjectList.h>
+#include <app/ReadClient.h>
+#include <app/ReadHandler.h>
+#include <app/StatusResponse.h>
+#include <app/SubscriptionManager.h>
 #include <app/SubscriptionResumptionSessionEstablisher.h>
+#include <app/TimedHandler.h>
+#include <app/WriteClient.h>
+#include <app/WriteHandler.h>
+#include <app/reporting/Engine.h>
+#include <app/reporting/ReportScheduler.h>
+#include <app/util/attribute-metadata.h>
+#include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
@@ -41,27 +62,6 @@
 #include <protocols/Protocols.h>
 #include <protocols/interaction_model/Constants.h>
 #include <system/SystemPacketBuffer.h>
-
-#include <app/AttributePathParams.h>
-#include <app/CommandHandler.h>
-#include <app/CommandHandlerInterface.h>
-#include <app/CommandSender.h>
-#include <app/ConcreteAttributePath.h>
-#include <app/ConcreteCommandPath.h>
-#include <app/ConcreteEventPath.h>
-#include <app/DataVersionFilter.h>
-#include <app/EventPathParams.h>
-#include <app/ObjectList.h>
-#include <app/ReadClient.h>
-#include <app/ReadHandler.h>
-#include <app/StatusResponse.h>
-#include <app/TimedHandler.h>
-#include <app/WriteClient.h>
-#include <app/WriteHandler.h>
-#include <app/reporting/Engine.h>
-#include <app/reporting/ReportScheduler.h>
-#include <app/util/attribute-metadata.h>
-#include <app/util/basic-types.h>
 
 #include <app/CASESessionManager.h>
 
@@ -79,7 +79,8 @@ class InteractionModelEngine : public Messaging::UnsolicitedMessageHandler,
                                public Messaging::ExchangeDelegate,
                                public CommandHandler::Callback,
                                public ReadHandler::ManagementCallback,
-                               public FabricTable::Delegate
+                               public FabricTable::Delegate,
+                               public SubscriptionManager
 {
 public:
     /**
@@ -323,8 +324,9 @@ public:
 
     CHIP_ERROR ResumeSubscriptions();
 
-    // Check if a given subject (CAT or NodeId) has at least 1 active subscription
-    bool SubjectHasActiveSubscription(const FabricIndex aFabricIndex, const NodeId & subject);
+    bool SubjectHasActiveSubcription(const FabricIndex & aFabricIndex, const NodeId & subject) override;
+
+    bool SubjectHasPersistedSubscription(const FabricIndex & aFabricIndex, const NodeId & subject) override;
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     //

--- a/src/app/SubscriptionManager.h
+++ b/src/app/SubscriptionManager.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    Copyright (c) 2024 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/app/SubscriptionManager.h
+++ b/src/app/SubscriptionManager.h
@@ -1,0 +1,68 @@
+/*
+ *
+ *    Copyright (c) 2020-2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines an interface that exposes all the public subscription management APIs.
+ *      The interface is implemented by the InteractionModelEngine to avoid creating unnecessary dependencies 
+ *      Since the IMEgine has more dependency than its consummers need.
+ *      By leveraging the SubscriptionManager APIs, a consummer avoids depending on the global data model functions.
+ */
+
+#pragma once
+
+#include <lib/core/NodeId.h>
+#include <lib/core/DataModelTypes.h>
+
+namespace chip {
+namespace app {
+
+class SubscriptionManager {
+public:
+    
+    virtual ~SubscriptionManager() {};
+
+    /**
+     * @brief Check if a given subject (CAT or operational NodeId) has at least 1 active subscription.
+     * 
+     * @param[in] aFabricIndex fabric index of the subject
+     * @param[in] subject NodeId of the subect
+     * 
+     * @return true subject has at least one active subscription with the device
+     *         false subject doesn't have any acitve subscription with the device
+     */
+    virtual bool SubjectHasActiveSubcription(const FabricIndex & aFabricIndex, const NodeId & subject) = 0;
+
+    
+    /**
+     * @brief Check if a given subject (CAT or operational NodeId) has at least 1 persisted subscription.
+     *        If CHIP_CONFIG_PERSIST_SUBSCRIPTIONS is not enable, function alweays returns false.
+     *        See the CHIP_CONFIG_PERSIST_SUBSCRIPTIONS for more information on persisted subscriptions.
+     * 
+     * @param[in] aFabricIndex fabric index of the subject
+     * @param[in] subject NodeId of the subect
+     * 
+     * @return true subject has at least one persisted subscription with the device
+     *         false subject doesn't have any acitve subscription with the device
+     *         false If CHIP_CONFIG_PERSIST_SUBSCRIPTIONS is not enabled
+     */
+    virtual bool SubjectHasPersistedSubscription(const FabricIndex & aFabricIndex, const NodeId & subject) = 0;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/SubscriptionManager.h
+++ b/src/app/SubscriptionManager.h
@@ -19,44 +19,43 @@
 /**
  *    @file
  *      This file defines an interface that exposes all the public subscription management APIs.
- *      The interface is implemented by the InteractionModelEngine to avoid creating unnecessary dependencies 
+ *      The interface is implemented by the InteractionModelEngine to avoid creating unnecessary dependencies
  *      Since the IMEgine has more dependency than its consummers need.
  *      By leveraging the SubscriptionManager APIs, a consummer avoids depending on the global data model functions.
  */
 
 #pragma once
 
-#include <lib/core/NodeId.h>
 #include <lib/core/DataModelTypes.h>
+#include <lib/core/NodeId.h>
 
 namespace chip {
 namespace app {
 
-class SubscriptionManager {
+class SubscriptionManager
+{
 public:
-    
-    virtual ~SubscriptionManager() {};
+    virtual ~SubscriptionManager(){};
 
     /**
      * @brief Check if a given subject (CAT or operational NodeId) has at least 1 active subscription.
-     * 
+     *
      * @param[in] aFabricIndex fabric index of the subject
      * @param[in] subject NodeId of the subect
-     * 
+     *
      * @return true subject has at least one active subscription with the device
      *         false subject doesn't have any acitve subscription with the device
      */
     virtual bool SubjectHasActiveSubcription(const FabricIndex & aFabricIndex, const NodeId & subject) = 0;
 
-    
     /**
      * @brief Check if a given subject (CAT or operational NodeId) has at least 1 persisted subscription.
      *        If CHIP_CONFIG_PERSIST_SUBSCRIPTIONS is not enable, function alweays returns false.
      *        See the CHIP_CONFIG_PERSIST_SUBSCRIPTIONS for more information on persisted subscriptions.
-     * 
+     *
      * @param[in] aFabricIndex fabric index of the subject
      * @param[in] subject NodeId of the subect
-     * 
+     *
      * @return true subject has at least one persisted subscription with the device
      *         false subject doesn't have any acitve subscription with the device
      *         false If CHIP_CONFIG_PERSIST_SUBSCRIPTIONS is not enabled

--- a/src/app/SubscriptionManager.h
+++ b/src/app/SubscriptionManager.h
@@ -46,7 +46,7 @@ public:
      * @return true subject has at least one active subscription with the device
      *         false subject doesn't have any acitve subscription with the device
      */
-    virtual bool SubjectHasActiveSubcription(const FabricIndex & aFabricIndex, const NodeId & subject) = 0;
+    virtual bool SubjectHasActiveSubscription(const FabricIndex & aFabricIndex, const NodeId & subject) = 0;
 
     /**
      * @brief Check if a given subject (CAT or operational NodeId) has at least 1 persisted subscription.

--- a/src/app/icd/BUILD.gn
+++ b/src/app/icd/BUILD.gn
@@ -70,7 +70,7 @@ source_set("manager") {
     ":notifier",
     ":observer",
     ":sender",
-    "${chip_root}/src/app:interaction-model",
+    "${chip_root}/src/app:subscription-manager",
     "${chip_root}/src/credentials:credentials",
   ]
 }

--- a/src/app/icd/BUILD.gn
+++ b/src/app/icd/BUILD.gn
@@ -114,5 +114,6 @@ source_set("configuration-data") {
   deps = [
     ":icd_config",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
   ]
 }

--- a/src/app/icd/ICDConfigurationData.cpp
+++ b/src/app/icd/ICDConfigurationData.cpp
@@ -37,7 +37,7 @@ System::Clock::Milliseconds32 ICDConfigurationData::GetSlowPollingInterval()
     return mSlowPollingInterval;
 }
 
-CHIP_ERROR ICDConfigurationData::SetDurations(uint32_t activeModeDuration_ms, uint32_t idleModeInterval_s)
+CHIP_ERROR ICDConfigurationData::SetModeDurations(uint32_t activeModeDuration_ms, uint32_t idleModeInterval_s)
 {
     VerifyOrReturnError(activeModeDuration_ms <= (idleModeInterval_s * 1000), CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(idleModeInterval_s <= kMaxIdleModeDuration_s, CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/app/icd/ICDConfigurationData.cpp
+++ b/src/app/icd/ICDConfigurationData.cpp
@@ -17,6 +17,7 @@
 
 #include "ICDConfigurationData.h"
 #include <app/icd/ICDConfig.h>
+#include <lib/support/CodeUtils.h>
 
 namespace chip {
 
@@ -34,6 +35,18 @@ System::Clock::Milliseconds32 ICDConfigurationData::GetSlowPollingInterval()
     }
 #endif
     return mSlowPollingInterval;
+}
+
+CHIP_ERROR ICDConfigurationData::SetDurations(uint32_t activeModeDuration_ms, uint32_t idleModeInterval_s)
+{
+    VerifyOrReturnError(activeModeDuration_ms <= (idleModeInterval_s * 1000), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(idleModeInterval_s <= kMaxIdleModeDuration_s, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(idleModeInterval_s >= kMinIdleModeDuration_s, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mIdleModeDuration_s    = idleModeInterval_s;
+    mActiveModeDuration_ms = activeModeDuration_ms;
+
+    return CHIP_NO_ERROR;
 }
 
 } // namespace chip

--- a/src/app/icd/ICDConfigurationData.h
+++ b/src/app/icd/ICDConfigurationData.h
@@ -114,7 +114,7 @@ private:
      *                                                is returned if idleModeDuration_s is smaller than 1 seconds
      *                    CHIP_NO_ERROR is returned if the new intervals were set
      */
-    CHIP_ERROR SetDurations(uint32_t activeModeDuration_ms, uint32_t idleModeDuration_s);
+    CHIP_ERROR SetModeDurations(uint32_t activeModeDuration_ms, uint32_t idleModeDuration_s);
 
     static constexpr uint32_t kMaxIdleModeDuration_s = 64800;
     static constexpr uint32_t kMinIdleModeDuration_s = 1;

--- a/src/app/icd/ICDConfigurationData.h
+++ b/src/app/icd/ICDConfigurationData.h
@@ -25,6 +25,11 @@ namespace chip {
 namespace app {
 // Forward declaration of ICDManager to allow it to be friend with ICDConfigurationData
 class ICDManager;
+
+// Forward declaration of TestICDManager to allow it to be friend with the ICDConfigurationData
+// Used in unit tests
+class TestICDManager;
+
 } // namespace app
 
 /**
@@ -47,9 +52,9 @@ public:
 
     static ICDConfigurationData & GetInstance() { return instance; };
 
-    uint32_t GetIdleModeDurationSec() { return mIdleInterval_s; }
+    uint32_t GetIdleModeDurationSec() { return mIdleModeDuration_s; }
 
-    uint32_t GetActiveModeDurationMs() { return mActiveInterval_ms; }
+    uint32_t GetActiveModeDurationMs() { return mActiveModeDuration_ms; }
 
     uint16_t GetActiveModeThresholdMs() { return mActiveThreshold_ms; }
 
@@ -89,6 +94,7 @@ private:
     // the ICDManager, the ICDManager is a friend that can access the private setters. If a consummer needs to be notified when a
     // value is changed, they can leverage the Observer events the ICDManager generates. See src/app/icd/ICDStateObserver.h
     friend class chip::app::ICDManager;
+    friend class chip::app::TestICDManager;
 
     void SetICDMode(ICDMode mode) { mICDMode = mode; };
     void SetICDCounter(uint32_t count) { mICDCounter = count; }
@@ -97,15 +103,31 @@ private:
 
     static constexpr uint32_t kMinLitActiveModeThreshold_ms = 5000;
 
-    static_assert((CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC) <= 64800,
+    /**
+     * @brief Change the ActiveModeDuration and IdleModeDuration value
+     *        To only change one value, pass the old value for the other one
+     *
+     * @param[in] activeModeDuration_ms new ActiveModeDuration value
+     * @param[in] idleModeDuration_s new IdleModeDuration value
+     * @return CHIP_ERROR CHIP_ERROR_INVALID_ARGUMENT is returned if idleModeDuration_s is smaller than activeModeDuration_ms
+     *                                                is returned if idleModeDuration_s is greater than 64800 seconds
+     *                                                is returned if idleModeDuration_s is smaller than 1 seconds
+     *                    CHIP_NO_ERROR is returned if the new intervals were set
+     */
+    CHIP_ERROR SetDurations(uint32_t activeModeDuration_ms, uint32_t idleModeDuration_s);
+
+    static constexpr uint32_t kMaxIdleModeDuration_s = 64800;
+    static constexpr uint32_t kMinIdleModeDuration_s = 1;
+
+    static_assert((CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC) <= kMaxIdleModeDuration_s,
                   "Spec requires the IdleModeDuration to be equal or inferior to 64800s.");
-    static_assert((CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC) >= 1,
+    static_assert((CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC) >= kMinIdleModeDuration_s,
                   "Spec requires the IdleModeDuration to be equal or greater to 1s.");
-    uint32_t mIdleInterval_s = CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC;
+    uint32_t mIdleModeDuration_s = CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC;
 
     static_assert((CHIP_CONFIG_ICD_ACTIVE_MODE_DURATION_MS) <= (CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC * kMillisecondsPerSecond),
                   "Spec requires the IdleModeDuration be equal or greater to the ActiveModeDuration.");
-    uint32_t mActiveInterval_ms = CHIP_CONFIG_ICD_ACTIVE_MODE_DURATION_MS;
+    uint32_t mActiveModeDuration_ms = CHIP_CONFIG_ICD_ACTIVE_MODE_DURATION_MS;
 
     uint16_t mActiveThreshold_ms = CHIP_CONFIG_ICD_ACTIVE_MODE_THRESHOLD_MS;
 

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -144,7 +144,7 @@ void ICDManager::SendCheckInMsgs()
                 continue;
             }
 
-            bool active = mSubManager->SubjectHasActiveSubcription(entry.fabricIndex, entry.monitoredSubject);
+            bool active = mSubManager->SubjectHasActiveSubscription(entry.fabricIndex, entry.monitoredSubject);
             if (active)
             {
                 continue;

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -577,7 +577,7 @@ bool ICDManager::CheckInMessagesWouldBeSent()
             }
 
             // At least one registration would require a Check-In message
-            VerifyOrReturnValue(mSubManager->SubjectHasActiveSubcription(entry.fabricIndex, entry.monitoredSubject), true);
+            VerifyOrReturnValue(mSubManager->SubjectHasActiveSubscription(entry.fabricIndex, entry.monitoredSubject), true);
         }
     }
 

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -18,7 +18,6 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
-#include <app/InteractionModelEngine.h>
 #include <app/icd/ICDConfig.h>
 #include <app/icd/ICDConfigurationData.h>
 #include <app/icd/ICDManager.h>
@@ -41,12 +40,13 @@ static_assert(UINT8_MAX >= CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS,
               "ICDManager::mOpenExchangeContextCount cannot hold count for the max exchange count");
 
 void ICDManager::Init(PersistentStorageDelegate * storage, FabricTable * fabricTable, Crypto::SymmetricKeystore * symmetricKeystore,
-                      Messaging::ExchangeManager * exchangeManager)
+                      Messaging::ExchangeManager * exchangeManager, SubscriptionManager * manager)
 {
     VerifyOrDie(storage != nullptr);
     VerifyOrDie(fabricTable != nullptr);
     VerifyOrDie(symmetricKeystore != nullptr);
     VerifyOrDie(exchangeManager != nullptr);
+    VerifyOrDie(manager != nullptr);
 
     // LIT ICD Verification Checks
     if (SupportsFeature(Feature::kLongIdleTimeSupport))
@@ -63,11 +63,13 @@ void ICDManager::Init(PersistentStorageDelegate * storage, FabricTable * fabricT
         //                    "LIT support is required for slow polling intervals superior to 15 seconds");
     }
 
-    mStorage     = storage;
-    mFabricTable = fabricTable;
     VerifyOrDie(ICDNotifier::GetInstance().Subscribe(this) == CHIP_NO_ERROR);
+
+    mStorage           = storage;
+    mFabricTable       = fabricTable;
     mSymmetricKeystore = symmetricKeystore;
     mExchangeManager   = exchangeManager;
+    mSubManager        = manager;
 
     VerifyOrDie(InitCounter() == CHIP_NO_ERROR);
 
@@ -78,14 +80,19 @@ void ICDManager::Init(PersistentStorageDelegate * storage, FabricTable * fabricT
 void ICDManager::Shutdown()
 {
     ICDNotifier::GetInstance().Unsubscribe(this);
+
     // cancel any running timer of the icd
     DeviceLayer::SystemLayer().CancelTimer(OnIdleModeDone, this);
     DeviceLayer::SystemLayer().CancelTimer(OnActiveModeDone, this);
     DeviceLayer::SystemLayer().CancelTimer(OnTransitionToIdle, this);
+
     ICDConfigurationData::GetInstance().SetICDMode(ICDConfigurationData::ICDMode::SIT);
     mOperationalState = OperationalState::ActiveMode;
-    mStorage          = nullptr;
-    mFabricTable      = nullptr;
+
+    mStorage     = nullptr;
+    mFabricTable = nullptr;
+    mSubManager  = nullptr;
+
     mStateObserverPool.ReleaseAll();
     mICDSenderPool.ReleaseAll();
 }
@@ -137,8 +144,7 @@ void ICDManager::SendCheckInMsgs()
                 continue;
             }
 
-            bool active =
-                InteractionModelEngine::GetInstance()->SubjectHasActiveSubscription(entry.fabricIndex, entry.monitoredSubject);
+            bool active = mSubManager->SubjectHasActiveSubcription(entry.fabricIndex, entry.monitoredSubject);
             if (active)
             {
                 continue;
@@ -570,13 +576,8 @@ bool ICDManager::CheckInMessagesWouldBeSent()
                 continue;
             }
 
-            bool isActive =
-                InteractionModelEngine::GetInstance()->SubjectHasActiveSubscription(entry.fabricIndex, entry.monitoredSubject);
-            if (!isActive)
-            {
-                // At least one registration would require a Check-In message
-                return true;
-            }
+            // At least one registration would require a Check-In message
+            VerifyOrReturnValue(mSubManager->SubjectHasActiveSubcription(entry.fabricIndex, entry.monitoredSubject), true);
         }
     }
 

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -274,7 +274,7 @@ void ICDManager::UpdateOperationState(OperationalState state)
         // When the active mode interval is 0, we stay in idleMode until a notification brings the icd into active mode
         // unless the device would need to send a Check-In messages
         // TODO(#30281) : Verify how persistant subscriptions affects this at ICDManager::Init
-        if (ICDConfigurationData::GetInstance().GetActiveModeDurationMs() > 0 || VerifyIfCheckInMessagesWouldBeSent())
+        if (ICDConfigurationData::GetInstance().GetActiveModeDurationMs() > 0 || CheckInMessagesWouldBeSent())
         {
             uint32_t idleModeDuration = ICDConfigurationData::GetInstance().GetIdleModeDurationSec();
             DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(idleModeDuration), OnIdleModeDone, this);
@@ -541,7 +541,7 @@ void ICDManager::postObserverEvent(ObserverEventType event)
     });
 }
 
-bool ICDManager::VerifyIfCheckInMessagesWouldBeSent()
+bool ICDManager::CheckInMessagesWouldBeSent()
 {
     for (const auto & fabricInfo : *mFabricTable)
     {

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -580,7 +580,7 @@ bool ICDManager::CheckInMessagesWouldBeSent()
         }
     }
 
-    // None of the registrations would require
+    // None of the registrations would require a Check-In message
     return false;
 }
 

--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -272,8 +272,8 @@ void ICDManager::UpdateOperationState(OperationalState state)
         mOperationalState = OperationalState::IdleMode;
 
         // When the active mode interval is 0, we stay in idleMode until a notification brings the icd into active mode
-        // unless the device would need to send a Check-In messages
-        // TODO(#30281) : Verify how persistant subscriptions affects this at ICDManager::Init
+        // unless the device would need to send Check-In messages
+        // TODO(#30281) : Verify how persistent subscriptions affects this at ICDManager::Init
         if (ICDConfigurationData::GetInstance().GetActiveModeDurationMs() > 0 || CheckInMessagesWouldBeSent())
         {
             uint32_t idleModeDuration = ICDConfigurationData::GetInstance().GetIdleModeDurationSec();

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <app-common/zap-generated/cluster-enums.h>
+#include <app/SubscriptionManager.h>
 #include <app/icd/ICDCheckInSender.h>
 #include <app/icd/ICDConfigurationData.h>
 #include <app/icd/ICDMonitoringTable.h>
@@ -66,7 +67,7 @@ public:
 
     ICDManager() {}
     void Init(PersistentStorageDelegate * storage, FabricTable * fabricTable, Crypto::SymmetricKeystore * symmetricKeyStore,
-              Messaging::ExchangeManager * exchangeManager);
+              Messaging::ExchangeManager * exchangeManager, SubscriptionManager * manager);
     void Shutdown();
     void UpdateICDMode();
     void UpdateOperationState(OperationalState state);
@@ -100,7 +101,7 @@ public:
 #endif
 
     // Implementation of ICDListener functions.
-    // Callers must origin from the chip task context or be holding the ChipStack lock.
+    // Callers must origin from the chip task context or hold the ChipStack lock.
     void OnNetworkActivity() override;
     void OnKeepActiveRequest(KeepActiveFlags request) override;
     void OnActiveRequestWithdrawal(KeepActiveFlags request) override;
@@ -141,12 +142,16 @@ private:
     KeepActiveFlags mKeepActiveFlags{ 0 };
 
     // Initialize mOperationalState to ActiveMode so the init sequence at bootup triggers the IdleMode behaviour first.
-    OperationalState mOperationalState             = OperationalState::ActiveMode;
+    OperationalState mOperationalState = OperationalState::ActiveMode;
+
     PersistentStorageDelegate * mStorage           = nullptr;
     FabricTable * mFabricTable                     = nullptr;
     Messaging::ExchangeManager * mExchangeManager  = nullptr;
-    bool mTransitionToIdleCalled                   = false;
     Crypto::SymmetricKeystore * mSymmetricKeystore = nullptr;
+    SubscriptionManager * mSubManager              = nullptr;
+
+    bool mTransitionToIdleCalled = false;
+
     ObjectPool<ObserverPointer, CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE> mStateObserverPool;
     ObjectPool<ICDCheckInSender, (CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC * CHIP_CONFIG_MAX_FABRICS)> mICDSenderPool;
 

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -129,6 +129,15 @@ protected:
     uint8_t mCheckInRequestCount      = 0;
 
 private:
+    /**
+     * @brief Function checks if at least one client registration would require a Check-In message
+     *
+     * @return true At least one registration would require an Check-In message if we were entering ActiveMode.
+     * @return false None of the registration would require a Check-In message either because there are no registration or because
+     *               they all have associated subscriptions.
+     */
+    bool VerifyIfCheckInMessagesWouldBeSent();
+
     KeepActiveFlags mKeepActiveFlags{ 0 };
 
     // Initialize mOperationalState to ActiveMode so the init sequence at bootup triggers the IdleMode behaviour first.

--- a/src/app/icd/ICDManager.h
+++ b/src/app/icd/ICDManager.h
@@ -136,7 +136,7 @@ private:
      * @return false None of the registration would require a Check-In message either because there are no registration or because
      *               they all have associated subscriptions.
      */
-    bool VerifyIfCheckInMessagesWouldBeSent();
+    bool CheckInMessagesWouldBeSent();
 
     KeepActiveFlags mKeepActiveFlags{ 0 };
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -339,7 +339,8 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     mICDManager.RegisterObserver(mReportScheduler);
     mICDManager.RegisterObserver(&app::DnssdServer::Instance());
 
-    mICDManager.Init(mDeviceStorage, &GetFabricTable(), mSessionKeystore, &mExchangeMgr);
+    mICDManager.Init(mDeviceStorage, &GetFabricTable(), mSessionKeystore, &mExchangeMgr,
+                     chip::app::InteractionModelEngine::GetInstance());
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
     // This code is necessary to restart listening to existing groups after a reboot

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -205,7 +205,6 @@ chip_test_suite_using_nltest("tests") {
     ":ota-requestor-test-srcs",
     ":time-sync-data-provider-test-srcs",
     "${chip_root}/src/app",
-    "${chip_root}/src/app:interaction-model",
     "${chip_root}/src/app/common:cluster-objects",
     "${chip_root}/src/app/icd:manager",
     "${chip_root}/src/app/icd/client:manager",
@@ -231,7 +230,7 @@ chip_test_suite_using_nltest("tests") {
   # Do not run TestCommissionManager when running ICD specific unit tests.
   # ICDManager has a dependency on the Accessors.h file which causes a link error
   # when building the TestCommissionManager
-  if (!chip_enable_icd_server && chip_config_network_layer_ble &&
+  if (chip_config_network_layer_ble &&
       (chip_device_platform == "linux" || chip_device_platform == "darwin")) {
     test_sources += [ "TestCommissionManager.cpp" ]
     public_deps += [ "${chip_root}/src/app/server" ]

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -205,6 +205,7 @@ chip_test_suite_using_nltest("tests") {
     ":ota-requestor-test-srcs",
     ":time-sync-data-provider-test-srcs",
     "${chip_root}/src/app",
+    "${chip_root}/src/app:interaction-model",
     "${chip_root}/src/app/common:cluster-objects",
     "${chip_root}/src/app/icd:manager",
     "${chip_root}/src/app/icd/client:manager",

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -79,7 +79,7 @@ public:
 
     void SetReturnValue(bool value) { mReturnValue = value; };
 
-    bool SubjectHasActiveSubcription(const FabricIndex & aFabricIndex, const NodeId & subject) { return mReturnValue; };
+    bool SubjectHasActiveSubscription(const FabricIndex & aFabricIndex, const NodeId & subject) { return mReturnValue; };
     bool SubjectHasPersistedSubscription(const FabricIndex & aFabricIndex, const NodeId & subject) { return mReturnValue; };
 
 private:
@@ -192,7 +192,7 @@ public:
         // Set FeatureMap - Configures CIP, UAT and LITS to 1
         ctx->mICDManager.SetTestFeatureMapValue(0x07);
 
-        // Set that there are not matching subscriptions
+        // Set that there are no matching subscriptions
         ctx->mSubManager.SetReturnValue(false);
 
         // Set New durations for test case

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -542,8 +542,10 @@ namespace {
 static const nlTest sTests[] = {
     NL_TEST_DEF("TestICDModeDurations", TestICDManager::TestICDModeDurations),
     NL_TEST_DEF("TestOnSubscriptionReport", TestICDManager::TestOnSubscriptionReport),
-    NL_TEST_DEF("TestICDModeDurationsWith0ActiveModeDurationWithoutActiveSub", TestICDManager::TestICDModeDurationsWith0ActiveModeDurationWithoutActiveSub),
-    NL_TEST_DEF("TestICDModeDurationsWith0ActiveModeDurationWithActiveSub", TestICDManager::TestICDModeDurationsWith0ActiveModeDurationWithActiveSub),
+    NL_TEST_DEF("TestICDModeDurationsWith0ActiveModeDurationWithoutActiveSub",
+                TestICDManager::TestICDModeDurationsWith0ActiveModeDurationWithoutActiveSub),
+    NL_TEST_DEF("TestICDModeDurationsWith0ActiveModeDurationWithActiveSub",
+                TestICDManager::TestICDModeDurationsWith0ActiveModeDurationWithActiveSub),
     NL_TEST_DEF("TestKeepActivemodeRequests", TestICDManager::TestKeepActivemodeRequests),
     NL_TEST_DEF("TestICDMRegisterUnregisterEvents", TestICDManager::TestICDMRegisterUnregisterEvents),
     NL_TEST_DEF("TestICDCounter", TestICDManager::TestICDCounter),

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -188,6 +188,7 @@ public:
     {
         TestContext * ctx = static_cast<TestContext *>(aContext);
         typedef ICDListener::ICDManagementEvents ICDMEvent;
+        ICDConfigurationData & icdConfigData = ICDConfigurationData::GetInstance();
 
         // Set FeatureMap - Configures CIP, UAT and LITS to 1
         ctx->mICDManager.SetTestFeatureMapValue(0x07);
@@ -196,23 +197,22 @@ public:
         ctx->mSubManager.SetReturnValue(false);
 
         // Set New durations for test case
-        uint32_t oldActiveModeDuration_ms = ICDConfigurationData::GetInstance().GetActiveModeDurationMs();
-        ICDConfigurationData::ICDConfigurationData::GetInstance().SetDurations(
-            0, ICDConfigurationData::GetInstance().GetIdleModeDurationSec());
+        uint32_t oldActiveModeDuration_ms = icdConfigData.GetActiveModeDurationMs();
+        icdConfigData.SetModeDurations(0, icdConfigData.GetIdleModeDurationSec());
 
         // Verify That ICDManager starts in Idle
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Reset IdleModeInterval since it was started before the ActiveModeDuration change
-        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(icdConfigData.GetIdleModeDurationSec()) + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Force the device to return to IdleMode - Increase time by ActiveModeThreshold since ActiveModeDuration is now 0
-        AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs() + 1);
+        AdvanceClockAndRunEventLoop(ctx, icdConfigData.GetActiveModeThresholdMs() + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Expire Idle mode duration; ICDManager should remain in IdleMode since it has no message to send
-        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(icdConfigData.GetIdleModeDurationSec()) + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Add an entry to the ICDMonitoringTable
@@ -228,7 +228,7 @@ public:
         ICDNotifier::GetInstance().NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
 
         // Check ICDManager is now in the LIT operating mode
-        NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::LIT);
+        NL_TEST_ASSERT(aSuite, icdConfigData.GetICDMode() == ICDConfigurationData::ICDMode::LIT);
 
         // Kick an ActiveModeThreshold since a Registration can only happen from an incoming message that would transition the ICD
         // to ActiveMode
@@ -236,11 +236,11 @@ public:
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Return the device to return to IdleMode - Increase time by ActiveModeThreshold since ActiveModeDuration is 0
-        AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs() + 1);
+        AdvanceClockAndRunEventLoop(ctx, icdConfigData.GetActiveModeThresholdMs() + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Expire IdleModeDuration - Device should be in ActiveMode since it has an ICDM registration
-        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(icdConfigData.GetIdleModeDurationSec()) + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Remove entry from the fabric - ICDManager won't have any messages to send
@@ -248,16 +248,15 @@ public:
         NL_TEST_ASSERT(aSuite, table.IsEmpty());
 
         // Return the device to return to IdleMode - Increase time by ActiveModeThreshold since ActiveModeDuration is 0
-        AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs() + 1);
+        AdvanceClockAndRunEventLoop(ctx, icdConfigData.GetActiveModeThresholdMs() + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Expire Idle mode duration; ICDManager should remain in IdleMode since it has no message to send
-        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(icdConfigData.GetIdleModeDurationSec()) + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Reset Old durations
-        ICDConfigurationData::ICDConfigurationData::GetInstance().SetDurations(
-            oldActiveModeDuration_ms, ICDConfigurationData::GetInstance().GetIdleModeDurationSec());
+        icdConfigData.SetModeDurations(oldActiveModeDuration_ms, icdConfigData.GetIdleModeDurationSec());
     }
 
     /**
@@ -268,6 +267,7 @@ public:
     {
         TestContext * ctx = static_cast<TestContext *>(aContext);
         typedef ICDListener::ICDManagementEvents ICDMEvent;
+        ICDConfigurationData & icdConfigData = ICDConfigurationData::GetInstance();
 
         // Set FeatureMap - Configures CIP, UAT and LITS to 1
         ctx->mICDManager.SetTestFeatureMapValue(0x07);
@@ -276,23 +276,22 @@ public:
         ctx->mSubManager.SetReturnValue(true);
 
         // Set New durations for test case
-        uint32_t oldActiveModeDuration_ms = ICDConfigurationData::GetInstance().GetActiveModeDurationMs();
-        ICDConfigurationData::ICDConfigurationData::GetInstance().SetDurations(
-            0, ICDConfigurationData::GetInstance().GetIdleModeDurationSec());
+        uint32_t oldActiveModeDuration_ms = icdConfigData.GetActiveModeDurationMs();
+        icdConfigData.SetModeDurations(0, icdConfigData.GetIdleModeDurationSec());
 
         // Verify That ICDManager starts in Idle
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Reset IdleModeInterval since it was started before the ActiveModeDuration change
-        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(icdConfigData.GetIdleModeDurationSec()) + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Force the device to return to IdleMode - Increase time by ActiveModeThreshold since ActiveModeDuration is now 0
-        AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs() + 1);
+        AdvanceClockAndRunEventLoop(ctx, icdConfigData.GetActiveModeThresholdMs() + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Expire Idle mode duration; ICDManager should remain in IdleMode since it has no message to send
-        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(icdConfigData.GetIdleModeDurationSec()) + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Add an entry to the ICDMonitoringTable
@@ -308,7 +307,7 @@ public:
         ICDNotifier::GetInstance().NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
 
         // Check ICDManager is now in the LIT operating mode
-        NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::LIT);
+        NL_TEST_ASSERT(aSuite, icdConfigData.GetICDMode() == ICDConfigurationData::ICDMode::LIT);
 
         // Kick an ActiveModeThreshold since a Registration can only happen from an incoming message that would transition the ICD
         // to ActiveMode
@@ -316,11 +315,11 @@ public:
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Return the device to return to IdleMode - Increase time by ActiveModeThreshold since ActiveModeDuration is 0
-        AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs() + 1);
+        AdvanceClockAndRunEventLoop(ctx, icdConfigData.GetActiveModeThresholdMs() + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Expire IdleModeDuration - Device stay in IdleMode since it has an active subscription for the ICDM entry
-        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(icdConfigData.GetIdleModeDurationSec()) + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Remove entry from the fabric
@@ -331,7 +330,7 @@ public:
         ICDNotifier::GetInstance().NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
 
         // Check ICDManager is now in the LIT operating mode
-        NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::SIT);
+        NL_TEST_ASSERT(aSuite, icdConfigData.GetICDMode() == ICDConfigurationData::ICDMode::SIT);
 
         // Kick an ActiveModeThreshold since a Unregistration can only happen from an incoming message that would transition the ICD
         // to ActiveMode
@@ -339,16 +338,15 @@ public:
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Return the device to return to IdleMode - Increase time by ActiveModeThreshold since ActiveModeDuration is 0
-        AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs() + 1);
+        AdvanceClockAndRunEventLoop(ctx, icdConfigData.GetActiveModeThresholdMs() + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Expire Idle mode duration; ICDManager should remain in IdleMode since it has no message to send
-        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(icdConfigData.GetIdleModeDurationSec()) + 1);
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
 
         // Reset Old durations
-        ICDConfigurationData::ICDConfigurationData::GetInstance().SetDurations(
-            oldActiveModeDuration_ms, ICDConfigurationData::GetInstance().GetIdleModeDurationSec());
+        icdConfigData.SetModeDurations(oldActiveModeDuration_ms, icdConfigData.GetIdleModeDurationSec());
     }
 
     static void TestKeepActivemodeRequests(nlTestSuite * aSuite, void * aContext)

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -16,11 +16,14 @@
  *    limitations under the License.
  */
 #include <app/EventManagement.h>
+#include <app/SubscriptionManager.h>
 #include <app/icd/ICDConfigurationData.h>
 #include <app/icd/ICDManager.h>
 #include <app/icd/ICDNotifier.h>
 #include <app/icd/ICDStateObserver.h>
 #include <app/tests/AppTestContext.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/core/NodeId.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/TimeUtils.h>
 #include <lib/support/UnitTestContext.h>
@@ -68,6 +71,21 @@ public:
     void OnICDModeChange() {}
 };
 
+class TestSubscriptionManager : public SubscriptionManager
+{
+public:
+    TestSubscriptionManager() = default;
+    ~TestSubscriptionManager(){};
+
+    void SetReturnValue(bool value) { mReturnValue = value; };
+
+    bool SubjectHasActiveSubcription(const FabricIndex & aFabricIndex, const NodeId & subject) { return mReturnValue; };
+    bool SubjectHasPersistedSubscription(const FabricIndex & aFabricIndex, const NodeId & subject) { return mReturnValue; };
+
+private:
+    bool mReturnValue = false;
+};
+
 class TestContext : public chip::Test::AppContext
 {
 public:
@@ -93,7 +111,7 @@ public:
     CHIP_ERROR SetUp() override
     {
         ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
-        mICDManager.Init(&testStorage, &GetFabricTable(), &mKeystore, &GetExchangeManager());
+        mICDManager.Init(&testStorage, &GetFabricTable(), &mKeystore, &GetExchangeManager(), &mSubManager);
         mICDManager.RegisterObserver(&mICDStateObserver);
         return CHIP_NO_ERROR;
     }
@@ -108,6 +126,7 @@ public:
     System::Clock::Internal::MockClock mMockClock;
     TestSessionKeystoreImpl mKeystore;
     app::ICDManager mICDManager;
+    TestSubscriptionManager mSubManager;
     TestPersistentStorageDelegate testStorage;
 
 private:
@@ -165,13 +184,16 @@ public:
      * @brief Test verifies that the ICDManager starts its timers correctly based on if it will have any messages to send
      *        when the IdleModeDuration expires
      */
-    static void TestICDModeDurationsWith0ActiveModeDuration(nlTestSuite * aSuite, void * aContext)
+    static void TestICDModeDurationsWith0ActiveModeDurationWithoutActiveSub(nlTestSuite * aSuite, void * aContext)
     {
         TestContext * ctx = static_cast<TestContext *>(aContext);
         typedef ICDListener::ICDManagementEvents ICDMEvent;
 
         // Set FeatureMap - Configures CIP, UAT and LITS to 1
         ctx->mICDManager.SetTestFeatureMapValue(0x07);
+
+        // Set that there are not matching subscriptions
+        ctx->mSubManager.SetReturnValue(false);
 
         // Set New durations for test case
         uint32_t oldActiveModeDuration_ms = ICDConfigurationData::GetInstance().GetActiveModeDurationMs();
@@ -224,6 +246,97 @@ public:
         // Remove entry from the fabric - ICDManager won't have any messages to send
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == table.Remove(0));
         NL_TEST_ASSERT(aSuite, table.IsEmpty());
+
+        // Return the device to return to IdleMode - Increase time by ActiveModeThreshold since ActiveModeDuration is 0
+        AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs() + 1);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        // Expire Idle mode duration; ICDManager should remain in IdleMode since it has no message to send
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        // Reset Old durations
+        ICDConfigurationData::ICDConfigurationData::GetInstance().SetDurations(
+            oldActiveModeDuration_ms, ICDConfigurationData::GetInstance().GetIdleModeDurationSec());
+    }
+
+    /**
+     * @brief Test verifies that the ICDManager remains in IdleMode since it will not have any messages to send
+     *        when the IdleModeDuration expires
+     */
+    static void TestICDModeDurationsWith0ActiveModeDurationWithActiveSub(nlTestSuite * aSuite, void * aContext)
+    {
+        TestContext * ctx = static_cast<TestContext *>(aContext);
+        typedef ICDListener::ICDManagementEvents ICDMEvent;
+
+        // Set FeatureMap - Configures CIP, UAT and LITS to 1
+        ctx->mICDManager.SetTestFeatureMapValue(0x07);
+
+        // Set that there are not matching subscriptions
+        ctx->mSubManager.SetReturnValue(true);
+
+        // Set New durations for test case
+        uint32_t oldActiveModeDuration_ms = ICDConfigurationData::GetInstance().GetActiveModeDurationMs();
+        ICDConfigurationData::ICDConfigurationData::GetInstance().SetDurations(
+            0, ICDConfigurationData::GetInstance().GetIdleModeDurationSec());
+
+        // Verify That ICDManager starts in Idle
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        // Reset IdleModeInterval since it was started before the ActiveModeDuration change
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+
+        // Force the device to return to IdleMode - Increase time by ActiveModeThreshold since ActiveModeDuration is now 0
+        AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs() + 1);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        // Expire Idle mode duration; ICDManager should remain in IdleMode since it has no message to send
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        // Add an entry to the ICDMonitoringTable
+        ICDMonitoringTable table(ctx->testStorage, kTestFabricIndex1, kMaxTestClients, &(ctx->mKeystore));
+
+        ICDMonitoringEntry entry(&(ctx->mKeystore));
+        entry.checkInNodeID    = kClientNodeId11;
+        entry.monitoredSubject = kClientNodeId11;
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == entry.SetKey(ByteSpan(kKeyBuffer1a)));
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == table.Set(0, entry));
+
+        // Trigger register event after first entry was added
+        ICDNotifier::GetInstance().NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
+
+        // Check ICDManager is now in the LIT operating mode
+        NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::LIT);
+
+        // Kick an ActiveModeThreshold since a Registration can only happen from an incoming message that would transition the ICD
+        // to ActiveMode
+        ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
+
+        // Return the device to return to IdleMode - Increase time by ActiveModeThreshold since ActiveModeDuration is 0
+        AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs() + 1);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        // Expire IdleModeDuration - Device stay in IdleMode since it has an active subscription for the ICDM entry
+        AdvanceClockAndRunEventLoop(ctx, SecondsToMilliseconds(ICDConfigurationData::GetInstance().GetIdleModeDurationSec()) + 1);
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::IdleMode);
+
+        // Remove entry from the fabric
+        NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == table.Remove(0));
+        NL_TEST_ASSERT(aSuite, table.IsEmpty());
+
+        // Trigger unregister event after last entry was removed
+        ICDNotifier::GetInstance().NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
+
+        // Check ICDManager is now in the LIT operating mode
+        NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::SIT);
+
+        // Kick an ActiveModeThreshold since a Unregistration can only happen from an incoming message that would transition the ICD
+        // to ActiveMode
+        ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Return the device to return to IdleMode - Increase time by ActiveModeThreshold since ActiveModeDuration is 0
         AdvanceClockAndRunEventLoop(ctx, ICDConfigurationData::GetInstance().GetActiveModeThresholdMs() + 1);
@@ -429,7 +542,8 @@ namespace {
 static const nlTest sTests[] = {
     NL_TEST_DEF("TestICDModeDurations", TestICDManager::TestICDModeDurations),
     NL_TEST_DEF("TestOnSubscriptionReport", TestICDManager::TestOnSubscriptionReport),
-    NL_TEST_DEF("TestICDModeDurationsWith0ActiveModeDuration", TestICDManager::TestICDModeDurationsWith0ActiveModeDuration),
+    NL_TEST_DEF("TestICDModeDurationsWith0ActiveModeDurationWithoutActiveSub", TestICDManager::TestICDModeDurationsWith0ActiveModeDurationWithoutActiveSub),
+    NL_TEST_DEF("TestICDModeDurationsWith0ActiveModeDurationWithActiveSub", TestICDManager::TestICDModeDurationsWith0ActiveModeDurationWithActiveSub),
     NL_TEST_DEF("TestKeepActivemodeRequests", TestICDManager::TestKeepActivemodeRequests),
     NL_TEST_DEF("TestICDMRegisterUnregisterEvents", TestICDManager::TestICDMRegisterUnregisterEvents),
     NL_TEST_DEF("TestICDCounter", TestICDManager::TestICDCounter),

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -203,14 +203,14 @@ public:
         NL_TEST_ASSERT(aSuite, CHIP_NO_ERROR == table.Set(0, entry));
 
         // Trigger register event after first entry was added
-        ICDNotifier::GetInstance().BroadcastICDManagementEvent(ICDMEvent::kTableUpdated);
+        ICDNotifier::GetInstance().NotifyICDManagementEvent(ICDMEvent::kTableUpdated);
 
         // Check ICDManager is now in the LIT operating mode
         NL_TEST_ASSERT(aSuite, ICDConfigurationData::GetInstance().GetICDMode() == ICDConfigurationData::ICDMode::LIT);
 
         // Kick an ActiveModeThreshold since a Registration can only happen from an incoming message that would transition the ICD
         // to ActiveMode
-        ICDNotifier::GetInstance().BroadcastNetworkActivityNotification();
+        ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
         NL_TEST_ASSERT(aSuite, ctx->mICDManager.mOperationalState == ICDManager::OperationalState::ActiveMode);
 
         // Return the device to return to IdleMode - Increase time by ActiveModeThreshold since ActiveModeDuration is 0


### PR DESCRIPTION
#### Description
Fixes issue where ICD was not sending at least 1 Check-In message every 1 IdleModeInterval.
PR adds a check when we determine if we need to start an IdleModeInterval timer.
Start timer if : 

1. ActiveModeInterval != 0
2. If ICD would send Check-In messages if it were entering ActiveMode.

Issue was introduced when the optimization for the ActiveModeInterval = 0 scenario was merged; Issue only happens if ActiveModeInterval = 0.
If the ActiveModeInterval is equal to 0, we do not start an timer for the IdleModeInterval since we would immediatly return to IdleMode if we have nothing to do. 
Since we didn't check if we would need to send Check-In message,s ICD would remain in IdleMode and not send a Check-In message every IdleModeInterval.

Tests didn't catch the regression because of the merge timing between Check-In support, the ActiveModeInterval optimization and the fact that the unit test do use ActiveModeInterval = 0.

PR also adds a new interface implemented by the InteractionModelEngine since depending on the InteractionModelEngine in the ICDManager forces the inclusion of global data model function that are not implemented in the unit test run.

_TODO in follow up_ :

- SubjectHasPersistedSubscription was added but not implemented
- ICDManager has the Check-In message sending compiled out - needs to be included in the test run with associated tests.

_By Product :_ 

- finish renaming variables to duration to match the spec
- Re-enable TestCommissionManager for the ICD run

### Tests
Add unit tests to validate OprationalState changes when ActiveModeInterval = 0
Manual tests were also done to validate the behavior


