### PR TITLE
Make attribute-storage.h API surface smaller

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -65,6 +65,10 @@ static bool emAfMatchCluster(const EmberAfCluster * cluster, const EmberAfAttrib
 static bool emAfMatchAttribute(const EmberAfCluster * cluster, const EmberAfAttributeMetadata * am,
                                const EmberAfAttributeSearchRecord * attRecord);
 
+// If server == true, returns the number of server clusters,
+// otherwise number of client clusters on the endpoint at the given index.
+static uint8_t emberAfClusterCountForEndpointType(const EmberAfEndpointType * endpointType, bool server);
+
 namespace {
 
 #if (!defined(ATTRIBUTE_SINGLETONS_SIZE)) || (ATTRIBUTE_SINGLETONS_SIZE == 0)

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -73,6 +73,21 @@ static uint8_t emberAfClusterCountForEndpointType(const EmberAfEndpointType * en
 // otherwise number of client clusters on the endpoint at the given index.
 static uint8_t emberAfClusterCountByIndex(uint16_t endpointIndex, bool server);
 
+// Check whether there is an endpoint defined with the given endpoint id that is
+// enabled.
+static bool emberAfEndpointIsEnabled(chip::EndpointId endpoint);
+
+// Note the difference in implementation from emberAfGetNthCluster().
+// emberAfGetClusterByIndex() retrieves the cluster by index regardless of server/client
+// and those indexes may be DIFFERENT than the indexes returned from
+// emberAfGetNthCluster().  In other words:
+//
+//  - Use emberAfGetClustersFromEndpoint()  with emberAfGetNthCluster() emberAfGetNthClusterId()
+//  - Use emberAfGetClusterCountForEndpoint() with emberAfGetClusterByIndex()
+//
+// Don't mix them.
+static const EmberAfCluster * emberAfGetClusterByIndex(chip::EndpointId endpoint, uint8_t clusterIndex);
+
 namespace {
 
 #if (!defined(ATTRIBUTE_SINGLETONS_SIZE)) || (ATTRIBUTE_SINGLETONS_SIZE == 0)

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -77,17 +77,6 @@ static uint8_t emberAfClusterCountByIndex(uint16_t endpointIndex, bool server);
 // enabled.
 static bool emberAfEndpointIsEnabled(chip::EndpointId endpoint);
 
-// Note the difference in implementation from emberAfGetNthCluster().
-// emberAfGetClusterByIndex() retrieves the cluster by index regardless of server/client
-// and those indexes may be DIFFERENT than the indexes returned from
-// emberAfGetNthCluster().  In other words:
-//
-//  - Use emberAfGetClustersFromEndpoint()  with emberAfGetNthCluster() emberAfGetNthClusterId()
-//  - Use emberAfGetClusterCountForEndpoint() with emberAfGetClusterByIndex()
-//
-// Don't mix them.
-static const EmberAfCluster * emberAfGetClusterByIndex(chip::EndpointId endpoint, uint8_t clusterIndex);
-
 namespace {
 
 #if (!defined(ATTRIBUTE_SINGLETONS_SIZE)) || (ATTRIBUTE_SINGLETONS_SIZE == 0)
@@ -1073,33 +1062,6 @@ uint8_t emberAfGetClusterCountForEndpoint(EndpointId endpoint)
         return 0;
     }
     return emAfEndpoints[index].endpointType->clusterCount;
-}
-
-// Note the difference in implementation from emberAfGetNthCluster().
-// emberAfGetClusterByIndex() retrieves the cluster by index regardless of server/client
-// and those indexes may be DIFFERENT than the indexes returned from
-// emberAfGetNthCluster().  In other words:
-//
-//  - Use emberAfGetClustersFromEndpoint()  with emberAfGetNthCluster()
-//  - Use emberAfGetClusterCountForEndpoint() with emberAfGetClusterByIndex()
-//
-// Don't mix them.
-const EmberAfCluster * emberAfGetClusterByIndex(EndpointId endpoint, uint8_t clusterIndex)
-{
-    uint16_t endpointIndex = emberAfIndexFromEndpoint(endpoint);
-    EmberAfDefinedEndpoint * definedEndpoint;
-
-    if (endpointIndex == kEmberInvalidEndpointIndex)
-    {
-        return nullptr;
-    }
-    definedEndpoint = &(emAfEndpoints[endpointIndex]);
-
-    if (clusterIndex >= definedEndpoint->endpointType->clusterCount)
-    {
-        return nullptr;
-    }
-    return &(definedEndpoint->endpointType->cluster[clusterIndex]);
 }
 
 chip::Span<const EmberAfDeviceType> emberAfDeviceTypeListFromEndpoint(chip::EndpointId endpoint, CHIP_ERROR & err)

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -69,6 +69,10 @@ static bool emAfMatchAttribute(const EmberAfCluster * cluster, const EmberAfAttr
 // otherwise number of client clusters on the endpoint at the given index.
 static uint8_t emberAfClusterCountForEndpointType(const EmberAfEndpointType * endpointType, bool server);
 
+// If server == true, returns the number of server clusters,
+// otherwise number of client clusters on the endpoint at the given index.
+static uint8_t emberAfClusterCountByIndex(uint16_t endpointIndex, bool server);
+
 namespace {
 
 #if (!defined(ATTRIBUTE_SINGLETONS_SIZE)) || (ATTRIBUTE_SINGLETONS_SIZE == 0)

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -159,15 +159,11 @@ void emAfClusterAttributeChangedCallback(const chip::app::ConcreteAttributePath 
 EmberAfStatus emAfClusterPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-// Note the difference in implementation from emberAfGetNthCluster().
-// emberAfGetClusterByIndex() retrieves the cluster by index regardless of server/client
-// and those indexes may be DIFFERENT than the indexes returned from
-// emberAfGetNthCluster().  In other words:
-//
+// Note the difference in for server filtering.
+// This method will return the cluster count for BOTH client and server
+// and those do NOT work with NthCluster/NthClusterId
 //  - Use emberAfGetClustersFromEndpoint()  with emberAfGetNthCluster() emberAfGetNthClusterId()
-//  - Use emberAfGetClusterCountForEndpoint() with emberAfGetClusterByIndex()
 //
-// Don't mix them.
 uint8_t emberAfGetClusterCountForEndpoint(chip::EndpointId endpoint);
 
 //

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -121,10 +121,6 @@ uint8_t emberAfClusterIndex(chip::EndpointId endpoint, chip::ClusterId clusterId
 // otherwise number of client clusters on this endpoint
 uint8_t emberAfClusterCount(chip::EndpointId endpoint, bool server);
 
-// If server == true, returns the number of server clusters,
-// otherwise number of client clusters on the endpoint at the given index.
-uint8_t emberAfClusterCountByIndex(uint16_t endpointIndex, bool server);
-
 // Returns the cluster of Nth server or client cluster,
 // depending on server toggle.
 const EmberAfCluster * emberAfGetNthCluster(chip::EndpointId endpoint, uint8_t n, bool server);

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -159,10 +159,6 @@ void emAfClusterAttributeChangedCallback(const chip::app::ConcreteAttributePath 
 EmberAfStatus emAfClusterPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                      EmberAfAttributeType attributeType, uint16_t size, uint8_t * value);
 
-// Check whether there is an endpoint defined with the given endpoint id that is
-// enabled.
-bool emberAfEndpointIsEnabled(chip::EndpointId endpoint);
-
 // Note the difference in implementation from emberAfGetNthCluster().
 // emberAfGetClusterByIndex() retrieves the cluster by index regardless of server/client
 // and those indexes may be DIFFERENT than the indexes returned from
@@ -173,7 +169,6 @@ bool emberAfEndpointIsEnabled(chip::EndpointId endpoint);
 //
 // Don't mix them.
 uint8_t emberAfGetClusterCountForEndpoint(chip::EndpointId endpoint);
-const EmberAfCluster * emberAfGetClusterByIndex(chip::EndpointId endpoint, uint8_t clusterIndex);
 
 //
 // Retrieve the device type list associated with a specific endpoint.

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -125,10 +125,6 @@ uint8_t emberAfClusterCount(chip::EndpointId endpoint, bool server);
 // otherwise number of client clusters on the endpoint at the given index.
 uint8_t emberAfClusterCountByIndex(uint16_t endpointIndex, bool server);
 
-// If server == true, returns the number of server clusters,
-// otherwise number of client clusters on the endpoint at the given index.
-uint8_t emberAfClusterCountForEndpointType(const EmberAfEndpointType * endpointType, bool server);
-
 // Returns the cluster of Nth server or client cluster,
 // depending on server toggle.
 const EmberAfCluster * emberAfGetNthCluster(chip::EndpointId endpoint, uint8_t n, bool server);


### PR DESCRIPTION
Moved several seemingly private APIs internally as static functions (may get a bit of size gains here), removed a seemingly unused getter by index (however the count is still used in scenes ... some review will be needed to understand if that usage is a bug or not - it seems odd to need the total count if all accessors use client or server indices)