### PR TITLE
Make it clearer that cluster-enums-check is returning kUnknownEnumValue.

### DIFF
--- a/src/app/zap-templates/templates/app/cluster-enums-check.zapt
+++ b/src/app/zap-templates/templates/app/cluster-enums-check.zapt
@@ -19,7 +19,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::{{asType label}
     {{/zcl_enum_items}}
         return val;
     default:
-        return static_cast<EnumType>({{first_unused_enum_value mode="first_unused"}});
+        return EnumType::kUnknownEnumValue;
     }
 }
 {{/unless}}
@@ -39,7 +39,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue({{asUpperCamelCase ../n
     {{/zcl_enum_items}}
         return val;
     default:
-        return static_cast<EnumType>({{first_unused_enum_value mode="first_unused"}});
+        return EnumType::kUnknownEnumValue;
     }
 }
 {{/unless}}

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
@@ -34,7 +34,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::ChangeIndicatio
     case EnumType::kCritical:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(detail::DegradationDirectionEnum val)
@@ -46,7 +46,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::DegradationDire
     case EnumType::kDown:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(detail::ErrorStateEnum val)
@@ -60,7 +60,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::ErrorStateEnum 
     case EnumType::kCommandInvalidInState:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(detail::LevelValueEnum val)
@@ -75,7 +75,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::LevelValueEnum 
     case EnumType::kCritical:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(detail::MeasurementMediumEnum val)
@@ -88,7 +88,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::MeasurementMedi
     case EnumType::kSoil:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(detail::MeasurementTypeEnum val)
@@ -113,7 +113,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::MeasurementType
     case EnumType::kElectricalEnergy:
         return val;
     default:
-        return static_cast<EnumType>(15);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(detail::MeasurementUnitEnum val)
@@ -131,7 +131,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::MeasurementUnit
     case EnumType::kBqm3:
         return val;
     default:
-        return static_cast<EnumType>(8);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(detail::OperationalStateEnum val)
@@ -145,7 +145,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::OperationalStat
     case EnumType::kError:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(detail::ProductIdentifierTypeEnum val)
@@ -160,7 +160,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::ProductIdentifi
     case EnumType::kOem:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -177,7 +177,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Identify::EffectIdentif
     case EnumType::kStopEffect:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Identify::EffectVariantEnum val)
@@ -188,7 +188,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Identify::EffectVariant
     case EnumType::kDefault:
         return val;
     default:
-        return static_cast<EnumType>(1);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Identify::IdentifyTypeEnum val)
@@ -204,7 +204,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Identify::IdentifyTypeE
     case EnumType::kActuator:
         return val;
     default:
-        return static_cast<EnumType>(6);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -218,7 +218,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OnOff::DelayedAllOffEff
     case EnumType::kDelayedOffSlowFade:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(OnOff::DyingLightEffectVariantEnum val)
@@ -229,7 +229,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OnOff::DyingLightEffect
     case EnumType::kDyingLightFadeOff:
         return val;
     default:
-        return static_cast<EnumType>(1);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(OnOff::EffectIdentifierEnum val)
@@ -241,7 +241,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OnOff::EffectIdentifier
     case EnumType::kDyingLight:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(OnOff::StartUpOnOffEnum val)
