### PR TITLE
[ICD] Remove ICDM `OnTransitionToActiveMode` event

### DIFF
--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -1959,9 +1959,6 @@ cluster IcdManagement = 70 {
     fabric_idx fabricIndex = 254;
   }
 
-  critical event OnTransitionToActiveMode = 0 {
-  }
-
   readonly attribute int32u idleModeDuration = 0;
   readonly attribute int32u activeModeDuration = 1;
   readonly attribute int16u activeModeThreshold = 2;

--- a/examples/light-switch-app/qpg/zap/switch.matter
+++ b/examples/light-switch-app/qpg/zap/switch.matter
@@ -1631,9 +1631,6 @@ cluster IcdManagement = 70 {
     fabric_idx fabricIndex = 254;
   }
 
-  critical event OnTransitionToActiveMode = 0 {
-  }
-
   readonly attribute int32u idleModeDuration = 0;
   readonly attribute int32u activeModeDuration = 1;
   readonly attribute int16u activeModeThreshold = 2;

--- a/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.matter
+++ b/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.matter
@@ -1417,9 +1417,6 @@ cluster IcdManagement = 70 {
     fabric_idx fabricIndex = 254;
   }
 
-  critical event OnTransitionToActiveMode = 0 {
-  }
-
   readonly attribute int32u idleModeDuration = 0;
   readonly attribute int32u activeModeDuration = 1;
   readonly attribute int16u activeModeThreshold = 2;
@@ -1743,7 +1740,6 @@ endpoint 0 {
   }
 
   server cluster IcdManagement {
-    emits event OnTransitionToActiveMode;
     callback attribute idleModeDuration;
     callback attribute activeModeDuration;
     callback attribute activeModeThreshold;

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -1777,9 +1777,6 @@ cluster IcdManagement = 70 {
     fabric_idx fabricIndex = 254;
   }
 
-  critical event OnTransitionToActiveMode = 0 {
-  }
-
   readonly attribute int32u idleModeDuration = 0;
   readonly attribute int32u activeModeDuration = 1;
   readonly attribute int16u activeModeThreshold = 2;

--- a/examples/lock-app/qpg/zap/lock.matter
+++ b/examples/lock-app/qpg/zap/lock.matter
@@ -1433,9 +1433,6 @@ cluster IcdManagement = 70 {
     fabric_idx fabricIndex = 254;
   }
 
-  critical event OnTransitionToActiveMode = 0 {
-  }
-
   readonly attribute int32u idleModeDuration = 0;
   readonly attribute int32u activeModeDuration = 1;
   readonly attribute int16u activeModeThreshold = 2;

--- a/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
+++ b/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
@@ -1753,9 +1753,6 @@ cluster IcdManagement = 70 {
     fabric_idx fabricIndex = 254;
   }
 
-  critical event OnTransitionToActiveMode = 0 {
-  }
-
   readonly attribute int32u idleModeDuration = 0;
   readonly attribute int32u activeModeDuration = 1;
   readonly attribute int16u activeModeThreshold = 2;

--- a/src/app/zap-templates/zcl/data-model/chip/icd-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/icd-management-cluster.xml
@@ -87,10 +87,6 @@ limitations under the License.
         <attribute side="server" code="0x07" define="USER_ACTIVE_MODE_TRIGGER_INSTRUCTION" type="char_string" length="128" writable="false" optional="true" isNullable="false">UserActiveModeTriggerInstruction</attribute>
         <attribute side="server" code="0x08" define="OPERATING_MODE" type="OperatingModeEnum" default="0" writable="false" optional="true" isNullable="false">OperatingMode</attribute>
 
-        <event side="server" code="0x00" priority="critical" name="OnTransitionToActiveMode" optional="true">
-            <description>OnTransitionToActiveMode</description>
-        </event>
-
         <command source="client" code="0x00" name="RegisterClient" response="RegisterClientResponse" isFabricScoped="true" optional="true">
             <description>Register a client to the end device</description>
             <arg name="CheckInNodeID" type="node_id" optional="false"/>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -2692,9 +2692,6 @@ cluster IcdManagement = 70 {
     fabric_idx fabricIndex = 254;
   }
 
-  critical event OnTransitionToActiveMode = 0 {
-  }
-
   readonly attribute int32u idleModeDuration = 0;
   readonly attribute int32u activeModeDuration = 1;
   readonly attribute int16u activeModeThreshold = 2;

--- a/src/controller/java/generated/java/chip/devicecontroller/ChipEventStructs.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ChipEventStructs.java
@@ -2297,34 +2297,6 @@ public static class BooleanStateClusterStateChangeEvent {
     return output.toString();
   }
 }
