### PR TITLE
[Tizen] Shink scope of `capi-system-peripheral-io` dep

### DIFF
--- a/config/tizen/chip-gn/platform/BUILD.gn
+++ b/config/tizen/chip-gn/platform/BUILD.gn
@@ -20,10 +20,6 @@ import("${chip_root}/config/tizen/chip-gn/args.gni")
 import("${build_root}/config/linux/pkg_config.gni")
 import("${chip_root}/src/platform/device.gni")
 
-pkg_config("capi-system-peripheral-io") {
-  packages = [ "capi-system-peripheral-io" ]
-}
-
 pkg_config("dlog") {
   packages = [ "dlog" ]
 }
@@ -73,7 +69,6 @@ source_set("tizen") {
     ":glib",
     ":capi-appfw-preference",
     ":capi-system-info",
-    ":capi-system-peripheral-io",
   ]
 
   if (chip_mdns == "platform") {

--- a/examples/lighting-app/tizen/BUILD.gn
+++ b/examples/lighting-app/tizen/BUILD.gn
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 import("//build_overrides/tizen.gni")
 
+import("${build_root}/config/linux/pkg_config.gni")
 import("${chip_root}/build/chip/linux/gdbus_library.gni")
 import("${chip_root}/build/chip/tools.gni")
 import("${chip_root}/src/app/common_flags.gni")
@@ -25,6 +27,10 @@ assert(chip_build_tools)
 declare_args() {
   # Enable D-Bus based UI functionality for example app
   chip_examples_enable_ui = false
+}
+
+pkg_config("capi-system-peripheral-io") {
+  packages = [ "capi-system-peripheral-io" ]
 }
 
 gdbus_library("chip-lighting-app-manager") {
@@ -49,6 +55,8 @@ executable("chip-lighting-app") {
     "${chip_root}/examples/platform/tizen:app-main",
     "${chip_root}/src/lib",
   ]
+
+  configs += [ ":capi-system-peripheral-io" ]
 
   if (chip_examples_enable_ui) {
     sources += [ "src/DBusInterface.cpp" ]


### PR DESCRIPTION
The addition of `capi-system-peripheral-io` places a hard requirement to use the Tizen 7.0 SDK, which wasn't the case before. The new dependency is only applicable to one example application, and so by reducing the scope of the dependency we remove the 7.0 SDK requirement for other consumers.

Tested by building targets `tizen-arm-light` and `tizen-arm-all-clusters` with the `chip-build-tizen` container.