### PR TITLE
[ICD] Remove check since ActiveModeDuration can be 0 for SIT and LIT ICDs

### DIFF
--- a/src/app/icd/ICDManager.cpp
+++ b/src/app/icd/ICDManager.cpp
@@ -66,11 +66,6 @@ void ICDManager::Init(PersistentStorageDelegate * storage, FabricTable * fabricT
 
     VerifyOrDie(InitCounter() == CHIP_NO_ERROR);
 
-    // Removing the check for now since it is possible for the Fast polling
-    // to be larger than the ActiveModeDuration for now
-    // uint32_t activeModeDuration = ICDConfigurationData::GetInstance().GetActiveModeDurationMs();
-    // VerifyOrDie(kFastPollingInterval.count() < activeModeDuration);
-
     UpdateICDMode();
     UpdateOperationState(OperationalState::IdleMode);
 }


### PR DESCRIPTION
#### Description
Specification allows the ActiveModeDuration to be 0 for LIT and SIT ICDs.
Removed commented check since it will not be applied anymore.

