### PR TITLE
[Documentation] Adding missing events in Matter Linux Air Quality Example

### DIFF
--- a/examples/air-quality-sensor-app/linux/README.md
+++ b/examples/air-quality-sensor-app/linux/README.md
@@ -158,3 +158,9 @@ Generate event `CarbonMonoxideConcentrationMeasurement`, to change the CO value.
 ```
 $ echo '{"Name":"CarbonMonoxideConcentrationMeasurement","NewValue":1}' > /tmp/chip_air_quality_fifo_<PID>
 ```
+
+Generate event `NitrogenDioxideConcentrationMeasurement`, to change the NO₂ value.
+
+```
+$ echo '{"Name":"NitrogenDioxideConcentrationMeasurement","NewValue":1}' > /tmp/chip_air_quality_fifo_<PID>
+```

--- a/examples/air-quality-sensor-app/linux/README.md
+++ b/examples/air-quality-sensor-app/linux/README.md
@@ -152,3 +152,9 @@ Generate event `CarbonDioxideConcentrationMeasurement`, to change the CO2 value.
 ```
 $ echo '{"Name":"CarbonDioxideConcentrationMeasurement","NewValue":400}' > /tmp/chip_air_quality_fifo_<PID>
 ```
+
+Generate event `CarbonMonoxideConcentrationMeasurement`, to change the CO value.
+
+```
+$ echo '{"Name":"CarbonMonoxideConcentrationMeasurement","NewValue":1}' > /tmp/chip_air_quality_fifo_<PID>
+```

--- a/examples/air-quality-sensor-app/linux/README.md
+++ b/examples/air-quality-sensor-app/linux/README.md
@@ -159,7 +159,8 @@ Generate event `CarbonMonoxideConcentrationMeasurement`, to change the CO value.
 $ echo '{"Name":"CarbonMonoxideConcentrationMeasurement","NewValue":1}' > /tmp/chip_air_quality_fifo_<PID>
 ```
 
-Generate event `NitrogenDioxideConcentrationMeasurement`, to change the NO₂ value.
+Generate event `NitrogenDioxideConcentrationMeasurement`, to change the NO₂
+value.
 
 ```
 $ echo '{"Name":"NitrogenDioxideConcentrationMeasurement","NewValue":1}' > /tmp/chip_air_quality_fifo_<PID>


### PR DESCRIPTION
Adding missing events in Matter Linux Air Quality Example:
- CarbonMonoxideConcentrationMeasurement
- NitrogenDioxideConcentrationMeasurement


Fixes #31855

