### PR TITLE
Correct dependencies of GlobalAttributes

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -97,7 +97,10 @@ source_set("global-attributes") {
   sources = [ "GlobalAttributes.h" ]
 
   # This also depends on zap-generated code which is currently impossible to split outs
-  public_deps = [ "${chip_root}/src/lib/support" ]
+  public_deps = [
+    ":app_config",
+    "${chip_root}/src/lib/support",
+  ]
 }
 
 source_set("pre-encoded-value") {

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -96,7 +96,8 @@ source_set("paths") {
 source_set("global-attributes") {
   sources = [ "GlobalAttributes.h" ]
 
-  # This also depends on zap-generated code which is currently impossible to split outs
+  # This also depends on zap-generated code which is currently impossible to split out
+  # as a dependency
   public_deps = [
     ":app_config",
     "${chip_root}/src/lib/support",

--- a/src/app/GlobalAttributes.h
+++ b/src/app/GlobalAttributes.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app-common/zap-generated/ids/Attributes.h>
+#include <app/AppConfig.h>
 #include <lib/support/CodeUtils.h>
 
 namespace chip {


### PR DESCRIPTION
GlobalAttributes makes use of CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE

This one is defined in the application build config which has to be imported through AppConfig.

Fix up this dependency:
  - actually include AppConfig in the Global attributes header
  - add a GN dependency on this