### PR TITLE
[Linux] Pass advertising name directly to BluezAdvertisement

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_DD_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_2_2.yaml
@@ -63,8 +63,6 @@ tests:
           [1657221603.350739][368108:368108] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J048N01KA0648G00
           [1657221603.350773][368108:368108] CHIP:SVR: Manual pairing code: [749701123365521327694]
           [1657221603.350846][368108:368108] CHIP:DMG: Endpoint 0, Cluster 0x0000_001D update version to 4dd11284
-          [1657221603.353048][368108:368113] CHIP:DL: TRACE: Bluez mainloop starting Thread
-          [1657221603.353167][368108:368111] CHIP:DL: TRACE: Bus acquired for name MATTER-3841
       disabled: true
 
     - label:

--- a/src/app/tests/suites/certification/Test_TC_DD_3_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_11.yaml
@@ -85,7 +85,6 @@ tests:
           [1667888323.967841][3151:3151] CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J042C00KA0648G00
           [1667888323.967940][3151:3151] CHIP:SVR: Manual pairing code: [34970112332]
           [1667888323.968031][3151:3151] CHIP:DMG: Endpoint 0, Cluster 0x0000_001D update version to ea7ea7b8
-          [1667888323.981832][3151:3153] CHIP:DL: TRACE: Bus acquired for name MATTER-3840
       disabled: true
 
     - label: "Step 1b: Scan the QR code from the previous step using the DUT."

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -571,7 +571,7 @@ void BLEManagerImpl::DriveBLEState()
     // Initializes the Bluez BLE layer if needed.
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kBluezBLELayerInitialized))
     {
-        SuccessOrExit(err = mEndpoint.Init(mAdapterId, mIsCentral, nullptr, mDeviceName));
+        SuccessOrExit(err = mEndpoint.Init(mAdapterId, mIsCentral, nullptr));
         mFlags.Set(Flags::kBluezBLELayerInitialized);
     }
 
@@ -595,7 +595,7 @@ void BLEManagerImpl::DriveBLEState()
             // Configure advertising data if it hasn't been done yet.
             if (!mFlags.Has(Flags::kAdvertisingConfigured))
             {
-                SuccessOrExit(err = mBLEAdvertisement.Init(mEndpoint, mBLEAdvType, mpBLEAdvUUID, mBLEAdvDurationMs));
+                SuccessOrExit(err = mBLEAdvertisement.Init(mEndpoint, mBLEAdvType, mpBLEAdvUUID, mBLEAdvDurationMs, mDeviceName));
                 mFlags.Set(Flags::kAdvertisingConfigured);
             }
 

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -47,8 +47,6 @@ BluezLEAdvertisement1 * BluezAdvertisement::CreateLEAdvertisement()
     GVariantBuilder serviceDataBuilder;
     GVariantBuilder serviceUUIDsBuilder;
     GAutoPtr<char> debugStr;
-    const char * localNamePtr;
-    char localName[32];
 
     ChipLogDetail(DeviceLayer, "Create BLE adv object at %s", mpAdvPath);
     object = bluez_object_skeleton_new(mpAdvPath);
@@ -61,13 +59,6 @@ BluezLEAdvertisement1 * BluezAdvertisement::CreateLEAdvertisement()
     g_variant_builder_add(&serviceDataBuilder, "{sv}", mpAdvUUID,
                           g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, &mDeviceIdInfo, sizeof(mDeviceIdInfo), sizeof(uint8_t)));
     g_variant_builder_add(&serviceUUIDsBuilder, "s", mpAdvUUID);
-
-    localNamePtr = mpAdvName;
-    if (localNamePtr == nullptr)
-    {
-        g_snprintf(localName, sizeof(localName), "%s%04x", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, getpid() & 0xffff);
-        localNamePtr = localName;
-    }
 
     serviceData = g_variant_builder_end(&serviceDataBuilder);
     serviceUUID = g_variant_builder_end(&serviceUUIDsBuilder);
@@ -88,8 +79,7 @@ BluezLEAdvertisement1 * BluezAdvertisement::CreateLEAdvertisement()
     if (mAdvType & BLUEZ_ADV_TYPE_SCANNABLE)
         bluez_leadvertisement1_set_discoverable_timeout(adv, UINT16_MAX);
 
-    // advertising name corresponding to the PID and object path, for debug purposes
-    bluez_leadvertisement1_set_local_name(adv, localNamePtr);
+    bluez_leadvertisement1_set_local_name(adv, mAdvName);
     bluez_leadvertisement1_set_service_uuids(adv, serviceUUID);
 
     // 0xffff means no appearance
