### PR TITLE
[Android] Fix global reference leaks across the android in matter

### DIFF
--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -63,11 +63,12 @@ CHIP_ERROR ChannelManager::HandleGetChannelList(AttributeValueEncoder & aEncoder
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received ChannelManager::HandleGetChannelList");
-    VerifyOrExit(mChannelManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mChannelManagerObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mGetChannelListMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     return aEncoder.EncodeList([this, env](const auto & encoder) -> CHIP_ERROR {
-        jobjectArray channelInfoList = (jobjectArray) env->CallObjectMethod(mChannelManagerObject, mGetChannelListMethod);
+        jobjectArray channelInfoList =
+            (jobjectArray) env->CallObjectMethod(mChannelManagerObject.ObjectRef(), mGetChannelListMethod);
         if (env->ExceptionCheck())
         {
             ChipLogError(Zcl, "Java exception in ChannelManager::HandleGetChannelList");
@@ -140,11 +141,11 @@ CHIP_ERROR ChannelManager::HandleGetLineup(AttributeValueEncoder & aEncoder)
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received ChannelManager::HandleGetLineup");
-    VerifyOrExit(mChannelManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mChannelManagerObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mGetLineupMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     {
-        jobject channelLineupObject = env->CallObjectMethod(mChannelManagerObject, mGetLineupMethod);
+        jobject channelLineupObject = env->CallObjectMethod(mChannelManagerObject.ObjectRef(), mGetLineupMethod);
         if (channelLineupObject != nullptr)
         {
             jclass channelLineupClazz = env->GetObjectClass(channelLineupObject);
@@ -203,11 +204,11 @@ CHIP_ERROR ChannelManager::HandleGetCurrentChannel(AttributeValueEncoder & aEnco
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received ChannelManager::HandleGetCurrentChannel");
-    VerifyOrExit(mChannelManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mChannelManagerObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mGetCurrentChannelMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     {
-        jobject channelInfoObject = env->CallObjectMethod(mChannelManagerObject, mGetCurrentChannelMethod);
+        jobject channelInfoObject = env->CallObjectMethod(mChannelManagerObject.ObjectRef(), mGetCurrentChannelMethod);
         if (channelInfoObject != nullptr)
         {
             jclass channelClass = env->GetObjectClass(channelInfoObject);
@@ -278,13 +279,13 @@ void ChannelManager::HandleChangeChannel(CommandResponseHelper<ChangeChannelResp
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received ChannelManager::HandleChangeChannel name %s", name.c_str());
-    VerifyOrExit(mChannelManagerObject != nullptr, ChipLogError(Zcl, "mChannelManagerObject null"));
+    VerifyOrExit(mChannelManagerObject.HasValidObjectRef(), ChipLogError(Zcl, "mChannelManagerObject null"));
     VerifyOrExit(mChangeChannelMethod != nullptr, ChipLogError(Zcl, "mChangeChannelMethod null"));
 
     {
         UtfString jniname(env, name.c_str());
         env->ExceptionClear();
-        jobject channelObject = env->CallObjectMethod(mChannelManagerObject, mChangeChannelMethod, jniname.jniValue());
+        jobject channelObject = env->CallObjectMethod(mChannelManagerObject.ObjectRef(), mChangeChannelMethod, jniname.jniValue());
         if (env->ExceptionCheck())
         {
             ChipLogError(DeviceLayer, "Java exception in ChannelManager::HandleChangeChannel");
@@ -325,12 +326,12 @@ bool ChannelManager::HandleChangeChannelByNumber(const uint16_t & majorNumber, c
 
     ChipLogProgress(Zcl, "Received ChannelManager::HandleChangeChannelByNumber majorNumber %d, minorNumber %d", majorNumber,
                     minorNumber);
-    VerifyOrExit(mChannelManagerObject != nullptr, ChipLogError(Zcl, "mChannelManagerObject null"));
+    VerifyOrExit(mChannelManagerObject.HasValidObjectRef(), ChipLogError(Zcl, "mChannelManagerObject null"));
     VerifyOrExit(mChangeChannelByNumberMethod != nullptr, ChipLogError(Zcl, "mChangeChannelByNumberMethod null"));
 
     env->ExceptionClear();
 
-    ret = env->CallBooleanMethod(mChannelManagerObject, mChangeChannelByNumberMethod, static_cast<jint>(majorNumber),
+    ret = env->CallBooleanMethod(mChannelManagerObject.ObjectRef(), mChangeChannelByNumberMethod, static_cast<jint>(majorNumber),
                                  static_cast<jint>(minorNumber));
     if (env->ExceptionCheck())
     {
@@ -352,12 +353,12 @@ bool ChannelManager::HandleSkipChannel(const int16_t & count)
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received ChannelManager::HandleSkipChannel count %d", count);
-    VerifyOrExit(mChannelManagerObject != nullptr, ChipLogError(Zcl, "mChannelManagerObject null"));
+    VerifyOrExit(mChannelManagerObject.HasValidObjectRef(), ChipLogError(Zcl, "mChannelManagerObject null"));
     VerifyOrExit(mSkipChannelMethod != nullptr, ChipLogError(Zcl, "mSkipChannelMethod null"));
 
     env->ExceptionClear();
 
-    ret = env->CallBooleanMethod(mChannelManagerObject, mSkipChannelMethod, static_cast<jint>(count));
+    ret = env->CallBooleanMethod(mChannelManagerObject.ObjectRef(), mSkipChannelMethod, static_cast<jint>(count));
     if (env->ExceptionCheck())
     {
         ChipLogError(DeviceLayer, "Java exception in ChannelManager::HandleSkipChannel");
@@ -390,7 +391,7 @@ void ChannelManager::HandleGetProgramGuide(
     std::vector<JniUtfString *> needToFreeStrings;
 
     ChipLogProgress(Zcl, "Received ChannelManager::HandleGetProgramGuide");
-    VerifyOrExit(mChannelManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mChannelManagerObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mGetProgramGuideMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     {
@@ -401,7 +402,7 @@ void ChannelManager::HandleGetProgramGuide(
         jobjectArray externalIDListArray = (jobjectArray) env->NewObjectArray(0, env->FindClass("java/util/Map$Entry"), NULL);
 
         jobject resp = env->CallObjectMethod(
-            mChannelManagerObject, mGetProgramGuideMethod, static_cast<jlong>(startTime.ValueOr(0)),
+            mChannelManagerObject.ObjectRef(), mGetProgramGuideMethod, static_cast<jlong>(startTime.ValueOr(0)),
             static_cast<jlong>(endTime.ValueOr(0)), channelsArray, jToken.jniValue(),
             static_cast<jboolean>(recordingFlag.ValueOr(0).Raw() != 0), externalIDListArray, jData.jniValue());
         if (env->ExceptionCheck())
@@ -596,7 +597,7 @@ bool ChannelManager::HandleRecordProgram(const chip::CharSpan & programIdentifie
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received ChannelManager::HandleRecordProgram");
-    VerifyOrExit(mChannelManagerObject != nullptr, ChipLogError(Zcl, "mChannelManagerObject null"));
+    VerifyOrExit(mChannelManagerObject.HasValidObjectRef(), ChipLogError(Zcl, "mChannelManagerObject null"));
     VerifyOrExit(mRecordProgramMethod != nullptr, ChipLogError(Zcl, "mRecordProgramMethod null"));
 
     env->ExceptionClear();
@@ -608,7 +609,7 @@ bool ChannelManager::HandleRecordProgram(const chip::CharSpan & programIdentifie
         UtfString jData(env, "");
         jobjectArray externalIDListArray = (jobjectArray) env->NewObjectArray(0, env->FindClass("java/util/Map$Entry"), NULL);
 
-        ret = env->CallBooleanMethod(mChannelManagerObject, mRecordProgramMethod, jIdentifier.jniValue(),
+        ret = env->CallBooleanMethod(mChannelManagerObject.ObjectRef(), mRecordProgramMethod, jIdentifier.jniValue(),
                                      static_cast<jboolean>(shouldRecordSeries), externalIDListArray, jData.jniValue());
         if (env->ExceptionCheck())
         {
@@ -633,7 +634,7 @@ bool ChannelManager::HandleCancelRecordProgram(const chip::CharSpan & programIde
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received ChannelManager::HandleCancelRecordProgram");
-    VerifyOrExit(mChannelManagerObject != nullptr, ChipLogError(Zcl, "mChannelManagerObject null"));
+    VerifyOrExit(mChannelManagerObject.HasValidObjectRef(), ChipLogError(Zcl, "mChannelManagerObject null"));
     VerifyOrExit(mCancelRecordProgramMethod != nullptr, ChipLogError(Zcl, "mCancelRecordProgramMethod null"));
 
     env->ExceptionClear();
@@ -645,7 +646,7 @@ bool ChannelManager::HandleCancelRecordProgram(const chip::CharSpan & programIde
         UtfString jData(env, "");
         jobjectArray externalIDListArray = (jobjectArray) env->NewObjectArray(0, env->FindClass("java/util/Map$Entry"), NULL);
 
-        ret = env->CallBooleanMethod(mChannelManagerObject, mCancelRecordProgramMethod, jIdentifier.jniValue(),
+        ret = env->CallBooleanMethod(mChannelManagerObject.ObjectRef(), mCancelRecordProgramMethod, jIdentifier.jniValue(),
                                      static_cast<jboolean>(shouldRecordSeries), externalIDListArray, jData.jniValue());
         if (env->ExceptionCheck())
         {
@@ -665,10 +666,10 @@ void ChannelManager::InitializeWithObjects(jobject managerObject)
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for ChannelManager"));
 
-    mChannelManagerObject = env->NewGlobalRef(managerObject);
-    VerifyOrReturn(mChannelManagerObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef ChannelManager"));
+    VerifyOrReturn(mChannelManagerObject.Init(managerObject) == CHIP_NO_ERROR,
+                   ChipLogError(Zcl, "Failed to init mChannelManagerObject"));
 
-    jclass managerClass = env->GetObjectClass(mChannelManagerObject);
+    jclass managerClass = env->GetObjectClass(managerObject);
     VerifyOrReturn(managerClass != nullptr, ChipLogError(Zcl, "Failed to get ChannelManager Java class"));
 
     mGetChannelListMethod = env->GetMethodID(managerClass, "getChannelList", "()[Lcom/matter/tv/server/tvapp/ChannelInfo;");

--- a/examples/tv-app/android/java/ChannelManager.h
+++ b/examples/tv-app/android/java/ChannelManager.h
@@ -19,6 +19,7 @@
 
 #include <app/clusters/channel-server/channel-server.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 using chip::CharSpan;
 using chip::app::AttributeValueEncoder;
@@ -66,7 +67,7 @@ public:
     uint32_t GetFeatureMap(chip::EndpointId endpoint) override;
 
 private:
-    jobject mChannelManagerObject      = nullptr;
+    chip::JniGlobalReference mChannelManagerObject;
     jmethodID mGetChannelListMethod    = nullptr;
     jmethodID mGetLineupMethod         = nullptr;
     jmethodID mGetCurrentChannelMethod = nullptr;

--- a/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
@@ -47,9 +47,9 @@ std::string ContentAppAttributeDelegate::Read(const chip::app::ConcreteReadAttri
     ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read being called for endpoint %d cluster %d attribute %d",
                     aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId);
 
-    jstring resp =
-        (jstring) env->CallObjectMethod(mContentAppEndpointManager, mReadAttributeMethod, static_cast<jint>(aPath.mEndpointId),
-                                        static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mAttributeId));
+    jstring resp = static_cast<jstring>(
+        env->CallObjectMethod(mContentAppEndpointManager.ObjectRef(), mReadAttributeMethod, static_cast<jint>(aPath.mEndpointId),
+                              static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mAttributeId)));
     if (env->ExceptionCheck())
     {
         ChipLogError(Zcl, "Java exception in ContentAppAttributeDelegate::Read");

--- a/examples/tv-app/android/java/ContentAppAttributeDelegate.h
+++ b/examples/tv-app/android/java/ContentAppAttributeDelegate.h
@@ -44,13 +44,6 @@ public:
         InitializeJNIObjects(manager);
     }
 
-    ~ContentAppAttributeDelegate()
-    {
-        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-        VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for ContentAppEndpointManager"));
-        env->DeleteGlobalRef(mContentAppEndpointManager);
-    }
-
     std::string Read(const chip::app::ConcreteReadAttributePath & aPath);
 
 private:
@@ -59,9 +52,8 @@ private:
         JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for ContentAppEndpointManager"));
 
-        mContentAppEndpointManager = env->NewGlobalRef(manager);
-        VerifyOrReturn(mContentAppEndpointManager != nullptr,
-                       ChipLogError(Zcl, "Failed to NewGlobalRef ContentAppEndpointManager"));
+        VerifyOrReturn(mContentAppEndpointManager.Init(manager) == CHIP_NO_ERROR,
+                       ChipLogError(Zcl, "Failed to init mContentAppEndpointManager"));
 
         jclass ContentAppEndpointManagerClass = env->GetObjectClass(manager);
         VerifyOrReturn(ContentAppEndpointManagerClass != nullptr,
@@ -75,8 +67,8 @@ private:
         }
     }
 
-    jobject mContentAppEndpointManager = nullptr;
-    jmethodID mReadAttributeMethod     = nullptr;
+    chip::JniGlobalReference mContentAppEndpointManager;
+    jmethodID mReadAttributeMethod = nullptr;
 };
 
 } // namespace AppPlatform

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.h
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.h
@@ -64,13 +64,6 @@ public:
         InitializeJNIObjects(manager);
     };
 
-    ~ContentAppCommandDelegate()
-    {
-        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-        VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for ContentAppEndpointManager"));
-        env->DeleteGlobalRef(mContentAppEndpointManager);
-    }
-
     void InvokeCommand(CommandHandlerInterface::HandlerContext & handlerContext) override;
 
     Status InvokeCommand(EndpointId epId, ClusterId clusterId, CommandId commandId, std::string payload, bool & commandHandled,
@@ -87,9 +80,8 @@ private:
         JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
         VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for ContentAppEndpointManager"));
 
-        mContentAppEndpointManager = env->NewGlobalRef(manager);
-        VerifyOrReturn(mContentAppEndpointManager != nullptr,
-                       ChipLogError(Zcl, "Failed to NewGlobalRef ContentAppEndpointManager"));
+        VerifyOrReturn(mContentAppEndpointManager.Init(manager) == CHIP_NO_ERROR,
+                       ChipLogError(Zcl, "Failed to init mContentAppEndpointManager"));
 
         jclass ContentAppEndpointManagerClass = env->GetObjectClass(manager);
         VerifyOrReturn(ContentAppEndpointManagerClass != nullptr,
@@ -106,8 +98,8 @@ private:
 
     void FormatResponseData(CommandHandlerInterface::HandlerContext & handlerContext, const char * response);
 
-    jobject mContentAppEndpointManager = nullptr;
-    jmethodID mSendCommandMethod       = nullptr;
+    chip::JniGlobalReference mContentAppEndpointManager;
+    jmethodID mSendCommandMethod = nullptr;
 };
 
 } // namespace AppPlatform

--- a/examples/tv-app/android/java/ContentLauncherManager.cpp
+++ b/examples/tv-app/android/java/ContentLauncherManager.cpp
@@ -58,7 +58,7 @@ void ContentLauncherManager::HandleLaunchContent(CommandResponseHelper<LaunchRes
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received ContentLauncherManager::LaunchContent");
-    VerifyOrExit(mContentLauncherManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mContentLauncherManagerObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mLaunchContentMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     {
@@ -67,7 +67,7 @@ void ContentLauncherManager::HandleLaunchContent(CommandResponseHelper<LaunchRes
         // Todo: make parameterList java
         jobjectArray parameterArray = nullptr;
 
-        jobject resp = env->CallObjectMethod(mContentLauncherManagerObject, mLaunchContentMethod, parameterArray,
+        jobject resp = env->CallObjectMethod(mContentLauncherManagerObject.ObjectRef(), mLaunchContentMethod, parameterArray,
                                              static_cast<jboolean>(autoplay), jData.jniValue());
         if (env->ExceptionCheck())
         {
@@ -113,7 +113,7 @@ void ContentLauncherManager::HandleLaunchUrl(CommandResponseHelper<LaunchRespons
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received ContentLauncherManager::LaunchContentUrl");
-    VerifyOrExit(mContentLauncherManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mContentLauncherManagerObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mLaunchUrlMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     {
@@ -123,7 +123,7 @@ void ContentLauncherManager::HandleLaunchUrl(CommandResponseHelper<LaunchRespons
         // Todo: make brandingInformation java
         jobjectArray branding = nullptr;
 
-        jobject resp = env->CallObjectMethod(mContentLauncherManagerObject, mLaunchUrlMethod, jContentUrl.jniValue(),
+        jobject resp = env->CallObjectMethod(mContentLauncherManagerObject.ObjectRef(), mLaunchUrlMethod, jContentUrl.jniValue(),
                                              jDisplayString.jniValue(), branding);
         if (env->ExceptionCheck())
         {
@@ -167,12 +167,12 @@ CHIP_ERROR ContentLauncherManager::HandleGetAcceptHeaderList(AttributeValueEncod
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received ContentLauncherManager::GetAcceptHeader");
-    VerifyOrExit(mContentLauncherManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mContentLauncherManagerObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mGetAcceptHeaderMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     return aEncoder.EncodeList([this, env](const auto & encoder) -> CHIP_ERROR {
         jobjectArray acceptedHeadersArray =
-            (jobjectArray) env->CallObjectMethod(mContentLauncherManagerObject, mGetAcceptHeaderMethod);
+            (jobjectArray) env->CallObjectMethod(mContentLauncherManagerObject.ObjectRef(), mGetAcceptHeaderMethod);
         if (env->ExceptionCheck())
         {
             ChipLogError(Zcl, "Java exception in ContentLauncherManager::GetAcceptHeader");
@@ -210,12 +210,12 @@ uint32_t ContentLauncherManager::HandleGetSupportedStreamingProtocols()
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received ContentLauncherManager::GetSupportedStreamingProtocols");
-    VerifyOrExit(mContentLauncherManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mContentLauncherManagerObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mGetSupportedStreamingProtocolsMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     {
         jlong jSupportedStreamingProtocols =
-            env->CallLongMethod(mContentLauncherManagerObject, mGetSupportedStreamingProtocolsMethod);
+            env->CallLongMethod(mContentLauncherManagerObject.ObjectRef(), mGetSupportedStreamingProtocolsMethod);
         supportedStreamingProtocols = (uint32_t) jSupportedStreamingProtocols;
         if (env->ExceptionCheck())
         {
@@ -241,8 +241,8 @@ void ContentLauncherManager::InitializeWithObjects(jobject managerObject)
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for ContentLauncherManager"));
 
-    mContentLauncherManagerObject = env->NewGlobalRef(managerObject);
-    VerifyOrReturn(mContentLauncherManagerObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef ContentLauncherManager"));
+    VerifyOrReturn(mContentLauncherManagerObject.Init(managerObject) == CHIP_NO_ERROR,
+                   ChipLogError(Zcl, "Failed to init mContentLauncherManagerObject"));
 
     jclass ContentLauncherClass = env->GetObjectClass(managerObject);
     VerifyOrReturn(ContentLauncherClass != nullptr, ChipLogError(Zcl, "Failed to get ContentLauncherManager Java class"));

--- a/examples/tv-app/android/java/ContentLauncherManager.h
+++ b/examples/tv-app/android/java/ContentLauncherManager.h
@@ -22,6 +22,7 @@
 #include <app/clusters/content-launch-server/content-launch-server.h>
 #include <jni.h>
 #include <lib/core/CHIPError.h>
+#include <lib/support/JniReferences.h>
 
 using chip::CharSpan;
 using chip::app::AttributeValueEncoder;
@@ -50,7 +51,7 @@ public:
     uint32_t GetFeatureMap(chip::EndpointId endpoint) override;
 
 private:
-    jobject mContentLauncherManagerObject           = nullptr;
+    chip::JniGlobalReference mContentLauncherManagerObject;
     jmethodID mGetAcceptHeaderMethod                = nullptr;
     jmethodID mGetSupportedStreamingProtocolsMethod = nullptr;
     jmethodID mLaunchContentMethod                  = nullptr;

--- a/examples/tv-app/android/java/DeviceCallbacks.cpp
+++ b/examples/tv-app/android/java/DeviceCallbacks.cpp
@@ -58,9 +58,9 @@ void DeviceCallbacks::InitializeWithObjects(jobject provider)
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(AppServer, "Failed to GetEnvForCurrentThread for DeviceEventProvider"));
 
-    mProvider = env->NewGlobalRef(provider);
-    VerifyOrReturn(mProvider != nullptr, ChipLogError(AppServer, "Failed to NewGlobalRef DeviceEventProvider"));
-    jclass deviceEventProviderCls = env->GetObjectClass(mProvider);
+    VerifyOrReturn(mProvider.Init(provider) == CHIP_NO_ERROR, ChipLogError(Zcl, "Failed to init mProvider"));
+
+    jclass deviceEventProviderCls = env->GetObjectClass(provider);
     VerifyOrReturn(deviceEventProviderCls != nullptr, ChipLogError(AppServer, "Failed to get KeypadInputManager Java class"));
 
     mCommissioningCompleteMethod = env->GetMethodID(deviceEventProviderCls, "onCommissioningComplete", "()V");
@@ -85,7 +85,10 @@ void DeviceCallbacks::OnCommissioningComplete(const ChipDeviceEvent * event)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for DeviceEventProvider"));
-    env->CallVoidMethod(mProvider, mCommissioningCompleteMethod);
+
+    VerifyOrReturn(mProvider.HasValidObjectRef(), ChipLogError(Zcl, "mProvider is not valid"));
+
+    env->CallVoidMethod(mProvider.ObjectRef(), mCommissioningCompleteMethod);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in DeviceEventProvider::onCommissioningComplete");

--- a/examples/tv-app/android/java/DeviceCallbacks.h
+++ b/examples/tv-app/android/java/DeviceCallbacks.h
@@ -18,6 +18,7 @@
 
 #include "lib/support/logging/CHIPLogging.h"
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 class DeviceCallbacks
 {
@@ -28,7 +29,7 @@ public:
     void InitializeWithObjects(jobject manager);
 
 private:
-    jobject mProvider                      = nullptr;
+    chip::JniGlobalReference mProvider;
     jmethodID mCommissioningCompleteMethod = nullptr;
     void OnCommissioningComplete(const chip::DeviceLayer::ChipDeviceEvent * event);
 };

--- a/examples/tv-app/android/java/JNIDACProvider.cpp
+++ b/examples/tv-app/android/java/JNIDACProvider.cpp
@@ -34,8 +34,8 @@ JNIDACProvider::JNIDACProvider(jobject provider)
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for JNIDACProvider"));
 
-    mJNIDACProviderObject = env->NewGlobalRef(provider);
-    VerifyOrReturn(mJNIDACProviderObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef JNIDACProvider"));
+    VerifyOrReturn(mJNIDACProviderObject.Init(provider) == CHIP_NO_ERROR,
+                   ChipLogError(Zcl, "Failed to init mJNIDACProviderObject"));
 
     jclass JNIDACProviderClass = env->GetObjectClass(provider);
     VerifyOrReturn(JNIDACProviderClass != nullptr, ChipLogError(Zcl, "Failed to get JNIDACProvider Java class"));
@@ -80,11 +80,11 @@ JNIDACProvider::JNIDACProvider(jobject provider)
 CHIP_ERROR JNIDACProvider::GetJavaByteByMethod(jmethodID method, MutableByteSpan & out_buffer)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    VerifyOrReturnLogError(mJNIDACProviderObject != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(mJNIDACProviderObject.HasValidObjectRef(), CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(method != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(env != nullptr, CHIP_JNI_ERROR_NO_ENV);
 
-    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIDACProviderObject, method);
+    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIDACProviderObject.ObjectRef(), method);
     if (env->ExceptionCheck())
     {
         ChipLogError(Zcl, "Java exception in get Method");
@@ -106,14 +106,14 @@ CHIP_ERROR JNIDACProvider::GetJavaByteByMethod(jmethodID method, MutableByteSpan
 CHIP_ERROR JNIDACProvider::GetJavaByteByMethod(jmethodID method, const ByteSpan & in_buffer, MutableByteSpan & out_buffer)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    VerifyOrReturnLogError(mJNIDACProviderObject != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(mJNIDACProviderObject.HasValidObjectRef(), CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(method != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(env != nullptr, CHIP_JNI_ERROR_NO_ENV);
 
     jbyteArray in_buffer_jbyteArray = env->NewByteArray((jsize) (in_buffer.size()));
     env->SetByteArrayRegion(in_buffer_jbyteArray, 0, (int) in_buffer.size(), reinterpret_cast<const jbyte *>(in_buffer.data()));
 
-    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIDACProviderObject, method, in_buffer_jbyteArray);
+    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIDACProviderObject.ObjectRef(), method, in_buffer_jbyteArray);
     if (env->ExceptionCheck())
     {
         ChipLogError(Zcl, "Java exception in get Method");

--- a/examples/tv-app/android/java/JNIDACProvider.h
+++ b/examples/tv-app/android/java/JNIDACProvider.h
@@ -19,6 +19,7 @@
 #include "lib/support/logging/CHIPLogging.h"
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 class JNIDACProvider : public chip::Credentials::DeviceAttestationCredentialsProvider
 {
@@ -34,7 +35,7 @@ public:
 private:
     CHIP_ERROR GetJavaByteByMethod(jmethodID method, chip::MutableByteSpan & out_buffer);
     CHIP_ERROR GetJavaByteByMethod(jmethodID method, const chip::ByteSpan & in_buffer, chip::MutableByteSpan & out_buffer);
-    jobject mJNIDACProviderObject                          = nullptr;
+    chip::JniGlobalReference mJNIDACProviderObject;
     jmethodID mGetCertificationDeclarationMethod           = nullptr;
     jmethodID mGetFirmwareInformationMethod                = nullptr;
     jmethodID mGetDeviceAttestationCertMethod              = nullptr;

--- a/examples/tv-app/android/java/KeypadInputManager.cpp
+++ b/examples/tv-app/android/java/KeypadInputManager.cpp
@@ -53,11 +53,11 @@ void KeypadInputManager::HandleSendKey(CommandResponseHelper<SendKeyResponseType
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received keypadInputClusterSendKey: %c", to_underlying(keyCode));
-    VerifyOrExit(mKeypadInputManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mKeypadInputManagerObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mSendKeyMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     env->ExceptionClear();
-    ret = env->CallIntMethod(mKeypadInputManagerObject, mSendKeyMethod, static_cast<jint>(keyCode));
+    ret = env->CallIntMethod(mKeypadInputManagerObject.ObjectRef(), mSendKeyMethod, static_cast<jint>(keyCode));
     VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
 exit:
@@ -78,8 +78,8 @@ void KeypadInputManager::InitializeWithObjects(jobject managerObject)
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for KeypadInputManager"));
     JniLocalReferenceScope scope(env);
 
-    mKeypadInputManagerObject = env->NewGlobalRef(managerObject);
-    VerifyOrReturn(mKeypadInputManagerObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef KeypadInputManager"));
+    VerifyOrReturn(mKeypadInputManagerObject.Init(managerObject) == CHIP_NO_ERROR,
+                   ChipLogError(Zcl, "Failed to init mKeypadInputManagerObject"));
 
     jclass KeypadInputManagerClass = env->GetObjectClass(managerObject);
     VerifyOrReturn(KeypadInputManagerClass != nullptr, ChipLogError(Zcl, "Failed to get KeypadInputManager Java class"));

--- a/examples/tv-app/android/java/KeypadInputManager.h
+++ b/examples/tv-app/android/java/KeypadInputManager.h
@@ -20,6 +20,7 @@
 
 #include <app/clusters/keypad-input-server/keypad-input-server.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 using chip::app::CommandResponseHelper;
 using KeypadInputDelegate = chip::app::Clusters::KeypadInput::Delegate;
@@ -37,8 +38,8 @@ public:
     uint32_t GetFeatureMap(chip::EndpointId endpoint) override;
 
 private:
-    jobject mKeypadInputManagerObject = nullptr;
-    jmethodID mSendKeyMethod          = nullptr;
+    chip::JniGlobalReference mKeypadInputManagerObject;
+    jmethodID mSendKeyMethod = nullptr;
 
     // TODO: set this based upon meta data from app
     uint32_t mDynamicEndpointFeatureMap = 7;

--- a/examples/tv-app/android/java/LevelManager.cpp
+++ b/examples/tv-app/android/java/LevelManager.cpp
@@ -94,8 +94,7 @@ CHIP_ERROR LevelManager::InitializeWithObjects(jobject managerObject)
     VerifyOrReturnLogError(env != nullptr, CHIP_ERROR_INCORRECT_STATE);
     JniLocalReferenceScope scope(env);
 
-    mLevelManagerObject = env->NewGlobalRef(managerObject);
-    VerifyOrReturnLogError(mLevelManagerObject != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnLogErrorOnFailure(mLevelManagerObject.Init(managerObject));
 
     jclass LevelManagerClass = env->GetObjectClass(managerObject);
     VerifyOrReturnLogError(LevelManagerClass != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -119,11 +118,11 @@ void LevelManager::HandleLevelChanged(uint8_t value)
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Could not get JNIEnv for current thread"));
     JniLocalReferenceScope scope(env);
 
-    VerifyOrReturn(mLevelManagerObject != nullptr, ChipLogProgress(Zcl, "mLevelManagerObject null"));
+    VerifyOrReturn(mLevelManagerObject.HasValidObjectRef(), ChipLogError(Zcl, "mLevelManagerObject is not valid"));
     VerifyOrReturn(mHandleLevelChangedMethod != nullptr, ChipLogProgress(Zcl, "mHandleLevelChangedMethod null"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mLevelManagerObject, mHandleLevelChangedMethod, static_cast<jint>(value));
+    env->CallVoidMethod(mLevelManagerObject.ObjectRef(), mHandleLevelChangedMethod, static_cast<jint>(value));
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in LevelManager::HandleLevelChanged");

--- a/examples/tv-app/android/java/LevelManager.h
+++ b/examples/tv-app/android/java/LevelManager.h
@@ -19,6 +19,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <cstdint>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 /**
  * @brief Handles interfacing between java code and C++ code for the purposes of LevelControl clusters.
@@ -41,6 +42,6 @@ public:
 private:
     // init with java objects
     CHIP_ERROR InitializeWithObjects(jobject managerObject);
-    jobject mLevelManagerObject         = nullptr;
+    chip::JniGlobalReference mLevelManagerObject;
     jmethodID mHandleLevelChangedMethod = nullptr;
 };

--- a/examples/tv-app/android/java/LowPowerManager.cpp
+++ b/examples/tv-app/android/java/LowPowerManager.cpp
@@ -48,8 +48,8 @@ void LowPowerManager::InitializeWithObjects(jobject managerObject)
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for LowPowerManager"));
     JniLocalReferenceScope scope(env);
 
-    mLowPowerManagerObject = env->NewGlobalRef(managerObject);
-    VerifyOrReturn(mLowPowerManagerObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef LowPowerManager"));
+    VerifyOrReturn(mLowPowerManagerObject.Init(managerObject) == CHIP_NO_ERROR,
+                   ChipLogError(Zcl, "Failed to init mLowPowerManagerObject"));
 
     jclass LowPowerManagerClass = env->GetObjectClass(managerObject);
     VerifyOrReturn(LowPowerManagerClass != nullptr, ChipLogError(Zcl, "Failed to get LowPowerManager Java class"));
@@ -69,12 +69,12 @@ bool LowPowerManager::HandleSleep()
     JniLocalReferenceScope scope(env);
 
     ChipLogProgress(Zcl, "Received LowPowerManager::Sleep");
-    VerifyOrExit(mLowPowerManagerObject != nullptr, ChipLogError(Zcl, "mLowPowerManagerObject null"));
+    VerifyOrExit(mLowPowerManagerObject.HasValidObjectRef(), ChipLogError(Zcl, "mLowPowerManagerObject null"));
     VerifyOrExit(mSleepMethod != nullptr, ChipLogError(Zcl, "mSleepMethod null"));
     VerifyOrExit(env != NULL, ChipLogError(Zcl, "env null"));
 
     env->ExceptionClear();
-    ret = env->CallBooleanMethod(mLowPowerManagerObject, mSleepMethod);
+    ret = env->CallBooleanMethod(mLowPowerManagerObject.ObjectRef(), mSleepMethod);
     if (env->ExceptionCheck())
     {
         ChipLogError(DeviceLayer, "Java exception in LowPowerManager::Sleep");

--- a/examples/tv-app/android/java/LowPowerManager.h
+++ b/examples/tv-app/android/java/LowPowerManager.h
@@ -22,6 +22,7 @@
 
 #include <jni.h>
 #include <lib/core/CHIPError.h>
+#include <lib/support/JniReferences.h>
 
 class LowPowerManager : public chip::app::Clusters::LowPower::Delegate
 {
@@ -32,6 +33,6 @@ public:
     bool HandleSleep() override;
 
 private:
-    jobject mLowPowerManagerObject = nullptr;
-    jmethodID mSleepMethod         = nullptr;
+    chip::JniGlobalReference mLowPowerManagerObject;
+    jmethodID mSleepMethod = nullptr;
 };

--- a/examples/tv-app/android/java/MediaInputManager.h
+++ b/examples/tv-app/android/java/MediaInputManager.h
@@ -21,6 +21,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/clusters/media-input-server/media-input-server.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 class MediaInputManager : public chip::app::Clusters::MediaInput::Delegate
 {
@@ -36,7 +37,7 @@ public:
     bool HandleRenameInput(const uint8_t index, const chip::CharSpan & name) override;
 
 private:
-    jobject mMediaInputManagerObject = nullptr;
+    chip::JniGlobalReference mMediaInputManagerObject;
     jmethodID mGetInputListMethod    = nullptr;
     jmethodID mGetCurrentInputMethod = nullptr;
     jmethodID mSelectInputMethod     = nullptr;

--- a/examples/tv-app/android/java/MediaPlaybackManager.h
+++ b/examples/tv-app/android/java/MediaPlaybackManager.h
@@ -21,6 +21,7 @@
 #include <app/clusters/media-playback-server/media-playback-server.h>
 #include <cstdint>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 #include <vector>
 
 enum MediaPlaybackRequestAttribute : uint8_t
@@ -105,7 +106,7 @@ public:
     uint32_t GetFeatureMap(chip::EndpointId endpoint) override;
 
 private:
-    jobject mMediaPlaybackManagerObject  = nullptr;
+    chip::JniGlobalReference mMediaPlaybackManagerObject;
     jmethodID mRequestMethod             = nullptr;
     jmethodID mGetAttributeMethod        = nullptr;
     jmethodID mGetPositionMethod         = nullptr;

--- a/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
+++ b/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
@@ -29,8 +29,8 @@ JNIMyUserPrompter::JNIMyUserPrompter(jobject provider)
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for JNIMyUserPrompter"));
 
-    mJNIMyUserPrompterObject = env->NewGlobalRef(provider);
-    VerifyOrReturn(mJNIMyUserPrompterObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef JNIMyUserPrompter"));
+    VerifyOrReturn(mJNIMyUserPrompterObject.Init(provider) == CHIP_NO_ERROR,
+                   ChipLogError(Zcl, "Failed to init mJNIMyUserPrompterObject"));
 
     jclass JNIMyUserPrompterClass = env->GetObjectClass(provider);
     VerifyOrReturn(JNIMyUserPrompterClass != nullptr, ChipLogError(Zcl, "Failed to get JNIMyUserPrompter Java class"));
@@ -82,15 +82,15 @@ void JNIMyUserPrompter::PromptForCommissionOKPermission(uint16_t vendorId, uint1
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     std::string stringCommissioneeName(commissioneeName);
 
-    VerifyOrExit(mJNIMyUserPrompterObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mJNIMyUserPrompterObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mPromptForCommissionOKPermissionMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
     {
         UtfString jniCommissioneeName(env, stringCommissioneeName.data());
         env->ExceptionClear();
-        env->CallVoidMethod(mJNIMyUserPrompterObject, mPromptForCommissionOKPermissionMethod, static_cast<jint>(vendorId),
-                            static_cast<jint>(productId), jniCommissioneeName.jniValue());
+        env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptForCommissionOKPermissionMethod,
+                            static_cast<jint>(vendorId), static_cast<jint>(productId), jniCommissioneeName.jniValue());
         if (env->ExceptionCheck())
         {
             ChipLogError(DeviceLayer, "Java exception in PromptForCommissionOKPermission");
@@ -123,14 +123,14 @@ void JNIMyUserPrompter::PromptForCommissionPasscode(uint16_t vendorId, uint16_t 
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     std::string stringCommissioneeName(commissioneeName);
 
-    VerifyOrExit(mJNIMyUserPrompterObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mJNIMyUserPrompterObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mPromptForCommissionPincodeMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
     {
         UtfString jniCommissioneeName(env, stringCommissioneeName.data());
         env->ExceptionClear();
-        env->CallVoidMethod(mJNIMyUserPrompterObject, mPromptForCommissionPincodeMethod, static_cast<jint>(vendorId),
+        env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptForCommissionPincodeMethod, static_cast<jint>(vendorId),
                             static_cast<jint>(productId), jniCommissioneeName.jniValue());
         if (env->ExceptionCheck())
         {
@@ -202,14 +202,14 @@ void JNIMyUserPrompter::PromptCommissioningSucceeded(uint16_t vendorId, uint16_t
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     std::string stringCommissioneeName(commissioneeName);
 
-    VerifyOrExit(mJNIMyUserPrompterObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mJNIMyUserPrompterObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mPromptCommissioningSucceededMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
     {
         UtfString jniCommissioneeName(env, stringCommissioneeName.data());
         env->ExceptionClear();
-        env->CallVoidMethod(mJNIMyUserPrompterObject, mPromptCommissioningSucceededMethod, static_cast<jint>(vendorId),
+        env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptCommissioningSucceededMethod, static_cast<jint>(vendorId),
                             static_cast<jint>(productId), jniCommissioneeName.jniValue());
 
         if (env->ExceptionCheck())
@@ -238,7 +238,7 @@ void JNIMyUserPrompter::PromptCommissioningFailed(const char * commissioneeName,
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
     std::string stringCommissioneeName(commissioneeName);
 
-    VerifyOrExit(mJNIMyUserPrompterObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mJNIMyUserPrompterObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mPromptCommissioningFailedMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
 
@@ -247,7 +247,7 @@ void JNIMyUserPrompter::PromptCommissioningFailed(const char * commissioneeName,
         UtfString jniCommissioneeName(env, stringCommissioneeName.data());
         UtfString jniCommissioneeError(env, stringError.data());
         env->ExceptionClear();
-        env->CallVoidMethod(mJNIMyUserPrompterObject, mPromptCommissioningFailedMethod, jniCommissioneeName.jniValue(),
+        env->CallVoidMethod(mJNIMyUserPrompterObject.ObjectRef(), mPromptCommissioningFailedMethod, jniCommissioneeName.jniValue(),
                             jniCommissioneeError.jniValue());
 
         if (env->ExceptionCheck())

--- a/examples/tv-app/android/java/MyUserPrompter-JNI.h
+++ b/examples/tv-app/android/java/MyUserPrompter-JNI.h
@@ -19,6 +19,7 @@
 #include "CommissionerMain.h"
 #include "lib/support/logging/CHIPLogging.h"
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 class JNIMyUserPrompter : public UserPrompter
 {
@@ -37,7 +38,7 @@ public:
     void PromptCommissioningFailed(const char * commissioneeName, CHIP_ERROR error) override;
 
 private:
-    jobject mJNIMyUserPrompterObject                 = nullptr;
+    chip::JniGlobalReference mJNIMyUserPrompterObject;
     jmethodID mPromptForCommissionOKPermissionMethod = nullptr;
     jmethodID mPromptForCommissionPincodeMethod      = nullptr;
     jmethodID mPromptCommissioningSucceededMethod    = nullptr;

--- a/examples/tv-app/android/java/OnOffManager.cpp
+++ b/examples/tv-app/android/java/OnOffManager.cpp
@@ -94,8 +94,7 @@ CHIP_ERROR OnOffManager::InitializeWithObjects(jobject managerObject)
     VerifyOrReturnError(env != nullptr, CHIP_JNI_ERROR_NO_ENV, ChipLogError(Zcl, "Could not get JNIEnv for current thread"));
     JniLocalReferenceScope scope(env);
 
-    mOnOffManagerObject = env->NewGlobalRef(managerObject);
-    VerifyOrReturnLogError(mOnOffManagerObject != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnLogErrorOnFailure(mOnOffManagerObject.Init(managerObject));
 
     jclass OnOffManagerClass = env->GetObjectClass(managerObject);
     VerifyOrReturnLogError(OnOffManagerClass != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -119,11 +118,11 @@ void OnOffManager::HandleOnOffChanged(bool value)
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Could not get JNIEnv for current thread"));
     JniLocalReferenceScope scope(env);
 
-    VerifyOrReturn(mOnOffManagerObject != nullptr, ChipLogProgress(Zcl, "mOnOffManagerObject null"));
+    VerifyOrReturn(mOnOffManagerObject.HasValidObjectRef(), ChipLogProgress(Zcl, "mOnOffManagerObject null"));
     VerifyOrReturn(mHandleOnOffChangedMethod != nullptr, ChipLogProgress(Zcl, "mHandleOnOffChangedMethod null"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mOnOffManagerObject, mHandleOnOffChangedMethod, static_cast<jboolean>(value));
+    env->CallVoidMethod(mOnOffManagerObject.ObjectRef(), mHandleOnOffChangedMethod, static_cast<jboolean>(value));
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in OnOffManager::HandleOnOffChanged");

--- a/examples/tv-app/android/java/OnOffManager.h
+++ b/examples/tv-app/android/java/OnOffManager.h
@@ -18,6 +18,7 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 /**
  * @brief Handles interfacing between java code and C++ code for the purposes of On/Off clusters.
@@ -40,6 +41,6 @@ public:
 private:
     // init with java objects
     CHIP_ERROR InitializeWithObjects(jobject managerObject);
-    jobject mOnOffManagerObject         = nullptr;
+    chip::JniGlobalReference mOnOffManagerObject;
     jmethodID mHandleOnOffChangedMethod = nullptr;
 };

--- a/examples/tv-app/android/java/TVApp-JNI.cpp
+++ b/examples/tv-app/android/java/TVApp-JNI.cpp
@@ -58,10 +58,9 @@ void TvAppJNI::InitializeWithObjects(jobject app)
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for TvAppJNI"));
 
-    mTvAppObject = env->NewGlobalRef(app);
-    VerifyOrReturn(mTvAppObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef TvAppJNI"));
+    VerifyOrReturn(mTvAppObject.Init(app) == CHIP_NO_ERROR, ChipLogError(Zcl, "Failed to init mTvAppObject"));
 
-    jclass managerClass = env->GetObjectClass(mTvAppObject);
+    jclass managerClass = env->GetObjectClass(app);
     VerifyOrReturn(managerClass != nullptr, ChipLogError(Zcl, "Failed to get TvAppJNI Java class"));
 
     mPostClusterInitMethod = env->GetMethodID(managerClass, "postClusterInit", "(JI)V");
@@ -76,10 +75,11 @@ void TvAppJNI::PostClusterInit(int clusterId, int endpoint)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for TvAppJNI::PostClusterInit"));
-    VerifyOrReturn(mTvAppObject != nullptr, ChipLogError(Zcl, "TvAppJNI::mTvAppObject null"));
+    VerifyOrReturn(mTvAppObject.HasValidObjectRef(), ChipLogError(Zcl, "TvAppJNI::mTvAppObject is not valid"));
     VerifyOrReturn(mPostClusterInitMethod != nullptr, ChipLogError(Zcl, "TvAppJNI::mPostClusterInitMethod null"));
 
-    env->CallVoidMethod(mTvAppObject, mPostClusterInitMethod, static_cast<jlong>(clusterId), static_cast<jint>(endpoint));
+    env->CallVoidMethod(mTvAppObject.ObjectRef(), mPostClusterInitMethod, static_cast<jlong>(clusterId),
+                        static_cast<jint>(endpoint));
     if (env->ExceptionCheck())
     {
         ChipLogError(Zcl, "Failed to call TvAppJNI 'postClusterInit' method");

--- a/examples/tv-app/android/java/TvApp-JNI.h
+++ b/examples/tv-app/android/java/TvApp-JNI.h
@@ -20,6 +20,7 @@
 
 #include "MyUserPrompter-JNI.h"
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 class TvAppJNI
 {
@@ -32,7 +33,7 @@ private:
     friend TvAppJNI & TvAppJNIMgr();
 
     static TvAppJNI sInstance;
-    jobject mTvAppObject             = nullptr;
+    chip::JniGlobalReference mTvAppObject;
     jmethodID mPostClusterInitMethod = nullptr;
 };
 

--- a/examples/tv-app/android/java/WakeOnLanManager.cpp
+++ b/examples/tv-app/android/java/WakeOnLanManager.cpp
@@ -59,11 +59,11 @@ CHIP_ERROR WakeOnLanManager::HandleGetMacAddress(chip::app::AttributeValueEncode
     chip::CharSpan macValue;
 
     ChipLogProgress(Zcl, "Received WakeOnLanManager::HandleGetMacAddress");
-    VerifyOrExit(mWakeOnLanManagerObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mWakeOnLanManagerObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mGetMacMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
     env->ExceptionClear();
-    javaMac = env->CallObjectMethod(mWakeOnLanManagerObject, mGetMacMethod);
+    javaMac = env->CallObjectMethod(mWakeOnLanManagerObject.ObjectRef(), mGetMacMethod);
     if (env->ExceptionCheck())
     {
         ChipLogError(DeviceLayer, "Java exception in WakeOnLanManager::getMac");
@@ -89,8 +89,8 @@ void WakeOnLanManager::InitializeWithObjects(jobject managerObject)
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Could not get JNIEnv for current thread"));
     JniLocalReferenceScope scope(env);
 
-    mWakeOnLanManagerObject = env->NewGlobalRef(managerObject);
-    VerifyOrReturn(mWakeOnLanManagerObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef WakeOnLanManager"));
+    VerifyOrReturn(mWakeOnLanManagerObject.Init(managerObject) == CHIP_NO_ERROR,
+                   ChipLogError(Zcl, "Failed to init WakeOnLanManager"));
 
     jclass WakeOnLanManagerClass = env->GetObjectClass(managerObject);
     VerifyOrReturn(WakeOnLanManagerClass != nullptr, ChipLogError(Zcl, "Failed to get WakeOnLanManager Java class"));

--- a/examples/tv-app/android/java/WakeOnLanManager.h
+++ b/examples/tv-app/android/java/WakeOnLanManager.h
@@ -20,6 +20,7 @@
 
 #include <app/clusters/wake-on-lan-server/wake-on-lan-server.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 class WakeOnLanManager : public chip::app::Clusters::WakeOnLan::Delegate
 {
@@ -30,6 +31,6 @@ public:
     CHIP_ERROR HandleGetMacAddress(chip::app::AttributeValueEncoder & aEncoder) override;
 
 private:
-    jobject mWakeOnLanManagerObject = nullptr;
-    jmethodID mGetMacMethod         = nullptr;
+    chip::JniGlobalReference mWakeOnLanManagerObject;
+    jmethodID mGetMacMethod = nullptr;
 };

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/JNIDACProvider.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/JNIDACProvider.cpp
@@ -34,9 +34,8 @@ JNIDACProvider::JNIDACProvider(jobject provider)
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for JNIDACProvider"));
 
-    mJNIDACProviderObject = env->NewGlobalRef(provider);
-    VerifyOrReturn(mJNIDACProviderObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef JNIDACProvider"));
-
+    VerifyOrReturn(mJNIDACProviderObject.Init(provider) == CHIP_NO_ERROR,
+                   ChipLogError(Zcl, "Failed to Init mJNIDACProviderObject"));
     jclass JNIDACProviderClass = env->GetObjectClass(provider);
     VerifyOrReturn(JNIDACProviderClass != nullptr, ChipLogError(Zcl, "Failed to get JNIDACProvider Java class"));
 
@@ -80,11 +79,11 @@ JNIDACProvider::JNIDACProvider(jobject provider)
 CHIP_ERROR JNIDACProvider::GetJavaByteByMethod(jmethodID method, MutableByteSpan & out_buffer)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    VerifyOrReturnLogError(mJNIDACProviderObject != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(mJNIDACProviderObject.HasValidObjectRef(), CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(method != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(env != nullptr, CHIP_JNI_ERROR_NO_ENV);
 
-    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIDACProviderObject, method);
+    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIDACProviderObject.ObjectRef(), method);
     if (env->ExceptionCheck())
     {
         ChipLogError(Zcl, "Java exception in get Method");
@@ -106,14 +105,14 @@ CHIP_ERROR JNIDACProvider::GetJavaByteByMethod(jmethodID method, MutableByteSpan
 CHIP_ERROR JNIDACProvider::GetJavaByteByMethod(jmethodID method, const ByteSpan & in_buffer, MutableByteSpan & out_buffer)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    VerifyOrReturnLogError(mJNIDACProviderObject != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(mJNIDACProviderObject.HasValidObjectRef(), CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(method != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(env != nullptr, CHIP_JNI_ERROR_NO_ENV);
 
     jbyteArray in_buffer_jbyteArray = env->NewByteArray((jsize) (in_buffer.size()));
     env->SetByteArrayRegion(in_buffer_jbyteArray, 0, (int) in_buffer.size(), reinterpret_cast<const jbyte *>(in_buffer.data()));
 
-    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIDACProviderObject, method, in_buffer_jbyteArray);
+    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIDACProviderObject.ObjectRef(), method, in_buffer_jbyteArray);
     if (env->ExceptionCheck())
     {
         ChipLogError(Zcl, "Java exception in get Method");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/JNIDACProvider.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/JNIDACProvider.h
@@ -19,6 +19,7 @@
 #include "lib/support/logging/CHIPLogging.h"
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 class JNIDACProvider : public chip::Credentials::DeviceAttestationCredentialsProvider
 {
@@ -34,7 +35,7 @@ public:
 private:
     CHIP_ERROR GetJavaByteByMethod(jmethodID method, chip::MutableByteSpan & out_buffer);
     CHIP_ERROR GetJavaByteByMethod(jmethodID method, const chip::ByteSpan & in_buffer, chip::MutableByteSpan & out_buffer);
-    jobject mJNIDACProviderObject                          = nullptr;
+    chip::JniGlobalReference mJNIDACProviderObject;
     jmethodID mGetCertificationDeclarationMethod           = nullptr;
     jmethodID mGetFirmwareInformationMethod                = nullptr;
     jmethodID mGetDeviceAttestationCertMethod              = nullptr;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
@@ -25,10 +25,9 @@ CHIP_ERROR CallbackBaseJNI::SetUp(JNIEnv * env, jobject inHandler)
     ChipLogProgress(AppServer, "CallbackBaseJNI::SetUp called");
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    mObject = env->NewGlobalRef(inHandler);
-    VerifyOrExit(mObject != nullptr, ChipLogError(AppServer, "Failed to NewGlobalRef for handler object"));
+    VerifyOrExit(mObject.Init(inHandler) == CHIP_NO_ERROR, ChipLogError(AppServer, "Failed to Init mObject"));
 
-    mClazz = env->GetObjectClass(mObject);
+    mClazz = env->GetObjectClass(mObject.ObjectRef());
     VerifyOrExit(mClazz != nullptr, ChipLogError(AppServer, "Failed to get handler Java class"));
 
     mSuperClazz = env->GetSuperclass(mClazz);
@@ -60,9 +59,9 @@ void FailureHandlerJNI::Handle(CHIP_ERROR callbackErr)
 
     chip::DeviceLayer::StackUnlock unlock;
     CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit(mObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    env->CallVoidMethod(mObject, mMethod, static_cast<jint>(callbackErr.AsInteger()), jniCallbackErrString.jniValue());
+    env->CallVoidMethod(mObject.ObjectRef(), mMethod, static_cast<jint>(callbackErr.AsInteger()), jniCallbackErrString.jniValue());
 exit:
     if (err != CHIP_NO_ERROR)
     {
@@ -78,10 +77,10 @@ void SubscriptionEstablishedHandlerJNI::Handle()
 
     chip::DeviceLayer::StackUnlock unlock;
     CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit(mObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(mMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    env->CallVoidMethod(mObject, mMethod);
+    env->CallVoidMethod(mObject.ObjectRef(), mMethod);
 exit:
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.h
@@ -37,7 +37,7 @@ public:
     CHIP_ERROR SetUp(JNIEnv * env, jobject inHandler);
 
 protected:
-    jobject mObject               = nullptr;
+    chip::JniGlobalReference mObject;
     jclass mClazz                 = nullptr;
     jclass mSuperClazz            = nullptr;
     jmethodID mMethod             = nullptr;
@@ -89,9 +89,9 @@ public:
 
         chip::DeviceLayer::StackUnlock unlock;
         CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit(mObject != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrExit(mObject.HasValidObjectRef(), err = CHIP_ERROR_INCORRECT_STATE);
         VerifyOrExit(mMethod != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-        env->CallVoidMethod(mObject, mMethod, jResponseData);
+        env->CallVoidMethod(mObject.ObjectRef(), mMethod, jResponseData);
     exit:
         if (err != CHIP_NO_ERROR)
         {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.cpp
@@ -36,9 +36,7 @@ CHIP_ERROR RotatingDeviceIdUniqueIdProviderJNI::Initialize(jobject provider)
     VerifyOrReturnValue(env != nullptr, CHIP_ERROR_INCORRECT_STATE,
                         ChipLogError(AppServer, "Failed to GetEnvForCurrentThread for RotatingDeviceIdUniqueIdProviderJNI"));
 
-    mJNIProviderObject = env->NewGlobalRef(provider);
-    VerifyOrReturnValue(mJNIProviderObject != nullptr, CHIP_ERROR_INCORRECT_STATE,
-                        ChipLogError(AppServer, "Failed to NewGlobalRef JNIProvider"));
+    ReturnLogErrorOnFailure(mJNIProviderObject.Init(provider));
 
     jclass JNIProviderClass = env->GetObjectClass(provider);
     VerifyOrReturnValue(JNIProviderClass != nullptr, CHIP_ERROR_INCORRECT_STATE,
@@ -56,11 +54,11 @@ CHIP_ERROR RotatingDeviceIdUniqueIdProviderJNI::Initialize(jobject provider)
 CHIP_ERROR RotatingDeviceIdUniqueIdProviderJNI::GetJavaByteByMethod(jmethodID method, MutableByteSpan & out_buffer)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    VerifyOrReturnLogError(mJNIProviderObject != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(mJNIProviderObject.HasValidObjectRef(), CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(method != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(env != nullptr, CHIP_JNI_ERROR_NO_ENV);
 
-    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIProviderObject, method);
+    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIProviderObject.ObjectRef(), method);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in get Method");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/RotatingDeviceIdUniqueIdProvider-JNI.h
@@ -19,6 +19,7 @@
 #include "core/Types.h"
 
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 namespace matter {
 namespace casting {
@@ -32,8 +33,8 @@ public:
 
 private:
     CHIP_ERROR GetJavaByteByMethod(jmethodID method, chip::MutableByteSpan & out_buffer);
-    jobject mJNIProviderObject = nullptr;
-    jmethodID mGetMethod       = nullptr;
+    chip::JniGlobalReference mJNIProviderObject;
+    jmethodID mGetMethod = nullptr;
 
     chip::MutableByteSpan mRotatingDeviceIdUniqueIdSpan;
     uint8_t mRotatingDeviceIdUniqueId[chip::DeviceLayer::ConfigurationManager::kRotatingDeviceIDUniqueIDLength];

--- a/examples/virtual-device-app/android/java/ColorControlManager.cpp
+++ b/examples/virtual-device-app/android/java/ColorControlManager.cpp
@@ -121,8 +121,7 @@ CHIP_ERROR ColorControlManager::InitializeWithObjects(jobject managerObject)
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturnLogError(env != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    mColorControlManagerObject = env->NewGlobalRef(managerObject);
-    VerifyOrReturnLogError(mColorControlManagerObject != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnLogErrorOnFailure(mColorControlManagerObject.Init(managerObject));
 
     jclass ColorControlManagerClass = env->GetObjectClass(managerObject);
     VerifyOrReturnLogError(ColorControlManagerClass != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -176,11 +175,11 @@ void ColorControlManager::HandleCurrentHueChanged(int value)
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
-    VerifyOrReturn(mColorControlManagerObject != nullptr, ChipLogProgress(Zcl, "mColorControlManagerObject null"));
+    VerifyOrReturn(mColorControlManagerObject.HasValidObjectRef(), ChipLogProgress(Zcl, "mColorControlManagerObject null"));
     VerifyOrReturn(mHandleCurrentHueChangedMethod != nullptr, ChipLogProgress(Zcl, "mHandleCurrentHueChangedMethod null"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mColorControlManagerObject, mHandleCurrentHueChangedMethod, value);
+    env->CallVoidMethod(mColorControlManagerObject.ObjectRef(), mHandleCurrentHueChangedMethod, value);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in ColorControlManager::HandleCurrentHueChanged");
@@ -195,12 +194,12 @@ void ColorControlManager::HandleCurrentSaturationChanged(int value)
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
-    VerifyOrReturn(mColorControlManagerObject != nullptr, ChipLogProgress(Zcl, "mColorControlManagerObject null"));
+    VerifyOrReturn(mColorControlManagerObject.HasValidObjectRef(), ChipLogProgress(Zcl, "mColorControlManagerObject null"));
     VerifyOrReturn(mHandleCurrentSaturationChangedMethod != nullptr,
                    ChipLogProgress(Zcl, "mHandleCurrentSaturationChangedMethod null"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mColorControlManagerObject, mHandleCurrentSaturationChangedMethod, value);
+    env->CallVoidMethod(mColorControlManagerObject.ObjectRef(), mHandleCurrentSaturationChangedMethod, value);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in ColorControlManager::HandleCurrentSaturationChanged");
@@ -215,12 +214,12 @@ void ColorControlManager::HandleColorTemperatureChanged(int value)
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
-    VerifyOrReturn(mColorControlManagerObject != nullptr, ChipLogProgress(Zcl, "mColorControlManagerObject null"));
+    VerifyOrReturn(mColorControlManagerObject.HasValidObjectRef(), ChipLogProgress(Zcl, "mColorControlManagerObject null"));
     VerifyOrReturn(mHandleColorTemperatureChangedMethod != nullptr,
                    ChipLogProgress(Zcl, "mHandleColorTemperatureChangedMethod null"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mColorControlManagerObject, mHandleColorTemperatureChangedMethod, value);
+    env->CallVoidMethod(mColorControlManagerObject.ObjectRef(), mHandleColorTemperatureChangedMethod, value);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in ColorControlManager::mHandleColorTemperatureChanged");
@@ -235,11 +234,11 @@ void ColorControlManager::HandleColorModeChanged(int value)
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
-    VerifyOrReturn(mColorControlManagerObject != nullptr, ChipLogProgress(Zcl, "mColorControlManagerObject null"));
+    VerifyOrReturn(mColorControlManagerObject.HasValidObjectRef(), ChipLogProgress(Zcl, "mColorControlManagerObject null"));
     VerifyOrReturn(mHandleColorModeChangedMethod != nullptr, ChipLogProgress(Zcl, "mHandleColorModeChangedMethod null"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mColorControlManagerObject, mHandleColorModeChangedMethod, value);
+    env->CallVoidMethod(mColorControlManagerObject.ObjectRef(), mHandleColorModeChangedMethod, value);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in ColorControlManager::HandleColorModeChanged");
@@ -254,12 +253,12 @@ void ColorControlManager::HandleEnhancedColorModeChanged(int value)
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
-    VerifyOrReturn(mColorControlManagerObject != nullptr, ChipLogProgress(Zcl, "mColorControlManagerObject null"));
+    VerifyOrReturn(mColorControlManagerObject.HasValidObjectRef(), ChipLogProgress(Zcl, "mColorControlManagerObject null"));
     VerifyOrReturn(mHandleEnhancedColorModeChangedMethod != nullptr,
                    ChipLogProgress(Zcl, "mHandleEnhancedColorModeChangedMethod null"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mColorControlManagerObject, mHandleEnhancedColorModeChangedMethod, value);
+    env->CallVoidMethod(mColorControlManagerObject.ObjectRef(), mHandleEnhancedColorModeChangedMethod, value);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in ColorControlManager::HandleEnhancedColorModeChanged");

--- a/examples/virtual-device-app/android/java/ColorControlManager.h
+++ b/examples/virtual-device-app/android/java/ColorControlManager.h
@@ -18,6 +18,7 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 class ColorControlManager
 {
@@ -46,7 +47,7 @@ public:
 
 private:
     CHIP_ERROR InitializeWithObjects(jobject managerObject);
-    jobject mColorControlManagerObject              = nullptr;
+    chip::JniGlobalReference mColorControlManagerObject;
     jmethodID mHandleCurrentHueChangedMethod        = nullptr;
     jmethodID mHandleCurrentSaturationChangedMethod = nullptr;
     jmethodID mHandleColorTemperatureChangedMethod  = nullptr;

--- a/examples/virtual-device-app/android/java/DeviceApp-JNI.cpp
+++ b/examples/virtual-device-app/android/java/DeviceApp-JNI.cpp
@@ -56,10 +56,9 @@ void DeviceAppJNI::InitializeWithObjects(jobject app)
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for DeviceAppJNI"));
 
-    mDeviceAppObject = env->NewGlobalRef(app);
-    VerifyOrReturn(mDeviceAppObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef DeviceAppJNI"));
+    VerifyOrReturn(mDeviceAppObject.Init(app) == CHIP_NO_ERROR, ChipLogError(Zcl, "Failed to init mDeviceAppObject"));
 
-    jclass managerClass = env->GetObjectClass(mDeviceAppObject);
+    jclass managerClass = env->GetObjectClass(app);
     VerifyOrReturn(managerClass != nullptr, ChipLogError(Zcl, "Failed to get DeviceAppJNI Java class"));
 
     mPostClusterInitMethod = env->GetMethodID(managerClass, "postClusterInit", "(JI)V");
@@ -81,10 +80,11 @@ void DeviceAppJNI::PostClusterInit(int clusterId, int endpoint)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for DeviceAppJNI::PostClusterInit"));
-    VerifyOrReturn(mDeviceAppObject != nullptr, ChipLogError(Zcl, "DeviceAppJNI::mDeviceAppObject null"));
+    VerifyOrReturn(mDeviceAppObject.HasValidObjectRef(), ChipLogError(Zcl, "DeviceAppJNI::mDeviceAppObject null"));
     VerifyOrReturn(mPostClusterInitMethod != nullptr, ChipLogError(Zcl, "DeviceAppJNI::mPostClusterInitMethod null"));
 
-    env->CallVoidMethod(mDeviceAppObject, mPostClusterInitMethod, static_cast<jlong>(clusterId), static_cast<jint>(endpoint));
+    env->CallVoidMethod(mDeviceAppObject.ObjectRef(), mPostClusterInitMethod, static_cast<jlong>(clusterId),
+                        static_cast<jint>(endpoint));
     if (env->ExceptionCheck())
     {
         ChipLogError(Zcl, "Failed to call DeviceAppJNI 'postClusterInit' method");
@@ -96,10 +96,10 @@ void DeviceAppJNI::PostEvent(int event)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for DeviceAppJNI::PostEvent"));
-    VerifyOrReturn(mDeviceAppObject != nullptr, ChipLogError(Zcl, "DeviceAppJNI::mDeviceAppObject null"));
+    VerifyOrReturn(mDeviceAppObject.HasValidObjectRef(), ChipLogError(Zcl, "DeviceAppJNI::mDeviceAppObject null"));
     VerifyOrReturn(mPostEventMethod != nullptr, ChipLogError(Zcl, "DeviceAppJNI::mPostEventMethod null"));
 
-    env->CallVoidMethod(mDeviceAppObject, mPostEventMethod, static_cast<jlong>(event));
+    env->CallVoidMethod(mDeviceAppObject.ObjectRef(), mPostEventMethod, static_cast<jlong>(event));
     if (env->ExceptionCheck())
     {
         ChipLogError(Zcl, "Failed to call DeviceAppJNI 'postEventMethod' method");

--- a/examples/virtual-device-app/android/java/DeviceApp-JNI.h
+++ b/examples/virtual-device-app/android/java/DeviceApp-JNI.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 class DeviceAppJNI
 {
@@ -31,7 +32,7 @@ private:
     friend DeviceAppJNI & DeviceAppJNIMgr();
 
     static DeviceAppJNI sInstance;
-    jobject mDeviceAppObject         = nullptr;
+    chip::JniGlobalReference mDeviceAppObject;
     jmethodID mPostClusterInitMethod = nullptr;
     jmethodID mPostEventMethod       = nullptr;
 };

--- a/examples/virtual-device-app/android/java/DoorLockManager.cpp
+++ b/examples/virtual-device-app/android/java/DoorLockManager.cpp
@@ -158,8 +158,7 @@ CHIP_ERROR DoorLockManager::InitializeWithObjects(jobject managerObject)
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturnLogError(env != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    mDoorLockManagerObject = env->NewGlobalRef(managerObject);
-    VerifyOrReturnLogError(mDoorLockManagerObject != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnLogErrorOnFailure(mDoorLockManagerObject.Init(managerObject));
 
     jclass DoorLockManagerClass = env->GetObjectClass(managerObject);
     VerifyOrReturnLogError(DoorLockManagerClass != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -181,11 +180,11 @@ void DoorLockManager::HandleLockStateChanged(jint endpoint, jint value)
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
-    VerifyOrReturn(mDoorLockManagerObject != nullptr, ChipLogProgress(Zcl, "mDoorLockManagerObject null"));
+    VerifyOrReturn(mDoorLockManagerObject.HasValidObjectRef(), ChipLogProgress(Zcl, "mDoorLockManagerObject null"));
     VerifyOrReturn(mHandleLockStateChangedMethod != nullptr, ChipLogProgress(Zcl, "mHandleLockStateChangedMethod null"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mDoorLockManagerObject, mHandleLockStateChangedMethod, value);
+    env->CallVoidMethod(mDoorLockManagerObject.ObjectRef(), mHandleLockStateChangedMethod, value);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in DoorLockManager::HandleLockStateChanged");

--- a/examples/virtual-device-app/android/java/DoorLockManager.h
+++ b/examples/virtual-device-app/android/java/DoorLockManager.h
@@ -22,6 +22,7 @@
 #include <app/clusters/door-lock-server/door-lock-server.h>
 #include <app/util/attribute-storage.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 /**
  * @brief Handles interfacing between java code and C++ code for the purposes of DoorLock clusters.
@@ -62,6 +63,6 @@ public:
 private:
     // init with java objects
     CHIP_ERROR InitializeWithObjects(jobject managerObject);
-    jobject mDoorLockManagerObject          = nullptr;
+    chip::JniGlobalReference mDoorLockManagerObject;
     jmethodID mHandleLockStateChangedMethod = nullptr;
 };

--- a/examples/virtual-device-app/android/java/JNIDACProvider.cpp
+++ b/examples/virtual-device-app/android/java/JNIDACProvider.cpp
@@ -33,9 +33,8 @@ JNIDACProvider::JNIDACProvider(jobject provider)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for JNIDACProvider"));
-
-    mJNIDACProviderObject = env->NewGlobalRef(provider);
-    VerifyOrReturn(mJNIDACProviderObject != nullptr, ChipLogError(Zcl, "Failed to NewGlobalRef JNIDACProvider"));
+    VerifyOrReturn(mJNIDACProviderObject.Init(provider) == CHIP_NO_ERROR,
+                   ChipLogError(Zcl, "Failed to Init mJNIDACProviderObject"));
 
     jclass JNIDACProviderClass = env->GetObjectClass(provider);
     VerifyOrReturn(JNIDACProviderClass != nullptr, ChipLogError(Zcl, "Failed to get JNIDACProvider Java class"));
@@ -88,11 +87,11 @@ JNIDACProvider::JNIDACProvider(jobject provider)
 CHIP_ERROR JNIDACProvider::GetJavaByteByMethod(jmethodID method, MutableByteSpan & out_buffer)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    VerifyOrReturnLogError(mJNIDACProviderObject != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnLogError(mJNIDACProviderObject.HasValidObjectRef(), CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(method != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnLogError(env != nullptr, CHIP_JNI_ERROR_NO_ENV);
 
-    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIDACProviderObject, method);
+    jbyteArray outArray = (jbyteArray) env->CallObjectMethod(mJNIDACProviderObject.ObjectRef(), method);
     if (env->ExceptionCheck())
     {
         ChipLogError(Zcl, "Java exception in get Method");

--- a/examples/virtual-device-app/android/java/JNIDACProvider.h
+++ b/examples/virtual-device-app/android/java/JNIDACProvider.h
@@ -19,6 +19,7 @@
 #include "lib/support/logging/CHIPLogging.h"
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 class JNIDACProvider : public chip::Credentials::DeviceAttestationCredentialsProvider
 {
@@ -33,7 +34,7 @@ public:
 
 private:
     CHIP_ERROR GetJavaByteByMethod(jmethodID method, chip::MutableByteSpan & out_buffer);
-    jobject mJNIDACProviderObject                          = nullptr;
+    chip::JniGlobalReference mJNIDACProviderObject;
     jmethodID mGetCertificationDeclarationMethod           = nullptr;
     jmethodID mGetFirmwareInformationMethod                = nullptr;
     jmethodID mGetDeviceAttestationCertMethod              = nullptr;

--- a/examples/virtual-device-app/android/java/OnOffManager.cpp
+++ b/examples/virtual-device-app/android/java/OnOffManager.cpp
@@ -90,9 +90,7 @@ CHIP_ERROR OnOffManager::InitializeWithObjects(jobject managerObject)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturnLogError(env != nullptr, CHIP_ERROR_INCORRECT_STATE);
-
-    mOnOffManagerObject = env->NewGlobalRef(managerObject);
-    VerifyOrReturnLogError(mOnOffManagerObject != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnLogErrorOnFailure(mOnOffManagerObject.Init(managerObject));
 
     jclass OnOffManagerClass = env->GetObjectClass(managerObject);
     VerifyOrReturnLogError(OnOffManagerClass != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -114,11 +112,11 @@ void OnOffManager::HandleOnOffChanged(bool value)
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != NULL, ChipLogProgress(Zcl, "env null"));
-    VerifyOrReturn(mOnOffManagerObject != nullptr, ChipLogProgress(Zcl, "mOnOffManagerObject null"));
+    VerifyOrReturn(mOnOffManagerObject.HasValidObjectRef(), ChipLogProgress(Zcl, "mOnOffManagerObject null"));
     VerifyOrReturn(mHandleOnOffChangedMethod != nullptr, ChipLogProgress(Zcl, "mHandleOnOffChangedMethod null"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mOnOffManagerObject, mHandleOnOffChangedMethod, static_cast<jboolean>(value));
+    env->CallVoidMethod(mOnOffManagerObject.ObjectRef(), mHandleOnOffChangedMethod, static_cast<jboolean>(value));
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in OnOffManager::HandleOnOffChanged");

--- a/examples/virtual-device-app/android/java/OnOffManager.h
+++ b/examples/virtual-device-app/android/java/OnOffManager.h
@@ -18,6 +18,7 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 /**
  * @brief Handles interfacing between java code and C++ code for the purposes of On/Off clusters.
@@ -40,6 +41,6 @@ public:
 private:
     // init with java objects
     CHIP_ERROR InitializeWithObjects(jobject managerObject);
-    jobject mOnOffManagerObject         = nullptr;
+    chip::JniGlobalReference mOnOffManagerObject;
     jmethodID mHandleOnOffChangedMethod = nullptr;
 };

--- a/examples/virtual-device-app/android/java/PowerSourceManager.cpp
+++ b/examples/virtual-device-app/android/java/PowerSourceManager.cpp
@@ -96,9 +96,7 @@ CHIP_ERROR PowerSourceManager::InitializeWithObjects(jobject managerObject)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturnLogError(env != nullptr, CHIP_ERROR_INCORRECT_STATE);
-
-    mPowerSourceManagerObject = env->NewGlobalRef(managerObject);
-    VerifyOrReturnLogError(mPowerSourceManagerObject != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnLogErrorOnFailure(mPowerSourceManagerObject.Init(managerObject));
 
     jclass PowerSourceManagerClass = env->GetObjectClass(managerObject);
     VerifyOrReturnLogError(PowerSourceManagerClass != nullptr, CHIP_ERROR_INVALID_ARGUMENT);

--- a/examples/virtual-device-app/android/java/PowerSourceManager.h
+++ b/examples/virtual-device-app/android/java/PowerSourceManager.h
@@ -21,6 +21,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/util/attribute-storage.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 /**
  * @brief Handles interfacing between java code and C++ code for the purposes of PowerSource clusters.
@@ -35,5 +36,5 @@ public:
 private:
     // init with java objects
     CHIP_ERROR InitializeWithObjects(jobject managerObject);
-    jobject mPowerSourceManagerObject = nullptr;
+    chip::JniGlobalReference mPowerSourceManagerObject;
 };

--- a/src/app/server/java/CHIPAppServer-JNI.cpp
+++ b/src/app/server/java/CHIPAppServer-JNI.cpp
@@ -51,9 +51,9 @@ using namespace chip::DeviceLayer;
 static void * IOThreadAppMain(void * arg);
 
 namespace {
-JavaVM * sJVM;
-pthread_t sIOThread               = PTHREAD_NULL;
-jclass sChipAppServerExceptionCls = NULL;
+JavaVM * sJVM       = nullptr;
+pthread_t sIOThread = PTHREAD_NULL;
+JniGlobalReference sChipAppServerExceptionCls;
 ChipAppServerDelegate sChipAppServerDelegate;
 } // namespace
 
@@ -77,7 +77,10 @@ jint AndroidAppServerJNI_OnLoad(JavaVM * jvm, void * reserved)
     ChipLogProgress(AppServer, "Loading Java class references.");
 
     // Get various class references need by the API.
-    err = JniReferences::GetInstance().GetClassRef(env, "chip/appserver/ChipAppServerException", sChipAppServerExceptionCls);
+    jclass appServerExceptionCls;
+    err = JniReferences::GetInstance().GetLocalClassRef(env, "chip/appserver/ChipAppServerException", appServerExceptionCls);
+    SuccessOrExit(err);
+    err = sChipAppServerExceptionCls.Init(static_cast<jobject>(appServerExceptionCls));
     SuccessOrExit(err);
     ChipLogProgress(AppServer, "Java class references loaded.");
 

--- a/src/app/server/java/ChipAppServerDelegate.cpp
+++ b/src/app/server/java/ChipAppServerDelegate.cpp
@@ -29,7 +29,9 @@ void ChipAppServerDelegate::OnCommissioningSessionEstablishmentStarted()
                    ChipLogError(AppServer, "mOnCommissioningSessionEstablishmentStartedMethod is nullptr"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mChipAppServerDelegateObject, mOnCommissioningSessionEstablishmentStartedMethod);
+    VerifyOrReturn(mChipAppServerDelegateObject.HasValidObjectRef(),
+                   ChipLogError(AppServer, "mChipAppServerDelegateObject is not valid"));
+    env->CallVoidMethod(mChipAppServerDelegateObject.ObjectRef(), mOnCommissioningSessionEstablishmentStartedMethod);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in OnCommissioningSessionEstablishmentStartedMethod");
@@ -46,7 +48,9 @@ void ChipAppServerDelegate::OnCommissioningSessionStarted()
                    ChipLogError(AppServer, "mOnCommissioningSessionStartedMethod is nullptr"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mChipAppServerDelegateObject, mOnCommissioningSessionStartedMethod);
+    VerifyOrReturn(mChipAppServerDelegateObject.HasValidObjectRef(),
+                   ChipLogError(AppServer, "mChipAppServerDelegateObject is not valid"));
+    env->CallVoidMethod(mChipAppServerDelegateObject.ObjectRef(), mOnCommissioningSessionStartedMethod);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in OnCommissioningSessionStartedMethod");
@@ -63,7 +67,9 @@ void ChipAppServerDelegate::OnCommissioningSessionEstablishmentError(CHIP_ERROR 
                    ChipLogError(AppServer, "mOnCommissioningSessionEstablishmentErrorMethod is nullptr"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mChipAppServerDelegateObject, mOnCommissioningSessionEstablishmentErrorMethod,
+    VerifyOrReturn(mChipAppServerDelegateObject.HasValidObjectRef(),
+                   ChipLogError(AppServer, "mChipAppServerDelegateObject is not valid"));
+    env->CallVoidMethod(mChipAppServerDelegateObject.ObjectRef(), mOnCommissioningSessionEstablishmentErrorMethod,
                         static_cast<jint>(err.AsInteger()));
     if (env->ExceptionCheck())
     {
@@ -81,7 +87,9 @@ void ChipAppServerDelegate::OnCommissioningSessionStopped()
                    ChipLogError(AppServer, "mOnCommissioningSessionStoppedMethod is nullptr"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mChipAppServerDelegateObject, mOnCommissioningSessionStoppedMethod);
+    VerifyOrReturn(mChipAppServerDelegateObject.HasValidObjectRef(),
+                   ChipLogError(AppServer, "mChipAppServerDelegateObject is not valid"));
+    env->CallVoidMethod(mChipAppServerDelegateObject.ObjectRef(), mOnCommissioningSessionStoppedMethod);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in OnCommissioningSessionStoppedMethod");
@@ -98,7 +106,9 @@ void ChipAppServerDelegate::OnCommissioningWindowOpened()
                    ChipLogError(AppServer, "mOnCommissioningWindowOpenedMethod is nullptr"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mChipAppServerDelegateObject, mOnCommissioningWindowOpenedMethod);
+    VerifyOrReturn(mChipAppServerDelegateObject.HasValidObjectRef(),
+                   ChipLogError(AppServer, "mChipAppServerDelegateObject is not valid"));
+    env->CallVoidMethod(mChipAppServerDelegateObject.ObjectRef(), mOnCommissioningWindowOpenedMethod);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in OnCommissioningWindowOpenedMethod");
@@ -115,7 +125,9 @@ void ChipAppServerDelegate::OnCommissioningWindowClosed()
                    ChipLogError(AppServer, "mOnCommissioningWindowClosedMethod is nullptr"));
 
     env->ExceptionClear();
-    env->CallVoidMethod(mChipAppServerDelegateObject, mOnCommissioningWindowClosedMethod);
+    VerifyOrReturn(mChipAppServerDelegateObject.HasValidObjectRef(),
+                   ChipLogError(AppServer, "mChipAppServerDelegateObject is not valid"));
+    env->CallVoidMethod(mChipAppServerDelegateObject.ObjectRef(), mOnCommissioningWindowClosedMethod);
     if (env->ExceptionCheck())
     {
         ChipLogError(AppServer, "Java exception in OnCommissioningWindowClosedMethod");
@@ -128,11 +140,9 @@ CHIP_ERROR ChipAppServerDelegate::InitializeWithObjects(jobject appDelegateObjec
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturnLogError(env != nullptr, CHIP_JNI_ERROR_NO_ENV);
+    ReturnLogErrorOnFailure(mChipAppServerDelegateObject.Init(appDelegateObject));
 
-    mChipAppServerDelegateObject = env->NewGlobalRef(appDelegateObject);
-    VerifyOrReturnLogError(mChipAppServerDelegateObject != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
-
-    jclass chipAppServerDelegateClass = env->GetObjectClass(mChipAppServerDelegateObject);
+    jclass chipAppServerDelegateClass = env->GetObjectClass(mChipAppServerDelegateObject.ObjectRef());
     VerifyOrReturnLogError(chipAppServerDelegateClass != nullptr, CHIP_JNI_ERROR_JAVA_ERROR);
 
     mOnCommissioningSessionEstablishmentStartedMethod =

--- a/src/app/server/java/ChipAppServerDelegate.h
+++ b/src/app/server/java/ChipAppServerDelegate.h
@@ -20,6 +20,7 @@
 #include <app/server/AppDelegate.h>
 #include <jni.h>
 #include <lib/core/CHIPError.h>
+#include <lib/support/JniReferences.h>
 
 class ChipAppServerDelegate : public AppDelegate
 {
@@ -34,7 +35,7 @@ public:
     CHIP_ERROR InitializeWithObjects(jobject appDelegateObject);
 
 private:
-    jobject mChipAppServerDelegateObject                        = nullptr;
+    chip::JniGlobalReference mChipAppServerDelegateObject;
     jmethodID mOnCommissioningSessionEstablishmentStartedMethod = nullptr;
     jmethodID mOnCommissioningSessionStartedMethod              = nullptr;
     jmethodID mOnCommissioningSessionEstablishmentErrorMethod   = nullptr;

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -500,7 +500,6 @@ CHIP_ERROR InvokeCallback::CreateInvokeElement(JNIEnv * env, const app::Concrete
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     jclass invokeElementCls = nullptr;
-    jobject localRef        = nullptr;
     err = JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/model/InvokeElement", invokeElementCls);
     ReturnErrorOnFailure(err);
 
@@ -536,20 +535,18 @@ CHIP_ERROR InvokeCallback::CreateInvokeElement(JNIEnv * env, const app::Concrete
         err = TlvToJson(readerForJson, json);
         ReturnErrorOnFailure(err);
         UtfString jsonString(env, json.c_str());
-        localRef = env->CallStaticObjectMethod(invokeElementCls, invokeElementCtor, static_cast<jint>(aPath.mEndpointId),
-                                               static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mCommandId),
-                                               jniByteArray.jniValue(), jsonString.jniValue());
+        outObj = env->CallStaticObjectMethod(invokeElementCls, invokeElementCtor, static_cast<jint>(aPath.mEndpointId),
+                                             static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mCommandId),
+                                             jniByteArray.jniValue(), jsonString.jniValue());
     }
     else
     {
-        localRef = env->CallStaticObjectMethod(invokeElementCls, invokeElementCtor, static_cast<jint>(aPath.mEndpointId),
-                                               static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mCommandId), nullptr,
-                                               nullptr);
+        outObj = env->CallStaticObjectMethod(invokeElementCls, invokeElementCtor, static_cast<jint>(aPath.mEndpointId),
+                                             static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mCommandId), nullptr,
+                                             nullptr);
     }
-    VerifyOrReturnError(localRef != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
-    outObj = env->NewGlobalRef(localRef);
     VerifyOrReturnError(outObj != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 void ReportCallback::OnError(CHIP_ERROR aError)

--- a/src/controller/java/AndroidCommissioningWindowOpener.h
+++ b/src/controller/java/AndroidCommissioningWindowOpener.h
@@ -19,6 +19,7 @@
 
 #include <controller/CommissioningWindowOpener.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 namespace chip {
 namespace Controller {
@@ -44,7 +45,6 @@ public:
 
 private:
     AndroidCommissioningWindowOpener(DeviceController * controller, jobject javaCallbackObject);
-    ~AndroidCommissioningWindowOpener();
 
     static void OnOpenCommissioningWindowResponse(void * context, NodeId deviceId, CHIP_ERROR status, chip::SetupPayload payload);
     static void OnOpenBasicCommissioningWindowResponse(void * context, NodeId deviceId, CHIP_ERROR status);
@@ -52,7 +52,7 @@ private:
     chip::Callback::Callback<chip::Controller::OnOpenCommissioningWindow> mOnOpenCommissioningWindowCallback;
     chip::Callback::Callback<chip::Controller::OnOpenBasicCommissioningWindow> mOnOpenBasicCommissioningWindowCallback;
 
-    jobject mJavaCallback;
+    chip::JniGlobalReference mJavaCallback;
     jmethodID mOnSuccessMethod = nullptr;
     jmethodID mOnErrorMethod   = nullptr;
 };

--- a/src/controller/java/AndroidCurrentFabricRemover.h
+++ b/src/controller/java/AndroidCurrentFabricRemover.h
@@ -19,6 +19,7 @@
 
 #include <controller/CurrentFabricRemover.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 namespace chip {
 namespace Controller {
@@ -34,12 +35,11 @@ public:
 
 private:
     AndroidCurrentFabricRemover(DeviceController * controller, jobject javaCallbackObject);
-    ~AndroidCurrentFabricRemover();
 
     static void OnRemoveCurrentFabric(void * context, NodeId remoteNodeId, CHIP_ERROR status);
     chip::Callback::Callback<OnCurrentFabricRemove> mOnRemoveCurrentFabricCallback;
 
-    jobject mJavaCallback;
+    chip::JniGlobalReference mJavaCallback;
     jmethodID mOnSuccessMethod = nullptr;
     jmethodID mOnErrorMethod   = nullptr;
 };

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -63,7 +63,7 @@ public:
 
     chip::Controller::DeviceCommissioner * Controller() { return mController.get(); }
     void SetJavaObjectRef(JavaVM * vm, jobject obj);
-    jobject JavaObjectRef() { return mJavaObjectRef; }
+    jobject JavaObjectRef() { return mJavaObjectRef.ObjectRef(); }
     jlong ToJNIHandle();
 
 #ifndef JAVA_MATTER_CONTROLLER_TEST
@@ -224,8 +224,8 @@ private:
 
     chip::app::DefaultICDClientStorage mICDClientStorage;
 
-    JavaVM * mJavaVM       = nullptr;
-    jobject mJavaObjectRef = nullptr;
+    JavaVM * mJavaVM = nullptr;
+    chip::JniGlobalReference mJavaObjectRef;
 #ifdef JAVA_MATTER_CONTROLLER_TEST
     ExampleOperationalCredentialsIssuerPtr mOpCredsIssuer;
     PersistentStorage mExampleStorage;

--- a/src/controller/java/AttestationTrustStoreBridge.cpp
+++ b/src/controller/java/AttestationTrustStoreBridge.cpp
@@ -25,17 +25,6 @@
 
 using namespace chip;
 
-AttestationTrustStoreBridge::~AttestationTrustStoreBridge()
-{
-    if (mAttestationTrustStoreDelegate != nullptr)
-    {
-        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-        VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
-        env->DeleteGlobalRef(mAttestationTrustStoreDelegate);
-        mAttestationTrustStoreDelegate = nullptr;
-    }
-}
-
 CHIP_ERROR AttestationTrustStoreBridge::GetProductAttestationAuthorityCert(const chip::ByteSpan & skid,
                                                                            chip::MutableByteSpan & outPaaDerBuffer) const
 {
@@ -73,19 +62,20 @@ CHIP_ERROR AttestationTrustStoreBridge::GetPaaCertFromJava(const chip::ByteSpan 
     VerifyOrReturnError(env != nullptr, CHIP_ERROR_INCORRECT_STATE);
     JniLocalReferenceScope scope(env);
 
+    VerifyOrReturnError(mAttestationTrustStoreDelegate.HasValidObjectRef(), CHIP_ERROR_INCORRECT_STATE);
     JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/AttestationTrustStoreDelegate",
                                                   attestationTrustStoreDelegateCls);
     VerifyOrReturnError(attestationTrustStoreDelegateCls != nullptr, CHIP_JNI_ERROR_TYPE_NOT_FOUND);
 
-    JniReferences::GetInstance().FindMethod(env, mAttestationTrustStoreDelegate, "getProductAttestationAuthorityCert", "([B)[B",
-                                            &getProductAttestationAuthorityCertMethod);
+    JniReferences::GetInstance().FindMethod(env, mAttestationTrustStoreDelegate.ObjectRef(), "getProductAttestationAuthorityCert",
+                                            "([B)[B", &getProductAttestationAuthorityCertMethod);
     VerifyOrReturnError(getProductAttestationAuthorityCertMethod != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
 
     JniReferences::GetInstance().N2J_ByteArray(env, skid.data(), static_cast<jsize>(skid.size()), javaSkid);
     VerifyOrReturnError(javaSkid != nullptr, CHIP_ERROR_NO_MEMORY);
 
-    jbyteArray javaPaaCert =
-        (jbyteArray) env->CallObjectMethod(mAttestationTrustStoreDelegate, getProductAttestationAuthorityCertMethod, javaSkid);
+    jbyteArray javaPaaCert = (jbyteArray) env->CallObjectMethod(mAttestationTrustStoreDelegate.ObjectRef(),
+                                                                getProductAttestationAuthorityCertMethod, javaSkid);
     VerifyOrReturnError(javaPaaCert != nullptr, CHIP_ERROR_CA_CERT_NOT_FOUND);
 
     JniByteArray paaCertBytes(env, javaPaaCert);

--- a/src/controller/java/AttestationTrustStoreBridge.h
+++ b/src/controller/java/AttestationTrustStoreBridge.h
@@ -21,16 +21,15 @@
 class AttestationTrustStoreBridge : public chip::Credentials::AttestationTrustStore
 {
 public:
-    AttestationTrustStoreBridge(jobject attestationTrustStoreDelegate) :
-        mAttestationTrustStoreDelegate(attestationTrustStoreDelegate)
+    AttestationTrustStoreBridge(chip::JniGlobalReference && attestationTrustStoreDelegate) :
+        mAttestationTrustStoreDelegate(std::move(attestationTrustStoreDelegate))
     {}
-    ~AttestationTrustStoreBridge();
 
     CHIP_ERROR GetProductAttestationAuthorityCert(const chip::ByteSpan & skid,
                                                   chip::MutableByteSpan & outPaaDerBuffer) const override;
 
 protected:
-    jobject mAttestationTrustStoreDelegate = nullptr;
+    chip::JniGlobalReference mAttestationTrustStoreDelegate;
 
     CHIP_ERROR GetPaaCertFromJava(const chip::ByteSpan & skid, chip::MutableByteSpan & outPaaDerBuffer) const;
 };

--- a/src/controller/java/DeviceAttestationDelegateBridge.h
+++ b/src/controller/java/DeviceAttestationDelegateBridge.h
@@ -17,6 +17,7 @@
 
 #include <jni.h>
 #include <lib/core/NodeId.h>
+#include <lib/support/JniReferences.h>
 #include <platform/CHIPDeviceConfig.h>
 
 #include <credentials/attestation_verifier/DeviceAttestationDelegate.h>
@@ -24,14 +25,12 @@
 class DeviceAttestationDelegateBridge : public chip::Credentials::DeviceAttestationDelegate
 {
 public:
-    DeviceAttestationDelegateBridge(jobject deviceAttestationDelegate, chip::Optional<uint16_t> expiryTimeoutSecs,
-                                    bool shouldWaitAfterDeviceAttestation) :
+    DeviceAttestationDelegateBridge(chip::JniGlobalReference && deviceAttestationDelegate,
+                                    chip::Optional<uint16_t> expiryTimeoutSecs, bool shouldWaitAfterDeviceAttestation) :
         mResult(chip::Credentials::AttestationVerificationResult::kSuccess),
-        mDeviceAttestationDelegate(deviceAttestationDelegate), mExpiryTimeoutSecs(expiryTimeoutSecs),
+        mDeviceAttestationDelegate(std::move(deviceAttestationDelegate)), mExpiryTimeoutSecs(expiryTimeoutSecs),
         mShouldWaitAfterDeviceAttestation(shouldWaitAfterDeviceAttestation)
     {}
-
-    ~DeviceAttestationDelegateBridge();
 
     chip::Optional<uint16_t> FailSafeExpiryTimeoutSecs() const override { return mExpiryTimeoutSecs; }
 
@@ -45,7 +44,7 @@ public:
 
 private:
     chip::Credentials::AttestationVerificationResult mResult;
-    jobject mDeviceAttestationDelegate = nullptr;
+    chip::JniGlobalReference mDeviceAttestationDelegate;
     chip::Optional<uint16_t> mExpiryTimeoutSecs;
     const bool mShouldWaitAfterDeviceAttestation;
 };

--- a/src/platform/android/AndroidChipPlatform-JNI.cpp
+++ b/src/platform/android/AndroidChipPlatform-JNI.cpp
@@ -53,9 +53,8 @@ static bool JavaBytesToUUID(JNIEnv * env, jbyteArray value, chip::Ble::ChipBleUU
 #endif
 
 namespace {
-JavaVM * sJVM;
-jclass sAndroidChipPlatformCls          = NULL;
-jclass sAndroidChipPlatformExceptionCls = NULL;
+JavaVM * sJVM = nullptr;
+JniGlobalReference sAndroidChipPlatformExceptionCls;
 } // namespace
 
 CHIP_ERROR AndroidChipPlatformJNI_OnLoad(JavaVM * jvm, void * reserved)
@@ -78,11 +77,14 @@ CHIP_ERROR AndroidChipPlatformJNI_OnLoad(JavaVM * jvm, void * reserved)
     ChipLogProgress(DeviceLayer, "Loading Java class references.");
 
     // Get various class references need by the API.
-    err = JniReferences::GetInstance().GetClassRef(env, "chip/platform/AndroidChipPlatform", sAndroidChipPlatformCls);
+
+    jclass androidChipPlatformException;
+    err = JniReferences::GetInstance().GetLocalClassRef(env, "chip/platform/AndroidChipPlatformException",
+                                                        androidChipPlatformException);
     SuccessOrExit(err);
-    err = JniReferences::GetInstance().GetClassRef(env, "chip/platform/AndroidChipPlatformException",
-                                                   sAndroidChipPlatformExceptionCls);
+    err = sAndroidChipPlatformExceptionCls.Init(static_cast<jobject>(androidChipPlatformException));
     SuccessOrExit(err);
+
     ChipLogProgress(DeviceLayer, "Java class references loaded.");
 
     err = BleConnectCallbackJNI_OnLoad(jvm, reserved);

--- a/src/platform/android/BLEManagerImpl.h
+++ b/src/platform/android/BLEManagerImpl.h
@@ -23,9 +23,9 @@
 
 #pragma once
 
-#include <jni.h>
-
 #include <ble/BleLayer.h>
+#include <jni.h>
+#include <lib/support/JniReferences.h>
 #include <platform/internal/BLEManager.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
@@ -124,7 +124,7 @@ private:
     CHIP_ERROR HasFlag(Flags flag, bool & has);
     CHIP_ERROR SetFlag(Flags flag, bool isSet);
 
-    jobject mBLEManagerObject = nullptr;
+    chip::JniGlobalReference mBLEManagerObject;
 
     jmethodID mInitMethod    = nullptr;
     jmethodID mSetFlagMethod = nullptr;

--- a/src/platform/android/CHIPP256KeypairBridge.h
+++ b/src/platform/android/CHIPP256KeypairBridge.h
@@ -16,11 +16,11 @@
  */
 #pragma once
 
-#include <jni.h>
-
 #include "crypto/CHIPCryptoPAL.h"
 #include "lib/core/CHIPError.h"
+#include "lib/support/JniReferences.h"
 #include "lib/support/logging/CHIPLogging.h"
+#include <jni.h>
 
 /**
  * Bridging implementation of P256Keypair to allow delegation of signing and
@@ -42,7 +42,7 @@ public:
      */
     CHIP_ERROR SetDelegate(jobject delegate);
 
-    bool HasKeypair() const { return mDelegate != nullptr; }
+    bool HasKeypair() const { return mDelegate.HasValidObjectRef(); }
 
     CHIP_ERROR Initialize(chip::Crypto::ECPKeyTarget key_target) override;
 
@@ -61,8 +61,8 @@ public:
     const chip::Crypto::P256PublicKey & Pubkey() const override { return mPublicKey; };
 
 private:
-    jobject mDelegate;
-    jclass mKeypairDelegateClass;
+    chip::JniGlobalReference mDelegate;
+    chip::JniGlobalReference mKeypairDelegateClass;
     jmethodID mGetPublicKeyMethod;
     jmethodID mCreateCertificateSigningRequestMethod;
     jmethodID mEcdsaSignMessageMethod;

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -50,11 +50,8 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 
 void ConfigurationManagerImpl::InitializeWithObject(jobject managerObject)
 {
-    JNIEnv * env                     = JniReferences::GetInstance().GetEnvForCurrentThread();
-    mConfigurationManagerObject      = env->NewGlobalRef(managerObject);
-    jclass configurationManagerClass = env->GetObjectClass(mConfigurationManagerObject);
-    VerifyOrReturn(configurationManagerClass != nullptr, ChipLogError(DeviceLayer, "Failed to get KVS Java class"));
-
+    VerifyOrReturn(mConfigurationManagerObject.Init(managerObject) == CHIP_NO_ERROR,
+                   ChipLogError(DeviceLayer, "Failed to init mConfigurationManagerObject"));
     AndroidConfig::InitializeWithObject(managerObject);
 }
 

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -28,6 +28,7 @@
 #include <platform/internal/GenericConfigurationManagerImpl.h>
 
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -74,7 +75,7 @@ private:
 
     static void DoFactoryReset(intptr_t arg);
 
-    jobject mConfigurationManagerObject = nullptr;
+    chip::JniGlobalReference mConfigurationManagerObject;
 };
 
 /**

--- a/src/platform/android/DiagnosticDataProviderImpl.h
+++ b/src/platform/android/DiagnosticDataProviderImpl.h
@@ -48,9 +48,9 @@ public:
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 
-    jobject mDiagnosticDataProviderManagerObject = nullptr;
-    jmethodID mGetRebootCountMethod              = nullptr;
-    jmethodID mGetNifMethod                      = nullptr;
+    JniGlobalReference mDiagnosticDataProviderManagerObject;
+    jmethodID mGetRebootCountMethod = nullptr;
+    jmethodID mGetNifMethod         = nullptr;
 };
 
 /**

--- a/src/platform/android/KeyValueStoreManagerImpl.h
+++ b/src/platform/android/KeyValueStoreManagerImpl.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -46,10 +47,10 @@ private:
 
     static KeyValueStoreManagerImpl sInstance;
 
-    jobject mKeyValueStoreManagerObject = nullptr;
-    jmethodID mGetMethod                = nullptr;
-    jmethodID mSetMethod                = nullptr;
-    jmethodID mDeleteMethod             = nullptr;
+    chip::JniGlobalReference mKeyValueStoreManagerObject;
+    jmethodID mGetMethod    = nullptr;
+    jmethodID mSetMethod    = nullptr;
+    jmethodID mDeleteMethod = nullptr;
 };
 
 /**


### PR DESCRIPTION
-- JNI global reference leaks happens in too many places in matter android code, we appy RAII JniGlobalReference to prevent the leak for global reference. 
-- Remove bad GetClassRef API, which leads to local and global reference leaks in lots of place.
-- Fix several heap leak in android JNI.