### PR TITLE
[Silabs]Move  fetching reboot cause code to our platform abstraction. 

### DIFF
--- a/src/platform/silabs/ConfigurationManagerImpl.h
+++ b/src/platform/silabs/ConfigurationManagerImpl.h
@@ -73,7 +73,6 @@ private:
     void RunConfigUnitTest(void) override;
 
     // ===== Private members reserved for use by this class only.
-    uint32_t rebootCause;
     static void DoFactoryReset(intptr_t arg);
 };
 

--- a/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
@@ -22,15 +22,12 @@
  *          for EFR32 platforms using the Silicon Labs SDK.
  */
 /* this file behaves like a config.h, comes first */
-#include <platform/internal/CHIPDeviceLayerInternal.h>
-
-#include <platform/internal/GenericConfigurationManagerImpl.ipp>
-
 #include <platform/ConfigurationManager.h>
 #include <platform/DiagnosticDataProvider.h>
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/internal/GenericConfigurationManagerImpl.ipp>
 #include <platform/silabs/SilabsConfig.h>
-
-#include "em_rmu.h"
+#include <platform/silabs/platformAbstraction/SilabsPlatform.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
 #include "wfx_host_events.h"
@@ -55,12 +52,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     err = Internal::GenericConfigurationManagerImpl<SilabsConfig>::Init();
     SuccessOrExit(err);
 
-    // TODO: Initialize the global GroupKeyStore object here (#1626)
-
     IncreaseBootCount();
-    rebootCause = RMU_ResetCauseGet();
-    RMU_ResetCauseClear();
-
     err = CHIP_NO_ERROR;
 
 exit:
@@ -99,6 +91,8 @@ CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
 {
     // rebootCause is obtained at bootup.
     BootReasonType matterBootCause;
+    uint32_t rebootCause = Silabs::GetPlatform().GetRebootCause();
+
 #if defined(_SILICON_LABS_32B_SERIES_1)
     if (rebootCause & RMU_RSTCAUSE_PORST || rebootCause & RMU_RSTCAUSE_EXTRST) // PowerOn or External pin reset
     {

--- a/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/GsdkSpam.cpp
@@ -17,6 +17,7 @@
 
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
 
+#include "em_rmu.h"
 #include "sl_system_kernel.h"
 
 #ifdef ENABLE_WSTK_LEDS
@@ -68,6 +69,10 @@ SilabsPlatform::SilabsButtonCb SilabsPlatform::mButtonCallback = nullptr;
 CHIP_ERROR SilabsPlatform::Init(void)
 {
     sl_system_init();
+
+    mRebootCause = RMU_ResetCauseGet();
+    // Clear register so it does accumualate the causes of each reset
+    RMU_ResetCauseClear();
 
 #if CHIP_ENABLE_OPENTHREAD
     sl_ot_sys_init();

--- a/src/platform/silabs/platformAbstraction/SilabsPlatform.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatform.h
@@ -49,6 +49,7 @@ public:
 #endif
 
     inline void SetButtonsCb(SilabsButtonCb callback) override { mButtonCallback = callback; }
+    inline uint32_t GetRebootCause() { return mRebootCause; }
 
     static SilabsButtonCb mButtonCallback;
 
@@ -64,6 +65,7 @@ private:
     SilabsPlatform(){};
     virtual ~SilabsPlatform() = default;
 
+    uint32_t mRebootCause = 0;
     static SilabsPlatform sSilabsPlatformAbstractionManager;
 };
 

--- a/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
+++ b/src/platform/silabs/platformAbstraction/SilabsPlatformBase.h
@@ -35,6 +35,7 @@ public:
     virtual CHIP_ERROR InitLCD() { return CHIP_ERROR_NOT_IMPLEMENTED; }
     virtual CHIP_ERROR SetGPIO(uint32_t port, uint32_t pin, bool state) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     virtual bool GetGPIO(uint32_t port, uint32_t pin) { return false; }
+    virtual uint32_t GetRebootCause() = 0;
 
     // Scheduler
     virtual void StartScheduler(void) = 0;


### PR DESCRIPTION
Moving the reboot cause to the platform abstraction allows for a better separation of our different SoC platforms. 

This fix and interaction issue with our thread stack where both matter and openhtread compete for the reboot cause register.  

Lastly, it will allow the cleanup of duplication in our ConfigurationManagerImpl.cpp in a follow-up PR.

