### PR TITLE
When dimming a light/bulb over time or changing color the thread network can be spammed

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -2602,6 +2602,21 @@ void ColorControlServer::updateTempCommand(EndpointId endpoint)
 
     isColorTempTransitionDone = computeNewColor16uValue(colorTempTransitionState);
 
+    if (!isColorTempTransitionDone) {
+        // Check whether our color temperature has actually changed.  If not, do
+        // nothing, and wait for it to change.
+        uint16_t currentColorTemp;
+        if (Attributes::ColorTemperatureMireds::Get(endpoint, &currentColorTemp) != EMBER_ZCL_STATUS_SUCCESS) {
+            // Why can't we read our attribute?
+            return;
+        }
+
+        if (currentColorTemp == colorTempTransitionState->currentValue) {
+            scheduleTimerCallbackMs(configureTempEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
+            return;
+        }
+    }
+
     Attributes::RemainingTime::Set(endpoint, colorTempTransitionState->timeRemaining);
 
     if (isColorTempTransitionDone)

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -2602,16 +2602,19 @@ void ColorControlServer::updateTempCommand(EndpointId endpoint)
 
     isColorTempTransitionDone = computeNewColor16uValue(colorTempTransitionState);
 
-    if (!isColorTempTransitionDone) {
+    if (!isColorTempTransitionDone)
+    {
         // Check whether our color temperature has actually changed.  If not, do
         // nothing, and wait for it to change.
         uint16_t currentColorTemp;
-        if (Attributes::ColorTemperatureMireds::Get(endpoint, &currentColorTemp) != EMBER_ZCL_STATUS_SUCCESS) {
+        if (Attributes::ColorTemperatureMireds::Get(endpoint, &currentColorTemp) != EMBER_ZCL_STATUS_SUCCESS)
+        {
             // Why can't we read our attribute?
             return;
         }
 
-        if (currentColorTemp == colorTempTransitionState->currentValue) {
+        if (currentColorTemp == colorTempTransitionState->currentValue)
+        {
             scheduleTimerCallbackMs(configureTempEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
             return;
         }


### PR DESCRIPTION
Ask a device to transition over 30 minutes between colors. Notice that the SDK will update the RemainingTime attribute every 100ms by default, we should only update this when the color changes