### PR TITLE
Fix build break on Linux all clusters app

### DIFF
--- a/examples/all-clusters-app/linux/diagnostic-logs-provider-delegate-impl.cpp
+++ b/examples/all-clusters-app/linux/diagnostic-logs-provider-delegate-impl.cpp
@@ -152,7 +152,7 @@ size_t LogProvider::GetSizeForIntent(IntentEnum intent)
     auto rv = fclose(fp);
     if (rv != 0)
     {
-        ChipLogError(NotSpecified, "Error when closing file pointer: %p (%d)", fp, errno);
+        ChipLogError(NotSpecified, "Error when closing file pointer (%d)", errno);
     }
 
     return fileSize;


### PR DESCRIPTION
Local compiler is more strict and it broke at build time. Not sure why CI did not catch it.

```
../../../examples/all-clusters-app/linux/third_party/connectedhomeip/examples/all-clusters-app/linux/diagnostic-logs-provider-delegate-impl.cpp: In member function ‘virtual size_t chip::app::Clusters::DiagnosticLogs::LogProvider::GetSizeForIntent(chip::app::Clusters::DiagnosticLogs::IntentEnum)’:
../../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/lib/support/logging/TextOnlyLogging.h:433:31: error: pointer ‘fp’ may be used after ‘int fclose(FILE*)’ [-Werror=use-after-free]
  433 |             chip::Logging::Log(chip::Logging::kLogModule_##MOD, CAT, MSG, ##__VA_ARGS__);                                          \
      |             ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/lib/support/logging/TextOnlyLogging.h:408:9: note: in expansion of macro ‘ChipInternalLogImpl’
  408 |         ChipInternalLogImpl(MOD, CHIP_LOG_CATEGORY_##CAT, MSG, ##__VA_ARGS__);                                                     \
      |         ^~~~~~~~~~~~~~~~~~~
../../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/lib/support/logging/TextOnlyLogging.h:94:37: note: in expansion of macro ‘ChipInternalLog’
   94 | #define ChipLogError(MOD, MSG, ...) ChipInternalLog(MOD, ERROR, MSG, ##__VA_ARGS__)
      |                                     ^~~~~~~~~~~~~~~
../../../examples/all-clusters-app/linux/third_party/connectedhomeip/examples/all-clusters-app/linux/diagnostic-logs-provider-delegate-impl.cpp:155:9: note: in expansion of macro ‘ChipLogError’
  155 |         ChipLogError(NotSpecified, "Error when closing file pointer: %p (%d)", fp, errno);
      |         ^~~~~~~~~~~~
../../../examples/all-clusters-app/linux/third_party/connectedhomeip/examples/all-clusters-app/linux/diagnostic-logs-provider-delegate-impl.cpp:152:21: note: call to ‘int fclose(FILE*)’ here
  152 |     auto rv = fclose(fp);
      |               ~~~~~~^~~~

```

This PR fixes by not logging the FP, which is needless to log anyway.

