### PR TITLE
Fix a typo in README.md

### DIFF
--- a/examples/minimal-mdns/README.md
+++ b/examples/minimal-mdns/README.md
@@ -44,7 +44,7 @@ which is likely to list a lot of answers.
 You can customize the queries run:
 
 ```sh
-./out/minimal_mdns/minimal-mdns-client -4 -q chip-mdns-demo._matter._tcp.local
+./out/minimal_mdns/minimal-mdns-client -q chip-mdns-demo._matter._tcp.local
 ```
 
 see

--- a/examples/minimal-mdns/README.md
+++ b/examples/minimal-mdns/README.md
@@ -44,7 +44,7 @@ which is likely to list a lot of answers.
 You can customize the queries run:
 
 ```sh
-/out/minimal_mdns/minimal-mdns-client -4 -q chip-mdns-demo._matter._tcp.local
+./out/minimal_mdns/minimal-mdns-client -4 -q chip-mdns-demo._matter._tcp.local
 ```
 
 see


### PR DESCRIPTION
Dear Maintainers,

I have found out that tiny typo in the documentation of the `minimal-mdns`.

The leading current directory `.` appears to be missing here; every other commands specify it.

Regards,
Gaël