### PR TITLE
Rvc op state delegate dummy start stop handlers

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/rvc-operational-state-delegate-impl.h
+++ b/examples/all-clusters-app/all-clusters-common/include/rvc-operational-state-delegate-impl.h
@@ -91,18 +91,6 @@ public:
     void HandleResumeStateCallback(OperationalState::GenericOperationalError & err) override;
 
     /**
-     * Handle Command Callback in application: Start
-     * @param[out] get operational error after callback.
-     */
-    void HandleStartStateCallback(OperationalState::GenericOperationalError & err) override;
-
-    /**
-     * Handle Command Callback in application: Stop
-     * @param[out] get operational error after callback.
-     */
-    void HandleStopStateCallback(OperationalState::GenericOperationalError & err) override;
-
-    /**
      * Handle the GoHome command.
      * @param err
      */

--- a/examples/all-clusters-app/all-clusters-common/src/rvc-operational-state-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/rvc-operational-state-delegate-impl.cpp
@@ -70,34 +70,6 @@ void RvcOperationalStateDelegate::HandleResumeStateCallback(OperationalState::Ge
     }
 }
 
-void RvcOperationalStateDelegate::HandleStartStateCallback(OperationalState::GenericOperationalError & err)
-{
-    // placeholder implementation
-    auto error = GetInstance()->SetOperationalState(to_underlying(OperationalState::OperationalStateEnum::kRunning));
-    if (error == CHIP_NO_ERROR)
-    {
-        err.Set(to_underlying(OperationalState::ErrorStateEnum::kNoError));
-    }
-    else
-    {
-        err.Set(to_underlying(OperationalState::ErrorStateEnum::kUnableToCompleteOperation));
-    }
-}
-
-void RvcOperationalStateDelegate::HandleStopStateCallback(OperationalState::GenericOperationalError & err)
-{
-    // placeholder implementation
-    auto error = GetInstance()->SetOperationalState(to_underlying(OperationalState::OperationalStateEnum::kStopped));
-    if (error == CHIP_NO_ERROR)
-    {
-        err.Set(to_underlying(OperationalState::ErrorStateEnum::kNoError));
-    }
-    else
-    {
-        err.Set(to_underlying(OperationalState::ErrorStateEnum::kUnableToCompleteOperation));
-    }
-}
-
 void RvcOperationalStateDelegate::HandleGoHomeCommandCallback(OperationalState::GenericOperationalError & err)
 {
     // placeholder implementation

--- a/examples/rvc-app/rvc-common/include/rvc-operational-state-delegate.h
+++ b/examples/rvc-app/rvc-common/include/rvc-operational-state-delegate.h
@@ -99,22 +99,6 @@ public:
      */
     void HandleResumeStateCallback(Clusters::OperationalState::GenericOperationalError & err) override;
 
-    /**
-     * Handle Command Callback in application: Start
-     * @param[out] get operational error after callback.
-     */
-    void HandleStartStateCallback(Clusters::OperationalState::GenericOperationalError & err) override{
-        // This command in not supported.
-    };
-
-    /**
-     * Handle Command Callback in application: Stop
-     * @param[out] get operational error after callback.
-     */
-    void HandleStopStateCallback(Clusters::OperationalState::GenericOperationalError & err) override{
-        // This command in not supported.
-    };
-
     void SetPauseCallback(HandleOpStateCommand aCallback, RvcDevice * aInstance)
     {
         mPauseCallback          = aCallback;

--- a/src/app/clusters/operational-state-server/operational-state-server.h
+++ b/src/app/clusters/operational-state-server/operational-state-server.h
@@ -351,7 +351,7 @@ public:
     };
 
     /**
-     * The start command is not supported by the RvcOpeartionalState cluster hence this method shold never de called.
+     * The start command is not supported by the RvcOperationalState cluster hence this method should never be called.
      * This is a dummy implementation of the handler method so the consumer of this class does not need to define it.
      */
     void HandleStartStateCallback(OperationalState::GenericOperationalError & err) override
@@ -360,7 +360,7 @@ public:
     };
 
     /**
-     * The stop command is not supported by the RvcOpeartionalState cluster hence this method shold never de called.
+     * The stop command is not supported by the RvcOperationalState cluster hence this method should never be called.
      * This is a dummy implementation of the handler method so the consumer of this class does not need to define it.
      */
     void HandleStopStateCallback(OperationalState::GenericOperationalError & err) override

--- a/src/app/clusters/operational-state-server/operational-state-server.h
+++ b/src/app/clusters/operational-state-server/operational-state-server.h
@@ -354,7 +354,8 @@ public:
      * The start command is not supported by the RvcOpeartionalState cluster hence this method shold never de called.
      * This is a dummy implementation of the handler method so the consumer of this class does not need to define it.
      */
-    void HandleStartStateCallback(OperationalState::GenericOperationalError & err) override {
+    void HandleStartStateCallback(OperationalState::GenericOperationalError & err) override
+    {
         err.Set(to_underlying(OperationalState::ErrorStateEnum::kUnknownEnumValue));
     };
 
@@ -362,10 +363,10 @@ public:
      * The stop command is not supported by the RvcOpeartionalState cluster hence this method shold never de called.
      * This is a dummy implementation of the handler method so the consumer of this class does not need to define it.
      */
-    void HandleStopStateCallback(OperationalState::GenericOperationalError & err) override {
+    void HandleStopStateCallback(OperationalState::GenericOperationalError & err) override
+    {
         err.Set(to_underlying(OperationalState::ErrorStateEnum::kUnknownEnumValue));
     };
-
 };
 
 class Instance : public OperationalState::Instance

--- a/src/app/clusters/operational-state-server/operational-state-server.h
+++ b/src/app/clusters/operational-state-server/operational-state-server.h
@@ -341,10 +341,31 @@ namespace RvcOperationalState {
 class Delegate : public OperationalState::Delegate
 {
 public:
+    /**
+     * Handle Command Callback in application: GoHome
+     * @param[out] err operational error after callback.
+     */
     virtual void HandleGoHomeCommandCallback(OperationalState::GenericOperationalError & err)
     {
         err.Set(to_underlying(OperationalState::ErrorStateEnum::kUnknownEnumValue));
     };
+
+    /**
+     * The start command is not supported by the RvcOpeartionalState cluster hence this method shold never de called.
+     * This is a dummy implementation of the handler method so the consumer of this class does not need to define it.
+     */
+    void HandleStartStateCallback(OperationalState::GenericOperationalError & err) override {
+        err.Set(to_underlying(OperationalState::ErrorStateEnum::kUnknownEnumValue));
+    };
+
+    /**
+     * The stop command is not supported by the RvcOpeartionalState cluster hence this method shold never de called.
+     * This is a dummy implementation of the handler method so the consumer of this class does not need to define it.
+     */
+    void HandleStopStateCallback(OperationalState::GenericOperationalError & err) override {
+        err.Set(to_underlying(OperationalState::ErrorStateEnum::kUnknownEnumValue));
+    };
+
 };
 
 class Instance : public OperationalState::Instance


### PR DESCRIPTION
Fixes #31761

In summary, this PR defines dummy implementations for the `start` and `stop` command handlers in the `RvcOperationalState::Delegate` class, and removes the definitions of the `start` and `stop` command handlers in the all-clusters-app and rvc-app.
