### PR TITLE
[Linux] Use sync version of BLE connect function

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -796,12 +796,11 @@ void BLEManagerImpl::OnDeviceScanned(BluezDevice1 & device, const chip::Ble::Chi
     if (mBLEScanConfig.mBleScanState == BleScanState::kScanForDiscriminator)
     {
         auto isMatch = mBLEScanConfig.mDiscriminator.MatchesLongDiscriminator(info.GetDeviceDiscriminator());
-        VerifyOrReturn(isMatch,
-                       const uint16_t value = mBLEScanConfig.mDiscriminator.IsShortDiscriminator()
-                           ? mBLEScanConfig.mDiscriminator.GetShortValue()
-                           : mBLEScanConfig.mDiscriminator.GetLongValue();
-                       ChipLogError(Ble, "Skip connection: Device discriminator does not match: %u != %u",
-                                    info.GetDeviceDiscriminator(), value));
+        VerifyOrReturn(
+            isMatch,
+            ChipLogError(Ble, "Skip connection: Device discriminator does not match: %u != %u", info.GetDeviceDiscriminator(),
+                         mBLEScanConfig.mDiscriminator.IsShortDiscriminator() ? mBLEScanConfig.mDiscriminator.GetShortValue()
+                                                                              : mBLEScanConfig.mDiscriminator.GetLongValue()));
         ChipLogProgress(Ble, "Device discriminator match. Attempting to connect.");
     }
     else if (mBLEScanConfig.mBleScanState == BleScanState::kScanForAddress)

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -694,8 +694,6 @@ void BluezEndpoint::Shutdown()
                 g_object_unref(self->mpObjMgr);
             if (self->mpAdapter != nullptr)
                 g_object_unref(self->mpAdapter);
-            if (self->mpDevice != nullptr)
-                g_object_unref(self->mpDevice);
             if (self->mpRoot != nullptr)
                 g_object_unref(self->mpRoot);
             if (self->mpService != nullptr)

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -50,6 +50,7 @@
 #include <memory>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <utility>
 
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
@@ -718,61 +719,42 @@ void BluezEndpoint::Shutdown()
 
 // ConnectDevice callbacks
 
-void BluezEndpoint::ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer apParams)
+CHIP_ERROR BluezEndpoint::ConnectDeviceImpl(BluezDevice1 & aDevice)
 {
-    BluezDevice1 * device  = BLUEZ_DEVICE1(aObject);
-    ConnectParams * params = static_cast<ConnectParams *>(apParams);
-    GAutoPtr<GError> error;
-
-    if (!bluez_device1_call_connect_finish(device, aResult, &MakeUniquePointerReceiver(error).Get()))
+    // Due to radio interferences or Wi-Fi coexistence, sometimes the BLE connection may not be
+    // established (e.g. Connection Indication Packet is missed by BLE peripheral). In such case,
+    // BlueZ returns "Software caused connection abort error", and we should make a connection retry.
+    // It's important to make sure that the connection is correctly ceased, by calling `Disconnect()`
+    // D-Bus method, or else `Connect()` returns immediately without any effect.
+    for (uint16_t i = 0; i < kMaxConnectRetries; i++)
     {
-        ChipLogError(DeviceLayer, "FAIL: ConnectDevice : %s (%d)", error->message, error->code);
-
-        // Due to radio interferences or Wi-Fi coexistence, sometimes the BLE connection may not be
-        // established (e.g. Connection Indication Packet is missed by BLE peripheral). In such case,
-        // BlueZ returns "Software caused connection abort error", and we should make a connection retry.
-        // It's important to make sure that the connection is correctly ceased, by calling `Disconnect()`
-        // D-Bus method, or else `Connect()` returns immediately without any effect.
-        if (g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_DBUS_ERROR) && params->mNumRetries++ < kMaxConnectRetries)
+        GAutoPtr<GError> error;
+        if (bluez_device1_call_connect_sync(&aDevice, mConnectCancellable.get(), &MakeUniquePointerReceiver(error).Get()))
         {
-            // Clear the error before usage in subsequent call.
-            g_clear_error(&MakeUniquePointerReceiver(error).Get());
-
-            bluez_device1_call_disconnect_sync(device, nullptr, &MakeUniquePointerReceiver(error).Get());
-            bluez_device1_call_connect(device, params->mEndpoint.mConnectCancellable.get(), ConnectDeviceDone, params);
-            return;
+            ChipLogDetail(DeviceLayer, "ConnectDevice complete");
+            return CHIP_NO_ERROR;
         }
 
-        BLEManagerImpl::HandleConnectFailed(CHIP_ERROR_INTERNAL);
-    }
-    else
-    {
-        ChipLogDetail(DeviceLayer, "ConnectDevice complete");
+        ChipLogError(DeviceLayer, "FAIL: ConnectDevice: %s (%d)", error->message, error->code);
+        if (!g_error_matches(error.get(), G_IO_ERROR, G_IO_ERROR_DBUS_ERROR))
+        {
+            break;
+        }
+
+        ChipLogProgress(DeviceLayer, "ConnectDevice retry: %u out of %u", i + 1, kMaxConnectRetries);
+        bluez_device1_call_disconnect_sync(&aDevice, nullptr, nullptr);
     }
 
