### PR TITLE
[Scenes] MaxCapacity fix

### DIFF
--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -928,7 +928,7 @@ void ScenesServer::HandleStoreScene(HandlerContext & ctx, const Commands::StoreS
     CHIP_ERROR err = StoreSceneParse(ctx.mCommandHandler.GetAccessingFabricIndex(), ctx.mRequestPath.mEndpointId, req.groupID,
                                      req.sceneID, mGroupProvider);
 
-    VerifyOrReturn(CHIP_NO_ERROR == AddResponseOnError(ctx, response, err));
+    ReturnOnFailure(AddResponseOnError(ctx, response, err));
 
     ReturnOnFailure(UpdateLastConfiguredBy(ctx, response));
     response.status = to_underlying(Protocols::InteractionModel::Status::Success);
@@ -1072,10 +1072,10 @@ void ScenesServer::HandleCopyScene(HandlerContext & ctx, const Commands::CopySce
                 ctx, response, sceneTable->SetSceneTableEntry(ctx.mCommandHandler.GetAccessingFabricIndex(), scene)));
 
             // Update SceneInfoStruct Attributes after each insert in case we hit max capacity in the middle of the loop
-            ReturnOnFailure(AddResponseOnError(ctx, response,
-                                               UpdateFabricSceneInfo(ctx.mRequestPath.mEndpointId,
-                                                                     ctx.mCommandHandler.GetAccessingFabricIndex(),
-                                                                     Optional<GroupId>(), Optional<SceneId>(), Optional<bool>())));
+            ReturnOnFailure(AddResponseOnError(
+                ctx, response,
+                UpdateFabricSceneInfo(ctx.mRequestPath.mEndpointId, ctx.mCommandHandler.GetAccessingFabricIndex(),
+                                      Optional<GroupId>(), Optional<SceneId>(), Optional<bool>() /* = sceneValid*/)));
         }
 
         ReturnOnFailure(UpdateLastConfiguredBy(ctx, response));

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -65,6 +65,10 @@ CHIP_ERROR AddResponseOnError(CommandHandlerInterface::HandlerContext & ctx, Res
         {
             resp.status = to_underlying(Protocols::InteractionModel::Status::NotFound);
         }
+        else if (CHIP_ERROR_NO_MEMORY == err)
+        {
+            resp.status = to_underlying(Protocols::InteractionModel::Status::ResourceExhausted);
+        }
         else
         {
             resp.status = to_underlying(StatusIB(err).mStatus);
@@ -167,7 +171,6 @@ CHIP_ERROR UpdateFabricSceneInfo(EndpointId endpoint, FabricIndex fabric, Option
 
 /// @brief Gets the SceneInfoStruct array associated to an endpoint
 /// @param endpoint target endpoint
-/// @param fabric target fabric
 /// @return Optional with no value not found, Span of SceneInfoStruct
 Span<Structs::SceneInfoStruct::Type> ScenesServer::FabricSceneInfo::GetFabricSceneInfo(EndpointId endpoint)
 {
@@ -674,13 +677,21 @@ void ScenesServer::InvokeCommand(HandlerContext & ctxt)
 // AttributeAccessInterface
 CHIP_ERROR ScenesServer::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
 {
+    uint16_t endpointTableSize = 0;
+    ReturnErrorOnFailure(StatusIB(Attributes::SceneTableSize::Get(aPath.mEndpointId, &endpointTableSize)).ToChipError());
+
+    // Get Scene Table Instance
+    SceneTable * sceneTable = scenes::GetSceneTableImpl(aPath.mEndpointId, endpointTableSize);
+
     switch (aPath.mAttributeId)
     {
     case Attributes::FabricSceneInfo::Id: {
-        return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
+        return aEncoder.EncodeList([&, sceneTable](const auto & encoder) -> CHIP_ERROR {
             Span<Structs::SceneInfoStruct::Type> fabricSceneInfoSpan = mFabricSceneInfo.GetFabricSceneInfo(aPath.mEndpointId);
             for (auto & info : fabricSceneInfoSpan)
             {
+                // Update the SceneInfoStruct's Capacity in case it's capacity was limited by other fabrics
+                sceneTable->GetRemainingCapacity(info.fabricIndex, info.remainingCapacity);
                 ReturnErrorOnFailure(encoder.Encode(info));
             }
             return CHIP_NO_ERROR;
@@ -917,12 +928,10 @@ void ScenesServer::HandleStoreScene(HandlerContext & ctx, const Commands::StoreS
     CHIP_ERROR err = StoreSceneParse(ctx.mCommandHandler.GetAccessingFabricIndex(), ctx.mRequestPath.mEndpointId, req.groupID,
                                      req.sceneID, mGroupProvider);
 
-    if (CHIP_NO_ERROR == err)
-    {
-        ReturnOnFailure(UpdateLastConfiguredBy(ctx, response));
-    }
+    VerifyOrReturn(CHIP_NO_ERROR == AddResponseOnError(ctx, response, err));
 
-    response.status = to_underlying(StatusIB(err).mStatus);
+    ReturnOnFailure(UpdateLastConfiguredBy(ctx, response));
+    response.status = to_underlying(Protocols::InteractionModel::Status::Success);
     ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
 }
 
@@ -1030,6 +1039,13 @@ void ScenesServer::HandleCopyScene(HandlerContext & ctx, const Commands::CopySce
     ReturnOnFailure(AddResponseOnError(ctx, response,
                                        sceneTable->GetRemainingCapacity(ctx.mCommandHandler.GetAccessingFabricIndex(), capacity)));
 
+    if (0 == capacity)
+    {
+        response.status = to_underlying(Protocols::InteractionModel::Status::ResourceExhausted);
+        ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
+        return;
+    }
+
     // Checks if we copy a single scene or all of them
     if (req.mode.GetField(app::Clusters::ScenesManagement::CopyModeBitmap::kCopyAllScenes))
     {
@@ -1041,13 +1057,6 @@ void ScenesServer::HandleCopyScene(HandlerContext & ctx, const Commands::CopySce
         ReturnOnFailure(AddResponseOnError(
             ctx, response,
             sceneTable->GetAllSceneIdsInGroup(ctx.mCommandHandler.GetAccessingFabricIndex(), req.groupIdentifierFrom, sceneList)));
-
-        if (0 == capacity)
-        {
-            response.status = to_underlying(Protocols::InteractionModel::Status::ResourceExhausted);
-            ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
-            return;
-        }
 
         for (auto & sceneId : sceneList)
         {
@@ -1061,13 +1070,13 @@ void ScenesServer::HandleCopyScene(HandlerContext & ctx, const Commands::CopySce
 
             ReturnOnFailure(AddResponseOnError(
                 ctx, response, sceneTable->SetSceneTableEntry(ctx.mCommandHandler.GetAccessingFabricIndex(), scene)));
-        }
 
-        // Update SceneInfoStruct Attributes
-        ReturnOnFailure(
-            AddResponseOnError(ctx, response,
-                               UpdateFabricSceneInfo(ctx.mRequestPath.mEndpointId, ctx.mCommandHandler.GetAccessingFabricIndex(),
-                                                     Optional<GroupId>(), Optional<SceneId>(), Optional<bool>())));
+            // Update SceneInfoStruct Attributes after each insert in case we hit max capacity in the middle of the loop
+            ReturnOnFailure(AddResponseOnError(ctx, response,
+                                               UpdateFabricSceneInfo(ctx.mRequestPath.mEndpointId,
+                                                                     ctx.mCommandHandler.GetAccessingFabricIndex(),
+                                                                     Optional<GroupId>(), Optional<SceneId>(), Optional<bool>())));
+        }
 
         ReturnOnFailure(UpdateLastConfiguredBy(ctx, response));
 

--- a/src/app/tests/suites/TestScenesMaxCapacity.yaml
+++ b/src/app/tests/suites/TestScenesMaxCapacity.yaml
@@ -1,0 +1,890 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# !!!!!!!!!! TEST INFORMATION !!!!!!!!!!!!!!!!!!
+# This test covers multi fabric support for scenes cluster attributes such as LastConfiguredBy and FabricSceneInfo
+
+name: Scenes Multi-fabric testing
+
+PICS:
+    - MCORE.ROLE.COMMISSIONEE
+    - APPDEVICE.S
+
+config:
+    nodeId: 0x12344321
+    cluster: "Scenes Management"
+    endpoint: 1
+    payload:
+        type: char_string
+        defaultValue: "MT:-24J0AFN00KA0648G00"
+    discriminator:
+        type: int16u
+        defaultValue: 3840
+    waitAfterCommissioning:
+        type: int16u
+        defaultValue: 5000
+    PakeVerifier:
+        type: octet_string
+        defaultValue: "hex:b96170aae803346884724fe9a3b287c30330c2a660375d17bb205a8cf1aecb350457f8ab79ee253ab6a8e46bb09e543ae422736de501e3db37d441fe344920d09548e4c18240630c4ff4913c53513839b7c07fcc0627a1b8573a149fcd1fa466cf"
+    G1:
+        type: group_id
+        defaultValue: 0x0001
+    G2:
+        type: group_id
+        defaultValue: 0x0002
+
+tests:
+    - label: "Commission DUT to TH1"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label: "TH1 reads the fabric index"
+      cluster: "Operational Credentials"
+      endpoint: 0
+      command: "readAttribute"
+      attribute: "CurrentFabricIndex"
+      response:
+          saveAs: th1FabricIndex
+
+    - label: "Read the commissioner node ID from the alpha fabric"
+      identity: "alpha"
+      endpoint: 0
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeIdAlpha
+
+    - label: "Open Commissioning Window from alpha"
+      endpoint: 0
+      cluster: "Administrator Commissioning"
+      command: "OpenCommissioningWindow"
+      timedInteractionTimeoutMs: 10000
+      arguments:
+          values:
+              - name: "CommissioningTimeout"
+                value: 180
+              - name: "PAKEPasscodeVerifier"
+                value: PakeVerifier
+              - name: "Discriminator"
+                value: discriminator
+              - name: "Iterations"
+                value: 1000
+              - name: "Salt"
+                value: "SPAKE2P Key Salt"
+
+    - label: "Waiting after opening commissioning window"
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: waitAfterCommissioning
+
+    - label: "Commission from TH2"
+      identity: "beta"
+      endpoint: 0
+      cluster: "CommissionerCommands"
+      command: "PairWithCode"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+              - name: "payload"
+                value: payload
+
+    - label: "Wait for the commissioned device to be retrieved for TH2"
+      endpoint: 0
+      identity: beta
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label: "TH2 reads the fabric index"
+      identity: "beta"
+      endpoint: 0
+      cluster: "Operational Credentials"
+      command: "readAttribute"
+      attribute: "CurrentFabricIndex"
+      response:
+          saveAs: th2FabricIndex
+
+    - label: "Read the commissioner node ID from the beta fabric"
+      identity: "beta"
+      endpoint: 0
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeIdBeta
+
+    - label: "Open Commissioning Window from alpha"
+      endpoint: 0
+      cluster: "Administrator Commissioning"
+      command: "OpenCommissioningWindow"
+      timedInteractionTimeoutMs: 10000
+      arguments:
+          values:
+              - name: "CommissioningTimeout"
+                value: 180
+              - name: "PAKEPasscodeVerifier"
+                value: PakeVerifier
+              - name: "Discriminator"
+                value: discriminator
+              - name: "Iterations"
+                value: 1000
+              - name: "Salt"
+                value: "SPAKE2P Key Salt"
+
+    - label: "Waiting after opening commissioning window"
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: waitAfterCommissioning
+
+    - label: "Commission from TH3"
+      identity: "gamma"
+      endpoint: 0
+      cluster: "CommissionerCommands"
+      command: "PairWithCode"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+              - name: "payload"
+                value: payload
+
+    - label: "Wait for the commissioned device to be retrieved for TH3"
+      endpoint: 0
+      identity: gamma
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label: "TH3 reads the fabric index"
+      identity: "gamma"
+      endpoint: 0
+      cluster: "Operational Credentials"
+      command: "readAttribute"
+      attribute: "CurrentFabricIndex"
+      response:
+          saveAs: th3FabricIndex
+
+    - label: "Read the commissioner node ID from the gamma fabric"
+      identity: "gamma"
+      endpoint: 0
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: commissionerNodeIdBeta
+
+    - label: "Read the FabricSceneInfo attribute (0x0007) "
+      command: "readAttribute"
+      attribute: "FabricSceneInfo"
+      response:
+          constraints:
+              type: list
+
+    - label: "TH reads from the DUT the (0x0006) SceneTableSize attribute"
+      command: "readAttribute"
+      attribute: "SceneTableSize"
+      response:
+          values:
+              - name: "SceneTableSize"
+                saveAs: maxScenes
+
+    - label: "Arithmetic operation to get the maxScenes - 1"
+      cluster: "Unit Testing"
+      command: "TestAddArguments"
+      arguments:
+          values:
+              - name: "arg1"
+                value: maxScenes - 1
+              - name: "arg2"
+                value: 0
+      response:
+          values:
+              - name: "returnValue"
+                saveAs: maxScenesMinusOne
+                value: maxScenes - 1
+
+    - label: "Arithmetic operation to get the fabric Capacity"
+      cluster: "Unit Testing"
+      command: "TestAddArguments"
+      arguments:
+          values:
+              - name: "arg1"
+                value: maxScenesMinusOne / 2
+              - name: "arg2"
+                value: 0
+      response:
+          values:
+              - name: "returnValue"
+                saveAs: fabricCapacity
+                value: maxScenesMinusOne / 2
+
+    - label: "Preparation step : TH 1 Add Group KeySet."
+      cluster: "Group Key Management"
+      endpoint: 0
+      command: "KeySetWrite"
+      arguments:
+          values:
+              - name: "GroupKeySet"
+                value:
+                    {
+                        GroupKeySetID: 0x01a1,
+                        GroupKeySecurityPolicy: 0,
+                        EpochKey0: "\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf",
+                        EpochStartTime0: 1110000,
+                        EpochKey1: "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf",
+                        EpochStartTime1: 1110001,
+                        EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
+                        EpochStartTime2: 1110002,
+                    }
+
+    - label: "Preparation step TH1 Map KeySets to GroupId."
+      cluster: "Group Key Management"
+      endpoint: 0
+      command: "writeAttribute"
+      attribute: "GroupKeyMap"
+      arguments:
+          value:
+              [
+                  { FabricIndex: 0, GroupId: G1, GroupKeySetID: 0x01a1 },
+                  { FabricIndex: 0, GroupId: G2, GroupKeySetID: 0x01a1 },
+              ]
+
+    - label: "TH1 sends a RemoveAllGroups command to DUT."
+      cluster: "Groups"
+      command: "RemoveAllGroups"
+
+    - label: "TH1 sends a AddGroup command to DUT for G1."
+      cluster: "Groups"
+      command: "AddGroup"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "GroupName"
+                value: "Group1"
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+
+    - label: "TH1 sends a AddGroup command to DUT for G2."
+      cluster: "Groups"
+      command: "AddGroup"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G2
+              - name: "GroupName"
+                value: "Group2"
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G2
+
+    - label: "Preparation step : TH 2 Add Group KeySet."
+      identity: "beta"
+      cluster: "Group Key Management"
+      endpoint: 0
+      command: "KeySetWrite"
+      arguments:
+          values:
+              - name: "GroupKeySet"
+                value:
+                    {
+                        GroupKeySetID: 0x01a2,
+                        GroupKeySecurityPolicy: 0,
+                        EpochKey0: "\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf",
+                        EpochStartTime0: 1120000,
+                        EpochKey1: "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf",
+                        EpochStartTime1: 1120001,
+                        EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
+                        EpochStartTime2: 1120002,
+                    }
+
+    - label: "Preparation step TH2 Map KeySets to GroupId."
+      identity: "beta"
+      cluster: "Group Key Management"
+      endpoint: 0
+      command: "writeAttribute"
+      attribute: "GroupKeyMap"
+      arguments:
+          value:
+              [
+                  { FabricIndex: 0, GroupId: G1, GroupKeySetID: 0x01a2 },
+                  { FabricIndex: 0, GroupId: G2, GroupKeySetID: 0x01a2 },
+              ]
+
+    - label: "TH2 sends a AddGroup command to DUT for G1."
+      identity: "beta"
+      cluster: "Groups"
+      command: "AddGroup"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "GroupName"
+                value: "Group1"
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+
+    - label: "TH2 sends a AddGroup command to DUT for G2."
+      identity: "beta"
+      cluster: "Groups"
+      command: "AddGroup"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G2
+              - name: "GroupName"
+                value: "Group1"
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G2
+
+    - label: "TH2 confirms the Fabric Capacity is Maximum"
+      command: "GetSceneMembership"
+      identity: "beta"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+      response:
+          values:
+              - name: "Status"
+                value: 0x00
+              - name: "Capacity"
+                value: fabricCapacity
+              - name: "GroupID"
+                value: G1
+
+    - label: "Preparation step : TH 3 Add Group KeySet."
+      identity: "gamma"
+      cluster: "Group Key Management"
+      endpoint: 0
+      command: "KeySetWrite"
+      arguments:
+          values:
+              - name: "GroupKeySet"
+                value:
+                    {
+                        GroupKeySetID: 0x01a2,
+                        GroupKeySecurityPolicy: 0,
+                        EpochKey0: "\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf",
+                        EpochStartTime0: 1120000,
+                        EpochKey1: "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf",
+                        EpochStartTime1: 1120001,
+                        EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
+                        EpochStartTime2: 1120002,
+                    }
+
+    - label: "Preparation step TH3 Map KeySets to GroupId."
+      identity: "gamma"
+      cluster: "Group Key Management"
+      endpoint: 0
+      command: "writeAttribute"
+      attribute: "GroupKeyMap"
+      arguments:
+          value: [{ FabricIndex: 0, GroupId: G1, GroupKeySetID: 0x01a2 }]
+
+    - label: "TH3 sends a AddGroup command to DUT for G1."
+      identity: "gamma"
+      cluster: "Groups"
+      command: "AddGroup"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "GroupName"
+                value: "Group1"
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+
+    - label: "TH3 confirms the Fabric Capacity is Maximum"
+      command: "GetSceneMembership"
+      identity: "gamma"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+      response:
+          values:
+              - name: "Status"
+                value: 0x00
+              - name: "Capacity"
+                value: fabricCapacity
+              - name: "GroupID"
+                value: G1
+
+    - label: "TH1 sends a StoreScene command to DUT for G1."
+      cluster: "Scenes Management"
+      command: "StoreScene"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0001
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0001
+
+    - label: "TH2 sends a StoreScene command to DUT for G1."
+      cluster: "Scenes Management"
+      identity: "beta"
+      command: "StoreScene"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0001
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0001
+
+    - label: "TH3 sends a StoreScene command to DUT for G1."
+      cluster: "Scenes Management"
+      identity: "gamma"
+      command: "StoreScene"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0001
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0001
+
+    - label: "TH1 confirms the Fabric Capacity is 0"
+      command: "GetSceneMembership"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+      response:
+          values:
+              - name: "Status"
+                value: 0x00
+              - name: "Capacity"
+                value: fabricCapacity - 1
+              - name: "GroupID"
+                value: G1
+
+    - label: "TH2 confirms the Fabric Capacity is 7"
+      command: "GetSceneMembership"
+      identity: "beta"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+      response:
+          values:
+              - name: "Status"
+                value: 0x00
+              - name: "Capacity"
+                value: fabricCapacity - 1
+              - name: "GroupID"
+                value: G1
+
+    - label: "TH2 confirms the Fabric Capacity is 7"
+      command: "GetSceneMembership"
+      identity: "beta"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+      response:
+          values:
+              - name: "Status"
+                value: 0x00
+              - name: "Capacity"
+                value: fabricCapacity - 1
+              - name: "GroupID"
+                value: G1
+
+    # Now we fill TH1
+    - label: "TH1 sends a StoreScene command to DUT for G1."
+      cluster: "Scenes Management"
+      command: "StoreScene"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0002
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0002
+
+    - label: "TH1 sends a StoreScene command to DUT for G1."
+      cluster: "Scenes Management"
+      command: "StoreScene"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0003
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0003
+
+    - label: "TH1 sends a StoreScene command to DUT for G1."
+      cluster: "Scenes Management"
+      command: "StoreScene"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0004
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0004
+
+    - label: "TH1 copies Scenes from G1 to G2"
+      command: "CopyScene"
+      arguments:
+          values:
+              - name: "Mode"
+                value: 0x01
+              - name: "GroupIdentifierFrom"
+                value: G1
+              - name: "SceneIdentifierFrom"
+                value: 0x01
+              - name: "GroupIdentifierTo"
+                value: G2
+              - name: "SceneIdentifierTo"
+                value: 0x02
+      response:
+          values:
+              - name: "Status"
+                value: 0x89
+              - name: "GroupIdentifierFrom"
+                value: G1
+              - name: "SceneIdentifierFrom"
+                value: 0x01
+
+    - label: "TH1 Read the FabricSceneInfo attribute (0x0002) "
+      command: "readAttribute"
+      attribute: "FabricSceneInfo"
+      response:
+          value:
+              [
+                  {
+                      SceneCount: 7,
+                      CurrentScene: 0x04,
+                      CurrentGroup: 0x0001,
+                      FabricIndex: th1FabricIndex,
+                      SceneValid: true,
+                      RemainingCapacity: fabricCapacity - 7,
+                  },
+              ]
+
+    - label: "TH2 Read the FabricSceneInfo attribute (0x0002) "
+      identity: "beta"
+      command: "readAttribute"
+      attribute: "FabricSceneInfo"
+      response:
+          value:
+              [
+                  {
+                      SceneCount: 1,
+                      CurrentScene: 0x01,
+                      CurrentGroup: 0x01,
+                      FabricIndex: th2FabricIndex,
+                      SceneValid: true,
+                      RemainingCapacity: fabricCapacity - 1,
+                  },
+              ]
+
+    - label: "TH3 Read the FabricSceneInfo attribute (0x0002) "
+      identity: "gamma"
+      command: "readAttribute"
+      attribute: "FabricSceneInfo"
+      response:
+          value:
+              [
+                  {
+                      SceneCount: 1,
+                      CurrentScene: 0x01,
+                      CurrentGroup: 0x01,
+                      FabricIndex: th3FabricIndex,
+                      SceneValid: true,
+                      RemainingCapacity: fabricCapacity - 1,
+                  },
+              ]
+
+    # Now we fill TH2
+    - label: "TH2 sends a StoreScene command to DUT for G1."
+      cluster: "Scenes Management"
+      identity: "beta"
+      command: "StoreScene"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0002
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0002
+
+    - label: "TH2 sends a StoreScene command to DUT for G1."
+      cluster: "Scenes Management"
+      identity: "beta"
+      command: "StoreScene"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0003
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0003
+
+    - label: "TH2 sends a StoreScene command to DUT for G1."
+      cluster: "Scenes Management"
+      command: "StoreScene"
+      identity: "beta"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0004
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0004
+
+    - label: "TH2 copies Scenes from G1 to G2"
+      cluster: "Scenes Management"
+      identity: "beta"
+      command: "CopyScene"
+      arguments:
+          values:
+              - name: "Mode"
+                value: 0x01
+              - name: "GroupIdentifierFrom"
+                value: G1
+              - name: "SceneIdentifierFrom"
+                value: 0x01
+              - name: "GroupIdentifierTo"
+                value: G2
+              - name: "SceneIdentifierTo"
+                value: 0x02
+      response:
+          values:
+              - name: "Status"
+                value: 0x89
+              - name: "GroupIdentifierFrom"
+                value: G1
+              - name: "SceneIdentifierFrom"
+                value: 0x01
+
+    - label: "TH1 Read the FabricSceneInfo attribute (0x0002) "
+      command: "readAttribute"
+      attribute: "FabricSceneInfo"
+      response:
+          value:
+              [
+                  {
+                      SceneCount: 7,
+                      CurrentScene: 0x04,
+                      CurrentGroup: 0x0001,
+                      FabricIndex: th1FabricIndex,
+                      SceneValid: true,
+                      RemainingCapacity: fabricCapacity - 7,
+                  },
+              ]
+
+    - label: "TH2 Read the FabricSceneInfo attribute (0x0002) "
+      identity: "beta"
+      command: "readAttribute"
+      attribute: "FabricSceneInfo"
+      response:
+          value:
+              [
+                  {
+                      SceneCount: 7,
+                      CurrentScene: 0x04,
+                      CurrentGroup: 0x0001,
+                      FabricIndex: th2FabricIndex,
+                      SceneValid: true,
+                      RemainingCapacity: fabricCapacity - 7,
+                  },
+              ]
+
+    - label: "TH3 Read the FabricSceneInfo attribute (0x0002) "
+      identity: "gamma"
+      command: "readAttribute"
+      attribute: "FabricSceneInfo"
+      response:
+          value:
+              [
+                  {
+                      SceneCount: 1,
+                      CurrentScene: 0x01,
+                      CurrentGroup: 0x01,
+                      FabricIndex: th3FabricIndex,
+                      SceneValid: true,
+                      RemainingCapacity: fabricCapacity - 6,
+                  },
+              ]
+
+    - label: "TH3 sends a StoreScene command to DUT for G1."
+      cluster: "Scenes Management"
+      identity: "gamma"
+      command: "StoreScene"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0002
+      response:
+          values:
+              - name: "Status"
+                value: 0
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0002
+
+    - label: "TH3 sends a StoreScene command to DUT for G1."
+      cluster: "Scenes Management"
+      identity: "gamma"
+      command: "StoreScene"
+      arguments:
+          values:
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0003
+      response:
+          values:
+              - name: "Status"
+                value: 0x89
+              - name: "GroupID"
+                value: G1
+              - name: "SceneID"
+                value: 0x0003
+
+    - label: "TH3 copies Scene 0x01 from G1 to 0x02 in G1"
+      cluster: "Scenes Management"
+      identity: "beta"
+      command: "CopyScene"
+      arguments:
+          values:
+              - name: "Mode"
+                value: 0x00
+              - name: "GroupIdentifierFrom"
+                value: G1
+              - name: "SceneIdentifierFrom"
+                value: 0x01
+              - name: "GroupIdentifierTo"
+                value: G1
+              - name: "SceneIdentifierTo"
+                value: 0x04
+      response:
+          values:
+              - name: "Status"
+                value: 0x89
+              - name: "GroupIdentifierFrom"
+                value: G1
+              - name: "SceneIdentifierFrom"
+                value: 0x01

--- a/src/app/tests/suites/certification/Test_TC_S_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_6.yaml
@@ -360,10 +360,10 @@ tests:
       disabled: true
 
     - label:
-          "TH sends a CopyScene command to DUT with the mode field set to 0x00,
-          the group identifier from field set to 0x0000, the scene identifier
-          from field set to 0x01, the group identifier to field set to 0x0000
-          and the scene identifier to field set to 0xFE."
+          "Step 8: TH sends a CopyScene command to DUT with the mode field set
+          to 0x00, the group identifier from field set to 0x0000, the scene
+          identifier from field set to 0x01, the group identifier to field set
+          to 0x0000 and the scene identifier to field set to 0xFE."
       PICS: S.S.C40.Rsp
       verification: |
           ./chip-tool scenesmanagement copy-scene 0 0x0000 0x01 0x4E20 sceneFE [] 1 1

--- a/src/app/tests/suites/ciTests.json
+++ b/src/app/tests/suites/ciTests.json
@@ -340,6 +340,7 @@
         "TestScenesFabricRemoval",
         "TestScenesFabricSceneInfo",
         "TestScenesMultiFabric",
+        "TestScenesMaxCapacity",
         "Test_TC_S_1_1",
         "Test_TC_S_2_1",
         "Test_TC_S_2_2",


### PR DESCRIPTION
Added refresh on read to the FabricSceneInfo capacity 
Patched Resource Exhausted for Copy Scene and Store Scene (proper mapping of CHIP->IMStatus errors is still needed)
Added a MaxCapacity yaml test to confirm everything works as expected.

Fixes: https://github.com/project-chip/connectedhomeip/issues/31955