@@ -254,7 +254,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OnOff::StartUpOnOffEnum
     case EnumType::kToggle:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -267,7 +267,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(LevelControl::MoveModeE
     case EnumType::kDown:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(LevelControl::StepModeEnum val)
@@ -279,7 +279,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(LevelControl::StepModeE
     case EnumType::kDown:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -293,7 +293,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(AccessControl::AccessCo
     case EnumType::kGroup:
         return val;
     default:
-        return static_cast<EnumType>(0);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(AccessControl::AccessControlEntryPrivilegeEnum val)
@@ -308,7 +308,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(AccessControl::AccessCo
     case EnumType::kAdminister:
         return val;
     default:
-        return static_cast<EnumType>(0);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(AccessControl::ChangeTypeEnum val)
@@ -321,7 +321,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(AccessControl::ChangeTy
     case EnumType::kRemoved:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -334,7 +334,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Actions::ActionErrorEnu
     case EnumType::kInterrupted:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Actions::ActionStateEnum val)
@@ -348,7 +348,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Actions::ActionStateEnu
     case EnumType::kDisabled:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Actions::ActionTypeEnum val)
@@ -365,7 +365,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Actions::ActionTypeEnum
     case EnumType::kAlarm:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Actions::EndpointListTypeEnum val)
@@ -378,7 +378,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Actions::EndpointListTy
     case EnumType::kZone:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -410,7 +410,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(BasicInformation::Color
     case EnumType::kGold:
         return val;
     default:
-        return static_cast<EnumType>(21);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(BasicInformation::ProductFinishEnum val)
@@ -426,7 +426,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(BasicInformation::Produ
     case EnumType::kFabric:
         return val;
     default:
-        return static_cast<EnumType>(6);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -440,7 +440,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OtaSoftwareUpdateProvid
     case EnumType::kDiscontinue:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(OtaSoftwareUpdateProvider::DownloadProtocolEnum val)
@@ -454,7 +454,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OtaSoftwareUpdateProvid
     case EnumType::kVendorSpecific:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(OtaSoftwareUpdateProvider::StatusEnum val)
@@ -468,7 +468,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OtaSoftwareUpdateProvid
     case EnumType::kDownloadProtocolNotSupported:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -482,7 +482,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OtaSoftwareUpdateReques
     case EnumType::kUrgentUpdateAvailable:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(OtaSoftwareUpdateRequestor::ChangeReasonEnum val)
@@ -497,7 +497,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OtaSoftwareUpdateReques
     case EnumType::kDelayByProvider:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(OtaSoftwareUpdateRequestor::UpdateStateEnum val)
@@ -516,7 +516,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OtaSoftwareUpdateReques
     case EnumType::kDelayedOnUserConsent:
         return val;
     default:
-        return static_cast<EnumType>(9);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -540,7 +540,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(TimeFormatLocalization:
     case EnumType::kUseActiveLocale:
         return val;
     default:
-        return static_cast<EnumType>(12);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(TimeFormatLocalization::HourFormatEnum val)
@@ -553,7 +553,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(TimeFormatLocalization:
     case EnumType::kUseActiveLocale:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -567,7 +567,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(UnitLocalization::TempU
     case EnumType::kKelvin:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -611,7 +611,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatApprove
     case EnumType::kZincCerium:
         return val;
     default:
-        return static_cast<EnumType>(33);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatChargeFaultEnum val)
@@ -632,7 +632,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatChargeF
     case EnumType::kSafetyTimeout:
         return val;
     default:
-        return static_cast<EnumType>(11);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatChargeLevelEnum val)
@@ -645,7 +645,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatChargeL
     case EnumType::kCritical:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatChargeStateEnum val)
@@ -659,7 +659,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatChargeS
     case EnumType::kIsNotCharging:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatCommonDesignationEnum val)
@@ -750,7 +750,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatCommonD
     case EnumType::k32600:
         return val;
     default:
-        return static_cast<EnumType>(81);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatFaultEnum val)
@@ -763,7 +763,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatFaultEn
     case EnumType::kUnderTemp:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatReplaceabilityEnum val)
@@ -777,7 +777,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::BatReplace
     case EnumType::kFactoryReplaceable:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::PowerSourceStatusEnum val)
@@ -791,7 +791,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::PowerSourc
     case EnumType::kUnavailable:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::WiredCurrentTypeEnum val)
@@ -803,7 +803,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::WiredCurre
     case EnumType::kDc:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::WiredFaultEnum val)
@@ -816,7 +816,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PowerSource::WiredFault
     case EnumType::kUnderVoltage:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -832,7 +832,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralCommissioning::C
     case EnumType::kBusyWithOtherAdmin:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralCommissioning::RegulatoryLocationTypeEnum val)
