### PR TITLE
Log the error when UpdateUTCTime fails.

### DIFF
--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -773,7 +773,7 @@ CHIP_ERROR TimeSynchronizationServer::SetUTCTime(EndpointId ep, uint64_t utcTime
     CHIP_ERROR err = UpdateUTCTime(utcTime);
     if (err != CHIP_NO_ERROR && !RuntimeOptionsProvider::Instance().GetSimulateNoInternalTime())
     {
-        ChipLogError(Zcl, "Error setting UTC time on the device");
+        ChipLogError(Zcl, "Error setting UTC time on the device: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
     GetDelegate()->UTCTimeAvailabilityChanged(utcTime);


### PR DESCRIPTION
Saying "error" without saying which error is a bit hostile to log-based debugging.
