### PR TITLE
[Examples] Remove EmberAfStatus from example files

### DIFF
--- a/examples/air-purifier-app/air-purifier-common/include/relative-humidity-sensor-manager.h
+++ b/examples/air-purifier-app/air-purifier-common/include/relative-humidity-sensor-manager.h
@@ -21,8 +21,6 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <protocols/interaction_model/StatusCode.h>
 
-using chip::Protocols::InteractionModel::Status;
-
 namespace chip {
 namespace app {
 namespace Clusters {
@@ -34,19 +32,20 @@ public:
 
     void Init()
     {
-        Status status = RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, 0);
-        VerifyOrReturn(Status::Success == status,
+        Protocols::InteractionModel::Status status = RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, 0);
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MinMeasuredValue attribute"));
 
         status = RelativeHumidityMeasurement::Attributes::MaxMeasuredValue::Set(mEndpointId, 10000);
-        VerifyOrReturn(Status::Success == status,
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MaxMeasuredValue attribute"));
     };
 
     void OnHumidityChangeHandler(uint16_t newValue)
     {
-        Status status = RelativeHumidityMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
-        VerifyOrReturn(Status::Success == status,
+        Protocols::InteractionModel::Status status =
+            RelativeHumidityMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MeasuredValue attribute"));
         ChipLogDetail(NotSpecified, "The new RelativeHumidityMeasurement value: %d", newValue);
     }

--- a/examples/air-purifier-app/air-purifier-common/include/relative-humidity-sensor-manager.h
+++ b/examples/air-purifier-app/air-purifier-common/include/relative-humidity-sensor-manager.h
@@ -19,6 +19,9 @@
 #pragma once
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <protocols/interaction_model/StatusCode.h>
+
+using chip::Protocols::InteractionModel::Status;
 
 namespace chip {
 namespace app {
@@ -31,19 +34,19 @@ public:
 
     void Init()
     {
-        EmberAfStatus status = RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, 0);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        Status status = RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, 0);
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MinMeasuredValue attribute"));
 
         status = RelativeHumidityMeasurement::Attributes::MaxMeasuredValue::Set(mEndpointId, 10000);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MaxMeasuredValue attribute"));
     };
 
     void OnHumidityChangeHandler(uint16_t newValue)
     {
-        EmberAfStatus status = RelativeHumidityMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        Status status = RelativeHumidityMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MeasuredValue attribute"));
         ChipLogDetail(NotSpecified, "The new RelativeHumidityMeasurement value: %d", newValue);
     }

--- a/examples/air-purifier-app/air-purifier-common/include/temperature-sensor-manager.h
+++ b/examples/air-purifier-app/air-purifier-common/include/temperature-sensor-manager.h
@@ -21,8 +21,6 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <protocols/interaction_model/StatusCode.h>
 
-using chip::Protocols::InteractionModel::Status;
-
 namespace chip {
 namespace app {
 namespace Clusters {
@@ -34,19 +32,19 @@ public:
 
     void Init()
     {
-        Status status = TemperatureMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, -500);
-        VerifyOrReturn(Status::Success == status,
+        Protocols::InteractionModel::Status status = TemperatureMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, -500);
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MinMeasuredValue attribute"));
 
         status = TemperatureMeasurement::Attributes::MaxMeasuredValue::Set(mEndpointId, 6000);
-        VerifyOrReturn(Status::Success == status,
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MaxMeasuredValue attribute"));
     }
 
     void OnTemperatureChangeHandler(int16_t newValue)
     {
-        Status status = TemperatureMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
-        VerifyOrReturn(Status::Success == status,
+        Protocols::InteractionModel::Status status = TemperatureMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MeasuredValue attribute"));
         ChipLogDetail(NotSpecified, "The new TemperatureMeasurement value: %d", newValue);
     }

--- a/examples/air-purifier-app/air-purifier-common/include/temperature-sensor-manager.h
+++ b/examples/air-purifier-app/air-purifier-common/include/temperature-sensor-manager.h
@@ -19,6 +19,9 @@
 #pragma once
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <protocols/interaction_model/StatusCode.h>
+
+using chip::Protocols::InteractionModel::Status;
 
 namespace chip {
 namespace app {
@@ -31,19 +34,19 @@ public:
 
     void Init()
     {
-        EmberAfStatus status = TemperatureMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, -500);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        Status status = TemperatureMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, -500);
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MinMeasuredValue attribute"));
 
         status = TemperatureMeasurement::Attributes::MaxMeasuredValue::Set(mEndpointId, 6000);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MaxMeasuredValue attribute"));
     }
 
     void OnTemperatureChangeHandler(int16_t newValue)
     {
-        EmberAfStatus status = TemperatureMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        Status status = TemperatureMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MeasuredValue attribute"));
         ChipLogDetail(NotSpecified, "The new TemperatureMeasurement value: %d", newValue);
     }

--- a/examples/air-purifier-app/air-purifier-common/src/air-purifier-manager.cpp
+++ b/examples/air-purifier-app/air-purifier-common/src/air-purifier-manager.cpp
@@ -197,12 +197,13 @@ void AirPurifierManager::PercentSettingWriteCallback(uint8_t aNewPercentSetting)
     if (aNewPercentSetting != percentCurrent)
     {
         ChipLogDetail(NotSpecified, "AirPurifierManager::PercentSettingWriteCallback: %d", aNewPercentSetting);
-        percentCurrent       = aNewPercentSetting;
-        EmberAfStatus status = FanControl::Attributes::PercentCurrent::Set(mEndpointId, percentCurrent);
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        percentCurrent = aNewPercentSetting;
+        Status status  = FanControl::Attributes::PercentCurrent::Set(mEndpointId, percentCurrent);
+        if (status != Status::Success)
         {
             ChipLogError(NotSpecified,
-                         "AirPurifierManager::PercentSettingWriteCallback: failed to set PercentCurrent attribute: %d", status);
+                         "AirPurifierManager::PercentSettingWriteCallback: failed to set PercentCurrent attribute: %d",
+                         to_underlying(status));
         }
     }
 }
@@ -212,12 +213,12 @@ void AirPurifierManager::SpeedSettingWriteCallback(uint8_t aNewSpeedSetting)
     if (aNewSpeedSetting != speedCurrent)
     {
         ChipLogDetail(NotSpecified, "AirPurifierManager::SpeedSettingWriteCallback: %d", aNewSpeedSetting);
-        speedCurrent         = aNewSpeedSetting;
-        EmberAfStatus status = FanControl::Attributes::SpeedCurrent::Set(mEndpointId, speedCurrent);
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        speedCurrent  = aNewSpeedSetting;
+        Status status = FanControl::Attributes::SpeedCurrent::Set(mEndpointId, speedCurrent);
+        if (status != Status::Success)
         {
             ChipLogError(NotSpecified, "AirPurifierManager::SpeedSettingWriteCallback: failed to set SpeedCurrent attribute: %d",
-                         status);
+                         to_underlying(status));
         }
 
         // Determine if the speed change should also change the fan mode
@@ -300,10 +301,11 @@ void AirPurifierManager::SetSpeedSetting(DataModel::Nullable<uint8_t> aNewSpeedS
 
     if (aNewSpeedSetting.Value() != speedCurrent)
     {
-        EmberAfStatus status = FanControl::Attributes::SpeedSetting::Set(mEndpointId, aNewSpeedSetting);
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        Status status = FanControl::Attributes::SpeedSetting::Set(mEndpointId, aNewSpeedSetting);
+        if (status != Status::Success)
         {
-            ChipLogError(NotSpecified, "AirPurifierManager::SetSpeedSetting: failed to set SpeedSetting attribute: %d", status);
+            ChipLogError(NotSpecified, "AirPurifierManager::SetSpeedSetting: failed to set SpeedSetting attribute: %d",
+                         to_underlying(status));
         }
     }
 }
@@ -311,11 +313,12 @@ void AirPurifierManager::SetSpeedSetting(DataModel::Nullable<uint8_t> aNewSpeedS
 DataModel::Nullable<uint8_t> AirPurifierManager::GetSpeedSetting()
 {
     DataModel::Nullable<uint8_t> speedSetting;
-    EmberAfStatus status = FanControl::Attributes::SpeedSetting::Get(mEndpointId, speedSetting);
+    Status status = FanControl::Attributes::SpeedSetting::Get(mEndpointId, speedSetting);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
-        ChipLogError(NotSpecified, "AirPurifierManager::GetSpeedSetting: failed to get SpeedSetting attribute: %d", status);
+        ChipLogError(NotSpecified, "AirPurifierManager::GetSpeedSetting: failed to get SpeedSetting attribute: %d",
+                     to_underlying(status));
     }
 
     return speedSetting;
@@ -324,11 +327,12 @@ DataModel::Nullable<uint8_t> AirPurifierManager::GetSpeedSetting()
 DataModel::Nullable<Percent> AirPurifierManager::GetPercentSetting()
 {
     DataModel::Nullable<Percent> percentSetting;
-    EmberAfStatus status = FanControl::Attributes::PercentSetting::Get(mEndpointId, percentSetting);
+    Status status = FanControl::Attributes::PercentSetting::Get(mEndpointId, percentSetting);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
-        ChipLogError(NotSpecified, "AirPurifierManager::GetPercentSetting: failed to get PercentSetting attribute: %d", status);
+        ChipLogError(NotSpecified, "AirPurifierManager::GetPercentSetting: failed to get PercentSetting attribute: %d",
+                     to_underlying(status));
     }
 
     return percentSetting;

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/include/relative-humidity-sensor-manager.h
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/include/relative-humidity-sensor-manager.h
@@ -1,4 +1,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <protocols/interaction_model/StatusCode.h>
+
+using chip::Protocols::InteractionModel::Status;
 
 #pragma once
 
@@ -11,19 +14,19 @@ class RelativeHumiditySensorManager
 public:
     RelativeHumiditySensorManager(EndpointId aEndpointId) : mEndpointId(aEndpointId)
     {
-        EmberAfStatus status = RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, 0);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        Status status = RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, 0);
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MinMeasuredValue attribute"));
 
         status = RelativeHumidityMeasurement::Attributes::MaxMeasuredValue::Set(mEndpointId, 100);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MaxMeasuredValue attribute"));
     };
 
     void OnHumidityChangeHandler(uint16_t newValue)
     {
-        EmberAfStatus status = RelativeHumidityMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        Status status = RelativeHumidityMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MeasuredValue attribute"));
         ChipLogDetail(NotSpecified, "The new RelativeHumidityMeasurement value: %d", newValue);
     }

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/include/relative-humidity-sensor-manager.h
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/include/relative-humidity-sensor-manager.h
@@ -1,8 +1,6 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <protocols/interaction_model/StatusCode.h>
 
-using chip::Protocols::InteractionModel::Status;
-
 #pragma once
 
 namespace chip {
@@ -14,19 +12,20 @@ class RelativeHumiditySensorManager
 public:
     RelativeHumiditySensorManager(EndpointId aEndpointId) : mEndpointId(aEndpointId)
     {
-        Status status = RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, 0);
-        VerifyOrReturn(Status::Success == status,
+        Protocols::InteractionModel::Status status = RelativeHumidityMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, 0);
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MinMeasuredValue attribute"));
 
         status = RelativeHumidityMeasurement::Attributes::MaxMeasuredValue::Set(mEndpointId, 100);
-        VerifyOrReturn(Status::Success == status,
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MaxMeasuredValue attribute"));
     };
 
     void OnHumidityChangeHandler(uint16_t newValue)
     {
-        Status status = RelativeHumidityMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
-        VerifyOrReturn(Status::Success == status,
+        Protocols::InteractionModel::Status status =
+            RelativeHumidityMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set RelativeHumidityMeasurement MeasuredValue attribute"));
         ChipLogDetail(NotSpecified, "The new RelativeHumidityMeasurement value: %d", newValue);
     }

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/include/temperature-sensor-manager.h
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/include/temperature-sensor-manager.h
@@ -4,8 +4,6 @@
 
 #include <protocols/interaction_model/StatusCode.h>
 
-using chip::Protocols::InteractionModel::Status;
-
 namespace chip {
 namespace app {
 namespace Clusters {
@@ -15,19 +13,19 @@ class TemperatureSensorManager
 public:
     TemperatureSensorManager(EndpointId aEndpointId) : mEndpointId(aEndpointId)
     {
-        Status status = TemperatureMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, -5);
-        VerifyOrReturn(Status::Success == status,
+        Protocols::InteractionModel::Status status = TemperatureMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, -5);
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MinMeasuredValue attribute"));
 
         status = TemperatureMeasurement::Attributes::MaxMeasuredValue::Set(mEndpointId, 60);
-        VerifyOrReturn(Status::Success == status,
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MaxMeasuredValue attribute"));
     };
 
     void OnTemperatureChangeHandler(int16_t newValue)
     {
-        Status status = TemperatureMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
-        VerifyOrReturn(Status::Success == status,
+        Protocols::InteractionModel::Status status = TemperatureMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
+        VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MeasuredValue attribute"));
         ChipLogDetail(NotSpecified, "The new TemperatureMeasurement value: %d", newValue);
     }

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/include/temperature-sensor-manager.h
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/include/temperature-sensor-manager.h
@@ -1,6 +1,10 @@
-#include <app-common/zap-generated/attributes/Accessors.h>
 
 #pragma once
+#include <app-common/zap-generated/attributes/Accessors.h>
+
+#include <protocols/interaction_model/StatusCode.h>
+
+using chip::Protocols::InteractionModel::Status;
 
 namespace chip {
 namespace app {
@@ -11,19 +15,19 @@ class TemperatureSensorManager
 public:
     TemperatureSensorManager(EndpointId aEndpointId) : mEndpointId(aEndpointId)
     {
-        EmberAfStatus status = TemperatureMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, -5);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        Status status = TemperatureMeasurement::Attributes::MinMeasuredValue::Set(mEndpointId, -5);
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MinMeasuredValue attribute"));
 
         status = TemperatureMeasurement::Attributes::MaxMeasuredValue::Set(mEndpointId, 60);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MaxMeasuredValue attribute"));
     };
 
     void OnTemperatureChangeHandler(int16_t newValue)
     {
-        EmberAfStatus status = TemperatureMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
-        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status,
+        Status status = TemperatureMeasurement::Attributes::MeasuredValue::Set(mEndpointId, newValue);
+        VerifyOrReturn(Status::Success == status,
                        ChipLogError(NotSpecified, "Failed to set TemperatureMeasurement MeasuredValue attribute"));
         ChipLogDetail(NotSpecified, "The new TemperatureMeasurement value: %d", newValue);
     }

--- a/examples/all-clusters-app/ameba/main/include/ManualDishWasherAlarmCommand.h
+++ b/examples/all-clusters-app/ameba/main/include/ManualDishWasherAlarmCommand.h
@@ -21,8 +21,6 @@
 #include <app/clusters/dishwasher-alarm-server/dishwasher-alarm-server.h>
 #include <protocols/interaction_model/StatusCode.h>
 
-using chip::Protocols::InteractionModel::Status;
-
 #if CONFIG_ENABLE_CHIP_SHELL
 #include "lib/shell/Engine.h"
 #include "lib/shell/commands/Help.h"
@@ -68,7 +66,7 @@ CHIP_ERROR ManualDishWasherAlarmSetRaiseCommandHandler(int argc, char ** argv)
     }
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    Status status;
+    Protocols::InteractionModel::Status status;
     DishwasherAlarmServer & serverInstance = DishwasherAlarmServer::Instance();
 
     BitMask<AlarmMap> supported;                       // Set dishwasher alarm supported value
@@ -91,21 +89,21 @@ CHIP_ERROR ManualDishWasherAlarmSetRaiseCommandHandler(int argc, char ** argv)
     state.SetField(AlarmMap::kTempTooLow, 1); // 0x08, 8
 
     status = serverInstance.SetSupportedValue(1, supported); // 0x2F, 47
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetMaskValue(1, mask); // 0x2F, 47
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetStateValue(1, state); // 0x0E, 14
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
@@ -127,7 +125,7 @@ CHIP_ERROR ManualDishWasherAlarmSetLowerCommandHandler(int argc, char ** argv)
     }
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    Status status;
+    Protocols::InteractionModel::Status status;
     DishwasherAlarmServer & serverInstance = DishwasherAlarmServer::Instance();
 
     BitMask<AlarmMap> supported;                       // Set dishwasher alarm supported value
@@ -145,21 +143,21 @@ CHIP_ERROR ManualDishWasherAlarmSetLowerCommandHandler(int argc, char ** argv)
     mask.SetField(AlarmMap::kWaterLevelError, 1); // 0x20, 32
 
     status = serverInstance.SetSupportedValue(1, supported); // 0x2F, 47
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetMaskValue(1, mask); // 0x2F, 47
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetStateValue(1, 0); // Set dishwasher alarm state value 0x00, 0
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;

--- a/examples/all-clusters-app/ameba/main/include/ManualDishWasherAlarmCommand.h
+++ b/examples/all-clusters-app/ameba/main/include/ManualDishWasherAlarmCommand.h
@@ -19,6 +19,9 @@
 #include "controller/InvokeInteraction.h"
 #include "controller/ReadInteraction.h"
 #include <app/clusters/dishwasher-alarm-server/dishwasher-alarm-server.h>
+#include <protocols/interaction_model/StatusCode.h>
+
+using chip::Protocols::InteractionModel::Status;
 
 #if CONFIG_ENABLE_CHIP_SHELL
 #include "lib/shell/Engine.h"
@@ -65,7 +68,7 @@ CHIP_ERROR ManualDishWasherAlarmSetRaiseCommandHandler(int argc, char ** argv)
     }
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    EmberAfStatus status;
+    Status status;
     DishwasherAlarmServer & serverInstance = DishwasherAlarmServer::Instance();
 
     BitMask<AlarmMap> supported;                       // Set dishwasher alarm supported value
@@ -88,21 +91,21 @@ CHIP_ERROR ManualDishWasherAlarmSetRaiseCommandHandler(int argc, char ** argv)
     state.SetField(AlarmMap::kTempTooLow, 1); // 0x08, 8
 
     status = serverInstance.SetSupportedValue(1, supported); // 0x2F, 47
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetMaskValue(1, mask); // 0x2F, 47
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetStateValue(1, state); // 0x0E, 14
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
@@ -124,7 +127,7 @@ CHIP_ERROR ManualDishWasherAlarmSetLowerCommandHandler(int argc, char ** argv)
     }
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    EmberAfStatus status;
+    Status status;
     DishwasherAlarmServer & serverInstance = DishwasherAlarmServer::Instance();
 
     BitMask<AlarmMap> supported;                       // Set dishwasher alarm supported value
@@ -142,21 +145,21 @@ CHIP_ERROR ManualDishWasherAlarmSetLowerCommandHandler(int argc, char ** argv)
     mask.SetField(AlarmMap::kWaterLevelError, 1); // 0x20, 32
 
     status = serverInstance.SetSupportedValue(1, supported); // 0x2F, 47
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetMaskValue(1, mask); // 0x2F, 47
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetStateValue(1, 0); // Set dishwasher alarm state value 0x00, 0
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;

--- a/examples/all-clusters-app/ameba/main/include/ManualRefrigeratorAlarmCommand.h
+++ b/examples/all-clusters-app/ameba/main/include/ManualRefrigeratorAlarmCommand.h
@@ -16,9 +16,14 @@
  *    limitations under the License.
  */
 
+#pragma once
+
 #include "controller/InvokeInteraction.h"
 #include "controller/ReadInteraction.h"
 #include <app/clusters/refrigerator-alarm-server/refrigerator-alarm-server.h>
+#include <protocols/interaction_model/StatusCode.h>
+
+using chip::Protocols::InteractionModel::Status;
 
 #if CONFIG_ENABLE_CHIP_SHELL
 #include "lib/shell/Engine.h"
@@ -60,25 +65,25 @@ CHIP_ERROR ManualRefrigeratorAlarmCommandHandler(int argc, char ** argv)
 CHIP_ERROR ManualRefrigeratorAlarmDoorOpenCommandHandler(int argc, char ** argv)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    EmberAfStatus status;
+    Status status;
     RefrigeratorAlarmServer & serverInstance = RefrigeratorAlarmServer::Instance();
 
     status = serverInstance.SetMaskValue(1, 0);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetStateValue(1, 1);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetSupportedValue(1, 0);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
@@ -96,25 +101,25 @@ exit:
 CHIP_ERROR ManualRefrigeratorAlarmDoorCloseCommandHandler(int argc, char ** argv)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    EmberAfStatus status;
+    Status status;
     RefrigeratorAlarmServer & serverInstance = RefrigeratorAlarmServer::Instance();
 
     status = serverInstance.SetMaskValue(1, 1);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetStateValue(1, 0);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetSupportedValue(1, 1);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
@@ -132,18 +137,18 @@ exit:
 CHIP_ERROR ManualRefrigeratorAlarmSuppressCommandHandler(int argc, char ** argv)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    EmberAfStatus status;
+    Status status;
     RefrigeratorAlarmServer & serverInstance = RefrigeratorAlarmServer::Instance();
 
     status = serverInstance.SetSupportedValue(1, 1);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetStateValue(1, 0);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;

--- a/examples/all-clusters-app/ameba/main/include/ManualRefrigeratorAlarmCommand.h
+++ b/examples/all-clusters-app/ameba/main/include/ManualRefrigeratorAlarmCommand.h
@@ -23,8 +23,6 @@
 #include <app/clusters/refrigerator-alarm-server/refrigerator-alarm-server.h>
 #include <protocols/interaction_model/StatusCode.h>
 
-using chip::Protocols::InteractionModel::Status;
-
 #if CONFIG_ENABLE_CHIP_SHELL
 #include "lib/shell/Engine.h"
 #include "lib/shell/commands/Help.h"
@@ -65,25 +63,25 @@ CHIP_ERROR ManualRefrigeratorAlarmCommandHandler(int argc, char ** argv)
 CHIP_ERROR ManualRefrigeratorAlarmDoorOpenCommandHandler(int argc, char ** argv)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    Status status;
+    Protocols::InteractionModel::Status status;
     RefrigeratorAlarmServer & serverInstance = RefrigeratorAlarmServer::Instance();
 
     status = serverInstance.SetMaskValue(1, 0);
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetStateValue(1, 1);
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetSupportedValue(1, 0);
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
@@ -101,25 +99,25 @@ exit:
 CHIP_ERROR ManualRefrigeratorAlarmDoorCloseCommandHandler(int argc, char ** argv)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    Status status;
+    Protocols::InteractionModel::Status status;
     RefrigeratorAlarmServer & serverInstance = RefrigeratorAlarmServer::Instance();
 
     status = serverInstance.SetMaskValue(1, 1);
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetStateValue(1, 0);
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetSupportedValue(1, 1);
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
@@ -137,18 +135,18 @@ exit:
 CHIP_ERROR ManualRefrigeratorAlarmSuppressCommandHandler(int argc, char ** argv)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    Status status;
+    Protocols::InteractionModel::Status status;
     RefrigeratorAlarmServer & serverInstance = RefrigeratorAlarmServer::Instance();
 
     status = serverInstance.SetSupportedValue(1, 1);
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;
     }
 
     status = serverInstance.SetStateValue(1, 0);
-    if (status != Status::Success)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         err = CHIP_ERROR_INTERNAL;
         goto exit;

--- a/examples/all-clusters-app/asr/src/AppTask.cpp
+++ b/examples/all-clusters-app/asr/src/AppTask.cpp
@@ -38,9 +38,12 @@
 #include <lega_rtos_api.h>
 #include <platform/ASR/NetworkCommissioningDriver.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <protocols/interaction_model/StatusCode.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 #include <static-supported-temperature-levels.h>
+
+using chip::Protocols::InteractionModel::Status;
 
 using namespace ::chip;
 using namespace ::chip::Credentials;
@@ -265,9 +268,9 @@ void AppTask::OnOffUpdateClusterState(void)
     uint8_t onoff = sLightLED.Get();
 
     // write the new on/off value
-    EmberAfStatus status = app::Clusters::OnOff::Attributes::OnOff::Set(1, onoff);
+    Status status = app::Clusters::OnOff::Attributes::OnOff::Set(1, onoff);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Status::Success)
     {
         ASR_LOG("ERR: updating on/off %x", status);
     }

--- a/examples/all-clusters-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/all-clusters-app/infineon/psoc6/src/AppTask.cpp
@@ -409,9 +409,9 @@ void AppTask::OnOffUpdateClusterState(intptr_t context)
     uint8_t onoff = sLightLED.Get();
 
     // write the new on/off value
-    EmberAfStatus status = app::Clusters::OnOff::Attributes::OnOff::Set(2, onoff);
+    Protocols::InteractionModel::Status status = app::Clusters::OnOff::Attributes::OnOff::Set(2, onoff);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         P6_LOG("ERR: updating on/off %x", status);
     }

--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -296,8 +296,9 @@ void AllClustersAppCommandHandler::OnSwitchLatchedHandler(uint8_t newPosition)
 {
     EndpointId endpoint = 1;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The latching switch is moved to a new position:%d", newPosition);
 
     Clusters::SwitchServer::Instance().OnSwitchLatch(endpoint, newPosition);
@@ -307,8 +308,9 @@ void AllClustersAppCommandHandler::OnSwitchInitialPressedHandler(uint8_t newPosi
 {
     EndpointId endpoint = 1;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The new position when the momentary switch starts to be pressed:%d", newPosition);
 
     Clusters::SwitchServer::Instance().OnInitialPress(endpoint, newPosition);
@@ -318,8 +320,9 @@ void AllClustersAppCommandHandler::OnSwitchLongPressedHandler(uint8_t newPositio
 {
     EndpointId endpoint = 1;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The new position when the momentary switch has been pressed for a long time:%d", newPosition);
 
     Clusters::SwitchServer::Instance().OnLongPress(endpoint, newPosition);
@@ -332,8 +335,9 @@ void AllClustersAppCommandHandler::OnSwitchShortReleasedHandler(uint8_t previous
 {
     EndpointId endpoint = 1;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The the previous value of the CurrentPosition when the momentary switch has been released:%d",
                   previousPosition);
 
@@ -344,8 +348,9 @@ void AllClustersAppCommandHandler::OnSwitchLongReleasedHandler(uint8_t previousP
 {
     EndpointId endpoint = 1;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
     ChipLogDetail(NotSpecified,
                   "The the previous value of the CurrentPosition when the momentary switch has been released after having been "
                   "pressed for a long time:%d",
@@ -358,8 +363,9 @@ void AllClustersAppCommandHandler::OnSwitchMultiPressOngoingHandler(uint8_t newP
 {
     EndpointId endpoint = 1;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The new position when the momentary switch has been pressed in a multi-press sequence:%d",
                   newPosition);
     ChipLogDetail(NotSpecified, "%d times the momentary switch has been pressed", count);
@@ -371,8 +377,9 @@ void AllClustersAppCommandHandler::OnSwitchMultiPressCompleteHandler(uint8_t pre
 {
     EndpointId endpoint = 1;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The previous position when the momentary switch has been pressed in a multi-press sequence:%d",
                   previousPosition);
     ChipLogDetail(NotSpecified, "%d times the momentary switch has been pressed", count);

--- a/examples/all-clusters-app/nrfconnect/main/ZclDoorLockCallbacks.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/ZclDoorLockCallbacks.cpp
@@ -55,8 +55,8 @@ void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 
     // Set FeatureMap to 0, default is:
     // (kUser|kAccessSchedules|kRfidCredential|kPinCredential) 0x113
-    EmberAfStatus status = DoorLock::Attributes::FeatureMap::Set(endpoint, 0);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = DoorLock::Attributes::FeatureMap::Set(endpoint, 0);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         LOG_ERR("Updating feature map %x", status);
     }

--- a/examples/all-clusters-app/nxp/mw320/main.cpp
+++ b/examples/all-clusters-app/nxp/mw320/main.cpp
@@ -286,7 +286,7 @@ void GPIO_IRQHandler(void)
 #endif /* __cplusplus */
 
 /*
-EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+Protocols::InteractionModel::Status emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
                                                    EmberAfAttributeMetadata * attributeMetadata, uint16_t manufacturerCode,
                                                    uint8_t * buffer, uint16_t maxReadLength, int32_t index)
 {
@@ -295,7 +295,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterI
     if(clusterId == Clusters::Switch::Id) {
         *buffer = g_ButtonPress;
     }
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 */
 
@@ -1616,20 +1616,21 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     return;
 }
 
-EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
-                                                    const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer)
+Protocols::InteractionModel::Status emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                          const EmberAfAttributeMetadata * attributeMetadata,
+                                                                          uint8_t * buffer)
 {
     PRINTF("====> %s() \r\n", __FUNCTION__);
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
-                                                   const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
-                                                   uint16_t maxReadLength)
+Protocols::InteractionModel::Status emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                         const EmberAfAttributeMetadata * attributeMetadata,
+                                                                         uint8_t * buffer, uint16_t maxReadLength)
 {
     // Added for the pairing of TE9 to report the commission_info
     // default function (in callback-stub.cpp)
     //
     PRINTF("-> %s()\n\r", __FUNCTION__);
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }

--- a/examples/all-clusters-app/telink/src/ZclDoorLockCallbacks.cpp
+++ b/examples/all-clusters-app/telink/src/ZclDoorLockCallbacks.cpp
@@ -55,8 +55,8 @@ void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 
     // Set FeatureMap to 0, default is:
     // (kUser|kAccessSchedules|kRfidCredential|kPinCredential) 0x113
-    EmberAfStatus status = DoorLock::Attributes::FeatureMap::Set(endpoint, 0);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = DoorLock::Attributes::FeatureMap::Set(endpoint, 0);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         LOG_ERR("Updating feature map %x", status);
     }

--- a/examples/all-clusters-minimal-app/asr/src/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/asr/src/AppTask.cpp
@@ -221,9 +221,9 @@ void AppTask::OnOffUpdateClusterState(void)
     uint8_t onoff = sLightLED.Get();
 
     // write the new on/off value
-    EmberAfStatus status = app::Clusters::OnOff::Attributes::OnOff::Set(2, onoff);
+    Protocols::InteractionModel::Status status = app::Clusters::OnOff::Attributes::OnOff::Set(2, onoff);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ASR_LOG("ERR: updating on/off %x", status);
     }

--- a/examples/all-clusters-minimal-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/infineon/psoc6/src/AppTask.cpp
@@ -406,9 +406,9 @@ void AppTask::OnOffUpdateClusterState(intptr_t context)
     uint8_t onoff = sLightLED.Get();
 
     // write the new on/off value
-    EmberAfStatus status = app::Clusters::OnOff::Attributes::OnOff::Set(2, onoff);
+    Protocols::InteractionModel::Status status = app::Clusters::OnOff::Attributes::OnOff::Set(2, onoff);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         P6_LOG("ERR: updating on/off %x", status);
     }

--- a/examples/bridge-app/asr/subdevice/SubDeviceManager.cpp
+++ b/examples/bridge-app/asr/subdevice/SubDeviceManager.cpp
@@ -103,8 +103,8 @@ CHIP_ERROR RemoveDeviceEndpoint(SubDevice * dev)
     return CHIP_ERROR_INTERNAL;
 }
 
-EmberAfStatus HandleReadBridgedDeviceBasicAttribute(SubDevice * dev, chip::AttributeId attributeId, uint8_t * buffer,
-                                                    uint16_t maxReadLength)
+Protocols::InteractionModel::Status HandleReadBridgedDeviceBasicAttribute(SubDevice * dev, chip::AttributeId attributeId,
+                                                                          uint8_t * buffer, uint16_t maxReadLength)
 {
     using namespace BridgedDeviceBasicInformation::Attributes;
     ChipLogProgress(DeviceLayer, "HandleReadBridgedDeviceBasicAttribute: attrId=%" PRIu32 ", maxReadLength=%u", attributeId,
@@ -125,13 +125,14 @@ EmberAfStatus HandleReadBridgedDeviceBasicAttribute(SubDevice * dev, chip::Attri
     }
     else
     {
-        return EMBER_ZCL_STATUS_FAILURE;
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus HandleReadOnOffAttribute(SubDevice * dev, chip::AttributeId attributeId, uint8_t * buffer, uint16_t maxReadLength)
+Protocols::InteractionModel::Status HandleReadOnOffAttribute(SubDevice * dev, chip::AttributeId attributeId, uint8_t * buffer,
+                                                             uint16_t maxReadLength)
 {
     ChipLogProgress(DeviceLayer, "HandleReadOnOffAttribute: attrId=%" PRIu32 ", maxReadLength=%u", attributeId, maxReadLength);
 
@@ -145,24 +146,25 @@ EmberAfStatus HandleReadOnOffAttribute(SubDevice * dev, chip::AttributeId attrib
     }
     else
     {
-        return EMBER_ZCL_STATUS_FAILURE;
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus HandleWriteOnOffAttribute(SubDevice * dev, chip::AttributeId attributeId, uint8_t * buffer)
+Protocols::InteractionModel::Status HandleWriteOnOffAttribute(SubDevice * dev, chip::AttributeId attributeId, uint8_t * buffer)
 {
     ChipLogProgress(DeviceLayer, "HandleWriteOnOffAttribute: attrId=%" PRIu32, attributeId);
 
-    ReturnErrorCodeIf((attributeId != OnOff::Attributes::OnOff::Id) || (!dev->IsReachable()), EMBER_ZCL_STATUS_FAILURE);
+    ReturnErrorCodeIf((attributeId != OnOff::Attributes::OnOff::Id) || (!dev->IsReachable()),
+                      Protocols::InteractionModel::Status::Failure);
     dev->SetOnOff(*buffer == 1);
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
-                                                   const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
-                                                   uint16_t maxReadLength)
+Protocols::InteractionModel::Status emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                         const EmberAfAttributeMetadata * attributeMetadata,
+                                                                         uint8_t * buffer, uint16_t maxReadLength)
 {
     uint16_t endpointIndex = emberAfGetDynamicIndexFromEndpoint(endpoint);
 
@@ -181,11 +183,12 @@ EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterI
         }
     }
 
-    return EMBER_ZCL_STATUS_FAILURE;
+    return Protocols::InteractionModel::Status::Failure;
 }
 
-EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
-                                                    const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer)
+Protocols::InteractionModel::Status emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                          const EmberAfAttributeMetadata * attributeMetadata,
+                                                                          uint8_t * buffer)
 {
     uint16_t endpointIndex = emberAfGetDynamicIndexFromEndpoint(endpoint);
 
@@ -199,7 +202,7 @@ EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, Cluster
         }
     }
 
-    return EMBER_ZCL_STATUS_FAILURE;
+    return Protocols::InteractionModel::Status::Failure;
 }
 
 namespace {

--- a/examples/bridge-app/asr/subdevice/SubDeviceManager.h
+++ b/examples/bridge-app/asr/subdevice/SubDeviceManager.h
@@ -68,8 +68,8 @@ extern "C" {
 int AddDeviceEndpoint(SubDevice * dev, EmberAfEndpointType * ep, const Span<const EmberAfDeviceType> & deviceTypeList,
                       const Span<DataVersion> & dataVersionStorage, chip::EndpointId parentEndpointId);
 CHIP_ERROR RemoveDeviceEndpoint(SubDevice * dev);
-EmberAfStatus HandleReadBridgedDeviceBasicAttribute(SubDevice * dev, chip::AttributeId attributeId, uint8_t * buffer,
-                                                    uint16_t maxReadLength);
+Protocols::InteractionModel::Status HandleReadBridgedDeviceBasicAttribute(SubDevice * dev, chip::AttributeId attributeId,
+                                                                          uint8_t * buffer, uint16_t maxReadLength);
 void HandleDeviceStatusChanged(SubDevice * dev, SubDevice::Changed_t itemChangedMask);
 void Init_Bridge_Endpoint();
 #ifdef __cplusplus

--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -213,8 +213,8 @@ CHIP_ERROR RemoveDeviceEndpoint(Device * dev)
     return CHIP_ERROR_INTERNAL;
 }
 
-EmberAfStatus HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer,
-                                                    uint16_t maxReadLength)
+Protocols::InteractionModel::Status HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::AttributeId attributeId,
+                                                                          uint8_t * buffer, uint16_t maxReadLength)
 {
     using namespace BridgedDeviceBasicInformation::Attributes;
     ChipLogProgress(DeviceLayer, "HandleReadBridgedDeviceBasicAttribute: attrId=%" PRIu32 ", maxReadLength=%u", attributeId,
@@ -236,13 +236,14 @@ EmberAfStatus HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::Attribut
     }
     else
     {
-        return EMBER_ZCL_STATUS_FAILURE;
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus HandleReadOnOffAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer, uint16_t maxReadLength)
+Protocols::InteractionModel::Status HandleReadOnOffAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer,
+                                                             uint16_t maxReadLength)
 {
     ChipLogProgress(DeviceLayer, "HandleReadOnOffAttribute: attrId=%" PRIu32 ", maxReadLength=%u", attributeId, maxReadLength);
 
@@ -257,24 +258,25 @@ EmberAfStatus HandleReadOnOffAttribute(Device * dev, chip::AttributeId attribute
     }
     else
     {
-        return EMBER_ZCL_STATUS_FAILURE;
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus HandleWriteOnOffAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer)
+Protocols::InteractionModel::Status HandleWriteOnOffAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer)
 {
     ChipLogProgress(DeviceLayer, "HandleWriteOnOffAttribute: attrId=%" PRIu32, attributeId);
 
-    ReturnErrorCodeIf((attributeId != OnOff::Attributes::OnOff::Id) || (!dev->IsReachable()), EMBER_ZCL_STATUS_FAILURE);
+    ReturnErrorCodeIf((attributeId != OnOff::Attributes::OnOff::Id) || (!dev->IsReachable()),
+                      Protocols::InteractionModel::Status::Failure);
     dev->SetOnOff(*buffer == 1);
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
-                                                   const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
-                                                   uint16_t maxReadLength)
+Protocols::InteractionModel::Status emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                         const EmberAfAttributeMetadata * attributeMetadata,
+                                                                         uint8_t * buffer, uint16_t maxReadLength)
 {
     uint16_t endpointIndex = emberAfGetDynamicIndexFromEndpoint(endpoint);
 
@@ -292,11 +294,12 @@ EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterI
         }
     }
 
-    return EMBER_ZCL_STATUS_FAILURE;
+    return Protocols::InteractionModel::Status::Failure;
 }
 
-EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
-                                                    const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer)
+Protocols::InteractionModel::Status emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                          const EmberAfAttributeMetadata * attributeMetadata,
+                                                                          uint8_t * buffer)
 {
     uint16_t endpointIndex = emberAfGetDynamicIndexFromEndpoint(endpoint);
 
@@ -310,7 +313,7 @@ EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, Cluster
         }
     }
 
