### PR TITLE
[Android] Remove JniClass and fix multiple local/global reference leaks in JNI

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
@@ -32,7 +32,7 @@ CHIP_ERROR convertJAppParametersToCppAppParams(jobject appParameters, AppParams 
 
     jclass jAppParametersClass;
     ReturnErrorOnFailure(
-        chip::JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/AppParameters", jAppParametersClass));
+        chip::JniReferences::GetInstance().GetLocalClassRef(env, "com/chip/casting/AppParameters", jAppParametersClass));
 
     jmethodID getRotatingDeviceIdUniqueIdMethod = env->GetMethodID(jAppParametersClass, "getRotatingDeviceIdUniqueId", "()[B");
     if (getRotatingDeviceIdUniqueIdMethod == nullptr)
@@ -67,7 +67,7 @@ CHIP_ERROR convertJContentAppToTargetEndpointInfo(jobject contentApp, TargetEndp
     JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
 
     jclass jContentAppClass;
-    ReturnErrorOnFailure(chip::JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/ContentApp", jContentAppClass));
+    ReturnErrorOnFailure(chip::JniReferences::GetInstance().GetLocalClassRef(env, "com/chip/casting/ContentApp", jContentAppClass));
 
     jfieldID jEndpointIdField = env->GetFieldID(jContentAppClass, "endpointId", "S");
     jshort jEndpointId        = env->GetShortField(contentApp, jEndpointIdField);
@@ -104,7 +104,8 @@ CHIP_ERROR convertTargetEndpointInfoToJContentApp(TargetEndpointInfo * targetEnd
         JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
 
         jclass jContentAppClass;
-        ReturnErrorOnFailure(chip::JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/ContentApp", jContentAppClass));
+        ReturnErrorOnFailure(
+            chip::JniReferences::GetInstance().GetLocalClassRef(env, "com/chip/casting/ContentApp", jContentAppClass));
         jmethodID jContentAppConstructor = env->GetMethodID(jContentAppClass, "<init>", "(SLjava/util/List;)V");
         chip::ClusterId * clusters       = targetEndpointInfo->GetClusters();
         jobject jClustersArrayList       = nullptr;
@@ -132,7 +133,8 @@ CHIP_ERROR convertJVideoPlayerToTargetVideoPlayerInfo(jobject videoPlayer, Targe
     JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
 
     jclass jVideoPlayerClass;
-    ReturnErrorOnFailure(chip::JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/VideoPlayer", jVideoPlayerClass));
+    ReturnErrorOnFailure(
+        chip::JniReferences::GetInstance().GetLocalClassRef(env, "com/chip/casting/VideoPlayer", jVideoPlayerClass));
 
     jfieldID jNodeIdField = env->GetFieldID(jVideoPlayerClass, "nodeId", "J");
     chip::NodeId nodeId   = static_cast<chip::NodeId>(env->GetLongField(videoPlayer, jNodeIdField));
@@ -206,7 +208,8 @@ CHIP_ERROR convertJVideoPlayerToTargetVideoPlayerInfo(jobject videoPlayer, Targe
         jobject jContentApp = env->CallObjectMethod(jIterator, jNextMid);
 
         jclass jContentAppClass;
-        ReturnErrorOnFailure(chip::JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/ContentApp", jContentAppClass));
+        ReturnErrorOnFailure(
+            chip::JniReferences::GetInstance().GetLocalClassRef(env, "com/chip/casting/ContentApp", jContentAppClass));
         jfieldID jEndpointIdField     = env->GetFieldID(jContentAppClass, "endpointId", "S");
         chip::EndpointId endpointId   = static_cast<chip::EndpointId>(env->GetShortField(jContentApp, jEndpointIdField));
         TargetEndpointInfo * endpoint = outTargetVideoPlayerInfo.GetOrAddEndpoint(endpointId);
@@ -226,7 +229,7 @@ CHIP_ERROR convertTargetVideoPlayerInfoToJVideoPlayer(TargetVideoPlayerInfo * ta
 
         jclass jVideoPlayerClass;
         ReturnErrorOnFailure(
-            chip::JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/VideoPlayer", jVideoPlayerClass));
+            chip::JniReferences::GetInstance().GetLocalClassRef(env, "com/chip/casting/VideoPlayer", jVideoPlayerClass));
         jmethodID jVideoPlayerConstructor = env->GetMethodID(jVideoPlayerClass, "<init>",
                                                              "(JBLjava/lang/String;IIILjava/util/List;ILjava/util/List;Ljava/lang/"
                                                              "String;Ljava/lang/String;IJLjava/lang/String;ZZ)V");
@@ -277,7 +280,8 @@ CHIP_ERROR convertTargetVideoPlayerInfoToJVideoPlayer(TargetVideoPlayerInfo * ta
                 jstring jIPAddressStr = env->NewStringUTF(addrCString);
 
                 jclass jIPAddressClass;
-                ReturnErrorOnFailure(chip::JniReferences::GetInstance().GetClassRef(env, "java/net/InetAddress", jIPAddressClass));
+                ReturnErrorOnFailure(
+                    chip::JniReferences::GetInstance().GetLocalClassRef(env, "java/net/InetAddress", jIPAddressClass));
                 jmethodID jGetByNameMid =
                     env->GetStaticMethodID(jIPAddressClass, "getByName", "(Ljava/lang/String;)Ljava/net/InetAddress;");
                 jobject jIPAddress = env->CallStaticObjectMethod(jIPAddressClass, jGetByNameMid, jIPAddressStr);
@@ -306,7 +310,7 @@ CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscovered
 
     jclass jDiscoveredNodeDataClass;
     ReturnErrorOnFailure(
-        chip::JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/DiscoveredNodeData", jDiscoveredNodeDataClass));
+        chip::JniReferences::GetInstance().GetLocalClassRef(env, "com/chip/casting/DiscoveredNodeData", jDiscoveredNodeDataClass));
 
     jfieldID getHostNameField = env->GetFieldID(jDiscoveredNodeDataClass, "hostName", "Ljava/lang/String;");
     jstring jHostName         = static_cast<jstring>(env->GetObjectField(jDiscoveredNodeData, getHostNameField));
@@ -392,7 +396,7 @@ CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscovered
     {
         jobject jIPAddress = env->CallObjectMethod(jIterator, jNextMid);
         jclass jIPAddressClass;
-        ReturnErrorOnFailure(chip::JniReferences::GetInstance().GetClassRef(env, "java/net/InetAddress", jIPAddressClass));
+        ReturnErrorOnFailure(chip::JniReferences::GetInstance().GetLocalClassRef(env, "java/net/InetAddress", jIPAddressClass));
         jmethodID jGetHostAddressMid = env->GetMethodID(jIPAddressClass, "getHostAddress", "()Ljava/lang/String;");
         jstring jIPAddressStr        = static_cast<jstring>(env->CallObjectMethod(jIPAddress, jGetHostAddressMid));
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
@@ -202,10 +202,12 @@ jobject CurrentStateSuccessHandlerJNI::ConvertToJObject(
 {
     ChipLogProgress(AppServer, "CurrentStateSuccessHandlerJNI::ConvertToJObject called");
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != nullptr, ChipLogError(AppServer, "Could not get JNIEnv for current thread"));
+    JniLocalReferenceManager manager(env);
 
     jclass enumClass = nullptr;
     CHIP_ERROR err =
-        JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/MediaPlaybackTypes$PlaybackStateEnum", enumClass);
+        JniReferences::GetInstance().GetLocalClassRef(env, "com/chip/casting/MediaPlaybackTypes$PlaybackStateEnum", enumClass);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "ConvertToJObject: Class for Response Type not found!");
@@ -251,6 +253,8 @@ jobject SampledPositionSuccessHandlerJNI::ConvertToJObject(
 {
     ChipLogProgress(AppServer, "SampledPositionSuccessHandlerJNI::ConvertToJObject called");
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != nullptr, ChipLogError(AppServer, "Could not get JNIEnv for current thread"));
+    JniLocalReferenceManager manager(env);
 
     jobject jSampledPosition = nullptr;
     if (!responseData.IsNull())
@@ -259,8 +263,8 @@ jobject SampledPositionSuccessHandlerJNI::ConvertToJObject(
             responseData.Value();
 
         jclass responseTypeClass = nullptr;
-        CHIP_ERROR err = JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/MediaPlaybackTypes$PlaybackPositionStruct",
-                                                                  responseTypeClass);
+        CHIP_ERROR err           = JniReferences::GetInstance().GetLocalClassRef(
+            env, "com/chip/casting/MediaPlaybackTypes$PlaybackPositionStruct", responseTypeClass);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "ConvertToJObject: Class for Response Type not found!");
@@ -318,6 +322,8 @@ jobject TargetListSuccessHandlerJNI::ConvertToJObject(
     ChipLogProgress(AppServer, "TargetListSuccessHandlerJNI::ConvertToJObject called");
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != nullptr, ChipLogError(AppServer, "Could not get JNIEnv for current thread"));
+    JniLocalReferenceManager manager(env);
 
     jobject jArrayList;
     chip::JniReferences::GetInstance().CreateArrayList(jArrayList);
@@ -327,8 +333,8 @@ jobject TargetListSuccessHandlerJNI::ConvertToJObject(
         const chip::app::Clusters::TargetNavigator::Structs::TargetInfoStruct::DecodableType & targetInfo = iter.GetValue();
 
         jclass responseTypeClass = nullptr;
-        CHIP_ERROR err =
-            JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/TargetNavigatorTypes$TargetInfo", responseTypeClass);
+        CHIP_ERROR err = JniReferences::GetInstance().GetLocalClassRef(env, "com/chip/casting/TargetNavigatorTypes$TargetInfo",
+                                                                       responseTypeClass);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "ConvertToJObject: Class for Response Type not found!");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
@@ -202,7 +202,7 @@ jobject CurrentStateSuccessHandlerJNI::ConvertToJObject(
 {
     ChipLogProgress(AppServer, "CurrentStateSuccessHandlerJNI::ConvertToJObject called");
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    VerifyOrReturn(env != nullptr, ChipLogError(AppServer, "Could not get JNIEnv for current thread"));
+    VerifyOrReturnValue(env != nullptr, nullptr);
     JniLocalReferenceManager manager(env);
 
     jclass enumClass = nullptr;
@@ -253,7 +253,7 @@ jobject SampledPositionSuccessHandlerJNI::ConvertToJObject(
 {
     ChipLogProgress(AppServer, "SampledPositionSuccessHandlerJNI::ConvertToJObject called");
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    VerifyOrReturn(env != nullptr, ChipLogError(AppServer, "Could not get JNIEnv for current thread"));
+    VerifyOrReturnValue(env != nullptr, nullptr);
     JniLocalReferenceManager manager(env);
 
     jobject jSampledPosition = nullptr;
@@ -322,7 +322,7 @@ jobject TargetListSuccessHandlerJNI::ConvertToJObject(
     ChipLogProgress(AppServer, "TargetListSuccessHandlerJNI::ConvertToJObject called");
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    VerifyOrReturn(env != nullptr, ChipLogError(AppServer, "Could not get JNIEnv for current thread"));
+    VerifyOrReturnValue(env != nullptr, nullptr);
     JniLocalReferenceManager manager(env);
 
     jobject jArrayList;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -124,7 +124,8 @@ JNI_METHOD(jboolean, openBasicCommissioningWindow)
 
     CommissioningCallbacks commissioningCallbacks;
     jclass jCommissioningCallbacksClass;
-    chip::JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/CommissioningCallbacks", jCommissioningCallbacksClass);
+    chip::JniReferences::GetInstance().GetLocalClassRef(env, "com/chip/casting/CommissioningCallbacks",
+                                                        jCommissioningCallbacksClass);
 
     jfieldID jCommissioningCompleteField =
         env->GetFieldID(jCommissioningCallbacksClass, "commissioningComplete", "Ljava/lang/Object;");
@@ -458,8 +459,8 @@ CHIP_ERROR CreateContentSearch(JNIEnv * env, jobject jSearch,
                                ListFreer & listFreer)
 {
     jclass jContentSearchClass;
-    ReturnErrorOnFailure(
-        JniReferences::GetInstance().GetClassRef(env, "com/chip/casting/ContentLauncherTypes$ContentSearch", jContentSearchClass));
+    ReturnErrorOnFailure(JniReferences::GetInstance().GetLocalClassRef(env, "com/chip/casting/ContentLauncherTypes$ContentSearch",
+                                                                       jContentSearchClass));
 
     jfieldID jParameterListField = env->GetFieldID(jContentSearchClass, "parameterList", "Ljava/util/ArrayList;");
     jobject jParameterList       = env->GetObjectField(jSearch, jParameterListField);

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
@@ -112,7 +112,7 @@ jobject extractJAppParameter(jobject jAppParameters, const char * methodName, co
 
     jclass jAppParametersClass;
     CHIP_ERROR err =
-        chip::JniReferences::GetInstance().GetClassRef(env, "com/matter/casting/support/AppParameters", jAppParametersClass);
+        chip::JniReferences::GetInstance().GetLocalClassRef(env, "com/matter/casting/support/AppParameters", jAppParametersClass);
     VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr);
 
     // get the RotatingDeviceIdUniqueIdProvider

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/ErrorConverter-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/ErrorConverter-JNI.cpp
@@ -30,7 +30,7 @@ jobject createJMatterError(CHIP_ERROR inErr)
     JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
     jclass jMatterErrorClass;
     CHIP_ERROR err =
-        chip::JniReferences::GetInstance().GetClassRef(env, "com/matter/casting/support/MatterError", jMatterErrorClass);
+        chip::JniReferences::GetInstance().GetLocalClassRef(env, "com/matter/casting/support/MatterError", jMatterErrorClass);
     VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr);
 
     jmethodID jMatterErrorConstructor = env->GetMethodID(jMatterErrorClass, "<init>", "(JLjava/lang/String;)V");

--- a/src/controller/java/AndroidClusterExceptions.cpp
+++ b/src/controller/java/AndroidClusterExceptions.cpp
@@ -30,76 +30,17 @@ CHIP_ERROR AndroidClusterExceptions::CreateChipClusterException(JNIEnv * env, ui
     jmethodID exceptionConstructor;
     jclass clusterExceptionCls;
 
-    err = chip::JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipClusterException", clusterExceptionCls);
+    err =
+        chip::JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/ChipClusterException", clusterExceptionCls);
     VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
-    chip::JniClass clusterExceptionJniCls(clusterExceptionCls);
 
     exceptionConstructor = env->GetMethodID(clusterExceptionCls, "<init>", "(J)V");
     VerifyOrReturnError(exceptionConstructor != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
 
-    outEx = (jthrowable) env->NewObject(clusterExceptionCls, exceptionConstructor, static_cast<jlong>(errorCode));
+    outEx = static_cast<jthrowable>(env->NewObject(clusterExceptionCls, exceptionConstructor, static_cast<jlong>(errorCode)));
     VerifyOrReturnError(outEx != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
 
     return err;
-}
-
-CHIP_ERROR AndroidClusterExceptions::CreateIllegalStateException(JNIEnv * env, const char message[], ChipError errorCode,
-                                                                 jthrowable & outEx)
-{
-    return CreateIllegalStateException(env, message, errorCode.AsInteger(), outEx);
-}
-
-CHIP_ERROR AndroidClusterExceptions::CreateIllegalStateException(JNIEnv * env, const char message[],
-                                                                 ChipError::StorageType errorCode, jthrowable & outEx)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    jmethodID exceptionConstructor;
-    jclass exceptionClass;
-    jstring errStr;
-
-    err = JniReferences::GetInstance().GetClassRef(env, "java/lang/IllegalStateException", exceptionClass);
-    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
-    JniClass exceptionJniClass(exceptionClass);
-
-    exceptionConstructor = env->GetMethodID(exceptionClass, "<init>", "(Ljava/lang/String;)V");
-    VerifyOrReturnError(exceptionConstructor != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
-
-    char buf[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
-    snprintf(buf, sizeof(buf), "%s: %d", message, errorCode);
-    errStr = env->NewStringUTF(buf);
-
-    outEx = static_cast<jthrowable>(env->NewObject(exceptionClass, exceptionConstructor, errStr));
-    VerifyOrReturnError(outEx != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
-
-    return err;
-}
-
-void AndroidClusterExceptions::ReturnIllegalStateException(JNIEnv * env, jobject callback, const char message[], ChipError error)
-{
-    ReturnIllegalStateException(env, callback, message, error.AsInteger());
-}
-
-void AndroidClusterExceptions::ReturnIllegalStateException(JNIEnv * env, jobject callback, const char message[],
-                                                           ChipError::StorageType errorCode)
-{
-    VerifyOrReturn(callback != nullptr, ChipLogDetail(Zcl, "Callback is null in ReturnIllegalStateException(), exiting early"));
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    jmethodID method;
-    err = JniReferences::GetInstance().FindMethod(env, callback, "onError", "(Ljava/lang/Exception;)V", &method);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Zcl, "Error throwing IllegalStateException %d", err.AsInteger());
-        return;
-    }
-
-    jthrowable exception;
-    err = CreateIllegalStateException(env, message, errorCode, exception);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Zcl, "Error throwing IllegalStateException %d", err.AsInteger());
-        return;
-    }
-    env->CallVoidMethod(callback, method, exception);
 }
 
 } // namespace chip

--- a/src/controller/java/AndroidClusterExceptions.h
+++ b/src/controller/java/AndroidClusterExceptions.h
@@ -39,21 +39,6 @@ public:
      */
     CHIP_ERROR CreateChipClusterException(JNIEnv * env, uint32_t errorCode, jthrowable & outEx);
 
-    /**
-     * Creates a Java IllegalStateException in outEx.
-     */
-    CHIP_ERROR CreateIllegalStateException(JNIEnv * env, const char message[], ChipError errorCode, jthrowable & outEx);
-
-    CHIP_ERROR CreateIllegalStateException(JNIEnv * env, const char message[], ChipError::StorageType errorCode,
-                                           jthrowable & outEx);
-
-    /**
-     * Creates an IllegalStateException and passes it to the Java onError() function of the provided callback object.
-     */
-    void ReturnIllegalStateException(JNIEnv * env, jobject callback, const char message[], ChipError errorCode);
-
-    void ReturnIllegalStateException(JNIEnv * env, jobject callback, const char message[], ChipError::StorageType errorCode);
-
 private:
     AndroidClusterExceptions() {}
 };

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -727,8 +727,10 @@ void AndroidDeviceControllerWrapper::OnScanNetworksSuccess(
 {
     chip::DeviceLayer::StackUnlock unlock;
     CHIP_ERROR err = CHIP_NO_ERROR;
-    JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     jmethodID javaMethod;
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
+    JniLocalReferenceManager manager(env);
 
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Error invoking Java callback: no JNIEnv"));
 
@@ -798,8 +800,8 @@ void AndroidDeviceControllerWrapper::OnScanNetworksSuccess(
             chip::JniReferences::GetInstance().CreateBoxedObject<jint>("java/lang/Integer", "(I)V", jniRssi, newElement_rssi);
 
             jclass wiFiInterfaceScanResultStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/WiFiScanResult",
-                                                                 wiFiInterfaceScanResultStructClass);
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/WiFiScanResult",
+                                                                      wiFiInterfaceScanResultStructClass);
             if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(Zcl, "Could not find class WiFiScanResult");
@@ -863,8 +865,8 @@ void AndroidDeviceControllerWrapper::OnScanNetworksSuccess(
             chip::JniReferences::GetInstance().CreateBoxedObject<jint>("java/lang/Integer", "(I)V", jniLqi, newElement_lqi);
 
             jclass threadInterfaceScanResultStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ThreadScanResult",
-                                                                 threadInterfaceScanResultStructClass);
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/ThreadScanResult",
+                                                                      threadInterfaceScanResultStructClass);
             if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(Zcl, "Could not find class ThreadScanResult");

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -127,6 +127,10 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::GenerateNOCChain(const ByteSpan 
                                                                  const ByteSpan & PAI,
                                                                  Callback::Callback<OnNOCChainGeneration> * onCompletion)
 {
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturnError(env != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    JniLocalReferenceManager manager(env);
+
     if (mUseJavaCallbackForNOCRequest)
     {
         return CallbackGenerateNOCChain(csrElements, csrNonce, attestationSignature, attestationChallenge, DAC, PAI, onCompletion);
@@ -464,8 +468,7 @@ CHIP_ERROR N2J_CSRInfo(JNIEnv * env, jbyteArray nonce, jbyteArray elements, jbyt
     jmethodID constructor;
     jclass infoClass;
 
-    err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/CSRInfo", infoClass);
-    JniClass attestationInfoClass(infoClass);
+    err = JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/CSRInfo", infoClass);
     SuccessOrExit(err);
 
     env->ExceptionClear();
@@ -487,8 +490,7 @@ CHIP_ERROR N2J_AttestationInfo(JNIEnv * env, jbyteArray challenge, jbyteArray no
     jmethodID constructor;
     jclass infoClass;
 
-    err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/AttestationInfo", infoClass);
-    JniClass attestationInfoClass(infoClass);
+    err = JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/AttestationInfo", infoClass);
     SuccessOrExit(err);
 
     env->ExceptionClear();

--- a/src/controller/java/AttestationTrustStoreBridge.cpp
+++ b/src/controller/java/AttestationTrustStoreBridge.cpp
@@ -65,15 +65,17 @@ CHIP_ERROR AttestationTrustStoreBridge::GetProductAttestationAuthorityCert(const
 CHIP_ERROR AttestationTrustStoreBridge::GetPaaCertFromJava(const chip::ByteSpan & skid,
                                                            chip::MutableByteSpan & outPaaDerBuffer) const
 {
-    JNIEnv * env                                       = JniReferences::GetInstance().GetEnvForCurrentThread();
     jclass attestationTrustStoreDelegateCls            = nullptr;
     jbyteArray javaSkid                                = nullptr;
     jmethodID getProductAttestationAuthorityCertMethod = nullptr;
 
-    JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/AttestationTrustStoreDelegate",
-                                             attestationTrustStoreDelegateCls);
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturnError(env != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    JniLocalReferenceManager manager(env);
+
+    JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/AttestationTrustStoreDelegate",
+                                                  attestationTrustStoreDelegateCls);
     VerifyOrReturnError(attestationTrustStoreDelegateCls != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
-    JniClass attestationTrustStoreDelegateJniCls(attestationTrustStoreDelegateCls);
 
     JniReferences::GetInstance().FindMethod(env, mAttestationTrustStoreDelegate, "getProductAttestationAuthorityCert", "([B)[B",
                                             &getProductAttestationAuthorityCertMethod);

--- a/src/controller/java/CHIPDefaultCallbacks.cpp
+++ b/src/controller/java/CHIPDefaultCallbacks.cpp
@@ -103,6 +103,9 @@ void chip::CHIPDefaultFailureCallback::CallbackFn(void * context, CHIP_ERROR err
     CHIP_ERROR err = CHIP_NO_ERROR;
     jmethodID javaMethod;
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
+    JniLocalReferenceManager manager(env);
+
     jobject javaCallbackRef;
     jthrowable exception;
     CHIPDefaultFailureCallback * cppCallback = nullptr;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -39,7 +39,6 @@
 #include <ble/BleUUID.h>
 #include <controller/CHIPDeviceController.h>
 #include <controller/CommissioningWindowOpener.h>
-#include <controller/java/AndroidClusterExceptions.h>
 #include <controller/java/GroupDeviceProxy.h>
 #include <credentials/CHIPCert.h>
 #include <jni.h>
@@ -3073,8 +3072,7 @@ CHIP_ERROR N2J_PaseVerifierParams(JNIEnv * env, jlong setupPincode, jbyteArray p
     jmethodID constructor;
     jclass paramsClass;
 
-    err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/PaseVerifierParams", paramsClass);
-    JniClass paseVerifierParamsClass(paramsClass);
+    err = JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/PaseVerifierParams", paramsClass);
     SuccessOrExit(err);
 
     env->ExceptionClear();
@@ -3094,8 +3092,7 @@ CHIP_ERROR N2J_NetworkLocation(JNIEnv * env, jstring ipAddress, jint port, jint 
     jmethodID constructor;
     jclass locationClass;
 
-    err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/NetworkLocation", locationClass);
-    JniClass networkLocationClass(locationClass);
+    err = JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/NetworkLocation", locationClass);
     SuccessOrExit(err);
 
     env->ExceptionClear();

--- a/src/controller/java/DeviceAttestationDelegateBridge.cpp
+++ b/src/controller/java/DeviceAttestationDelegateBridge.cpp
@@ -37,8 +37,7 @@ CHIP_ERROR N2J_AttestationInfo(JNIEnv * env, const chip::Credentials::DeviceAtte
     const ByteSpan PAI                                    = info.paiDerBuffer();
     const Optional<ByteSpan> certificationDeclarationSpan = info.cdBuffer();
 
-    err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/AttestationInfo", infoClass);
-    JniClass attestationInfoClass(infoClass);
+    err = JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/AttestationInfo", infoClass);
     SuccessOrExit(err);
 
     env->ExceptionClear();
@@ -71,16 +70,14 @@ void DeviceAttestationDelegateBridge::OnDeviceAttestationCompleted(
     mResult = attestationResult;
     if (mDeviceAttestationDelegate != nullptr)
     {
-        JNIEnv * env                        = JniReferences::GetInstance().GetEnvForCurrentThread();
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+        VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
+        JniLocalReferenceManager manager(env);
         jclass deviceAttestationDelegateCls = nullptr;
-
-        JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/DeviceAttestationDelegate",
-                                                 deviceAttestationDelegateCls);
+        JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/DeviceAttestationDelegate",
+                                                      deviceAttestationDelegateCls);
         VerifyOrReturn(deviceAttestationDelegateCls != nullptr,
                        ChipLogError(Controller, "Could not find device attestation delegate class."));
-
-        // Auto delete deviceAttestationDelegateCls object when exit from the local scope
-        JniClass deviceAttestationDelegateJniCls(deviceAttestationDelegateCls);
 
         if (env->IsInstanceOf(mDeviceAttestationDelegate, deviceAttestationDelegateCls))
         {

--- a/src/controller/java/OTAProviderDelegateBridge.cpp
+++ b/src/controller/java/OTAProviderDelegateBridge.cpp
@@ -109,6 +109,7 @@ void OTAProviderDelegateBridge::HandleQueryImage(CommandHandler * commandObj, co
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
     chip::JniLocalReferenceManager manager(env);
 
     jobject otaProviderDelegate      = nullptr;

--- a/src/controller/java/templates/CHIPEventTLVValueDecoder-src.zapt
+++ b/src/controller/java/templates/CHIPEventTLVValueDecoder-src.zapt
@@ -55,7 +55,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
 
                     {{/zcl_event_fields}}
                     jclass {{asLowerCamelCase name}}StructClass;
-                    err = chip::JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipEventStructs${{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event", {{asLowerCamelCase name}}StructClass);
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/ChipEventStructs${{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event", {{asLowerCamelCase name}}StructClass);
                     if (err != CHIP_NO_ERROR) {
                         ChipLogError(Zcl, "Could not find class ChipEventStructs${{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event");
                         return nullptr;

--- a/src/controller/java/templates/partials/decode_value.zapt
+++ b/src/controller/java/templates/partials/decode_value.zapt
@@ -32,7 +32,7 @@ if ({{source}}.IsNull()) {
     {{/zcl_struct_items_by_struct_and_cluster_name}}
 
     jclass {{asLowerCamelCase type}}StructClass_{{depth}};
-    err = chip::JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/ChipStructs${{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase type}}", {{asLowerCamelCase type}}StructClass_{{depth}});
+    err = chip::JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/ChipStructs${{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase type}}", {{asLowerCamelCase type}}StructClass_{{depth}});
     if (err != CHIP_NO_ERROR) {
       ChipLogError(Zcl, "Could not find class ChipStructs${{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase type}}");
       return {{earlyReturn}};

--- a/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
@@ -1632,7 +1632,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_revision, newElement_0_revision);
 
                 jclass deviceTypeStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$DescriptorClusterDeviceTypeStruct", deviceTypeStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -1796,7 +1796,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass semanticTagStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$DescriptorClusterSemanticTagStruct", semanticTagStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -2054,7 +2054,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_fabricIndex, newElement_0_fabricIndex);
 
                 jclass targetStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$BindingClusterTargetStruct", targetStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -2332,7 +2332,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         }
 
                         jclass accessControlTargetStructStructClass_4;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$AccessControlClusterAccessControlTargetStruct",
                             accessControlTargetStructStructClass_4);
                         if (err != CHIP_NO_ERROR)
@@ -2366,7 +2366,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_fabricIndex, newElement_0_fabricIndex);
 
                 jclass accessControlEntryStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$AccessControlClusterAccessControlEntryStruct",
                     accessControlEntryStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -2423,7 +2423,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_fabricIndex, newElement_0_fabricIndex);
 
                 jclass accessControlExtensionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$AccessControlClusterAccessControlExtensionStruct",
                     accessControlExtensionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -2693,7 +2693,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_state, newElement_0_state);
 
                 jclass actionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ActionsClusterActionStruct", actionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -2769,7 +2769,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass endpointListStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ActionsClusterEndpointListStruct", endpointListStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -3230,7 +3230,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 jnivalue_subscriptionsPerFabric, value_subscriptionsPerFabric);
 
             jclass capabilityMinimaStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$BasicInformationClusterCapabilityMinimaStruct",
                 capabilityMinimaStructStructClass_0);
             if (err != CHIP_NO_ERROR)
@@ -3284,7 +3284,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             }
 
             jclass productAppearanceStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$BasicInformationClusterProductAppearanceStruct",
                 productAppearanceStructStructClass_0);
             if (err != CHIP_NO_ERROR)
@@ -3662,7 +3662,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_fabricIndex, newElement_0_fabricIndex);
 
                 jclass providerLocationStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$OtaSoftwareUpdateRequestorClusterProviderLocation",
                     providerLocationStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -5354,7 +5354,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 jnivalue_maxCumulativeFailsafeSeconds, value_maxCumulativeFailsafeSeconds);
 
             jclass basicCommissioningInfoStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$GeneralCommissioningClusterBasicCommissioningInfo",
                 basicCommissioningInfoStructClass_0);
             if (err != CHIP_NO_ERROR)
@@ -5661,7 +5661,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass networkInfoStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$NetworkCommissioningClusterNetworkInfoStruct",
                     networkInfoStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -6245,7 +6245,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_type, newElement_0_type);
 
                 jclass networkInterfaceStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$GeneralDiagnosticsClusterNetworkInterface",
                     networkInterfaceStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -6660,7 +6660,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass threadMetricsStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$SoftwareDiagnosticsClusterThreadMetricsStruct",
                     threadMetricsStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -7156,7 +7156,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                jninewElement_0_isChild, newElement_0_isChild);
 
                 jclass neighborTableStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ThreadNetworkDiagnosticsClusterNeighborTableStruct",
                     neighborTableStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -7275,7 +7275,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     jninewElement_0_linkEstablished, newElement_0_linkEstablished);
 
                 jclass routeTableStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ThreadNetworkDiagnosticsClusterRouteTableStruct",
                     routeTableStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -8190,7 +8190,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     value_flagsClassName.c_str(), value_flagsCtorSignature.c_str(), jnivalue_flags, value_flags);
 
                 jclass securityPolicyStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ThreadNetworkDiagnosticsClusterSecurityPolicy",
                     securityPolicyStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -8336,7 +8336,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     jnivalue_channelMaskPresent, value_channelMaskPresent);
 
                 jclass operationalDatasetComponentsStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ThreadNetworkDiagnosticsClusterOperationalDatasetComponents",
                     operationalDatasetComponentsStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -9373,7 +9373,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     value_endpointClassName.c_str(), value_endpointCtorSignature.c_str(), jnivalue_endpoint, value_endpoint);
 
                 jclass trustedTimeSourceStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$TimeSynchronizationClusterTrustedTimeSourceStruct",
                     trustedTimeSourceStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -9460,7 +9460,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass timeZoneStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$TimeSynchronizationClusterTimeZoneStruct", timeZoneStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -9530,7 +9530,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass DSTOffsetStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$TimeSynchronizationClusterDSTOffsetStruct",
                     DSTOffsetStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -10027,7 +10027,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             }
 
             jclass productAppearanceStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$BridgedDeviceBasicInformationClusterProductAppearanceStruct",
                 productAppearanceStructStructClass_0);
             if (err != CHIP_NO_ERROR)
@@ -10629,7 +10629,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_fabricIndex, newElement_0_fabricIndex);
 
                 jclass NOCStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$OperationalCredentialsClusterNOCStruct", NOCStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -10706,7 +10706,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_fabricIndex, newElement_0_fabricIndex);
 
                 jclass fabricDescriptorStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$OperationalCredentialsClusterFabricDescriptorStruct",
                     fabricDescriptorStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -10986,7 +10986,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_fabricIndex, newElement_0_fabricIndex);
 
                 jclass groupKeyMapStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$GroupKeyManagementClusterGroupKeyMapStruct",
                     groupKeyMapStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -11070,7 +11070,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_fabricIndex, newElement_0_fabricIndex);
 
                 jclass groupInfoMapStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$GroupKeyManagementClusterGroupInfoMapStruct",
                     groupInfoMapStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -11292,7 +11292,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(entry_0.value, newElement_0_value));
 
                 jclass labelStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$FixedLabelClusterLabelStruct", labelStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -11479,7 +11479,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(entry_0.value, newElement_0_value));
 
                 jclass labelStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$UserLabelClusterLabelStruct", labelStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -12315,7 +12315,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_fabricIndex, newElement_0_fabricIndex);
 
                 jclass monitoringRegistrationStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$IcdManagementClusterMonitoringRegistrationStruct",
                     monitoringRegistrationStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -12860,7 +12860,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass operationalStateStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$OvenCavityOperationalStateClusterOperationalStateStruct",
                     operationalStateStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -12944,7 +12944,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             }
 
             jclass errorStateStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$OvenCavityOperationalStateClusterErrorStateStruct",
                 errorStateStructStructClass_0);
             if (err != CHIP_NO_ERROR)
@@ -13168,7 +13168,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                jninewElement_2_value, newElement_2_value);
 
                     jclass modeTagStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$OvenModeClusterModeTagStruct", modeTagStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -13192,7 +13192,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass modeOptionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$OvenModeClusterModeOptionStruct", modeOptionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -13694,7 +13694,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                jninewElement_2_value, newElement_2_value);
 
                     jclass semanticTagStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$ModeSelectClusterSemanticTagStruct",
                         semanticTagStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
@@ -13719,7 +13719,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass modeOptionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ModeSelectClusterModeOptionStruct", modeOptionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -14006,7 +14006,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                jninewElement_2_value, newElement_2_value);
 
                     jclass modeTagStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$LaundryWasherModeClusterModeTagStruct", modeTagStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -14030,7 +14030,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass modeOptionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$LaundryWasherModeClusterModeOptionStruct",
                     modeOptionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -14318,7 +14318,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                jninewElement_2_value, newElement_2_value);
 
                     jclass modeTagStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env,
                         "chip/devicecontroller/ChipStructs$RefrigeratorAndTemperatureControlledCabinetModeClusterModeTagStruct",
                         modeTagStructStructClass_3);
@@ -14348,7 +14348,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass modeOptionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$RefrigeratorAndTemperatureControlledCabinetModeClusterModeOptionStruct",
                     modeOptionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -14867,7 +14867,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                jninewElement_2_value, newElement_2_value);
 
                     jclass modeTagStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$RvcRunModeClusterModeTagStruct", modeTagStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -14891,7 +14891,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass modeOptionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$RvcRunModeClusterModeOptionStruct", modeOptionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -15132,7 +15132,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                jninewElement_2_value, newElement_2_value);
 
                     jclass modeTagStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$RvcCleanModeClusterModeTagStruct", modeTagStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -15156,7 +15156,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass modeOptionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$RvcCleanModeClusterModeOptionStruct", modeOptionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -15830,7 +15830,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                jninewElement_2_value, newElement_2_value);
 
                     jclass modeTagStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$DishwasherModeClusterModeTagStruct", modeTagStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -15854,7 +15854,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass modeOptionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$DishwasherModeClusterModeOptionStruct", modeOptionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -16855,7 +16855,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                jninewElement_2_value, newElement_2_value);
 
                     jclass modeTagStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$MicrowaveOvenModeClusterModeTagStruct", modeTagStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -16879,7 +16879,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass modeOptionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$MicrowaveOvenModeClusterModeOptionStruct",
                     modeOptionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -17469,7 +17469,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass operationalStateStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$OperationalStateClusterOperationalStateStruct",
                     operationalStateStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -17552,7 +17552,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             }
 
             jclass errorStateStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$OperationalStateClusterErrorStateStruct", errorStateStructStructClass_0);
             if (err != CHIP_NO_ERROR)
             {
@@ -17828,7 +17828,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass operationalStateStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$RvcOperationalStateClusterOperationalStateStruct",
                     operationalStateStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -17911,7 +17911,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             }
 
             jclass errorStateStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$RvcOperationalStateClusterErrorStateStruct", errorStateStructStructClass_0);
             if (err != CHIP_NO_ERROR)
             {
@@ -18174,7 +18174,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_fabricIndex, newElement_0_fabricIndex);
 
                 jclass sceneInfoStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ScenesManagementClusterSceneInfoStruct", sceneInfoStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -18458,7 +18458,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                      newElement_0_productIdentifierValue));
 
                 jclass replacementProductStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$HepaFilterMonitoringClusterReplacementProductStruct",
                     replacementProductStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -18740,7 +18740,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                      newElement_0_productIdentifierValue));
 
                 jclass replacementProductStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ActivatedCarbonFilterMonitoringClusterReplacementProductStruct",
                     replacementProductStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -19720,7 +19720,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass measurementAccuracyRangeStructStructClass_2;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ElectricalEnergyMeasurementClusterMeasurementAccuracyRangeStruct",
                     measurementAccuracyRangeStructStructClass_2);
                 if (err != CHIP_NO_ERROR)
