### PR TITLE
TC-IDM-10.1: Support write-only attributes

### DIFF
--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -153,7 +153,7 @@ PyChipError pychip_DeviceController_EstablishPASESessionIP(chip::Controller::Dev
                                                            uint32_t setupPINCode, chip::NodeId nodeid, uint16_t port);
 PyChipError pychip_DeviceController_EstablishPASESessionBLE(chip::Controller::DeviceCommissioner * devCtrl, uint32_t setupPINCode,
                                                             uint16_t discriminator, chip::NodeId nodeid);
-PyChipError pychip_DeviceController_EstablishPASESession(chip::Controller::DeviceCommissioner * devCtrl, const char* setUpCode,
+PyChipError pychip_DeviceController_EstablishPASESession(chip::Controller::DeviceCommissioner * devCtrl, const char * setUpCode,
                                                          chip::NodeId nodeid);
 PyChipError pychip_DeviceController_Commission(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid);
 
@@ -622,8 +622,9 @@ PyChipError pychip_DeviceController_EstablishPASESessionBLE(chip::Controller::De
     return ToPyChipError(devCtrl->EstablishPASEConnection(nodeid, params));
 }
 
-PyChipError pychip_DeviceController_EstablishPASESession(chip::Controller::DeviceCommissioner * devCtrl, const char* setUpCode,
-                                                         chip::NodeId nodeid) {
+PyChipError pychip_DeviceController_EstablishPASESession(chip::Controller::DeviceCommissioner * devCtrl, const char * setUpCode,
+                                                         chip::NodeId nodeid)
+{
     sPairingDelegate.SetExpectingPairingComplete(true);
     return ToPyChipError(devCtrl->EstablishPASEConnection(nodeid, setUpCode));
 }

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -153,6 +153,8 @@ PyChipError pychip_DeviceController_EstablishPASESessionIP(chip::Controller::Dev
                                                            uint32_t setupPINCode, chip::NodeId nodeid, uint16_t port);
 PyChipError pychip_DeviceController_EstablishPASESessionBLE(chip::Controller::DeviceCommissioner * devCtrl, uint32_t setupPINCode,
                                                             uint16_t discriminator, chip::NodeId nodeid);
+PyChipError pychip_DeviceController_EstablishPASESession(chip::Controller::DeviceCommissioner * devCtrl, const char* setUpCode,
+                                                         chip::NodeId nodeid);
 PyChipError pychip_DeviceController_Commission(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid);
 
 PyChipError pychip_DeviceController_DiscoverCommissionableNodesLongDiscriminator(chip::Controller::DeviceCommissioner * devCtrl,
@@ -618,6 +620,12 @@ PyChipError pychip_DeviceController_EstablishPASESessionBLE(chip::Controller::De
     params.SetPeerAddress(addr).SetDiscriminator(discriminator);
     sPairingDelegate.SetExpectingPairingComplete(true);
     return ToPyChipError(devCtrl->EstablishPASEConnection(nodeid, params));
+}
+
+PyChipError pychip_DeviceController_EstablishPASESession(chip::Controller::DeviceCommissioner * devCtrl, const char* setUpCode,
+                                                         chip::NodeId nodeid) {
+    sPairingDelegate.SetExpectingPairingComplete(true);
+    return ToPyChipError(devCtrl->EstablishPASEConnection(nodeid, setUpCode));
 }
 
 PyChipError pychip_DeviceController_Commission(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid)

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -500,6 +500,15 @@ class ChipDeviceControllerBase():
                 self.devCtrl, ipaddr.encode("utf-8"), setupPinCode, nodeid, port)
         )
 
+    def EstablishPASESession(self, setUpCode: str, nodeid: int):
+        self.CheckIsActive()
+
+        self.state = DCState.RENDEZVOUS_ONGOING
+        return self._ChipStack.CallAsync(
+            lambda: self._dmLib.pychip_DeviceController_EstablishPASESession(
+                self.devCtrl, setUpCode.encode("utf-8"), nodeid)
+        )
+
     def GetTestCommissionerUsed(self):
         return self._ChipStack.Call(
             lambda: self._dmLib.pychip_TestCommissionerUsed()
@@ -1605,6 +1614,9 @@ class ChipDeviceControllerBase():
             self._dmLib.pychip_DeviceController_EstablishPASESessionBLE.argtypes = [
                 c_void_p, c_uint32, c_uint16, c_uint64]
             self._dmLib.pychip_DeviceController_EstablishPASESessionBLE.restype = PyChipError
+            self._dmLib.pychip_DeviceController_EstablishPASESession.argtypes = [
+                c_void_p, c_char_p, c_uint64]
+            self._dmLib.pychip_DeviceController_EstablishPASESession.restype = PyChipError
 
             self._dmLib.pychip_DeviceController_DiscoverAllCommissionableNodes.argtypes = [
                 c_void_p]

--- a/src/controller/python/chip/clusters/ClusterObjects.py
+++ b/src/controller/python/chip/clusters/ClusterObjects.py
@@ -301,7 +301,7 @@ class ClusterAttributeDescriptor:
         """Register a subclass."""
         super().__init_subclass__(*args, **kwargs)
         try:
-            if cls.cluster_id not in ALL_ATTRIBUTES:
+            if cls.standard_attribute and cls.cluster_id not in ALL_ATTRIBUTES:
                 ALL_ATTRIBUTES[cls.cluster_id] = {}
             # register this clusterattribute in the ALL_ATTRIBUTES dict for quick lookups
             ALL_ATTRIBUTES[cls.cluster_id][cls.attribute_id] = cls
@@ -344,6 +344,10 @@ class ClusterAttributeDescriptor:
     @ChipUtility.classproperty
     def must_use_timed_write(cls) -> bool:
         return False
+
+    @ChipUtility.classproperty
+    def standard_attribute(cls) -> bool:
+        return True
 
     @ChipUtility.classproperty
     def _cluster_object(cls) -> ClusterObject:

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -262,6 +262,9 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
                                               problem=f"Failed validation of value on {location.as_string(self.cluster_mapper)}: {str(e)}", spec_location="Global Elements")
                             success = False
                             continue
+                        except KeyError:
+                            # This would have been caught already in the previous step
+                            continue
 
         self.print_step(4, "Validate the attribute list exactly matches the set of reported attributes")
         if success:

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -196,7 +196,6 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
         except KeyError:
             attr_ret = None
 
-        print(attr_ret)
 
         error_type_ok = attr_ret is not None and isinstance(
             attr_ret, Clusters.Attribute.ValueDecodeFailure) and isinstance(attr_ret.Reason, InteractionModelError)

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -36,9 +36,6 @@ from taglist_and_topology_test_support import (create_device_type_list_for_root,
                                                find_tree_roots, get_all_children, get_direct_children_of_root, parts_list_cycles,
                                                separate_endpoint_types)
 
-# The above code is importing various classes from the "ClusterObjects" module and assigning them to
-# variables. These classes are likely used for creating and managing clusters of objects in a program.
-
 
 def check_int_in_range(min_value: int, max_value: int, allow_null: bool = False) -> Callable:
     """Returns a checker for whether `obj` is an int that fits in a range."""

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -261,7 +261,8 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
                             success = False
                             continue
                         except KeyError:
-                            # This would have been caught already in the previous step
+                            # A KeyError here means the attribute does not exist. This problem was already recorded in step 2,
+                            # but we don't assert until the end of the test, so ignore this and don't re-record the error.
                             continue
 
         self.print_step(4, "Validate the attribute list exactly matches the set of reported attributes")

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -196,7 +196,6 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
         except KeyError:
             attr_ret = None
 
-
         error_type_ok = attr_ret is not None and isinstance(
             attr_ret, Clusters.Attribute.ValueDecodeFailure) and isinstance(attr_ret.Reason, InteractionModelError)
 

--- a/src/python_testing/basic_composition_support.py
+++ b/src/python_testing/basic_composition_support.py
@@ -105,24 +105,9 @@ class BasicCompositionTests:
         dump_device_composition_path: Optional[str] = self.user_params.get("dump_device_composition_path", None)
 
         if do_test_over_pase:
-            info = self.get_setup_payload_info()
-
-            commissionable_nodes = dev_ctrl.DiscoverCommissionableNodes(
-                info.filter_type, info.filter_value, stopOnFirst=True, timeoutSecond=15)
-            logging.info(f"Commissionable nodes: {commissionable_nodes}")
-            # TODO: Support BLE
-            if commissionable_nodes is not None and len(commissionable_nodes) > 0:
-                commissionable_node = commissionable_nodes[0]
-                instance_name = f"{commissionable_node.instanceName}._matterc._udp.local"
-                vid = f"{commissionable_node.vendorId}"
-                pid = f"{commissionable_node.productId}"
-                address = f"{commissionable_node.addresses[0]}"
-                logging.info(f"Found instance {instance_name}, VID={vid}, PID={pid}, Address={address}")
-
-                node_id = self.dut_node_id
-                dev_ctrl.EstablishPASESessionIP(address, info.passcode, node_id)
-            else:
-                asserts.fail("Failed to find the DUT according to command line arguments.")
+            setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
+            asserts.assert_true(setupCode, "Require either --qr-code or --manual-code.")
+            dev_ctrl.EstablishPASESession(setupCode, self.dut_node_id)
         else:
             # Using the already commissioned node
             node_id = self.dut_node_id

--- a/src/python_testing/basic_composition_support.py
+++ b/src/python_testing/basic_composition_support.py
@@ -119,7 +119,7 @@ class BasicCompositionTests:
                 address = f"{commissionable_node.addresses[0]}"
                 logging.info(f"Found instance {instance_name}, VID={vid}, PID={pid}, Address={address}")
 
-                node_id = 1
+                node_id = self.dut_node_id
                 dev_ctrl.EstablishPASESessionIP(address, info.passcode, node_id)
             else:
                 asserts.fail("Failed to find the DUT according to command line arguments.")

--- a/src/python_testing/basic_composition_support.py
+++ b/src/python_testing/basic_composition_support.py
@@ -107,7 +107,8 @@ class BasicCompositionTests:
         if do_test_over_pase:
             setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
             asserts.assert_true(setupCode, "Require either --qr-code or --manual-code.")
-            dev_ctrl.EstablishPASESession(setupCode, self.dut_node_id)
+            node_id = self.dut_node_id
+            dev_ctrl.EstablishPASESession(setupCode, node_id)
         else:
             # Using the already commissioned node
             node_id = self.dut_node_id

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -60,6 +60,7 @@ from chip.interaction_model import InteractionModelError, Status
 from chip.setup_payload import SetupPayload
 from chip.storage import PersistentStorage
 from chip.tracing import TracingContext
+from global_attribute_ids import GlobalAttributeIds
 from mobly import asserts, base_test, signals, utils
 from mobly.config_parser import ENV_MOBLY_LOGPATH, TestRunConfig
 from mobly.test_runner import TestRunner
@@ -412,6 +413,8 @@ class ClusterMapper:
             return f"Cluster {name} ({cluster_id}, 0x{cluster_id:04X})"
 
     def get_attribute_string(self, cluster_id: int, attribute_id) -> str:
+        if attribute_id in GlobalAttributeIds:
+            return f"Attribute {GlobalAttributeIds(attribute_id).name} {attribute_id}, 0x{attribute_id:04X}"
         mapping = self._mapping._CLUSTER_ID_DICT.get(cluster_id, None)
         if not mapping:
             return f"Attribute Unknown ({attribute_id}, 0x{attribute_id:08X})"

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -413,8 +413,9 @@ class ClusterMapper:
             return f"Cluster {name} ({cluster_id}, 0x{cluster_id:04X})"
 
     def get_attribute_string(self, cluster_id: int, attribute_id) -> str:
-        if attribute_id in GlobalAttributeIds:
-            return f"Attribute {GlobalAttributeIds(attribute_id).name} {attribute_id}, 0x{attribute_id:04X}"
+        global_attrs = [item.value for item in GlobalAttributeIds]
+        if attribute_id in global_attrs:
+            return f"Attribute {GlobalAttributeIds(attribute_id).to_name()} {attribute_id}, 0x{attribute_id:04X}"
         mapping = self._mapping._CLUSTER_ID_DICT.get(cluster_id, None)
         if not mapping:
             return f"Attribute Unknown ({attribute_id}, 0x{attribute_id:08X})"


### PR DESCRIPTION
Write only attributes are not returned in the wildcard, but will return the UNSUPPORTED_READ error if we attempt to read them in a concrete path. We can detect their presence by probing for this error via a read.

Also fix the base test to support running the test over PASE on BLE. 

Test: unit testing cluster has a write-only attribute that was previously hacked around. Also tested on a product with a known write-only attribute in the MEI cluster.

issue: https://github.com/CHIP-Specifications/chip-test-plans/issues/3971
