### PR TITLE
Update thermostat-cluster.xml to match spec

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
@@ -18,17 +18,16 @@ limitations under the License.
   <domain name="HVAC"/>
   <bitmap name="Feature" type="bitmap32">
     <cluster code="0x0201"/>
-    <field name="Heating" mask="0x1"/>
-    <field name="Cooling" mask="0x2"/>
-    <field name="Occupancy" mask="0x4"/>
-    <field name="ScheduleConfiguration" mask="0x8"/>
+    <field name="Heating" mask="0x01"/>
+    <field name="Cooling" mask="0x02"/>
+    <field name="Occupancy" mask="0x04"/>
+    <field name="ScheduleConfiguration" mask="0x08"/>
     <field name="Setback" mask="0x10"/>
     <field name="AutoMode" mask="0x20"/>
     <field name="LocalTemperatureNotExposed" mask="0x40"/>
     <field name="MatterScheduleConfiguration" mask="0x80"/>
     <field name="Presets" mask="0x100"/>
-    <field name="Setpoints" mask="0x200"/>
-    <field name="QueuedPresetsSupported" mask="0x400"/>
+    <field name="QueuedPresetsSupported" mask="0x200"/>
   </bitmap>
 
   <bitmap name="ACErrorCodeBitmap" type="bitmap32">
@@ -104,13 +103,6 @@ limitations under the License.
     <field name="Automatic" mask="0x01"/>
     <field name="SupportsNames" mask="0x02"/>
   </bitmap>
-
-  <bitmap name="TemperatureSetpointHoldPolicyBitmap" type="bitmap8">
-    <cluster code="0x0201"/>
-    <field name="HoldDurationElapsed" mask="0x01"/>
-    <field name="HoldDurationElapsedOrPresetChanged" mask="0x02"/>
-  </bitmap>
-
   <enum name="SystemModeEnum" type="enum8">
     <cluster code="0x0201"/>
     <item name="Off" value="0x00"/>
@@ -225,7 +217,7 @@ limitations under the License.
   <struct name="WeeklyScheduleTransitionStruct">
     <cluster code="0x0201"/>
     <!-- See https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/6217 for HeatSetpoint and CoolSetpoint.  They might end up being nullable. -->
-    <item fieldId="0" name="TransitionTime" type="int16u" min="0" max="1439"/>
+    <item fieldId="0" name="TransitionTime" type="int16u" max="1439"/>
     <item fieldId="1" name="HeatSetpoint" type="temperature" isNullable="true"/>
     <item fieldId="2" name="CoolSetpoint" type="temperature" isNullable="true"/>
   </struct>
@@ -246,11 +238,11 @@ limitations under the License.
   <struct name="PresetStruct" apiMaturity="provisional">
     <cluster code="0x0201"/>
     <item fieldId="0" name="PresetHandle" type="octet_string" length="16" isNullable="true"/>
-    <item fieldId="1" name="PresetScenario" type="PresetScenarioEnum" min="0x0" max="0x6"/>
+    <item fieldId="1" name="PresetScenario" type="PresetScenarioEnum" min="0x00" max="0x06"/>
     <item fieldId="2" name="Name" type="char_string" length="64" isNullable="true" optional="true"/>
-    <item fieldId="3" name="CoolingSetpoint" type="temperature" optional="true" default="0x0A28"/>
-    <item fieldId="4" name="HeatingSetpoint" type="temperature" optional="true" default="0x07D0"/>
-    <item fieldId="5" name="BuiltIn" type="boolean" isNullable="true"/>
+    <item fieldId="3" name="CoolingSetpoint" type="temperature" optional="true" default="2600"/>
+    <item fieldId="4" name="HeatingSetpoint" type="temperature" optional="true" default="2000"/>
+    <item fieldId="5" name="BuiltIn" type="boolean" isNullable="true" default="0"/>
   </struct>
 
   <struct name="PresetTypeStruct" apiMaturity="provisional">
