### PR TITLE
[Boolean State Configuration] Fixes to test steps found during TE2 prep

### DIFF
--- a/src/python_testing/TC_BOOLCFG_4_4.py
+++ b/src/python_testing/TC_BOOLCFG_4_4.py
@@ -109,7 +109,7 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
             logging.info("Test step skipped")
 
         self.step("5b")
-        if is_vis_feature_supported:
+        if is_aud_feature_supported:
             enabledAlarms |= Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible
         else:
             logging.info("Test step skipped")

--- a/src/python_testing/TC_BOOLCFG_5_1.py
+++ b/src/python_testing/TC_BOOLCFG_5_1.py
@@ -102,7 +102,7 @@ class TC_BOOLCFG_5_1(MatterBaseTest):
             logging.info("Test step skipped")
 
         self.step("5b")
-        if is_vis_feature_supported:
+        if is_aud_feature_supported:
             enabledAlarms |= Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible
         else:
             logging.info("Test step skipped")

--- a/src/python_testing/TC_BOOLCFG_5_1.py
+++ b/src/python_testing/TC_BOOLCFG_5_1.py
@@ -160,7 +160,7 @@ class TC_BOOLCFG_5_1(MatterBaseTest):
         self.step("9b")
         if not is_aud_feature_supported:
             try:
-                await self.send_single_cmd(cmd=Clusters.Objects.BooleanStateConfiguration.Commands.SuppressAlarm(alarmsToSuppress=Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kVisual), endpoint=endpoint)
+                await self.send_single_cmd(cmd=Clusters.Objects.BooleanStateConfiguration.Commands.SuppressAlarm(alarmsToSuppress=Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible), endpoint=endpoint)
                 asserts.fail("Received Success response when an CONSTRAINT_ERROR was expected")
             except InteractionModelError as e:
                 asserts.assert_equal(e.status, Status.ConstraintError, "Unexpected error returned")

--- a/src/python_testing/TC_BOOLCFG_5_2.py
+++ b/src/python_testing/TC_BOOLCFG_5_2.py
@@ -101,7 +101,7 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
             logging.info("Test step skipped")
 
         self.step("5b")
-        if is_vis_feature_supported:
+        if is_aud_feature_supported:
             enabledAlarms |= Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap.kAudible
         else:
             logging.info("Test step skipped")


### PR DESCRIPTION
This PR fixes a wrong guard for a few test steps, this was noted during the prep for TE2 when testing against a device that does not support both VIS and AUD.