### PR TITLE
Fix mypy complaints about nullability

### DIFF
--- a/scripts/py_matter_idl/matter_idl/backwards_compatibility.py
+++ b/scripts/py_matter_idl/matter_idl/backwards_compatibility.py
@@ -279,8 +279,10 @@ class CompatibilityChecker:
         for original_cluster in original:
             updated_cluster = updated_clusters.get(original_cluster.name)
 
-            if not_stable(updated_cluster.api_maturity) or not_stable(original_cluster.api_maturity):
-                # no point in checking
+            if not_stable(original_cluster.api_maturity):
+                continue
+
+            if updated_cluster and not_stable(updated_cluster.api_maturity):
                 continue
 
             self._check_cluster_compatible(original_cluster, updated_cluster)


### PR DESCRIPTION
Ran `MYPYPATH=scripts/py_matter_idl mypy scripts/backwards_compatibility_checker.py` and it says that I am trying to use a property on something that is potentially None.

It was correct, so I fixed it.
