### PR TITLE
[Util] Quick cleanup of unused type

### DIFF
--- a/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -459,7 +459,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
 void AppTask::InitOnOffClusterState()
 {
 
-    EmberStatus status;
+    EmberAfStatus status;
 
     ChipLogProgress(NotSpecified, "Init On/Off clusterstate");
 
@@ -482,7 +482,7 @@ void AppTask::UpdateClusterState(void)
 
 void AppTask::UpdateCluster(intptr_t context)
 {
-    EmberStatus status;
+    EmberAfStatus status;
     BitMask<PumpConfigurationAndControl::PumpStatusBitmap> pumpStatus;
 
     ChipLogProgress(NotSpecified, "Update Cluster State");

--- a/examples/pump-app/cc13x4_26x4/main/AppTask.cpp
+++ b/examples/pump-app/cc13x4_26x4/main/AppTask.cpp
@@ -456,7 +456,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
 void AppTask::InitOnOffClusterState()
 {
 
-    EmberStatus status;
+    EmberAfStatus status;
 
     ChipLogProgress(NotSpecified, "Init On/Off clusterstate");
 
@@ -479,7 +479,7 @@ void AppTask::UpdateClusterState(void)
 
 void AppTask::UpdateCluster(intptr_t context)
 {
-    EmberStatus status;
+    EmberAfStatus status;
     BitMask<PumpConfigurationAndControl::PumpStatusBitmap> pumpStatus;
 
     ChipLogProgress(NotSpecified, "Update Cluster State");

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -562,7 +562,7 @@ void AppTask::DispatchEvent(const AppEvent & event)
 
 void AppTask::UpdateClusterState()
 {
-    EmberStatus status;
+    EmberAfStatus status;
 
     ChipLogProgress(NotSpecified, "UpdateClusterState");
 

--- a/examples/pump-app/silabs/src/AppTask.cpp
+++ b/examples/pump-app/silabs/src/AppTask.cpp
@@ -242,7 +242,7 @@ void AppTask::ActionCompleted(PumpManager::Action_t aAction, int32_t aActor)
 void AppTask::UpdateClusterState(intptr_t context)
 {
     // Set On/Off state
-    EmberStatus status;
+    EmberAfStatus status;
     bool onOffState = !PumpMgr().IsStopped();
     status          = chip::app::Clusters::OnOff::Attributes::OnOff::Set(PCC_CLUSTER_ENDPOINT, onOffState);
     if (status != EMBER_ZCL_STATUS_SUCCESS)

--- a/examples/pump-app/telink/src/AppTask.cpp
+++ b/examples/pump-app/telink/src/AppTask.cpp
@@ -131,7 +131,7 @@ void AppTask::UpdateClusterState()
     // Write the new values
     bool onOffState = !PumpMgr().IsStopped();
 
-    EmberStatus status = Clusters::OnOff::Attributes::OnOff::Set(kOnOffClusterEndpoint, onOffState);
+    EmberAfStatus status = Clusters::OnOff::Attributes::OnOff::Set(kOnOffClusterEndpoint, onOffState);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
         LOG_ERR("ERR: Updating On/Off state  %x", status);

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -470,7 +470,7 @@ static void writeRemainingTime(EndpointId endpoint, uint16_t remainingTimeMs)
         // This is done to ensure that the attribute, in tenths of a second, only
         // goes to zero when the remaining time in milliseconds is actually zero.
         uint16_t remainingTimeDs = static_cast<uint16_t>((remainingTimeMs + 99) / 100);
-        EmberStatus status       = LevelControl::Attributes::RemainingTime::Set(endpoint, remainingTimeDs);
+        EmberAfStatus status     = LevelControl::Attributes::RemainingTime::Set(endpoint, remainingTimeDs);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
         {
             ChipLogProgress(Zcl, "ERR: writing remaining time %x", status);

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -149,32 +149,6 @@ struct EmberBindingTableEntry
     }
 };
 
-#ifdef DOXYGEN_SHOULD_SKIP_THIS
-enum EmberStatus
-#else
-typedef uint8_t EmberStatus;
-enum
-#endif // DOXYGEN_SHOULD_SKIP_THIS
-{
-    /**
-     * @name Generic Messages
-     * These messages are system wide.
-     */
-    //@{
-
-    /**
-     * @brief The generic "no error" message.
-     */
-    EMBER_SUCCESS = 0x00,
-
-    /**
-     * @brief An invalid value was passed as an argument to a function.
-     */
-    EMBER_BAD_ARGUMENT = 0x02,
-
-    //@} // END Generic Messages
-};
-
 /**
  * @brief Function pointer for timer callback
  */


### PR DESCRIPTION
`EmberStatus` was never properly used. Only time it was used in the stack is when it was mistaken for `EmberAfStatus`

