### PR TITLE
Python testing: Fix spec parsing for derived cluster commands

### DIFF
--- a/src/python_testing/TestSpecParsingSupport.py
+++ b/src/python_testing/TestSpecParsingSupport.py
@@ -267,9 +267,9 @@ class TestSpecParsingSupport(MatterBaseTest):
             [0, 1, 2, 3] + expected_global_attrs), "Unexpected attribute list")
         # Ensure the conformance overrides from the derived cluster are on the attributes
         asserts.assert_equal(str(clusters[0xFFFF].attributes[0].conformance), "M", "Unexpected conformance on attribute 0")
-        asserts.assert_equal(str(clusters[0xFFFF].attributes[1].conformance), "M", "Unexpected conformance on attribute 0")
-        asserts.assert_equal(str(clusters[0xFFFF].attributes[2].conformance), "X", "Unexpected conformance on attribute 1")
-        asserts.assert_equal(str(clusters[0xFFFF].attributes[3].conformance), "X", "Unexpected conformance on attribute 1")
+        asserts.assert_equal(str(clusters[0xFFFF].attributes[1].conformance), "M", "Unexpected conformance on attribute 1")
+        asserts.assert_equal(str(clusters[0xFFFF].attributes[2].conformance), "X", "Unexpected conformance on attribute 2")
+        asserts.assert_equal(str(clusters[0xFFFF].attributes[3].conformance), "X", "Unexpected conformance on attribute 3")
 
         # Ensure both the accepted and generated command overrides work
         asserts.assert_true(set(clusters[0xFFFF].accepted_commands.keys()),

--- a/src/python_testing/TestSpecParsingSupport.py
+++ b/src/python_testing/TestSpecParsingSupport.py
@@ -19,7 +19,7 @@ import xml.etree.ElementTree as ElementTree
 
 import chip.clusters as Clusters
 from global_attribute_ids import GlobalAttributeIds
-from matter_testing_support import MatterBaseTest, default_matter_test_main
+from matter_testing_support import MatterBaseTest, ProblemNotice, default_matter_test_main
 from mobly import asserts
 from spec_parsing_support import (ClusterParser, XmlCluster, add_cluster_data_from_xml, check_clusters_for_unknown_commands,
                                   combine_derived_clusters_with_base)

--- a/src/python_testing/TestSpecParsingSupport.py
+++ b/src/python_testing/TestSpecParsingSupport.py
@@ -235,7 +235,7 @@ class TestSpecParsingSupport(MatterBaseTest):
         add_cluster_data_from_xml(derived_cluster_xml, clusters, pure_base_clusters, ids_by_name, problems)
 
         asserts.assert_equal(len(clusters), 1, "Unexpected number of clusters")
-        asserts.assert_equal(len(pure_base_clusters), 1, "Unexpected number of derived clusters")
+        asserts.assert_equal(len(pure_base_clusters), 1, "Unexpected number of pure base clusters")
         asserts.assert_equal(len(ids_by_name), 1, "Unexpected number of IDs per name")
         asserts.assert_equal(len(problems), 0, "Unexpected number of problems")
         asserts.assert_equal(ids_by_name["Test Derived"], 0xFFFF, "Test derived name not added to IDs")

--- a/src/python_testing/TestSpecParsingSupport.py
+++ b/src/python_testing/TestSpecParsingSupport.py
@@ -21,7 +21,7 @@ import chip.clusters as Clusters
 from global_attribute_ids import GlobalAttributeIds
 from matter_testing_support import MatterBaseTest, default_matter_test_main
 from mobly import asserts
-from spec_parsing_support import ClusterParser, XmlCluster
+from spec_parsing_support import ClusterParser, XmlCluster, add_cluster_data_from_xml, combine_derived_clusters_with_base
 
 # TODO: improve the test coverage here
 # https://github.com/project-chip/connectedhomeip/issues/30958
@@ -77,6 +77,105 @@ def get_access_enum_from_string(access_str: str) -> Clusters.AccessControl.Enums
     asserts.fail("Unknown access string")
 
 
+BASE_CLUSTER_XML_STR = (
+    '<cluster xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="types types.xsd cluster cluster.xsd" id="" name="Test Base" revision="1">'
+    '  <revisionHistory>'
+    '    <revision revision="1" summary="Initial version"/>'
+    '  </revisionHistory>'
+    '  <classification hierarchy="base" role="application" picsCode="BASE" scope="Endpoint"/>'
+    '  <features>'
+    '    <feature bit="0" code="DEPONOFF" name="OnOff" summary="Dependency with the OnOff cluster">'
+    '      <optionalConform/>'
+    '    </feature>'
+    '  </features>'
+    '  <attributes>'
+    '    <attribute id="0x0000" name="SupportedModes" type="list" default="MS">'
+    '      <entry type="ModeOptionStruct"/>'
+    '      <access read="true" readPrivilege="view"/>'
+    '      <quality changeOmitted="false" nullable="false" scene="false" persistence="fixed" reportable="false"/>'
+    '      <mandatoryConform/>'
+    '      <constraint type="countBetween" from="2" to="255"/>'
+    '    </attribute>'
+    '    <attribute id="0x0001" name="CurrentMode" type="uint8" default="MS">'
+    '      <access read="true" readPrivilege="view"/>'
+    '      <quality changeOmitted="false" nullable="false" scene="true" persistence="nonVolatile" reportable="false"/>'
+    '      <mandatoryConform/>'
+    '      <constraint type="desc"/>'
+    '   </attribute>'
+    '    <attribute id="0x0002" name="StartUpMode" type="uint8" default="MS">'
+    '      <access read="true" write="true" readPrivilege="view" writePrivilege="operate"/>'
+    '      <quality changeOmitted="false" nullable="true" scene="false" persistence="nonVolatile" reportable="false"/>'
+    '      <optionalConform/>'
+    '      <constraint type="desc"/>'
+    '    </attribute>'
+    '    <attribute id="0x0003" name="OnMode" type="uint8" default="null">'
+    '      <access read="true" write="true" readPrivilege="view" writePrivilege="operate"/>'
+    '      <quality changeOmitted="false" nullable="true" scene="false" persistence="nonVolatile" reportable="false"/>'
+    '      <mandatoryConform>'
+    '        <feature name="DEPONOFF"/>'
+    '      </mandatoryConform>'
+    '      <constraint type="desc"/>'
+    '    </attribute>'
+    '  </attributes>'
+    '  <commands>'
+    '    <command id="0x00" name="ChangeToMode" response="ChangeToModeResponse">'
+    '      <access invokePrivilege="operate"/>'
+    '      <mandatoryConform/>'
+    '      <field id="0" name="NewMode" type="uint8">'
+    '        <mandatoryConform/>'
+    '        <constraint type="desc"/>'
+    '      </field>'
+    '    </command>'
+    '    <command id="0x01" name="ChangeToModeResponse" direction="responseFromServer">'
+    '      <access invokePrivilege="operate"/>'
+    '      <mandatoryConform/>'
+    '      <field id="0" name="Status" type="enum8">'
+    '        <enum>'
+    '          <item from="0x00" to="0x3F" name="CommonCodes" summary="Common standard values defined in the generic Mode Base cluster specification.">'
+    '            <mandatoryConform/>'
+    '          </item>'
+    '        </enum>'
+    '        <mandatoryConform/>'
+    '        <constraint type="desc"/>'
+    '      </field>'
+    '      <field id="1" name="StatusText" type="string">'
+    '        <constraint type="maxLength" value="64"/>'
+    '      </field>'
+    '    </command>'
+    '  </commands>'
+    '</cluster>')
+
+DERIVED_CLUSTER_XML_STR = (
+    '<cluster xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="types types.xsd cluster cluster.xsd" id="0xFFFF" name="Test Derived" revision="1">'
+    '  <revisionHistory>'
+    '    <revision revision="1" summary="Initial Release"/>'
+    '  </revisionHistory>'
+    '  <classification hierarchy="derived" baseCluster="Test Base" role="application" picsCode="MWOM" scope="Endpoint"/>'
+    '  <attributes>'
+    '    <attribute id="0x0000" name="SupportedModes">'
+    '      <mandatoryConform/>'
+    '    </attribute>'
+    '    <attribute id="0x0002" name="StartUpMode">'
+    '      <disallowConform/>'
+    '    </attribute>'
+    '    <attribute id="0x0003" name="OnMode">'
+    '      <disallowConform/>'
+    '    </attribute>'
+    '  </attributes>'
+    '  <commands>'
+    '    <command id="0x00" name="ChangeToMode" direction="commandToClient">'
+    '      <access invokePrivilege="operate"/>'
+    '      <disallowConform/>'
+    '    </command>'
+    '    <command id="0x01" name="ChangeToModeResponse" direction="commandToClient">'
+    '      <access invokePrivilege="operate"/>'
+    '      <disallowConform/>'
+    '    </command>'
+    '  </commands>'
+    '</cluster>'
+)
+
+
 class TestSpecParsingSupport(MatterBaseTest):
     def test_spec_parsing_access(self):
         strs = [None, 'view', 'operate', 'manage', 'admin']
@@ -105,6 +204,51 @@ class TestSpecParsingSupport(MatterBaseTest):
                                 "Did not find test attribute in XmlCluster.attributes")
             asserts.assert_equal(xml_cluster.attributes[ATTRIBUTE_ID].write_optional,
                                  write_support == 'optional', "Unexpected write_optional value")
