### PR TITLE
fix: include Encode definitions for List

### DIFF
--- a/src/app/data-model/WrappedStructEncoder.h
+++ b/src/app/data-model/WrappedStructEncoder.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app/data-model/Encode.h>
+#include <app/data-model/List.h>
 
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>


### PR DESCRIPTION
Avoid compile errors:
```
In file included from <some/path>/zap-generated/cluster-objects.cpp:20:
/media/psf/arcadia/contrib/libs/connectedhomeip/src/app/data-model/WrappedStructEncoder.h:45:22: error: no matching function for call to 'Encode'
        mLastError = DataModel::Encode(mWriter, TLV::ContextTag(contextTag), std::forward<Args>(args)...);
                     ^~~~~~~~~~~~~~~~~
<some/path>/zap-generated/cluster-objects.cpp:122:13: note: in instantiation of function template specialization 'chip::app::DataModel::WrappedStructEncoder::Encode<const chip::app::DataModel::List<const chip::app::Clusters::detail::Structs::ModeTagStruct::Type> &>' requested here
    encoder.Encode(to_underlying(Fields::kModeTags), modeTags);
            ^
```