@@ -19752,7 +19752,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             }
 
             jclass measurementAccuracyStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$ElectricalEnergyMeasurementClusterMeasurementAccuracyStruct",
                 measurementAccuracyStructStructClass_0);
             if (err != CHIP_NO_ERROR)
@@ -19866,7 +19866,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass energyMeasurementStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct",
                     energyMeasurementStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -19980,7 +19980,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass energyMeasurementStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct",
                     energyMeasurementStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -20094,7 +20094,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass energyMeasurementStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct",
                     energyMeasurementStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -20208,7 +20208,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass energyMeasurementStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct",
                     energyMeasurementStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -20444,7 +20444,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass loadControlProgramStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterLoadControlProgramStruct",
                     loadControlProgramStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -20745,7 +20745,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         }
 
                         jclass temperatureControlStructStructClass_5;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterTemperatureControlStruct",
                             temperatureControlStructStructClass_5);
                         if (err != CHIP_NO_ERROR)
@@ -20797,7 +20797,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             newElement_2_averageLoadControlInsideOptional_loadAdjustment);
 
                         jclass averageLoadControlStructStructClass_5;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterAverageLoadControlStruct",
                             averageLoadControlStructStructClass_5);
                         if (err != CHIP_NO_ERROR)
