### PR TITLE
[Python] CommissonWithCode support discoveryType

### DIFF
--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -137,7 +137,7 @@ PyChipError pychip_DeviceController_ConnectBLE(chip::Controller::DeviceCommissio
 PyChipError pychip_DeviceController_ConnectIP(chip::Controller::DeviceCommissioner * devCtrl, const char * peerAddrStr,
                                               uint32_t setupPINCode, chip::NodeId nodeid);
 PyChipError pychip_DeviceController_ConnectWithCode(chip::Controller::DeviceCommissioner * devCtrl, const char * onboardingPayload,
-                                                    chip::NodeId nodeid, bool networkOnly);
+                                                    chip::NodeId nodeid, uint8_t discoveryType);
 PyChipError pychip_DeviceController_UnpairDevice(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId remoteDeviceId,
                                                  DeviceUnpairingCompleteFunct callback);
 PyChipError pychip_DeviceController_SetThreadOperationalDataset(const char * threadOperationalDataset, uint32_t size);
@@ -401,13 +401,11 @@ PyChipError pychip_DeviceController_ConnectIP(chip::Controller::DeviceCommission
 }
 
 PyChipError pychip_DeviceController_ConnectWithCode(chip::Controller::DeviceCommissioner * devCtrl, const char * onboardingPayload,
-                                                    chip::NodeId nodeid, bool networkOnly)
+                                                    chip::NodeId nodeid, uint8_t discoveryType)
 {
-    chip::Controller::DiscoveryType discoveryType = chip::Controller::DiscoveryType::kAll;
     sPairingDelegate.SetExpectingPairingComplete(true);
-    if (networkOnly)
-        discoveryType = chip::Controller::DiscoveryType::kDiscoveryNetworkOnly;
-    return ToPyChipError(devCtrl->PairDevice(nodeid, onboardingPayload, sCommissioningParameters, discoveryType));
+    return ToPyChipError(devCtrl->PairDevice(nodeid, onboardingPayload, sCommissioningParameters,
+                                             static_cast<chip::Controller::DiscoveryType>(DiscoveryType)));
 }
 
 namespace {

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -405,7 +405,7 @@ PyChipError pychip_DeviceController_ConnectWithCode(chip::Controller::DeviceComm
 {
     sPairingDelegate.SetExpectingPairingComplete(true);
     return ToPyChipError(devCtrl->PairDevice(nodeid, onboardingPayload, sCommissioningParameters,
-                                             static_cast<chip::Controller::DiscoveryType>(DiscoveryType)));
+                                             static_cast<chip::Controller::DiscoveryType>(discoveryType)));
 }
 
 namespace {

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -238,6 +238,7 @@ class DeviceProxyWrapper():
 
 
 DiscoveryFilterType = discovery.FilterType
+DiscoveryType = discovery.DiscoveryType
 
 
 class ChipDeviceControllerBase():
@@ -1624,7 +1625,7 @@ class ChipDeviceControllerBase():
             self._dmLib.pychip_DeviceController_ConnectIP.restype = PyChipError
 
             self._dmLib.pychip_DeviceController_ConnectWithCode.argtypes = [
-                c_void_p, c_char_p, c_uint64, c_bool]
+                c_void_p, c_char_p, c_uint64, c_uint8]
             self._dmLib.pychip_DeviceController_ConnectWithCode.restype = PyChipError
 
             self._dmLib.pychip_DeviceController_UnpairDevice.argtypes = [
@@ -1937,7 +1938,7 @@ class ChipDeviceController(ChipDeviceControllerBase):
             return PyChipError(CHIP_ERROR_TIMEOUT)
         return self._ChipStack.commissioningEventRes
 
-    def CommissionWithCode(self, setupPayload: str, nodeid: int, networkOnly: bool = False) -> PyChipError:
+    def CommissionWithCode(self, setupPayload: str, nodeid: int, discoveryType: DiscoveryType = DiscoveryType.DISCOVERY_ALL) -> PyChipError:
         ''' Commission with the given nodeid from the setupPayload.
             setupPayload may be a QR or manual code.
         '''
@@ -1953,7 +1954,7 @@ class ChipDeviceController(ChipDeviceControllerBase):
 
         self._ChipStack.CallAsync(
             lambda: self._dmLib.pychip_DeviceController_ConnectWithCode(
-                self.devCtrl, setupPayload, nodeid, networkOnly)
+                self.devCtrl, setupPayload, nodeid, discoveryType.value)
         )
         if not self._ChipStack.commissioningCompleteEvent.isSet():
             # Error 50 is a timeout

--- a/src/controller/python/chip/discovery/__init__.py
+++ b/src/controller/python/chip/discovery/__init__.py
@@ -26,6 +26,12 @@ from chip.discovery.types import DiscoverFailureCallback_t, DiscoverSuccessCallb
 from chip.native import PyChipError
 
 
