### PR TITLE
Python: consolidate endpoint selection

### DIFF
--- a/src/python_testing/TC_BOOLCFG_2_1.py
+++ b/src/python_testing/TC_BOOLCFG_2_1.py
@@ -56,7 +56,7 @@ class TC_BOOLCFG_2_1(MatterBaseTest):
     @async_test_body
     async def test_TC_BOOLCFG_2_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         all_alarm_mode_bitmap_bits = functools.reduce(
             ior, [b.value for b in Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap])
         all_sensor_fault_bitmap_bits = functools.reduce(

--- a/src/python_testing/TC_BOOLCFG_3_1.py
+++ b/src/python_testing/TC_BOOLCFG_3_1.py
@@ -58,7 +58,7 @@ class TC_BOOLCFG_3_1(MatterBaseTest):
     @async_test_body
     async def test_TC_BOOLCFG_3_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.BooleanStateConfiguration.Attributes

--- a/src/python_testing/TC_BOOLCFG_4_1.py
+++ b/src/python_testing/TC_BOOLCFG_4_1.py
@@ -51,7 +51,7 @@ class TC_BOOLCFG_4_1(MatterBaseTest):
     @async_test_body
     async def test_TC_BOOLCFG_4_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.BooleanStateConfiguration.Attributes

--- a/src/python_testing/TC_BOOLCFG_4_2.py
+++ b/src/python_testing/TC_BOOLCFG_4_2.py
@@ -68,7 +68,7 @@ class TC_BOOLCFG_4_2(MatterBaseTest):
                             "the --hex-arg flag as PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:<key>, "
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)

--- a/src/python_testing/TC_BOOLCFG_4_3.py
+++ b/src/python_testing/TC_BOOLCFG_4_3.py
@@ -80,7 +80,7 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
                             "the --hex-arg flag as PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:<key>, "
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)

--- a/src/python_testing/TC_BOOLCFG_4_4.py
+++ b/src/python_testing/TC_BOOLCFG_4_4.py
@@ -72,7 +72,7 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
                             "the --hex-arg flag as PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:<key>, "
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)

--- a/src/python_testing/TC_BOOLCFG_5_1.py
+++ b/src/python_testing/TC_BOOLCFG_5_1.py
@@ -67,7 +67,7 @@ class TC_BOOLCFG_5_1(MatterBaseTest):
                             "the --hex-arg flag as PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:<key>, "
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)

--- a/src/python_testing/TC_BOOLCFG_5_2.py
+++ b/src/python_testing/TC_BOOLCFG_5_2.py
@@ -66,7 +66,7 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
                             "the --hex-arg flag as PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:<key>, "
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)

--- a/src/python_testing/TC_EEVSE_2_2.py
+++ b/src/python_testing/TC_EEVSE_2_2.py
@@ -101,7 +101,7 @@ class TC_EEVSE_2_2(MatterBaseTest, EEVSEBaseTestHelper):
         events_callback = EventChangeCallback(Clusters.EnergyEvse)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint())
 
         self.step("2")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_EEVSE_2_4.py
+++ b/src/python_testing/TC_EEVSE_2_4.py
@@ -77,7 +77,7 @@ class TC_EEVSE_2_4(MatterBaseTest, EEVSEBaseTestHelper):
         events_callback = EventChangeCallback(Clusters.EnergyEvse)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint())
 
         self.step("2")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_EEVSE_2_5.py
+++ b/src/python_testing/TC_EEVSE_2_5.py
@@ -71,7 +71,7 @@ class TC_EEVSE_2_5(MatterBaseTest, EEVSEBaseTestHelper):
         events_callback = EventChangeCallback(Clusters.EnergyEvse)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint())
 
         self.step("2")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_EEVSE_Utils.py
+++ b/src/python_testing/TC_EEVSE_Utils.py
@@ -72,7 +72,7 @@ class EEVSEBaseTestHelper:
 
     async def write_user_max_charge(self, endpoint: int = None, user_max_charge: int = 0):
         if endpoint is None:
