### PR TITLE
Remove include InteractionModelEngine.h in reporting/Engine.h

### DIFF
--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include <access/AccessControl.h>
-#include <app/InteractionModelEngine.h>
 #include <app/MessageDef/ReportDataMessage.h>
 #include <app/ReadHandler.h>
 #include <app/util/basic-types.h>
@@ -41,6 +40,7 @@
 namespace chip {
 namespace app {
 
+class InteractionModelEngine;
 class TestReadInteraction;
 
 namespace reporting {


### PR DESCRIPTION
This was introduced in https://github.com/project-chip/connectedhomeip/pull/31494 that Engine.h and InteractionModelEngine.h are cross including each other.

Use a forward declaration of InteractionModelEngine in Engine.h instead.

