### PR TITLE
[ESP32] Fix build and crash and add DeviceManagementCluster, EVSE mode and DeviceManagementCluster mode.

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -165,3 +165,6 @@ jobs:
 
             - name: Build example Lighting App (external platform)
               run: scripts/examples/esp_example.sh lighting-app sdkconfig.ext_plat.defaults
+
+            - name: Build example Energy Management App
+              run: scripts/examples/esp_example.sh energy-management-app sdkconfig.defaults

--- a/examples/energy-management-app/energy-management-common/src/EnergyEvseManager.cpp
+++ b/examples/energy-management-app/energy-management-common/src/EnergyEvseManager.cpp
@@ -27,7 +27,12 @@ CHIP_ERROR EnergyEvseManager::LoadPersistentAttributes()
 {
 
     SafeAttributePersistenceProvider * aProvider = GetSafeAttributePersistenceProvider();
-    EndpointId aEndpointId                       = mDelegate->GetEndpointId();
+    if (aProvider == nullptr)
+    {
+        ChipLogError(AppServer, "GetSafeAttributePersistenceProvider returned NULL");
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
+    EndpointId aEndpointId = mDelegate->GetEndpointId();
     CHIP_ERROR err;
 
     // Restore ChargingEnabledUntil value

--- a/examples/energy-management-app/esp32/main/CMakeLists.txt
+++ b/examples/energy-management-app/esp32/main/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/time-format-localization-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/barrier-control-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/energy-evse-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/device-energy-management-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/network-commissioning"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/occupancy-sensor-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/operational-credentials-server"

--- a/examples/energy-management-app/esp32/main/CMakeLists.txt
+++ b/examples/energy-management-app/esp32/main/CMakeLists.txt
@@ -64,6 +64,7 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/ota-requestor"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/groups-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/group-key-mgmt-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/mode-base-server"
 )
 
 set(PRIV_REQUIRES_LIST chip QRCode bt led_strip app_update openthread driver nvs_flash spi_flash)

--- a/examples/energy-management-app/esp32/main/main.cpp
+++ b/examples/energy-management-app/esp32/main/main.cpp
@@ -75,11 +75,11 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 
-static EnergyEvseDelegate * gEvseDelegate       = nullptr;
-static EnergyEvseManager * gEvseInstance        = nullptr;
-static EVSEManufacturer * gEvseManufacturer = nullptr;
-static DeviceEnergyManagementDelegate * gDEMDelegate       = nullptr;
-static DeviceEnergyManagementManager * gDEMInstance        = nullptr;
+static EnergyEvseDelegate * gEvseDelegate            = nullptr;
+static EnergyEvseManager * gEvseInstance             = nullptr;
+static EVSEManufacturer * gEvseManufacturer          = nullptr;
+static DeviceEnergyManagementDelegate * gDEMDelegate = nullptr;
+static DeviceEnergyManagementManager * gDEMInstance  = nullptr;
 
 #if CONFIG_ENABLE_ESP_INSIGHTS_TRACE
 extern const char insights_auth_key_start[] asm("_binary_insights_auth_key_txt_start");
@@ -181,7 +181,6 @@ void ApplicationInit()
 
 static void InitServer(intptr_t context)
 {
-    ApplicationInit();
     // Print QR Code URL
     PrintOnboardingCodes(chip::RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE));
 
@@ -203,6 +202,9 @@ static void InitServer(intptr_t context)
     static Tracing::Insights::ESP32Backend backend;
     Tracing::Register(backend);
 #endif
+
+    // Application code should always be initialised after the initialisation of server.
+    ApplicationInit();
 }
 
 extern "C" void app_main()


### PR DESCRIPTION
- Problems
> - There was build failure on energy-management-app/esp32
> - App was crashing

- Changes
> - Fixed crash and build failure.
> - Add DeviceManagementCluster initialisation for ESP32
> - Support EVSE mode and DeviceManagementCluster mode

- Testing
> - Tested device management, evse mode, device management mode cluster control