-            endpoint = self.matter_test_config.endpoint
+            endpoint = self.get_endpoint()
         result = await self.default_controller.WriteAttribute(self.dut_node_id,
                                                               [(endpoint,
                                                                Clusters.EnergyEvse.Attributes.UserMaximumChargeCurrent(user_max_charge))])

--- a/src/python_testing/TC_FAN_3_1.py
+++ b/src/python_testing/TC_FAN_3_1.py
@@ -54,7 +54,7 @@ class TC_FAN_3_1(MatterBaseTest):
 
     @async_test_body
     async def test_TC_FAN_3_1(self):
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.print_step(1, "Commissioning, already done")
 

--- a/src/python_testing/TC_FAN_3_2.py
+++ b/src/python_testing/TC_FAN_3_2.py
@@ -53,7 +53,7 @@ class TC_FAN_3_2(MatterBaseTest):
             logger.info("Test skipped because PICS FAN.S.F00 is not set")
             return
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.print_step(1, "Commissioning, already done")
 

--- a/src/python_testing/TC_FAN_3_3.py
+++ b/src/python_testing/TC_FAN_3_3.py
@@ -51,7 +51,7 @@ class TC_FAN_3_3(MatterBaseTest):
             logger.info("Test skipped because PICS FAN.S.F02 is not set")
             return
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.print_step(1, "Commissioning, already done")
 

--- a/src/python_testing/TC_FAN_3_4.py
+++ b/src/python_testing/TC_FAN_3_4.py
@@ -51,7 +51,7 @@ class TC_FAN_3_4(MatterBaseTest):
             logger.info("Test skipped because PICS FAN.S.F03 is not set")
             return
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.print_step(1, "Commissioning, already done")
 

--- a/src/python_testing/TC_FAN_3_5.py
+++ b/src/python_testing/TC_FAN_3_5.py
@@ -67,7 +67,7 @@ class TC_FAN_3_5(MatterBaseTest):
             logger.info("Test skipped because PICS FAN.S.F04 is not set")
             return
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         # Part 1
 

--- a/src/python_testing/TC_ICDM_2_1.py
+++ b/src/python_testing/TC_ICDM_2_1.py
@@ -39,7 +39,7 @@ class TC_ICDM_2_1(MatterBaseTest):
             logger.info("Test skipped because PICS ICDM.S is not set")
             return
 
-        endpoint = self.user_params.get("endpoint", 0)
+        endpoint = self.get_endpoint(default=1)
 
         self.print_step(1, "Commissioning, already done")
         attributes = Clusters.IcdManagement.Attributes

--- a/src/python_testing/TC_RVCCLEANM_1_2.py
+++ b/src/python_testing/TC_RVCCLEANM_1_2.py
@@ -48,7 +48,7 @@ class TC_RVCCLEANM_1_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_RVCCLEANM_1_2(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
 
         attributes = Clusters.RvcCleanMode.Attributes
 

--- a/src/python_testing/TC_RVCCLEANM_2_1.py
+++ b/src/python_testing/TC_RVCCLEANM_2_1.py
@@ -57,7 +57,7 @@ class TC_RVCCLEANM_2_1(MatterBaseTest):
                             "PIXIT.RVCCLEANM.MODE_CHANGE_FAIL must be included on the command line in "
                             "the --int-arg flag as PIXIT.RVCCLEANM.MODE_CHANGE_FAIL:<mode id>")
 
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         self.mode_ok = self.matter_test_config.global_test_params['PIXIT.RVCCLEANM.MODE_CHANGE_OK']
         self.mode_fail = self.matter_test_config.global_test_params['PIXIT.RVCCLEANM.MODE_CHANGE_FAIL']
 