@@ -20845,7 +20845,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             newElement_2_dutyCycleControlInsideOptional_dutyCycle);
 
                         jclass dutyCycleControlStructStructClass_5;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterDutyCycleControlStruct",
                             dutyCycleControlStructStructClass_5);
                         if (err != CHIP_NO_ERROR)
@@ -20893,7 +20893,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             newElement_2_powerSavingsControlInsideOptional_powerSavings);
 
                         jclass powerSavingsControlStructStructClass_5;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterPowerSavingsControlStruct",
                             powerSavingsControlStructStructClass_5);
                         if (err != CHIP_NO_ERROR)
@@ -20941,7 +20941,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             newElement_2_heatingSourceControlInsideOptional_heatingSource);
 
                         jclass heatingSourceControlStructStructClass_5;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct",
                             heatingSourceControlStructStructClass_5);
                         if (err != CHIP_NO_ERROR)
@@ -20971,7 +20971,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     }
 
                     jclass loadControlEventTransitionStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterLoadControlEventTransitionStruct",
                         loadControlEventTransitionStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
@@ -21005,7 +21005,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass loadControlEventStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterLoadControlEventStruct",
                     loadControlEventStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -21292,7 +21292,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         }
 
                         jclass temperatureControlStructStructClass_5;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterTemperatureControlStruct",
                             temperatureControlStructStructClass_5);
                         if (err != CHIP_NO_ERROR)
