### PR TITLE
TC-ACE-2.1/2: Update default timeout

### DIFF
--- a/src/python_testing/TC_AccessChecker.py
+++ b/src/python_testing/TC_AccessChecker.py
@@ -61,6 +61,9 @@ class AccessChecker(MatterBaseTest, BasicCompositionTests):
         fabric_admin = self.certificate_authority_manager.activeCaList[0].adminList[0]
         self.TH2_nodeid = self.matter_test_config.controller_node_id + 1
         self.TH2 = fabric_admin.NewController(nodeId=self.TH2_nodeid)
+        # Both the tests in this suite are potentially long-running if there are a large number of attributes on the DUT
+        # and the network is slow. Set the default to 3 minutes to account for this.
+        self.default_timeout = 180
 
     @async_test_body
     async def setup_test(self):

--- a/src/python_testing/TC_AccessChecker.py
+++ b/src/python_testing/TC_AccessChecker.py
@@ -61,9 +61,12 @@ class AccessChecker(MatterBaseTest, BasicCompositionTests):
         fabric_admin = self.certificate_authority_manager.activeCaList[0].adminList[0]
         self.TH2_nodeid = self.matter_test_config.controller_node_id + 1
         self.TH2 = fabric_admin.NewController(nodeId=self.TH2_nodeid)
-        # Both the tests in this suite are potentially long-running if there are a large number of attributes on the DUT
-        # and the network is slow. Set the default to 3 minutes to account for this.
-        self.default_timeout = 180
+
+    # Both the tests in this suite are potentially long-running if there are a large number of attributes on the DUT
+    # and the network is slow. Set the default to 3 minutes to account for this.
+    @property
+    def default_timeout(self) -> int:
+        return 180
 
     @async_test_body
     async def setup_test(self):


### PR DESCRIPTION
Both the tests in this suite are potentially long-running if there are a large number of attributes on the DUT and the network is slow. Set the default to 3 minutes to account for this.