### PR TITLE
Add support to Linux examples to report 5GHz Wi-Fi support

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -193,23 +193,24 @@ void InitNetworkCommissioning()
         emberAfEndpointEnableDisable(sSecondaryNetworkCommissioningEndpoint.Value(), false);
     }
 
-    const bool kThreadEnabled = {
+    bool isThreadEnabled = false;
 #if CHIP_APP_MAIN_HAS_THREAD_DRIVER
-        LinuxDeviceOptions::GetInstance().mThread
-#else
-        false
-#endif
-    };
+    isThreadEnabled = LinuxDeviceOptions::GetInstance().mThread;
+#endif // CHIP_APP_MAIN_HAS_THREAD_DRIVER
 
-    const bool kWiFiEnabled = {
+    bool isWiFiEnabled = false;
 #if CHIP_APP_MAIN_HAS_WIFI_DRIVER
-        LinuxDeviceOptions::GetInstance().mWiFi
-#else
-        false
-#endif
-    };
+    isWiFiEnabled = LinuxDeviceOptions::GetInstance().mWiFi;
 
-    if (kThreadEnabled && kWiFiEnabled)
+    // On Linux, command-line indicates whether Wi-Fi is supported since determining it from
+    // the OS level is not easily portable.
+#if CHIP_DEVICE_LAYER_TARGET_LINUX
+    sWiFiDriver.Set5gSupport(LinuxDeviceOptions::GetInstance().wifiSupports5g);
+#endif // CHIP_DEVICE_LAYER_TARGET_LINUX
+
+#endif // CHIP_APP_MAIN_HAS_WIFI_DRIVER
+
+    if (isThreadEnabled && isWiFiEnabled)
     {
         if (sSecondaryNetworkCommissioningEndpoint.HasValue())
         {
@@ -224,11 +225,11 @@ void InitNetworkCommissioning()
             EnableThreadNetworkCommissioning();
         }
     }
-    else if (kThreadEnabled)
+    else if (isThreadEnabled)
     {
         EnableThreadNetworkCommissioning();
     }
-    else if (kWiFiEnabled)
+    else if (isWiFiEnabled)
     {
         EnableWiFiNetworkCommissioning(kRootEndpointId);
     }

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -90,7 +90,7 @@ enum
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     kDeviceOption_SubscriptionCapacity = 0x1024,
 #endif
-    kDeviceOption_WiFiSupports5g                        = 0x1025
+    kDeviceOption_WiFiSupports5g = 0x1025
 };
 
 constexpr unsigned kAppUsageLength = 64;

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -90,6 +90,7 @@ enum
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     kDeviceOption_SubscriptionCapacity = 0x1024,
 #endif
+    kDeviceOption_WiFiSupports5g                        = 0x1025
 };
 
 constexpr unsigned kAppUsageLength = 64;
@@ -100,6 +101,7 @@ OptionDef sDeviceOptionDefs[] = {
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     { "wifi", kNoArgument, kDeviceOption_WiFi },
+    { "wifi-supports-5g", kNoArgument, kDeviceOption_WiFiSupports5g },
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 #if CHIP_ENABLE_OPENTHREAD
     { "thread", kNoArgument, kDeviceOption_Thread },
@@ -161,8 +163,13 @@ const char * sDeviceOptionHelp =
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     "\n"
     "  --wifi\n"
-    "       Enable WiFi management via wpa_supplicant.\n"
+    "       Enable Wi-Fi management via wpa_supplicant.\n"
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    "\n"
+    "  --wifi-supports-5g\n"
+    "       Indicate that local Wi-Fi hardware should report 5GHz support.\n"
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 #if CHIP_ENABLE_OPENTHREAD
     "\n"
     "  --thread\n"
@@ -309,6 +316,10 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 
     case kDeviceOption_WiFi:
         LinuxDeviceOptions::GetInstance().mWiFi = true;
+        break;
+
+    case kDeviceOption_WiFiSupports5g:
+        LinuxDeviceOptions::GetInstance().wifiSupports5g = true;
         break;
 
     case kDeviceOption_Thread:

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -46,6 +46,7 @@ struct LinuxDeviceOptions
     chip::Optional<std::vector<uint8_t>> spake2pSalt;
     uint32_t spake2pIterations = 0; // When not provided (0), will default elsewhere
     uint32_t mBleDevice        = 0;
+    bool wifiSupports5g        = false;
     bool mWiFi                 = false;
     bool mThread               = false;
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE || CHIP_DEVICE_ENABLE_PORT_PARAMS

--- a/src/platform/Linux/NetworkCommissioningDriver.h
+++ b/src/platform/Linux/NetworkCommissioningDriver.h
@@ -77,6 +77,8 @@ public:
         uint8_t credentialsLen = 0;
     };
 