@@ -21344,7 +21344,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             newElement_2_averageLoadControlInsideOptional_loadAdjustment);
 
                         jclass averageLoadControlStructStructClass_5;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterAverageLoadControlStruct",
                             averageLoadControlStructStructClass_5);
                         if (err != CHIP_NO_ERROR)
@@ -21392,7 +21392,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             newElement_2_dutyCycleControlInsideOptional_dutyCycle);
 
                         jclass dutyCycleControlStructStructClass_5;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterDutyCycleControlStruct",
                             dutyCycleControlStructStructClass_5);
                         if (err != CHIP_NO_ERROR)
@@ -21440,7 +21440,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             newElement_2_powerSavingsControlInsideOptional_powerSavings);
 
                         jclass powerSavingsControlStructStructClass_5;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterPowerSavingsControlStruct",
                             powerSavingsControlStructStructClass_5);
                         if (err != CHIP_NO_ERROR)
@@ -21488,7 +21488,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             newElement_2_heatingSourceControlInsideOptional_heatingSource);
 
                         jclass heatingSourceControlStructStructClass_5;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct",
                             heatingSourceControlStructStructClass_5);
                         if (err != CHIP_NO_ERROR)
@@ -21518,7 +21518,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     }
 
                     jclass loadControlEventTransitionStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterLoadControlEventTransitionStruct",
                         loadControlEventTransitionStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