@@ -263,11 +255,11 @@ limitations under the License.
   <struct name="ScheduleStruct" apiMaturity="provisional">
     <cluster code="0x0201"/>
     <item fieldId="0" name="ScheduleHandle" type="octet_string" length="16" isNullable="true"/>
-    <item fieldId="1" name="SystemMode" type="SystemModeEnum" min="0x0" max="0x9"/>
+    <item fieldId="1" name="SystemMode" type="SystemModeEnum" min="0x00" max="0x09"/>
     <item fieldId="2" name="Name" type="char_string" length="64" optional="true"/>
     <item fieldId="3" name="PresetHandle" type="octet_string" length="16" optional="true"/>
     <item fieldId="4" name="Transitions" array="true" type="ScheduleTransitionStruct" minLength="1"/>
-    <item fieldId="5" name="BuiltIn" type="boolean" isNullable="true" optional="true"/>
+    <item fieldId="5" name="BuiltIn" type="boolean" isNullable="true" default="0"/>
   </struct>
 
   <struct name="ScheduleTransitionStruct" apiMaturity="provisional">
@@ -288,46 +280,43 @@ limitations under the License.
     <define>THERMOSTAT_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
-    <globalAttribute side="either" code="0xFFFD" value="6"/>
-
+    <globalAttribute side="either" code="0xFFFD" value="7"/>
     <!-- Attributes -->
 
     <attribute side="server" code="0x0000" define="LOCAL_TEMPERATURE" type="temperature" writable="false" reportable="true" optional="false" isNullable="true">LocalTemperature</attribute>
     <attribute side="server" code="0x0001" define="OUTDOOR_TEMPERATURE" type="temperature" writable="false" optional="true" isNullable="true">OutdoorTemperature</attribute>
-    <attribute side="server" code="0x0002" define="THERMOSTAT_OCCUPANCY" type="bitmap8" writable="false" default="1" optional="true">Occupancy</attribute>
-
+    <attribute side="server" code="0x0002" define="THERMOSTAT_OCCUPANCY" type="bitmap8" default="0x01" optional="true" min="0x00" max="0x01">Occupancy</attribute>
     <attribute side="server" code="0x0003" define="ABS_MIN_HEAT_SETPOINT_LIMIT" type="temperature" writable="false" default="700" optional="true">AbsMinHeatSetpointLimit</attribute>
     <attribute side="server" code="0x0004" define="ABS_MAX_HEAT_SETPOINT_LIMIT" type="temperature" writable="false" default="3000" optional="true">AbsMaxHeatSetpointLimit</attribute>
     <attribute side="server" code="0x0005" define="ABS_MIN_COOL_SETPOINT_LIMIT" type="temperature" writable="false" default="1600" optional="true">AbsMinCoolSetpointLimit</attribute>
     <attribute side="server" code="0x0006" define="ABS_MAX_COOL_SETPOINT_LIMIT" type="temperature" writable="false" default="3200" optional="true">AbsMaxCoolSetpointLimit</attribute>
     <attribute side="server" code="0x0007" define="PI_COOLING_DEMAND" type="int8u" min="0" max="100" writable="false" reportable="true" optional="true">PICoolingDemand</attribute>
     <attribute side="server" code="0x0008" define="PI_HEATING_DEMAND" type="int8u" min="0" max="100" writable="false" reportable="true" optional="true">PIHeatingDemand</attribute>
-    <attribute side="server" code="0x0009" define="HVAC_SYSTEM_TYPE_CONFIGURATION" type="bitmap8" min="0x00" max="0xFF" writable="true" optional="true">
+    <attribute side="server" code="0x0009" define="HVAC_SYSTEM_TYPE_CONFIGURATION" type="HVACSystemTypeBitmap" min="0x00" max="0x3F" writable="true" optional="true" default="0x00">
       <description>HVACSystemTypeConfiguration</description>