@@ -845,7 +845,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralCommissioning::R
     case EnumType::kIndoorOutdoor:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -869,7 +869,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(NetworkCommissioning::N
     case EnumType::kUnknownError:
         return val;
     default:
-        return static_cast<EnumType>(13);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(NetworkCommissioning::WiFiBandEnum val)
@@ -885,7 +885,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(NetworkCommissioning::W
     case EnumType::k1g:
         return val;
     default:
-        return static_cast<EnumType>(6);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -899,7 +899,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DiagnosticLogs::IntentE
     case EnumType::kCrashLogs:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DiagnosticLogs::StatusEnum val)
@@ -914,7 +914,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DiagnosticLogs::StatusE
     case EnumType::kDenied:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DiagnosticLogs::TransferProtocolEnum val)
@@ -926,7 +926,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DiagnosticLogs::Transfe
     case EnumType::kBdx:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -944,7 +944,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::Boo
     case EnumType::kSoftwareReset:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::HardwareFaultEnum val)
@@ -965,7 +965,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::Har
     case EnumType::kTamperDetected:
         return val;
     default:
-        return static_cast<EnumType>(11);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::InterfaceTypeEnum val)
@@ -980,7 +980,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::Int
     case EnumType::kThread:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::NetworkFaultEnum val)
@@ -994,7 +994,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::Net
     case EnumType::kConnectionFailed:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::RadioFaultEnum val)
@@ -1011,7 +1011,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(GeneralDiagnostics::Rad
     case EnumType::kEthernetFault:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1024,7 +1024,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ThreadNetworkDiagnostic
     case EnumType::kNotConnected:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ThreadNetworkDiagnostics::NetworkFaultEnum val)
@@ -1038,7 +1038,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ThreadNetworkDiagnostic
     case EnumType::kNetworkJammed:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ThreadNetworkDiagnostics::RoutingRoleEnum val)
