### PR TITLE
Restore state before restart dnssd

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -423,8 +423,8 @@ void DiscoveryImplPlatform::HandleDnssdError(void * context, CHIP_ERROR error)
 
     if (error == CHIP_ERROR_FORCED_RESET)
     {
-        // Restore dnssd state before restart
-        publisher->mState = State::kUninitialized;
+        // Restore dnssd state before restart, also needs to call ChipDnssdShutdown()
+        publisher->Shutdown();
 
         DeviceLayer::ChipDeviceEvent event;
         event.Type = DeviceLayer::DeviceEventType::kDnssdRestartNeeded;

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -419,8 +419,13 @@ void DiscoveryImplPlatform::HandleDnssdInit(void * context, CHIP_ERROR initError
 
 void DiscoveryImplPlatform::HandleDnssdError(void * context, CHIP_ERROR error)
 {
+    DiscoveryImplPlatform * publisher = static_cast<DiscoveryImplPlatform *>(context);
+
     if (error == CHIP_ERROR_FORCED_RESET)
     {
+        // Restore dnssd state before restart
+        publisher->mState = State::kUninitialized;
+
         DeviceLayer::ChipDeviceEvent event;
         event.Type = DeviceLayer::DeviceEventType::kDnssdRestartNeeded;
         error      = DeviceLayer::PlatformMgr().PostEvent(&event);


### PR DESCRIPTION
After `ChipDnssdInit` received the error callback (error code: `CHIP_ERROR_FORCED_RESET`), it did not restore the status to `kUninitialized`, and dnssd will not be initialized again (`DiscoveryImplPlatform::InitImpl()` will exit immediately)