### PR TITLE
[chip-tool] Support LIT ICD in chip-tool for subscriptions

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -77,9 +77,9 @@ void ModelCommand::Shutdown()
 
 void ModelCommand::CheckPeerICDType()
 {
-    if (mIsPeerLITCLI.HasValue())
+    if (mIsPeerLIT.HasValue())
     {
-        ChipLogProgress(chipTool, "Peer is ICD type set to %s", mIsPeerLITCLI.Value() == 1 ? "LIT-ICD" : "non LIT-ICD");
+        ChipLogProgress(chipTool, "Peer ICD type is set to %s", mIsPeerLIT.Value() == 1 ? "LIT-ICD" : "non LIT-ICD");
         return;
     }
 
@@ -87,12 +87,17 @@ void ModelCommand::CheckPeerICDType()
     auto destinationPeerId = chip::ScopedNodeId(mDestinationId, CurrentCommissioner().GetFabricIndex());
     auto iter              = CHIPCommand::sICDClientStorage.IterateICDClientInfo();
 
+    if (iter == nullptr)
+    {
+        return;
+    }
+
     while (iter->Next(info))
     {
         if (ScopedNodeId(info.peer_node.GetNodeId(), info.peer_node.GetFabricIndex()) == destinationPeerId)
         {
             ChipLogProgress(chipTool, "Peer is a registered LIT ICD.");
-            mIsPeerLITCLI.SetValue(true);
+            mIsPeerLIT.SetValue(true);
             return;
         }
     }

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -19,6 +19,7 @@
 #include "ModelCommand.h"
 
 #include <app/InteractionModelEngine.h>
+#include <app/icd/client/DefaultICDClientStorage.h>
 #include <inttypes.h>
 
 using namespace ::chip;
@@ -86,11 +87,11 @@ void ModelCommand::CheckPeerICDType()
     app::ICDClientInfo info;
     auto destinationPeerId = chip::ScopedNodeId(mDestinationId, CurrentCommissioner().GetFabricIndex());
     auto iter              = CHIPCommand::sICDClientStorage.IterateICDClientInfo();
-
     if (iter == nullptr)
     {
         return;
     }
+    app::DefaultICDClientStorage::ICDClientInfoIteratorWrapper clientInfoIteratorWrapper(iter);
 
     while (iter->Next(info))
     {

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -52,9 +52,10 @@ public:
                             "Endpoint the command is targeted at.");
             }
         }
-        AddArgument("lit-icd-peer", 0, 1, &mIsPeerLITCLI,
-                    "Whether to treat the peer as a LIT ICD. 0: Always no, 1: Always yes, (not set): Yes if the peer is registered "
-                    "to this controller.");
+        AddArgument(
+            "lit-icd-peer", 0, 1, &mIsPeerLIT,
+            "Whether to treat the peer as a LIT ICD. false: Always no, true: Always yes, (not set): Yes if the peer is registered "
+            "to this controller.");
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
 
@@ -69,12 +70,14 @@ public:
     void Shutdown() override;
 
 protected:
+    bool IsPeerLIT() { return mIsPeerLIT.ValueOr(false); }
+
     chip::Optional<uint16_t> mTimeout;
-    chip::Optional<int> mIsPeerLITCLI;
 
 private:
     chip::NodeId mDestinationId;
     std::vector<chip::EndpointId> mEndPointId;
+    chip::Optional<bool> mIsPeerLIT;
 
     void CheckPeerICDType();
 

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -52,6 +52,9 @@ public:
                             "Endpoint the command is targeted at.");
             }
         }
+        AddArgument("lit-icd-peer", 0, 1, &mIsPeerLITCLI,
+                    "Whether to treat the peer as a LIT ICD. 0: Always no, 1: Always yes, (not set): Yes if the peer is registered "
+                    "to this controller.");
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
 
@@ -67,10 +70,13 @@ public:
 
 protected:
     chip::Optional<uint16_t> mTimeout;
