### PR TITLE
[ESP32] Added a config option to set the permit list size for esp32 traces. 

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -966,6 +966,12 @@ menu "CHIP Device Layer"
            default n
            help
                This option enables the system statistics to be sent to the insights cloud.
+
+      config INSIGHTS_TRACE_PERMIT_LIST_SIZE
+           int "Config option to set permitlist size"
+           range 5 30
+           depends on ESP_INSIGHTS_ENABLED
+           default 20
     endmenu
 
 

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -967,11 +967,15 @@ menu "CHIP Device Layer"
            help
                This option enables the system statistics to be sent to the insights cloud.
 
-      config INSIGHTS_TRACE_PERMIT_LIST_SIZE
-           int "Config option to set permitlist size"
+      config MAX_PERMIT_LIST_SIZE
+           int "Set permit list size for Insights traces"
            range 5 30
            depends on ESP_INSIGHTS_ENABLED
            default 20
+           help
+               Maximum number of group entries that can be included in the permit list for reporting
+               the traces to insights.
+
     endmenu
 
 

--- a/src/tracing/esp32_trace/counter.h
+++ b/src/tracing/esp32_trace/counter.h
@@ -24,8 +24,7 @@
 
 namespace Insights {
 
-/*
- *
+/**
  * This class is used to monotonically increment the counters as per the label of the counter macro
  * 'MATTER_TRACE_COUNTER(label)' and report the metrics to esp-insights.
  * As per the label of the counter macro, it adds the counter in the linked list with the name label if not
@@ -37,7 +36,7 @@ class ESPInsightsCounter
 {
 private:
     static ESPInsightsCounter * mHead; // head of the counter list
-    const char * label;                // unique key
+    const char * label;                // unique key ,it is used as a static string.
     int instanceCount;
     ESPInsightsCounter * mNext; // pointer to point to the next entry in the list
     bool registered = false;

--- a/src/tracing/esp32_trace/esp32_tracing.cpp
+++ b/src/tracing/esp32_trace/esp32_tracing.cpp
@@ -32,7 +32,7 @@ namespace Tracing {
 namespace Insights {
 namespace {
 
-constexpr size_t kPermitListMaxSize = CONFIG_INSIGHTS_TRACE_PERMIT_LIST_SIZE;
+constexpr size_t kPermitListMaxSize = CONFIG_MAX_PERMIT_LIST_SIZE;
 using HashValue                     = uint32_t;
 
 // Implements a murmurhash with 0 seed.

--- a/src/tracing/esp32_trace/esp32_tracing.cpp
+++ b/src/tracing/esp32_trace/esp32_tracing.cpp
@@ -32,7 +32,7 @@ namespace Tracing {
 namespace Insights {
 namespace {
 
-constexpr size_t kPermitListMaxSize = 20;
+constexpr size_t kPermitListMaxSize = CONFIG_INSIGHTS_TRACE_PERMIT_LIST_SIZE;
 using HashValue                     = uint32_t;
 
 // Implements a murmurhash with 0 seed.


### PR DESCRIPTION
 **Problem**
  Issue [#31536](https://github.com/project-chip/connectedhomeip/issues/31536)

**Change Overview**
  Added the config option to set the permit list size for the esp32 traces.

**Testing**
  Tested successfully the esp32 lighting app with the change.



