### PR TITLE
Add missing dependencies to GN in bluez module

### DIFF
--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -97,6 +97,8 @@ static_library("Linux") {
       "bluez/BluezConnection.h",
       "bluez/BluezEndpoint.cpp",
       "bluez/BluezEndpoint.h",
+      "bluez/BluezObjectIterator.h",
+      "bluez/BluezObjectList.h",
       "bluez/ChipDeviceScanner.cpp",
       "bluez/ChipDeviceScanner.h",
       "bluez/Types.h",


### PR DESCRIPTION
Files used in other BlueZ module files were not added to GN.