@@ -1055,7 +1055,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ThreadNetworkDiagnostic
     case EnumType::kLeader:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1070,7 +1070,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(WiFiNetworkDiagnostics:
     case EnumType::kSsidNotFound:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(WiFiNetworkDiagnostics::ConnectionStatusEnum val)
@@ -1082,7 +1082,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(WiFiNetworkDiagnostics:
     case EnumType::kNotConnected:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(WiFiNetworkDiagnostics::SecurityTypeEnum val)
@@ -1098,7 +1098,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(WiFiNetworkDiagnostics:
     case EnumType::kWpa3:
         return val;
     default:
-        return static_cast<EnumType>(6);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(WiFiNetworkDiagnostics::WiFiVersionEnum val)
@@ -1115,7 +1115,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(WiFiNetworkDiagnostics:
     case EnumType::kAh:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1136,7 +1136,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(EthernetNetworkDiagnost
     case EnumType::kRate400G:
         return val;
     default:
-        return static_cast<EnumType>(10);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1152,7 +1152,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(TimeSynchronization::Gr
     case EnumType::kMicrosecondsGranularity:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(TimeSynchronization::StatusCode val)
@@ -1163,7 +1163,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(TimeSynchronization::St
     case EnumType::kTimeNotAccepted:
         return val;
     default:
-        return static_cast<EnumType>(0);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(TimeSynchronization::TimeSourceEnum val)
@@ -1190,7 +1190,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(TimeSynchronization::Ti
     case EnumType::kGnss:
         return val;
     default:
-        return static_cast<EnumType>(17);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(TimeSynchronization::TimeZoneDatabaseEnum val)
@@ -1203,7 +1203,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(TimeSynchronization::Ti
     case EnumType::kNone:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1235,7 +1235,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(BridgedDeviceBasicInfor
     case EnumType::kGold:
         return val;
     default:
-        return static_cast<EnumType>(21);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(BridgedDeviceBasicInformation::ProductFinishEnum val)
@@ -1251,7 +1251,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(BridgedDeviceBasicInfor
     case EnumType::kFabric:
         return val;
     default:
-        return static_cast<EnumType>(6);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1265,7 +1265,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(AdministratorCommission
     case EnumType::kBasicWindowOpen:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(AdministratorCommissioning::StatusCode val)
@@ -1278,7 +1278,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(AdministratorCommission
     case EnumType::kWindowNotOpen:
         return val;
     default:
-        return static_cast<EnumType>(0);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1291,7 +1291,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OperationalCredentials:
     case EnumType::kPAICertificate:
         return val;
     default:
-        return static_cast<EnumType>(0);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(OperationalCredentials::NodeOperationalCertStatusEnum val)
@@ -1311,7 +1311,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OperationalCredentials:
     case EnumType::kInvalidFabricIndex:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1324,7 +1324,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(GroupKeyManagement::Gro
     case EnumType::kCacheAndSync:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1337,7 +1337,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(IcdManagement::Operatin
     case EnumType::kLit:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1352,7 +1352,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Timer::TimerStatusEnum 
     case EnumType::kReady:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1372,7 +1372,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OvenMode::ModeTag val)
     case EnumType::kProofing:
         return val;
     default:
-        return static_cast<EnumType>(0);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1387,7 +1387,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(LaundryDryerControls::D
     case EnumType::kMax:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1402,7 +1402,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(LaundryWasherControls::
     case EnumType::kMax:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1420,7 +1420,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(AirQuality::AirQualityE
     case EnumType::kExtremelyPoor:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1434,7 +1434,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(SmokeCoAlarm::AlarmStat
     case EnumType::kCritical:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(SmokeCoAlarm::ContaminationStateEnum val)
@@ -1448,7 +1448,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(SmokeCoAlarm::Contamina
     case EnumType::kCritical:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(SmokeCoAlarm::EndOfServiceEnum val)
@@ -1460,7 +1460,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(SmokeCoAlarm::EndOfServ
     case EnumType::kExpired:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(SmokeCoAlarm::ExpressedStateEnum val)
@@ -1479,7 +1479,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(SmokeCoAlarm::Expressed
     case EnumType::kInterconnectCO:
         return val;
     default:
-        return static_cast<EnumType>(9);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(SmokeCoAlarm::MuteStateEnum val)
@@ -1491,7 +1491,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(SmokeCoAlarm::MuteState
     case EnumType::kMuted:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(SmokeCoAlarm::SensitivityEnum val)
@@ -1504,7 +1504,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(SmokeCoAlarm::Sensitivi
     case EnumType::kLow:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1517,7 +1517,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(MicrowaveOvenMode::Mode
     case EnumType::kDefrost:
         return val;
     default:
-        return static_cast<EnumType>(0);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1529,7 +1529,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ValveConfigurationAndCo
     case EnumType::kFailureDueToFault:
         return val;
     default:
-        return static_cast<EnumType>(0);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ValveConfigurationAndControl::ValveStateEnum val)
@@ -1542,7 +1542,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ValveConfigurationAndCo
     case EnumType::kTransitioning:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1556,7 +1556,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ElectricalPowerMeasurem
     case EnumType::kAc:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1577,7 +1577,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DemandResponseLoadContr
     case EnumType::kServiceDisconnect:
         return val;
     default:
-        return static_cast<EnumType>(10);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DemandResponseLoadControl::HeatingSourceEnum val)
@@ -1590,7 +1590,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DemandResponseLoadContr
     case EnumType::kNonElectric:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DemandResponseLoadControl::LoadControlEventChangeSourceEnum val)
@@ -1602,7 +1602,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DemandResponseLoadContr
     case EnumType::kUserAction:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DemandResponseLoadControl::LoadControlEventStatusEnum val)
@@ -1625,7 +1625,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DemandResponseLoadContr
     case EnumType::kFailed:
         return val;
     default:
-        return static_cast<EnumType>(13);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1641,7 +1641,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Messages::FutureMessage
     case EnumType::kBanned:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Messages::MessagePriorityEnum val)
@@ -1655,7 +1655,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Messages::MessagePriori
     case EnumType::kCritical:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1668,7 +1668,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement:
     case EnumType::kGridOptimization:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement::CauseEnum val)
@@ -1683,7 +1683,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement:
     case EnumType::kCancelled:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement::CostTypeEnum val)
@@ -1697,7 +1697,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement:
     case EnumType::kTemperature:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement::ESAStateEnum val)
@@ -1712,7 +1712,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement:
     case EnumType::kPaused:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement::ESATypeEnum val)
@@ -1737,7 +1737,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement:
     case EnumType::kOther:
         return val;
     default:
-        return static_cast<EnumType>(14);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement::ForecastUpdateReasonEnum val)
@@ -1750,7 +1750,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement:
     case EnumType::kGridOptimization:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement::OptOutStateEnum val)
@@ -1764,7 +1764,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DeviceEnergyManagement:
     case EnumType::kOptOut:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1778,7 +1778,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(EnergyEvse::EnergyTrans
     case EnumType::kOther:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(EnergyEvse::FaultStateEnum val)
@@ -1805,7 +1805,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(EnergyEvse::FaultStateE
     case EnumType::kOther:
         return val;
     default:
-        return static_cast<EnumType>(16);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(EnergyEvse::StateEnum val)
@@ -1822,7 +1822,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(EnergyEvse::StateEnum v
     case EnumType::kFault:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(EnergyEvse::SupplyStateEnum val)
@@ -1837,7 +1837,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(EnergyEvse::SupplyState
     case EnumType::kDisabledDiagnostics:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1852,7 +1852,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(EnergyPreference::Energ
     case EnumType::kWaterConsumption:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -1871,7 +1871,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::AlarmCodeEnum
     case EnumType::kForcedUser:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::CredentialRuleEnum val)
@@ -1884,7 +1884,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::CredentialRul
     case EnumType::kTri:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::CredentialTypeEnum val)
@@ -1903,7 +1903,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::CredentialTyp
     case EnumType::kAliroNonEvictableEndpointKey:
         return val;
     default:
-        return static_cast<EnumType>(9);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DataOperationTypeEnum val)
@@ -1916,7 +1916,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DataOperation
     case EnumType::kModify:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DlLockState val)
@@ -1930,7 +1930,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DlLockState v
     case EnumType::kUnlatched:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DlLockType val)
@@ -1952,7 +1952,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DlLockType va
     case EnumType::kEurocylinder:
         return val;
     default:
-        return static_cast<EnumType>(12);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DlStatus val)
@@ -1969,7 +1969,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DlStatus val)
     case EnumType::kNotFound:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorLockOperationEventCode val)
@@ -1994,7 +1994,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorLockOpera
     case EnumType::kManualUnlock:
         return val;
     default:
-        return static_cast<EnumType>(15);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorLockProgrammingEventCode val)
@@ -2011,7 +2011,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorLockProgr
     case EnumType::kIdDeleted:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorLockSetPinOrIdStatus val)
@@ -2025,7 +2025,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorLockSetPi
     case EnumType::kDuplicateCodeError:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorLockUserStatus val)
@@ -2039,7 +2039,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorLockUserS
     case EnumType::kNotSupported:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorLockUserType val)
@@ -2055,7 +2055,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorLockUserT
     case EnumType::kNotSupported:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorStateEnum val)
@@ -2071,7 +2071,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::DoorStateEnum
     case EnumType::kDoorAjar:
         return val;
     default:
-        return static_cast<EnumType>(6);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::LockDataTypeEnum val)
@@ -2095,7 +2095,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::LockDataTypeE
     case EnumType::kAliroNonEvictableEndpointKey:
         return val;
     default:
-        return static_cast<EnumType>(14);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::LockOperationTypeEnum val)
@@ -2110,7 +2110,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::LockOperation
     case EnumType::kUnlatch:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::OperatingModeEnum val)
@@ -2125,7 +2125,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::OperatingMode
     case EnumType::kPassage:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::OperationErrorEnum val)
@@ -2140,7 +2140,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::OperationErro
     case EnumType::kInsufficientBattery:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::OperationSourceEnum val)