--- a/src/python_testing/TC_RVCCLEANM_2_2.py
+++ b/src/python_testing/TC_RVCCLEANM_2_2.py
@@ -62,7 +62,7 @@ class TC_RVCCLEANM_2_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_RVCCLEANM_2_2(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
 
         asserts.assert_true(self.check_pics("RVCCLEANM.S"), "RVCCLEANM.S must be supported")
         asserts.assert_true(self.check_pics("RVCRUNM.S.A0000"), "RVCRUNM.S.A0000 must be supported")

--- a/src/python_testing/TC_RVCOPSTATE_2_1.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_1.py
@@ -53,7 +53,7 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
 
     @async_test_body
     async def test_TC_RVCOPSTATE_2_1(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint(default=None)
         asserts.assert_false(self.endpoint is None, "--endpoint <endpoint> must be included on the command line in.")
 
         attributes = Clusters.RvcOperationalState.Attributes

--- a/src/python_testing/TC_RVCOPSTATE_2_3.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_3.py
@@ -130,7 +130,7 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
     @async_test_body
     async def test_TC_RVCOPSTATE_2_3(self):
 
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint(default=None)
         asserts.assert_false(self.endpoint is None, "--endpoint <endpoint> must be included on the command line in.")
 
         asserts.assert_true(self.check_pics("RVCOPSTATE.S.A0003"), "RVCOPSTATE.S.A0003 must be supported")

--- a/src/python_testing/TC_RVCRUNM_1_2.py
+++ b/src/python_testing/TC_RVCRUNM_1_2.py
@@ -48,7 +48,7 @@ class TC_RVCRUNM_1_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_RVCRUNM_1_2(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
 
         attributes = Clusters.RvcRunMode.Attributes
 

--- a/src/python_testing/TC_RVCRUNM_2_1.py
+++ b/src/python_testing/TC_RVCRUNM_2_1.py
@@ -57,7 +57,7 @@ class TC_RVCRUNM_2_1(MatterBaseTest):
                             "PIXIT.RVCRUNM.MODE_CHANGE_FAIL must be included on the command line in "
                             "the --int-arg flag as PIXIT.RVCRUNM.MODE_CHANGE_FAIL:<mode id>")
 
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         self.mode_ok = self.matter_test_config.global_test_params['PIXIT.RVCRUNM.MODE_CHANGE_OK']
         self.mode_fail = self.matter_test_config.global_test_params['PIXIT.RVCRUNM.MODE_CHANGE_FAIL']
 

--- a/src/python_testing/TC_RVCRUNM_2_2.py
+++ b/src/python_testing/TC_RVCRUNM_2_2.py
@@ -97,7 +97,7 @@ class TC_RVCRUNM_2_2(MatterBaseTest):
                          "PIXIT.RVCRUNM.MODE_A:<mode id> \n"
                          "PIXIT.RVCRUNM.MODE_B:<mode id>")
 
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         self.mode_a = self.matter_test_config.global_test_params['PIXIT.RVCRUNM.MODE_A']
         self.mode_b = self.matter_test_config.global_test_params['PIXIT.RVCRUNM.MODE_B']
 

--- a/src/python_testing/TC_TIMESYNC_2_1.py
+++ b/src/python_testing/TC_TIMESYNC_2_1.py
@@ -35,7 +35,7 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
     @async_test_body
     async def test_TC_TIMESYNC_2_1(self):
 
-        endpoint = self.user_params.get("endpoint", 0)
+        endpoint = self.get_endpoint(default=1)
 
         self.print_step(1, "Commissioning, already done")
         attributes = Clusters.TimeSynchronization.Attributes

--- a/src/python_testing/TC_VALCC_2_1.py
+++ b/src/python_testing/TC_VALCC_2_1.py
@@ -58,7 +58,7 @@ class TC_VALCC_2_1(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_2_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_3_1.py
+++ b/src/python_testing/TC_VALCC_3_1.py
@@ -53,7 +53,7 @@ class TC_VALCC_3_1(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_3_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_3_2.py
+++ b/src/python_testing/TC_VALCC_3_2.py
@@ -55,7 +55,7 @@ class TC_VALCC_3_2(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_3_2(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_3_3.py
+++ b/src/python_testing/TC_VALCC_3_3.py
@@ -56,7 +56,7 @@ class TC_VALCC_3_3(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_3_3(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_3_4.py
+++ b/src/python_testing/TC_VALCC_3_4.py
@@ -51,7 +51,7 @@ class TC_VALCC_3_4(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_3_4(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_4_1.py
+++ b/src/python_testing/TC_VALCC_4_1.py
@@ -55,7 +55,7 @@ class TC_VALCC_4_1(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_4_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_4_2.py
+++ b/src/python_testing/TC_VALCC_4_2.py
@@ -58,7 +58,7 @@ class TC_VALCC_4_2(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_4_2(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_4_3.py
+++ b/src/python_testing/TC_VALCC_4_3.py
@@ -61,7 +61,7 @@ class TC_VALCC_4_3(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_4_3(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_4_4.py
+++ b/src/python_testing/TC_VALCC_4_4.py
@@ -55,7 +55,7 @@ class TC_VALCC_4_4(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_4_4(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_pics_checker.py
+++ b/src/python_testing/TC_pics_checker.py
@@ -112,7 +112,7 @@ class TC_PICS_Checker(MatterBaseTest, BasicCompositionTests):
     def test_TC_IDM_10_4(self):
         # wildcard read is done in setup_class
         self.step(1)
-        self.endpoint_id = self.matter_test_config.endpoint
+        self.endpoint_id = self.get_endpoint()
         self.endpoint = self.endpoints_tlv[self.endpoint_id]
         self.success = True
 

--- a/src/python_testing/drlk_2_x_common.py
+++ b/src/python_testing/drlk_2_x_common.py
@@ -97,7 +97,7 @@ class DRLK_COMMON:
 
         self.createdCredential = None
 
-        self.endpoint = self.user_params.get("endpoint", 1)
+        self.endpoint = self.get_endpoint(default=1)
 
         # Allow for user overrides of these values
         credentialIndex = self.user_params.get("credential_index", 1)

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -1246,7 +1246,7 @@ def convert_args_to_matter_config(args: argparse.Namespace) -> MatterTestConfig:
     config.pics = {} if args.PICS is None else read_pics_from_file(args.PICS)
     config.tests = [] if args.tests is None else args.tests
     config.timeout = args.timeout  # This can be none, we pull the default from the test if it's unspecified
-    config.endpoint = 0 if args.endpoint is None else args.endpoint
+    config.endpoint = args.endpoint  # This can be None, the get_endpoint function allows the tests to supply a default
 
     config.controller_node_id = args.controller_node_id
     config.trace_to = args.trace_to

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -690,6 +690,9 @@ class MatterBaseTest(base_test.BaseTestClass):
     def dut_node_id(self) -> int:
         return self.matter_test_config.dut_node_ids[0]
 
+    def get_endpoint(self, default: Optional[int] = 0) -> int:
+        return self.matter_test_config.endpoint if self.matter_test_config.endpoint is not None else default
+
     def setup_class(self):
         super().setup_class()
 
@@ -761,7 +764,7 @@ class MatterBaseTest(base_test.BaseTestClass):
         if node_id is None:
             node_id = self.dut_node_id
         if endpoint is None:
-            endpoint = self.matter_test_config.endpoint
+            endpoint = self.get_endpoint()
 
         result = await dev_ctrl.ReadAttribute(node_id, [(endpoint, attribute)], fabricFiltered=fabric_filtered)
         attr_ret = result[endpoint][cluster][attribute]
@@ -793,7 +796,7 @@ class MatterBaseTest(base_test.BaseTestClass):
         if node_id is None:
             node_id = self.dut_node_id
         if endpoint is None:
-            endpoint = self.matter_test_config.endpoint
+            endpoint = self.get_endpoint()
 
         result = await dev_ctrl.ReadAttribute(node_id, [(endpoint, attribute)], fabricFiltered=fabric_filtered)
         attr_ret = result[endpoint][cluster][attribute]
@@ -820,7 +823,7 @@ class MatterBaseTest(base_test.BaseTestClass):
         if node_id is None:
             node_id = self.dut_node_id
         if endpoint is None:
-            endpoint = self.matter_test_config.endpoint
+            endpoint = self.get_endpoint()
 
         result = await dev_ctrl.SendCommand(nodeid=node_id, endpoint=endpoint, payload=cmd, timedRequestTimeoutMs=timedRequestTimeoutMs)
         return result


### PR DESCRIPTION
Add a function to get the endpoint from the config with an explicit default. This makes it so folks don't have to remember where that parameter comes in.

TL;DR - all tests should now use --endpoint to set endpoint


