### PR TITLE
[Docker][K32W1] Update to SDK 2.12.6

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-32 : [Telink] Update Docker image (Zephyr update)
+33 : [K32W1] Update to SDK 2.12.6

--- a/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
@@ -24,9 +24,9 @@ RUN set -x \
 
 RUN set -x \
     && mkdir -p k32w1 \
-    && wget https://cache.nxp.com/lgfiles/bsps/SDK_2_12_5_K32W148-EVK.zip \
-    && unzip SDK_2_12_5_K32W148-EVK.zip -d k32w1 \
-    && rm -rf SDK_2_12_5_K32W148-EVK.zip
+    && wget https://cache.nxp.com/lgfiles/bsps/SDK_2_12_6_K32W148-EVK.zip \
+    && unzip SDK_2_12_6_K32W148-EVK.zip -d k32w1 \
+    && rm -rf SDK_2_12_6_K32W148-EVK.zip
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}
 


### PR DESCRIPTION
Update docker image to pull K32W1 SDK 2.12.6
An upcoming PR will bring SDK 2.12.6 changes to K32W1 platform.