-    return EMBER_ZCL_STATUS_FAILURE;
+    return Protocols::InteractionModel::Status::Failure;
 }
 
 namespace {

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -436,8 +436,8 @@ void HandleDeviceTempSensorStatusChanged(DeviceTempSensor * dev, DeviceTempSenso
     }
 }
 
-EmberAfStatus HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer,
-                                                    uint16_t maxReadLength)
+Protocols::InteractionModel::Status HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::AttributeId attributeId,
+                                                                          uint8_t * buffer, uint16_t maxReadLength)
 {
     using namespace BridgedDeviceBasicInformation::Attributes;
 
@@ -464,13 +464,14 @@ EmberAfStatus HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::Attribut
     }
     else
     {
-        return EMBER_ZCL_STATUS_FAILURE;
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus HandleReadOnOffAttribute(DeviceOnOff * dev, chip::AttributeId attributeId, uint8_t * buffer, uint16_t maxReadLength)
+Protocols::InteractionModel::Status HandleReadOnOffAttribute(DeviceOnOff * dev, chip::AttributeId attributeId, uint8_t * buffer,
+                                                             uint16_t maxReadLength)
 {
     ChipLogProgress(DeviceLayer, "HandleReadOnOffAttribute: attrId=%d, maxReadLength=%d", attributeId, maxReadLength);
 
@@ -485,13 +486,13 @@ EmberAfStatus HandleReadOnOffAttribute(DeviceOnOff * dev, chip::AttributeId attr
     }
     else
     {
-        return EMBER_ZCL_STATUS_FAILURE;
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus HandleWriteOnOffAttribute(DeviceOnOff * dev, chip::AttributeId attributeId, uint8_t * buffer)
+Protocols::InteractionModel::Status HandleWriteOnOffAttribute(DeviceOnOff * dev, chip::AttributeId attributeId, uint8_t * buffer)
 {
     ChipLogProgress(DeviceLayer, "HandleWriteOnOffAttribute: attrId=%d", attributeId);
 
@@ -508,14 +509,14 @@ EmberAfStatus HandleWriteOnOffAttribute(DeviceOnOff * dev, chip::AttributeId att
     }
     else
     {
-        return EMBER_ZCL_STATUS_FAILURE;
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus HandleReadTempMeasurementAttribute(DeviceTempSensor * dev, chip::AttributeId attributeId, uint8_t * buffer,
-                                                 uint16_t maxReadLength)
+Protocols::InteractionModel::Status HandleReadTempMeasurementAttribute(DeviceTempSensor * dev, chip::AttributeId attributeId,
+                                                                       uint8_t * buffer, uint16_t maxReadLength)
 {
     using namespace TemperatureMeasurement::Attributes;
 
@@ -546,19 +547,19 @@ EmberAfStatus HandleReadTempMeasurementAttribute(DeviceTempSensor * dev, chip::A
     }
     else
     {
-        return EMBER_ZCL_STATUS_FAILURE;
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
-                                                   const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
-                                                   uint16_t maxReadLength)
+Protocols::InteractionModel::Status emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                         const EmberAfAttributeMetadata * attributeMetadata,
+                                                                         uint8_t * buffer, uint16_t maxReadLength)
 {
     uint16_t endpointIndex = emberAfGetDynamicIndexFromEndpoint(endpoint);
 
-    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+    Protocols::InteractionModel::Status ret = Protocols::InteractionModel::Status::Failure;
 
     if ((endpointIndex < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT) && (gDevices[endpointIndex] != nullptr))
     {
@@ -643,12 +644,13 @@ public:
 
 BridgedPowerSourceAttrAccess gPowerAttrAccess;
 
-EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
-                                                    const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer)
+Protocols::InteractionModel::Status emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                          const EmberAfAttributeMetadata * attributeMetadata,
+                                                                          uint8_t * buffer)
 {
     uint16_t endpointIndex = emberAfGetDynamicIndexFromEndpoint(endpoint);
 
-    EmberAfStatus ret = EMBER_ZCL_STATUS_FAILURE;
+    Protocols::InteractionModel::Status ret = Protocols::InteractionModel::Status::Failure;
 
     // ChipLogProgress(DeviceLayer, "emberAfExternalAttributeWriteCallback: ep=%d", endpoint);
 

--- a/examples/bridge-app/telink/src/AppTask.cpp
+++ b/examples/bridge-app/telink/src/AppTask.cpp
@@ -36,8 +36,8 @@ int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const E
                       const Span<DataVersion> & dataVersionStorage, chip::EndpointId parentEndpointId);
 CHIP_ERROR RemoveDeviceEndpoint(Device * dev);
 void HandleDeviceTempSensorStatusChanged(DeviceTempSensor * dev, DeviceTempSensor::Changed_t itemChangedMask);
-EmberAfStatus HandleReadTempMeasurementAttribute(DeviceTempSensor * dev, chip::AttributeId attributeId, uint8_t * buffer,
-                                                 uint16_t maxReadLength);
+Protocols::InteractionModel::Status HandleReadTempMeasurementAttribute(DeviceTempSensor * dev, chip::AttributeId attributeId,
+                                                                       uint8_t * buffer, uint16_t maxReadLength);
 
 static const int kNodeLabelSize = 32;
 // Current ZCL implementation of Struct uses a max-size array of 254 bytes
@@ -236,8 +236,8 @@ CHIP_ERROR RemoveDeviceEndpoint(Device * dev)
     return CHIP_ERROR_INTERNAL;
 }
 
-EmberAfStatus HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer,
-                                                    uint16_t maxReadLength)
+Protocols::InteractionModel::Status HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::AttributeId attributeId,
+                                                                          uint8_t * buffer, uint16_t maxReadLength)
 {
     using namespace chip::app::Clusters::BridgedDeviceBasicInformation::Attributes;
     ChipLogProgress(DeviceLayer, "HandleReadBridgedDeviceBasicAttribute: attrId=%" PRIu32 ", maxReadLength=%u", attributeId,
@@ -264,13 +264,14 @@ EmberAfStatus HandleReadBridgedDeviceBasicAttribute(Device * dev, chip::Attribut
     }
     else
     {
-        return EMBER_ZCL_STATUS_FAILURE;
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus HandleReadOnOffAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer, uint16_t maxReadLength)
+Protocols::InteractionModel::Status HandleReadOnOffAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer,
+                                                             uint16_t maxReadLength)
 {
     ChipLogProgress(DeviceLayer, "HandleReadOnOffAttribute: attrId=%" PRIu32 ", maxReadLength=%u", attributeId, maxReadLength);
 
@@ -285,24 +286,25 @@ EmberAfStatus HandleReadOnOffAttribute(Device * dev, chip::AttributeId attribute
     }
     else
     {
-        return EMBER_ZCL_STATUS_FAILURE;
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus HandleWriteOnOffAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer)
+Protocols::InteractionModel::Status HandleWriteOnOffAttribute(Device * dev, chip::AttributeId attributeId, uint8_t * buffer)
 {
     ChipLogProgress(DeviceLayer, "HandleWriteOnOffAttribute: attrId=%" PRIu32, attributeId);
 
-    ReturnErrorCodeIf((attributeId != Clusters::OnOff::Attributes::OnOff::Id) || (!dev->IsReachable()), EMBER_ZCL_STATUS_FAILURE);
+    ReturnErrorCodeIf((attributeId != Clusters::OnOff::Attributes::OnOff::Id) || (!dev->IsReachable()),
+                      Protocols::InteractionModel::Status::Failure);
     dev->SetOnOff(*buffer == 1);
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
-EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
-                                                   const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
-                                                   uint16_t maxReadLength)
+Protocols::InteractionModel::Status emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                         const EmberAfAttributeMetadata * attributeMetadata,
+                                                                         uint8_t * buffer, uint16_t maxReadLength)
 {
     using namespace Clusters;
 
@@ -327,11 +329,12 @@ EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterI
         }
     }
 
-    return EMBER_ZCL_STATUS_FAILURE;
+    return Protocols::InteractionModel::Status::Failure;
 }
 
-EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
-                                                    const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer)
+Protocols::InteractionModel::Status emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                          const EmberAfAttributeMetadata * attributeMetadata,
+                                                                          uint8_t * buffer)
 {
     uint16_t endpointIndex = emberAfGetDynamicIndexFromEndpoint(endpoint);
 
@@ -345,7 +348,7 @@ EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, Cluster
         }
     }
 
