### PR TITLE
Add missing function to set delegate in Door Lock Server

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -87,6 +87,18 @@ struct EmberAfDoorLockEndpointContext
     int wrongCodeEntryAttempts;
 };
 
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace DoorLock {
+
+void SetDefaultDelegate(EndpointId endpoint, Delegate * delegate);
+
+} // namespace AccountLogin
+} // namespace Clusters
+} // namespace app
+} // namespace chip
+
 /**
  * @brief Door Lock Server Plugin class.
  */

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -94,7 +94,7 @@ namespace DoorLock {
 
 void SetDefaultDelegate(EndpointId endpoint, Delegate * delegate);
 
-} // namespace AccountLogin
+} // namespace DoorLock
 } // namespace Clusters
 } // namespace app
 } // namespace chip


### PR DESCRIPTION
Fixes #31845 
There was a delegate recently added to door lock, but not exposed in the header. This PR adds the function the the door lock server header file.


