### PR TITLE
Use `include-what-you-use` on lib/core

### DIFF
--- a/iwyu.imp
+++ b/iwyu.imp
@@ -1,0 +1,21 @@
+# General IWYU command example:
+#
+# iwyu_tool.py                                                  \
+#    -p out/linux-x64-all-clusters-clang/compile_commands.json  \
+#    --mapping_file iwyu.imp                                    \
+#    src/lib/core/                                              \
+#    --                                                         \
+#    -Xiwyu --no_comments                                       \
+#    -Xiwyu --comment_style=none                                \
+#    -Xiwyu --cxx17ns                                           \
+#    -Xiwyu no_fwd_decls                                        \
+#  | tee out/iwyu.out
+#
+# cd out/linux-x64-all-clusters-clang
+#
+# fix_includes.py <../iwyu.out
+#
+[
+    { include: [ '"system/SystemBuildConfig"', private, '<system/SystemConfig.h>', public ] },
+    { include: [ '"core/CHIPBuildConfig"', private, '<lib/core/BuildConfig.h>', public ] },
+]

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -4,7 +4,7 @@
 #    -p out/linux-x64-all-clusters-clang/compile_commands.json  \
 #    src/lib/core/                                              \
 #    --                                                         \
-#    -Xiwyu --mapping_file=iwyu.imp                             \
+#    -Xiwyu --mapping_file=$(pwd)/iwyu.imp                      \
 #    -Xiwyu --no_comments                                       \
 #    -Xiwyu --comment_style=none                                \
 #    -Xiwyu --cxx17ns                                           \
@@ -16,6 +16,7 @@
 # fix_includes.py <../iwyu.out
 #
 [
-    { include: [ '"system/SystemBuildConfig"', private, '<system/SystemConfig.h>', public ] },
-    { include: [ '"core/CHIPBuildConfig"', private, '<lib/core/BuildConfig.h>', public ] },
+    { include: [ '"system/SystemBuildConfig.h"', private, '<system/SystemConfig.h>', public ] },
+    { include: [ '"core/CHIPBuildConfig.h"', private, '<lib/core/BuildConfig.h>', public ] },
+    { include: [ '@"platform/.*/CHIPPlatformConfig.h"', private, '<lib/core/BuildConfig.h>', public ] },
 ]

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -17,6 +17,6 @@
 #
 [
     { include: [ '"system/SystemBuildConfig.h"', private, '<system/SystemConfig.h>', public ] },
-    { include: [ '"core/CHIPBuildConfig.h"', private, '<lib/core/BuildConfig.h>', public ] },
-    { include: [ '@"platform/.*/CHIPPlatformConfig.h"', private, '<lib/core/BuildConfig.h>', public ] },
+    { include: [ '"core/CHIPBuildConfig.h"', private, '<lib/core/CHIPConfig.h>', public ] },
+    { include: [ '@"platform/.*/CHIPPlatformConfig.h"', private, '<lib/core/CHIPConfig.h>', public ] },
 ]

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -2,9 +2,9 @@
 #
 # iwyu_tool.py                                                  \
 #    -p out/linux-x64-all-clusters-clang/compile_commands.json  \
-#    --mapping_file iwyu.imp                                    \
 #    src/lib/core/                                              \
 #    --                                                         \
+#    -Xiwyu --mapping_file=iwyu.imp                             \
 #    -Xiwyu --no_comments                                       \
 #    -Xiwyu --comment_style=none                                \
 #    -Xiwyu --cxx17ns                                           \

--- a/src/lib/core/CHIPError.cpp
+++ b/src/lib/core/CHIPError.cpp
@@ -21,10 +21,12 @@
  *      This file contains functions for working with CHIP errors.
  */
 
-#include <stddef.h>
+#include <lib/core/ErrorStr.h>
+
+#include <stdint.h>
 
 #include <lib/core/CHIPConfig.h>