-    return EMBER_ZCL_STATUS_FAILURE;
+    return Protocols::InteractionModel::Status::Failure;
 }
 
 namespace {
@@ -488,8 +491,8 @@ void HandleDeviceTempSensorStatusChanged(DeviceTempSensor * dev, DeviceTempSenso
     }
 }
 
-EmberAfStatus HandleReadTempMeasurementAttribute(DeviceTempSensor * dev, chip::AttributeId attributeId, uint8_t * buffer,
-                                                 uint16_t maxReadLength)
+Protocols::InteractionModel::Status HandleReadTempMeasurementAttribute(DeviceTempSensor * dev, chip::AttributeId attributeId,
+                                                                       uint8_t * buffer, uint16_t maxReadLength)
 {
     using namespace Clusters::TemperatureMeasurement::Attributes;
 
@@ -520,10 +523,10 @@ EmberAfStatus HandleReadTempMeasurementAttribute(DeviceTempSensor * dev, chip::A
     }
     else
     {
-        return EMBER_ZCL_STATUS_FAILURE;
+        return Protocols::InteractionModel::Status::Failure;
     }
 
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
 void AppTask::LightingActionEventHandler(AppEvent * aEvent)
@@ -590,15 +593,15 @@ void AppTask::UpdateClusterState(void)
     bool isTurnedOn = sAppTask.mPwmRgbBlueLed.IsTurnedOn();
 
     // write the new on/off value
-    EmberAfStatus status = Clusters::OnOff::Attributes::OnOff::Set(kExampleEndpointId, isTurnedOn);
+    Protocols::InteractionModel::Status status = Clusters::OnOff::Attributes::OnOff::Set(kExampleEndpointId, isTurnedOn);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         LOG_ERR("Update OnOff fail: %x", status);
     }
     uint8_t setLevel = sAppTask.mPwmRgbBlueLed.GetLevel();
     status           = Clusters::LevelControl::Attributes::CurrentLevel::Set(kExampleEndpointId, setLevel);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         LOG_ERR("Update CurrentLevel fail: %x", status);
     }

--- a/examples/bridge-app/telink/src/ZclCallbacks.cpp
+++ b/examples/bridge-app/telink/src/ZclCallbacks.cpp
@@ -43,12 +43,12 @@ using namespace chip::app::Clusters::OnOff;
  */
 void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     bool storedValue;
 
     // Read storedValue on/off value
     status = Attributes::OnOff::Get(1, &storedValue);
-    if (status == EMBER_ZCL_STATUS_SUCCESS)
+    if (status == Protocols::InteractionModel::Status::Success)
     {
         // Set actual state to stored before reboot
         GetAppTask().GetPWMDevice().Set(storedValue);

--- a/examples/chef/common/chef-air-quality.cpp
+++ b/examples/chef/common/chef-air-quality.cpp
@@ -40,15 +40,16 @@ void emberAfAirQualityClusterInitCallback(chip::EndpointId endpointId)
     gAirQualityClusterInstance[endpointId] = clusterInstance;
 }
 
-EmberAfStatus chefAirQualityWriteCallback(EndpointId endpoint, ClusterId clusterId,
-                                          const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer)
+Protocols::InteractionModel::Status chefAirQualityWriteCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                const EmberAfAttributeMetadata * attributeMetadata,
+                                                                uint8_t * buffer)
 {
-    EmberAfStatus ret = EMBER_ZCL_STATUS_SUCCESS;
+    Protocols::InteractionModel::Status ret = Protocols::InteractionModel::Status::Success;
 
     if (gAirQualityClusterInstance.find(endpoint) == gAirQualityClusterInstance.end())
     {
         ChipLogError(DeviceLayer, "Invalid Endpoind ID: %d", endpoint);
-        return EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT;
+        return Protocols::InteractionModel::Status::UnsupportedEndpoint;
     }
 
     Instance * clusterInstance = gAirQualityClusterInstance[endpoint];
@@ -63,12 +64,12 @@ EmberAfStatus chefAirQualityWriteCallback(EndpointId endpoint, ClusterId cluster
         {
             break;
         }
-        ret = EMBER_ZCL_STATUS_UNSUPPORTED_WRITE;
+        ret = Protocols::InteractionModel::Status::UnsupportedWrite;
         ChipLogError(DeviceLayer, "Invalid Attribute Update status: %d", static_cast<int>(status));
     }
     break;
     default:
-        ret = EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
+        ret = Protocols::InteractionModel::Status::UnsupportedAttribute;
         ChipLogError(DeviceLayer, "Unsupported Attribute ID: %d", static_cast<int>(attributeId));
         break;
     }
@@ -76,11 +77,11 @@ EmberAfStatus chefAirQualityWriteCallback(EndpointId endpoint, ClusterId cluster
     return ret;
 }
 
-EmberAfStatus chefAirQualityReadCallback(EndpointId endpoint, ClusterId clusterId,
-                                         const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
-                                         uint16_t maxReadLength)
+Protocols::InteractionModel::Status chefAirQualityReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                               const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
+                                                               uint16_t maxReadLength)
 {
-    EmberAfStatus ret = EMBER_ZCL_STATUS_SUCCESS;
+    Protocols::InteractionModel::Status ret = Protocols::InteractionModel::Status::Success;
 
     return ret;
 }

--- a/examples/chef/common/chef-air-quality.h
+++ b/examples/chef/common/chef-air-quality.h
@@ -22,9 +22,10 @@
 #include <lib/core/DataModelTypes.h>
 
 #ifdef MATTER_DM_PLUGIN_AIR_QUALITY_SERVER
-EmberAfStatus chefAirQualityWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                          const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer);
-EmberAfStatus chefAirQualityReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                         const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
-                                         uint16_t maxReadLength);
+Protocols::InteractionModel::Status chefAirQualityWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                const EmberAfAttributeMetadata * attributeMetadata,
+                                                                uint8_t * buffer);
+Protocols::InteractionModel::Status chefAirQualityReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                               const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
+                                                               uint16_t maxReadLength);
 #endif

--- a/examples/chef/common/chef-concentration-measurement.cpp
+++ b/examples/chef/common/chef-concentration-measurement.cpp
@@ -55,19 +55,19 @@ static std::map<int, Instance<true, true, true, true, true, true> *>
 
 template <bool NumericMeasurementEnabled, bool LevelIndicationEnabled, bool MediumLevelEnabled, bool CriticalLevelEnabled,
           bool PeakMeasurementEnabled, bool AverageMeasurementEnabled>
-EmberAfStatus chefConcentrationMeasurementWriteCallback(
+Protocols::InteractionModel::Status chefConcentrationMeasurementWriteCallback(
     std::map<int,
              Instance<NumericMeasurementEnabled, LevelIndicationEnabled, MediumLevelEnabled, CriticalLevelEnabled,
                       PeakMeasurementEnabled, LevelIndicationEnabled> *> & map,
     AttributeId measuredValueId, chip::EndpointId endpoint, chip::ClusterId clusterId,
     const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer)
 {
-    EmberAfStatus ret = EMBER_ZCL_STATUS_SUCCESS;
+    Protocols::InteractionModel::Status ret = Protocols::InteractionModel::Status::Success;
 
     if (map.find(endpoint) == map.end())
     {
         ChipLogError(DeviceLayer, "Invalid Endpoind ID: %d", endpoint);
-        return EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT;
+        return Protocols::InteractionModel::Status::UnsupportedEndpoint;
     }
 
     Instance<NumericMeasurementEnabled, LevelIndicationEnabled, MediumLevelEnabled, CriticalLevelEnabled, PeakMeasurementEnabled,
@@ -95,23 +95,24 @@ EmberAfStatus chefConcentrationMeasurementWriteCallback(
         }
         else
         {
-            ret = EMBER_ZCL_STATUS_UNSUPPORTED_WRITE;
+            ret = Protocols::InteractionModel::Status::UnsupportedWrite;
             ChipLogError(DeviceLayer, "Invalid Attribute Update status: %" CHIP_ERROR_FORMAT, err.Format());
         }
     }
     else
     {
-        ret = EMBER_ZCL_STATUS_UNSUPPORTED_ATTRIBUTE;
+        ret = Protocols::InteractionModel::Status::UnsupportedAttribute;
         ChipLogError(DeviceLayer, "Unsupported Attribute ID: %d", static_cast<int>(attributeId));
     }
 
     return ret;
 }
 
-EmberAfStatus chefConcentrationMeasurementWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                        const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer)
+Protocols::InteractionModel::Status chefConcentrationMeasurementWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                              const EmberAfAttributeMetadata * attributeMetadata,
+                                                                              uint8_t * buffer)
 {
-    EmberAfStatus ret = EMBER_ZCL_STATUS_SUCCESS;
+    Protocols::InteractionModel::Status ret = Protocols::InteractionModel::Status::Success;
 
     switch (clusterId)
     {
@@ -174,11 +175,11 @@ EmberAfStatus chefConcentrationMeasurementWriteCallback(chip::EndpointId endpoin
     return ret;
 }
 
-EmberAfStatus chefConcentrationMeasurementReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                       const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
-                                                       uint16_t maxReadLength)
+Protocols::InteractionModel::Status chefConcentrationMeasurementReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                             const EmberAfAttributeMetadata * attributeMetadata,
+                                                                             uint8_t * buffer, uint16_t maxReadLength)
 {
-    EmberAfStatus ret = EMBER_ZCL_STATUS_SUCCESS;
+    Protocols::InteractionModel::Status ret = Protocols::InteractionModel::Status::Success;
 
     return ret;
 }

--- a/examples/chef/common/chef-concentration-measurement.h
+++ b/examples/chef/common/chef-concentration-measurement.h
@@ -31,9 +31,10 @@
     defined(MATTER_DM_PLUGIN_PM10_CONCENTRATION_MEASUREMENT_SERVER) ||                                                             \
     defined(MATTER_DM_PLUGIN_TOTAL_VOLATILE_ORGANIC_COMPOUNDS_CONCENTRATION_MEASUREMENT_SERVER) ||                                 \
     defined(MATTER_DM_PLUGIN_RADON_CONCENTRATION_MEASUREMENT_SERVER)
-EmberAfStatus chefConcentrationMeasurementWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                        const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer);
-EmberAfStatus chefConcentrationMeasurementReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                       const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
-                                                       uint16_t maxReadLength);
+Protocols::InteractionModel::Status chefConcentrationMeasurementWriteCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                              const EmberAfAttributeMetadata * attributeMetadata,
+                                                                              uint8_t * buffer);
+Protocols::InteractionModel::Status chefConcentrationMeasurementReadCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
+                                                                             const EmberAfAttributeMetadata * attributeMetadata,
+                                                                             uint8_t * buffer, uint16_t maxReadLength);
 #endif

--- a/examples/chef/common/chef-fan-control-manager.cpp
+++ b/examples/chef/common/chef-fan-control-manager.cpp
@@ -57,9 +57,9 @@ CHIP_ERROR ChefFanControlManager::ReadPercentCurrent(AttributeValueEncoder & aEn
 {
     // Return PercentSetting attribute value for now
     DataModel::Nullable<Percent> percentSetting;
-    EmberAfStatus status = PercentSetting::Get(mEndpoint, percentSetting);
+    Protocols::InteractionModel::Status status = PercentSetting::Get(mEndpoint, percentSetting);
 
-    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, CHIP_ERROR_READ_FAILED);
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, CHIP_ERROR_READ_FAILED);
 
     return aEncoder.Encode(percentSetting.ValueOr(0));
 }
@@ -68,9 +68,9 @@ CHIP_ERROR ChefFanControlManager::ReadSpeedCurrent(AttributeValueEncoder & aEnco
 {
     // Return SpeedCurrent attribute value for now
     DataModel::Nullable<uint8_t> speedSetting;
-    EmberAfStatus status = SpeedSetting::Get(mEndpoint, speedSetting);
+    Protocols::InteractionModel::Status status = SpeedSetting::Get(mEndpoint, speedSetting);
 
-    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, CHIP_ERROR_READ_FAILED);
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, CHIP_ERROR_READ_FAILED);
 
     return aEncoder.Encode(speedSetting.ValueOr(0));
 }
@@ -82,19 +82,19 @@ Status ChefFanControlManager::HandleStep(StepDirectionEnum aDirection, bool aWra
 
     VerifyOrReturnError(aDirection != StepDirectionEnum::kUnknownEnumValue, Status::InvalidCommand);
 
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
 
     uint8_t speedMax;
     status = SpeedMax::Get(mEndpoint, &speedMax);
-    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, Status::InvalidCommand);
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, Status::InvalidCommand);
 
     uint8_t speedCurrent;
     status = SpeedCurrent::Get(mEndpoint, &speedCurrent);
-    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, Status::InvalidCommand);
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, Status::InvalidCommand);
 
     DataModel::Nullable<uint8_t> speedSetting;
     status = SpeedSetting::Get(mEndpoint, speedSetting);
-    VerifyOrReturnError(EMBER_ZCL_STATUS_SUCCESS == status, Status::InvalidCommand);
+    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, Status::InvalidCommand);
 
     uint8_t newSpeedSetting    = speedSetting.ValueOr(0);
     uint8_t speedValue         = speedSetting.ValueOr(speedCurrent);

--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -23,9 +23,9 @@ using chip::app::DataModel::Nullable;
 
 using namespace chip;
 
-EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
-                                                   const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer,
-                                                   uint16_t maxReadLength)
+Protocols::InteractionModel::Status emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                         const EmberAfAttributeMetadata * attributeMetadata,
+                                                                         uint8_t * buffer, uint16_t maxReadLength)
 {
     switch (clusterId)
     {
@@ -58,7 +58,7 @@ EmberAfStatus emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterI
     default:
         break;
     }
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
 /*
@@ -71,8 +71,9 @@ $1 = {defaultValue = {ptrToDefaultValue = 0x0, defaultValue = 0, ptrToMinMaxValu
 48 '0', mask = 16 '\020'} (gdb)
 */
 
-EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
-                                                    const EmberAfAttributeMetadata * attributeMetadata, uint8_t * buffer)
+Protocols::InteractionModel::Status emberAfExternalAttributeWriteCallback(EndpointId endpoint, ClusterId clusterId,
+                                                                          const EmberAfAttributeMetadata * attributeMetadata,
+                                                                          uint8_t * buffer)
 {
     switch (clusterId)
     {
@@ -105,7 +106,7 @@ EmberAfStatus emberAfExternalAttributeWriteCallback(EndpointId endpoint, Cluster
     default:
         break;
     }
-    return EMBER_ZCL_STATUS_SUCCESS;
+    return Protocols::InteractionModel::Status::Success;
 }
 
 // Include door lock callbacks only when the server is enabled

--- a/examples/common/imgui_ui/windows/light.cpp
+++ b/examples/common/imgui_ui/windows/light.cpp
@@ -70,11 +70,11 @@ void Light::UpdateState()
 {
     if (mTargetLightIsOn.HasValue())
     {
-        EmberAfStatus status = OnOffServer::Instance().setOnOffValue(
+        Protocols::InteractionModel::Status status = OnOffServer::Instance().setOnOffValue(
             mEndpointId, mTargetLightIsOn.Value() ? OnOff::Commands::On::Id : OnOff::Commands::Off::Id,
             false /* initiatedByLevelChange */);
 
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        if (status != Protocols::InteractionModel::Status::Success)
         {
             ChipLogError(AppServer, "Failed to set on/off value: %d", status);
         }

--- a/examples/common/imgui_ui/windows/light.cpp
+++ b/examples/common/imgui_ui/windows/light.cpp
@@ -70,11 +70,11 @@ void Light::UpdateState()
 {
     if (mTargetLightIsOn.HasValue())
     {
-        Protocols::InteractionModel::Status status = OnOffServer::Instance().setOnOffValue(
+        chip::Protocols::InteractionModel::Status status = OnOffServer::Instance().setOnOffValue(
             mEndpointId, mTargetLightIsOn.Value() ? OnOff::Commands::On::Id : OnOff::Commands::Off::Id,
             false /* initiatedByLevelChange */);
 
-        if (status != Protocols::InteractionModel::Status::Success)
+        if (status != chip::Protocols::InteractionModel::Status::Success)
         {
             ChipLogError(AppServer, "Failed to set on/off value: %d", status);
         }

--- a/examples/common/pigweed/rpc_services/internal/StatusUtils.h
+++ b/examples/common/pigweed/rpc_services/internal/StatusUtils.h
@@ -36,15 +36,15 @@
 namespace chip {
 namespace rpc {
 
-constexpr pw::Status ToPwStatus(EmberAfStatus ember_status)
+constexpr pw::Status ToPwStatus(Protocols::InteractionModel::Status ember_status)
 {
     switch (ember_status)
     {
-    case EMBER_ZCL_STATUS_SUCCESS:
+    case Protocols::InteractionModel::Status::Success:
         return pw::OkStatus();
-    case EMBER_ZCL_STATUS_NOT_FOUND:
+    case Protocols::InteractionModel::Status::NotFound:
         return pw::Status::NotFound();
-    case EMBER_ZCL_STATUS_UNSUPPORTED_ACCESS:
+    case Protocols::InteractionModel::Status::UnsupportedAccess:
         return pw::Status::PermissionDenied();
     default:
         return pw::Status::Unknown();

--- a/examples/contact-sensor-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/contact-sensor-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -892,8 +892,8 @@ void AppTask::UpdateClusterStateInternal(intptr_t arg)
     uint8_t newValue = ContactSensorMgr().IsContactClosed();
 
     // write the new on/off value
-    EmberAfStatus status = app::Clusters::BooleanState::Attributes::StateValue::Set(1, newValue);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = app::Clusters::BooleanState::Attributes::StateValue::Set(1, newValue);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: updating boolean status value %x", status);
     }

--- a/examples/contact-sensor-app/nxp/k32w/k32w1/main/AppTask.cpp
+++ b/examples/contact-sensor-app/nxp/k32w/k32w1/main/AppTask.cpp
@@ -794,9 +794,9 @@ void AppTask::UpdateClusterStateInternal(intptr_t arg)
     uint8_t newValue = ContactSensorMgr().IsContactClosed();
 
     // write the new on/off value
-    EmberAfStatus status = app::Clusters::BooleanState::Attributes::StateValue::Set(1, newValue);
+    Protocols::InteractionModel::Status status = app::Clusters::BooleanState::Attributes::StateValue::Set(1, newValue);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: updating boolean status value %x", status);
     }

--- a/examples/contact-sensor-app/telink/src/AppTask.cpp
+++ b/examples/contact-sensor-app/telink/src/AppTask.cpp
@@ -95,8 +95,8 @@ void AppTask::UpdateClusterStateInternal(intptr_t arg)
     ChipLogProgress(NotSpecified, "StateValue::Set : %d", newValue);
 
     // write the new boolean state value
-    EmberAfStatus status = app::Clusters::BooleanState::Attributes::StateValue::Set(1, newValue);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = app::Clusters::BooleanState::Attributes::StateValue::Set(1, newValue);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: updating boolean status value %x", status);
     }

--- a/examples/light-switch-app/infineon/cyw30739/src/ZclCallbacks.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/ZclCallbacks.cpp
@@ -33,7 +33,8 @@ void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attrib
         if (attributePath.mAttributeId == Identify::Attributes::IdentifyTime::Id)
         {
             uint16_t identifyTime;
-            if (EMBER_ZCL_STATUS_SUCCESS == Identify::Attributes::IdentifyTime::Get(attributePath.mEndpointId, &identifyTime))
+            if (Protocols::InteractionModel::Status::Success ==
+                Identify::Attributes::IdentifyTime::Get(attributePath.mEndpointId, &identifyTime))
             {
                 ChipLogProgress(Zcl, "IdentifyTime %u", identifyTime);
                 return;

--- a/examples/light-switch-app/qpg/src/AppTask.cpp
+++ b/examples/light-switch-app/qpg/src/AppTask.cpp
@@ -495,9 +495,10 @@ void AppTask::UpdateClusterState(void)
     /* write the new attribute value based on attribute setter API.
        example API usage of on-off attribute:
 
-        EmberAfStatus status = Clusters::OnOff::Attributes::OnOff::Set(QPG_LIGHT_ENDPOINT_ID, LightingMgr().IsTurnedOn());
+        Protocols::InteractionModel::Status status = Clusters::OnOff::Attributes::OnOff::Set(QPG_LIGHT_ENDPOINT_ID,
+       LightingMgr().IsTurnedOn());
 
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        if (status != Protocols::InteractionModel::Status::Success)
         {
             ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
         }

--- a/examples/lighting-app/asr/src/AppTask.cpp
+++ b/examples/lighting-app/asr/src/AppTask.cpp
@@ -82,11 +82,11 @@ CHIP_ERROR AppTask::StartAppTask()
 
 bool IsLightOn()
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     bool on = true;
     status  = app::Clusters::OnOff::Attributes::OnOff::Get(1, &on);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ASR_LOG("Error Read OnOff Attribute 0x%02x\n", status);
     }
@@ -96,12 +96,12 @@ bool IsLightOn()
 
 uint8_t GetLightLevel()
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     app::DataModel::Nullable<uint8_t> currentLevel;
 
     status = app::Clusters::LevelControl::Attributes::CurrentLevel::Get(1, currentLevel);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ASR_LOG("Error Read CurrentLevel Attribute 0x%02x\n", status);
         return -1;

--- a/examples/lighting-app/bouffalolab/common/AppTask.cpp
+++ b/examples/lighting-app/bouffalolab/common/AppTask.cpp
@@ -252,22 +252,25 @@ void AppTask::LightingUpdate(app_event_t status)
         {
             do
             {
-                if (EMBER_ZCL_STATUS_SUCCESS != Clusters::OnOff::Attributes::OnOff::Get(endpoint, &onoff))
+                if (Protocols::InteractionModel::Status::Success != Clusters::OnOff::Attributes::OnOff::Get(endpoint, &onoff))
                 {
                     break;
                 }
 
-                if (EMBER_ZCL_STATUS_SUCCESS != Clusters::LevelControl::Attributes::CurrentLevel::Get(endpoint, v))
+                if (Protocols::InteractionModel::Status::Success !=
+                    Clusters::LevelControl::Attributes::CurrentLevel::Get(endpoint, v))
                 {
                     break;
                 }
 
-                if (EMBER_ZCL_STATUS_SUCCESS != Clusters::ColorControl::Attributes::CurrentHue::Get(endpoint, &hue))
+                if (Protocols::InteractionModel::Status::Success !=
+                    Clusters::ColorControl::Attributes::CurrentHue::Get(endpoint, &hue))
                 {
                     break;
                 }
 
-                if (EMBER_ZCL_STATUS_SUCCESS != Clusters::ColorControl::Attributes::CurrentSaturation::Get(endpoint, &sat))
+                if (Protocols::InteractionModel::Status::Success !=
+                    Clusters::ColorControl::Attributes::CurrentSaturation::Get(endpoint, &sat))
                 {
                     break;
                 }

--- a/examples/lighting-app/esp32/main/AppTask.cpp
+++ b/examples/lighting-app/esp32/main/AppTask.cpp
@@ -189,9 +189,9 @@ void AppTask::UpdateClusterState()
 {
     ESP_LOGI(TAG, "Writing to OnOff cluster");
     // write the new on/off value
-    EmberAfStatus status = Clusters::OnOff::Attributes::OnOff::Set(kLightEndpointId, AppLED.IsTurnedOn());
+    Protocols::InteractionModel::Status status = Clusters::OnOff::Attributes::OnOff::Set(kLightEndpointId, AppLED.IsTurnedOn());
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ESP_LOGE(TAG, "Updating on/off cluster failed: %x", status);
     }
@@ -199,7 +199,7 @@ void AppTask::UpdateClusterState()
     ESP_LOGI(TAG, "Writing to Current Level cluster");
     status = Clusters::LevelControl::Attributes::CurrentLevel::Set(kLightEndpointId, AppLED.GetLevel());
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ESP_LOGE(TAG, "Updating level cluster failed: %x", status);
     }

--- a/examples/lighting-app/genio/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/genio/src/ZclCallbacks.cpp
@@ -55,7 +55,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     }
     else if (clusterId == ColorControl::Id)
     {
-        EmberAfStatus status;
+        Protocols::InteractionModel::Status status;
         /* ignore several attributes that are currently not processed */
         if ((attributeId == ColorControl::Attributes::RemainingTime::Id) ||
             (attributeId == ColorControl::Attributes::EnhancedColorMode::Id) ||

--- a/examples/lighting-app/infineon/cyw30739/src/LightingManager.cpp
+++ b/examples/lighting-app/infineon/cyw30739/src/LightingManager.cpp
@@ -49,10 +49,10 @@ bool LightingManager::IsActionInProgress()
 
 bool LightingManager::IsLightOn(void)
 {
-    bool on                    = true;
-    const EmberAfStatus status = OnOff::Attributes::OnOff::Get(1, &on);
+    bool on                                          = true;
+    const Protocols::InteractionModel::Status status = OnOff::Attributes::OnOff::Get(1, &on);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         printf("Error ReadServerAttribute 0x%02x\n", status);
     }
@@ -99,9 +99,9 @@ bool LightingManager::InitiateAction(Actor_t aActor, Action_t aAction, uint8_t v
 
 void LightingManager::WriteClusterState(uint8_t value)
 {
-    const EmberAfStatus status = OnOff::Attributes::OnOff::Set(1, value);
+    const Protocols::InteractionModel::Status status = OnOff::Attributes::OnOff::Set(1, value);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         printf("Error WriteServerAttribute 0x%02x\n", status);
     }
@@ -109,9 +109,9 @@ void LightingManager::WriteClusterState(uint8_t value)
 
 void LightingManager::WriteClusterLevel(uint8_t value)
 {
-    const EmberAfStatus status = LevelControl::Attributes::CurrentLevel::Set(1, value);
+    const Protocols::InteractionModel::Status status = LevelControl::Attributes::CurrentLevel::Set(1, value);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         printf("Error WriteServerAttribute 0x%02x\n", status);
     }

--- a/examples/lighting-app/infineon/cyw30739/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/infineon/cyw30739/src/ZclCallbacks.cpp
@@ -53,7 +53,8 @@ void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attrib
         if (attributePath.mAttributeId == Identify::Attributes::IdentifyTime::Id)
         {
             uint16_t identifyTime;
-            if (EMBER_ZCL_STATUS_SUCCESS == Identify::Attributes::IdentifyTime::Get(attributePath.mEndpointId, &identifyTime))
+            if (Protocols::InteractionModel::Status::Success ==
+                Identify::Attributes::IdentifyTime::Get(attributePath.mEndpointId, &identifyTime))
             {
                 ChipLogProgress(Zcl, "IdentifyTime %u", identifyTime);
                 return;

--- a/examples/lighting-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lighting-app/infineon/psoc6/src/AppTask.cpp
@@ -555,8 +555,8 @@ void AppTask::UpdateClusterState(intptr_t context)
     uint8_t newValue = LightMgr().IsLightOn();
 
     // write the new on/off value
-    EmberAfStatus status = app::Clusters::OnOff::Attributes::OnOff::Set(1, newValue);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = app::Clusters::OnOff::Attributes::OnOff::Set(1, newValue);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         P6_LOG("ERR: updating on/off %x", status);
     }

--- a/examples/lighting-app/linux/LightingAppCommandDelegate.cpp
+++ b/examples/lighting-app/linux/LightingAppCommandDelegate.cpp
@@ -259,8 +259,9 @@ void LightingAppCommandHandler::OnSwitchLatchedHandler(uint8_t newPosition)
 {
     EndpointId endpoint = 0;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The latching switch is moved to a new position:%d", newPosition);
 
     Clusters::SwitchServer::Instance().OnSwitchLatch(endpoint, newPosition);
@@ -270,8 +271,9 @@ void LightingAppCommandHandler::OnSwitchInitialPressedHandler(uint8_t newPositio
 {
     EndpointId endpoint = 0;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The new position when the momentary switch starts to be pressed:%d", newPosition);
 
     Clusters::SwitchServer::Instance().OnInitialPress(endpoint, newPosition);
@@ -281,8 +283,9 @@ void LightingAppCommandHandler::OnSwitchLongPressedHandler(uint8_t newPosition)
 {
     EndpointId endpoint = 0;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The new position when the momentary switch has been pressed for a long time:%d", newPosition);
 
     Clusters::SwitchServer::Instance().OnLongPress(endpoint, newPosition);
@@ -292,8 +295,9 @@ void LightingAppCommandHandler::OnSwitchShortReleasedHandler(uint8_t previousPos
 {
     EndpointId endpoint = 0;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The the previous value of the CurrentPosition when the momentary switch has been released:%d",
                   previousPosition);
 
@@ -304,8 +308,9 @@ void LightingAppCommandHandler::OnSwitchLongReleasedHandler(uint8_t previousPosi
 {
     EndpointId endpoint = 0;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
     ChipLogDetail(NotSpecified,
                   "The the previous value of the CurrentPosition when the momentary switch has been released after having been "
                   "pressed for a long time:%d",
@@ -318,8 +323,9 @@ void LightingAppCommandHandler::OnSwitchMultiPressOngoingHandler(uint8_t newPosi
 {
     EndpointId endpoint = 0;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The new position when the momentary switch has been pressed in a multi-press sequence:%d",
                   newPosition);
     ChipLogDetail(NotSpecified, "%d times the momentary switch has been pressed", count);
@@ -331,8 +337,9 @@ void LightingAppCommandHandler::OnSwitchMultiPressCompleteHandler(uint8_t previo
 {
     EndpointId endpoint = 0;
 
-    EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
-    VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
+    Protocols::InteractionModel::Status status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
+    VerifyOrReturn(Protocols::InteractionModel::Status::Success == status,
+                   ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
     ChipLogDetail(NotSpecified, "The previous position when the momentary switch has been pressed in a multi-press sequence:%d",
                   previousPosition);
     ChipLogDetail(NotSpecified, "%d times the momentary switch has been pressed", count);

--- a/examples/lighting-app/mbed/main/AppTask.cpp
+++ b/examples/lighting-app/mbed/main/AppTask.cpp
@@ -462,8 +462,8 @@ void AppTask::UpdateClusterState()
     uint8_t onoff = LightingMgr().IsTurnedOn();
 
     // write the new on/off value
-    EmberAfStatus status = app::Clusters::OnOff::Attributes::OnOff::Set(1, onoff);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = app::Clusters::OnOff::Attributes::OnOff::Set(1, onoff);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "Updating on/off cluster failed: %x", status);
     }
@@ -472,7 +472,7 @@ void AppTask::UpdateClusterState()
 
     status = app::Clusters::LevelControl::Attributes::CurrentLevel::Set(1, level);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "Updating level cluster failed: %x", status);
     }

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -689,9 +689,10 @@ void AppTask::UpdateClusterState()
 {
     SystemLayer().ScheduleLambda([this] {
         // write the new on/off value
-        EmberAfStatus status = Clusters::OnOff::Attributes::OnOff::Set(kLightEndpointId, mPWMDevice.IsTurnedOn());
+        Protocols::InteractionModel::Status status =
+            Clusters::OnOff::Attributes::OnOff::Set(kLightEndpointId, mPWMDevice.IsTurnedOn());
 
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        if (status != Protocols::InteractionModel::Status::Success)
         {
             LOG_ERR("Updating on/off cluster failed: %x", status);
         }
@@ -699,7 +700,7 @@ void AppTask::UpdateClusterState()
         // write the current level
         status = Clusters::LevelControl::Attributes::CurrentLevel::Set(kLightEndpointId, mPWMDevice.GetLevel());
 
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        if (status != Protocols::InteractionModel::Status::Success)
         {
             LOG_ERR("Updating level cluster failed: %x", status);
         }

--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -73,12 +73,12 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
  */
 void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     bool storedValue;
 
     // Read storedValue on/off value
     status = Attributes::OnOff::Get(endpoint, &storedValue);
-    if (status == EMBER_ZCL_STATUS_SUCCESS)
+    if (status == Protocols::InteractionModel::Status::Success)
     {
         // Set actual state to the cluster state that was last persisted
         AppTask::Instance().GetPWMDevice().InitiateAction(storedValue ? PWMDevice::ON_ACTION : PWMDevice::OFF_ACTION,

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -955,8 +955,8 @@ void AppTask::UpdateClusterStateInternal(intptr_t arg)
     uint8_t newValue = !LightingMgr().IsTurnedOff();
 
     // write the new on/off value
-    EmberAfStatus status = app::Clusters::OnOff::Attributes::OnOff::Set(1, newValue);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = app::Clusters::OnOff::Attributes::OnOff::Set(1, newValue);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
     }

--- a/examples/lighting-app/nxp/k32w/k32w1/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w1/main/AppTask.cpp
@@ -838,8 +838,8 @@ void AppTask::UpdateClusterStateInternal(intptr_t arg)
     uint8_t newValue = !LightingMgr().IsTurnedOff();
 
     // write the new on/off value
-    EmberAfStatus status = app::Clusters::OnOff::Attributes::OnOff::Set(1, newValue);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = app::Clusters::OnOff::Attributes::OnOff::Set(1, newValue);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
     }

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -642,16 +642,17 @@ void AppTask::UpdateClusterState(void)
         ChipLogProgress(NotSpecified, "UpdateClusterState");
 
         // Write the new on/off value
-        EmberAfStatus status = Clusters::OnOff::Attributes::OnOff::Set(QPG_LIGHT_ENDPOINT_ID, LightingMgr().IsTurnedOn());
+        Protocols::InteractionModel::Status status =
+            Clusters::OnOff::Attributes::OnOff::Set(QPG_LIGHT_ENDPOINT_ID, LightingMgr().IsTurnedOn());
 
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        if (status != Protocols::InteractionModel::Status::Success)
         {
             ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
         }
 
         // Write new level value
         status = Clusters::LevelControl::Attributes::CurrentLevel::Set(QPG_LIGHT_ENDPOINT_ID, LightingMgr().GetLevel());
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        if (status != Protocols::InteractionModel::Status::Success)
         {
             ChipLogError(NotSpecified, "ERR: updating level %x", status);
         }

--- a/examples/lighting-app/qpg/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/qpg/src/ZclCallbacks.cpp
@@ -78,15 +78,15 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
             {
                 xy.x = *reinterpret_cast<uint16_t *>(value);
                 // get Y from cluster value storage
-                EmberAfStatus status = ColorControl::Attributes::CurrentY::Get(endpoint, &xy.y);
-                assert(status == EMBER_ZCL_STATUS_SUCCESS);
+                Protocols::InteractionModel::Status status = ColorControl::Attributes::CurrentY::Get(endpoint, &xy.y);
+                assert(status == Protocols::InteractionModel::Status::Success);
             }
             if (attributeId == ColorControl::Attributes::CurrentY::Id)
             {
                 xy.y = *reinterpret_cast<uint16_t *>(value);
                 // get X from cluster value storage
-                EmberAfStatus status = ColorControl::Attributes::CurrentX::Get(endpoint, &xy.x);
-                assert(status == EMBER_ZCL_STATUS_SUCCESS);
+                Protocols::InteractionModel::Status status = ColorControl::Attributes::CurrentX::Get(endpoint, &xy.x);
+                assert(status == Protocols::InteractionModel::Status::Success);
             }
 
             ChipLogProgress(Zcl, "New XY color: %u|%u", xy.x, xy.y);
@@ -108,22 +108,22 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
                 // We only support 8-bit hue. Assuming hue is linear, normalize 16-bit to 8-bit.
                 hsv.h = (uint8_t) ((*reinterpret_cast<uint16_t *>(value)) >> 8);
                 // get saturation from cluster value storage
-                EmberAfStatus status = ColorControl::Attributes::CurrentSaturation::Get(endpoint, &hsv.s);
-                assert(status == EMBER_ZCL_STATUS_SUCCESS);
+                Protocols::InteractionModel::Status status = ColorControl::Attributes::CurrentSaturation::Get(endpoint, &hsv.s);
+                assert(status == Protocols::InteractionModel::Status::Success);
             }
             else if (attributeId == ColorControl::Attributes::CurrentHue::Id)
             {
                 hsv.h = *value;
                 // get saturation from cluster value storage
-                EmberAfStatus status = ColorControl::Attributes::CurrentSaturation::Get(endpoint, &hsv.s);
-                assert(status == EMBER_ZCL_STATUS_SUCCESS);
+                Protocols::InteractionModel::Status status = ColorControl::Attributes::CurrentSaturation::Get(endpoint, &hsv.s);
+                assert(status == Protocols::InteractionModel::Status::Success);
             }
             else if (attributeId == ColorControl::Attributes::CurrentSaturation::Id)
             {
                 hsv.s = *value;
                 // get hue from cluster value storage
-                EmberAfStatus status = ColorControl::Attributes::CurrentHue::Get(endpoint, &hsv.h);
-                assert(status == EMBER_ZCL_STATUS_SUCCESS);
+                Protocols::InteractionModel::Status status = ColorControl::Attributes::CurrentHue::Get(endpoint, &hsv.h);
+                assert(status == Protocols::InteractionModel::Status::Success);
             }
             ChipLogProgress(Zcl, "New HSV color: %u|%u", hsv.h, hsv.s);
             LightingMgr().InitiateAction(LightingManager::COLOR_ACTION_HSV, 0, sizeof(hsv), (uint8_t *) &hsv);
@@ -164,11 +164,11 @@ void emberAfOnOffClusterInitCallback(EndpointId endpoint)
     XyColor_t xy;
     bool onOffValue = false;
     app::DataModel::Nullable<uint8_t> currentLevel;
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
 
     status = OnOff::Attributes::OnOff::Get(1, &onOffValue);
 
-    if (status == EMBER_ZCL_STATUS_SUCCESS)
+    if (status == Protocols::InteractionModel::Status::Success)
     {
         LightingMgr().InitiateAction(onOffValue ? LightingManager::ON_ACTION : LightingManager::OFF_ACTION, 0, 1,
                                      (uint8_t *) onOffValue);
@@ -176,7 +176,7 @@ void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 
     /* restore values saved by DeferredAttributePersistenceProvider */
     status = LevelControl::Attributes::CurrentLevel::Get(endpoint, currentLevel);
-    if (status != EMBER_ZCL_STATUS_SUCCESS || currentLevel.IsNull())
+    if (status != Protocols::InteractionModel::Status::Success || currentLevel.IsNull())
     {
         return;
     }
@@ -184,12 +184,12 @@ void emberAfOnOffClusterInitCallback(EndpointId endpoint)
     levelValue = currentLevel.Value();
 
     status = ColorControl::Attributes::CurrentY::Get(endpoint, &xy.y);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         return;
     }
     status = ColorControl::Attributes::CurrentX::Get(endpoint, &xy.x);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         return;
     }

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -246,9 +246,9 @@ void AppTask::UpdateClusterState(intptr_t context)
     uint8_t newValue = LightMgr().IsLightOn();
 
     // write the new on/off value
-    EmberAfStatus status = OnOffServer::Instance().setOnOffValue(1, newValue, false);
+    Protocols::InteractionModel::Status status = OnOffServer::Instance().setOnOffValue(1, newValue, false);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         SILABS_LOG("ERR: updating on/off %x", status);
     }

--- a/examples/lighting-app/stm32/src/STM32WB5/AppTask.cpp
+++ b/examples/lighting-app/stm32/src/STM32WB5/AppTask.cpp
@@ -444,15 +444,16 @@ void AppTask::UpdateClusterState(void)
 {
     ChipLogProgress(NotSpecified, "UpdateClusterState");
     // Write the new on/off value
-    EmberAfStatus status = Clusters::OnOff::Attributes::OnOff::Set(STM32_LIGHT_ENDPOINT_ID, LightingMgr().IsTurnedOn());
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status =
+        Clusters::OnOff::Attributes::OnOff::Set(STM32_LIGHT_ENDPOINT_ID, LightingMgr().IsTurnedOn());
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
     }
 
     // Write new level value
     status = Clusters::LevelControl::Attributes::CurrentLevel::Set(STM32_LIGHT_ENDPOINT_ID, LightingMgr().GetLevel());
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: updating level %x", status);
     }

--- a/examples/lighting-app/telink/src/AppTask.cpp
+++ b/examples/lighting-app/telink/src/AppTask.cpp
@@ -204,7 +204,7 @@ void AppTask::ActionCompleted(PWMDevice::Action_t aAction, int32_t aActor)
 
 void AppTask::UpdateClusterState(void)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     bool isTurnedOn;
     uint8_t setLevel;
 
@@ -240,13 +240,13 @@ void AppTask::UpdateClusterState(void)
 
     // write the new on/off value
     status = Clusters::OnOff::Attributes::OnOff::Set(kExampleEndpointId, isTurnedOn);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         LOG_ERR("Update OnOff fail: %x", status);
     }
 
     status = Clusters::LevelControl::Attributes::CurrentLevel::Set(kExampleEndpointId, setLevel);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         LOG_ERR("Update CurrentLevel fail: %x", status);
     }

--- a/examples/lighting-app/telink/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/telink/src/ZclCallbacks.cpp
@@ -130,12 +130,12 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
  */
 void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     bool storedValue;
 
     // Read storedValue on/off value
     status = Attributes::OnOff::Get(1, &storedValue);
-    if (status == EMBER_ZCL_STATUS_SUCCESS)
+    if (status == Protocols::InteractionModel::Status::Success)
     {
         // Set actual state to stored before reboot
         GetAppTask().GetLightingDevice().Set(storedValue);

--- a/examples/lighting-app/tizen/src/DBusInterface.cpp
+++ b/examples/lighting-app/tizen/src/DBusInterface.cpp
@@ -206,7 +206,8 @@ void DBusInterface::InitOnOff()
 {
     bool isOn   = false;
     auto status = Clusters::OnOff::Attributes::OnOff::Get(mEndpointId, &isOn);
-    VerifyOrReturn(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(NotSpecified, "Error getting OnOff: 0x%x", status));
+    VerifyOrReturn(status == Protocols::InteractionModel::Status::Success,
+                   ChipLogError(NotSpecified, "Error getting OnOff: 0x%x", status));
     light_app_on_off_set_on_off(mIfaceOnOff, isOn);
 }
 
@@ -215,13 +216,14 @@ void DBusInterface::InitColor()
     {
         uint8_t value = 0;
         auto status   = Clusters::ColorControl::Attributes::ColorMode::Get(mEndpointId, &value);
-        VerifyOrReturn(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(NotSpecified, "Error getting ColorMode: 0x%x", status));
+        VerifyOrReturn(status == Protocols::InteractionModel::Status::Success,
+                       ChipLogError(NotSpecified, "Error getting ColorMode: 0x%x", status));
         light_app_color_control_set_color_mode(mIfaceColorControl, value);
     }
     {
         uint16_t value = 0;
         auto status    = Clusters::ColorControl::Attributes::ColorTemperatureMireds::Get(mEndpointId, &value);
-        VerifyOrReturn(status == EMBER_ZCL_STATUS_SUCCESS,
+        VerifyOrReturn(status == Protocols::InteractionModel::Status::Success,
                        ChipLogError(NotSpecified, "Error getting ColorTemperatureMireds: 0x%x", status));
         light_app_color_control_set_color_temperature_mireds(mIfaceColorControl, value);
     }

--- a/examples/lighting-app/tizen/src/LedManager.cpp
+++ b/examples/lighting-app/tizen/src/LedManager.cpp
@@ -62,7 +62,8 @@ void LedManager::InitOnOff()
 {
     bool isOn   = false;
     auto status = Clusters::OnOff::Attributes::OnOff::Get(mEndpointId, &isOn);
-    VerifyOrReturn(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(NotSpecified, "Error getting OnOff: 0x%x", status));
+    VerifyOrReturn(status == Protocols::InteractionModel::Status::Success,
+                   ChipLogError(NotSpecified, "Error getting OnOff: 0x%x", status));
     SetOnOff(isOn);
 }
 

--- a/examples/lock-app/asr/src/AppTask.cpp
+++ b/examples/lock-app/asr/src/AppTask.cpp
@@ -480,9 +480,10 @@ void AppTask::UpdateCluster(intptr_t context)
 
     OperationSourceEnum source = OperationSourceEnum::kUnspecified;
     // write the new lock value
-    EmberAfStatus status =
-        DoorLockServer::Instance().SetLockState(1, newState, source) ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = DoorLockServer::Instance().SetLockState(1, newState, source)
+        ? Protocols::InteractionModel::Status::Success
+        : Protocols::InteractionModel::Status::Failure;
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ASR_LOG("ERR: updating lock state %x", status);
     }

--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -468,8 +468,8 @@ void AppTask::UpdateClusterState(intptr_t context)
     uint8_t newValue = !BoltLockMgr().IsUnlocked();
 
     // write the new on/off value
-    EmberAfStatus status = chip::app::Clusters::OnOff::Attributes::OnOff::Set(1, newValue);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = chip::app::Clusters::OnOff::Attributes::OnOff::Set(1, newValue);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ESP_LOGI(TAG, "ERR: updating on/off %x", status);
     }

--- a/examples/lock-app/genio/src/AppTask.cpp
+++ b/examples/lock-app/genio/src/AppTask.cpp
@@ -596,10 +596,11 @@ void AppTask::UpdateClusterState(intptr_t context)
     OperationSourceEnum source = OperationSourceEnum::kUnspecified;
 
     // write the new lock value
-    EmberAfStatus status =
-        DoorLockServer::Instance().SetLockState(1, newState, source) ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
+    Protocols::InteractionModel::Status status = DoorLockServer::Instance().SetLockState(1, newState, source)
+        ? Protocols::InteractionModel::Status::Success
+        : Protocols::InteractionModel::Status::Failure;
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         MT793X_LOG("ERR: updating lock state %x", status);
     }

--- a/examples/lock-app/genio/src/ZclCallbacks.cpp
+++ b/examples/lock-app/genio/src/ZclCallbacks.cpp
@@ -61,34 +61,34 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
  */
 void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
 
     status = DoorLock::Attributes::LockType::Set(endpoint, DlLockType::kDeadBolt);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(Zcl, "Failed to set LockType %x", status);
     }
 
     status = DoorLock::Attributes::NumberOfTotalUsersSupported::Set(endpoint, CONFIG_LOCK_NUM_USERS);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(Zcl, "Failed to set number of users %x", status);
     }
 
     status = DoorLock::Attributes::NumberOfPINUsersSupported::Set(endpoint, CONFIG_LOCK_NUM_USERS);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(Zcl, "Failed to set number of PIN users %x", status);
     }
 
     status = DoorLock::Attributes::NumberOfRFIDUsersSupported::Set(endpoint, 0);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(Zcl, "Failed to set number of RFID users %x", status);
     }
 
     status = DoorLock::Attributes::NumberOfCredentialsSupportedPerUser::Set(endpoint, CONFIG_LOCK_NUM_CREDENTIALS_PER_USER);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(Zcl, "Failed to set number of credentials per user %x", status);
     }
@@ -97,7 +97,7 @@ void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
     // at the same time.
     // Set FeatureMap to (kUser|kPinCredential)
     status = DoorLock::Attributes::FeatureMap::Set(endpoint, 0x101);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(Zcl, "Failed to set number of credentials per user %x", status);
     }

--- a/examples/lock-app/infineon/cyw30739/src/main.cpp
+++ b/examples/lock-app/infineon/cyw30739/src/main.cpp
@@ -324,10 +324,11 @@ void UpdateClusterState(intptr_t context)
     OperationSourceEnum source = OperationSourceEnum::kUnspecified;
 
     // write the new lock value
-    EmberAfStatus status =
-        DoorLockServer::Instance().SetLockState(1, newState, source) ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
+    Protocols::InteractionModel::Status status = DoorLockServer::Instance().SetLockState(1, newState, source)
+        ? Protocols::InteractionModel::Status::Success
+        : Protocols::InteractionModel::Status::Failure;
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(Zcl, "ERR: updating lock state %x", status);
     }

--- a/examples/lock-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lock-app/infineon/psoc6/src/AppTask.cpp
@@ -660,9 +660,10 @@ void AppTask::UpdateCluster(intptr_t context)
     OperationSourceEnum source = OperationSourceEnum::kUnspecified;
 
     // write the new lock value
-    EmberAfStatus status =
-        DoorLockServer::Instance().SetLockState(1, newState, source) ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = DoorLockServer::Instance().SetLockState(1, newState, source)
+        ? Protocols::InteractionModel::Status::Success
+        : Protocols::InteractionModel::Status::Failure;
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         P6_LOG("ERR: updating lock state %x", status);
     }

--- a/examples/lock-app/mbed/main/AppTask.cpp
+++ b/examples/lock-app/mbed/main/AppTask.cpp
@@ -461,8 +461,8 @@ void AppTask::UpdateClusterState()
     uint8_t newValue = !BoltLockMgr().IsUnlocked();
 
     // write the new on/off value
-    EmberAfStatus status = app::Clusters::OnOff::Attributes::OnOff::Set(1, newValue);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = app::Clusters::OnOff::Attributes::OnOff::Set(1, newValue);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ZCL update failed: %lx", status);
     }

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -112,8 +112,8 @@ void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 {
     DoorLockServer::Instance().InitServer(endpoint);
 
-    const auto logOnFailure = [](EmberAfStatus status, const char * attributeName) {
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+    const auto logOnFailure = [](Protocols::InteractionModel::Status status, const char * attributeName) {
+        if (status != Protocols::InteractionModel::Status::Success)
         {
             ChipLogError(Zcl, "Failed to set DoorLock %s: %x", attributeName, status);
         }

--- a/examples/lock-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lock-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -777,9 +777,9 @@ void AppTask::UpdateClusterStateInternal(intptr_t arg)
     }
 
     // write the new door lock state
-    EmberAfStatus status = Attributes::LockState::Set(1, newValue);
+    Protocols::InteractionModel::Status status = Attributes::LockState::Set(1, newValue);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: updating door lock state %x", status);
     }

--- a/examples/lock-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lock-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -777,9 +777,9 @@ void AppTask::UpdateClusterStateInternal(intptr_t arg)
     }
 
     // write the new door lock state
-    Protocols::InteractionModel::Status status = Attributes::LockState::Set(1, newValue);
+    chip::Protocols::InteractionModel::Status status = Attributes::LockState::Set(1, newValue);
 
-    if (status != Protocols::InteractionModel::Status::Success)
+    if (status != chip::Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: updating door lock state %x", status);
     }

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -622,8 +622,8 @@ void AppTask::UpdateClusterState(void)
 
         if (currentLockState.IsNull())
         {
-            EmberAfStatus status = DoorLock::Attributes::LockState::Set(QPG_LOCK_ENDPOINT_ID, newValue);
-            if (status != EMBER_ZCL_STATUS_SUCCESS)
+            Protocols::InteractionModel::Status status = DoorLock::Attributes::LockState::Set(QPG_LOCK_ENDPOINT_ID, newValue);
+            if (status != Protocols::InteractionModel::Status::Success)
             {
                 ChipLogError(NotSpecified, "ERR: updating DoorLock %x", status);
             }

--- a/examples/lock-app/qpg/src/ZclCallbacks.cpp
+++ b/examples/lock-app/qpg/src/ZclCallbacks.cpp
@@ -114,8 +114,8 @@ void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 {
     DoorLockServer::Instance().InitServer(endpoint);
 
-    const auto logOnFailure = [](EmberAfStatus status, const char * attributeName) {
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+    const auto logOnFailure = [](Protocols::InteractionModel::Status status, const char * attributeName) {
+        if (status != Protocols::InteractionModel::Status::Success)
         {
             ChipLogError(Zcl, "Failed to set DoorLock %s: %x", attributeName, status);
         }

--- a/examples/lock-app/silabs/src/AppTask.cpp
+++ b/examples/lock-app/silabs/src/AppTask.cpp
@@ -353,10 +353,11 @@ void AppTask::UpdateClusterState(intptr_t context)
     DlLockState newState = unlocked ? DlLockState::kUnlocked : DlLockState::kLocked;
 
     // write the new lock value
-    EmberAfStatus status =
-        DoorLockServer::Instance().SetLockState(1, newState) ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
+    Protocols::InteractionModel::Status status = DoorLockServer::Instance().SetLockState(1, newState)
+        ? Protocols::InteractionModel::Status::Success
+        : Protocols::InteractionModel::Status::Failure;
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         SILABS_LOG("ERR: updating lock state %x", status);
     }

--- a/examples/platform/asr/shell/matter_shell.cpp
+++ b/examples/platform/asr/shell/matter_shell.cpp
@@ -83,10 +83,10 @@ void asr_matter_onoff(int value)
 {
     ChipLogProgress(Zcl, "updating on/off = %d", value);
 
-    EmberAfStatus status = chip::app::Clusters::OnOff::Attributes::OnOff::Set(
+    Protocols::InteractionModel::Status status = chip::app::Clusters::OnOff::Attributes::OnOff::Set(
         /* endpoint ID */ 1, (uint8_t *) &value);
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogProgress(Zcl, "ERR: updating on/off %x", status);
     }

--- a/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -459,13 +459,13 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
 void AppTask::InitOnOffClusterState()
 {
 
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
 
     ChipLogProgress(NotSpecified, "Init On/Off clusterstate");
 
     // Write false as pump always boots in stopped mode
     status = OnOff::Attributes::OnOff::Set(ONOFF_CLUSTER_ENDPOINT, false);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Init On/Off state  %x", status);
     }
@@ -482,7 +482,7 @@ void AppTask::UpdateClusterState(void)
 
 void AppTask::UpdateCluster(intptr_t context)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     BitMask<PumpConfigurationAndControl::PumpStatusBitmap> pumpStatus;
 
     ChipLogProgress(NotSpecified, "Update Cluster State");
@@ -501,25 +501,25 @@ void AppTask::UpdateCluster(intptr_t context)
 
     status = PumpConfigurationAndControl::Attributes::ControlMode::Set(PCC_CLUSTER_ENDPOINT,
                                                                        PumpConfigurationAndControl::ControlModeEnum::kConstantFlow);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Constant Flow error  %x", status);
     }
     status = PumpConfigurationAndControl::Attributes::ControlMode::Set(
         PCC_CLUSTER_ENDPOINT, PumpConfigurationAndControl::ControlModeEnum::kConstantPressure);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Constant Pressure error  %x", status);
     }
     status = PumpConfigurationAndControl::Attributes::ControlMode::Set(
         PCC_CLUSTER_ENDPOINT, PumpConfigurationAndControl::ControlModeEnum::kConstantSpeed);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Constant Speed error  %x", status);
     }
     status = PumpConfigurationAndControl::Attributes::ControlMode::Set(
         PCC_CLUSTER_ENDPOINT, PumpConfigurationAndControl::ControlModeEnum::kConstantTemperature);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Constant Temperature error  %x", status);
     }
@@ -527,98 +527,98 @@ void AppTask::UpdateCluster(intptr_t context)
     // Write the new values
     bool onOffState = !PumpMgr().IsStopped();
     status          = OnOff::Attributes::OnOff::Set(ONOFF_CLUSTER_ENDPOINT, onOffState);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating On/Off state  %x", status);
     }
 
     int16_t maxPressure = PumpMgr().GetMaxPressure();
     status              = PumpConfigurationAndControl::Attributes::MaxPressure::Set(PCC_CLUSTER_ENDPOINT, maxPressure);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxPressure  %x", status);
     }
 
     uint16_t maxSpeed = PumpMgr().GetMaxSpeed();
     status            = PumpConfigurationAndControl::Attributes::MaxSpeed::Set(PCC_CLUSTER_ENDPOINT, maxSpeed);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxSpeed  %x", status);
     }
 
     uint16_t maxFlow = PumpMgr().GetMaxFlow();
     status           = PumpConfigurationAndControl::Attributes::MaxFlow::Set(PCC_CLUSTER_ENDPOINT, maxFlow);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxFlow  %x", status);
     }
 
     int16_t minConstPress = PumpMgr().GetMinConstPressure();
     status                = PumpConfigurationAndControl::Attributes::MinConstPressure::Set(PCC_CLUSTER_ENDPOINT, minConstPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstPressure  %x", status);
     }
 
     int16_t maxConstPress = PumpMgr().GetMaxConstPressure();
     status                = PumpConfigurationAndControl::Attributes::MaxConstPressure::Set(PCC_CLUSTER_ENDPOINT, maxConstPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstPressure  %x", status);
     }
 
     int16_t minCompPress = PumpMgr().GetMinCompPressure();
     status               = PumpConfigurationAndControl::Attributes::MinCompPressure::Set(PCC_CLUSTER_ENDPOINT, minCompPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinCompPressure  %x", status);
     }
 
     int16_t maxCompPress = PumpMgr().GetMaxCompPressure();
     status               = PumpConfigurationAndControl::Attributes::MaxCompPressure::Set(PCC_CLUSTER_ENDPOINT, maxCompPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxCompPressure  %x", status);
     }
 
     uint16_t minConstSpeed = PumpMgr().GetMinConstSpeed();
     status                 = PumpConfigurationAndControl::Attributes::MinConstSpeed::Set(PCC_CLUSTER_ENDPOINT, minConstSpeed);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstSpeed  %x", status);
     }
 
     uint16_t maxConstSpeed = PumpMgr().GetMaxConstSpeed();
     status                 = PumpConfigurationAndControl::Attributes::MaxConstSpeed::Set(PCC_CLUSTER_ENDPOINT, maxConstSpeed);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstSpeed  %x", status);
     }
 
     uint16_t minConstFlow = PumpMgr().GetMinConstFlow();
     status                = PumpConfigurationAndControl::Attributes::MinConstFlow::Set(PCC_CLUSTER_ENDPOINT, minConstFlow);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstFlow  %x", status);
     }
 
     uint16_t maxConstFlow = PumpMgr().GetMaxConstFlow();
     status                = PumpConfigurationAndControl::Attributes::MaxConstFlow::Set(PCC_CLUSTER_ENDPOINT, maxConstFlow);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstFlow  %x", status);
     }
 
     int16_t minConstTemp = PumpMgr().GetMinConstTemp();
     status               = PumpConfigurationAndControl::Attributes::MinConstTemp::Set(PCC_CLUSTER_ENDPOINT, minConstTemp);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstTemp  %x", status);
     }
 
     int16_t maxConstTemp = PumpMgr().GetMaxConstTemp();
     status               = PumpConfigurationAndControl::Attributes::MaxConstTemp::Set(PCC_CLUSTER_ENDPOINT, maxConstTemp);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstTemp  %x", status);
     }

