### PR TITLE
Remove dependency on nlio in src/app

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlio.gni")
 import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/src/lib/core/core.gni")
 import("${chip_root}/src/platform/device.gni")
@@ -339,7 +338,6 @@ static_library("app") {
     "${chip_root}/src/messaging",
     "${chip_root}/src/protocols/interaction_model",
     "${chip_root}/src/system",
-    "${nlio_root}:nlio",
   ]
 
   if (chip_enable_read_client) {


### PR DESCRIPTION
I could not find any include for `nlio-*` into app and I am unsure why app would want nlio.