+    chip::Optional<int> mIsPeerLITCLI;
 
 private:
     chip::NodeId mDestinationId;
     std::vector<chip::EndpointId> mEndPointId;
+
+    void CheckPeerICDType();
 
     static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
                                     const chip::SessionHandle & sessionHandle);

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -277,6 +277,7 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
+        SubscribeCommand::SetPeerLIT(mIsPeerLITCLI.ValueOr(0));
         return SubscribeCommand::SubscribeAttribute(device, endpointIds, mClusterIds, mAttributeIds);
     }
 
@@ -407,6 +408,7 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
+        SubscribeCommand::SetPeerLIT(mIsPeerLITCLI.ValueOr(0));
         return SubscribeCommand::SubscribeEvent(device, endpointIds, mClusterIds, mEventIds);
     }
 
@@ -538,6 +540,7 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
+        SubscribeCommand::SetPeerLIT(mIsPeerLITCLI.ValueOr(0));
         return SubscribeCommand::SubscribeAll(device, endpointIds, mClusterIds, mAttributeIds, mEventIds);
     }
 

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -277,7 +277,7 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        SubscribeCommand::SetPeerLIT(mIsPeerLITCLI.ValueOr(0));
+        SubscribeCommand::SetPeerLIT(IsPeerLIT());
         return SubscribeCommand::SubscribeAttribute(device, endpointIds, mClusterIds, mAttributeIds);
     }
 
@@ -408,7 +408,7 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        SubscribeCommand::SetPeerLIT(mIsPeerLITCLI.ValueOr(0));
+        SubscribeCommand::SetPeerLIT(IsPeerLIT());
         return SubscribeCommand::SubscribeEvent(device, endpointIds, mClusterIds, mEventIds);
     }
 
@@ -540,7 +540,7 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        SubscribeCommand::SetPeerLIT(mIsPeerLITCLI.ValueOr(0));
+        SubscribeCommand::SetPeerLIT(IsPeerLIT());
         return SubscribeCommand::SubscribeAll(device, endpointIds, mClusterIds, mAttributeIds, mEventIds);
     }
 

--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -18,6 +18,7 @@
 
 #include "ICDCommand.h"
 
+#include <app/icd/client/DefaultICDClientStorage.h>
 #include <crypto/DefaultSessionKeystore.h>
 #include <crypto/RawKeySessionKeystore.h>
 
@@ -29,6 +30,11 @@ CHIP_ERROR ICDListCommand::RunCommand()
     auto iter = CHIPCommand::sICDClientStorage.IterateICDClientInfo();
     char icdAesKeyHex[Crypto::kAES_CCM128_Key_Length * 2 + 1];
     char icdHmacKeyHex[Crypto::kHMAC_CCM128_Key_Length * 2 + 1];
+    if (iter == nullptr)
+    {
+        return CHIP_ERROR_NO_MEMORY;
+    }
+    app::DefaultICDClientStorage::ICDClientInfoIteratorWrapper clientInfoIteratorWrapper(iter);
     fprintf(stderr, "  +-----------------------------------------------------------------------------+\n");
     fprintf(stderr, "  | %-75s |\n", "Known ICDs:");
     fprintf(stderr, "  +-----------------------------------------------------------------------------+\n");
@@ -54,8 +60,6 @@ CHIP_ERROR ICDListCommand::RunCommand()
     }
 
     fprintf(stderr, "  +-----------------------------------------------------------------------------+\n");
-
-    iter->Release();
     SetCommandExitStatus(CHIP_NO_ERROR);
     return CHIP_NO_ERROR;
 }

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -53,6 +53,28 @@ class DefaultICDClientStorage : public ICDClientStorage
 public:
     using ICDClientInfoIterator = CommonIterator<ICDClientInfo>;
 