+    void Set5gSupport(bool is5gSupported) { mIs5gSupported = is5gSupported; }
+
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init(BaseDriver::NetworkStatusChangeCallback * networkStatusChangeCallback) override;
@@ -99,11 +101,24 @@ public:
                               uint8_t & outNetworkIndex) override;
     void ScanNetworks(ByteSpan ssid, ScanCallback * callback) override;
 
+    uint32_t GetSupportedWiFiBandsMask() const override
+    {
+        // Default to 2.4G support.
+        uint32_t supportedBands = static_cast<uint32_t>(1UL << chip::to_underlying(WiFiBandEnum::k2g4));
+        if (mIs5gSupported)
+        {
+            supportedBands |= static_cast<uint32_t>(1UL << chip::to_underlying(WiFiBandEnum::k5g));
+        }
+        return supportedBands;
+    }
+
 private:
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
 
     WiFiNetwork mSavedNetwork;
     WiFiNetwork mStagingNetwork;
+    // Whether 5GHz band is supported.
+    bool mIs5gSupported = false;
 };
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 

--- a/src/platform/Linux/NetworkCommissioningDriver.h
+++ b/src/platform/Linux/NetworkCommissioningDriver.h
@@ -103,7 +103,6 @@ public:
 
     uint32_t GetSupportedWiFiBandsMask() const override
     {
-        // Default to 2.4G support.
         uint32_t supportedBands = static_cast<uint32_t>(1UL << chip::to_underlying(WiFiBandEnum::k2g4));
         if (mIs5gSupported)
         {
@@ -117,7 +116,7 @@ private:
 
     WiFiNetwork mSavedNetwork;
     WiFiNetwork mStagingNetwork;
-    // Whether 5GHz band is supported.
+    // Whether 5GHz band is supported, as claimed by callers (`Set5gSupport()`) rather than syscalls.
     bool mIs5gSupported = false;
 };
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA


### PR DESCRIPTION
- Linux has noo easy/portable API to determine 5GHz Wi-Fisupport that could be used in Linux platform examples without large changes.
- To be able to test SupportedWiFiBands attribute, we have to allow reporting the support for 5GHz Wi-Fi when available.
- A workaround was found by adding `--wifi-supports-5g` command line argument to examples, and the requisite plumbing in Linux Wi-Fi driver.

Fixes #30109

Testing done:
- Automated test of TC-CNET-* that use this support the new argument will come in a follow-up.
- Manually testing between invocations with the following:

```
Terminal1: rm -f kvs1 && out/debug/standalone/chip-all-clusters-app --KVS kvs1 --wifi --wifi-supports-5g
Terminal2: ./out/debug/standalone/chip-tool pairing onnetwork 1 20202021
Terminal2: ./out/debug/standalone/chip-tool networkcommissioning read supported-wi-fi-bands 1 0

Verify read has 2 entries: [0, 2]

Terminal1: killall chip-all-clusters-app
Terminal1: out/debug/standalone/chip-all-clusters-app --KVS kvs1 --wifi
Terminal2: ./out/debug/standalone/chip-tool networkcommissioning read supported-wi-fi-bands 1 0

Verify read has 1 entry: [0]
```