@@ -21552,7 +21552,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass loadControlEventStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterLoadControlEventStruct",
                     loadControlEventStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -21902,7 +21902,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         }
 
                         jclass messageResponseOptionStructStructClass_4;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$MessagesClusterMessageResponseOptionStruct",
                             messageResponseOptionStructStructClass_4);
                         if (err != CHIP_NO_ERROR)
@@ -21930,7 +21930,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass messageStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$MessagesClusterMessageStruct", messageStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -22255,7 +22255,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         jninewElement_1_maxDuration, newElement_1_maxDuration);
 
                     jclass powerAdjustStructStructClass_2;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$DeviceEnergyManagementClusterPowerAdjustStruct",
                         powerAdjustStructStructClass_2);
                     if (err != CHIP_NO_ERROR)
@@ -22624,7 +22624,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             }
 
                             jclass costStructStructClass_6;
-                            err = chip::JniReferences::GetInstance().GetClassRef(
+                            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                                 env, "chip/devicecontroller/ChipStructs$DeviceEnergyManagementClusterCostStruct",
                                 costStructStructClass_6);
                             if (err != CHIP_NO_ERROR)
@@ -22728,7 +22728,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     }
 
                     jclass slotStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$DeviceEnergyManagementClusterSlotStruct", slotStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -22768,7 +22768,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     jnivalue_forecastUpdateReason, value_forecastUpdateReason);
 
                 jclass forecastStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$DeviceEnergyManagementClusterForecastStruct",
                     forecastStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -23601,7 +23601,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass balanceStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$EnergyPreferenceClusterBalanceStruct", balanceStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -23703,7 +23703,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass balanceStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$EnergyPreferenceClusterBalanceStruct", balanceStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -23944,7 +23944,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                jninewElement_2_value, newElement_2_value);
 
                     jclass modeTagStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$EnergyEvseModeClusterModeTagStruct", modeTagStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -23968,7 +23968,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass modeOptionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$EnergyEvseModeClusterModeOptionStruct", modeOptionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -24255,7 +24255,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                jninewElement_2_value, newElement_2_value);
 
                     jclass modeTagStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$DeviceEnergyManagementModeClusterModeTagStruct",
                         modeTagStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
@@ -24280,7 +24280,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass modeOptionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$DeviceEnergyManagementModeClusterModeOptionStruct",
                     modeOptionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -27802,7 +27802,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     jninewElement_0_presetTypeFeatures, newElement_0_presetTypeFeatures);
 
                 jclass presetTypeStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ThermostatClusterPresetTypeStruct", presetTypeStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -27866,7 +27866,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     jninewElement_0_scheduleTypeFeatures, newElement_0_scheduleTypeFeatures);
 
                 jclass scheduleTypeStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ThermostatClusterScheduleTypeStruct", scheduleTypeStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -28114,7 +28114,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass presetStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ThermostatClusterPresetStruct", presetStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -28301,7 +28301,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     }
 
                     jclass scheduleTransitionStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$ThermostatClusterScheduleTransitionStruct",
                         scheduleTransitionStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
@@ -28354,7 +28354,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass scheduleStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ThermostatClusterScheduleStruct", scheduleStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -28480,7 +28480,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass queuedPresetStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ThermostatClusterQueuedPresetStruct", queuedPresetStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -36012,7 +36012,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass channelInfoStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ChannelClusterChannelInfoStruct", channelInfoStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -36091,7 +36091,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jnivalue_lineupInfoType, value_lineupInfoType);
 
                 jclass lineupInfoStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ChannelClusterLineupInfoStruct", lineupInfoStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -36211,7 +36211,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass channelInfoStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ChannelClusterChannelInfoStruct", channelInfoStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -36406,7 +36406,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(entry_0.name, newElement_0_name));
 
                 jclass targetInfoStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$TargetNavigatorClusterTargetInfoStruct", targetInfoStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -36686,7 +36686,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass playbackPositionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$MediaPlaybackClusterPlaybackPositionStruct",
                     playbackPositionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -36822,7 +36822,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     }
 
                     jclass trackAttributesStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct",
                         trackAttributesStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
@@ -36846,7 +36846,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass trackStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackStruct", trackStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -36926,7 +36926,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         }
 
                         jclass trackAttributesStructStructClass_4;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct",
                             trackAttributesStructStructClass_4);
                         if (err != CHIP_NO_ERROR)
@@ -36951,7 +36951,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     }
 
                     jclass trackStructStructClass_2;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackStruct", trackStructStructClass_2);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -37027,7 +37027,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     }
 
                     jclass trackAttributesStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct",
                         trackAttributesStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
@@ -37051,7 +37051,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass trackStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackStruct", trackStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -37131,7 +37131,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         }
 
                         jclass trackAttributesStructStructClass_4;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackAttributesStruct",
                             trackAttributesStructStructClass_4);
                         if (err != CHIP_NO_ERROR)
@@ -37156,7 +37156,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     }
 
                     jclass trackStructStructClass_2;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$MediaPlaybackClusterTrackStruct", trackStructStructClass_2);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -37361,7 +37361,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     chip::JniReferences::GetInstance().CharToStringUTF(entry_0.description, newElement_0_description));
 
                 jclass inputInfoStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$MediaInputClusterInputInfoStruct", inputInfoStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -38040,7 +38040,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(entry_0.name, newElement_0_name));
 
                 jclass outputInfoStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$AudioOutputClusterOutputInfoStruct", outputInfoStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -38275,7 +38275,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                                      value_application_applicationID));
 
                 jclass applicationStructStructClass_2;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplicationStruct",
                     applicationStructStructClass_2);
                 if (err != CHIP_NO_ERROR)
@@ -38314,7 +38314,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass applicationEPStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ApplicationLauncherClusterApplicationEPStruct",
                     applicationEPStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -38557,7 +38557,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(cppValue.applicationID, value_applicationID));
 
             jclass applicationStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$ApplicationBasicClusterApplicationStruct", applicationStructStructClass_0);
             if (err != CHIP_NO_ERROR)
             {
@@ -38965,7 +38965,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass ratingNameStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ContentControlClusterRatingNameStruct", ratingNameStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -39034,7 +39034,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass ratingNameStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ContentControlClusterRatingNameStruct", ratingNameStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -42086,7 +42086,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 newElement_0_member2 = newElement_0_member2ByteArray;
 
                 jclass testListStructOctetStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$UnitTestingClusterTestListStructOctet",
                     testListStructOctetStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -42375,7 +42375,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         jninewElement_0_nullableStruct_h, newElement_0_nullableStruct_h);
 
                     jclass simpleStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct", simpleStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -42470,7 +42470,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                         jninewElement_0_optionalStructInsideOptional_h, newElement_0_optionalStructInsideOptional_h);
 
                     jclass simpleStructStructClass_3;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct", simpleStructStructClass_3);
                     if (err != CHIP_NO_ERROR)
                     {
@@ -42587,7 +42587,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                             newElement_0_nullableOptionalStructInsideOptional_h);
 
                         jclass simpleStructStructClass_4;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct", simpleStructStructClass_4);
                         if (err != CHIP_NO_ERROR)
                         {
@@ -42704,7 +42704,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 }
 
                 jclass nullablesAndOptionalsStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$UnitTestingClusterNullablesAndOptionalsStruct",
                     nullablesAndOptionalsStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -42806,7 +42806,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                           jnivalue_h, value_h);
 
             jclass simpleStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct", simpleStructStructClass_0);
             if (err != CHIP_NO_ERROR)
             {
@@ -43069,7 +43069,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     newElement_0_fabricSensitiveStruct_h);
 
                 jclass simpleStructStructClass_2;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct", simpleStructStructClass_2);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -43119,7 +43119,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                            jninewElement_0_fabricIndex, newElement_0_fabricIndex);
 
                 jclass testFabricScopedStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$UnitTestingClusterTestFabricScoped", testFabricScopedStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -43911,7 +43911,7 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                                                                               value_hCtorSignature.c_str(), jnivalue_h, value_h);
 
                 jclass simpleStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct", simpleStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {

--- a/src/controller/java/zap-generated/CHIPEventTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPEventTLVValueDecoder.cpp
@@ -276,7 +276,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                         }
 
                         jclass accessControlTargetStructStructClass_4;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$AccessControlClusterAccessControlTargetStruct",
                             accessControlTargetStructStructClass_4);
                         if (err != CHIP_NO_ERROR)
@@ -310,7 +310,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     jnivalue_latestValue_fabricIndex, value_latestValue_fabricIndex);
 
                 jclass accessControlEntryStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$AccessControlClusterAccessControlEntryStruct",
                     accessControlEntryStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -345,7 +345,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        value_fabricIndex);
 
             jclass accessControlEntryChangedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$AccessControlClusterAccessControlEntryChangedEvent",
                 accessControlEntryChangedStructClass);
             if (err != CHIP_NO_ERROR)
@@ -439,7 +439,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     jnivalue_latestValue_fabricIndex, value_latestValue_fabricIndex);
 
                 jclass accessControlExtensionStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$AccessControlClusterAccessControlExtensionStruct",
                     accessControlExtensionStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -472,7 +472,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        value_fabricIndex);
 
             jclass accessControlExtensionChangedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$AccessControlClusterAccessControlExtensionChangedEvent",
                 accessControlExtensionChangedStructClass);
             if (err != CHIP_NO_ERROR)
@@ -539,7 +539,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_newStateClassName.c_str(), value_newStateCtorSignature.c_str(), jnivalue_newState, value_newState);
 
             jclass stateChangedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$ActionsClusterStateChangedEvent", stateChangedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -598,7 +598,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_errorClassName.c_str(), value_errorCtorSignature.c_str(), jnivalue_error, value_error);
 
             jclass actionFailedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$ActionsClusterActionFailedEvent", actionFailedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -647,7 +647,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                         jnivalue_softwareVersion, value_softwareVersion);
 
             jclass startUpStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$BasicInformationClusterStartUpEvent", startUpStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -676,7 +676,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass shutDownStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$BasicInformationClusterShutDownEvent", shutDownStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -712,7 +712,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        value_fabricIndex);
 
             jclass leaveStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$BasicInformationClusterLeaveEvent", leaveStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -749,7 +749,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                            jnivalue_reachableNewValue, value_reachableNewValue);
 
             jclass reachableChangedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$BasicInformationClusterReachableChangedEvent",
                 reachableChangedStructClass);
             if (err != CHIP_NO_ERROR)
@@ -836,7 +836,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass stateTransitionStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$OtaSoftwareUpdateRequestorClusterStateTransitionEvent",
                 stateTransitionStructClass);
             if (err != CHIP_NO_ERROR)