+    // ICDClientInfoIterator wrapper to release ICDClientInfoIterator when it is out of scope
+    class ICDClientInfoIteratorWrapper
+    {
+    public:
+        ICDClientInfoIteratorWrapper(ICDClientInfoIterator * apICDClientInfoIterator)
+        {
+            mpICDClientInfoIterator = apICDClientInfoIterator;
+        }
+
+        ~ICDClientInfoIteratorWrapper()
+        {
+            if (mpICDClientInfoIterator != nullptr)
+            {
+                mpICDClientInfoIterator->Release();
+                mpICDClientInfoIterator = nullptr;
+            }
+        }
+
+    private:
+        ICDClientInfoIterator * mpICDClientInfoIterator = nullptr;
+    };
+
     static constexpr size_t kIteratorsMax = CHIP_CONFIG_MAX_ICD_CLIENTS_INFO_STORAGE_CONCURRENT_ITERATORS;
 
     CHIP_ERROR Init(PersistentStorageDelegate * clientInfoStore, Crypto::SymmetricKeystore * keyStore);

--- a/src/app/tests/TestDefaultICDClientStorage.cpp
+++ b/src/app/tests/TestDefaultICDClientStorage.cpp
@@ -179,6 +179,8 @@ void TestClientInfoCountMultipleFabric(nlTestSuite * apSuite, void * apContext)
     err = manager.DeleteEntry(ScopedNodeId(nodeId1, fabricId1));
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     iterator = manager.IterateICDClientInfo();
+    NL_TEST_ASSERT(apSuite, iterator != nullptr);
+    DefaultICDClientStorage::ICDClientInfoIteratorWrapper clientInfoIteratorWrapper(iterator);
     NL_TEST_ASSERT(apSuite, iterator->Count() == 2);
 
     err = manager.DeleteEntry(ScopedNodeId(nodeId2, fabricId1));
@@ -196,7 +198,7 @@ void TestClientInfoCountMultipleFabric(nlTestSuite * apSuite, void * apContext)
     {
         count++;
     }
-    iterator->Release();
+
     NL_TEST_ASSERT(apSuite, count == 0);
 }
 

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
@@ -350,7 +350,7 @@ CHIP_ERROR InteractionModelReports::ReportAttribute(DeviceProxy * device, std::v
         {
             params.mKeepSubscriptions = mKeepSubscriptions.Value();
         }
-        params.mIsPeerLIT = mIsPeerLIT.ValueOr(false);
+        params.mIsPeerLIT = mIsPeerLIT;
     }
 
     auto client = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
@@ -480,7 +480,7 @@ CHIP_ERROR InteractionModelReports::ReportEvent(DeviceProxy * device, std::vecto
         {
             params.mKeepSubscriptions = mKeepSubscriptions.Value();
         }
-        params.mIsPeerLIT = mIsPeerLIT.ValueOr(false);
+        params.mIsPeerLIT = mIsPeerLIT;
     }
 
     auto client = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
@@ -654,7 +654,7 @@ CHIP_ERROR InteractionModelReports::ReportAll(chip::DeviceProxy * device, std::v
         {
             params.mKeepSubscriptions = mKeepSubscriptions.Value();
         }
-        params.mIsPeerLIT = mIsPeerLIT.ValueOr(false);
+        params.mIsPeerLIT = mIsPeerLIT;
     }
 
     auto client = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
@@ -350,6 +350,7 @@ CHIP_ERROR InteractionModelReports::ReportAttribute(DeviceProxy * device, std::v
         {
             params.mKeepSubscriptions = mKeepSubscriptions.Value();
         }
+        params.mIsPeerLIT = mIsPeerLIT.ValueOr(false);
     }
 
     auto client = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
@@ -479,6 +480,7 @@ CHIP_ERROR InteractionModelReports::ReportEvent(DeviceProxy * device, std::vecto
         {
             params.mKeepSubscriptions = mKeepSubscriptions.Value();
         }
+        params.mIsPeerLIT = mIsPeerLIT.ValueOr(false);
     }
 
     auto client = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
