### PR TITLE
[MatterYamlTests][darwin-framework-tool] Use a list of tests to run f…

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -106,6 +106,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
+                     --runner darwin_framework_tool_python \
                      --chip-tool ./out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT_FRAMEWORK_TOOL}/darwin-framework-tool \
                      --target-skip-glob '{TestAccessControlConstraints}' \
                      run \

--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
@@ -322,7 +322,7 @@ class StructFieldsNameConverter():
                     provided_field_name = provided_field_name[0].lower(
                     ) + provided_field_name[1:]
 
-                if provided_field_name in value:
+                if provided_field_name in value and provided_field_name != field_name:
                     value[field_name] = self.run(
                         specs,
                         value[provided_field_name],


### PR DESCRIPTION
…rom scripts/tests/chiptest/__init__.py if chip_tool_python is used in conjunction with darwinframeworktool.py

#### Problem

There are multiple ways to run the tests with `tests_suites.py`. One of them involve running codegen tests because `darwin-framework-tool` still use this behaviour. This PR is an attempt to run the `darwin-framework-tool` tests using the python YAML interpreter instead.