-    chip::Platform::Delete(params);
-}
-
-CHIP_ERROR BluezEndpoint::ConnectDeviceImpl(ConnectParams * apParams)
-{
-    bluez_device1_call_connect(apParams->mpDevice, apParams->mEndpoint.mConnectCancellable.get(), ConnectDeviceDone, apParams);
-    return CHIP_NO_ERROR;
+    BLEManagerImpl::HandleConnectFailed(CHIP_ERROR_INTERNAL);
+    return CHIP_ERROR_INTERNAL;
 }
 
 CHIP_ERROR BluezEndpoint::ConnectDevice(BluezDevice1 & aDevice)
 {
-    auto params = chip::Platform::New<ConnectParams>(*this, &aDevice);
-    VerifyOrReturnError(params != nullptr, CHIP_ERROR_NO_MEMORY);
-
+    auto params = std::make_pair(this, &aDevice);
     mConnectCancellable.reset(g_cancellable_new());
-    if (PlatformMgrImpl().GLibMatterContextInvokeSync(ConnectDeviceImpl, params) != CHIP_NO_ERROR)
-    {
-        ChipLogError(Ble, "Failed to schedule ConnectDeviceImpl() on CHIPoBluez thread");
-        chip::Platform::Delete(params);
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    return CHIP_NO_ERROR;
+    return PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](typeof(params) * aParams) { return aParams->first->ConnectDeviceImpl(*aParams->second); }, &params);
 }
 
 void BluezEndpoint::CancelConnect()

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -83,16 +83,6 @@ public:
     void CancelConnect();
 
 private:
-    struct ConnectParams
-    {
-        ConnectParams(const BluezEndpoint & aEndpoint, BluezDevice1 * apDevice) : mEndpoint(aEndpoint), mpDevice(apDevice) {}
-        ~ConnectParams() = default;
-
-        const BluezEndpoint & mEndpoint;
-        BluezDevice1 * mpDevice;
-        uint16_t mNumRetries = 0;
-    };
-
     CHIP_ERROR StartupEndpointBindings();
 
     void SetupAdapter();

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -139,7 +139,6 @@ private:
     // Objects (interfaces) subscribed to by this service
     GDBusObjectManager * mpObjMgr = nullptr;
     BluezAdapter1 * mpAdapter     = nullptr;
-    BluezDevice1 * mpDevice       = nullptr;
 
     // Objects (interfaces) published by this service
     GDBusObjectManagerServer * mpRoot = nullptr;

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -122,8 +122,7 @@ private:
     void RegisterGattApplicationDone(GObject * aObject, GAsyncResult * aResult);
     CHIP_ERROR RegisterGattApplicationImpl();
 
