### PR TITLE
tv-casting-app: simplified android connection API

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -11,6 +11,7 @@ import com.chip.casting.DiscoveredNodeData;
 import com.chip.casting.TvCastingApp;
 import com.chip.casting.util.GlobalCastingConstants;
 import com.chip.casting.util.PreferencesConfigurationManager;
+import com.matter.casting.ConnectionExampleFragment;
 import com.matter.casting.DiscoveryExampleFragment;
 import com.matter.casting.InitializationExample;
 import com.matter.casting.core.CastingPlayer;
@@ -20,7 +21,8 @@ public class MainActivity extends AppCompatActivity
     implements CommissionerDiscoveryFragment.Callback,
         ConnectionFragment.Callback,
         SelectClusterFragment.Callback,
-        DiscoveryExampleFragment.Callback {
+        DiscoveryExampleFragment.Callback,
+        ConnectionExampleFragment.Callback {
 
   private static final String TAG = MainActivity.class.getSimpleName();
 
@@ -58,15 +60,25 @@ public class MainActivity extends AppCompatActivity
   }
 
   @Override
-  public void handleConnectionButtonClicked(CastingPlayer player) {
+  public void handleConnectionButtonClicked(CastingPlayer castingPlayer) {
     Log.i(TAG, "MainActivity.handleConnectionButtonClicked() called");
-    // TODO: In future PR, show fragment that connects to the player.
-    // showFragment(ConnectionFragment.newInstance(CastingPlayer player));
+    showFragment(ConnectionExampleFragment.newInstance(castingPlayer));
   }
 
   @Override
   public void handleCommissioningComplete() {
     showFragment(SelectClusterFragment.newInstance(tvCastingApp));
+  }
+
+  @Override
+  public void handleConnectionComplete(CastingPlayer castingPlayer) {
+    Log.i(
+        TAG,
+        "MainActivity.handleConnectionComplete() called with CastingPlayer with deviceId: "
+            + castingPlayer.getDeviceId());
+
+    // TODO: Implement in following PRs. Select Cluster Fragment.
+    // showFragment(SelectClusterFragment.newInstance(tvCastingApp));
   }
 
   @Override
@@ -115,7 +127,7 @@ public class MainActivity extends AppCompatActivity
   private void showFragment(Fragment fragment, boolean showOnBack) {
     Log.d(
         TAG,
-        "showFragment called with " + fragment.getClass().getSimpleName() + " and " + showOnBack);
+        "showFragment() called with " + fragment.getClass().getSimpleName() + " and " + showOnBack);
     FragmentTransaction fragmentTransaction =
         getSupportFragmentManager()
             .beginTransaction()

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -72,10 +72,7 @@ public class MainActivity extends AppCompatActivity
 
   @Override
   public void handleConnectionComplete(CastingPlayer castingPlayer) {
-    Log.i(
-        TAG,
-        "MainActivity.handleConnectionComplete() called with CastingPlayer with deviceId: "
-            + castingPlayer.getDeviceId());
+    Log.i(TAG, "MainActivity.handleConnectionComplete() called ");
 
     // TODO: Implement in following PRs. Select Cluster Fragment.
     // showFragment(SelectClusterFragment.newInstance(tvCastingApp));

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -1,0 +1,127 @@
+/*
+ *   Copyright (c) 2024 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.matter.casting;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import com.R;
+import com.matter.casting.core.CastingPlayer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+
+/** A {@link Fragment} to Verify or establish a connection with a selected Casting Player. */
+public class ConnectionExampleFragment extends Fragment {
+  private static final String TAG = ConnectionExampleFragment.class.getSimpleName();
+  // Time (in sec) to keep the commissioning window open, if commissioning is required.
+  // Must be >= 3 minutes.
+  private static final long MIN_CONNECTION_TIMEOUT_SEC = 3*60;
+  private final CastingPlayer selectedCastingPlayer;
+  private TextView connectionFragmentStatusTextView;
+  private Button connectionFragmentNextButton;
+
+  public ConnectionExampleFragment(CastingPlayer selectedCastingPlayer) {
+      Log.i(TAG, "ConnectionExampleFragment() called with CastingPlayer with deviceId: " + selectedCastingPlayer.getDeviceId());
+    this.selectedCastingPlayer = selectedCastingPlayer;
+  }
+
+  /**
+   * Use this factory method to create a new instance of this fragment using the provided
+   * parameters.
+   *
+   * @return A new instance of fragment ConnectionExampleFragment.
+   */
+  public static ConnectionExampleFragment newInstance(CastingPlayer castingPlayer) {
+      Log.i(TAG, "newInstance() called");
+      return new ConnectionExampleFragment(castingPlayer);
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      Log.i(TAG, "onCreate() called");
+  }
+
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+      Log.i(TAG, "onCreateView() called");
+      // Inflate the layout for this fragment
+      return inflater.inflate(R.layout.fragment_matter_connection_example, container, false);
+  }
+
+  @Override
+  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    Log.i(TAG, "onViewCreated() called");
+
+    connectionFragmentStatusTextView = getView().findViewById(R.id.connectionWindowStatus);
+    connectionFragmentStatusTextView.setText("Verifying or establishing connection with Casting Player with device name: " + selectedCastingPlayer.getDeviceName());
+
+    connectionFragmentNextButton = getView().findViewById(R.id.connectionWindowNextButton);
+    Callback callback = (ConnectionExampleFragment.Callback) this.getActivity();
+    connectionFragmentNextButton.setOnClickListener(
+      v -> {
+          Log.i(TAG, "onViewCreated() connectionWindowNextButton button clicked. Calling MainActivity.handleConnectionComplete()");
+          callback.handleConnectionComplete(selectedCastingPlayer);
+      });
+
+    Executors.newSingleThreadExecutor().submit( () -> {
+        Log.d(TAG, "onViewCreated() calling verifyOrEstablishConnection() on CastingPlayer with deviceId: " + selectedCastingPlayer.getDeviceId());
+
+        CompletableFuture<Void> completableFuture = selectedCastingPlayer.VerifyOrEstablishConnection();
+        // Optionally, we can specify the desired commissioning window duration and Endpoint Filter.
+        //EndpointFilter desiredEndpointFilter = new EndpointFilter(0, 0, new ArrayList<DeviceTypeStruct>());
+        //CompletableFuture<Void> completableFuture = selectedCastingPlayer.VerifyOrEstablishConnection(MIN_CONNECTION_TIMEOUT_SEC, desiredEndpointFilter);
+
+        Log.d(TAG, "onViewCreated() verifyOrEstablishConnection() called");
+        if (completableFuture == null) {
+            Log.e(TAG, "onViewCreated() verifyOrEstablishConnection() Warning: completableFuture == null");
+        }
+
+        completableFuture.thenRun(
+          () -> {
+              Log.i(TAG, "onViewCreated() CompletableFuture.thenRun(), Connected to CastingPlayer with deviceId: " + selectedCastingPlayer.getDeviceId());
+              getActivity().runOnUiThread(
+                      () -> {
+                          connectionFragmentStatusTextView.setText("Connected to Casting Player with device name: " + selectedCastingPlayer.getDeviceName());
+                          connectionFragmentNextButton.setEnabled(true);
+                      });
+          }).exceptionally(
+          exc -> {
+              Log.e(TAG, "onViewCreated() CompletableFuture.exceptionally(), CastingPlayer connection failed due to exception: " + exc.getMessage());
+              getActivity().runOnUiThread(
+                      () -> {
+                          connectionFragmentStatusTextView.setText("Casting Player connection failed due to: " + exc.getMessage());
+                      });
+              return null;
+          });
+    });
+  }
+
+  /** Interface for notifying the host. */
+  public interface Callback {
+    /** Notifies listener to trigger transition on completion of commissioning */
+    void handleConnectionComplete(CastingPlayer castingPlayer);
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -35,13 +35,16 @@ public class ConnectionExampleFragment extends Fragment {
   private static final String TAG = ConnectionExampleFragment.class.getSimpleName();
   // Time (in sec) to keep the commissioning window open, if commissioning is required.
   // Must be >= 3 minutes.
-  private static final long MIN_CONNECTION_TIMEOUT_SEC = 3*60;
+  private static final long MIN_CONNECTION_TIMEOUT_SEC = 3 * 60;
   private final CastingPlayer selectedCastingPlayer;
   private TextView connectionFragmentStatusTextView;
   private Button connectionFragmentNextButton;
 
   public ConnectionExampleFragment(CastingPlayer selectedCastingPlayer) {
-      Log.i(TAG, "ConnectionExampleFragment() called with CastingPlayer with deviceId: " + selectedCastingPlayer.getDeviceId());
+    Log.i(
+        TAG,
+        "ConnectionExampleFragment() called with CastingPlayer with deviceId: "
+            + selectedCastingPlayer.getDeviceId());
     this.selectedCastingPlayer = selectedCastingPlayer;
   }
 
@@ -52,22 +55,22 @@ public class ConnectionExampleFragment extends Fragment {
    * @return A new instance of fragment ConnectionExampleFragment.
    */
   public static ConnectionExampleFragment newInstance(CastingPlayer castingPlayer) {
-      Log.i(TAG, "newInstance() called");
-      return new ConnectionExampleFragment(castingPlayer);
+    Log.i(TAG, "newInstance() called");
+    return new ConnectionExampleFragment(castingPlayer);
   }
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
-      super.onCreate(savedInstanceState);
-      Log.i(TAG, "onCreate() called");
+    super.onCreate(savedInstanceState);
+    Log.i(TAG, "onCreate() called");
   }
 
   @Override
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-      Log.i(TAG, "onCreateView() called");
-      // Inflate the layout for this fragment
-      return inflater.inflate(R.layout.fragment_matter_connection_example, container, false);
+    Log.i(TAG, "onCreateView() called");
+    // Inflate the layout for this fragment
+    return inflater.inflate(R.layout.fragment_matter_connection_example, container, false);
   }
 
   @Override
@@ -76,47 +79,77 @@ public class ConnectionExampleFragment extends Fragment {
     Log.i(TAG, "onViewCreated() called");
 
     connectionFragmentStatusTextView = getView().findViewById(R.id.connectionWindowStatus);
-    connectionFragmentStatusTextView.setText("Verifying or establishing connection with Casting Player with device name: " + selectedCastingPlayer.getDeviceName());
+    connectionFragmentStatusTextView.setText(
+        "Verifying or establishing connection with Casting Player with device name: "
+            + selectedCastingPlayer.getDeviceName());
 
     connectionFragmentNextButton = getView().findViewById(R.id.connectionWindowNextButton);
     Callback callback = (ConnectionExampleFragment.Callback) this.getActivity();
     connectionFragmentNextButton.setOnClickListener(
-      v -> {
-          Log.i(TAG, "onViewCreated() connectionWindowNextButton button clicked. Calling MainActivity.handleConnectionComplete()");
+        v -> {
+          Log.i(
+              TAG,
+              "onViewCreated() connectionWindowNextButton button clicked. Calling MainActivity.handleConnectionComplete()");
           callback.handleConnectionComplete(selectedCastingPlayer);
-      });
+        });
 
-    Executors.newSingleThreadExecutor().submit( () -> {
-        Log.d(TAG, "onViewCreated() calling verifyOrEstablishConnection() on CastingPlayer with deviceId: " + selectedCastingPlayer.getDeviceId());
+    Executors.newSingleThreadExecutor()
+        .submit(
+            () -> {
+              Log.d(
+                  TAG,
+                  "onViewCreated() calling verifyOrEstablishConnection() on CastingPlayer with deviceId: "
+                      + selectedCastingPlayer.getDeviceId());
 
-        CompletableFuture<Void> completableFuture = selectedCastingPlayer.VerifyOrEstablishConnection();
-        // Optionally, we can specify the desired commissioning window duration and Endpoint Filter.
-        //EndpointFilter desiredEndpointFilter = new EndpointFilter(0, 0, new ArrayList<DeviceTypeStruct>());
-        //CompletableFuture<Void> completableFuture = selectedCastingPlayer.VerifyOrEstablishConnection(MIN_CONNECTION_TIMEOUT_SEC, desiredEndpointFilter);
+              CompletableFuture<Void> completableFuture =
+                  selectedCastingPlayer.VerifyOrEstablishConnection();
+              // Optionally, we can specify the desired commissioning window duration and Endpoint
+              // Filter.
+              // EndpointFilter desiredEndpointFilter = new EndpointFilter(0, 0, new
+              // ArrayList<DeviceTypeStruct>());
+              // CompletableFuture<Void> completableFuture =
+              // selectedCastingPlayer.VerifyOrEstablishConnection(MIN_CONNECTION_TIMEOUT_SEC,
+              // desiredEndpointFilter);
 
-        Log.d(TAG, "onViewCreated() verifyOrEstablishConnection() called");
-        if (completableFuture == null) {
-            Log.e(TAG, "onViewCreated() verifyOrEstablishConnection() Warning: completableFuture == null");
-        }
+              Log.d(TAG, "onViewCreated() verifyOrEstablishConnection() called");
+              if (completableFuture == null) {
+                Log.e(
+                    TAG,
+                    "onViewCreated() verifyOrEstablishConnection() Warning: completableFuture == null");
+              }
 
-        completableFuture.thenRun(
-          () -> {
-              Log.i(TAG, "onViewCreated() CompletableFuture.thenRun(), Connected to CastingPlayer with deviceId: " + selectedCastingPlayer.getDeviceId());
-              getActivity().runOnUiThread(
+              completableFuture
+                  .thenRun(
                       () -> {
-                          connectionFragmentStatusTextView.setText("Connected to Casting Player with device name: " + selectedCastingPlayer.getDeviceName());
-                          connectionFragmentNextButton.setEnabled(true);
+                        Log.i(
+                            TAG,
+                            "onViewCreated() CompletableFuture.thenRun(), Connected to CastingPlayer with deviceId: "
+                                + selectedCastingPlayer.getDeviceId());
+                        getActivity()
+                            .runOnUiThread(
+                                () -> {
+                                  connectionFragmentStatusTextView.setText(
+                                      "Connected to Casting Player with device name: "
+                                          + selectedCastingPlayer.getDeviceName());
+                                  connectionFragmentNextButton.setEnabled(true);
+                                });
+                      })
+                  .exceptionally(
+                      exc -> {
+                        Log.e(
+                            TAG,
+                            "onViewCreated() CompletableFuture.exceptionally(), CastingPlayer connection failed due to exception: "
+                                + exc.getMessage());
+                        getActivity()
+                            .runOnUiThread(
+                                () -> {
+                                  connectionFragmentStatusTextView.setText(
+                                      "Casting Player connection failed due to: "
+                                          + exc.getMessage());
+                                });
+                        return null;
                       });
-          }).exceptionally(
-          exc -> {
-              Log.e(TAG, "onViewCreated() CompletableFuture.exceptionally(), CastingPlayer connection failed due to exception: " + exc.getMessage());
-              getActivity().runOnUiThread(
-                      () -> {
-                          connectionFragmentStatusTextView.setText("Casting Player connection failed due to: " + exc.getMessage());
-                      });
-              return null;
-          });
-    });
+            });
   }
 
   /** Interface for notifying the host. */

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
@@ -338,11 +338,10 @@ class CastingPlayerArrayAdapter extends ArrayAdapter<CastingPlayer> {
           CastingPlayer castingPlayer = playerList.get(i);
           Log.d(
               TAG,
-              "OnItemClickListener.onClick() called for castingPlayer with deviceId: "
+              "OnClickListener.onClick() called for CastingPlayer with deviceId: "
                   + castingPlayer.getDeviceId());
           DiscoveryExampleFragment.Callback callback1 = (DiscoveryExampleFragment.Callback) context;
-          // TODO: In following PRs. Implement CastingPlayer connection
-          // callback1.handleCommissioningButtonClicked(castingPlayer);
+          callback1.handleConnectionButtonClicked(castingPlayer);
         };
     playerDescription.setOnClickListener(clickListener);
     return view;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -16,8 +16,10 @@
  */
 package com.matter.casting.core;
 
+import com.matter.casting.support.EndpointFilter;
 import java.net.InetAddress;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * The CastingPlayer interface defines a Matter commissioner that is able to play media to a
@@ -55,12 +57,44 @@ public interface CastingPlayer {
   @Override
   int hashCode();
 
-  // TODO: Implement in following PRs. Related to player connection implementation.
-  //    List<Endpoint> getEndpoints();
-  //
+  /**
+   * Verifies that a connection exists with this CastingPlayer, or triggers a new session request.
+   * If the CastingApp does not have the nodeId and fabricIndex of this CastingPlayer cached on
+   * disk, this will execute the user directed commissioning process.
+   *
+   * @param commissioningWindowTimeoutSec (Optional) time (in sec) to keep the commissioning window
+   *     open, if commissioning is required. Needs to be >= MIN_CONNECTION_TIMEOUT_SEC.
+   * @param desiredEndpointFilter (Optional) Attributes (such as VendorId) describing an Endpoint
+   *     that the client wants to interact with after commissioning. If this value is passed in, the
+   *     VerifyOrEstablishConnection will force User Directed Commissioning, in case the desired
+   *     Endpoint is not found in the on device CastingStore.
+   * @return A CompletableFuture that completes when the VerifyOrEstablishConnection is completed.
+   *     The CompletableFuture will be completed with a Void value if the
+   *     VerifyOrEstablishConnection is successful. Otherwise, the CompletableFuture will be
+   *     completed with an Exception. The Exception will be of type
+   *     com.matter.casting.core.CastingException. If the VerifyOrEstablishConnection fails, the
+   *     CastingException will contain the error code and message from the CastingApp.
+   */
+  CompletableFuture<Void> VerifyOrEstablishConnection(
+      long commissioningWindowTimeoutSec, EndpointFilter desiredEndpointFilter);
+
+  /**
+   * Verifies that a connection exists with this CastingPlayer, or triggers a new session request.
+   * If the CastingApp does not have the nodeId and fabricIndex of this CastingPlayer cached on
+   * disk, this will execute the user directed commissioning process.
+   *
+   * @return A CompletableFuture that completes when the VerifyOrEstablishConnection is completed.
+   *     The CompletableFuture will be completed with a Void value if the
+   *     VerifyOrEstablishConnection is successful. Otherwise, the CompletableFuture will be
+   *     completed with an Exception. The Exception will be of type
+   *     com.matter.casting.core.CastingException. If the VerifyOrEstablishConnection fails, the
+   *     CastingException will contain the error code and message from the CastingApp.
+   */
+  CompletableFuture<Void> VerifyOrEstablishConnection();
+
+  // TODO: Implement in following PRs.
+
   //    ConnectionState getConnectionState();
-  //
-  //    CompletableFuture<Void> connect(long timeout);
   //
   //    static class ConnectionState extends Observable {
   //        private boolean connected;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -91,22 +91,4 @@ public interface CastingPlayer {
    *     CastingException will contain the error code and message from the CastingApp.
    */
   CompletableFuture<Void> VerifyOrEstablishConnection();
-
-  // TODO: Implement in following PRs.
-
-  //    ConnectionState getConnectionState();
-  //
-  //    static class ConnectionState extends Observable {
-  //        private boolean connected;
-  //
-  //        void setConnected(boolean connected) {
-  //            this.connected = connected;
-  //            setChanged();
-  //            notifyObservers(this.connected);
-  //        }
-  //
-  //        boolean isConnected() {
-  //            return connected;
-  //        }
-  //    }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/DeviceTypeStruct.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/DeviceTypeStruct.java
@@ -16,17 +16,13 @@
  */
 package com.matter.casting.support;
 
-/**
- * A class to describe a Matter device type.
- */
+/** A class to describe a Matter device type. */
 public class DeviceTypeStruct {
-    public long deviceType;
-    public int revision;
+  public long deviceType;
+  public int revision;
 
-    public DeviceTypeStruct(
-            long deviceType,
-            int revision) {
-        this.deviceType = deviceType;
-        this.revision = revision;
-    }
+  public DeviceTypeStruct(long deviceType, int revision) {
+    this.deviceType = deviceType;
+    this.revision = revision;
+  }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/DeviceTypeStruct.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/DeviceTypeStruct.java
@@ -1,0 +1,32 @@
+/*
+ *   Copyright (c) 2024 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.matter.casting.support;
+
+/**
+ * A class to describe a Matter device type.
+ */
+public class DeviceTypeStruct {
+    public long deviceType;
+    public int revision;
+
+    public DeviceTypeStruct(
+            long deviceType,
+            int revision) {
+        this.deviceType = deviceType;
+        this.revision = revision;
+    }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/EndpointFilter.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/EndpointFilter.java
@@ -20,13 +20,14 @@ import java.util.List;
 
 /** Describes an Endpoint that the client wants to connect to. */
 public class EndpointFilter {
-  // Value of 0 means unspecified
-  public int productId;
-  // Value of 0 means unspecified
-  public int vendorId;
+  // Value of null means unspecified
+  public Integer productId;
+  // Value of null means unspecified
+  public Integer vendorId;
   public List<DeviceTypeStruct> requiredDeviceTypes;
 
-  public EndpointFilter(int productId, int vendorId, List<DeviceTypeStruct> requiredDeviceTypes) {
+  public EndpointFilter(
+      Integer productId, Integer vendorId, List<DeviceTypeStruct> requiredDeviceTypes) {
     this.productId = productId;
     this.vendorId = vendorId;
     this.requiredDeviceTypes = requiredDeviceTypes;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/EndpointFilter.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/EndpointFilter.java
@@ -18,22 +18,17 @@ package com.matter.casting.support;
 
 import java.util.List;
 
-/**
- * Describes an Endpoint that the client wants to connect to.
- */
+/** Describes an Endpoint that the client wants to connect to. */
 public class EndpointFilter {
-    // Value of 0 means unspecified
-    public int productId;
-    // Value of 0 means unspecified
-    public int vendorId;
-    public List<DeviceTypeStruct> requiredDeviceTypes;
+  // Value of 0 means unspecified
+  public int productId;
+  // Value of 0 means unspecified
+  public int vendorId;
+  public List<DeviceTypeStruct> requiredDeviceTypes;
 
-    public EndpointFilter(
-            int productId,
-            int vendorId,
-            List<DeviceTypeStruct> requiredDeviceTypes) {
-        this.productId = productId;
-        this.vendorId = vendorId;
-        this.requiredDeviceTypes = requiredDeviceTypes;
-    }
+  public EndpointFilter(int productId, int vendorId, List<DeviceTypeStruct> requiredDeviceTypes) {
+    this.productId = productId;
+    this.vendorId = vendorId;
+    this.requiredDeviceTypes = requiredDeviceTypes;
+  }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/EndpointFilter.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/EndpointFilter.java
@@ -1,0 +1,39 @@
+/*
+ *   Copyright (c) 2024 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.matter.casting.support;
+
+import java.util.List;
+
+/**
+ * Describes an Endpoint that the client wants to connect to.
+ */
+public class EndpointFilter {
+    // Value of 0 means unspecified
+    public int productId;
+    // Value of 0 means unspecified
+    public int vendorId;
+    public List<DeviceTypeStruct> requiredDeviceTypes;
+
+    public EndpointFilter(
+            int productId,
+            int vendorId,
+            List<DeviceTypeStruct> requiredDeviceTypes) {
+        this.productId = productId;
+        this.vendorId = vendorId;
+        this.requiredDeviceTypes = requiredDeviceTypes;
+    }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayer-JNI.cpp
@@ -1,0 +1,118 @@
+/*
+ *   Copyright (c) 2024 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "CastingPlayer-JNI.h"
+
+#include "../JNIDACProvider.h"
+#include "../support/CastingPlayerConverter-JNI.h"
+#include "../support/ErrorConverter-JNI.h"
+#include "../support/RotatingDeviceIdUniqueIdProvider-JNI.h"
+#include "core/CastingApp.h"// from tv-casting-common
+#include "core/CastingPlayer.h"// from tv-casting-common
+#include "core/CastingPlayerDiscovery.h" // from tv-casting-common
+
+#include <app/clusters/bindings/BindingManager.h>
+#include <app/server/Server.h>
+#include <jni.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
+
+using namespace chip;
+
+#define JNI_METHOD(RETURN, METHOD_NAME)                                                                                            \
+    extern "C" JNIEXPORT RETURN JNICALL Java_com_matter_casting_core_MatterCastingPlayer_##METHOD_NAME
+
+namespace matter {
+namespace casting {
+namespace core {
+
+JNI_METHOD(jobject, VerifyOrEstablishConnection)(JNIEnv * env, jobject thiz, jlong commissioningWindowTimeoutSec, jobject desiredEndpointFilterJavaObject)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "CastingPlayer-JNI::VerifyOrEstablishConnection() called with a timeout of: %ld seconds", static_cast<long>(commissioningWindowTimeoutSec));
+
+    // Convert the CastingPlayer jlong to a CastingPlayer pointer
+    jclass castingPlayerClass = env->GetObjectClass(thiz);
+    jfieldID _cppCastingPlayerFieldId = env->GetFieldID(castingPlayerClass, "_cppCastingPlayer", "J");
+    VerifyOrReturnValue(_cppCastingPlayerFieldId != nullptr, nullptr, ChipLogError(AppServer, "CastingPlayer-JNI::VerifyOrEstablishConnection() Warning: _cppCastingPlayerFieldId == nullptr"));
+    
+    jlong _cppCastingPlayerValue = env->GetLongField(thiz, _cppCastingPlayerFieldId);
+    CastingPlayer* castingPlayer = reinterpret_cast<CastingPlayer*>(_cppCastingPlayerValue);
+    VerifyOrReturnValue(castingPlayer != nullptr, nullptr, ChipLogError(AppServer, "CastingPlayer-JNI::VerifyOrEstablishConnection() Warning: castingPlayer == nullptr"));
+
+    // Create a new Java CompletableFuture
+    jclass completableFutureClass = env->FindClass("java/util/concurrent/CompletableFuture");
+    jmethodID completableFutureConstructor = env->GetMethodID(completableFutureClass, "<init>", "()V");
+    jobject completableFutureObj = env->NewObject(completableFutureClass, completableFutureConstructor);
+    jobject completableFutureObjGlobalRef = env->NewGlobalRef(completableFutureObj);
+    VerifyOrReturnValue(completableFutureObjGlobalRef != nullptr, nullptr, ChipLogError(AppServer, "CastingPlayer-JNI::VerifyOrEstablishConnection() Warning: completableFutureObjGlobalRef == nullptr"));
+
+    ConnectCallback callback = [completableFutureObjGlobalRef](CHIP_ERROR err, CastingPlayer* playerPtr) {
+        ChipLogProgress(AppServer, "CastingPlayer-JNI::VerifyOrEstablishConnection() ConnectCallback called");
+        if (completableFutureObjGlobalRef == nullptr) {
+            // Prevents an app crash at CallBooleanMethod
+            ChipLogError(AppServer, "CastingPlayer-JNI::VerifyOrEstablishConnection() ConnectCallback, Warning: completableFutureObjGlobalRef == nullptr");
+        } else {
+            JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+            jclass completableFutureClass = env->FindClass("java/util/concurrent/CompletableFuture");
+
+            if (err == CHIP_NO_ERROR) {
+                ChipLogProgress(AppServer, "CastingPlayer-JNI::VerifyOrEstablishConnection() ConnectCallback, Casting Player connection successful!");
+                jmethodID completeMethod = env->GetMethodID(completableFutureClass, "complete", "(Ljava/lang/Object;)Z");
+                env->CallBooleanMethod(completableFutureObjGlobalRef, completeMethod, NULL);
+            } else {
+                ChipLogError(AppServer, "CastingPlayer-JNI::VerifyOrEstablishConnection() ConnectCallback, Warning: connection error: %" CHIP_ERROR_FORMAT, err.Format());
+                jmethodID completeExceptionallyMethod = env->GetMethodID(completableFutureClass, "completeExceptionally", "(Ljava/lang/Throwable;)Z");
+                // Create a Throwable object (e.g., RuntimeException) to pass to completeExceptionallyMethod
+                jclass throwableClass = env->FindClass("java/lang/RuntimeException");
+                jmethodID throwableConstructor = env->GetMethodID(throwableClass, "<init>", "(Ljava/lang/String;)V");
+                jstring errorMessage = env->NewStringUTF(err.Format());
+                jobject throwableObject = env->NewObject(throwableClass, throwableConstructor, errorMessage);
+                env->CallBooleanMethod(completableFutureObjGlobalRef, completeExceptionallyMethod, throwableObject);
+            }
+            env->DeleteGlobalRef(completableFutureObjGlobalRef);
+        }
+    };
+
+    if (desiredEndpointFilterJavaObject == nullptr) {
+        ChipLogProgress(AppServer, "CastingPlayer-JNI::VerifyOrEstablishConnection() calling CastingPlayer::VerifyOrEstablishConnection() on Casting Player with device ID: %s", castingPlayer->GetId());
+        castingPlayer->VerifyOrEstablishConnection(callback, static_cast<unsigned long long int>(commissioningWindowTimeoutSec));
+    } else {
+        ChipLogProgress(AppServer, "CastingPlayer-JNI::VerifyOrEstablishConnection() calling CastingPlayer::VerifyOrEstablishConnection(desiredEndpointFilter) on Casting Player with device ID: %s", castingPlayer->GetId());
+        // Convert the EndpointFilter Java class to a C++ EndpointFilter
+        jclass endpointFilterJavaClass = env->GetObjectClass(desiredEndpointFilterJavaObject);
+        jfieldID vendorIdFieldId = env->GetFieldID(endpointFilterJavaClass, "productId", "I");
+        jfieldID productIdFieldId = env->GetFieldID(endpointFilterJavaClass, "vendorId", "I");
+        jfieldID requiredDeviceTypesFieldId = env->GetFieldID(endpointFilterJavaClass, "requiredDeviceTypes", "Ljava/util/List;");
+
+        matter::casting::core::EndpointFilter desiredEndpointFilter;
+        desiredEndpointFilter.vendorId = static_cast<uint16_t>(env->GetIntField(desiredEndpointFilterJavaObject, vendorIdFieldId));
+        desiredEndpointFilter.productId = static_cast<uint16_t>(env->GetIntField(desiredEndpointFilterJavaObject, vendorIdFieldId));
+        // TODO: In following PRs. Translate the Java requiredDeviceTypes list to a C++ requiredDeviceTypes vector. For now we're
+        // passing an empty list of.
+
+        castingPlayer->VerifyOrEstablishConnection(callback, static_cast<unsigned long long int>(commissioningWindowTimeoutSec), desiredEndpointFilter);
+    }
+
+    return completableFutureObjGlobalRef; 
+}
+
+
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayer-JNI.cpp
@@ -127,14 +127,16 @@ JNI_METHOD(jobject, VerifyOrEstablishConnection)
                         "CastingPlayer::VerifyOrEstablishConnection(desiredEndpointFilter) on Casting Player with device ID: %s",
                         castingPlayer->GetId());
         // Convert the EndpointFilter Java class to a C++ EndpointFilter
-        jclass endpointFilterJavaClass      = env->GetObjectClass(desiredEndpointFilterJavaObject);
-        jfieldID vendorIdFieldId            = env->GetFieldID(endpointFilterJavaClass, "productId", "I");
-        jfieldID productIdFieldId           = env->GetFieldID(endpointFilterJavaClass, "vendorId", "I");
-        jfieldID requiredDeviceTypesFieldId = env->GetFieldID(endpointFilterJavaClass, "requiredDeviceTypes", "Ljava/util/List;");
+        jclass endpointFilterJavaClass = env->GetObjectClass(desiredEndpointFilterJavaObject);
+        jfieldID vendorIdFieldId       = env->GetFieldID(endpointFilterJavaClass, "vendorId", "I");
+        jfieldID productIdFieldId      = env->GetFieldID(endpointFilterJavaClass, "productId", "I");
+        // jfieldID requiredDeviceTypesFieldId = env->GetFieldID(endpointFilterJavaClass, "requiredDeviceTypes",
+        // "Ljava/util/List;");
 
         matter::casting::core::EndpointFilter desiredEndpointFilter;
-        desiredEndpointFilter.vendorId  = static_cast<uint16_t>(env->GetIntField(desiredEndpointFilterJavaObject, vendorIdFieldId));
-        desiredEndpointFilter.productId = static_cast<uint16_t>(env->GetIntField(desiredEndpointFilterJavaObject, vendorIdFieldId));
+        desiredEndpointFilter.vendorId = static_cast<uint16_t>(env->GetIntField(desiredEndpointFilterJavaObject, vendorIdFieldId));
+        desiredEndpointFilter.productId =
+            static_cast<uint16_t>(env->GetIntField(desiredEndpointFilterJavaObject, productIdFieldId));
         // TODO: In following PRs. Translate the Java requiredDeviceTypes list to a C++ requiredDeviceTypes vector. For now we're
         // passing an empty list of.
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayer-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayer-JNI.h
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <jni.h>
+
+namespace matter {
+namespace casting {
+namespace core {
+
+class CastingPlayerJNI
+{
+public:
+private:
+    friend CastingPlayerJNI & CastingAppJNIMgr();
+    static CastingPlayerJNI sInstance;
+};
+
+inline class CastingPlayerJNI & CastingAppJNIMgr()
+{
+    return CastingPlayerJNI::sInstance;
+}
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.cpp
@@ -88,6 +88,7 @@ public:
                                     "CastingPlayer jobject"));
 
         JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+        chip::DeviceLayer::StackUnlock unlock;
         env->CallVoidMethod(castingPlayerChangeListenerJavaObject, onAddedCallbackJavaMethodID, matterCastingPlayerJavaObject);
     }
 
@@ -113,6 +114,7 @@ public:
                                     "create CastingPlayer jobject"));
 
         JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+        chip::DeviceLayer::StackUnlock unlock;
         env->CallVoidMethod(castingPlayerChangeListenerJavaObject, onChangedCallbackJavaMethodID, matterCastingPlayerJavaObject);
     }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/CastingPlayerConverter-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/CastingPlayerConverter-JNI.cpp
@@ -83,7 +83,11 @@ jobject createJCastingPlayer(matter::casting::memory::Strong<core::CastingPlayer
     {
         ChipLogError(AppServer,
                      "CastingPlayerConverter-JNI.createJCastingPlayer() Warning: Could not create MatterCastingPlayer Java object");
+        return jMatterCastingPlayer;
     }
+    // Set the value of the _cppCastingPlayer field in the Java object to the C++ CastingPlayer pointer.
+    jfieldID longFieldId = env->GetFieldID(matterCastingPlayerJavaClass, "_cppCastingPlayer", "J");
+    env->SetLongField(jMatterCastingPlayer, longFieldId, reinterpret_cast<jlong>(player.get()));
     return jMatterCastingPlayer;
 }
 

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_connection_example.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_connection_example.xml
@@ -7,15 +7,15 @@
     android:padding="10sp">
 
     <TextView
-        android:id="@+id/connectionWindowStatus"
+        android:id="@+id/connectionFragmentStatusText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textSize="24sp"/>
 
     <Button
         android:enabled="false"
-        android:id="@+id/connectionWindowNextButton"
-        android:layout_below="@id/connectionWindowStatus"
+        android:id="@+id/connectionFragmentNextButton"
+        android:layout_below="@id/connectionFragmentStatusText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/matter_connection_next_button_text" />

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_connection_example.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_connection_example.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".matter.casting.ConnectionExampleFragment"
+    android:padding="10sp">
+
+    <TextView
+        android:id="@+id/connectionWindowStatus"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="24sp"/>
+
+    <Button
+        android:enabled="false"
+        android:id="@+id/connectionWindowNextButton"
+        android:layout_below="@id/connectionWindowStatus"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/matter_connection_next_button_text" />
+
+</RelativeLayout>

--- a/examples/tv-casting-app/android/App/app/src/main/res/values/strings.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/values/strings.xml
@@ -33,4 +33,5 @@
     <string name="matter_discovery_message_initializing_text">Initializing</string>
     <string name="matter_discovery_message_discovering_text">Casting Players on-network:</string>
     <string name="matter_discovery_message_stopped_text">Discovery Stopped</string>
+    <string name="matter_connection_next_button_text">Next</string>
 </resources>

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -38,6 +38,8 @@ shared_library("jni") {
   sources += [
     "App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp",
     "App/app/src/main/jni/cpp/core/CastingApp-JNI.h",
+    "App/app/src/main/jni/cpp/core/CastingPlayer-JNI.cpp",
+    "App/app/src/main/jni/cpp/core/CastingPlayer-JNI.h",
     "App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.cpp",
     "App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.h",
     "App/app/src/main/jni/cpp/support/CastingPlayerConverter-JNI.cpp",
@@ -109,6 +111,8 @@ android_library("java") {
     "App/app/src/main/jni/com/matter/casting/support/CommissionableData.java",
     "App/app/src/main/jni/com/matter/casting/support/DACProvider.java",
     "App/app/src/main/jni/com/matter/casting/support/DataProvider.java",
+    "App/app/src/main/jni/com/matter/casting/support/DeviceTypeStruct.java",
+    "App/app/src/main/jni/com/matter/casting/support/EndpointFilter.java",
     "App/app/src/main/jni/com/matter/casting/support/MatterError.java",
   ]
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -32,7 +32,7 @@ CastingPlayer * CastingPlayer::mTargetCastingPlayer = nullptr;
 void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, unsigned long long int commissioningWindowTimeoutSec,
                                                 EndpointFilter desiredEndpointFilter)
 {
-    ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection called");
+    ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() called");
 
     std::vector<core::CastingPlayer>::iterator it;
     std::vector<core::CastingPlayer> cachedCastingPlayers = support::CastingStore::GetInstance()->ReadAll();
@@ -41,9 +41,10 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, uns
 
     // ensure the app was not already in the process of connecting to this CastingPlayer
     err = (mConnectionState != CASTING_PLAYER_CONNECTING ? CHIP_NO_ERROR : CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(mConnectionState != CASTING_PLAYER_CONNECTING,
-                 ChipLogError(AppServer,
-                              "CastingPlayer::VerifyOrEstablishConnection called while already connecting to this CastingPlayer"));
+    VerifyOrExit(
+        mConnectionState != CASTING_PLAYER_CONNECTING,
+        ChipLogError(AppServer,
+                     "CastingPlayer::VerifyOrEstablishConnection() called while already connecting to this CastingPlayer"));
     mConnectionState               = CASTING_PLAYER_CONNECTING;
     mOnCompleted                   = onCompleted;
     mCommissioningWindowTimeoutSec = commissioningWindowTimeoutSec;
@@ -64,14 +65,15 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, uns
             if (ContainsDesiredEndpoint(&cachedCastingPlayers[index], desiredEndpointFilter))
             {
                 ChipLogProgress(
-                    AppServer, "CastingPlayer::VerifyOrEstablishConnection calling FindOrEstablishSession on cached CastingPlayer");
+                    AppServer,
+                    "CastingPlayer::VerifyOrEstablishConnection() calling FindOrEstablishSession on cached CastingPlayer");
                 *this = cachedCastingPlayers[index];
 
                 FindOrEstablishSession(
                     nullptr,
                     [](void * context, chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle) {
                         ChipLogProgress(AppServer,
-                                        "CastingPlayer::VerifyOrEstablishConnection Connection to CastingPlayer successful");
+                                        "CastingPlayer::VerifyOrEstablishConnection() Connection to CastingPlayer successful");
                         CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_CONNECTED;
 
                         // this async call will Load all the endpoints with their respective attributes into the TargetCastingPlayer
@@ -80,7 +82,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, uns
                         support::EndpointListLoader::GetInstance()->Load();
                     },
                     [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
-                        ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection Connection to CastingPlayer failed");
+                        ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection() Connection to CastingPlayer failed");
                         CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
                         CHIP_ERROR e = support::CastingStore::GetInstance()->Delete(*CastingPlayer::GetTargetCastingPlayer());
                         if (e != CHIP_NO_ERROR)
@@ -102,7 +104,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, uns
     // will require User Directed Commissioning.
     if (chip::Server::GetInstance().GetFailSafeContext().IsFailSafeArmed())
     {
-        ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection Forcing expiry of armed FailSafe timer");
+        ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() Forcing expiry of armed FailSafe timer");
         // ChipDeviceEventHandler will handle the kFailSafeTimerExpired event by Opening the Basic Commissioning Window and Sending
         // the User Directed Commissioning Request
         chip::Server::GetInstance().GetFailSafeContext().ForceFailSafeTimerExpiry();
@@ -120,7 +122,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, uns
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection failed with %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection() failed with %" CHIP_ERROR_FORMAT, err.Format());
         support::ChipDeviceEventHandler::SetUdcStatus(false);
         mConnectionState               = CASTING_PLAYER_NOT_CONNECTED;
         mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;

--- a/src/lib/support/JniTypeWrappers.h
+++ b/src/lib/support/JniTypeWrappers.h
@@ -185,7 +185,11 @@ class JniGlobalRefWrapper
 {
 public:
     explicit JniGlobalRefWrapper(jobject mGlobalRef) : mGlobalRef(mGlobalRef) {}
-    ~JniGlobalRefWrapper() { chip::JniReferences::GetInstance().GetEnvForCurrentThread()->DeleteGlobalRef(mGlobalRef); }
+    ~JniGlobalRefWrapper()
+    {
+        chip::JniReferences::GetInstance().GetEnvForCurrentThread()->DeleteGlobalRef(mGlobalRef);
+        mGlobalRef = nullptr;
+    }
     jobject classRef() { return mGlobalRef; }
 
 private:

--- a/src/lib/support/JniTypeWrappers.h
+++ b/src/lib/support/JniTypeWrappers.h
@@ -180,6 +180,18 @@ private:
     jclass mClassRef;
 };
 
+// Manages an pre-existing global reference to a jobject.
+class JniGlobalRefWrapper
+{
+public:
+    explicit JniGlobalRefWrapper(jobject mGlobalRef) : mGlobalRef(mGlobalRef) {}
+    ~JniGlobalRefWrapper() { chip::JniReferences::GetInstance().GetEnvForCurrentThread()->DeleteGlobalRef(mGlobalRef); }
+    jobject classRef() { return mGlobalRef; }
+
+private:
+    jobject mGlobalRef;
+};
+
 class JniLocalReferenceManager
 {
 public:

--- a/src/lib/support/JniTypeWrappers.h
+++ b/src/lib/support/JniTypeWrappers.h
@@ -193,7 +193,7 @@ public:
     jobject classRef() { return mGlobalRef; }
 
 private:
-    jobject mGlobalRef;
+    jobject mGlobalRef = nullptr;
 };
 
 class JniLocalReferenceManager


### PR DESCRIPTION
This change implements and demonstrates the use of a simplified Casting Player connection API on Android. This simplified API delegates the work to the common connection implantation in C++ Native. 

**Change summary**
1.	Implemented VerifyOrEstablishConnection() in MatterCastingPlayer.java and the corresponding C++ JNI function in CastingPlayer-JNI.cpp. These delegate to the common implementation for verifying an existing connection or establishing a new connection through the full UDC process.
2.	Provided an example of how to use the simplified connection API in ConnectionExampleFragment.java

**Testing**
Verified and tested locally with the Android tv-casting-app example app. The example app discovers Casting Players and is able to connect to the selected Casting Player.
