### PR TITLE
Add orphan files in `src/transport` to gn

### DIFF
--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -44,6 +44,7 @@ static_library("transport") {
     "SessionManager.h",
     "SessionMessageCounter.h",
     "SessionMessageDelegate.h",
+    "SessionUpdateDelegate.h",
     "TracingStructs.h",
     "TransportMgr.h",
     "TransportMgrBase.cpp",
@@ -70,7 +71,10 @@ static_library("transport") {
   ]
 
   if (chip_enable_transport_trace) {
-    sources += [ "TraceMessage.cpp" ]
+    sources += [
+      "TraceMessage.cpp",
+      "TraceMessage.h",
+    ]
   }
   if (chip_enable_transport_pw_trace) {
     public_deps += [ "$dir_pw_trace" ]

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -19,7 +19,10 @@ import("//build_overrides/nlunit_test.gni")
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
 source_set("helpers") {
-  sources = [ "LoopbackTransportManager.h" ]
+  sources = [
+    "LoopbackTransportManager.h",
+    "UDPTransportManager.h",
+  ]
 
   public_deps = [
     "${chip_root}/src/transport:transport",


### PR DESCRIPTION
This helps enforce layering and forces other gn projects to include and depend on what they use. 