### PR TITLE
Improve the logic around schedule application in LockEndpoint.

### DIFF
--- a/examples/lock-app/lock-common/include/LockEndpoint.h
+++ b/examples/lock-app/lock-common/include/LockEndpoint.h
@@ -106,8 +106,16 @@ private:
                       OperationSourceEnum opSource = OperationSourceEnum::kUnspecified);
     const char * lockStateToString(DlLockState lockState) const;
 
-    bool weekDayScheduleInAction(uint16_t userIndex) const;
-    bool yearDayScheduleInAction(uint16_t userIndex) const;
+    // Returns true if week day schedules should apply to the user, there are
+    // schedules defined for the user, and access is not currently allowed by
+    // those schedules.  The outparam indicates whether there were in fact any
+    // year day schedules defined for the user.
+    bool weekDayScheduleForbidsAccess(uint16_t userIndex, bool * haveSchedule) const;
+    // Returns true if year day schedules should apply to the user, there are
+    // schedules defined for the user, and access is not currently allowed by
+    // those schedules.  The outparam indicates whether there were in fact any
+    // year day schedules defined for the user.
+    bool yearDayScheduleForbidsAccess(uint16_t userIndex, bool * haveSchedule) const;
 
     static void OnLockActionCompleteCallback(chip::System::Layer *, void * callbackContext);
 


### PR DESCRIPTION
The old logic had several bugs:

* For kYearDayScheduleUser users, there was no schedule enforcement at all, since the outer "if" never tested true.
* For kWeekDayScheduleUser users, there was no schedule enforcement at all, since the inner "if" never tested true.
* For kScheduleRestrictedUser users, access was allowed if there was any schedule, weekday or yearday, that granted access.  But the intent is that access should be disallowed if there are year day schedules and none of them grants access, no matter what's going on with weekday.  And vice versa.
