### PR TITLE
update mStagingNetwork to the dataset in NVS after thread panid changed

### DIFF
--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
@@ -116,6 +116,7 @@ public:
 private:
     uint8_t scanNetworkTimeoutSeconds;
     uint8_t connectNetworkTimeout;
+    static void OnThreadStateChangeHandler(const ChipDeviceEvent * event, intptr_t arg);
     Status MatchesNetworkId(const Thread::OperationalDataset & dataset, const ByteSpan & networkId) const;
     CHIP_ERROR BackupConfiguration();
 


### PR DESCRIPTION
The Apple commissioning API checks the 'Networks' attribute of the 'Network Commissioning' cluster during on-network commissioning. If the attribute is not set, 'Thread Border Router Required' will be returned. The attribute remains null after a new end device joins a Thread network through OpenThread CLI commands or other methods. This issue arises because 'mStagingNetwork' is not promptly updated, even though the dataset has already been saved in NVS. To address this, update the 'mStagingNetwork' after activating an OpenThread dataset.