+class DiscoveryType(enum.IntEnum):
+    DISCOVERY_NETWORK_ONLY = 0
+    DISCOVERY_NETWORK_ONLY_WITHOUT_PASE_AUTO_RETRY = 1
+    DISCOVERY_ALL = 2
+
+
 class FilterType(enum.IntEnum):
     # These must match chip::Dnssd::DiscoveryFilterType values (barring the naming convention)
     NONE = 0

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -341,9 +341,9 @@ class BaseTestHelper:
         self.logger.info("Commissioning finished.")
         return True
 
-    def TestCommissioningWithSetupPayload(self, setupPayload: str, nodeid: int):
+    def TestCommissioningWithSetupPayload(self, setupPayload: str, nodeid: int, discoveryType: int = 2):
         self.logger.info("Commissioning device with setup payload {}".format(setupPayload))
-        if not self.devCtrl.CommissionWithCode(setupPayload, nodeid):
+        if not self.devCtrl.CommissionWithCode(setupPayload, nodeid, chip.discovery.DiscoveryType(discoveryType)):
             self.logger.info(
                 "Failed to finish commissioning device {}".format(setupPayload))
             return False

--- a/src/controller/python/test/test_scripts/commissioning_test.py
+++ b/src/controller/python/test/test_scripts/commissioning_test.py
@@ -39,6 +39,7 @@ TEST_THREAD_NETWORK_DATASET_TLV = "0e080000000000010000" + \
 # Network id, for the thread network, current a const value, will be changed to XPANID of the thread network.
 TEST_THREAD_NETWORK_ID = "fedcba9876543210"
 TEST_DISCRIMINATOR = 3840
+TEST_DISCOVERY_TYPE = 2
 
 ENDPOINT_ID = 0
 LIGHTING_ENDPOINT_ID = 1
@@ -104,6 +105,15 @@ def main():
         help="Path that contains valid and trusted PAA Root Certificates.",
         metavar="<paa-trust-store-path>"
     )
+    optParser.add_option(
+        "--discovery-type",
+        action="store",
+        dest="discoveryType",
+        default=TEST_DISCOVERY_TYPE,
+        type=int,
+        help="Discovery type of commissioning. (0: networkOnly 1: networkOnlyWithoutPASEAutoRetry 2: All<Ble & Network>)",
+        metavar="<discovery-type>"
+    )
 
     (options, remainingArgs) = optParser.parse_args(sys.argv[1:])
 
@@ -129,7 +139,8 @@ def main():
     elif options.setupPayload:
         logger.info("Testing commissioning (w/ Setup Payload)")
         FailIfNot(test.TestCommissioningWithSetupPayload(setupPayload=options.setupPayload,
-                                                         nodeid=options.nodeid),
+                                                         nodeid=options.nodeid,
+                                                         discoveryType=options.discoveryType),
                   "Failed to finish commissioning")
     else:
         TestFail("Must provide device address or setup payload to commissioning the device")

