### PR TITLE
Fix outdated documentation

### DIFF
--- a/examples/minimal-mdns/README.md
+++ b/examples/minimal-mdns/README.md
@@ -36,7 +36,7 @@ unicast queries.
 Example run:
 
 ```sh
-./out/minimal_mdns/minimal-mdns-client -4
+./out/minimal_mdns/minimal-mdns-client
 ```
 
 which is likely to list a lot of answers.
@@ -44,7 +44,7 @@ which is likely to list a lot of answers.
 You can customize the queries run:
 
 ```sh
-/out/minimal_mdns/minimal-mdns-client -4 -q chip-mdns-demo._matter._tcp.local
+/out/minimal_mdns/minimal-mdns-client -q chip-mdns-demo._matter._tcp.local
 ```
 
 see


### PR DESCRIPTION
Dear Maintainers,

I have found out that the minimal-mdns-client option `-4` has been removed since the commit 0bc15781be9a1bd1f1af7cfd3637150bb1e8b5d5, but the documentation still mention about it.

Regards,
Gaël