-public static class IcdManagementClusterOnTransitionToActiveModeEvent {
-
-  public IcdManagementClusterOnTransitionToActiveModeEvent(
-  ) {
-  }
-
-  public StructType encodeTlv() {
-    ArrayList<StructElement> values = new ArrayList<>();
-
-    return new StructType(values);
-  }
-
-  public static IcdManagementClusterOnTransitionToActiveModeEvent decodeTlv(BaseTLVType tlvValue) {
-    if (tlvValue == null || tlvValue.type() != TLVType.Struct) {
-      return null;
-    }
-    return new IcdManagementClusterOnTransitionToActiveModeEvent(
-    );
-  }
-
-  @Override
-  public String toString() {
-    StringBuilder output = new StringBuilder();
-    output.append("IcdManagementClusterOnTransitionToActiveModeEvent {\n");
-    output.append("}\n");
-    return output.toString();
-  }
-}
 public static class OvenCavityOperationalStateClusterOperationalErrorEvent {
   public ChipStructs.OvenCavityOperationalStateClusterErrorStateStruct errorState;
   private static final long ERROR_STATE_ID = 0L;

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterIDMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterIDMapping.java
@@ -5779,8 +5779,7 @@ public class ClusterIDMapping {
             }
         }
 
-        public enum Event {
-            OnTransitionToActiveMode(0L),;
+        public enum Event {;
             private final long id;
             Event(long id) {
                 this.id = id;

--- a/src/controller/java/zap-generated/CHIPEventTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPEventTLVValueDecoder.cpp
@@ -2584,36 +2584,6 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
         using namespace app::Clusters::IcdManagement;
         switch (aPath.mEventId)
         {
-        case Events::OnTransitionToActiveMode::Id: {
-            Events::OnTransitionToActiveMode::DecodableType cppValue;
-            *aError = app::DataModel::Decode(aReader, cppValue);
-            if (*aError != CHIP_NO_ERROR)
-            {
-                return nullptr;
-            }
-            jclass onTransitionToActiveModeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
-                env, "chip/devicecontroller/ChipEventStructs$IcdManagementClusterOnTransitionToActiveModeEvent",
-                onTransitionToActiveModeStructClass);
-            if (err != CHIP_NO_ERROR)
-            {
-                ChipLogError(Zcl, "Could not find class ChipEventStructs$IcdManagementClusterOnTransitionToActiveModeEvent");
-                return nullptr;
-            }
-
-            jmethodID onTransitionToActiveModeStructCtor;
-            err = chip::JniReferences::GetInstance().FindMethod(env, onTransitionToActiveModeStructClass, "<init>", "()V",
-                                                                &onTransitionToActiveModeStructCtor);
-            if (err != CHIP_NO_ERROR || onTransitionToActiveModeStructCtor == nullptr)
-            {
-                ChipLogError(Zcl, "Could not find ChipEventStructs$IcdManagementClusterOnTransitionToActiveModeEvent constructor");
-                return nullptr;
-            }
-
-            jobject value = env->NewObject(onTransitionToActiveModeStructClass, onTransitionToActiveModeStructCtor);
-
-            return value;
-        }
         default:
             *aError = CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB;
             break;

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -14523,23 +14523,6 @@ class IcdManagement(Cluster):
 
             value: 'uint' = 0
 
-    class Events:
-        @dataclass
-        class OnTransitionToActiveMode(ClusterEvent):
-            @ChipUtility.classproperty
-            def cluster_id(cls) -> int:
-                return 0x00000046
-
-            @ChipUtility.classproperty
-            def event_id(cls) -> int:
-                return 0x00000000
-
-            @ChipUtility.classproperty
-            def descriptor(cls) -> ClusterObjectDescriptor:
-                return ClusterObjectDescriptor(
-                    Fields=[
-                    ])
-
 
 @dataclass
 class Timer(Cluster):

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -7103,9 +7103,6 @@ typedef NS_ENUM(uint32_t, MTREventIDType) {
     // Cluster BooleanState events
     MTREventIDTypeClusterBooleanStateEventStateChangeID MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4)) = 0x00000000,
 
-    // Cluster ICDManagement events
-    MTREventIDTypeClusterICDManagementEventOnTransitionToActiveModeID MTR_PROVISIONALLY_AVAILABLE = 0x00000000,
-
     // Cluster OvenCavityOperationalState events
     MTREventIDTypeClusterOvenCavityOperationalStateEventOperationalErrorID MTR_PROVISIONALLY_AVAILABLE = 0x00000000,
     MTREventIDTypeClusterOvenCavityOperationalStateEventOperationCompletionID MTR_PROVISIONALLY_AVAILABLE = 0x00000001,

--- a/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
@@ -1624,17 +1624,6 @@ static id _Nullable DecodeEventPayloadForICDManagementCluster(EventId aEventId, 
 {
     using namespace Clusters::IcdManagement;
     switch (aEventId) {
-    case Events::OnTransitionToActiveMode::Id: {
-        Events::OnTransitionToActiveMode::DecodableType cppValue;
-        *aError = DataModel::Decode(aReader, cppValue);
-        if (*aError != CHIP_NO_ERROR) {
-            return nil;
-        }
-
-        __auto_type * value = [MTRICDManagementClusterOnTransitionToActiveModeEvent new];
-
-        return value;
-    }
     default: {
         break;
     }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -766,10 +766,6 @@ MTR_PROVISIONALLY_AVAILABLE
 @end
 
 MTR_PROVISIONALLY_AVAILABLE
-@interface MTRICDManagementClusterOnTransitionToActiveModeEvent : NSObject <NSCopying>
-@end
-
-MTR_PROVISIONALLY_AVAILABLE
 @interface MTROvenCavityOperationalStateClusterErrorStateStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull errorStateID MTR_PROVISIONALLY_AVAILABLE;
 @property (nonatomic, copy) NSString * _Nullable errorStateLabel MTR_PROVISIONALLY_AVAILABLE;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -2798,29 +2798,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@implementation MTRICDManagementClusterOnTransitionToActiveModeEvent
-- (instancetype)init
-{
-    if (self = [super init]) {
-    }
-    return self;
-}
-
-- (id)copyWithZone:(NSZone * _Nullable)zone
-{
-    auto other = [[MTRICDManagementClusterOnTransitionToActiveModeEvent alloc] init];
-
-    return other;
-}
-
-- (NSString *)description
-{
-    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
-    return descriptionString;
-}
-
-@end
-
 @implementation MTROvenCavityOperationalStateClusterErrorStateStruct
 - (instancetype)init
 {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -9682,29 +9682,7 @@ CHIP_ERROR TypeInfo::DecodableType::Decode(TLV::TLVReader & reader, const Concre
 }
 } // namespace Attributes
 
-namespace Events {
-namespace OnTransitionToActiveMode {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
-{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(aWriter.StartContainer(aTag, TLV::kTLVType_Structure, outer));
-    return aWriter.EndContainer(outer);
-}
-
-CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
-{
-    detail::StructDecodeIterator __iterator(reader);
-    while (true)
-    {
-        auto __element = __iterator.Next();
-        if (std::holds_alternative<CHIP_ERROR>(__element))
-        {
-            return std::get<CHIP_ERROR>(__element);
-        }
-    }
-}
-} // namespace OnTransitionToActiveMode.
-} // namespace Events
+namespace Events {} // namespace Events
 
 } // namespace IcdManagement
 namespace Timer {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -13384,36 +13384,6 @@ struct TypeInfo
     };
 };
 } // namespace Attributes
-namespace Events {
-namespace OnTransitionToActiveMode {
-static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Critical;
-
-enum class Fields : uint8_t
-{
-};
-
-struct Type
-{
-public:
-    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
-    static constexpr EventId GetEventId() { return Events::OnTransitionToActiveMode::Id; }
-    static constexpr ClusterId GetClusterId() { return Clusters::IcdManagement::Id; }
-    static constexpr bool kIsFabricScoped = false;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
-};
-
-struct DecodableType
-{
-public:
-    static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
-    static constexpr EventId GetEventId() { return Events::OnTransitionToActiveMode::Id; }
-    static constexpr ClusterId GetClusterId() { return Clusters::IcdManagement::Id; }
-
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-};
-} // namespace OnTransitionToActiveMode
-} // namespace Events
 } // namespace IcdManagement
 namespace Timer {
 

--- a/zzz_generated/app-common/app-common/zap-generated/ids/Events.h
+++ b/zzz_generated/app-common/app-common/zap-generated/ids/Events.h
@@ -267,16 +267,6 @@ static constexpr EventId Id = 0x00000000;
 } // namespace Events
 } // namespace BooleanState
 