@@ -652,6 +654,7 @@ CHIP_ERROR InteractionModelReports::ReportAll(chip::DeviceProxy * device, std::v
         {
             params.mKeepSubscriptions = mKeepSubscriptions.Value();
         }
+        params.mIsPeerLIT = mIsPeerLIT.ValueOr(false);
     }
 
     auto client = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -207,12 +207,6 @@ protected:
 
     InteractionModelReports & SetPeerLIT(bool isPeerLIT)
     {
-        mIsPeerLIT.SetValue(isPeerLIT);
-        return *this;
-    }
-
-    InteractionModelReports & SetPeerLIT(const chip::Optional<bool> & isPeerLIT)
-    {
         mIsPeerLIT = isPeerLIT;
         return *this;
     }
@@ -225,7 +219,7 @@ protected:
         mFabricFiltered    = chip::Optional<bool>(true);
         mKeepSubscriptions = chip::NullOptional;
         mAutoResubscribe   = chip::NullOptional;
-        mIsPeerLIT         = chip::NullOptional;
+        mIsPeerLIT         = false;
         mMinInterval       = 0;
         mMaxInterval       = 0;
     }
@@ -236,7 +230,7 @@ protected:
     chip::Optional<bool> mFabricFiltered;
     chip::Optional<bool> mKeepSubscriptions;
     chip::Optional<bool> mAutoResubscribe;
-    chip::Optional<bool> mIsPeerLIT;
+    bool mIsPeerLIT;
     uint16_t mMinInterval;
     uint16_t mMaxInterval;
 };

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -205,6 +205,18 @@ protected:
         return *this;
     }
 
+    InteractionModelReports & SetPeerLIT(bool isPeerLIT)
+    {
+        mIsPeerLIT.SetValue(isPeerLIT);
+        return *this;
+    }
+
+    InteractionModelReports & SetPeerLIT(const chip::Optional<bool> & isPeerLIT)
+    {
+        mIsPeerLIT = isPeerLIT;
+        return *this;
+    }
+
     void ResetOptions()
     {
         mDataVersions      = chip::NullOptional;
@@ -213,6 +225,7 @@ protected:
         mFabricFiltered    = chip::Optional<bool>(true);
         mKeepSubscriptions = chip::NullOptional;
         mAutoResubscribe   = chip::NullOptional;
+        mIsPeerLIT         = chip::NullOptional;
         mMinInterval       = 0;
         mMaxInterval       = 0;
     }
@@ -223,6 +236,7 @@ protected:
     chip::Optional<bool> mFabricFiltered;
     chip::Optional<bool> mKeepSubscriptions;
     chip::Optional<bool> mAutoResubscribe;
+    chip::Optional<bool> mIsPeerLIT;
     uint16_t mMinInterval;
     uint16_t mMaxInterval;
 };

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -2176,6 +2176,8 @@ JNI_METHOD(jobject, getICDClientInfo)(JNIEnv * env, jobject self, jlong handle, 
                         ChipLogError(Controller, "CreateArrayList failed!: %" CHIP_ERROR_FORMAT, err.Format()));
 
     auto iter = wrapper->getICDClientStorage()->IterateICDClientInfo();
+    VerifyOrReturnValue(iter != nullptr, nullptr, ChipLogError(Controller, "IterateICDClientInfo failed!"));
+    app::DefaultICDClientStorage::ICDClientInfoIteratorWrapper clientInfoIteratorWrapper(iter);
 
     jmethodID constructor;
     jclass infoClass;
@@ -2218,8 +2220,6 @@ JNI_METHOD(jobject, getICDClientInfo)(JNIEnv * env, jobject self, jlong handle, 
         VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr,
                             ChipLogError(Controller, "AddToList error!: %" CHIP_ERROR_FORMAT, err.Format()));
     }
-
-    iter->Release();
 
     return jInfo;
 }


### PR DESCRIPTION
Fixes #31461 

This PR adds support for LIT ICD subscription handling to chip-tool based on local registration info.

This PR also adds a `--lit-icd-peer` to force treating peer as LIT-ICD or not. The flag is available to all cluster commands, which can be used by other features (like #30936) later.