### PR TITLE
Upload Xcode derived data on failure in Darwin tests as an artifact.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -123,6 +123,13 @@ jobs:
               run: |
                   xcodebuild -target "MatterTvCastingBridge" -sdk iphoneos
               working-directory: examples/tv-casting-app/darwin/MatterTvCastingBridge
+            - name: Uploading .ips files in Xcode derived data to debug the failure
+              uses: actions/upload-artifact@v4
+              if: ${{ failure() && !env.ACT }}
+              with:
+                  name: darwin-framework-derived-data
+                  path: ~/Library/Developer/Xcode/DerivedData/**/*.ips
+                  retention-days: 5
             - name: Uploading log files
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}


### PR DESCRIPTION
If there are crashes in the test, the crash logs should be in there, and we can try to debug those.