-      <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute side="server" code="0x0010" define="LOCAL_TEMPERATURE_CALIBRATION" type="int8s" min="0xE7" max="0x19" writable="true" default="0x00" optional="true">
+    <attribute side="server" code="0x0010" define="LOCAL_TEMPERATURE_CALIBRATION" type="int8s" min="-25" max="25" writable="true" default="0" optional="true">
       <description>LocalTemperatureCalibration</description>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute side="server" code="0x0011" define="OCCUPIED_COOLING_SETPOINT" type="int16s" min="-27315" max="0x7FFF" writable="true" default="2600" optional="true">OccupiedCoolingSetpoint</attribute>
-    <attribute side="server" code="0x0012" define="OCCUPIED_HEATING_SETPOINT" type="int16s" min="-27315" max="0x7FFF" writable="true" default="2000" optional="true">OccupiedHeatingSetpoint</attribute>
-    <attribute side="server" code="0x0013" define="UNOCCUPIED_COOLING_SETPOINT" type="int16s" min="-27315" max="0x7FFF" writable="true" default="2600" optional="true">UnoccupiedCoolingSetpoint</attribute>
-    <attribute side="server" code="0x0014" define="UNOCCUPIED_HEATING_SETPOINT" type="int16s" min="-27315" max="0x7FFF" writable="true" default="2000" optional="true">UnoccupiedHeatingSetpoint</attribute>
-    <attribute side="server" code="0x0015" define="MIN_HEAT_SETPOINT_LIMIT" type="int16s" min="-27315" max="0x7FFF" writable="true" default="700" optional="true">
+    <attribute side="server" code="0x0011" define="OCCUPIED_COOLING_SETPOINT" type="temperature" min="-27315" max="32767" writable="true" default="2600" optional="true">OccupiedCoolingSetpoint</attribute>
+    <attribute side="server" code="0x0012" define="OCCUPIED_HEATING_SETPOINT" type="temperature" min="-27315" max="32767" writable="true" default="2000" optional="true">OccupiedHeatingSetpoint</attribute>
+    <attribute side="server" code="0x0013" define="UNOCCUPIED_COOLING_SETPOINT" type="temperature" min="-27315" max="32767" writable="true" default="2600" optional="true">UnoccupiedCoolingSetpoint</attribute>
+    <attribute side="server" code="0x0014" define="UNOCCUPIED_HEATING_SETPOINT" type="temperature" min="-27315" max="32767" writable="true" default="2000" optional="true">UnoccupiedHeatingSetpoint</attribute>
+    <attribute side="server" code="0x0015" define="MIN_HEAT_SETPOINT_LIMIT" type="temperature" min="-27315" max="32767" writable="true" default="700" optional="true">
       <description>MinHeatSetpointLimit</description>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute side="server" code="0x0016" define="MAX_HEAT_SETPOINT_LIMIT" type="int16s" min="-27315" max="0x7FFF" writable="true" default="3000" optional="true">
+    <attribute side="server" code="0x0016" define="MAX_HEAT_SETPOINT_LIMIT" type="temperature" min="-27315" max="32767" writable="true" default="3000" optional="true">
       <description>MaxHeatSetpointLimit</description>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute side="server" code="0x0017" define="MIN_COOL_SETPOINT_LIMIT" type="int16s" min="-27315" max="0x7FFF" writable="true" default="1600" optional="true">
+    <attribute side="server" code="0x0017" define="MIN_COOL_SETPOINT_LIMIT" type="temperature" min="-27315" max="32767" writable="true" default="1600" optional="true">
       <description>MinCoolSetpointLimit</description>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute side="server" code="0x0018" define="MAX_COOL_SETPOINT_LIMIT" type="int16s" min="-27315" max="0x7FFF" writable="true" default="3200" optional="true">
+    <attribute side="server" code="0x0018" define="MAX_COOL_SETPOINT_LIMIT" type="temperature" min="-27315" max="32767" writable="true" default="3200" optional="true">
       <description>MaxCoolSetpointLimit</description>
       <access op="write" privilege="manage"/>
     </attribute>
@@ -371,9 +360,9 @@ limitations under the License.
       <description>OccupiedSetback</description>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute side="server" code="0x0035" define="OCCUPIED_SETBACK_MIN" type="int8u" writable="false" optional="true" isNullable="true">OccupiedSetbackMin</attribute>