@@ -884,7 +884,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_productIDClassName.c_str(), value_productIDCtorSignature.c_str(), jnivalue_productID, value_productID);
 
             jclass versionAppliedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$OtaSoftwareUpdateRequestorClusterVersionAppliedEvent",
                 versionAppliedStructClass);
             if (err != CHIP_NO_ERROR)
@@ -962,7 +962,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass downloadErrorStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$OtaSoftwareUpdateRequestorClusterDownloadErrorEvent",
                 downloadErrorStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1077,7 +1077,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass wiredFaultChangeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PowerSourceClusterWiredFaultChangeEvent", wiredFaultChangeStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -1139,7 +1139,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass batFaultChangeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PowerSourceClusterBatFaultChangeEvent", batFaultChangeStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -1201,7 +1201,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass batChargeFaultChangeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PowerSourceClusterBatChargeFaultChangeEvent",
                 batChargeFaultChangeStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1305,7 +1305,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass hardwareFaultChangeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$GeneralDiagnosticsClusterHardwareFaultChangeEvent",
                 hardwareFaultChangeStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1369,7 +1369,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass radioFaultChangeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$GeneralDiagnosticsClusterRadioFaultChangeEvent",
                 radioFaultChangeStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1432,7 +1432,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass networkFaultChangeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$GeneralDiagnosticsClusterNetworkFaultChangeEvent",
                 networkFaultChangeStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1471,7 +1471,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_bootReasonClassName.c_str(), value_bootReasonCtorSignature.c_str(), jnivalue_bootReason, value_bootReason);
 
             jclass bootReasonStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$GeneralDiagnosticsClusterBootReasonEvent", bootReasonStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -1547,7 +1547,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass softwareFaultStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SoftwareDiagnosticsClusterSoftwareFaultEvent",
                 softwareFaultStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1597,7 +1597,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        jnivalue_connectionStatus, value_connectionStatus);
 
             jclass connectionStatusStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$ThreadNetworkDiagnosticsClusterConnectionStatusEvent",
                 connectionStatusStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1660,7 +1660,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass networkFaultChangeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$ThreadNetworkDiagnosticsClusterNetworkFaultChangeEvent",
                 networkFaultChangeStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1710,7 +1710,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_reasonCodeClassName.c_str(), value_reasonCodeCtorSignature.c_str(), jnivalue_reasonCode, value_reasonCode);
 
             jclass disconnectionStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$WiFiNetworkDiagnosticsClusterDisconnectionEvent",
                 disconnectionStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1755,7 +1755,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_statusClassName.c_str(), value_statusCtorSignature.c_str(), jnivalue_status, value_status);
 
             jclass associationFailureStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$WiFiNetworkDiagnosticsClusterAssociationFailureEvent",
                 associationFailureStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1796,7 +1796,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        jnivalue_connectionStatus, value_connectionStatus);
 
             jclass connectionStatusStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$WiFiNetworkDiagnosticsClusterConnectionStatusEvent",
                 connectionStatusStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1846,7 +1846,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass DSTTableEmptyStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$TimeSynchronizationClusterDSTTableEmptyEvent",
                 DSTTableEmptyStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1884,7 +1884,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                            jnivalue_DSTOffsetActive, value_DSTOffsetActive);
 
             jclass DSTStatusStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$TimeSynchronizationClusterDSTStatusEvent", DSTStatusStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -1933,7 +1933,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass timeZoneStatusStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$TimeSynchronizationClusterTimeZoneStatusEvent",
                 timeZoneStatusStructClass);
             if (err != CHIP_NO_ERROR)
@@ -1963,7 +1963,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass timeFailureStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$TimeSynchronizationClusterTimeFailureEvent", timeFailureStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -1992,7 +1992,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass missingTrustedTimeSourceStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$TimeSynchronizationClusterMissingTrustedTimeSourceEvent",
                 missingTrustedTimeSourceStructClass);
             if (err != CHIP_NO_ERROR)
@@ -2041,7 +2041,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                         jnivalue_softwareVersion, value_softwareVersion);
 
             jclass startUpStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$BridgedDeviceBasicInformationClusterStartUpEvent", startUpStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -2070,7 +2070,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass shutDownStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$BridgedDeviceBasicInformationClusterShutDownEvent",
                 shutDownStructClass);
             if (err != CHIP_NO_ERROR)
@@ -2099,7 +2099,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass leaveStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$BridgedDeviceBasicInformationClusterLeaveEvent", leaveStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -2135,7 +2135,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                            jnivalue_reachableNewValue, value_reachableNewValue);
 
             jclass reachableChangedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$BridgedDeviceBasicInformationClusterReachableChangedEvent",
                 reachableChangedStructClass);
             if (err != CHIP_NO_ERROR)
@@ -2185,7 +2185,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        value_newPosition);
 
             jclass switchLatchedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SwitchClusterSwitchLatchedEvent", switchLatchedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -2222,7 +2222,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        value_newPosition);
 
             jclass initialPressStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SwitchClusterInitialPressEvent", initialPressStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -2259,7 +2259,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        value_newPosition);
 
             jclass longPressStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SwitchClusterLongPressEvent", longPressStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -2296,7 +2296,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        jnivalue_previousPosition, value_previousPosition);
 
             jclass shortReleaseStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SwitchClusterShortReleaseEvent", shortReleaseStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -2333,7 +2333,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        jnivalue_previousPosition, value_previousPosition);
 
             jclass longReleaseStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SwitchClusterLongReleaseEvent", longReleaseStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -2378,7 +2378,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 jnivalue_currentNumberOfPressesCounted, value_currentNumberOfPressesCounted);
 
             jclass multiPressOngoingStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SwitchClusterMultiPressOngoingEvent", multiPressOngoingStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -2425,7 +2425,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 jnivalue_totalNumberOfPressesCounted, value_totalNumberOfPressesCounted);
 
             jclass multiPressCompleteStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SwitchClusterMultiPressCompleteEvent", multiPressCompleteStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -2553,7 +2553,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_stateValueClassName.c_str(), value_stateValueCtorSignature.c_str(), jnivalue_stateValue, value_stateValue);
 
             jclass stateChangeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$BooleanStateClusterStateChangeEvent", stateChangeStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -2647,7 +2647,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass errorStateStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$OvenCavityOperationalStateClusterErrorStateStruct",
                 errorStateStructStructClass_0);
             if (err != CHIP_NO_ERROR)
@@ -2671,7 +2671,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                value_errorState_errorStateLabel, value_errorState_errorStateDetails);
 
             jclass operationalErrorStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$OvenCavityOperationalStateClusterOperationalErrorEvent",
                 operationalErrorStructClass);
             if (err != CHIP_NO_ERROR)
@@ -2763,7 +2763,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass operationCompletionStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$OvenCavityOperationalStateClusterOperationCompletionEvent",
                 operationCompletionStructClass);
             if (err != CHIP_NO_ERROR)
@@ -2925,7 +2925,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                         value_maskCtorSignature.c_str(), jnivalue_mask, value_mask);
 
             jclass notifyStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$RefrigeratorAlarmClusterNotifyEvent", notifyStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -2994,7 +2994,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        jnivalue_alarmSeverityLevel, value_alarmSeverityLevel);
 
             jclass smokeAlarmStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SmokeCoAlarmClusterSmokeAlarmEvent", smokeAlarmStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -3031,7 +3031,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        jnivalue_alarmSeverityLevel, value_alarmSeverityLevel);
 
             jclass COAlarmStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SmokeCoAlarmClusterCOAlarmEvent", COAlarmStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -3068,7 +3068,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        jnivalue_alarmSeverityLevel, value_alarmSeverityLevel);
 
             jclass lowBatteryStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SmokeCoAlarmClusterLowBatteryEvent", lowBatteryStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -3097,7 +3097,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass hardwareFaultStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SmokeCoAlarmClusterHardwareFaultEvent", hardwareFaultStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -3126,7 +3126,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass endOfServiceStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SmokeCoAlarmClusterEndOfServiceEvent", endOfServiceStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -3155,7 +3155,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass selfTestCompleteStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SmokeCoAlarmClusterSelfTestCompleteEvent",
                 selfTestCompleteStructClass);
             if (err != CHIP_NO_ERROR)
@@ -3185,7 +3185,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass alarmMutedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SmokeCoAlarmClusterAlarmMutedEvent", alarmMutedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -3213,7 +3213,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass muteEndedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SmokeCoAlarmClusterMuteEndedEvent", muteEndedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -3249,7 +3249,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        jnivalue_alarmSeverityLevel, value_alarmSeverityLevel);
 
             jclass interconnectSmokeAlarmStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SmokeCoAlarmClusterInterconnectSmokeAlarmEvent",
                 interconnectSmokeAlarmStructClass);
             if (err != CHIP_NO_ERROR)
@@ -3288,7 +3288,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        jnivalue_alarmSeverityLevel, value_alarmSeverityLevel);
 
             jclass interconnectCOAlarmStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SmokeCoAlarmClusterInterconnectCOAlarmEvent",
                 interconnectCOAlarmStructClass);
             if (err != CHIP_NO_ERROR)
@@ -3318,7 +3318,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass allClearStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SmokeCoAlarmClusterAllClearEvent", allClearStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -3384,7 +3384,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                         value_maskCtorSignature.c_str(), jnivalue_mask, value_mask);
 
             jclass notifyStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$DishwasherAlarmClusterNotifyEvent", notifyStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -3480,7 +3480,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass errorStateStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$OperationalStateClusterErrorStateStruct", errorStateStructStructClass_0);
             if (err != CHIP_NO_ERROR)
             {
@@ -3503,7 +3503,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                value_errorState_errorStateLabel, value_errorState_errorStateDetails);
 
             jclass operationalErrorStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$OperationalStateClusterOperationalErrorEvent",
                 operationalErrorStructClass);
             if (err != CHIP_NO_ERROR)
@@ -3593,7 +3593,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass operationCompletionStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$OperationalStateClusterOperationCompletionEvent",
                 operationCompletionStructClass);
             if (err != CHIP_NO_ERROR)
@@ -3670,7 +3670,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass errorStateStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$RvcOperationalStateClusterErrorStateStruct", errorStateStructStructClass_0);
             if (err != CHIP_NO_ERROR)
             {
@@ -3693,7 +3693,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                value_errorState_errorStateLabel, value_errorState_errorStateDetails);
 
             jclass operationalErrorStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$RvcOperationalStateClusterOperationalErrorEvent",
                 operationalErrorStructClass);
             if (err != CHIP_NO_ERROR)
