### PR TITLE
Board-specific LWIP options for silabs boards (rs911, wf200, thread) were never used

### DIFF
--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -226,11 +226,14 @@ if (current_os == "zephyr" || current_os == "mbed") {
     } else if (lwip_platform == "silabs") {
       public_deps += [ "${efr32_sdk_build_root}:efr32_sdk" ]
 
-      sources += [
-        "${lwip_platform}/lwipopts-rs911x.h",
-        "${lwip_platform}/lwipopts-thread.h",
-        "${lwip_platform}/lwipopts-wf200.h",
-      ]
+      # TODO: the files below are mutually exclusive,
+      if (use_rs9116 || use_SiWx917) {
+        sources += [ "${lwip_platform}/lwipopts-rs911x.h" ]
+      } else if (use_wf200) {
+        sources += [ "${lwip_platform}/lwipopts-wf200.h" ]
+      } else {
+        sources += [ "${lwip_platform}/lwipopts-thread.h" ]
+      }
     } else if (lwip_platform == "standalone") {
       public_deps += [ "${chip_root}/src/lib/support" ]
     } else if (lwip_platform == "k32w0") {

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -226,14 +226,11 @@ if (current_os == "zephyr" || current_os == "mbed") {
     } else if (lwip_platform == "silabs") {
       public_deps += [ "${efr32_sdk_build_root}:efr32_sdk" ]
 
-      # TODO: the files below are mutually exclusive,
-      if (use_rs9116 || use_SiWx917) {
-        sources += [ "${lwip_platform}/lwipopts-rs911x.h" ]
-      } else if (use_wf200) {
-        sources += [ "${lwip_platform}/lwipopts-wf200.h" ]
-      } else {
-        sources += [ "${lwip_platform}/lwipopts-thread.h" ]
-      }
+      sources += [
+        "${lwip_platform}/lwipopts-rs911x.h",
+        "${lwip_platform}/lwipopts-thread.h",
+        "${lwip_platform}/lwipopts-wf200.h",
+      ]
     } else if (lwip_platform == "standalone") {
       public_deps += [ "${chip_root}/src/lib/support" ]
     } else if (lwip_platform == "k32w0") {

--- a/src/lwip/BUILD.gn
+++ b/src/lwip/BUILD.gn
@@ -225,6 +225,12 @@ if (current_os == "zephyr" || current_os == "mbed") {
           [ "${chip_root}/third_party/lwip/repo/lwip/src/apps/mdns/mdns.c" ]
     } else if (lwip_platform == "silabs") {
       public_deps += [ "${efr32_sdk_build_root}:efr32_sdk" ]
+
+      sources += [
+        "${lwip_platform}/lwipopts-rs911x.h",
+        "${lwip_platform}/lwipopts-thread.h",
+        "${lwip_platform}/lwipopts-wf200.h",
+      ]
     } else if (lwip_platform == "standalone") {
       public_deps += [ "${chip_root}/src/lib/support" ]
     } else if (lwip_platform == "k32w0") {

--- a/third_party/silabs/silabs_lwip/BUILD.gn
+++ b/third_party/silabs/silabs_lwip/BUILD.gn
@@ -33,7 +33,12 @@ lwip_target("silabs_lwip") {
     "${chip_root}/src/lwip/silabs/lwippools.h",
   ]
 
-  sources = [ "${chip_root}/src/lwip/freertos/sys_arch.c" ]
+  sources = [
+    "${chip_root}/src/lwip/freertos/sys_arch.c",
+    "${chip_root}/src/lwip/silabs/lwipopts-rs911x.h",
+    "${chip_root}/src/lwip/silabs/lwipopts-thread.h",
+    "${chip_root}/src/lwip/silabs/lwipopts-wf200.h",
+  ]
 
   public_deps = [
     "${chip_root}/src/lwip:lwip_buildconfig",


### PR DESCRIPTION
Add these includes to GN to have include tracking and layer enforcement.

The files mentioned here are `#include`-ed by silabs/lwipopts.h.

Also will allow us to have scripts in the future that forces all header and source files to be known to GN.