### PR TITLE
[Python] Allow early logging initialization

### DIFF
--- a/src/controller/python/chip/logging/__init__.py
+++ b/src/controller/python/chip/logging/__init__.py
@@ -32,7 +32,7 @@ def _RedirectToPythonLogging(category, module, message):
     module = module.decode('utf-8')
     message = message.decode('utf-8')
 
-    logger = logging.getLogger('chip.%s' % module)
+    logger = logging.getLogger('chip.native.%s' % module)
 
     if category == ERROR_CATEGORY_ERROR:
         logger.error("%s", message)

--- a/src/controller/python/chip/logging/library_handle.py
+++ b/src/controller/python/chip/logging/library_handle.py
@@ -27,7 +27,9 @@ def _GetLoggingLibraryHandle() -> ctypes.CDLL:
       native methods.
       """
 
-    handle = chip.native.GetLibraryHandle()
+    # Getting a handle without requiring init, as logging methods
+    # do not require chip stack startup
+    handle = chip.native.GetLibraryHandle(chip.native.HandleFlags(0))
 
     # Uses one of the type decorators as an indicator for everything being
     # initialized.


### PR DESCRIPTION
Allow to initialize logging before initializing the stack. Similar to tracing, logging doesn't need the stack to be setup. This allows to redirect logging to Python as early as possible.