--- a/examples/pump-app/cc13x4_26x4/main/AppTask.cpp
+++ b/examples/pump-app/cc13x4_26x4/main/AppTask.cpp
@@ -456,13 +456,13 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
 void AppTask::InitOnOffClusterState()
 {
 
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
 
     ChipLogProgress(NotSpecified, "Init On/Off clusterstate");
 
     // Write false as pump always boots in stopped mode
     status = OnOff::Attributes::OnOff::Set(ONOFF_CLUSTER_ENDPOINT, false);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Init On/Off state  %x", status);
     }
@@ -479,7 +479,7 @@ void AppTask::UpdateClusterState(void)
 
 void AppTask::UpdateCluster(intptr_t context)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     BitMask<PumpConfigurationAndControl::PumpStatusBitmap> pumpStatus;
 
     ChipLogProgress(NotSpecified, "Update Cluster State");
@@ -498,25 +498,25 @@ void AppTask::UpdateCluster(intptr_t context)
 
     status = PumpConfigurationAndControl::Attributes::ControlMode::Set(PCC_CLUSTER_ENDPOINT,
                                                                        PumpConfigurationAndControl::ControlModeEnum::kConstantFlow);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Constant Flow error  %x", status);
     }
     status = PumpConfigurationAndControl::Attributes::ControlMode::Set(
         PCC_CLUSTER_ENDPOINT, PumpConfigurationAndControl::ControlModeEnum::kConstantPressure);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Constant Pressure error  %x", status);
     }
     status = PumpConfigurationAndControl::Attributes::ControlMode::Set(
         PCC_CLUSTER_ENDPOINT, PumpConfigurationAndControl::ControlModeEnum::kConstantSpeed);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Constant Speed error  %x", status);
     }
     status = PumpConfigurationAndControl::Attributes::ControlMode::Set(
         PCC_CLUSTER_ENDPOINT, PumpConfigurationAndControl::ControlModeEnum::kConstantTemperature);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Constant Temperature error  %x", status);
     }
