### PR TITLE
Reduce CommandHandler::TryAddResponseData compiled code size

### DIFF
--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -552,14 +552,14 @@ private:
 
     /**
      * @brief Non-templated coded to be called before DataModel::Encode in trying to add response.
-     * 
+     *
      * If this function fails, it may leave our TLV buffer in an inconsistent state.
      * Callers should snapshot as needed before calling this function, and roll back
      * as needed afterward.
-     * 
+     *
      * Intended to be called only by TryAddResponseData. This code was factored out, to be called
      * before Encode. This reduces generated codesize.
-     * 
+     *
      * @param [in] aRequestCommandPath the concrete path of the command we are
      *             responding to.
      * @param [in] aResponseCommandPath the concrete command response path.

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -360,8 +360,7 @@ public:
     template <typename CommandData>
     CHIP_ERROR AddResponseData(const ConcreteCommandPath & aRequestCommandPath, const CommandData & aData)
     {
-        return TryAddingResponse(
-            [&]() -> CHIP_ERROR { return TryAddResponseData(aRequestCommandPath, aData); });
+        return TryAddingResponse([&]() -> CHIP_ERROR { return TryAddResponseData(aRequestCommandPath, aData); });
     }
 
     /**
@@ -563,7 +562,8 @@ private:
      * @param aRequestCommandPath  The concrete path of the command being responded to.
      * @param aResponseCommandPath The concrete path of the command response.
      */