-    static void ConnectDeviceDone(GObject * aObject, GAsyncResult * aResult, gpointer apParams);
-    static CHIP_ERROR ConnectDeviceImpl(ConnectParams * apParams);
+    CHIP_ERROR ConnectDeviceImpl(BluezDevice1 & aDevice);
 
     bool mIsCentral     = false;
     bool mIsInitialized = false;

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -542,10 +542,7 @@ void BLEManagerImpl::OnChipDeviceScanned(void * device, const Ble::ChipBLEDevice
     /* Initiate Connect */
     auto params = std::make_pair(this, deviceInfo->remote_address);
     PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](typeof(params) * aParams) {
-            return reinterpret_cast<BLEManagerImpl *>(aParams->first)->ConnectChipThing(aParams->second);
-        },
-        &params);
+        +[](typeof(params) * aParams) { return aParams->first->ConnectChipThing(aParams->second); }, &params);
 }
 
 void BLEManagerImpl::OnScanComplete()


### PR DESCRIPTION
### Problem

In case of async connection it's not possible to report connection error from the `BluezEndpoint::ConnectDevice` function.

### Changes

- Use `bluez_device1_call_connect_sync`, this way we can report the connection error to the caller. The connection happens on the GLib thread anyway.
- Remove unused BluezEndpoint member - `mpDevice`

### Testing

Locally tested connection retries:
```
[1707390924.227600][2118706:2118707] CHIP:BLE: New device scanned: B8:27:EB:BC:FA:D1                                                                                                                                 
[1707390924.227711][2118706:2118707] CHIP:BLE: Device discriminator match. Attempting to connect.                                                                                                                    
[1707390924.237330][2118706:2118707] CHIP:BLE: ChipDeviceScanner has stopped scanning!                                                                                                                               
[1707390929.221037][2118706:2118707] CHIP:DL: FAIL: ConnectDevice : GDBus.Error:org.bluez.Error.Failed: le-connection-abort-by-local (36)                                                                            
[1707390929.221050][2118706:2118707] CHIP:DL: ConnectDevice retry: 1 out of 4                                                                                                                                        
[1707390930.151042][2118706:2118707] CHIP:DL: FAIL: ConnectDevice : GDBus.Error:org.bluez.Error.Failed: le-connection-abort-by-local (36)                                                                            
[1707390930.151059][2118706:2118707] CHIP:DL: ConnectDevice retry: 2 out of 4                                                                                                                                        
[1707390930.577811][2118706:2118707] CHIP:DL: FAIL: ConnectDevice : GDBus.Error:org.bluez.Error.Failed: le-connection-abort-by-local (36)                                                                            
[1707390930.577859][2118706:2118707] CHIP:DL: ConnectDevice retry: 3 out of 4                                                                                                                                        
[1707390931.075639][2118706:2118707] CHIP:DL: FAIL: ConnectDevice : GDBus.Error:org.bluez.Error.Failed: le-connection-abort-by-local (36)                                                                            
[1707390931.075681][2118706:2118707] CHIP:DL: ConnectDevice retry: 4 out of 4                                                                                                                                        
[1707390931.110232][2118706:2118708] CHIP:DL: HandlePlatformSpecificBLEEvent 16386                                                                                                                                   
[1707390931.110301][2118706:2118708] CHIP:DIS: Closing all BLE connections   
```

```
[1707390969.831984][2120512:2120513] CHIP:BLE: New device scanned: B8:27:EB:BC:FA:D1                                                                                                                                 
[1707390969.831996][2120512:2120513] CHIP:BLE: Device discriminator match. Attempting to connect.                                                                                                                    
[1707390969.837787][2120512:2120513] CHIP:BLE: ChipDeviceScanner has stopped scanning!                                                                                                                               
[1707390974.925944][2120512:2120513] CHIP:DL: FAIL: ConnectDevice : GDBus.Error:org.bluez.Error.Failed: le-connection-abort-by-local (36)
[1707390974.925957][2120512:2120513] CHIP:DL: ConnectDevice retry: 1 out of 4
[1707390977.181141][2120512:2120513] CHIP:DL: ConnectDevice complete
```