@@ -524,98 +524,98 @@ void AppTask::UpdateCluster(intptr_t context)
     // Write the new values
     bool onOffState = !PumpMgr().IsStopped();
     status          = OnOff::Attributes::OnOff::Set(ONOFF_CLUSTER_ENDPOINT, onOffState);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating On/Off state  %x", status);
     }
 
     int16_t maxPressure = PumpMgr().GetMaxPressure();
     status              = PumpConfigurationAndControl::Attributes::MaxPressure::Set(PCC_CLUSTER_ENDPOINT, maxPressure);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxPressure  %x", status);
     }
 
     uint16_t maxSpeed = PumpMgr().GetMaxSpeed();
     status            = PumpConfigurationAndControl::Attributes::MaxSpeed::Set(PCC_CLUSTER_ENDPOINT, maxSpeed);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxSpeed  %x", status);
     }
 
     uint16_t maxFlow = PumpMgr().GetMaxFlow();
     status           = PumpConfigurationAndControl::Attributes::MaxFlow::Set(PCC_CLUSTER_ENDPOINT, maxFlow);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxFlow  %x", status);
     }
 
     int16_t minConstPress = PumpMgr().GetMinConstPressure();
     status                = PumpConfigurationAndControl::Attributes::MinConstPressure::Set(PCC_CLUSTER_ENDPOINT, minConstPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstPressure  %x", status);
     }
 
     int16_t maxConstPress = PumpMgr().GetMaxConstPressure();
     status                = PumpConfigurationAndControl::Attributes::MaxConstPressure::Set(PCC_CLUSTER_ENDPOINT, maxConstPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstPressure  %x", status);
     }
 
     int16_t minCompPress = PumpMgr().GetMinCompPressure();
     status               = PumpConfigurationAndControl::Attributes::MinCompPressure::Set(PCC_CLUSTER_ENDPOINT, minCompPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinCompPressure  %x", status);
     }
 
     int16_t maxCompPress = PumpMgr().GetMaxCompPressure();
     status               = PumpConfigurationAndControl::Attributes::MaxCompPressure::Set(PCC_CLUSTER_ENDPOINT, maxCompPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxCompPressure  %x", status);
     }
 
     uint16_t minConstSpeed = PumpMgr().GetMinConstSpeed();
     status                 = PumpConfigurationAndControl::Attributes::MinConstSpeed::Set(PCC_CLUSTER_ENDPOINT, minConstSpeed);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstSpeed  %x", status);
     }
 
     uint16_t maxConstSpeed = PumpMgr().GetMaxConstSpeed();
     status                 = PumpConfigurationAndControl::Attributes::MaxConstSpeed::Set(PCC_CLUSTER_ENDPOINT, maxConstSpeed);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstSpeed  %x", status);
     }
 
     uint16_t minConstFlow = PumpMgr().GetMinConstFlow();
     status                = PumpConfigurationAndControl::Attributes::MinConstFlow::Set(PCC_CLUSTER_ENDPOINT, minConstFlow);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstFlow  %x", status);
     }
 
     uint16_t maxConstFlow = PumpMgr().GetMaxConstFlow();
     status                = PumpConfigurationAndControl::Attributes::MaxConstFlow::Set(PCC_CLUSTER_ENDPOINT, maxConstFlow);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstFlow  %x", status);
     }
 
     int16_t minConstTemp = PumpMgr().GetMinConstTemp();
     status               = PumpConfigurationAndControl::Attributes::MinConstTemp::Set(PCC_CLUSTER_ENDPOINT, minConstTemp);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstTemp  %x", status);
     }
 
     int16_t maxConstTemp = PumpMgr().GetMaxConstTemp();
     status               = PumpConfigurationAndControl::Attributes::MaxConstTemp::Set(PCC_CLUSTER_ENDPOINT, maxConstTemp);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstTemp  %x", status);
     }

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -562,7 +562,7 @@ void AppTask::DispatchEvent(const AppEvent & event)
 
 void AppTask::UpdateClusterState()
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
 
     ChipLogProgress(NotSpecified, "UpdateClusterState");
 
@@ -571,98 +571,98 @@ void AppTask::UpdateClusterState()
     bool onOffState = !PumpMgr().IsStopped();
 
     status = OnOff::Attributes::OnOff::Set(kOnOffClusterEndpoint, onOffState);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating On/Off state  %x", status);
     }
 
     int16_t maxPressure = PumpMgr().GetMaxPressure();
     status              = PumpConfigurationAndControl::Attributes::MaxPressure::Set(kPccClusterEndpoint, maxPressure);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxPressure  %x", status);
     }
 
     uint16_t maxSpeed = PumpMgr().GetMaxSpeed();
     status            = PumpConfigurationAndControl::Attributes::MaxSpeed::Set(kPccClusterEndpoint, maxSpeed);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxSpeed  %x", status);
     }
 
     uint16_t maxFlow = PumpMgr().GetMaxFlow();
     status           = PumpConfigurationAndControl::Attributes::MaxFlow::Set(kPccClusterEndpoint, maxFlow);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxFlow  %x", status);
     }
 
     int16_t minConstPress = PumpMgr().GetMinConstPressure();
     status                = PumpConfigurationAndControl::Attributes::MinConstPressure::Set(kPccClusterEndpoint, minConstPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstPressure  %x", status);
     }
 
     int16_t maxConstPress = PumpMgr().GetMaxConstPressure();
     status                = PumpConfigurationAndControl::Attributes::MaxConstPressure::Set(kPccClusterEndpoint, maxConstPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstPressure  %x", status);
     }
 
     int16_t minCompPress = PumpMgr().GetMinCompPressure();
     status               = PumpConfigurationAndControl::Attributes::MinCompPressure::Set(kPccClusterEndpoint, minCompPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinCompPressure  %x", status);
     }
 
     int16_t maxCompPress = PumpMgr().GetMaxCompPressure();
     status               = PumpConfigurationAndControl::Attributes::MaxCompPressure::Set(kPccClusterEndpoint, maxCompPress);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxCompPressure  %x", status);
     }
 
     uint16_t minConstSpeed = PumpMgr().GetMinConstSpeed();
     status                 = PumpConfigurationAndControl::Attributes::MinConstSpeed::Set(kPccClusterEndpoint, minConstSpeed);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstSpeed  %x", status);
     }
 
     uint16_t maxConstSpeed = PumpMgr().GetMaxConstSpeed();
     status                 = PumpConfigurationAndControl::Attributes::MaxConstSpeed::Set(kPccClusterEndpoint, maxConstSpeed);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstSpeed  %x", status);
     }
 
     uint16_t minConstFlow = PumpMgr().GetMinConstFlow();
     status                = PumpConfigurationAndControl::Attributes::MinConstFlow::Set(kPccClusterEndpoint, minConstFlow);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstFlow  %x", status);
     }
 
     uint16_t maxConstFlow = PumpMgr().GetMaxConstFlow();
     status                = PumpConfigurationAndControl::Attributes::MaxConstFlow::Set(kPccClusterEndpoint, maxConstFlow);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstFlow  %x", status);
     }
 
     int16_t minConstTemp = PumpMgr().GetMinConstTemp();
     status               = PumpConfigurationAndControl::Attributes::MinConstTemp::Set(kPccClusterEndpoint, minConstTemp);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MinConstTemp  %x", status);
     }
 
     int16_t maxConstTemp = PumpMgr().GetMaxConstTemp();
     status               = PumpConfigurationAndControl::Attributes::MaxConstTemp::Set(kPccClusterEndpoint, maxConstTemp);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating MaxConstTemp  %x", status);
     }

--- a/examples/pump-app/silabs/src/AppTask.cpp
+++ b/examples/pump-app/silabs/src/AppTask.cpp
@@ -242,10 +242,10 @@ void AppTask::ActionCompleted(PumpManager::Action_t aAction, int32_t aActor)
 void AppTask::UpdateClusterState(intptr_t context)
 {
     // Set On/Off state
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     bool onOffState = !PumpMgr().IsStopped();
     status          = chip::app::Clusters::OnOff::Attributes::OnOff::Set(PCC_CLUSTER_ENDPOINT, onOffState);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogError(NotSpecified, "ERR: Updating On/Off state  %x", status);
     }

--- a/examples/pump-app/telink/src/AppTask.cpp
+++ b/examples/pump-app/telink/src/AppTask.cpp
@@ -131,8 +131,8 @@ void AppTask::UpdateClusterState()
     // Write the new values
     bool onOffState = !PumpMgr().IsStopped();
 
-    EmberAfStatus status = Clusters::OnOff::Attributes::OnOff::Set(kOnOffClusterEndpoint, onOffState);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = Clusters::OnOff::Attributes::OnOff::Set(kOnOffClusterEndpoint, onOffState);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         LOG_ERR("ERR: Updating On/Off state  %x", status);
     }

--- a/examples/thermostat/qpg/src/ThermostaticRadiatorValveManager.cpp
+++ b/examples/thermostat/qpg/src/ThermostaticRadiatorValveManager.cpp
@@ -304,7 +304,7 @@ void ThermostaticRadiatorValveManager::UpdateLocalTemperature(int16_t aLocalTemp
 {
     SystemLayer().ScheduleLambda([aLocalTemperature] {
         ChipLogProgress(NotSpecified, "UpdateLocalTemperature with value (0.01 degC) %u", aLocalTemperature);
-        if (EMBER_ZCL_STATUS_SUCCESS !=
+        if (Protocols::InteractionModel::Status::Success !=
             Thermostat::Attributes::LocalTemperature::Set(QPG_THERMOSTATIC_ENDPOINT_ID, aLocalTemperature))
         {
             ChipLogProgress(NotSpecified, "UpdateLocalTemperature failure");

--- a/examples/thermostat/qpg/src/ZclCallbacks.cpp
+++ b/examples/thermostat/qpg/src/ZclCallbacks.cpp
@@ -56,8 +56,8 @@ void emberAfThermostatClusterInitCallback(EndpointId endpoint)
 {
 
     // Temp. code for testing purpose, need to be updated
-    const auto logOnFailure = [](EmberAfStatus status, const char * attributeName) {
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+    const auto logOnFailure = [](Protocols::InteractionModel::Status status, const char * attributeName) {
+        if (status != Protocols::InteractionModel::Status::Success)
         {
             ChipLogError(Zcl, "Failed to set DoorLock %s: %x", attributeName, status);
         }

--- a/examples/tv-app/android/include/account-login/AccountLoginManager.cpp
+++ b/examples/tv-app/android/include/account-login/AccountLoginManager.cpp
@@ -112,7 +112,7 @@ uint16_t AccountLoginManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "AccountLoginManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/include/account-login/AccountLoginManager.cpp
+++ b/examples/tv-app/android/include/account-login/AccountLoginManager.cpp
@@ -112,7 +112,8 @@ uint16_t AccountLoginManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "AccountLoginManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -174,7 +174,8 @@ uint16_t AppContentLauncherManager::GetClusterRevision(chip::EndpointId endpoint
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "AppContentLauncherManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -174,7 +174,7 @@ uint16_t AppContentLauncherManager::GetClusterRevision(chip::EndpointId endpoint
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "AppContentLauncherManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
+++ b/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
@@ -292,7 +292,7 @@ uint16_t AppMediaPlaybackManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "AppMediaPlaybackManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
+++ b/examples/tv-app/android/include/media-playback/AppMediaPlaybackManager.cpp
@@ -292,7 +292,8 @@ uint16_t AppMediaPlaybackManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "AppMediaPlaybackManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
@@ -154,7 +154,8 @@ uint16_t TargetNavigatorManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "TargetNavigatorManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
@@ -154,7 +154,7 @@ uint16_t TargetNavigatorManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "TargetNavigatorManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -761,7 +761,8 @@ uint16_t ChannelManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "ChannelManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/java/ChannelManager.cpp
+++ b/examples/tv-app/android/java/ChannelManager.cpp
@@ -761,7 +761,7 @@ uint16_t ChannelManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "ChannelManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
@@ -41,7 +41,7 @@ using LaunchResponseType         = chip::app::Clusters::ContentLauncher::Command
 using PlaybackResponseType       = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::Type;
 using NavigateTargetResponseType = chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::Type;
 using GetSetupPINResponseType    = chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::Type;
-using Status                     = Protocols::InteractionModel::Status;
+using Status                     = chip::Protocols::InteractionModel::Status;
 
 const std::string FAILURE_KEY        = "PlatformError";
 const std::string FAILURE_STATUS_KEY = "Status";
@@ -60,7 +60,7 @@ void ContentAppCommandDelegate::InvokeCommand(CommandHandlerInterface::HandlerCo
         {
             handlerContext.SetCommandHandled();
             handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath,
-                                                     Protocols::InteractionModel::Status::InvalidCommand);
+                                                     chip::Protocols::InteractionModel::Status::InvalidCommand);
             return;
         }
 
@@ -112,7 +112,7 @@ Status ContentAppCommandDelegate::InvokeCommand(EndpointId epId, ClusterId clust
 
         if (!mContentAppEndpointManager.HasValidObjectRef())
         {
-            return Protocols::InteractionModel::Status::Failure;
+            return chip::Protocols::InteractionModel::Status::Failure;
         }
 
         jstring resp =
@@ -133,7 +133,7 @@ Status ContentAppCommandDelegate::InvokeCommand(EndpointId epId, ClusterId clust
             if (!reader.parse(respStr.c_str(), value))
             {
                 env->DeleteLocalRef(resp);
-                return Protocols::InteractionModel::Status::Failure;
+                return chip::Protocols::InteractionModel::Status::Failure;
             }
         }
         env->DeleteLocalRef(resp);
@@ -146,15 +146,15 @@ Status ContentAppCommandDelegate::InvokeCommand(EndpointId epId, ClusterId clust
             {
                 return static_cast<Protocols::InteractionModel::Status>(value[FAILURE_STATUS_KEY].asUInt());
             }
-            return Protocols::InteractionModel::Status::Failure;
+            return chip::Protocols::InteractionModel::Status::Failure;
         }
 
-        return Protocols::InteractionModel::Status::UnsupportedEndpoint;
+        return chip::Protocols::InteractionModel::Status::UnsupportedEndpoint;
     }
     else
     {
         commandHandled = false;
-        return Protocols::InteractionModel::Status::UnsupportedEndpoint;
+        return chip::Protocols::InteractionModel::Status::UnsupportedEndpoint;
     }
 }
 
@@ -178,7 +178,7 @@ void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::Hand
                 handlerContext.mRequestPath, static_cast<Protocols::InteractionModel::Status>(value[FAILURE_STATUS_KEY].asUInt()));
             return;
         }
-        handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, Protocols::InteractionModel::Status::Failure);
+        handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, chip::Protocols::InteractionModel::Status::Failure);
         return;
     }
 
@@ -187,7 +187,7 @@ void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::Hand
     case app::Clusters::ContentLauncher::Id: {
         Status status;
         LaunchResponseType launchResponse = FormatContentLauncherResponse(value, status);
-        if (status != Protocols::InteractionModel::Status::Success)
+        if (status != chip::Protocols::InteractionModel::Status::Success)
         {
             handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, status);
         }
@@ -201,7 +201,7 @@ void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::Hand
     case app::Clusters::TargetNavigator::Id: {
         Status status;
         NavigateTargetResponseType navigateTargetResponse = FormatNavigateTargetResponse(value, status);
-        if (status != Protocols::InteractionModel::Status::Success)
+        if (status != chip::Protocols::InteractionModel::Status::Success)
         {
             handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, status);
         }
@@ -215,7 +215,7 @@ void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::Hand
     case app::Clusters::MediaPlayback::Id: {
         Status status;
         PlaybackResponseType playbackResponse = FormatMediaPlaybackResponse(value, status);
-        if (status != Protocols::InteractionModel::Status::Success)
+        if (status != chip::Protocols::InteractionModel::Status::Success)
         {
             handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, status);
         }
@@ -234,7 +234,7 @@ void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::Hand
         }
         Status status;
         GetSetupPINResponseType getSetupPINresponse = FormatGetSetupPINResponse(value, status);
-        if (status != Protocols::InteractionModel::Status::Success)
+        if (status != chip::Protocols::InteractionModel::Status::Success)
         {
             handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, status);
         }
