### PR TITLE
[nrfconnect] Fix memory leak in Window Covering sample.

### DIFF
--- a/examples/window-app/nrfconnect/main/WindowCovering.cpp
+++ b/examples/window-app/nrfconnect/main/WindowCovering.cpp
@@ -343,4 +343,6 @@ void WindowCovering::DoPostAttributeChange(intptr_t aArg)
     VerifyOrReturn(data != nullptr);
 
     PostAttributeChange(data->mEndpoint, data->mAttributeId);
+
+    chip::Platform::Delete(data);
 }


### PR DESCRIPTION
We were leaking 8 bytes each time the new attribute change was reported by the WindowCovering Server. It was resulting in running out of heap when stressing the device (by sending multiple up-or-open/down-or-close commands).
