### PR TITLE
[shell] Fixes for Matter cli

### DIFF
--- a/examples/shell/shell_common/cmd_otcli.cpp
+++ b/examples/shell/shell_common/cmd_otcli.cpp
@@ -48,6 +48,7 @@ static char sTxBuffer[SHELL_OTCLI_TX_BUFFER_SIZE];
 static constexpr uint16_t sTxLength = SHELL_OTCLI_TX_BUFFER_SIZE;
 #endif // !CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI)
 #endif
+static constexpr uint16_t kMaxLineLength = 384;
 #else
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -81,8 +82,6 @@ CHIP_ERROR cmd_otcli_dispatch(int argc, char ** argv)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
 
-// From OT CLI internal lib, kMaxLineLength = 128
-#define kMaxLineLength 128
     char buff[kMaxLineLength] = { 0 };
     char * buff_ptr           = buff;
     int i                     = 0;

--- a/src/lib/shell/MainLoopDefault.cpp
+++ b/src/lib/shell/MainLoopDefault.cpp
@@ -69,6 +69,7 @@ size_t ReadLine(char * buffer, size_t max)
                 done = true;
             }
             break;
+        case 0x08:
         case 0x7F:
             // Do not accept backspace character (i.e. don't increment line_sz) and remove 1 additional character if it exists.
             if (line_sz >= 1u)


### PR DESCRIPTION
* Add backspace character handling in ReadLine
* The otcli command buffer (128) was to small for some ot commands like otcli dataset set active <hex dataset>. The 128 value was taken from an OT config a long time ago and since was increased to 384.