-    <attribute side="server" code="0x0036" define="OCCUPIED_SETBACK_MAX" type="int8u" writable="false" optional="true" isNullable="true">OccupiedSetbackMax</attribute>
-    <attribute side="server" code="0x0037" define="UNOCCUPIED_SETBACK" type="int8u" writable="true" optional="true" isNullable="true">
+    <attribute side="server" code="0x0035" define="OCCUPIED_SETBACK_MIN" type="int8u" optional="true" isNullable="true" max="254">OccupiedSetbackMin</attribute>
+    <attribute side="server" code="0x0036" define="OCCUPIED_SETBACK_MAX" type="int8u" optional="true" isNullable="true" max="254">OccupiedSetbackMax</attribute>
+    <attribute side="server" code="0x0037" define="UNOCCUPIED_SETBACK" type="int8u" writable="true" optional="true" isNullable="true" max="254">
       <description>UnoccupiedSetback</description>
       <access op="write" privilege="manage"/>
     </attribute>
@@ -412,27 +401,25 @@ limitations under the License.
       <description>ACCapacityformat</description>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute code="0x0048" side="server" type="ARRAY" entryType="PresetTypeStruct" define="PRESET_TYPES" writable="false" optional="true">PresetTypes</attribute>
-    <attribute code="0x0049" side="server" type="ARRAY" entryType="ScheduleTypeStruct" define="SCHEDULE_TYPES" writable="false" optional="true">ScheduleTypes</attribute>
-    <attribute code="0x004A" side="server" type="int8u" define="NUMBER_OF_PRESETS" default="0" writable="false" optional="true">NumberOfPresets</attribute>
-    <attribute code="0x004B" side="server" type="int8u" define="NUMBER_OF_SCHEDULES" default="0" writable="false" optional="true">NumberOfSchedules</attribute>
-    <attribute code="0x004C" side="server" type="int8u" define="NUMBER_OF_SCHEDULE_TRANSITIONS" default="0" writable="false" optional="true">NumberOfScheduleTransitions</attribute>
-    <attribute code="0x004D" side="server" type="int8u" define="NUMBER_OF_SCHEDULE_TRANSITION_PER_DAY" isNullable="true" writable="false" optional="true">NumberOfScheduleTransitionPerDay</attribute>
-    <attribute code="0x004E" side="server" type="octet_string" define="ACTIVE_PRESET_HANDLE" isNullable="true" length="16" writable="false" optional="true">ActivePresetHandle</attribute>
-    <attribute code="0x004F" side="server" type="octet_string" define="ACTIVE_SCHEDULE_HANDLE" isNullable="true" length="16" writable="false" optional="true">ActiveScheduleHandle</attribute>
-    <attribute code="0x0050" side="server" type="ARRAY" entryType="PresetStruct" define="PRESETS" writable="true" optional="true">
+    <attribute code="0x0048" side="server" type="array" entryType="PresetTypeStruct" define="PRESET_TYPES" optional="true">PresetTypes</attribute>
+    <attribute code="0x0049" side="server" type="array" entryType="ScheduleTypeStruct" define="SCHEDULE_TYPES" optional="true">ScheduleTypes</attribute>
+    <attribute code="0x004A" side="server" type="int8u" define="NUMBER_OF_PRESETS" default="0" optional="true">NumberOfPresets</attribute>
+    <attribute code="0x004B" side="server" type="int8u" define="NUMBER_OF_SCHEDULES" default="0" optional="true">NumberOfSchedules</attribute>
+    <attribute code="0x004C" side="server" type="int8u" define="NUMBER_OF_SCHEDULE_TRANSITIONS" default="0" optional="true">NumberOfScheduleTransitions</attribute>
+    <attribute code="0x004D" side="server" type="int8u" define="NUMBER_OF_SCHEDULE_TRANSITION_PER_DAY" isNullable="true" optional="true">NumberOfScheduleTransitionPerDay</attribute>
+    <attribute code="0x004E" side="server" type="octet_string" define="ACTIVE_PRESET_HANDLE" isNullable="true" length="16" optional="true">ActivePresetHandle</attribute>
+    <attribute code="0x004F" side="server" type="octet_string" define="ACTIVE_SCHEDULE_HANDLE" isNullable="true" length="16" optional="true">ActiveScheduleHandle</attribute>
+    <attribute code="0x0050" side="server" type="array" entryType="PresetStruct" define="PRESETS" writable="true" optional="true">
       <description>Presets</description>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute code="0x0051" side="server" type="ARRAY" entryType="ScheduleStruct" define="SCHEDULES" writable="true" optional="true">
