### PR TITLE
Remove some unneeded dependencies from generic-callbacks.h

### DIFF
--- a/src/app/util/generic-callbacks.h
+++ b/src/app/util/generic-callbacks.h
@@ -21,11 +21,7 @@
 #include <app/util/attribute-metadata.h>
 #include <app/util/basic-types.h>
 
-#include <app/CommandHandler.h>
-#include <app/CommandSender.h>
 #include <app/ConcreteAttributePath.h>
-#include <app/ConcreteCommandPath.h>
-#include <lib/support/Span.h>
 #include <protocols/interaction_model/Constants.h>
 
 /** @brief Cluster Init


### PR DESCRIPTION
Without this, we have seemingly looping dependencies in via stuff that is related to CommandHandling and app/util/af.h.

Before:

![image](https://github.com/project-chip/connectedhomeip/assets/1832280/22e869ba-ebfe-44c2-a4d0-c619dbeb1f29)

After:

![image](https://github.com/project-chip/connectedhomeip/assets/1832280/e3565811-0add-4083-b124-404c59576175)
