### PR TITLE
Update Darwin availability annotations.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -8544,6 +8544,10 @@
 - release: "Future"
   versions: "future"
   provisional:
+      clusters:
+          # Targeting Spring 2024 Matter release
+          - EnergyEVSEMode
+          - DeviceEnergyManagementMode
       attributes:
           DoorLock:
               # Aliro is not ready yet.


### PR DESCRIPTION
Explicitly list EnergyEVSEMode and DeviceEnergyManagementMode as provisional.
