### PR TITLE
Improve JniLocalReferenceManager class

### DIFF
--- a/src/lib/support/JniTypeWrappers.h
+++ b/src/lib/support/JniTypeWrappers.h
@@ -186,13 +186,14 @@ private:
 class JniLocalReferenceManager
 {
 public:
-    JniLocalReferenceManager(JNIEnv * env) : mEnv(env)
+    explicit JniLocalReferenceManager(JNIEnv * env) : mEnv(env)
     {
         if (mEnv->PushLocalFrame(JNI_LOCAL_REF_COUNT) == 0)
         {
             mlocalFramePushed = true;
         }
     }
+
     ~JniLocalReferenceManager()
     {
         if (mlocalFramePushed)
@@ -202,8 +203,12 @@ public:
         }
     }
 
+    // Delete copy constructor and copy assignment operator
+    JniLocalReferenceManager(const JniLocalReferenceManager &)             = delete;
+    JniLocalReferenceManager & operator=(const JniLocalReferenceManager &) = delete;
+
 private:
-    JNIEnv * mEnv          = nullptr;
+    JNIEnv * const mEnv;
     bool mlocalFramePushed = false;
 };
 


### PR DESCRIPTION
1. Mark the constructor as explicit to prevent implicit conversions or copy-initialization that might lead to unexpected behavior.
cpp

2. The class should explicitly delete its copy constructor and copy assignment operator to prevent copying, as it manages a resource (local references in JNI).

3. Since mEnv is not supposed to change after the object's construction, you could make it const to enforce this constraint.

