### PR TITLE
[Silabs]Clear all srp client services on factory reset

### DIFF
--- a/src/platform/silabs/ThreadStackManagerImpl.h
+++ b/src/platform/silabs/ThreadStackManagerImpl.h
@@ -72,12 +72,19 @@ public:
 
     using ThreadStackManager::InitThreadStack;
     CHIP_ERROR InitThreadStack(otInstance * otInst);
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void RemoveAllSrpServices();
+#endif
 
 private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    static void OnSrpClientRemoveCallback(otError aError, const otSrpClientHostInfo * aHostInfo,
+                                          const otSrpClientService * aServices, const otSrpClientService * aRemovedServices,
+                                          void * aContext);
+#endif
     // ===== Members for internal use by the following friends.
 
     friend ThreadStackManager & ::chip::DeviceLayer::ThreadStackMgr(void);
@@ -87,6 +94,9 @@ private:
     static ThreadStackManagerImpl sInstance;
 
     static bool IsInitialized();
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    TaskHandle_t srpRemoveRequester = nullptr;
+#endif
 
     // ===== Private members for use by this class only.
 

--- a/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
@@ -277,10 +277,11 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    ThreadStackMgrImpl().RemoveAllSrpServices();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     ChipLogProgress(DeviceLayer, "Clearing Thread provision");
     ThreadStackMgr().ErasePersistentInfo();
-
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
     PersistedStorage::KeyValueStoreMgrImpl().ErasePartition();

--- a/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
@@ -66,6 +66,58 @@ bool ThreadStackManagerImpl::IsInitialized()
     return sInstance.mThreadStackLock != NULL;
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+/*
+ * @brief Notifies `RemoveAllSrpServices` that the Srp Client removal has completed
+ *        and unblock the calling task.
+ *
+ *  No data is processed.
+ */
+void ThreadStackManagerImpl::OnSrpClientRemoveCallback(otError aError, const otSrpClientHostInfo * aHostInfo,
+                                                       const otSrpClientService * aServices,
+                                                       const otSrpClientService * aRemovedServices, void * aContext)
+{
+    if (ThreadStackMgrImpl().srpRemoveRequester)
+    {
+        xTaskNotifyGive(ThreadStackMgrImpl().srpRemoveRequester);
+    }
+}
+
+/*
+ * @brief This is a utility function to remove all Thread client Srp services
+ * established between the device and the srp server (in most cases the OTBR).
+ * The calling task is blocked until OnSrpClientRemoveCallback.
+ *
+ * Note: This function is meant to be used during the factory reset sequence.
+ *       It overrides the generic SrpClient callback `OnSrpClientNotification` with
+ *       OnSrpClientRemoveCallback which doesn't process any of the callback data.
+ *
+ *       If there is a usecase where this function would be needed in a non-Factory reset context,
+ *       OnSrpClientRemoveCallback should be extended and tied back with the GenericThreadStackManagerImpl_OpenThread
+ *       management of the srp clients.
+ */
+void ThreadStackManagerImpl::RemoveAllSrpServices()
+{
+    // This check ensure that only one srp services removal is running
+    if (ThreadStackMgrImpl().srpRemoveRequester == nullptr)
+    {
+        srpRemoveRequester = xTaskGetCurrentTaskHandle();
+        otSrpClientSetCallback(OTInstance(), &OnSrpClientRemoveCallback, nullptr);
+        InvalidateAllSrpServices();
+        if (RemoveInvalidSrpServices() == CHIP_NO_ERROR)
+        {
+            // Wait for the OnSrpClientRemoveCallback.
+            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(2000));
+        }
+        else
+        {
+            ChipLogError(DeviceLayer, "Failed to remove srp services");
+        }
+        ThreadStackMgrImpl().srpRemoveRequester = nullptr;
+    }
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
 } // namespace DeviceLayer
 } // namespace chip
 


### PR DESCRIPTION
This PR adds a step to the factory reset sequence to remove all srp client services, of the device, established with the OTBR. This ensures that there is no "old" device's DNS entries that can be mistakenly discovered.