-    CHIP_ERROR TryAddResponseDataPreEncode(const ConcreteCommandPath & aRequestCommandPath, const ConcreteCommandPath & aResponseCommandPath)
+    CHIP_ERROR TryAddResponseDataPreEncode(const ConcreteCommandPath & aRequestCommandPath,
+                                           const ConcreteCommandPath & aResponseCommandPath)
     {
         // Return early in case of requests targeted to a group, since they should not add a response.
         VerifyOrReturnValue(!IsGroupRequest(), CHIP_NO_ERROR);
@@ -586,8 +586,7 @@ private:
      * @param [in] aData the data for the response.
      */
     template <typename CommandData>
-    CHIP_ERROR TryAddResponseData(const ConcreteCommandPath & aRequestCommandPath,
-                                  const CommandData & aData)
+    CHIP_ERROR TryAddResponseData(const ConcreteCommandPath & aRequestCommandPath, const CommandData & aData)
     {
         // This method, templated with CommandData, captures all the components needs
         // from CommandData with as little code as possible.

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -360,8 +360,7 @@ public:
     template <typename CommandData>
     CHIP_ERROR AddResponseData(const ConcreteCommandPath & aRequestCommandPath, const CommandData & aData)
     {
-        return TryAddingResponse(
-            [&]() -> CHIP_ERROR { return TryAddResponseData(aRequestCommandPath, aData); });
+        return TryAddingResponse([&]() -> CHIP_ERROR { return TryAddResponseData(aRequestCommandPath, aData); });
     }
 
     /**
@@ -564,7 +563,8 @@ private:
      *             responding to.
      * @param [in] aResponseCommandPath the concrete command response path.
      */
-    CHIP_ERROR TryAddResponseDataPreEncode(const ConcreteCommandPath & aRequestCommandPath, const ConcreteCommandPath & aResponseCommandPath)
+    CHIP_ERROR TryAddResponseDataPreEncode(const ConcreteCommandPath & aRequestCommandPath,
+                                           const ConcreteCommandPath & aResponseCommandPath)
     {
         // Return early in case of requests targeted to a group, since they should not add a response.
         VerifyOrReturnValue(!IsGroupRequest(), CHIP_NO_ERROR);
@@ -587,8 +587,7 @@ private:
      * @param [in] aData the data for the response.
      */
     template <typename CommandData>
-    CHIP_ERROR TryAddResponseData(const ConcreteCommandPath & aRequestCommandPath,
-                                  const CommandData & aData)
+    CHIP_ERROR TryAddResponseData(const ConcreteCommandPath & aRequestCommandPath, const CommandData & aData)
     {
         // This method, templated with CommandData, captures all the components needs
         // from CommandData with as little code as possible.

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -360,24 +360,8 @@ public:
     template <typename CommandData>
     CHIP_ERROR AddResponseData(const ConcreteCommandPath & aRequestCommandPath, const CommandData & aData)
     {
-        // This method, templated with CommandData, captures all the components needs
-        // from CommandData with as little code as possible. This in theory should
-        // reduce compiled code size.
-        //
-        // TODO(#30453): Verify the accuracy of the theory outlined below.
-        //
-        // Theory on code reduction: Previously, non-essential code was unnecessarily
-        // templated, leading to compilation and duplication N times. The lambda
-        // function below mitigates this issue by isolating only the code segments
-        // that genuinely require templating, thereby minimizing duplicate compiled
-        // code.
-        ConcreteCommandPath responsePath = { aRequestCommandPath.mEndpointId, aRequestCommandPath.mClusterId,
-                                             CommandData::GetCommandId() };
-        auto encodeCommandDataClosure    = [&](TLV::TLVWriter & writer) -> CHIP_ERROR {
-            return DataModel::Encode(writer, TLV::ContextTag(CommandDataIB::Tag::kFields), aData);
-        };
         return TryAddingResponse(
-            [&]() -> CHIP_ERROR { return TryAddResponseData(aRequestCommandPath, responsePath, encodeCommandDataClosure); });
+            [&]() -> CHIP_ERROR { return TryAddResponseData(aRequestCommandPath, aData); });
     }
 
     /**
@@ -567,18 +551,20 @@ private:
     CHIP_ERROR AddStatusInternal(const ConcreteCommandPath & aCommandPath, const StatusIB & aStatus);
 
     /**
-     * If this function fails, it may leave our TLV buffer in an inconsistent state.  Callers should snapshot as needed before
-     * calling this function, and roll back as needed afterward.
-     *
+     * @brief Non-templated coded to be called before DataModel::Encode in trying to add response.
+     * 
+     * If this function fails, it may leave our TLV buffer in an inconsistent state.
+     * Callers should snapshot as needed before calling this function, and roll back
+     * as needed afterward.
+     * 
+     * Intended to be called only by TryAddResponseData. This code was factored out, to be called
+     * before Encode. This reduces generated codesize.
+     * 
      * @param [in] aRequestCommandPath the concrete path of the command we are
      *             responding to.
      * @param [in] aResponseCommandPath the concrete command response path.
-     * @param [in] encodeCommandDataFunction A lambda function responsible for
-     *             encoding the CommandData field.
      */
-    template <typename Function>
-    CHIP_ERROR TryAddResponseData(const ConcreteCommandPath & aRequestCommandPath, const ConcreteCommandPath & aResponseCommandPath,
-                                  Function && encodeCommandDataFunction)
+    CHIP_ERROR TryAddResponseDataPreEncode(const ConcreteCommandPath & aRequestCommandPath, const ConcreteCommandPath & aResponseCommandPath)
     {
         // Return early in case of requests targeted to a group, since they should not add a response.
         VerifyOrReturnValue(!IsGroupRequest(), CHIP_NO_ERROR);
@@ -587,11 +573,40 @@ private:
         prepareParams.SetStartOrEndDataStruct(false);
 
         ScopedChange<bool> internalCallToAddResponse(mInternalCallToAddResponseData, true);
-        ReturnErrorOnFailure(PrepareInvokeResponseCommand(aResponseCommandPath, prepareParams));
+        return PrepareInvokeResponseCommand(aResponseCommandPath, prepareParams);
+    }
+
+    // TODO(#31627): It would be awesome if we could remove this template all together.
+    /**
+     * If this function fails, it may leave our TLV buffer in an inconsistent state.
+     * Callers should snapshot as needed before calling this function, and roll back
+     * as needed afterward.
+     *
+     * @param [in] aRequestCommandPath the concrete path of the command we are
+     *             responding to.
+     * @param [in] aData the data for the response.
+     */
+    template <typename CommandData>
+    CHIP_ERROR TryAddResponseData(const ConcreteCommandPath & aRequestCommandPath,
+                                  const CommandData & aData)
+    {
+        // This method, templated with CommandData, captures all the components needs
+        // from CommandData with as little code as possible.
+        //
+        // Previously, non-essential code was unnecessarily templated, leading to
+        // compilation and duplication N times. By isolating only the code segments
+        // that genuinely require templating, minimizes duplicate compiled code.
+        ConcreteCommandPath responseCommandPath = { aRequestCommandPath.mEndpointId, aRequestCommandPath.mClusterId,
+                                                    CommandData::GetCommandId() };
+        ReturnErrorOnFailure(TryAddResponseDataPreEncode(aRequestCommandPath, responseCommandPath));
         TLV::TLVWriter * writer = GetCommandDataIBTLVWriter();
         VerifyOrReturnError(writer != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        ReturnErrorOnFailure(encodeCommandDataFunction(*writer));
+        ReturnErrorOnFailure(DataModel::Encode(*writer, TLV::ContextTag(CommandDataIB::Tag::kFields), aData));
 
+        // FinishCommand technically should be refactored out as it is not a command that needs templating.
+        // But because there is only a single function call keeping it here takes less code. If there is
+        // ever more code between DataModel::Encode and the end of this function is should be broken out into
+        // TryAddResponseDataPostEncode.
         return FinishCommand(/* aEndDataStruct = */ false);
     }
 

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -550,7 +550,8 @@ private:
     CHIP_ERROR AddStatusInternal(const ConcreteCommandPath & aCommandPath, const StatusIB & aStatus);
 
     /**
-     * Non-templated function called before DataModel::Encode when attempting to add a response.
+     * Non-templated function called before DataModel::Encode when attempting to add a response,
+     * which does all the work needed before encoding the actual type-dependent data into the buffer.
      *
      * **Important:** If this function fails, the TLV buffer may be left in an inconsistent state.
      * Callers should create snapshots as necessary before invoking this function and implement


### PR DESCRIPTION
Analysis using `report_summary.py --by=region --config-file=platform/linux.cfg <path_to_all-cluster_app>`:
* Lambda introduced in https://github.com/project-chip/connectedhomeip/pull/31516 (ToT master) actually increased codesize
  * `FLASH     5347646`
* Going back to pre https://github.com/project-chip/connectedhomeip/pull/31516, we got some saving
  * `FLASH     5344606`
* With this PR refactor out pre encode to separate non-templated method
  * `FLASH     5335102`

In the future it would be nice if we could remove need for templating entirely. For now we went with low hanging fruit by breaking out