@@ -251,13 +251,13 @@ void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::Hand
 
 LaunchResponseType ContentAppCommandDelegate::FormatContentLauncherResponse(Json::Value value, Status & status)
 {
-    status = Protocols::InteractionModel::Status::Success;
+    status = chip::Protocols::InteractionModel::Status::Success;
     LaunchResponseType launchResponse;
     std::string statusFieldId =
         std::to_string(to_underlying(app::Clusters::ContentLauncher::Commands::LauncherResponse::Fields::kStatus));
     if (value[statusFieldId].empty())
     {
-        status = Protocols::InteractionModel::Status::Failure;
+        status = chip::Protocols::InteractionModel::Status::Failure;
         return launchResponse;
     }
     else
@@ -275,13 +275,13 @@ LaunchResponseType ContentAppCommandDelegate::FormatContentLauncherResponse(Json
 
 NavigateTargetResponseType ContentAppCommandDelegate::FormatNavigateTargetResponse(Json::Value value, Status & status)
 {
-    status = Protocols::InteractionModel::Status::Success;
+    status = chip::Protocols::InteractionModel::Status::Success;
     NavigateTargetResponseType navigateTargetResponse;
     std::string statusFieldId =
         std::to_string(to_underlying(app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::Fields::kStatus));
     if (value[statusFieldId].empty())
     {
-        status = Protocols::InteractionModel::Status::Failure;
+        status = chip::Protocols::InteractionModel::Status::Failure;
         return navigateTargetResponse;
     }
     else
@@ -299,13 +299,13 @@ NavigateTargetResponseType ContentAppCommandDelegate::FormatNavigateTargetRespon
 
 PlaybackResponseType ContentAppCommandDelegate::FormatMediaPlaybackResponse(Json::Value value, Status & status)
 {
-    status = Protocols::InteractionModel::Status::Success;
+    status = chip::Protocols::InteractionModel::Status::Success;
     PlaybackResponseType playbackResponse;
     std::string statusFieldId =
         std::to_string(to_underlying(app::Clusters::MediaPlayback::Commands::PlaybackResponse::Fields::kStatus));
     if (value[statusFieldId].empty())
     {
-        status = Protocols::InteractionModel::Status::Failure;
+        status = chip::Protocols::InteractionModel::Status::Failure;
         return playbackResponse;
     }
     else
@@ -323,7 +323,7 @@ PlaybackResponseType ContentAppCommandDelegate::FormatMediaPlaybackResponse(Json
 
 GetSetupPINResponseType ContentAppCommandDelegate::FormatGetSetupPINResponse(Json::Value value, Status & status)
 {
-    status = Protocols::InteractionModel::Status::Success;
+    status = chip::Protocols::InteractionModel::Status::Success;
     GetSetupPINResponseType getSetupPINresponse;
     std::string setupPINFieldId =
         std::to_string(to_underlying(app::Clusters::AccountLogin::Commands::GetSetupPINResponse::Fields::kSetupPIN));

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.h
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.h
@@ -34,7 +34,7 @@ namespace chip {
 namespace AppPlatform {
 
 using CommandHandlerInterface    = chip::app::CommandHandlerInterface;
-using Status                     = Protocols::InteractionModel::Status;
+using Status                     = chip::Protocols::InteractionModel::Status;
 using LaunchResponseType         = chip::app::Clusters::ContentLauncher::Commands::LauncherResponse::Type;
 using PlaybackResponseType       = chip::app::Clusters::MediaPlayback::Commands::PlaybackResponse::Type;
 using NavigateTargetResponseType = chip::app::Clusters::TargetNavigator::Commands::NavigateTargetResponse::Type;

--- a/examples/tv-app/android/java/ContentLauncherManager.cpp
+++ b/examples/tv-app/android/java/ContentLauncherManager.cpp
@@ -295,7 +295,7 @@ uint16_t ContentLauncherManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "ContentLauncherManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/java/ContentLauncherManager.cpp
+++ b/examples/tv-app/android/java/ContentLauncherManager.cpp
@@ -295,7 +295,8 @@ uint16_t ContentLauncherManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "ContentLauncherManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/java/LevelManager.cpp
+++ b/examples/tv-app/android/java/LevelManager.cpp
@@ -83,9 +83,9 @@ void LevelManager::PostLevelChanged(chip::EndpointId endpoint, uint8_t value)
 
 jboolean LevelManager::SetLevel(jint endpoint, jint value)
 {
-    EmberAfStatus status = app::Clusters::LevelControl::Attributes::CurrentLevel::Set(static_cast<chip::EndpointId>(endpoint),
-                                                                                      static_cast<uint8_t>(value));
-    return status == EMBER_ZCL_STATUS_SUCCESS;
+    Protocols::InteractionModel::Status status = app::Clusters::LevelControl::Attributes::CurrentLevel::Set(
+        static_cast<chip::EndpointId>(endpoint), static_cast<uint8_t>(value));
+    return status == Protocols::InteractionModel::Status::Success;
 }
 
 CHIP_ERROR LevelManager::InitializeWithObjects(jobject managerObject)

--- a/examples/tv-app/android/java/LevelManager.cpp
+++ b/examples/tv-app/android/java/LevelManager.cpp
@@ -83,9 +83,9 @@ void LevelManager::PostLevelChanged(chip::EndpointId endpoint, uint8_t value)
 
 jboolean LevelManager::SetLevel(jint endpoint, jint value)
 {
-    Protocols::InteractionModel::Status status = app::Clusters::LevelControl::Attributes::CurrentLevel::Set(
+    chip::Protocols::InteractionModel::Status status = app::Clusters::LevelControl::Attributes::CurrentLevel::Set(
         static_cast<chip::EndpointId>(endpoint), static_cast<uint8_t>(value));
-    return status == Protocols::InteractionModel::Status::Success;
+    return status == chip::Protocols::InteractionModel::Status::Success;
 }
 
 CHIP_ERROR LevelManager::InitializeWithObjects(jobject managerObject)

--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -614,7 +614,7 @@ uint16_t MediaPlaybackManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "MediaPlaybackManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -614,7 +614,8 @@ uint16_t MediaPlaybackManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "MediaPlaybackManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/android/java/OnOffManager.cpp
+++ b/examples/tv-app/android/java/OnOffManager.cpp
@@ -84,9 +84,9 @@ void OnOffManager::PostOnOffChanged(chip::EndpointId endpoint, bool value)
 jboolean OnOffManager::SetOnOff(jint endpoint, bool value)
 {
     chip::DeviceLayer::StackLock stack;
-    Protocols::InteractionModel::Status status =
+    chip::Protocols::InteractionModel::Status status =
         app::Clusters::OnOff::Attributes::OnOff::Set(static_cast<chip::EndpointId>(endpoint), value);
-    return status == Protocols::InteractionModel::Status::Success;
+    return status == chip::Protocols::InteractionModel::Status::Success;
 }
 
 CHIP_ERROR OnOffManager::InitializeWithObjects(jobject managerObject)

--- a/examples/tv-app/android/java/OnOffManager.cpp
+++ b/examples/tv-app/android/java/OnOffManager.cpp
@@ -84,8 +84,9 @@ void OnOffManager::PostOnOffChanged(chip::EndpointId endpoint, bool value)
 jboolean OnOffManager::SetOnOff(jint endpoint, bool value)
 {
     chip::DeviceLayer::StackLock stack;
-    EmberAfStatus status = app::Clusters::OnOff::Attributes::OnOff::Set(static_cast<chip::EndpointId>(endpoint), value);
-    return status == EMBER_ZCL_STATUS_SUCCESS;
+    Protocols::InteractionModel::Status status =
+        app::Clusters::OnOff::Attributes::OnOff::Set(static_cast<chip::EndpointId>(endpoint), value);
+    return status == Protocols::InteractionModel::Status::Success;
 }
 
 CHIP_ERROR OnOffManager::InitializeWithObjects(jobject managerObject)

--- a/examples/tv-app/tv-common/clusters/account-login/AccountLoginManager.cpp
+++ b/examples/tv-app/tv-common/clusters/account-login/AccountLoginManager.cpp
@@ -74,7 +74,8 @@ uint16_t AccountLoginManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "AccountLoginManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/tv-common/clusters/account-login/AccountLoginManager.cpp
+++ b/examples/tv-app/tv-common/clusters/account-login/AccountLoginManager.cpp
@@ -74,7 +74,7 @@ uint16_t AccountLoginManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "AccountLoginManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/tv-common/clusters/channel/ChannelManager.cpp
+++ b/examples/tv-app/tv-common/clusters/channel/ChannelManager.cpp
@@ -347,7 +347,7 @@ uint16_t ChannelManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "ChannelManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/tv-common/clusters/channel/ChannelManager.cpp
+++ b/examples/tv-app/tv-common/clusters/channel/ChannelManager.cpp
@@ -347,7 +347,8 @@ uint16_t ChannelManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "ChannelManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/tv-common/clusters/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/tv-common/clusters/content-launcher/ContentLauncherManager.cpp
@@ -214,7 +214,7 @@ uint16_t ContentLauncherManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "ContentLauncherManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/tv-common/clusters/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/tv-common/clusters/content-launcher/ContentLauncherManager.cpp
@@ -214,7 +214,8 @@ uint16_t ContentLauncherManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "ContentLauncherManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/tv-common/clusters/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/tv-common/clusters/media-playback/MediaPlaybackManager.cpp
@@ -335,7 +335,7 @@ uint16_t MediaPlaybackManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "MediaPlaybackManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/tv-common/clusters/media-playback/MediaPlaybackManager.cpp
+++ b/examples/tv-app/tv-common/clusters/media-playback/MediaPlaybackManager.cpp
@@ -335,7 +335,8 @@ uint16_t MediaPlaybackManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "MediaPlaybackManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/tv-common/clusters/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/tv-common/clusters/target-navigator/TargetNavigatorManager.cpp
@@ -76,7 +76,8 @@ uint16_t TargetNavigatorManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
+    bool success =
+        (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == chip::Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "TargetNavigatorManager::GetClusterRevision error reading cluster revision");

--- a/examples/tv-app/tv-common/clusters/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/tv-common/clusters/target-navigator/TargetNavigatorManager.cpp
@@ -76,7 +76,7 @@ uint16_t TargetNavigatorManager::GetClusterRevision(chip::EndpointId endpoint)
     }
 
     uint16_t clusterRevision = 0;
-    bool success             = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == EMBER_ZCL_STATUS_SUCCESS);
+    bool success = (Attributes::ClusterRevision::Get(endpoint, &clusterRevision) == Protocols::InteractionModel::Status::Success);
     if (!success)
     {
         ChipLogError(Zcl, "TargetNavigatorManager::GetClusterRevision error reading cluster revision");

--- a/examples/virtual-device-app/android/java/DoorLockManager.cpp
+++ b/examples/virtual-device-app/android/java/DoorLockManager.cpp
@@ -49,8 +49,8 @@ void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
     ChipLogProgress(Zcl, "Device App::DoorLock::PostClusterInit");
     DeviceAppJNIMgr().PostClusterInit(chip::app::Clusters::DoorLock::Id, endpoint);
     DoorLockServer::Instance().InitServer(endpoint);
-    EmberAfStatus status = DoorLock::Attributes::FeatureMap::Set(endpoint, 0);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    Protocols::InteractionModel::Status status = DoorLock::Attributes::FeatureMap::Set(endpoint, 0);
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         ChipLogProgress(Zcl, "Device App::DoorLock::emberAfDoorLockClusterInitCallback()::Updating feature map %x", status);
     }
@@ -104,9 +104,9 @@ DoorLockManager * GetDoorLockManager(EndpointId endpoint)
 
 jboolean DoorLockManager::SetLockType(jint endpoint, jint value)
 {
-    EmberAfStatus status = app::Clusters::DoorLock::Attributes::LockType::Set(
+    Protocols::InteractionModel::Status status = app::Clusters::DoorLock::Attributes::LockType::Set(
         static_cast<chip::EndpointId>(endpoint), static_cast<app::Clusters::DoorLock::DlLockType>(value));
-    return status == EMBER_ZCL_STATUS_SUCCESS;
+    return status == Protocols::InteractionModel::Status::Success;
 }
 
 jboolean DoorLockManager::SetLockState(jint endpoint, jint value)
@@ -127,16 +127,16 @@ jboolean DoorLockManager::SetAutoRelockTime(jint endpoint, jint value)
 
 jboolean DoorLockManager::SetOperatingMode(jint endpoint, jint value)
 {
-    EmberAfStatus status = app::Clusters::DoorLock::Attributes::OperatingMode::Set(
+    Protocols::InteractionModel::Status status = app::Clusters::DoorLock::Attributes::OperatingMode::Set(
         static_cast<chip::EndpointId>(endpoint), static_cast<app::Clusters::DoorLock::OperatingModeEnum>(value));
-    return status == EMBER_ZCL_STATUS_SUCCESS;
+    return status == Protocols::InteractionModel::Status::Success;
 }
 
 jboolean DoorLockManager::SetSupportedOperatingModes(jint endpoint, jint value)
 {
-    EmberAfStatus status = app::Clusters::DoorLock::Attributes::SupportedOperatingModes::Set(
+    Protocols::InteractionModel::Status status = app::Clusters::DoorLock::Attributes::SupportedOperatingModes::Set(
         static_cast<chip::EndpointId>(endpoint), static_cast<app::Clusters::DoorLock::DlSupportedOperatingModes>(value));
-    return status == EMBER_ZCL_STATUS_SUCCESS;
+    return status == Protocols::InteractionModel::Status::Success;
 }
 
 jboolean DoorLockManager::SendLockAlarmEvent(jint endpoint)

--- a/examples/virtual-device-app/android/java/OnOffManager.cpp
+++ b/examples/virtual-device-app/android/java/OnOffManager.cpp
@@ -82,8 +82,9 @@ void OnOffManager::PostOnOffChanged(chip::EndpointId endpoint, bool value)
 
 jboolean OnOffManager::SetOnOff(jint endpoint, bool value)
 {
-    EmberAfStatus status = app::Clusters::OnOff::Attributes::OnOff::Set(static_cast<chip::EndpointId>(endpoint), value);
-    return status == EMBER_ZCL_STATUS_SUCCESS;
+    Protocols::InteractionModel::Status status =
+        app::Clusters::OnOff::Attributes::OnOff::Set(static_cast<chip::EndpointId>(endpoint), value);
+    return status == Protocols::InteractionModel::Status::Success;
 }
 
 CHIP_ERROR OnOffManager::InitializeWithObjects(jobject managerObject)

--- a/examples/virtual-device-app/android/java/PowerSourceManager.cpp
+++ b/examples/virtual-device-app/android/java/PowerSourceManager.cpp
@@ -83,13 +83,13 @@ jboolean PowerSourceManager::SetBatPercentRemaining(jint endpoint, jint value)
 {
     using namespace chip::app::Clusters;
     using namespace chip::DeviceLayer;
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    Protocols::InteractionModel::Status status = Protocols::InteractionModel::Status::Success;
 
     status =
         PowerSource::Attributes::BatPercentRemaining::Set(static_cast<chip::EndpointId>(endpoint), static_cast<uint8_t>(value * 2));
 
     ChipLogDetail(Zcl, "Device App::PowerSource::SetBatPercentRemaining: endpoint:%d, percent:%d", endpoint, value);
-    return status == EMBER_ZCL_STATUS_SUCCESS;
+    return status == Protocols::InteractionModel::Status::Success;
 }
 
 CHIP_ERROR PowerSourceManager::InitializeWithObjects(jobject managerObject)

--- a/examples/window-app/common/src/WindowApp.cpp
+++ b/examples/window-app/common/src/WindowApp.cpp
@@ -455,7 +455,7 @@ void WindowApp::Cover::Finish()
 
 void WindowApp::Cover::LiftStepToward(OperationalState direction)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     chip::Percent100ths percent100ths;
     NPercent100ths current;
 
@@ -463,7 +463,7 @@ void WindowApp::Cover::LiftStepToward(OperationalState direction)
     status = Attributes::CurrentPositionLiftPercent100ths::Get(mEndpoint, current);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-    if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
+    if ((status == Protocols::InteractionModel::Status::Success) && !current.IsNull())
     {
         percent100ths = ComputePercent100thsStep(direction, current.Value(), LIFT_DELTA);
     }
@@ -519,7 +519,7 @@ void WindowApp::Cover::LiftUpdate(bool newTarget)
 
 void WindowApp::Cover::TiltStepToward(OperationalState direction)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     chip::Percent100ths percent100ths;
     NPercent100ths current;
 
@@ -527,7 +527,7 @@ void WindowApp::Cover::TiltStepToward(OperationalState direction)
     status = Attributes::CurrentPositionTiltPercent100ths::Get(mEndpoint, current);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-    if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
+    if ((status == Protocols::InteractionModel::Status::Success) && !current.IsNull())
     {
         percent100ths = ComputePercent100thsStep(direction, current.Value(), TILT_DELTA);
     }
@@ -595,7 +595,7 @@ void WindowApp::Cover::StepToward(OperationalState direction, bool isTilt)
 
 void WindowApp::Cover::UpdateTargetPosition(OperationalState direction, bool isTilt)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     NPercent100ths current;
     chip::Percent100ths target;
 
@@ -604,7 +604,7 @@ void WindowApp::Cover::UpdateTargetPosition(OperationalState direction, bool isT
     if (isTilt)
     {
         status = Attributes::CurrentPositionTiltPercent100ths::Get(mEndpoint, current);
-        if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
+        if ((status == Protocols::InteractionModel::Status::Success) && !current.IsNull())
         {
 
             target = ComputePercent100thsStep(direction, current.Value(), TILT_DELTA);
@@ -614,7 +614,7 @@ void WindowApp::Cover::UpdateTargetPosition(OperationalState direction, bool isT
     else
     {
         status = Attributes::CurrentPositionLiftPercent100ths::Get(mEndpoint, current);
-        if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
+        if ((status == Protocols::InteractionModel::Status::Success) && !current.IsNull())
         {
 
             target = ComputePercent100thsStep(direction, current.Value(), LIFT_DELTA);

--- a/examples/window-app/nrfconnect/main/WindowCovering.cpp
+++ b/examples/window-app/nrfconnect/main/WindowCovering.cpp
@@ -59,8 +59,10 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
     NPercent100ths target{};
     NPercent100ths positionToSet{};
 
-    VerifyOrReturn(Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), current) == EMBER_ZCL_STATUS_SUCCESS);
-    VerifyOrReturn(Attributes::TargetPositionLiftPercent100ths::Get(Endpoint(), target) == EMBER_ZCL_STATUS_SUCCESS);
+    VerifyOrReturn(Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), current) ==
+                   Protocols::InteractionModel::Status::Success);
+    VerifyOrReturn(Attributes::TargetPositionLiftPercent100ths::Get(Endpoint(), target) ==
+                   Protocols::InteractionModel::Status::Success);
 
     OperationalState state = ComputeOperationalState(target, current);
     UpdateOperationalStatus(MoveType::LIFT, state);
@@ -85,7 +87,8 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
     // assume single move completed
     Instance().mInLiftMove = false;
 
-    VerifyOrReturn(Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), current) == EMBER_ZCL_STATUS_SUCCESS);
+    VerifyOrReturn(Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), current) ==
+                   Protocols::InteractionModel::Status::Success);
 
     if (!TargetCompleted(MoveType::LIFT, current, target))
     {
@@ -101,7 +104,7 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
 
 chip::Percent100ths WindowCovering::CalculateNextPosition(MoveType aMoveType)
 {
-    EmberAfStatus status{};
+    Protocols::InteractionModel::Status status{};
     chip::Percent100ths percent100ths{};
     NPercent100ths current{};
     OperationalState opState{};
@@ -117,7 +120,7 @@ chip::Percent100ths WindowCovering::CalculateNextPosition(MoveType aMoveType)
         opState = OperationalStateGet(Endpoint(), OperationalStatus::kTilt);
     }
 
-    if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
+    if ((status == Protocols::InteractionModel::Status::Success) && !current.IsNull())
     {
         static constexpr auto sPercentDelta{ WC_PERCENT100THS_MAX_CLOSED / 20 };
         percent100ths = ComputePercent100thsStep(opState, current.Value(), sPercentDelta);
@@ -168,8 +171,10 @@ void WindowCovering::DriveCurrentTiltPosition(intptr_t)
     NPercent100ths target{};
     NPercent100ths positionToSet{};
 
-    VerifyOrReturn(Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), current) == EMBER_ZCL_STATUS_SUCCESS);
-    VerifyOrReturn(Attributes::TargetPositionTiltPercent100ths::Get(Endpoint(), target) == EMBER_ZCL_STATUS_SUCCESS);
+    VerifyOrReturn(Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), current) ==
+                   Protocols::InteractionModel::Status::Success);
+    VerifyOrReturn(Attributes::TargetPositionTiltPercent100ths::Get(Endpoint(), target) ==
+                   Protocols::InteractionModel::Status::Success);
 
     OperationalState state = ComputeOperationalState(target, current);
     UpdateOperationalStatus(MoveType::TILT, state);
@@ -194,7 +199,8 @@ void WindowCovering::DriveCurrentTiltPosition(intptr_t)
     // assume single move completed
     Instance().mInTiltMove = false;
 
-    VerifyOrReturn(Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), current) == EMBER_ZCL_STATUS_SUCCESS);
+    VerifyOrReturn(Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), current) ==
+                   Protocols::InteractionModel::Status::Success);
 
     if (!TargetCompleted(MoveType::TILT, current, target))
     {
@@ -256,7 +262,7 @@ void WindowCovering::UpdateOperationalStatus(MoveType aMoveType, OperationalStat
 
 void WindowCovering::SetTargetPosition(OperationalState aDirection, chip::Percent100ths aPosition)
 {
-    EmberAfStatus status{};
+    Protocols::InteractionModel::Status status{};
     if (Instance().mCurrentUIMoveType == MoveType::LIFT)
     {
         status = Attributes::TargetPositionLiftPercent100ths::Set(Endpoint(), aPosition);
@@ -266,7 +272,7 @@ void WindowCovering::SetTargetPosition(OperationalState aDirection, chip::Percen
         status = Attributes::TargetPositionTiltPercent100ths::Set(Endpoint(), aPosition);
     }
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         LOG_ERR("Cannot set the target position. Error: %d", static_cast<uint8_t>(status));
     }
@@ -274,13 +280,13 @@ void WindowCovering::SetTargetPosition(OperationalState aDirection, chip::Percen
 
 void WindowCovering::PositionLEDUpdate(MoveType aMoveType)
 {
-    EmberAfStatus status{};
+    Protocols::InteractionModel::Status status{};
     NPercent100ths currentPosition{};
 
     if (aMoveType == MoveType::LIFT)
     {
         status = Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), currentPosition);
-        if (EMBER_ZCL_STATUS_SUCCESS == status && !currentPosition.IsNull())
+        if (Protocols::InteractionModel::Status::Success == status && !currentPosition.IsNull())
         {
             Instance().SetBrightness(MoveType::LIFT, currentPosition.Value());
         }
@@ -288,7 +294,7 @@ void WindowCovering::PositionLEDUpdate(MoveType aMoveType)
     else if (aMoveType == MoveType::TILT)
     {
         status = Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), currentPosition);
-        if (EMBER_ZCL_STATUS_SUCCESS == status && !currentPosition.IsNull())
+        if (Protocols::InteractionModel::Status::Success == status && !currentPosition.IsNull())
         {
             Instance().SetBrightness(MoveType::TILT, currentPosition.Value());
         }

--- a/examples/window-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/window-app/nrfconnect/main/ZclCallbacks.cpp
@@ -82,8 +82,8 @@ void MatterWindowCoveringClusterServerAttributeChangedCallback(const app::Concre
 
 void emberAfWindowCoveringClusterInitCallback(chip::EndpointId endpoint)
 {
-    const auto logOnFailure = [](EmberAfStatus status, const char * attributeName) {
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
+    const auto logOnFailure = [](Protocols::InteractionModel::Status status, const char * attributeName) {
+        if (status != Protocols::InteractionModel::Status::Success)
         {
             ChipLogError(Zcl, "Failed to set WindowCovering %s: %x", attributeName, status);
         }
@@ -92,7 +92,7 @@ void emberAfWindowCoveringClusterInitCallback(chip::EndpointId endpoint)
     app::DataModel::Nullable<chip::Percent100ths> currentPercent100ths;
     app::DataModel::Nullable<chip::Percent100ths> targetPercent100ths;
     app::DataModel::Nullable<chip::Percent> currentPercentage;
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
 
     status = Attributes::CurrentPositionLiftPercentage::Get(endpoint, currentPercentage);
     if (currentPercentage.IsNull())

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -275,7 +275,7 @@ void WindowManager::Cover::Init(chip::EndpointId endpoint)
 
 void WindowManager::Cover::LiftStepToward(OperationalState direction)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     chip::Percent100ths percent100ths;
     NPercent100ths current;
 
@@ -283,7 +283,7 @@ void WindowManager::Cover::LiftStepToward(OperationalState direction)
     status = Attributes::CurrentPositionLiftPercent100ths::Get(mEndpoint, current);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-    if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
+    if ((status == Protocols::InteractionModel::Status::Success) && !current.IsNull())
     {
         percent100ths = ComputePercent100thsStep(direction, current.Value(), LIFT_DELTA);
     }
@@ -339,7 +339,7 @@ void WindowManager::Cover::LiftUpdate(bool newTarget)
 
 void WindowManager::Cover::TiltStepToward(OperationalState direction)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     chip::Percent100ths percent100ths;
     NPercent100ths current;
 
@@ -347,7 +347,7 @@ void WindowManager::Cover::TiltStepToward(OperationalState direction)
     status = Attributes::CurrentPositionTiltPercent100ths::Get(mEndpoint, current);
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-    if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
+    if ((status == Protocols::InteractionModel::Status::Success) && !current.IsNull())
     {
         percent100ths = ComputePercent100thsStep(direction, current.Value(), TILT_DELTA);
     }
@@ -403,7 +403,7 @@ void WindowManager::Cover::TiltUpdate(bool newTarget)
 
 void WindowManager::Cover::UpdateTargetPosition(OperationalState direction, bool isTilt)
 {
-    EmberAfStatus status;
+    Protocols::InteractionModel::Status status;
     NPercent100ths current;
     chip::Percent100ths target;
 
@@ -412,7 +412,7 @@ void WindowManager::Cover::UpdateTargetPosition(OperationalState direction, bool
     if (isTilt)
     {
         status = Attributes::CurrentPositionTiltPercent100ths::Get(mEndpoint, current);
-        if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
+        if ((status == Protocols::InteractionModel::Status::Success) && !current.IsNull())
         {
             target = ComputePercent100thsStep(direction, current.Value(), TILT_DELTA);
             (void) Attributes::TargetPositionTiltPercent100ths::Set(mEndpoint, target);
@@ -421,7 +421,7 @@ void WindowManager::Cover::UpdateTargetPosition(OperationalState direction, bool
     else
     {
         status = Attributes::CurrentPositionLiftPercent100ths::Get(mEndpoint, current);
-        if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
+        if ((status == Protocols::InteractionModel::Status::Success) && !current.IsNull())
         {
             target = ComputePercent100thsStep(direction, current.Value(), LIFT_DELTA);
             (void) Attributes::TargetPositionLiftPercent100ths::Set(mEndpoint, target);

--- a/examples/window-app/telink/src/WindowCovering.cpp
+++ b/examples/window-app/telink/src/WindowCovering.cpp
@@ -59,8 +59,10 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
     NPercent100ths target{};
     NPercent100ths positionToSet{};
 
-    VerifyOrReturn(Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), current) == EMBER_ZCL_STATUS_SUCCESS);
-    VerifyOrReturn(Attributes::TargetPositionLiftPercent100ths::Get(Endpoint(), target) == EMBER_ZCL_STATUS_SUCCESS);
+    VerifyOrReturn(Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), current) ==
+                   Protocols::InteractionModel::Status::Success);
+    VerifyOrReturn(Attributes::TargetPositionLiftPercent100ths::Get(Endpoint(), target) ==
+                   Protocols::InteractionModel::Status::Success);
 
     UpdateOperationalStatus(WindowCoveringType::Lift, ComputeOperationalState(target, current));
 
@@ -70,7 +72,8 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
     // assume single move completed
     Instance().mInLiftMove = false;
 
-    VerifyOrReturn(Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), current) == EMBER_ZCL_STATUS_SUCCESS);
+    VerifyOrReturn(Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), current) ==
+                   Protocols::InteractionModel::Status::Success);
 
     if (!TargetCompleted(WindowCoveringType::Lift, current, target))
     {
@@ -86,7 +89,7 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
 
 chip::Percent100ths WindowCovering::CalculateSingleStep(WindowCoveringType aMoveType)
 {
-    EmberAfStatus status{};
+    Protocols::InteractionModel::Status status{};
     chip::Percent100ths percent100ths{};
     NPercent100ths current{};
     OperationalState opState = OperationalState::Stall;
@@ -102,7 +105,7 @@ chip::Percent100ths WindowCovering::CalculateSingleStep(WindowCoveringType aMove
         opState = OperationalStateGet(Endpoint(), OperationalStatus::kTilt);
     }
 
-    if ((status == EMBER_ZCL_STATUS_SUCCESS) && !current.IsNull())
+    if ((status == Protocols::InteractionModel::Status::Success) && !current.IsNull())
     {
         percent100ths = ComputePercent100thsStep(opState, current.Value(), sPercentDelta);
     }
@@ -152,8 +155,10 @@ void WindowCovering::DriveCurrentTiltPosition(intptr_t)
     NPercent100ths target{};
     NPercent100ths positionToSet{};
 
-    VerifyOrReturn(Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), current) == EMBER_ZCL_STATUS_SUCCESS);
-    VerifyOrReturn(Attributes::TargetPositionTiltPercent100ths::Get(Endpoint(), target) == EMBER_ZCL_STATUS_SUCCESS);
+    VerifyOrReturn(Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), current) ==
+                   Protocols::InteractionModel::Status::Success);
+    VerifyOrReturn(Attributes::TargetPositionTiltPercent100ths::Get(Endpoint(), target) ==
+                   Protocols::InteractionModel::Status::Success);
 
     UpdateOperationalStatus(WindowCoveringType::Lift, ComputeOperationalState(target, current));
 
@@ -163,7 +168,8 @@ void WindowCovering::DriveCurrentTiltPosition(intptr_t)
     // assume single move completed
     Instance().mInTiltMove = false;
 
-    VerifyOrReturn(Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), current) == EMBER_ZCL_STATUS_SUCCESS);
+    VerifyOrReturn(Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), current) ==
+                   Protocols::InteractionModel::Status::Success);
 
     if (!TargetCompleted(WindowCoveringType::Tilt, current, target))
     {
@@ -225,7 +231,7 @@ void WindowCovering::UpdateOperationalStatus(WindowCoveringType aMoveType, Opera
 
 void WindowCovering::SetTargetPosition(OperationalState aDirection, chip::Percent100ths aPosition)
 {
-    EmberAfStatus status{};
+    Protocols::InteractionModel::Status status{};
     if (Instance().mCurrentUIMoveType == WindowCoveringType::Lift)
     {
         status = Attributes::TargetPositionLiftPercent100ths::Set(Endpoint(), aPosition);
@@ -235,7 +241,7 @@ void WindowCovering::SetTargetPosition(OperationalState aDirection, chip::Percen
         status = Attributes::TargetPositionTiltPercent100ths::Set(Endpoint(), aPosition);
     }
 
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    if (status != Protocols::InteractionModel::Status::Success)
     {
         LOG_ERR("Cannot set the target position. Error: %d", static_cast<uint8_t>(status));
     }
@@ -243,13 +249,13 @@ void WindowCovering::SetTargetPosition(OperationalState aDirection, chip::Percen
 
 void WindowCovering::PositionLEDUpdate(WindowCoveringType aMoveType)
 {
-    EmberAfStatus status{};
+    Protocols::InteractionModel::Status status{};
     NPercent100ths currentPosition{};
 
     if (aMoveType == WindowCoveringType::Lift)
     {
         status = Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), currentPosition);
-        if (EMBER_ZCL_STATUS_SUCCESS == status && !currentPosition.IsNull())
+        if (Protocols::InteractionModel::Status::Success == status && !currentPosition.IsNull())
         {
             Instance().SetBrightness(WindowCoveringType::Lift, currentPosition.Value());
         }
@@ -257,7 +263,7 @@ void WindowCovering::PositionLEDUpdate(WindowCoveringType aMoveType)
     else if (aMoveType == WindowCoveringType::Tilt)
     {
         status = Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), currentPosition);
-        if (EMBER_ZCL_STATUS_SUCCESS == status && !currentPosition.IsNull())
+        if (Protocols::InteractionModel::Status::Success == status && !currentPosition.IsNull())
         {
             Instance().SetBrightness(WindowCoveringType::Tilt, currentPosition.Value());
         }

--- a/examples/window-app/telink/src/WindowCovering.cpp
+++ b/examples/window-app/telink/src/WindowCovering.cpp
@@ -60,9 +60,9 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
     NPercent100ths positionToSet{};
 
     VerifyOrReturn(Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), current) ==
-                   Protocols::InteractionModel::Status::Success);
+                   chip::Protocols::InteractionModel::Status::Success);
     VerifyOrReturn(Attributes::TargetPositionLiftPercent100ths::Get(Endpoint(), target) ==
-                   Protocols::InteractionModel::Status::Success);
+                   chip::Protocols::InteractionModel::Status::Success);
 
     UpdateOperationalStatus(WindowCoveringType::Lift, ComputeOperationalState(target, current));
 
@@ -73,7 +73,7 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
     Instance().mInLiftMove = false;
 
     VerifyOrReturn(Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), current) ==
-                   Protocols::InteractionModel::Status::Success);
+                   chip::Protocols::InteractionModel::Status::Success);
 
     if (!TargetCompleted(WindowCoveringType::Lift, current, target))
     {
@@ -89,7 +89,7 @@ void WindowCovering::DriveCurrentLiftPosition(intptr_t)
 
 chip::Percent100ths WindowCovering::CalculateSingleStep(WindowCoveringType aMoveType)
 {
-    Protocols::InteractionModel::Status status{};
+    chip::Protocols::InteractionModel::Status status{};
     chip::Percent100ths percent100ths{};
     NPercent100ths current{};
     OperationalState opState = OperationalState::Stall;
@@ -105,7 +105,7 @@ chip::Percent100ths WindowCovering::CalculateSingleStep(WindowCoveringType aMove
         opState = OperationalStateGet(Endpoint(), OperationalStatus::kTilt);
     }
 
-    if ((status == Protocols::InteractionModel::Status::Success) && !current.IsNull())
+    if ((status == chip::Protocols::InteractionModel::Status::Success) && !current.IsNull())
     {
         percent100ths = ComputePercent100thsStep(opState, current.Value(), sPercentDelta);
     }
@@ -156,9 +156,9 @@ void WindowCovering::DriveCurrentTiltPosition(intptr_t)
     NPercent100ths positionToSet{};
 
     VerifyOrReturn(Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), current) ==
-                   Protocols::InteractionModel::Status::Success);
+                   chip::Protocols::InteractionModel::Status::Success);
     VerifyOrReturn(Attributes::TargetPositionTiltPercent100ths::Get(Endpoint(), target) ==
-                   Protocols::InteractionModel::Status::Success);
+                   chip::Protocols::InteractionModel::Status::Success);
 
     UpdateOperationalStatus(WindowCoveringType::Lift, ComputeOperationalState(target, current));
 
