### PR TITLE
[ESP32] updated guide for esp-idf v5.1.2

### DIFF
--- a/docs/guides/esp32/setup_idf_chip.md
+++ b/docs/guides/esp32/setup_idf_chip.md
@@ -13,25 +13,25 @@ step.
 
 ### Install Prerequisites
 
--   [Linux](https://docs.espressif.com/projects/esp-idf/en/v5.1/esp32/get-started/linux-macos-setup.html#for-linux-users)
--   [macOS](https://docs.espressif.com/projects/esp-idf/en/v5.1/esp32/get-started/linux-macos-setup.html#for-macos-users)
+-   [Linux](https://docs.espressif.com/projects/esp-idf/en/v5.1.2/esp32/get-started/linux-macos-setup.html#for-linux-users)
+-   [macOS](https://docs.espressif.com/projects/esp-idf/en/v5.1.2/esp32/get-started/linux-macos-setup.html#for-macos-users)
 
-### Get IDF v5.1.1
+### Get IDF v5.1.2
 
--   Clone ESP-IDF [v5.1.1
-    release](https://github.com/espressif/esp-idf/releases/tag/v5.1.1
+-   Clone ESP-IDF [v5.1.2
+    release](https://github.com/espressif/esp-idf/releases/tag/v5.1.2
 
     ```
-    git clone -b v5.1.1 --recursive --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git
+    git clone -b v5.1.2 --recursive --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git
     cd esp-idf
     ./install.sh
     ```
 
--   To update an existing esp-idf toolchain to v5.1.1:
+-   To update an existing esp-idf toolchain to v5.1.2:
 
     ```
     cd path/to/esp-idf
-    git fetch --depth 1 origin v5.1.1
+    git fetch --depth 1 origin v5.1.2
     git reset --hard FETCH_HEAD
     git submodule update --depth 1 --recursive --init
 


### PR DESCRIPTION
Updating documentation for ESP-IDF [v5.1.2](https://github.com/espressif/esp-idf/releases/tag/v5.1.2)

**Tests**
Green CI for ESP32
Built and tested bootstrap, commissioning and control locally.

