### PR TITLE
Fix output read from the include-what-you-use tool

### DIFF
--- a/scripts/helpers/iwyu-check.py
+++ b/scripts/helpers/iwyu-check.py
@@ -172,8 +172,8 @@ def main(compile_commands_glob, scanning_destination, mapping_file_dir,
         logging.info("============== IWYU output start  ================")
 
         logger = logging.info
-        while status.poll() is None:
-            line = status.stdout.readline().rstrip()
+        for line in status.stdout:
+            line = line.rstrip()
 
             if re.match(r"^warning:.*$", line):
                 logger = logging.warning

--- a/scripts/helpers/platforms/iwyu.imp
+++ b/scripts/helpers/platforms/iwyu.imp
@@ -32,7 +32,12 @@
     ## lib/*
     { include: [ '"lib/core/CHIPError.h"', private, '<lib/core/CHIPError.h>', public ] },
     { include: [ '"lib/dnssd/ServiceNaming.h"', private, '<lib/dnssd/platform/Dnssd.h>', public ] },
+
+    ## lib/support/logging/*
+    { include: [ '"lib/support/logging/BinaryLogging.h"', private, '<lib/support/logging/CHIPLogging.h>', public ] },
     { include: [ '"lib/support/logging/CHIPLogging.h"', private, '<lib/support/logging/CHIPLogging.h>', public ] },
+    { include: [ '"lib/support/logging/Constants.h"', private, '<lib/support/logging/CHIPLogging.h>', public ] },
+    { include: [ '"lib/support/logging/TextOnlyLogging.h"', private, '<lib/support/logging/CHIPLogging.h>', public ] },
 
     ## platform/*
     { include: [ '"platform/NetworkCommissioning.h"', private, '<platform/NetworkCommissioning.h>', public ] },


### PR DESCRIPTION
### Problem

Reading one line and checking whether process is alive might lead to premature read termination in case when subprocess outputs lots of lines and terminates right away.