@@ -3783,7 +3783,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass operationCompletionStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$RvcOperationalStateClusterOperationCompletionEvent",
                 operationCompletionStructClass);
             if (err != CHIP_NO_ERROR)
@@ -3881,7 +3881,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass alarmsStateChangedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$BooleanStateConfigurationClusterAlarmsStateChangedEvent",
                 alarmsStateChangedStructClass);
             if (err != CHIP_NO_ERROR)
@@ -3922,7 +3922,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        value_sensorFault);
 
             jclass sensorFaultStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$BooleanStateConfigurationClusterSensorFaultEvent",
                 sensorFaultStructClass);
             if (err != CHIP_NO_ERROR)
@@ -3986,7 +3986,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass valveStateChangedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$ValveConfigurationAndControlClusterValveStateChangedEvent",
                 valveStateChangedStructClass);
             if (err != CHIP_NO_ERROR)
@@ -4027,7 +4027,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_valveFaultClassName.c_str(), value_valveFaultCtorSignature.c_str(), jnivalue_valveFault, value_valveFault);
 
             jclass valveFaultStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$ValveConfigurationAndControlClusterValveFaultEvent",
                 valveFaultStructClass);
             if (err != CHIP_NO_ERROR)
@@ -4165,7 +4165,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 }
 
                 jclass energyMeasurementStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct",
                     energyMeasurementStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -4293,7 +4293,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 }
 
                 jclass energyMeasurementStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct",
                     energyMeasurementStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -4323,7 +4323,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass cumulativeEnergyMeasuredStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$ElectricalEnergyMeasurementClusterCumulativeEnergyMeasuredEvent",
                 cumulativeEnergyMeasuredStructClass);
             if (err != CHIP_NO_ERROR)
@@ -4456,7 +4456,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 }
 
                 jclass energyMeasurementStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct",
                     energyMeasurementStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -4584,7 +4584,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 }
 
                 jclass energyMeasurementStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$ElectricalEnergyMeasurementClusterEnergyMeasurementStruct",
                     energyMeasurementStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
@@ -4614,7 +4614,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass periodicEnergyMeasuredStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$ElectricalEnergyMeasurementClusterPeriodicEnergyMeasuredEvent",
                 periodicEnergyMeasuredStructClass);
             if (err != CHIP_NO_ERROR)
@@ -4841,7 +4841,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     }
 
                     jclass temperatureControlStructStructClass_2;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterTemperatureControlStruct",
                         temperatureControlStructStructClass_2);
                     if (err != CHIP_NO_ERROR)
@@ -4899,7 +4899,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                         value_averageLoadControlInsideOptional_loadAdjustment);
 
                     jclass averageLoadControlStructStructClass_2;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterAverageLoadControlStruct",
                         averageLoadControlStructStructClass_2);
                     if (err != CHIP_NO_ERROR)
@@ -4952,7 +4952,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                         jnivalue_dutyCycleControlInsideOptional_dutyCycle, value_dutyCycleControlInsideOptional_dutyCycle);
 
                     jclass dutyCycleControlStructStructClass_2;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterDutyCycleControlStruct",
                         dutyCycleControlStructStructClass_2);
                     if (err != CHIP_NO_ERROR)
@@ -5006,7 +5006,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                         value_powerSavingsControlInsideOptional_powerSavings);
 
                     jclass powerSavingsControlStructStructClass_2;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterPowerSavingsControlStruct",
                         powerSavingsControlStructStructClass_2);
                     if (err != CHIP_NO_ERROR)
@@ -5062,7 +5062,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                         value_heatingSourceControlInsideOptional_heatingSource);
 
                     jclass heatingSourceControlStructStructClass_2;
-                    err = chip::JniReferences::GetInstance().GetClassRef(
+                    err = chip::JniReferences::GetInstance().GetLocalClassRef(
                         env, "chip/devicecontroller/ChipStructs$DemandResponseLoadControlClusterHeatingSourceControlStruct",
                         heatingSourceControlStructStructClass_2);
                     if (err != CHIP_NO_ERROR)
@@ -5093,7 +5093,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass loadControlEventStatusChangeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$DemandResponseLoadControlClusterLoadControlEventStatusChangeEvent",
                 loadControlEventStatusChangeStructClass);
             if (err != CHIP_NO_ERROR)
@@ -5148,7 +5148,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             value_messageID = value_messageIDByteArray;
 
             jclass messageQueuedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$MessagesClusterMessageQueuedEvent", messageQueuedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -5183,7 +5183,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             value_messageID = value_messageIDByteArray;
 
             jclass messagePresentedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$MessagesClusterMessagePresentedEvent", messagePresentedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -5277,7 +5277,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass messageCompleteStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$MessagesClusterMessageCompleteEvent", messageCompleteStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -5318,7 +5318,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass powerAdjustStartStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$DeviceEnergyManagementClusterPowerAdjustStartEvent",
                 powerAdjustStartStructClass);
             if (err != CHIP_NO_ERROR)
@@ -5369,7 +5369,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_energyUseClassName.c_str(), value_energyUseCtorSignature.c_str(), jnivalue_energyUse, value_energyUse);
 
             jclass powerAdjustEndStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$DeviceEnergyManagementClusterPowerAdjustEndEvent",
                 powerAdjustEndStructClass);
             if (err != CHIP_NO_ERROR)
@@ -5401,7 +5401,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass pausedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$DeviceEnergyManagementClusterPausedEvent", pausedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -5436,7 +5436,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_causeClassName.c_str(), value_causeCtorSignature.c_str(), jnivalue_cause, value_cause);
 
             jclass resumedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$DeviceEnergyManagementClusterResumedEvent", resumedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -5482,7 +5482,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_sessionIDClassName.c_str(), value_sessionIDCtorSignature.c_str(), jnivalue_sessionID, value_sessionID);
 
             jclass EVConnectedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$EnergyEvseClusterEVConnectedEvent", EVConnectedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -5560,7 +5560,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass EVNotDetectedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$EnergyEvseClusterEVNotDetectedEvent", EVNotDetectedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -5614,7 +5614,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                         jnivalue_maximumCurrent, value_maximumCurrent);
 
             jclass energyTransferStartedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$EnergyEvseClusterEnergyTransferStartedEvent",
                 energyTransferStartedStructClass);
             if (err != CHIP_NO_ERROR)
@@ -5675,7 +5675,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                         jnivalue_energyTransferred, value_energyTransferred);
 
             jclass energyTransferStoppedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$EnergyEvseClusterEnergyTransferStoppedEvent",
                 energyTransferStoppedStructClass);
             if (err != CHIP_NO_ERROR)
@@ -5744,7 +5744,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 jnivalue_faultStateCurrentState, value_faultStateCurrentState);
 
             jclass faultStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$EnergyEvseClusterFaultEvent", faultStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -5781,7 +5781,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             value_uid = value_uidByteArray;
 
             jclass rfidStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$EnergyEvseClusterRfidEvent", rfidStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -5856,7 +5856,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_alarmCodeClassName.c_str(), value_alarmCodeCtorSignature.c_str(), jnivalue_alarmCode, value_alarmCode);
 
             jclass doorLockAlarmStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$DoorLockClusterDoorLockAlarmEvent", doorLockAlarmStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -5892,7 +5892,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_doorStateClassName.c_str(), value_doorStateCtorSignature.c_str(), jnivalue_doorState, value_doorState);
 
             jclass doorStateChangeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$DoorLockClusterDoorStateChangeEvent", doorStateChangeStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -6017,7 +6017,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                             jninewElement_2_credentialIndex, newElement_2_credentialIndex);
 
                         jclass credentialStructStructClass_3;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DoorLockClusterCredentialStruct",
                             credentialStructStructClass_3);
                         if (err != CHIP_NO_ERROR)
@@ -6045,7 +6045,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass lockOperationStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$DoorLockClusterLockOperationEvent", lockOperationStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -6182,7 +6182,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                             jninewElement_2_credentialIndex, newElement_2_credentialIndex);
 
                         jclass credentialStructStructClass_3;
-                        err = chip::JniReferences::GetInstance().GetClassRef(
+                        err = chip::JniReferences::GetInstance().GetLocalClassRef(
                             env, "chip/devicecontroller/ChipStructs$DoorLockClusterCredentialStruct",
                             credentialStructStructClass_3);
                         if (err != CHIP_NO_ERROR)
@@ -6210,7 +6210,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass lockOperationErrorStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$DoorLockClusterLockOperationErrorEvent",
                 lockOperationErrorStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6327,7 +6327,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass lockUserChangeStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$DoorLockClusterLockUserChangeEvent", lockUserChangeStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -6391,7 +6391,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass supplyVoltageLowStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterSupplyVoltageLowEvent",
                 supplyVoltageLowStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6422,7 +6422,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass supplyVoltageHighStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterSupplyVoltageHighEvent",
                 supplyVoltageHighStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6453,7 +6453,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass powerMissingPhaseStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterPowerMissingPhaseEvent",
                 powerMissingPhaseStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6484,7 +6484,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass systemPressureLowStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterSystemPressureLowEvent",
                 systemPressureLowStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6515,7 +6515,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass systemPressureHighStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterSystemPressureHighEvent",
                 systemPressureHighStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6547,7 +6547,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass dryRunningStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterDryRunningEvent",
                 dryRunningStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6576,7 +6576,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass motorTemperatureHighStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterMotorTemperatureHighEvent",
                 motorTemperatureHighStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6608,7 +6608,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass pumpMotorFatalFailureStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterPumpMotorFatalFailureEvent",
                 pumpMotorFatalFailureStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6641,7 +6641,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass electronicTemperatureHighStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterElectronicTemperatureHighEvent",
                 electronicTemperatureHighStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6674,7 +6674,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass pumpBlockedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterPumpBlockedEvent",
                 pumpBlockedStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6704,7 +6704,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass sensorFailureStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterSensorFailureEvent",
                 sensorFailureStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6735,7 +6735,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass electronicNonFatalFailureStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterElectronicNonFatalFailureEvent",
                 electronicNonFatalFailureStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6768,7 +6768,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass electronicFatalFailureStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterElectronicFatalFailureEvent",
                 electronicFatalFailureStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6801,7 +6801,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass generalFaultStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterGeneralFaultEvent",
                 generalFaultStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6832,7 +6832,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass leakageStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterLeakageEvent", leakageStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -6860,7 +6860,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass airDetectionStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterAirDetectionEvent",
                 airDetectionStructClass);
             if (err != CHIP_NO_ERROR)
