### PR TITLE
Allow sample apps to override BaseApplication's default lcd screen

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -458,11 +458,7 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
             // - Cycle LCD screen
             CancelFunctionTimer();
 
-            OutputQrCode(false);
-#ifdef DISPLAY_ENABLED
-            UpdateLCDStatusScreen();
-            slLCD.CycleScreens();
-#endif
+            AppTask::GetAppTask().UpdateDisplay();
 
 #ifdef SL_WIFI
             if (!ConnectivityMgr().IsWiFiStationProvisioned())
@@ -491,6 +487,15 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
             }
         }
     }
+}
+
+void BaseApplication::UpdateDisplay()
+{
+    OutputQrCode(false);
+#ifdef DISPLAY_ENABLED
+    UpdateLCDStatusScreen();
+    slLCD.CycleScreens();
+#endif
 }
 
 void BaseApplication::CancelFunctionTimer()

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -105,6 +105,11 @@ public:
      */
     static void PostEvent(const AppEvent * event);
 
+    /**
+     * @brief Overridable function used to update display on button press
+     */
+    static void UpdateDisplay();
+    
 #ifdef DISPLAY_ENABLED
     /**
      * @brief Return LCD object

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -109,7 +109,7 @@ public:
      * @brief Overridable function used to update display on button press
      */
     static void UpdateDisplay();
-    
+
 #ifdef DISPLAY_ENABLED
     /**
      * @brief Return LCD object

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -108,7 +108,7 @@ public:
     /**
      * @brief Overridable function used to update display on button press
      */
-    static void UpdateDisplay();
+    virtual void UpdateDisplay();
 
 #ifdef DISPLAY_ENABLED
     /**

--- a/examples/platform/silabs/display/lcd.h
+++ b/examples/platform/silabs/display/lcd.h
@@ -71,6 +71,7 @@ public:
     void SetScreen(Screen_e screen);
     void CycleScreens(void);
     void SetStatus(DisplayStatus_t & status);
+    void WriteStatus();
 
 #ifdef QR_CODE_ENABLED
     void SetQRCode(uint8_t * str, uint32_t size);
@@ -85,7 +86,6 @@ private:
     } DemoState_t;
 
     void WriteDemoUI();
-    void WriteStatus();
 
 #ifdef QR_CODE_ENABLED
     void WriteQRCode();


### PR DESCRIPTION
This allows Silabs sample apps to override the BaseApplications default LCD functionality.

