### PR TITLE
fix: replace C-style initialization with correct C++ initialization

### DIFF
--- a/src/platform/Linux/bluez/BluezConnection.h
+++ b/src/platform/Linux/bluez/BluezConnection.h
@@ -123,12 +123,12 @@ private:
     BluezGattService1 * mpService = nullptr;
 
     BluezGattCharacteristic1 * mpC1 = nullptr;
-    IOChannel mC1Channel            = { 0 };
+    IOChannel mC1Channel            = {};
     BluezGattCharacteristic1 * mpC2 = nullptr;
-    IOChannel mC2Channel            = { 0 };
+    IOChannel mC2Channel            = {};
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
     BluezGattCharacteristic1 * mpC3 = nullptr;
-    IOChannel mC3Channel            = { 0 };
+    IOChannel mC3Channel            = {};
 #endif
 };
 


### PR DESCRIPTION
Avoid `clang++` compilation error:
```
connectedhomeip/src/platform/Linux/bluez/BluezConnection.h:127:39: error: no matching constructor for initialization of 'IOChannel'
    IOChannel mC1Channel            = { 0 };
```