--- a/src/test_driver/linux-cirque/CommissioningTest.py
+++ b/src/test_driver/linux-cirque/CommissioningTest.py
@@ -38,6 +38,8 @@ CHIP_REPO = os.path.join(os.path.abspath(
 TEST_EXTPANID = "fedcba9876543210"
 TEST_DISCRIMINATOR = 3840
 TEST_DISCRIMINATOR2 = 3584
+TEST_DISCRIMINATOR3 = 1203
+TEST_DISCRIMINATOR4 = 2145
 TEST_DISCOVERY_TYPE = [0, 1, 2]
 MATTER_DEVELOPMENT_PAA_ROOT_CERTS = "credentials/development/paa-root-certs"
 
@@ -61,6 +63,24 @@ DEVICE_CONFIG = {
         "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
     },
     'device2': {
+        'type': 'CHIPEndDevice',
+        'base_image': '@default',
+        'capability': ['Thread', 'TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 100},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    },
+    'device3': {
+        'type': 'CHIPEndDevice',
+        'base_image': '@default',
+        'capability': ['Thread', 'TrafficControl', 'Mount'],
+        'rcp_mode': True,
+        'docker_network': 'Ipv6',
+        'traffic_control': {'latencyMs': 100},
+        "mount_pairs": [[CHIP_REPO, CHIP_REPO]],
+    },
+    'device4': {
         'type': 'CHIPEndDevice',
         'base_image': '@default',
         'capability': ['Thread', 'TrafficControl', 'Mount'],
@@ -96,6 +116,10 @@ class TestCommissioner(CHIPVirtualHome):
         servers[0]['nodeid'] = 1
         servers[1]['discriminator'] = TEST_DISCRIMINATOR2
         servers[1]['nodeid'] = 2
+        servers[2]['discriminator'] = TEST_DISCRIMINATOR3
+        servers[2]['nodeid'] = 3
+        servers[3]['discriminator'] = TEST_DISCRIMINATOR4
+        servers[3]['nodeid'] = 4
 
         for server in servers:
             self.execute_device_cmd(
@@ -128,22 +152,47 @@ class TestCommissioner(CHIPVirtualHome):
         self.assertEqual(ret['return_code'], '0',
                          "Test failed: non-zero return code")
 
-        for discovery_type in TEST_DISCOVERY_TYPE:
-            self.reset_thread_devices([servers[1]['id']])
+        command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
+                   "{} -t 150 --paa-trust-store-path {} --discriminator {} --setup-payload {} --nodeid {} --discovery-type {}").format(
+            os.path.join(
+                CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_test.py"),
+            os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
+            servers[1]['discriminator'],
+            "33331712336",
+            servers[1]['nodeid'],
+            TEST_DISCOVERY_TYPE[2])
+        ret = self.execute_device_cmd(req_device_id, command)
 
-            command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
-                       "{} -t 150 --paa-trust-store-path {} --discriminator {} --setup-payload {} --nodeid {} --discovery-type {}").format(
-                os.path.join(
-                    CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_test.py"),
-                os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
-                servers[1]['discriminator'],
-                "33331712336",
-                servers[1]['nodeid'],
-                discovery_type)
-            ret = self.execute_device_cmd(req_device_id, command)
+        self.assertEqual(ret['return_code'], '0',
+                         "Test failed: non-zero return code")
 
-            self.assertEqual(ret['return_code'], '0',
-                             "Test failed: non-zero return code")
+        command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
+                   "{} -t 150 --paa-trust-store-path {} --discriminator {} --setup-payload {} --nodeid {} --discovery-type {}").format(
+            os.path.join(
+                CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_test.py"),
+            os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
+            servers[2]['discriminator'],
+            "10054912339",
+            servers[2]['nodeid'],
+            TEST_DISCOVERY_TYPE[0])
+        ret = self.execute_device_cmd(req_device_id, command)
+
+        self.assertEqual(ret['return_code'], '0',
+                         "Test failed: non-zero return code")
+
+        command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
+                   "{} -t 150 --paa-trust-store-path {} --discriminator {} --setup-payload {} --nodeid {} --discovery-type {}").format(
+            os.path.join(
+                CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_test.py"),
+            os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
+            servers[3]['discriminator'],
+            "2145",
+            servers[3]['nodeid'],
+            TEST_DISCOVERY_TYPE[1])
+        ret = self.execute_device_cmd(req_device_id, command)
+
+        self.assertEqual(ret['return_code'], '0',
+                         "Test failed: non-zero return code")
 
 
 if __name__ == "__main__":

--- a/src/test_driver/linux-cirque/CommissioningTest.py
+++ b/src/test_driver/linux-cirque/CommissioningTest.py
@@ -38,6 +38,7 @@ CHIP_REPO = os.path.join(os.path.abspath(
 TEST_EXTPANID = "fedcba9876543210"
 TEST_DISCRIMINATOR = 3840
 TEST_DISCRIMINATOR2 = 3584
+TEST_DISCOVERY_TYPE = [0, 1, 2]
 MATTER_DEVELOPMENT_PAA_ROOT_CERTS = "credentials/development/paa-root-certs"
 
 DEVICE_CONFIG = {
@@ -127,18 +128,22 @@ class TestCommissioner(CHIPVirtualHome):
         self.assertEqual(ret['return_code'], '0',
                          "Test failed: non-zero return code")
 
-        command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
-                   "{} -t 150 --paa-trust-store-path {} --discriminator {} --setup-payload {} --nodeid {}").format(
-            os.path.join(
-                CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_test.py"),
-            os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
-            servers[1]['discriminator'],
-            "33331712336",
-            servers[1]['nodeid'])
-        ret = self.execute_device_cmd(req_device_id, command)
+        for discovery_type in TEST_DISCOVERY_TYPE:
+            self.reset_thread_devices([servers[1]['id']])
 
-        self.assertEqual(ret['return_code'], '0',
-                         "Test failed: non-zero return code")
+            command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
+                       "{} -t 150 --paa-trust-store-path {} --discriminator {} --setup-payload {} --nodeid {} --discovery-type {}").format(
+                os.path.join(
+                    CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_test.py"),
+                os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
+                servers[1]['discriminator'],
+                "33331712336",
+                servers[1]['nodeid'],
+                discovery_type)
+            ret = self.execute_device_cmd(req_device_id, command)
+
+            self.assertEqual(ret['return_code'], '0',
+                             "Test failed: non-zero return code")
 
 
 if __name__ == "__main__":

--- a/src/test_driver/linux-cirque/CommissioningTest.py
+++ b/src/test_driver/linux-cirque/CommissioningTest.py
@@ -186,7 +186,7 @@ class TestCommissioner(CHIPVirtualHome):
                 CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_test.py"),
             os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
             servers[3]['discriminator'],
-            "2145",
+            "20054912334",
             servers[3]['nodeid'],
             TEST_DISCOVERY_TYPE[1])
         ret = self.execute_device_cmd(req_device_id, command)


### PR DESCRIPTION
In the current Python API, `CommissionWithCode` does not support the specified `discoveryType`, so the `TC-CADMIN-1.9#4#5` steps cannot use this interface for debugging normally. The internal Commisionner will automatically retry the operation and change the parameters of the original interface. Change `networkOnly` to an enumeration value (searched the code, `networkOnly` is not used anywhere)
