### PR TITLE
[ASR] fix double init in BLEManager and OTA

### DIFF
--- a/src/platform/ASR/ASROTAImageProcessor.cpp
+++ b/src/platform/ASR/ASROTAImageProcessor.cpp
@@ -20,9 +20,6 @@
 #include <app/clusters/ota-requestor/OTADownloader.h>
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 
-/// No error, operation OK
-#define LEGA_OTA_OK 0L
-
 namespace chip {
 
 CHIP_ERROR ASROTAImageProcessor::PrepareDownload()
@@ -121,7 +118,7 @@ void ASROTAImageProcessor::HandlePrepareDownload(intptr_t context)
 
     imageProcessor->mHeaderParser.Init();
 
-    imageProcessor->mDownloader->OnPreparedForDownload(err == LEGA_OTA_OK ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL);
+    imageProcessor->mDownloader->OnPreparedForDownload(((err == LEGA_OTA_OK) || (err == LEGA_OTA_INIT_ALREADY)) ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL);
 }
 
 void ASROTAImageProcessor::HandleFinalize(intptr_t context)

--- a/src/platform/ASR/ASROTAImageProcessor.cpp
+++ b/src/platform/ASR/ASROTAImageProcessor.cpp
@@ -118,7 +118,8 @@ void ASROTAImageProcessor::HandlePrepareDownload(intptr_t context)
 
     imageProcessor->mHeaderParser.Init();
 
-    imageProcessor->mDownloader->OnPreparedForDownload(((err == LEGA_OTA_OK) || (err == LEGA_OTA_INIT_ALREADY)) ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL);
+    imageProcessor->mDownloader->OnPreparedForDownload(
+        ((err == LEGA_OTA_OK) || (err == LEGA_OTA_INIT_ALREADY)) ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL);
 }
 
 void ASROTAImageProcessor::HandleFinalize(intptr_t context)

--- a/src/platform/ASR/ASROTAImageProcessor.h
+++ b/src/platform/ASR/ASROTAImageProcessor.h
@@ -69,7 +69,7 @@ private:
     const char * mImageFile = nullptr;
 };
 
-#define LEGA_OTA_OK 0 // No error, operation OK
+#define LEGA_OTA_OK 0            // No error, operation OK
 #define LEGA_OTA_INIT_ALREADY -2 // ota init already
 
 } // namespace chip

--- a/src/platform/ASR/ASROTAImageProcessor.h
+++ b/src/platform/ASR/ASROTAImageProcessor.h
@@ -69,7 +69,4 @@ private:
     const char * mImageFile = nullptr;
 };
 
-#define LEGA_OTA_OK 0            // No error, operation OK
-#define LEGA_OTA_INIT_ALREADY -2 // ota init already
-
 } // namespace chip

--- a/src/platform/ASR/ASROTAImageProcessor.h
+++ b/src/platform/ASR/ASROTAImageProcessor.h
@@ -69,4 +69,7 @@ private:
     const char * mImageFile = nullptr;
 };
 
+#define LEGA_OTA_OK 0 // No error, operation OK
+#define LEGA_OTA_INIT_ALREADY -2 // ota init already
+
 } // namespace chip

--- a/src/platform/ASR/BLEManagerImpl.cpp
+++ b/src/platform/ASR/BLEManagerImpl.cpp
@@ -110,6 +110,9 @@ CHIP_ERROR BLEManagerImpl::_Init()
     }
     else
     {
+        matter_ble_stack_open();
+        matter_ble_add_service();
+        BLEMgrImpl().SetStackInit();
         mFlags.Set(Flags::kFlag_StackInitialized, true);
         log_i("ble is alread open!\n");
     }


### PR DESCRIPTION
1, In some special cases, BLE manager will init twice, but BLE service may lost, because the initialization time of ble is earlier the callback registration time. we must add the BLE service
2, In some special cases, OTA will init twitce, but lega_ota_int return INIT_ALREADY, this should be allowed