@@ -6891,7 +6891,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass turbineOperationStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$PumpConfigurationAndControlClusterTurbineOperationEvent",
                 turbineOperationStructClass);
             if (err != CHIP_NO_ERROR)
@@ -7180,7 +7180,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(entry_0.name, newElement_0_name));
 
                 jclass targetInfoStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$TargetNavigatorClusterTargetInfoStruct", targetInfoStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -7218,7 +7218,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             value_data = value_dataByteArray;
 
             jclass targetUpdatedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$TargetNavigatorClusterTargetUpdatedEvent", targetUpdatedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -7303,7 +7303,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass playbackPositionStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$MediaPlaybackClusterPlaybackPositionStruct",
                 playbackPositionStructStructClass_0);
             if (err != CHIP_NO_ERROR)
@@ -7373,7 +7373,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                            jnivalue_audioAdvanceUnmuted, value_audioAdvanceUnmuted);
 
             jclass stateChangedStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$MediaPlaybackClusterStateChangedEvent", stateChangedStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -7505,7 +7505,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass loggedOutStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$AccountLoginClusterLoggedOutEvent", loggedOutStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -7544,7 +7544,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
             jclass remainingScreenTimeExpiredStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$ContentControlClusterRemainingScreenTimeExpiredEvent",
                 remainingScreenTimeExpiredStructClass);
             if (err != CHIP_NO_ERROR)
@@ -7671,7 +7671,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 value_arg4_hClassName.c_str(), value_arg4_hCtorSignature.c_str(), jnivalue_arg4_h, value_arg4_h);
 
             jclass simpleStructStructClass_0;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct", simpleStructStructClass_0);
             if (err != CHIP_NO_ERROR)
             {
@@ -7747,7 +7747,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                     newElement_0_hClassName.c_str(), newElement_0_hCtorSignature.c_str(), jninewElement_0_h, newElement_0_h);
 
                 jclass simpleStructStructClass_1;
-                err = chip::JniReferences::GetInstance().GetClassRef(
+                err = chip::JniReferences::GetInstance().GetLocalClassRef(
                     env, "chip/devicecontroller/ChipStructs$UnitTestingClusterSimpleStruct", simpleStructStructClass_1);
                 if (err != CHIP_NO_ERROR)
                 {
@@ -7790,7 +7790,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             }
 
             jclass testEventStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$UnitTestingClusterTestEventEvent", testEventStructClass);
             if (err != CHIP_NO_ERROR)
             {
@@ -7831,7 +7831,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        value_fabricIndex);
 
             jclass testFabricScopedEventStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$UnitTestingClusterTestFabricScopedEventEvent",
                 testFabricScopedEventStructClass);
             if (err != CHIP_NO_ERROR)
@@ -7868,7 +7868,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        jnivalue_arg1, value_arg1);
 
             jclass testDifferentVendorMeiEventStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$UnitTestingClusterTestDifferentVendorMeiEventEvent",
                 testDifferentVendorMeiEventStructClass);
             if (err != CHIP_NO_ERROR)
@@ -7934,7 +7934,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                                        value_fabricIndex);
 
             jclass pingCountEventStructClass;
-            err = chip::JniReferences::GetInstance().GetClassRef(
+            err = chip::JniReferences::GetInstance().GetLocalClassRef(
                 env, "chip/devicecontroller/ChipEventStructs$SampleMeiClusterPingCountEventEvent", pingCountEventStructClass);
             if (err != CHIP_NO_ERROR)
             {

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -254,9 +254,8 @@ CHIP_ERROR JniReferences::CreateOptional(jobject objectToWrap, jobject & outOpti
 {
     JNIEnv * env = GetEnvForCurrentThread();
     jclass optionalCls;
-    chip::JniReferences::GetInstance().GetClassRef(env, "java/util/Optional", optionalCls);
+    chip::JniReferences::GetInstance().GetLocalClassRef(env, "java/util/Optional", optionalCls);
     VerifyOrReturnError(optionalCls != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
-    chip::JniClass jniClass(optionalCls);
 
     jmethodID ofMethod = env->GetStaticMethodID(optionalCls, "ofNullable", "(Ljava/lang/Object;)Ljava/util/Optional;");
     env->ExceptionClear();
@@ -280,9 +279,8 @@ CHIP_ERROR JniReferences::GetOptionalValue(jobject optionalObj, jobject & option
 {
     JNIEnv * env = GetEnvForCurrentThread();
     jclass optionalCls;
-    chip::JniReferences::GetInstance().GetClassRef(env, "java/util/Optional", optionalCls);
+    chip::JniReferences::GetInstance().GetLocalClassRef(env, "java/util/Optional", optionalCls);
     VerifyOrReturnError(optionalCls != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
-    chip::JniClass jniClass(optionalCls);
 
     jmethodID isPresentMethod = env->GetMethodID(optionalCls, "isPresent", "()Z");
     VerifyOrReturnError(isPresentMethod != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
@@ -304,8 +302,7 @@ jint JniReferences::IntegerToPrimitive(jobject boxedInteger)
 {
     JNIEnv * env = GetEnvForCurrentThread();
     jclass boxedTypeCls;
-    chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Integer", boxedTypeCls);
-    chip::JniClass jniClass(boxedTypeCls);
+    chip::JniReferences::GetInstance().GetLocalClassRef(env, "java/lang/Integer", boxedTypeCls);
 
     jmethodID valueMethod = env->GetMethodID(boxedTypeCls, "intValue", "()I");
     return env->CallIntMethod(boxedInteger, valueMethod);
@@ -315,8 +312,7 @@ jlong JniReferences::LongToPrimitive(jobject boxedLong)
 {
     JNIEnv * env = GetEnvForCurrentThread();
     jclass boxedTypeCls;
-    chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Long", boxedTypeCls);
-    chip::JniClass jniClass(boxedTypeCls);
+    chip::JniReferences::GetInstance().GetLocalClassRef(env, "java/lang/Long", boxedTypeCls);
 
     jmethodID valueMethod = env->GetMethodID(boxedTypeCls, "longValue", "()J");
     return env->CallLongMethod(boxedLong, valueMethod);
@@ -326,8 +322,7 @@ jboolean JniReferences::BooleanToPrimitive(jobject boxedBoolean)
 {
     JNIEnv * env = GetEnvForCurrentThread();
     jclass boxedTypeCls;
-    chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Boolean", boxedTypeCls);
-    chip::JniClass jniClass(boxedTypeCls);
+    chip::JniReferences::GetInstance().GetLocalClassRef(env, "java/lang/Boolean", boxedTypeCls);
 
     jmethodID valueMethod = env->GetMethodID(boxedTypeCls, "booleanValue", "()Z");
     return env->CallBooleanMethod(boxedBoolean, valueMethod);
@@ -337,8 +332,7 @@ jfloat JniReferences::FloatToPrimitive(jobject boxedFloat)
 {
     JNIEnv * env = GetEnvForCurrentThread();
     jclass boxedTypeCls;
-    chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Float", boxedTypeCls);
-    chip::JniClass jniClass(boxedTypeCls);
+    chip::JniReferences::GetInstance().GetLocalClassRef(env, "java/lang/Float", boxedTypeCls);
 
     jmethodID valueMethod = env->GetMethodID(boxedTypeCls, "floatValue", "()F");
     return env->CallFloatMethod(boxedFloat, valueMethod);
@@ -348,8 +342,7 @@ jdouble JniReferences::DoubleToPrimitive(jobject boxedDouble)
 {
     JNIEnv * env = GetEnvForCurrentThread();
     jclass boxedTypeCls;
-    chip::JniReferences::GetInstance().GetClassRef(env, "java/lang/Double", boxedTypeCls);
-    chip::JniClass jniClass(boxedTypeCls);
+    chip::JniReferences::GetInstance().GetLocalClassRef(env, "java/lang/Double", boxedTypeCls);
 
     jmethodID valueMethod = env->GetMethodID(boxedTypeCls, "doubleValue", "()D");
     return env->CallDoubleMethod(boxedDouble, valueMethod);

--- a/src/lib/support/JniTypeWrappers.h
+++ b/src/lib/support/JniTypeWrappers.h
@@ -167,19 +167,6 @@ private:
     jbyteArray mArray = nullptr;
 };
 
-/// Manages an pre-existing global reference to a jclass.
-class JniClass
-{
-public:
-    explicit JniClass(jclass mClassRef) : mClassRef(mClassRef) {}
-    ~JniClass() { chip::JniReferences::GetInstance().GetEnvForCurrentThread()->DeleteGlobalRef(mClassRef); }
-
-    jclass classRef() { return mClassRef; }
-
-private:
-    jclass mClassRef;
-};
-
 // Manages an pre-existing global reference to a jobject.
 class JniGlobalRefWrapper
 {

--- a/src/platform/android/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/android/DiagnosticDataProviderImpl.cpp
@@ -96,10 +96,12 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
 {
     chip::DeviceLayer::StackUnlock unlock;
     CHIP_ERROR err = CHIP_NO_ERROR;
-    JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrExit(mDiagnosticDataProviderManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mGetNifMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
+    JniLocalReferenceManager manager(env);
+
     {
         ChipLogProgress(DeviceLayer, "Received GetNetworkInterfaces");
         jobjectArray nifList = (jobjectArray) env->CallObjectMethod(mDiagnosticDataProviderManagerObject, mGetNifMethod);

--- a/src/platform/android/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/android/DiagnosticDataProviderImpl.cpp
@@ -96,12 +96,12 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
 {
     chip::DeviceLayer::StackUnlock unlock;
     CHIP_ERROR err = CHIP_NO_ERROR;
+    JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturnError(env != nullptr, CHIP_JNI_ERROR_NULL_OBJECT,
+                        ChipLogError(DeviceLayer, "Could not get JNIEnv for current thread"));
+    JniLocalReferenceManager manager(env);
     VerifyOrExit(mDiagnosticDataProviderManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mGetNifMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
-    JniLocalReferenceManager manager(env);
-
     {
         ChipLogProgress(DeviceLayer, "Received GetNetworkInterfaces");
         jobjectArray nifList = (jobjectArray) env->CallObjectMethod(mDiagnosticDataProviderManagerObject, mGetNifMethod);


### PR DESCRIPTION
JniClass is used to release global reference for jni class when using GetClassRef, and GetClassRef creates both local and global reference, which is causing multiple leaks for local references because we don't release local one sometimes in callback code path from c++ to java/kotlin. In order to resolve this issue, in previous PR, we applied the below 
1. Use GetLocalClassRef to get jni class without creating global reference, so we don't need GetClassRef.
2. For local reference leak, we use RAII JniLocalReferenceManager to release local reference in callback path from c++ to java/kotlin

This PR use GetLocalClassRef and fix the local/global reference leak, and fully remove JniClass.