-namespace IcdManagement {
-namespace Events {
-
-namespace OnTransitionToActiveMode {
-static constexpr EventId Id = 0x00000000;
-} // namespace OnTransitionToActiveMode
-
-} // namespace Events
-} // namespace IcdManagement
-
 namespace OvenCavityOperationalState {
 namespace Events {
 

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -4180,7 +4180,6 @@ private:
 | * ClusterRevision                                                   | 0xFFFD |
 |------------------------------------------------------------------------------|
 | Events:                                                             |        |
-| * OnTransitionToActiveMode                                          | 0x0000 |
 \*----------------------------------------------------------------------------*/
 
 /*
@@ -18030,10 +18029,8 @@ void registerClusterIcdManagement(Commands & commands, CredentialIssuerCommands 
         //
         // Events
         //
-        make_unique<ReadEvent>(Id, credsIssuerConfig),                                                                            //
-        make_unique<ReadEvent>(Id, "on-transition-to-active-mode", Events::OnTransitionToActiveMode::Id, credsIssuerConfig),      //
-        make_unique<SubscribeEvent>(Id, credsIssuerConfig),                                                                       //
-        make_unique<SubscribeEvent>(Id, "on-transition-to-active-mode", Events::OnTransitionToActiveMode::Id, credsIssuerConfig), //
+        make_unique<ReadEvent>(Id, credsIssuerConfig),      //
+        make_unique<SubscribeEvent>(Id, credsIssuerConfig), //
     };
 
     commands.RegisterCluster(clusterName, clusterCommands);

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -5454,14 +5454,6 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
     return CHIP_NO_ERROR;
 }
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
-                                     const IcdManagement::Events::OnTransitionToActiveMode::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
-CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
                                      const OvenCavityOperationalState::Events::OperationalError::DecodableType & value)
 {
     DataModelLogger::LogString(label, indent, "{");
@@ -18347,17 +18339,6 @@ CHIP_ERROR DataModelLogger::LogEvent(const chip::app::EventHeader & header, chip
             chip::app::Clusters::BooleanState::Events::StateChange::DecodableType value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("StateChange", 1, value);
-        }
-        }
-        break;
-    }
-    case IcdManagement::Id: {
-        switch (header.mPath.mEventId)
-        {
-        case IcdManagement::Events::OnTransitionToActiveMode::Id: {
-            chip::app::Clusters::IcdManagement::Events::OnTransitionToActiveMode::DecodableType value;
-            ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
-            return DataModelLogger::LogValue("OnTransitionToActiveMode", 1, value);
         }
         }
         break;

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.h
@@ -448,8 +448,6 @@ static CHIP_ERROR LogValue(const char * label, size_t indent,
 static CHIP_ERROR LogValue(const char * label, size_t indent,
                            const chip::app::Clusters::BooleanState::Events::StateChange::DecodableType & value);
 static CHIP_ERROR LogValue(const char * label, size_t indent,
-                           const chip::app::Clusters::IcdManagement::Events::OnTransitionToActiveMode::DecodableType & value);
-static CHIP_ERROR LogValue(const char * label, size_t indent,
                            const chip::app::Clusters::OvenCavityOperationalState::Events::OperationalError::DecodableType & value);
 static CHIP_ERROR
 LogValue(const char * label, size_t indent,


### PR DESCRIPTION
#### Description
`OnTransitionToActiveMode` was removed from the ICDM cluster spec.
PR removes the event from the xml

Only change is the xml. Everything else is a regen.
