### PR TITLE
Python testing hello example: Fix for TH expectations

### DIFF
--- a/src/python_testing/hello_external_runner.py
+++ b/src/python_testing/hello_external_runner.py
@@ -137,9 +137,9 @@ def main():
     app_process = subprocess.Popen([app_cmd], stdout=sys.stdout, stderr=sys.stderr, bufsize=0)
 
     commission()
-    one_test('test_failure_on_wrong_endpoint')
-    one_test('test_names_as_expected')
-    one_test('test_pics')
+    one_test('test_TC_NAMES_2_1')
+    one_test('test_TC_ENDPOINT_2_1')
+    one_test('test_TC_PICSTEST_2_1')
 
     app_process.send_signal(signal.SIGINT.value)
     app_process.wait()

--- a/src/python_testing/hello_test.py
+++ b/src/python_testing/hello_test.py
@@ -27,8 +27,10 @@ class HelloTest(MatterBaseTest):
     # This example test does not include the step_ and desc_ markers
     # The MatterBaseTest will assume a single step and create a description
     # based on the test name
+    # To work in the Test harness, all tests should be named as
+    # TC_PICSCODE_#_#, (substituting the appropriate pics codes and numbers for the test)
     @async_test_body
-    async def test_names_as_expected(self):
+    async def test_TC_NAMES_2_1(self):
         dev_ctrl = self.default_controller
         vendor_name = await self.read_single_attribute(
             dev_ctrl,
@@ -44,17 +46,19 @@ class HelloTest(MatterBaseTest):
     # for the test, then use self.step(#) to indicate how the test proceeds through the test plan.
     # Support for keeping the TH up to date is built into MatterBaseTest when you use the step()
     # function.
-    def steps_failure_on_wrong_endpoint(self) -> list[TestStep]:
+    # If the device needs to be commissioned before running the test, ensure the first step in
+    # this function is marked is_commissioning=True.
+    def steps_TC_ENDPOINT_2_1(self) -> list[TestStep]:
         steps = [TestStep(1, "Commissioning, already done", is_commissioning=True),
                  TestStep(2, "Read ProductName on endpoint 9999"),
                  ]
         return steps
 
-    def desc_failure_on_wrong_endpoint(self) -> str:
+    def desc_TC_ENDPOINT_2_1(self) -> str:
         return '#.#.#. [TC-HELLO-x.x] Test Failure On Wrong Endpoint'
 
     @async_test_body
-    async def test_failure_on_wrong_endpoint(self):
+    async def test_TC_ENDPOINT_2_1(self):
         self.step(1)  # Commissioning
 
         self.step(2)
@@ -68,7 +72,7 @@ class HelloTest(MatterBaseTest):
         asserts.assert_true(isinstance(result, Clusters.Attribute.ValueDecodeFailure), "Should fail to read on endpoint 9999")
         asserts.assert_equal(result.Reason.status, Status.UnsupportedEndpoint, "Failure reason should be UnsupportedEndpoint")
 
-    def steps_pics(self) -> list[TestStep]:
+    def steps_TC_PICSTEST_2_1(self) -> list[TestStep]:
         steps = [TestStep(1, "Commissioning, already done", is_commissioning=True),
                  TestStep(2, "Skip this step based on pics"),
                  TestStep(3, "Run this step"),
@@ -76,11 +80,11 @@ class HelloTest(MatterBaseTest):
                  ]
         return steps
 
-    def desc_pics(self) -> str:
+    def desc_TC_PICSTEST_2_1(self) -> str:
         return "#.#.#. [TC-HELLO-x.x] Test pics"
 
     @async_test_body
-    async def test_pics(self):
+    async def test_TC_PICSTEST_2_1(self):
         self.step(1)  # commissioning
         print('This should be run')
 


### PR DESCRIPTION
The TH expects tests to appear in a certain way to be properly picked up and parsed. Add instructions in the hello test and change the example names to match the expectations.