### PR TITLE
Update IDM_1_4 to be more accurate and correct

### DIFF
--- a/src/python_testing/TC_IDM_1_4.py
+++ b/src/python_testing/TC_IDM_1_4.py
@@ -94,7 +94,8 @@ class TC_IDM_1_4(MatterBaseTest):
             await dev_ctrl.TestOnlySendBatchCommands(dut_node_id, list_of_commands_to_send, remoteMaxPathsPerInvoke=number_of_commands_to_send)
             # This might happen after TCP is enabled and DUT supports TCP. See comment above `cap_for_batch_commands`
             # for more information.
-            asserts.assert_not_equal(number_of_commands_to_send, cap_for_batch_commands, "Test needs to be updated! Soft cap `cap_for_batch_commands` added in test is no longer correct")
+            asserts.assert_not_equal(number_of_commands_to_send, cap_for_batch_commands,
+                                     "Test needs to be updated! Soft cap `cap_for_batch_commands` added in test is no longer correct")
             asserts.fail(
                 f"Unexpected success return from sending too many commands, we sent {number_of_commands_to_send}, test capped at {cap_for_batch_commands}")
         except InteractionModelError as e:

--- a/src/python_testing/TC_IDM_1_4.py
+++ b/src/python_testing/TC_IDM_1_4.py
@@ -95,11 +95,13 @@ class TC_IDM_1_4(MatterBaseTest):
             # This might happen after TCP is enabled and DUT supports TCP. See comment above `cap_for_batch_commands`
             # for more information.
             asserts.assert_not_equal(number_of_commands_to_send, cap_for_batch_commands,
-                                     "Test needs to be updated! Soft cap `cap_for_batch_commands` added in test is no longer correct")
+                                     "Test needs to be updated! Soft cap `cap_for_batch_commands` used in test is no longer correct")
             asserts.fail(
                 f"Unexpected success return from sending too many commands, we sent {number_of_commands_to_send}, test capped at {cap_for_batch_commands}")
         except InteractionModelError as e:
-            # This check is for 2.b, mentioned above. If this assert occurs test likely needs updating. Although DUT is still going to fail.
+            # This check is for 2.b, mentioned above. If this assert occurs, test likely needs updating. Although DUT
+            # is still going to fail since it seemingly is failing to process a smaller number then it is reporting
+            # that it is capable of processing.
             asserts.assert_equal(number_of_commands_to_send, max_paths_per_invoke + 1,
                                  "Test didn't send as many command as max_paths_per_invoke + 1, likely due to MTU cap_for_batch_commands, but we still got an error from server. This should have been a success from server")
             asserts.assert_equal(e.status, Status.InvalidAction,
@@ -114,13 +116,7 @@ class TC_IDM_1_4(MatterBaseTest):
             logging.info("DUTs reported MaxPathsPerInvoke + 1 is larger than what fits into MTU. Test step is skipped")
 
         if max_paths_per_invoke == 1:
-            self.skip_step(3)
-            self.skip_step(4)
-            self.skip_step(5)
-            self.skip_step(6)
-            self.skip_step(7)
-            self.skip_step(8)
-            self.skip_step(9)
+            self.skip_all_remaining_steps(3)
         else:
             await self.steps_3_to_9(False)
 

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -888,7 +888,6 @@ class MatterBaseTest(base_test.BaseTestClass):
             steps = self.get_test_steps(self.current_test_info.name)
             if self.current_step_index == 0:
                 asserts.fail("Script error: mark_current_step_skipped cannot be called before step()")
-            print(self.current_step_index-1)
             num = steps[self.current_step_index-1].test_plan_number
         except KeyError:
             num = self.current_step_index
@@ -905,6 +904,17 @@ class MatterBaseTest(base_test.BaseTestClass):
     def skip_step(self, step):
         self.step(step)
         self.mark_current_step_skipped()
+
+    def skip_all_remaining_steps(self, starting_step):
+        ''' Skips all remaining test steps starting with provided starting step
+
+            starting_step must be provided, and is not derived intentionally. By providing argument
+                test is more deliberately identifying where test skips are starting from, making
+                it easier to validate against the test plan for correctness.
+        '''
+        last_step = len(self.get_test_steps(self.current_test_info.name)) +1
+        for index in range(starting_step, last_step):
+            self.skip_step(index)
 
     def step(self, step: typing.Union[int, str]):
         test_name = self.current_test_info.name

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -912,7 +912,7 @@ class MatterBaseTest(base_test.BaseTestClass):
                 test is more deliberately identifying where test skips are starting from, making
                 it easier to validate against the test plan for correctness.
         '''
-        last_step = len(self.get_test_steps(self.current_test_info.name)) +1
+        last_step = len(self.get_test_steps(self.current_test_info.name)) + 1
         for index in range(starting_step, last_step):
             self.skip_step(index)
 


### PR DESCRIPTION
Fixes:
* Fixes typos and copy and paste errors
* Properly use `step` instead of `print_step`
  * This requires properly listing off step
* Now that #31139 is addressed, make use of `skip_step`