@@ -169,7 +169,7 @@ void WindowCovering::DriveCurrentTiltPosition(intptr_t)
     Instance().mInTiltMove = false;
 
     VerifyOrReturn(Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), current) ==
-                   Protocols::InteractionModel::Status::Success);
+                   chip::Protocols::InteractionModel::Status::Success);
 
     if (!TargetCompleted(WindowCoveringType::Tilt, current, target))
     {
@@ -231,7 +231,7 @@ void WindowCovering::UpdateOperationalStatus(WindowCoveringType aMoveType, Opera
 
 void WindowCovering::SetTargetPosition(OperationalState aDirection, chip::Percent100ths aPosition)
 {
-    Protocols::InteractionModel::Status status{};
+    chip::Protocols::InteractionModel::Status status{};
     if (Instance().mCurrentUIMoveType == WindowCoveringType::Lift)
     {
         status = Attributes::TargetPositionLiftPercent100ths::Set(Endpoint(), aPosition);
@@ -241,7 +241,7 @@ void WindowCovering::SetTargetPosition(OperationalState aDirection, chip::Percen
         status = Attributes::TargetPositionTiltPercent100ths::Set(Endpoint(), aPosition);
     }
 
-    if (status != Protocols::InteractionModel::Status::Success)
+    if (status != chip::Protocols::InteractionModel::Status::Success)
     {
         LOG_ERR("Cannot set the target position. Error: %d", static_cast<uint8_t>(status));
     }
@@ -249,13 +249,13 @@ void WindowCovering::SetTargetPosition(OperationalState aDirection, chip::Percen
 
 void WindowCovering::PositionLEDUpdate(WindowCoveringType aMoveType)
 {
-    Protocols::InteractionModel::Status status{};
+    chip::Protocols::InteractionModel::Status status{};
     NPercent100ths currentPosition{};
 
     if (aMoveType == WindowCoveringType::Lift)
     {
         status = Attributes::CurrentPositionLiftPercent100ths::Get(Endpoint(), currentPosition);
-        if (Protocols::InteractionModel::Status::Success == status && !currentPosition.IsNull())
+        if (chip::Protocols::InteractionModel::Status::Success == status && !currentPosition.IsNull())
         {
             Instance().SetBrightness(WindowCoveringType::Lift, currentPosition.Value());
         }
@@ -263,7 +263,7 @@ void WindowCovering::PositionLEDUpdate(WindowCoveringType aMoveType)
     else if (aMoveType == WindowCoveringType::Tilt)
     {
         status = Attributes::CurrentPositionTiltPercent100ths::Get(Endpoint(), currentPosition);
-        if (Protocols::InteractionModel::Status::Success == status && !currentPosition.IsNull())
+        if (chip::Protocols::InteractionModel::Status::Success == status && !currentPosition.IsNull())
         {
             Instance().SetBrightness(WindowCoveringType::Tilt, currentPosition.Value());
         }


### PR DESCRIPTION
Replace all occurence of EmberAfStatus in the examples files with the Protocols::InteractionModel::Status. Considering the amount of reference this was done with a mass find and replace. All the namespace where added to ensure compilation


