### PR TITLE
Add size report gathering for stm32

### DIFF
--- a/.github/workflows/examples-stm32.yaml
+++ b/.github/workflows/examples-stm32.yaml
@@ -62,7 +62,14 @@ jobs:
                      "./scripts/build/build_examples.py \
                        --target stm32-STM32WB5MM-DK-light build \
                      "
-        
+
+            - name: Gather size reports
+              run: |
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    stm32 STM32WB5MM-DK light \
+                    out/stm32-stm32wb5mm-dk-light/chip-stm32-lighting-example.elf \
+                    /tmp/bloat_reports/
+
             - name: Uploading Size Reports
               uses: ./.github/actions/upload-size-reports
               if: ${{ !env.ACT }}


### PR DESCRIPTION
STM builds were compiling and attempting to upload size reports, however no reports were actually being gathered.

This adds the `gh_sizes` step required to upload size reports.