@@ -2161,7 +2161,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::OperationSour
     case EnumType::kAliro:
         return val;
     default:
-        return static_cast<EnumType>(11);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::UserStatusEnum val)
@@ -2174,7 +2174,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::UserStatusEnu
     case EnumType::kOccupiedDisabled:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::UserTypeEnum val)
@@ -2194,7 +2194,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(DoorLock::UserTypeEnum 
     case EnumType::kRemoteOnlyUser:
         return val;
     default:
-        return static_cast<EnumType>(10);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2230,7 +2230,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(WindowCovering::EndProd
     case EnumType::kUnknown:
         return val;
     default:
-        return static_cast<EnumType>(24);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(WindowCovering::Type val)
@@ -2251,7 +2251,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(WindowCovering::Type va
     case EnumType::kUnknown:
         return val;
     default:
-        return static_cast<EnumType>(10);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2268,7 +2268,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PumpConfigurationAndCon
     case EnumType::kAutomatic:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(PumpConfigurationAndControl::OperationModeEnum val)
@@ -2282,7 +2282,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(PumpConfigurationAndCon
     case EnumType::kLocal:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2294,7 +2294,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ACCapacityF
     case EnumType::kBTUh:
         return val;
     default:
-        return static_cast<EnumType>(1);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ACCompressorTypeEnum val)
@@ -2308,7 +2308,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ACCompresso
     case EnumType::kT3:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ACLouverPositionEnum val)
@@ -2323,7 +2323,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ACLouverPos
     case EnumType::kThreeQuarters:
         return val;
     default:
-        return static_cast<EnumType>(0);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ACRefrigerantTypeEnum val)
@@ -2337,7 +2337,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ACRefrigera
     case EnumType::kR407c:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ACTypeEnum val)