+
+    def test_derived_clusters(self):
+        clusters: dict[int, XmlCluster] = {}
+        derived_clusters: dict[str, XmlCluster] = {}
+        ids_by_name: dict[str, int] = {}
+        problems: list[ProblemNotice] = []
+        base_cluster_xml = ElementTree.fromstring(BASE_CLUSTER_XML_STR)
+        derived_cluster_xml = ElementTree.fromstring(DERIVED_CLUSTER_XML_STR)
+        expected_global_attrs = [GlobalAttributeIds.FEATURE_MAP_ID, GlobalAttributeIds.ATTRIBUTE_LIST_ID,
+                                 GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID, GlobalAttributeIds.GENERATED_COMMAND_LIST_ID, GlobalAttributeIds.CLUSTER_REVISION_ID]
+
+        add_cluster_data_from_xml(base_cluster_xml, clusters, derived_clusters, ids_by_name, problems)
+        add_cluster_data_from_xml(derived_cluster_xml, clusters, derived_clusters, ids_by_name, problems)
+
+        asserts.assert_equal(len(clusters), 1, "Unexpected number of clusters")
+        asserts.assert_equal(len(derived_clusters), 1, "Unexpected number of derived clusters")
+        asserts.assert_equal(len(ids_by_name), 1, "Unexpected number of IDs per name")
+        asserts.assert_equal(len(problems), 0, "Unexpected number of problems")
+        asserts.assert_equal(ids_by_name["Test Derived"], 0xFFFF, "Test derived name not added to IDs")
+
+        asserts.assert_true(0xFFFF in clusters, "Derived ID not found in clusters")
+        asserts.assert_equal(set(clusters[0xFFFF].attributes.keys()), set(
+            [0, 2, 3] + expected_global_attrs), "Unexpected attribute list")
+        asserts.assert_equal(set(clusters[0xFFFF].accepted_commands.keys()), set([]), "Unexpected accepted commands")
+        asserts.assert_equal(set(clusters[0xFFFF].generated_commands.keys()), set([]), "Unexpected generated commands")
+
+        asserts.assert_true("Test Base" in derived_clusters, "Base ID not found in derived clusters")
+        asserts.assert_equal(set(derived_clusters["Test Base"].attributes.keys()), set(
+            [0, 1, 2, 3] + expected_global_attrs), "Unexpected attribute list")
+        asserts.assert_equal(set(derived_clusters["Test Base"].accepted_commands.keys()), set([0]), "Unexpected accepted commands")
+        asserts.assert_equal(set(derived_clusters["Test Base"].generated_commands.keys()),
+                             set([1]), "Unexpected generated commands")
+
+        combine_derived_clusters_with_base(clusters, derived_clusters, ids_by_name)
+        # Ensure the base-only attribute (1) was added to the derived cluster
+        asserts.assert_equal(set(clusters[0xFFFF].attributes.keys()), set(
+            [0, 1, 2, 3] + expected_global_attrs), "Unexpected attribute list")
+        # Ensure the conformance overrides from the derived cluster are on the attributes
+        asserts.assert_equal(str(clusters[0xFFFF].attributes[0].conformance), "M", "Unexpected conformance on attribute 0")
+        asserts.assert_equal(str(clusters[0xFFFF].attributes[1].conformance), "M", "Unexpected conformance on attribute 0")
+        asserts.assert_equal(str(clusters[0xFFFF].attributes[2].conformance), "X", "Unexpected conformance on attribute 1")
+        asserts.assert_equal(str(clusters[0xFFFF].attributes[3].conformance), "X", "Unexpected conformance on attribute 1")
+
+    def test_missing_command_direction(self):
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Because derived clusters don't have markings for direction, it wasn't clear whether the commands were requests or responses. The code incorrectly fell through to assume requests. Instead, we need to mark commands with no direction marking specifically, and combine with the base commands using ID and name as the marker.

- moves parsing function out and adds a basic test with a base and derived cluster with overrides for attributes and commands in both directions
- adds a warning if commands make it through the spec parsing function with unresolved unknown direction clusters (with test)


sorry for the large diff. Most of the changes are just moves out to separate functions so the code pieces can be tested.