-#include <lib/core/ErrorStr.h>
+#include <lib/core/CHIPError.h>
 
 namespace chip {
 

--- a/src/lib/core/CHIPError.cpp
+++ b/src/lib/core/CHIPError.cpp
@@ -17,8 +17,6 @@
  */
 #include <lib/core/CHIPError.h>
 
-#include <stdint.h>
-
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/ErrorStr.h>
 

--- a/src/lib/core/CHIPError.cpp
+++ b/src/lib/core/CHIPError.cpp
@@ -15,18 +15,12 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- *    @file
- *      This file contains functions for working with CHIP errors.
- */
-
-#include <lib/core/ErrorStr.h>
+#include <lib/core/CHIPError.h>
 
 #include <stdint.h>
 
 #include <lib/core/CHIPConfig.h>
-#include <lib/core/CHIPError.h>
+#include <lib/core/ErrorStr.h>
 
 namespace chip {
 

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -33,7 +33,6 @@
 
 #include <inttypes.h>
 #include <limits>
-#include <stdint.h>
 #include <type_traits>
 
 namespace chip {

--- a/src/lib/core/CHIPKeyIds.cpp
+++ b/src/lib/core/CHIPKeyIds.cpp
@@ -15,15 +15,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <lib/core/CHIPKeyIds.h>
 
-/**
- *    @file
- *      This file implements CHIP key types helper functions.
- *
- */
-#include "CHIPKeyIds.h"
-
-#include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
 
 namespace chip {

--- a/src/lib/core/CHIPKeyIds.h
+++ b/src/lib/core/CHIPKeyIds.h
@@ -22,10 +22,8 @@
  *      key flags, key ID fields, and helper API functions.
  *
  */
-
 #pragma once
 
-#include <limits.h>
 #include <stdint.h>
 
 namespace chip {

--- a/src/lib/core/ErrorStr.cpp
+++ b/src/lib/core/ErrorStr.cpp
@@ -15,25 +15,18 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- *    @file
- *      This file implements functions to translate error codes used
- *      throughout the CHIP package into human-readable strings.
- *
- */
+#include <lib/core/ErrorStr.h>
 
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
 
-#include <inttypes.h>
-#include <stdio.h>
-
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPError.h>
-#include <lib/core/ErrorStr.h>
 #include <lib/support/DLLUtil.h>
+
+#include <inttypes.h>
+#include <stdio.h>
 
 namespace chip {
 

--- a/src/lib/core/ErrorStr.cpp
+++ b/src/lib/core/ErrorStr.cpp
@@ -31,7 +31,9 @@
 #include <stdio.h>
 
 #include <lib/core/CHIPConfig.h>
+#include <lib/core/CHIPError.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/support/DLLUtil.h>
 
 namespace chip {
 

--- a/src/lib/core/ErrorStr.h
+++ b/src/lib/core/ErrorStr.h
@@ -28,7 +28,6 @@
 #include <stdint.h>
 
 #include <lib/core/CHIPError.h>
-#include <lib/support/DLLUtil.h>
 
 namespace chip {
 

--- a/src/lib/core/OTAImageHeader.cpp
+++ b/src/lib/core/OTAImageHeader.cpp
@@ -14,19 +14,19 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 #include <lib/core/OTAImageHeader.h>
 
-#include <lib/support/BufferReader.h>
-#include <lib/support/CodeUtils.h>
-#include <string.h>
-
+#include <lib/core/CHIPError.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLVReader.h>
 #include <lib/core/TLVTags.h>
 #include <lib/core/TLVTypes.h>
+#include <lib/support/BufferReader.h>
+#include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/Span.h>
+
+#include <string.h>
 
 namespace chip {
 

--- a/src/lib/core/OTAImageHeader.cpp
+++ b/src/lib/core/OTAImageHeader.cpp
@@ -15,11 +15,18 @@
  *    limitations under the License.
  */
 
-#include "OTAImageHeader.h"
+#include <lib/core/OTAImageHeader.h>
 
-#include <lib/core/TLV.h>
 #include <lib/support/BufferReader.h>
 #include <lib/support/CodeUtils.h>
+#include <string.h>
+
+#include <lib/core/Optional.h>
+#include <lib/core/TLVReader.h>
+#include <lib/core/TLVTags.h>
+#include <lib/core/TLVTypes.h>
+#include <lib/support/ScopedBuffer.h>
+#include <lib/support/Span.h>
 
 namespace chip {
 

--- a/src/lib/core/OTAImageHeader.h
+++ b/src/lib/core/OTAImageHeader.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <lib/core/CHIPError.h>
 #include <lib/core/Optional.h>
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/Span.h>

--- a/src/lib/core/TLVCircularBuffer.cpp
+++ b/src/lib/core/TLVCircularBuffer.cpp
@@ -26,13 +26,13 @@
  *      to continually add top-level TLV elements by evicting
  *      pre-existing elements.
  */
+#include <lib/core/TLVCircularBuffer.h>
 
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif
 
 #include <lib/core/CHIPError.h>
-#include <lib/core/TLVCircularBuffer.h>
 #include <lib/core/TLVTags.h>
 #include <lib/support/BufferWriter.h>
 #include <lib/support/CodeUtils.h>

--- a/src/lib/core/TLVCircularBuffer.cpp
+++ b/src/lib/core/TLVCircularBuffer.cpp
@@ -30,12 +30,11 @@
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif
+
+#include <lib/core/CHIPError.h>
 #include <lib/core/TLVCircularBuffer.h>
-
-#include <lib/core/CHIPCore.h>
-#include <lib/core/CHIPEncoding.h>
-#include <lib/core/TLV.h>
-
+#include <lib/core/TLVTags.h>
+#include <lib/support/BufferWriter.h>
 #include <lib/support/CodeUtils.h>
 
 #include <stdint.h>

--- a/src/lib/core/TLVCircularBuffer.cpp
+++ b/src/lib/core/TLVCircularBuffer.cpp
@@ -33,7 +33,9 @@
 #endif
 
 #include <lib/core/CHIPError.h>
+#include <lib/core/TLVReader.h>
 #include <lib/core/TLVTags.h>
+#include <lib/core/TLVWriter.h>
 #include <lib/support/BufferWriter.h>
 #include <lib/support/CodeUtils.h>
 

--- a/src/lib/core/TLVCircularBuffer.h
+++ b/src/lib/core/TLVCircularBuffer.h
@@ -31,11 +31,14 @@
 
 #include <lib/core/CHIPError.h>
 #include <lib/core/TLV.h>
+#include <lib/core/TLVBackingStore.h>
+#include <lib/core/TLVReader.h>
 #include <lib/core/TLVTags.h>
 #include <lib/core/TLVTypes.h>
-
+#include <lib/core/TLVWriter.h>
 #include <lib/support/DLLUtil.h>
 
+#include <stdint.h>
 #include <stdlib.h>
 
 namespace chip {

--- a/src/lib/core/TLVCircularBuffer.h
+++ b/src/lib/core/TLVCircularBuffer.h
@@ -30,11 +30,8 @@
 #pragma once
 
 #include <lib/core/CHIPError.h>
-#include <lib/core/TLV.h>
 #include <lib/core/TLVBackingStore.h>
 #include <lib/core/TLVReader.h>
-#include <lib/core/TLVTags.h>
-#include <lib/core/TLVTypes.h>
 #include <lib/core/TLVWriter.h>
 #include <lib/support/DLLUtil.h>
 

--- a/src/lib/core/TLVDebug.cpp
+++ b/src/lib/core/TLVDebug.cpp
@@ -27,6 +27,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/TLVReader.h>
 #include <lib/core/TLVTags.h>
+#include <lib/core/TLVTypes.h>
 #include <lib/core/TLVUtilities.h>
 #include <lib/support/CodeUtils.h>
 

--- a/src/lib/core/TLVDebug.cpp
+++ b/src/lib/core/TLVDebug.cpp
@@ -15,27 +15,20 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- *    @file
- *      This file implements interfaces for debugging and logging
- *      CHIP TLV.
- *
- */
+#include <lib/core/TLVDebug.h>
 
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
 
-#include <ctype.h>
 #include <inttypes.h>
-#include <string.h>
+#include <stdint.h>
 
-#include <lib/core/TLV.h>
-#include <lib/core/TLVDebug.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/TLVReader.h>
+#include <lib/core/TLVTags.h>
 #include <lib/core/TLVUtilities.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/logging/CHIPLogging.h>
 
 namespace chip {
 

--- a/src/lib/core/TLVDebug.cpp
+++ b/src/lib/core/TLVDebug.cpp
@@ -22,7 +22,6 @@
 #endif
 
 #include <inttypes.h>
-#include <stdint.h>
 
 #include <lib/core/CHIPError.h>
 #include <lib/core/TLVReader.h>

--- a/src/lib/core/TLVDebug.h
+++ b/src/lib/core/TLVDebug.h
@@ -20,9 +20,9 @@
 #include <stddef.h>
 
 #include <lib/core/CHIPError.h>
-#include <lib/core/TLVTypes.h>
-#include <lib/core/TLVTags.h>
 #include <lib/core/TLVReader.h>
+#include <lib/core/TLVTags.h>
+#include <lib/core/TLVTypes.h>
 
 namespace chip {
 namespace TLV {

--- a/src/lib/core/TLVDebug.h
+++ b/src/lib/core/TLVDebug.h
@@ -18,11 +18,11 @@
 #pragma once
 
 #include <stddef.h>
-#include <stdint.h>
 
 #include <lib/core/CHIPError.h>
-#include <lib/core/TLV.h>
 #include <lib/core/TLVTypes.h>
+#include <lib/core/TLVTags.h>
+#include <lib/core/TLVReader.h>
 
 namespace chip {
 namespace TLV {

--- a/src/lib/core/TLVDebug.h
+++ b/src/lib/core/TLVDebug.h
@@ -25,10 +25,7 @@
 #include <lib/core/TLVTypes.h>
 
 namespace chip {
-
 namespace TLV {
-class TLVReader;
-enum class TLVTagControl : uint8_t;
 
 /**
  *   @namespace chip::TLV::Debug

--- a/src/lib/core/TLVDebug.h
+++ b/src/lib/core/TLVDebug.h
@@ -15,14 +15,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- *    @file
- *      This file defines types and interfaces for debugging and
- *      logging CHIP TLV.
- *
- */
-
 #pragma once
 
 #include <stddef.h>
@@ -30,10 +22,13 @@
 
 #include <lib/core/CHIPError.h>
 #include <lib/core/TLV.h>
+#include <lib/core/TLVTypes.h>
 
 namespace chip {
 
 namespace TLV {
+class TLVReader;
+enum class TLVTagControl : uint8_t;
 
 /**
  *   @namespace chip::TLV::Debug

--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -39,6 +39,10 @@
 #include <lib/support/Span.h>
 #include <lib/support/logging/TextOnlyLogging.h>
 
+#if CHIP_CONFIG_TLV_VALIDATE_CHAR_STRING_ON_READ
+#include <lib/support/utf8.h>
+#endif
+
 namespace chip {
 namespace TLV {
 

--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -15,6 +15,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <lib/core/TLVReader.h>
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -27,7 +29,6 @@
 #include <lib/core/Optional.h>
 #include <lib/core/TLVBackingStore.h>
 #include <lib/core/TLVCommon.h>
-#include <lib/core/TLVReader.h>
 #include <lib/core/TLVTags.h>
 #include <lib/core/TLVTypes.h>
 #include <lib/support/BufferWriter.h>

--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -15,24 +15,28 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- *    @file
- *      This file implements a parser for the CHIP TLV (Tag-Length-Value) encoding format.
- *
- */
-
+#include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPEncoding.h>
+#include <lib/core/CHIPError.h>
 #include <lib/core/CHIPSafeCasts.h>
-#include <lib/core/TLV.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/core/Optional.h>
+#include <lib/core/TLVBackingStore.h>
+#include <lib/core/TLVCommon.h>
+#include <lib/core/TLVReader.h>
+#include <lib/core/TLVTags.h>
+#include <lib/core/TLVTypes.h>
+#include <lib/support/BufferWriter.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
-#include <lib/support/utf8.h>
+#include <lib/support/Span.h>
+#include <lib/support/logging/TextOnlyLogging.h>
 
 namespace chip {
 namespace TLV {

--- a/src/lib/core/TLVReader.cpp
+++ b/src/lib/core/TLVReader.cpp
@@ -18,7 +18,6 @@
 #include <lib/core/TLVReader.h>
 
 #include <stdint.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include <lib/core/CHIPConfig.h>

--- a/src/lib/core/TLVReader.h
+++ b/src/lib/core/TLVReader.h
@@ -34,10 +34,9 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
-#include <lib/core/TLVCommon.h>
+#include <lib/core/TLVBackingStore.h>
 #include <lib/core/TLVTags.h>
 #include <lib/core/TLVTypes.h>
-#include <lib/core/TLVWriter.h>
 #include <lib/support/BitFlags.h>
 #include <lib/support/BitMask.h>
 #include <lib/support/CodeUtils.h>

--- a/src/lib/core/TLVReader.h
+++ b/src/lib/core/TLVReader.h
@@ -24,14 +24,26 @@
  *      shares many properties with the commonly used JSON serialization format while being considerably
  *      more compact over the wire.
  */
-
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+#include <type_traits>
+#include <utility>
+
+#include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
-
-#include "TLVCommon.h"
-#include "TLVWriter.h"
+#include <lib/core/TLVCommon.h>
+#include <lib/core/TLVTags.h>
+#include <lib/core/TLVTypes.h>
+#include <lib/core/TLVWriter.h>
+#include <lib/support/BitFlags.h>
+#include <lib/support/BitMask.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/DLLUtil.h>
+#include <lib/support/ScopedBuffer.h>
+#include <lib/support/Span.h>
 
 /**
  * @namespace chip::TLV

--- a/src/lib/core/TLVTags.cpp
+++ b/src/lib/core/TLVTags.cpp
@@ -15,7 +15,12 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "TLVTags.h"
+#include <lib/core/TLVTags.h>
+
+#include <inttypes.h>
+
+#include <lib/support/StringBuilder.h>
+#include <lib/support/logging/TextOnlyLogging.h>
 
 namespace chip {
 namespace TLV {

--- a/src/lib/core/TLVTags.h
+++ b/src/lib/core/TLVTags.h
@@ -15,21 +15,17 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- *    @file
- *      This file contains definitions for working with CHIP TLV tags.
- *
- */
-
 #pragma once
 
-#include <cstdint>
 #include <lib/support/StringBuilder.h>
 #include <lib/support/TypeTraits.h>
+
+#include <cstdint>
 #include <type_traits>
 
 namespace chip {
+class StringBuilderBase;
+
 namespace TLV {
 
 class Tag

--- a/src/lib/core/TLVTags.h
+++ b/src/lib/core/TLVTags.h
@@ -24,8 +24,6 @@
 #include <type_traits>
 
 namespace chip {
-class StringBuilderBase;
-
 namespace TLV {
 
 class Tag

--- a/src/lib/core/TLVUpdater.cpp
+++ b/src/lib/core/TLVUpdater.cpp
@@ -15,18 +15,21 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <stdint.h>
+#include <string.h>
 
-/**
- *    @file
- *      This file implements an updating encoder for the CHIP TLV
- *      (Tag-Length-Value) encoding format.
- *
- */
-
-#include <lib/core/CHIPCore.h>
-#include <lib/core/CHIPEncoding.h>
-#include <lib/core/TLV.h>
+#include <lib/core/CHIPConfig.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/TLVCommon.h>
+#include <lib/core/TLVReader.h>
+#include <lib/core/TLVTags.h>
+#include <lib/core/TLVTypes.h>
+#include <lib/core/TLVUpdater.h>
+#include <lib/core/TLVWriter.h>
+#include <lib/support/BufferWriter.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/logging/Constants.h>
+#include <lib/support/logging/TextOnlyLogging.h>
 
 namespace chip {
 namespace TLV {

--- a/src/lib/core/TLVUpdater.cpp
+++ b/src/lib/core/TLVUpdater.cpp
@@ -15,6 +15,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <lib/core/TLVUpdater.h>
+
 #include <stdint.h>
 #include <string.h>
 
@@ -24,7 +26,6 @@
 #include <lib/core/TLVReader.h>
 #include <lib/core/TLVTags.h>
 #include <lib/core/TLVTypes.h>
-#include <lib/core/TLVUpdater.h>
 #include <lib/core/TLVWriter.h>
 #include <lib/support/BufferWriter.h>
 #include <lib/support/CodeUtils.h>

--- a/src/lib/core/TLVUpdater.h
+++ b/src/lib/core/TLVUpdater.h
@@ -20,7 +20,6 @@
 #include <stdint.h>
 
 #include <lib/core/CHIPError.h>
-#include <lib/core/TLVCommon.h>
 #include <lib/core/TLVReader.h>
 #include <lib/core/TLVTags.h>
 #include <lib/core/TLVTypes.h>

--- a/src/lib/core/TLVUpdater.h
+++ b/src/lib/core/TLVUpdater.h
@@ -15,22 +15,18 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- *    @file
- *      This file contains definitions for working with data encoded in CHIP TLV format.
- *
- *      CHIP TLV (Tag-Length-Value) is a generalized encoding method for simple structured data. It
- *      shares many properties with the commonly used JSON serialization format while being considerably
- *      more compact over the wire.
- */
-
 #pragma once
 
-#include "TLVCommon.h"
+#include <stdint.h>
 
-#include "TLVReader.h"
-#include "TLVWriter.h"
+#include <lib/core/CHIPError.h>
+#include <lib/core/TLVCommon.h>
+#include <lib/core/TLVReader.h>
+#include <lib/core/TLVTags.h>
+#include <lib/core/TLVTypes.h>
+#include <lib/core/TLVWriter.h>
+#include <lib/support/DLLUtil.h>
+#include <lib/support/Span.h>
 
 /**
  * @namespace chip::TLV

--- a/src/lib/core/TLVUtilities.cpp
+++ b/src/lib/core/TLVUtilities.cpp
@@ -23,8 +23,12 @@
  *
  */
 
-#include <lib/core/TLVDebug.h>
 #include <lib/core/TLVUtilities.h>
+
+#include <lib/core/CHIPError.h>
+#include <lib/core/TLVReader.h>
+#include <lib/core/TLVTags.h>
+#include <lib/core/TLVTypes.h>
 #include <lib/support/CodeUtils.h>
 
 namespace chip {

--- a/src/lib/core/TLVUtilities.h
+++ b/src/lib/core/TLVUtilities.h
@@ -25,11 +25,10 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
-
 #include <lib/core/CHIPError.h>
 #include <lib/core/TLV.h>
+#include <stddef.h>
+#include <stdint.h>
 
 namespace chip {
 

--- a/src/lib/core/TLVUtilities.h
+++ b/src/lib/core/TLVUtilities.h
@@ -15,20 +15,11 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- *    @file
- *      This file specifies types and utility interfaces for managing and
- *      working with CHIP TLV.
- *
- */
-
 #pragma once
 
 #include <lib/core/CHIPError.h>
-#include <lib/core/TLV.h>
+
 #include <stddef.h>
-#include <stdint.h>
 
 namespace chip {
 

--- a/src/lib/core/TLVUtilities.h
+++ b/src/lib/core/TLVUtilities.h
@@ -19,6 +19,8 @@
 
 #include <lib/core/CHIPError.h>
 
+#include <lib/core/TLVReader.h>
+
 #include <stddef.h>
 
 namespace chip {

--- a/src/lib/core/TLVUtilities.h
+++ b/src/lib/core/TLVUtilities.h
@@ -20,6 +20,7 @@
 #include <lib/core/CHIPError.h>
 
 #include <lib/core/TLVReader.h>
+#include <lib/core/TLVTags.h>
 
 #include <stddef.h>
 

--- a/src/lib/core/TLVWriter.cpp
+++ b/src/lib/core/TLVWriter.cpp
@@ -15,29 +15,34 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- *    @file
- *      This file implements an encoder for the CHIP TLV (Tag-Length-Value) encoding format.
- *
- */
+#include <lib/core/TLVWriter.h>
 
 #ifndef __STDC_LIMIT_MACROS
 #define __STDC_LIMIT_MACROS
 #endif
-#include <lib/core/TLV.h>
-
-#include <lib/core/CHIPCore.h>
-#include <lib/core/CHIPEncoding.h>
-
-#include <lib/support/CHIPMem.h>
-#include <lib/support/CodeUtils.h>
-#include <lib/support/SafeInt.h>
-#include <lib/support/utf8.h>
 
 #include <stdarg.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
+
+#include <lib/core/CHIPConfig.h>
+#include <lib/core/CHIPEncoding.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/TLVBackingStore.h>
+#include <lib/core/TLVCommon.h>
+#include <lib/core/TLVReader.h>
+#include <lib/core/TLVTags.h>
+#include <lib/core/TLVTypes.h>
+#include <lib/support/BufferWriter.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/SafeInt.h>
+#include <lib/support/Span.h>
+#include <lib/support/logging/Constants.h>
+#include <lib/support/logging/TextOnlyLogging.h>
+#include <lib/support/utf8.h>
+#include <system/SystemConfig.h>
 
 // Doxygen is confused by the __attribute__ annotation
 #ifndef DOXYGEN

--- a/src/lib/core/TLVWriter.h
+++ b/src/lib/core/TLVWriter.h
@@ -33,8 +33,6 @@
 #include <utility>
 
 #include <lib/core/CHIPError.h>
-#include <lib/core/TLVBackingStore.h>
-#include <lib/core/TLVCommon.h>
 #include <lib/core/TLVReader.h>
 #include <lib/core/TLVTags.h>
 #include <lib/core/TLVTypes.h>

--- a/src/lib/core/TLVWriter.h
+++ b/src/lib/core/TLVWriter.h
@@ -27,12 +27,26 @@
 
 #pragma once
 
+#include <cstdio>
+#include <stdint.h>
+#include <type_traits>
+#include <utility>
+
+#include <lib/core/CHIPError.h>
+#include <lib/core/TLVBackingStore.h>
+#include <lib/core/TLVCommon.h>
+#include <lib/core/TLVReader.h>
 #include <lib/core/TLVTags.h>
-
-#include "TLVCommon.h"
-
-#include "TLVBackingStore.h"
-#include "TLVReader.h"
+#include <lib/core/TLVTypes.h>
+#include <lib/support/BitFlags.h>
+#include <lib/support/BitMask.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/DLLUtil.h>
+#include <lib/support/EnforceFormat.h>
+#include <lib/support/ScopedBuffer.h>
+#include <lib/support/Span.h>
+#include <lib/support/TypeTraits.h>
+#include <system/SystemConfig.h>
 
 /**
  * @namespace chip::TLV

--- a/src/platform/Ameba/Logging.cpp
+++ b/src/platform/Ameba/Logging.cpp
@@ -24,7 +24,7 @@
 /* this file behaves like a config.h, comes first */
 #include <platform/logging/LogV.h>
 
-#include <lib/core/CHIPConfig.h>
+#include <core/CHIPConfig.h>
 #include <support/TypeTraits.h>
 #include <support/logging/Constants.h>
 

--- a/src/platform/Ameba/Logging.cpp
+++ b/src/platform/Ameba/Logging.cpp
@@ -24,7 +24,7 @@
 /* this file behaves like a config.h, comes first */
 #include <platform/logging/LogV.h>
 
-#include <core/CHIPConfig.h>
+#include <lib/core/CHIPConfig.h>
 #include <support/TypeTraits.h>
 #include <support/logging/Constants.h>
 

--- a/src/platform/Beken/Logging.cpp
+++ b/src/platform/Beken/Logging.cpp
@@ -24,7 +24,7 @@
 /* this file behaves like a config.h, comes first */
 #include <platform/logging/LogV.h>
 
-#include <lib/core/CHIPConfig.h>
+#include <core/CHIPConfig.h>
 #include <support/logging/Constants.h>
 
 #include <stdio.h>

--- a/src/platform/Beken/Logging.cpp
+++ b/src/platform/Beken/Logging.cpp
@@ -24,7 +24,7 @@
 /* this file behaves like a config.h, comes first */
 #include <platform/logging/LogV.h>
 
-#include <core/CHIPConfig.h>
+#include <lib/core/CHIPConfig.h>
 #include <support/logging/Constants.h>
 
 #include <stdio.h>


### PR DESCRIPTION
### Changes:

ran:

```
iwyu_tool.py \
    -p out/linux-x64-all-clusters-clang/compile_commands.json  \
    src/lib/core/ \
    -- \
    -Xiwyu --no_comments \
    -Xiwyu --comment_style=none \
    -Xiwyu --cxx17ns  \
    -Xiwyu no_fwd_decls \
  | tee out/iwyu.out

cd out/linux-x64-all-clusters-clang

fix_includes.py <../iwyu.out 
```

After this I had to make some fixes:
  - IWYU for some reason added some extra forward declares which I removed (this may need eventual fixing...)
  - fixed SystemBuildConfig and CHIPBuildConfig includes since those are private. Moved them to SystemConfig/CHIPConfig instead
  - re-arranged some of the includes to split system and chip includes as well as removed some redundant `@file` comments.
  
### Testing

Compile should succeed.