@@ -2352,7 +2352,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ACTypeEnum 
     case EnumType::kHeatPumpInverter:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ControlSequenceOfOperationEnum val)
@@ -2368,7 +2368,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ControlSequ
     case EnumType::kCoolingAndHeatingWithReheat:
         return val;
     default:
-        return static_cast<EnumType>(6);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::PresetScenarioEnum val)
@@ -2385,7 +2385,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::PresetScena
     case EnumType::kUserDefined:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::SetpointChangeSourceEnum val)
@@ -2398,7 +2398,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::SetpointCha
     case EnumType::kExternal:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::SetpointRaiseLowerModeEnum val)
@@ -2411,7 +2411,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::SetpointRai
     case EnumType::kBoth:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::StartOfWeekEnum val)
@@ -2428,7 +2428,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::StartOfWeek
     case EnumType::kSaturday:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::SystemModeEnum val)
@@ -2447,7 +2447,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::SystemModeE
     case EnumType::kSleep:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::TemperatureSetpointHoldEnum val)
@@ -2459,7 +2459,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::Temperature
     case EnumType::kSetpointHoldOn:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ThermostatRunningModeEnum val)
@@ -2472,7 +2472,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Thermostat::ThermostatR
     case EnumType::kHeat:
         return val;
     default:
-        return static_cast<EnumType>(1);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2485,7 +2485,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(FanControl::AirflowDire
     case EnumType::kReverse:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(FanControl::FanModeEnum val)
@@ -2502,7 +2502,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(FanControl::FanModeEnum
     case EnumType::kSmart:
         return val;
     default:
-        return static_cast<EnumType>(7);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(FanControl::FanModeSequenceEnum val)
@@ -2518,7 +2518,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(FanControl::FanModeSequ
     case EnumType::kOffHigh:
         return val;
     default:
-        return static_cast<EnumType>(6);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(FanControl::StepDirectionEnum val)
@@ -2530,7 +2530,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(FanControl::StepDirecti
     case EnumType::kDecrease:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2547,7 +2547,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ThermostatUserInterface
     case EnumType::kLockout5:
         return val;
     default:
-        return static_cast<EnumType>(6);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused))
@@ -2560,7 +2560,7 @@ EnsureKnownEnumValue(ThermostatUserInterfaceConfiguration::ScheduleProgrammingVi
     case EnumType::kScheduleProgrammingDenied:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ThermostatUserInterfaceConfiguration::TemperatureDisplayModeEnum val)
@@ -2572,7 +2572,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ThermostatUserInterface
     case EnumType::kFahrenheit:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2586,7 +2586,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::ColorLoop
     case EnumType::kActivateFromEnhancedCurrentHue:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::ColorLoopDirection val)
@@ -2598,7 +2598,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::ColorLoop
     case EnumType::kIncrementHue:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::ColorMode val)
@@ -2611,7 +2611,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::ColorMode
     case EnumType::kColorTemperature:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::HueDirection val)
@@ -2625,7 +2625,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::HueDirect
     case EnumType::kDown:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::HueMoveMode val)
@@ -2638,7 +2638,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::HueMoveMo
     case EnumType::kDown:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::HueStepMode val)
@@ -2650,7 +2650,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::HueStepMo
     case EnumType::kDown:
         return val;
     default:
-        return static_cast<EnumType>(0);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::SaturationMoveMode val)
@@ -2663,7 +2663,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::Saturatio
     case EnumType::kDown:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::SaturationStepMode val)
@@ -2675,7 +2675,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ColorControl::Saturatio
     case EnumType::kDown:
         return val;
     default:
-        return static_cast<EnumType>(0);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2688,7 +2688,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(IlluminanceMeasurement:
     case EnumType::kCmos:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2703,7 +2703,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(OccupancySensing::Occup
     case EnumType::kPhysicalContact:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2718,7 +2718,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Channel::ChannelTypeEnu
     case EnumType::kOtt:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Channel::LineupInfoTypeEnum val)
@@ -2729,7 +2729,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Channel::LineupInfoType
     case EnumType::kMso:
         return val;
     default:
-        return static_cast<EnumType>(1);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(Channel::StatusEnum val)
@@ -2742,7 +2742,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Channel::StatusEnum val
     case EnumType::kNoMatches:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2756,7 +2756,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(TargetNavigator::Status
     case EnumType::kNotAllowed:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2785,7 +2785,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(MediaPlayback::Characte
     case EnumType::kKaraoke:
         return val;
     default:
-        return static_cast<EnumType>(18);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(MediaPlayback::PlaybackStateEnum val)
@@ -2799,7 +2799,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(MediaPlayback::Playback
     case EnumType::kBuffering:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(MediaPlayback::StatusEnum val)
@@ -2815,7 +2815,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(MediaPlayback::StatusEn
     case EnumType::kSeekOutOfRange:
         return val;
     default:
-        return static_cast<EnumType>(6);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2838,7 +2838,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(MediaInput::InputTypeEn
     case EnumType::kOther:
         return val;
     default:
-        return static_cast<EnumType>(12);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2935,7 +2935,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(KeypadInput::CECKeyCode
     case EnumType::kData:
         return val;
     default:
-        return static_cast<EnumType>(14);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(KeypadInput::StatusEnum val)
@@ -2948,7 +2948,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(KeypadInput::StatusEnum
     case EnumType::kInvalidKeyInCurrentState:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -2977,7 +2977,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ContentLauncher::Charac
     case EnumType::kKaraoke:
         return val;
     default:
-        return static_cast<EnumType>(18);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ContentLauncher::MetricTypeEnum val)
@@ -2989,7 +2989,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ContentLauncher::Metric
     case EnumType::kPercentage:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ContentLauncher::ParameterEnum val)
@@ -3016,7 +3016,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ContentLauncher::Parame
     case EnumType::kAny:
         return val;
     default:
-        return static_cast<EnumType>(17);
+        return EnumType::kUnknownEnumValue;
     }
 }
 static auto __attribute__((unused)) EnsureKnownEnumValue(ContentLauncher::StatusEnum val)
@@ -3031,7 +3031,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ContentLauncher::Status
     case EnumType::kAudioTrackNotAvailable:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -3048,7 +3048,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(AudioOutput::OutputType
     case EnumType::kOther:
         return val;
     default:
-        return static_cast<EnumType>(6);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -3062,7 +3062,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ApplicationLauncher::St
     case EnumType::kSystemBusy:
         return val;
     default:
-        return static_cast<EnumType>(3);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -3077,7 +3077,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ApplicationBasic::Appli
     case EnumType::kActiveVisibleNotFocus:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -3090,7 +3090,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ContentAppObserver::Sta
     case EnumType::kUnexpectedData:
         return val;
     default:
-        return static_cast<EnumType>(2);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -3105,7 +3105,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(UnitTesting::SimpleEnum
     case EnumType::kValueC:
         return val;
     default:
-        return static_cast<EnumType>(4);
+        return EnumType::kUnknownEnumValue;
     }
 }
 
@@ -3121,7 +3121,7 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(FaultInjection::FaultTy
     case EnumType::kCertFault:
         return val;
     default:
-        return static_cast<EnumType>(5);
+        return EnumType::kUnknownEnumValue;
     }
 }
 


### PR DESCRIPTION
Instead of hardcoding the returns via the ZAP template, just use the symbolic name.


