### PR TITLE
Add some more progress-style logging to Darwin server endpoints.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -983,9 +983,12 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
     [self asyncDispatchToMatterQueue:^() {
         [self->_serverEndpoints addObject:endpoint];
         [endpoint registerMatterEndpoint];
+        MTR_LOG_DEFAULT("Added server endpoint %u to controller %@", static_cast<chip::EndpointId>(endpoint.endpointID.unsignedLongLongValue),
+            self->_uniqueIdentifier);
     }
         errorHandler:^(NSError * error) {
-            MTR_LOG_ERROR("Unexpected failure dispatching to Matter queue on running controller in addServerEndpoint");
+            MTR_LOG_ERROR("Unexpected failure dispatching to Matter queue on running controller in addServerEndpoint, adding endpoint %u",
+                static_cast<chip::EndpointId>(endpoint.endpointID.unsignedLongLongValue));
         }];
     return YES;
 }
@@ -1008,12 +1011,16 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
     // tearing it down.
     [self asyncDispatchToMatterQueue:^() {
         [self removeServerEndpointOnMatterQueue:endpoint];
+        MTR_LOG_DEFAULT("Removed server endpoint %u from controller %@", static_cast<chip::EndpointId>(endpoint.endpointID.unsignedLongLongValue),
+            self->_uniqueIdentifier);
         if (queue != nil && completion != nil) {
             dispatch_async(queue, completion);
         }
     }
         errorHandler:^(NSError * error) {
             // Error means we got shut down, so the endpoint is removed now.
+            MTR_LOG_DEFAULT("controller %@ already shut down, so endpoint %u has already been removed", self->_uniqueIdentifier,
+                static_cast<chip::EndpointId>(endpoint.endpointID.unsignedLongLongValue));
             if (queue != nil && completion != nil) {
                 dispatch_async(queue, completion);
             }

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAttribute.mm
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAttribute.mm
@@ -137,6 +137,8 @@ MTR_DIRECT_MEMBERS
 
     _value = [value copy];
 
+    MTR_LOG_DEFAULT("Attribute value updated: %@", self); // Logs new as part of our description.
+
     MTRDeviceController * deviceController = _deviceController;
     if (deviceController == nil) {
         // We're not bound to a controller, so safe to directly update
@@ -183,6 +185,8 @@ MTR_DIRECT_MEMBERS
 
     _deviceController = controller;
 
+    MTR_LOG_DEFAULT("Associated %@ with controller", self);
+
     return YES;
 }
 
@@ -216,6 +220,11 @@ MTR_DIRECT_MEMBERS
 {
     std::lock_guard lock(_lock);
     return _parentCluster;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MTRServerAttribute endpoint %u, cluster " ChipLogFormatMEI ", id " ChipLogFormatMEI ", value '%@'>", static_cast<EndpointId>(_parentCluster.mEndpointId), ChipLogValueMEI(_parentCluster.mClusterId), ChipLogValueMEI(_attributeID.unsignedLongLongValue), _value];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.mm
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.mm
@@ -313,6 +313,9 @@ static constexpr EmberAfAttributeMetadata sDescriptorAttributesMetadata[] = {
 
     _deviceController = controller;
 
+    MTR_LOG_DEFAULT("Associated %@, attribute count %llu, with controller", self,
+        static_cast<unsigned long long>(attributeCount));
+
     return YES;
 }
 
@@ -406,6 +409,12 @@ static constexpr EmberAfAttributeMetadata sDescriptorAttributesMetadata[] = {
     }
     matterCommandList[commandList.count] = kInvalidClusterId;
     return matterCommandList;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MTRServerCluster endpoint %u, id " ChipLogFormatMEI ">",
+                     _parentEndpoint, ChipLogValueMEI(_clusterID.unsignedLongLongValue)];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint.mm
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint.mm
@@ -317,6 +317,9 @@ static constexpr EmberAfAttributeMetadata sDescriptorAttributesMetadata[] = {
 
     _deviceController = controller;
 
+    MTR_LOG_DEFAULT("Associated %@, cluster count %llu, with controller",
+        self, static_cast<unsigned long long>(clusterCount));
+
     return YES;
 }
 
@@ -413,6 +416,11 @@ static constexpr EmberAfAttributeMetadata sDescriptorAttributesMetadata[] = {
 - (NSArray<MTRServerCluster *> *)serverClusters
 {
     return [_serverClusters copy];
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MTRServerEndpoint id %u>", static_cast<EndpointId>(_endpointID.unsignedLongLongValue)];
 }
 
 @end


### PR DESCRIPTION
Lets us track when endpoints/clusters/attributes are set up and attribute values changed.