@@ -148,9 +138,18 @@ CHIP_ERROR BluezAdvertisement::Init(const BluezEndpoint & aEndpoint, ChipAdvType
     g_object_get(G_OBJECT(mpRoot), "object-path", &MakeUniquePointerReceiver(rootPath).Get(), nullptr);
     mpAdvPath      = g_strdup_printf("%s/advertising", rootPath.get());
     mAdvType       = aAdvType;
-    mpAdvName      = g_strdup(aAdvName);
     mpAdvUUID      = g_strdup(aAdvUUID);
     mAdvDurationMs = aAdvDurationMs;
+
+    if (aAdvName != nullptr)
+    {
+        g_snprintf(mAdvName, sizeof(mAdvName), "%s", aAdvName);
+    }
+    else
+    {
+        // Advertising name corresponding to the PID, for debug purposes.
+        g_snprintf(mAdvName, sizeof(mAdvName), "%s%04x", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, getpid() & 0xffff);
+    }
 
     err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(mDeviceIdInfo);
     ReturnErrorOnFailure(err);
@@ -209,8 +208,6 @@ void BluezAdvertisement::Shutdown()
 
     g_free(mpAdvPath);
     mpAdvPath = nullptr;
-    g_free(mpAdvName);
-    mpAdvName = nullptr;
     g_free(mpAdvUUID);
     mpAdvUUID = nullptr;
 

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -41,7 +41,8 @@ public:
     BluezAdvertisement() = default;
     ~BluezAdvertisement() { Shutdown(); }
 
-    CHIP_ERROR Init(const BluezEndpoint & aEndpoint, ChipAdvType aAdvType, const char * aAdvUUID, uint32_t aAdvDurationMs);
+    CHIP_ERROR Init(const BluezEndpoint & aEndpoint, ChipAdvType aAdvType, const char * aAdvUUID, uint32_t aAdvDurationMs,
+                    const char * aAdvName);
     void Shutdown();
 
     /// Start BLE advertising.
@@ -77,9 +78,9 @@ private:
     bool mIsAdvertising = false;
 
     Ble::ChipBLEDeviceIdentificationInfo mDeviceIdInfo;
-    char * mpAdvPath     = nullptr;
-    char * mpAdapterName = nullptr;
-    char * mpAdvUUID     = nullptr;
+    char * mpAdvPath = nullptr;
+    char * mpAdvName = nullptr;
+    char * mpAdvUUID = nullptr;
     ChipAdvType mAdvType;
     uint16_t mAdvDurationMs = 0;
 };

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -79,10 +79,10 @@ private:
 
     Ble::ChipBLEDeviceIdentificationInfo mDeviceIdInfo;
     char * mpAdvPath = nullptr;
-    char * mpAdvName = nullptr;
     char * mpAdvUUID = nullptr;
     ChipAdvType mAdvType;
     uint16_t mAdvDurationMs = 0;
+    char mAdvName[32]       = "";
 };
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -617,12 +617,6 @@ CHIP_ERROR BluezEndpoint::StartupEndpointBindings()
     VerifyOrReturnError(conn != nullptr, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "FAIL: get bus sync in %s, error: %s", __func__, err->message));
 
-    if (mpAdapterName != nullptr)
-        mpOwningName = g_strdup_printf("%s", mpAdapterName);
-    else
-        mpOwningName = g_strdup_printf("C-%04x", getpid() & 0xffff);
-    ChipLogDetail(DeviceLayer, "TRACE: Bus acquired for name %s", mpOwningName);
-
     SetupGattServer(conn.get());
 
     mpObjMgr = g_dbus_object_manager_client_new_sync(
@@ -662,7 +656,7 @@ CHIP_ERROR BluezEndpoint::RegisterGattApplication()
     return err;
 }
 
-CHIP_ERROR BluezEndpoint::Init(uint32_t aAdapterId, bool aIsCentral, const char * apBleAddr, const char * apBleName)
+CHIP_ERROR BluezEndpoint::Init(uint32_t aAdapterId, bool aIsCentral, const char * apBleAddr)
 {
     CHIP_ERROR err;
 
@@ -672,11 +666,7 @@ CHIP_ERROR BluezEndpoint::Init(uint32_t aAdapterId, bool aIsCentral, const char 
     if (apBleAddr != nullptr)
         mpAdapterAddr = g_strdup(apBleAddr);
 
-    if (!aIsCentral)
-    {
-        mpAdapterName = g_strdup(apBleName);
-    }
-    else
+    if (aIsCentral)
     {
         mpConnectCancellable = g_cancellable_new();
     }
@@ -723,8 +713,6 @@ void BluezEndpoint::Shutdown()
         },
         this);
 
-    g_free(mpOwningName);
-    g_free(mpAdapterName);
     g_free(mpAdapterAddr);
     g_free(mpRootPath);
     g_free(mpServicePath);

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -69,11 +69,10 @@ public:
     BluezEndpoint()  = default;
     ~BluezEndpoint() = default;
 
-    CHIP_ERROR Init(uint32_t aAdapterId, bool aIsCentral, const char * apBleAddr, const char * apBleName);
+    CHIP_ERROR Init(uint32_t aAdapterId, bool aIsCentral, const char * apBleAddr);
     void Shutdown();
 
     BluezAdapter1 * GetAdapter() const { return mpAdapter; }
-    const char * GetAdapterName() const { return mpAdapterName; }
 
     CHIP_ERROR RegisterGattApplication();
     GDBusObjectManagerServer * GetGattApplicationObjectManager() const { return mpRoot; }
@@ -127,12 +126,8 @@ private:
     bool mIsCentral     = false;
     bool mIsInitialized = false;
 
-    // Bus owning name
-    char * mpOwningName = nullptr;
-
     // Adapter properties
     uint32_t mAdapterId  = 0;
-    char * mpAdapterName = nullptr;
     char * mpAdapterAddr = nullptr;
 
     // Paths for objects published by this service


### PR DESCRIPTION
### Problem

The name passed to the `BluezEndpoint` is not the owning name of the D-Bus - Matter SDK does not own any D-Bus name. In current form the code is misleading.

### Changes

- Pass advertising name directly to `BluezAdvertisement`
- Remove non-existing strings from certification TC

### Testing

CI will verify potential build breaks.