+    <attribute code="0x0051" side="server" type="array" entryType="ScheduleStruct" define="SCHEDULES" writable="true" optional="true">
       <description>Schedules</description>
       <access op="write" privilege="manage"/>
     </attribute>
-    <attribute code="0x0052" side="server" type="boolean" define="PRESETS_SCHEDULES_EDITABLE" writable="false" optional="true">PresetsSchedulesEditable</attribute>
-    <attribute code="0x0053" side="server" type="TemperatureSetpointHoldPolicyBitmap" define="TEMPERATURE_SETPOINT_HOLD_POLICY" default="0" writable="false" optional="true" min="0x0" max="0x3">TemperatureSetpointHoldPolicy</attribute>
-    <attribute code="0x0054" side="server" type="epoch_s" define="SETPOINT_HOLD_EXPIRY_TIMESTAMP" isNullable="true" writable="false" optional="true">SetpointHoldExpiryTimestamp</attribute>
-    <attribute code="0x0055" side="server" type="QueuedPresetStruct" define="QUEUED_PRESET" isNullable="true" writable="false" optional="true">QueuedPreset</attribute>
-
+    <attribute code="0x0052" side="server" type="boolean" define="PRESETS_SCHEDULES_EDITABLE" optional="true" default="0">PresetsSchedulesEditable</attribute>
+    <attribute code="0x0053" side="server" type="epoch_s" define="SETPOINT_HOLD_EXPIRY_TIMESTAMP" optional="true" isNullable="true">SetpointHoldExpiryTimestamp</attribute>
+    <attribute code="0x0054" side="server" type="QueuedPresetStruct" define="QUEUED_PRESET" isNullable="true" optional="true">QueuedPreset</attribute>
     <!-- Client Commands -->
 
     <command source="client" code="0x00" name="SetpointRaiseLower" optional="false">
@@ -462,7 +449,7 @@ limitations under the License.
     <command source="client" code="0x03" name="ClearWeeklySchedule" optional="true">
       <description>This command is used to clear the weekly schedule. The ClearWeeklySchedule command has no payload.</description>
       <access op="invoke" privilege="manage"/>
-    </command>  
+    </command>
     <command source="client" code="0x05" name="SetActiveScheduleRequest" optional="true">
       <description>This command is used to set the active schedule.</description>
       <arg name="ScheduleHandle" type="octet_string" length="16"/>
@@ -487,11 +474,6 @@ limitations under the License.
     </command>
     <command source="client" code="0x0A" name="CancelSetActivePresetRequest" optional="true">
       <description>This command is sent to cancel a queued preset.</description>
-      <access op="invoke" privilege="manage"/>
-    </command>
-    <command source="client" code="0x0B" name="SetTemperatureSetpointHoldPolicy" optional="true">
-      <description>This command sets the set point hold policy.</description>
-      <arg name="TemperatureSetpointHoldPolicy" type="TemperatureSetpointHoldPolicyBitmap" min="0x0" max="0x3"/>
     </command>
 
     <!-- Server Commands/Responses -->


### PR DESCRIPTION
This PR updates the XML for the Thermostat Cluster to match the current version of the spec.

This integrates the changes from https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/7848

### Changes

- Removed unused SETP feature
- Removed TemperatureSetpointHoldPolicyBitmap
- Removed TemperatureSetpointHoldPolicy attribute
- Normalized use of "temperature" type across attributes and structs
