### PR TITLE
Fixes #31578 Removed provisional features from DEM to align to 1.3 TE2 test plans

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/device-energy-management-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/device-energy-management-stub.cpp
@@ -52,8 +52,7 @@ void emberAfDeviceEnergyManagementClusterInitCallback(chip::EndpointId endpointI
         BitMask<DeviceEnergyManagement::Feature, uint32_t>(
             DeviceEnergyManagement::Feature::kPowerAdjustment, DeviceEnergyManagement::Feature::kPowerForecastReporting,
             DeviceEnergyManagement::Feature::kStateForecastReporting, DeviceEnergyManagement::Feature::kStartTimeAdjustment,
-            DeviceEnergyManagement::Feature::kPausable, DeviceEnergyManagement::Feature::kForecastAdjustment,
-            DeviceEnergyManagement::Feature::kConstraintBasedAdjustment));
+            DeviceEnergyManagement::Feature::kPausable));
 
     if (!gInstance)
     {

--- a/examples/energy-management-app/esp32/main/main.cpp
+++ b/examples/energy-management-app/esp32/main/main.cpp
@@ -154,8 +154,7 @@ CHIP_ERROR DeviceEnergyManagementInit()
         BitMask<DeviceEnergyManagement::Feature, uint32_t>(
             DeviceEnergyManagement::Feature::kPowerAdjustment, DeviceEnergyManagement::Feature::kPowerForecastReporting,
             DeviceEnergyManagement::Feature::kStateForecastReporting, DeviceEnergyManagement::Feature::kStartTimeAdjustment,
-            DeviceEnergyManagement::Feature::kPausable, DeviceEnergyManagement::Feature::kForecastAdjustment,
-            DeviceEnergyManagement::Feature::kConstraintBasedAdjustment));
+            DeviceEnergyManagement::Feature::kPausable));
 
     if (!gDEMInstance)
     {

--- a/examples/energy-management-app/linux/main.cpp
+++ b/examples/energy-management-app/linux/main.cpp
@@ -77,8 +77,7 @@ CHIP_ERROR DeviceEnergyManagementInit()
         BitMask<DeviceEnergyManagement::Feature, uint32_t>(
             DeviceEnergyManagement::Feature::kPowerAdjustment, DeviceEnergyManagement::Feature::kPowerForecastReporting,
             DeviceEnergyManagement::Feature::kStateForecastReporting, DeviceEnergyManagement::Feature::kStartTimeAdjustment,
-            DeviceEnergyManagement::Feature::kPausable, DeviceEnergyManagement::Feature::kForecastAdjustment,
-            DeviceEnergyManagement::Feature::kConstraintBasedAdjustment));
+            DeviceEnergyManagement::Feature::kPausable));
 
     if (!gDEMInstance)
     {


### PR DESCRIPTION
Fixes #31578 

Removed provisional features from:
- all-clusters-app/device-energy-management-stub.cpp
- energy-management-app/linux/main.cpp
- energy-management-app/esp32/main.cpp