### PR TITLE
Fixes: #31672 avoids a deliberate crash on targets which don't suppor…

### DIFF
--- a/examples/energy-management-app/energy-management-common/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/energy-management-app/energy-management-common/src/EnergyEvseDelegateImpl.cpp
@@ -1474,7 +1474,11 @@ CHIP_ERROR GetEpochTS(uint32_t & chipEpoch)
      * This should not be certifiable since getting time is a Mandatory
      * feature of EVSE Cluster
      */
-    VerifyOrDie(err != CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+    if (err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+    {
+        ChipLogError(Zcl, "Platform does not support GetClock_RealTimeMS.");
+        return err;
+    }
 
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/energy-management-app/energy-management-common/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/energy-management-app/energy-management-common/src/EnergyEvseDelegateImpl.cpp
@@ -1476,7 +1476,7 @@ CHIP_ERROR GetEpochTS(uint32_t & chipEpoch)
      */
     if (err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
     {
-        ChipLogError(Zcl, "Platform does not support GetClock_RealTimeMS.");
+        ChipLogError(Zcl, "Platform does not support GetClock_RealTimeMS. Check EVSE certification requirements!");
         return err;
     }
 


### PR DESCRIPTION
Fixes: #31672 
 - #31672 

This was caused by a VerifyOrDie() when the platform System::SystemClock().GetClock_RealTimeMS(cTMs) returns CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE.

- [x] Removed the VerifyOrDie and made it fail more gracefully

Note platforms not supporting realtime clock cannot support EVSE cluster.
