### PR TITLE
Darwin: Simplify test setup and teardown

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRBackwardsCompatTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRBackwardsCompatTests.m
@@ -30,6 +30,8 @@
 // system dependencies
 #import <XCTest/XCTest.h>
 
+// Fixture: chip-all-clusters-app --KVS "$(mktemp -t chip-test-kvs)" --interface-id -1
+
 static const uint16_t kPairingTimeoutInSeconds = 10;
 static const uint16_t kCASESetupTimeoutInSeconds = 30;
 static const uint16_t kTimeoutInSeconds = 3;
@@ -73,7 +75,7 @@ static MTRBaseDevice * GetConnectedDevice(void)
     XCTAssertEqual(error.code, 0);
 
     NSError * commissionError = nil;
-    [sController commissionDevice:kDeviceId commissioningParams:[[MTRCommissioningParameters alloc] init] error:&commissionError];
+    XCTAssertTrue([sController commissionDevice:kDeviceId commissioningParams:[[MTRCommissioningParameters alloc] init] error:&commissionError]);
     XCTAssertNil(commissionError);
 
     // Keep waiting for onCommissioningComplete
@@ -91,45 +93,13 @@ static MTRBaseDevice * GetConnectedDevice(void)
 @interface MTRBackwardsCompatTests : XCTestCase
 @end
 
-static BOOL sStackInitRan = NO;
-static BOOL sNeedsStackShutdown = YES;
-
 @implementation MTRBackwardsCompatTests
 
-+ (void)tearDown
++ (void)setUp
 {
-    // Global teardown, runs once
-    if (sNeedsStackShutdown) {
-        // We don't need to worry about ResetCommissionee.  If we get here,
-        // we're running only one of our test methods (using
-        // -only-testing:MatterTests/MTROTAProviderTests/testMethodName), since
-        // we did not run test999_TearDown.
-        [self shutdownStack];
-    }
-}
-
-- (void)setUp
-{
-    // Per-test setup, runs before each test.
     [super setUp];
-    [self setContinueAfterFailure:NO];
 
-    if (sStackInitRan == NO) {
-        [self initStack];
-    }
-}
-
-- (void)tearDown
-{
-    // Per-test teardown, runs after each test.
-    [super tearDown];
-}
-
-- (void)initStack
-{
-    sStackInitRan = YES;
-
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Pairing Complete"];
+    XCTestExpectation * expectation = [[XCTestExpectation alloc] initWithDescription:@"Pairing Complete"];
 
     __auto_type * factory = [MTRControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
@@ -137,18 +107,13 @@ static BOOL sNeedsStackShutdown = YES;
     __auto_type * storage = [[MTRTestStorage alloc] init];
     __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
     factoryParams.port = @(kLocalPort);
+    XCTAssertTrue([factory startup:factoryParams]);
 
-    BOOL ok = [factory startup:factoryParams];
-    XCTAssertTrue(ok);
-
-    __auto_type * testKeys = [[MTRTestKeys alloc] init];
-    XCTAssertNotNil(testKeys);
-
-    sTestKeys = testKeys;
+    XCTAssertNotNil(sTestKeys = [[MTRTestKeys alloc] init]);
 
     // Needs to match what startControllerOnExistingFabric calls elsewhere in
     // this file do.
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys fabricId:1 ipk:testKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:sTestKeys fabricId:1 ipk:sTestKeys.ipk];
     params.vendorId = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
@@ -166,12 +131,12 @@ static BOOL sNeedsStackShutdown = YES;
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
-    [controller setupCommissioningSessionWithPayload:payload newNodeID:@(kDeviceId) error:&error];
+    XCTAssertTrue([controller setupCommissioningSessionWithPayload:payload newNodeID:@(kDeviceId) error:&error]);
     XCTAssertNil(error);
 
-    [self waitForExpectationsWithTimeout:kPairingTimeoutInSeconds handler:nil];
+    XCTAssertEqual([XCTWaiter waitForExpectations:@[ expectation ] timeout:kPairingTimeoutInSeconds], XCTWaiterResultCompleted);
 
-    __block XCTestExpectation * connectionExpectation = [self expectationWithDescription:@"CASE established"];
+    __block XCTestExpectation * connectionExpectation = [[XCTestExpectation alloc] initWithDescription:@"CASE established"];
     [controller getBaseDevice:kDeviceId
                         queue:dispatch_get_main_queue()
             completionHandler:^(MTRBaseDevice * _Nullable device, NSError * _Nullable error) {
@@ -180,57 +145,54 @@ static BOOL sNeedsStackShutdown = YES;
                 sConnectedDevice = device;
                 connectionExpectation = nil;
             }];
-    [self waitForExpectationsWithTimeout:kCASESetupTimeoutInSeconds handler:nil];
+    XCTAssertEqual([XCTWaiter waitForExpectations:@[ connectionExpectation ] timeout:kCASESetupTimeoutInSeconds], XCTWaiterResultCompleted);
 }
 
-+ (void)shutdownStack
++ (void)tearDown
 {
-    sNeedsStackShutdown = NO;
+    ResetCommissionee(GetConnectedDevice(), dispatch_get_main_queue(), nil, kTimeoutInSeconds);
 
-    MTRDeviceController * controller = sController;
-    XCTAssertNotNil(controller);
-
-    [controller shutdown];
-    XCTAssertFalse([controller isRunning]);
-
+    [sController shutdown];
+    XCTAssertFalse([sController isRunning]);
     [[MTRControllerFactory sharedInstance] shutdown];
+
+    [super tearDown];
 }
 
-- (void)test000_SetUp
+- (void)setUp
 {
-    // Nothing to do here; our setUp method handled this already.  This test
-    // just exists to make the setup not look like it's happening inside other
-    // tests.
+    [super setUp];
+    [self setContinueAfterFailure:NO];
 }
 
-#define CHECK_RETURN_TYPE(sig, type)                                                                                               \
-    do {                                                                                                                           \
-        XCTAssertNotNil(sig);                                                                                                      \
-        XCTAssertTrue(strcmp([sig methodReturnType], @encode(type)) == 0);                                                         \
+#define CHECK_RETURN_TYPE(sig, type)                                       \
+    do {                                                                   \
+        XCTAssertNotNil(sig);                                              \
+        XCTAssertTrue(strcmp([sig methodReturnType], @encode(type)) == 0); \
     } while (0)
 
 /**
  * Arguments 0 and 1 are the implicit self and _cmd arguments; the real arguments begin at index 2.
  */
-#define CHECK_ARGUMENT(sig, index, type)                                                                                           \
-    do {                                                                                                                           \
-        XCTAssertTrue(strcmp([sig getArgumentTypeAtIndex:(index) + 2], @encode(type)) == 0);                                       \
+#define CHECK_ARGUMENT(sig, index, type)                                                     \
+    do {                                                                                     \
+        XCTAssertTrue(strcmp([sig getArgumentTypeAtIndex:(index) + 2], @encode(type)) == 0); \
     } while (0)
 
-#define CHECK_READONLY_PROPERTY(instance, propName, type)                                                                          \
-    do {                                                                                                                           \
-        NSMethodSignature * signature = [instance methodSignatureForSelector:@selector(propName)];                                 \
-        CHECK_RETURN_TYPE(signature, type);                                                                                        \
-        /* Check that getting the property directly compiles too */                                                                \
-        (void) instance.propName;                                                                                                  \
+#define CHECK_READONLY_PROPERTY(instance, propName, type)                                          \
+    do {                                                                                           \
+        NSMethodSignature * signature = [instance methodSignatureForSelector:@selector(propName)]; \
+        CHECK_RETURN_TYPE(signature, type);                                                        \
+        /* Check that getting the property directly compiles too */                                \
+        (void) instance.propName;                                                                  \
     } while (0)
 
-#define CHECK_PROPERTY(instance, propName, setterName, type)                                                                       \
-    do {                                                                                                                           \
-        CHECK_READONLY_PROPERTY(instance, propName, type);                                                                         \
-        NSMethodSignature * signature = [instance methodSignatureForSelector:@selector(setterName:)];                              \
-        CHECK_RETURN_TYPE(signature, void);                                                                                        \
-        CHECK_ARGUMENT(signature, 0, type);                                                                                        \
+#define CHECK_PROPERTY(instance, propName, setterName, type)                                          \
+    do {                                                                                              \
+        CHECK_READONLY_PROPERTY(instance, propName, type);                                            \
+        NSMethodSignature * signature = [instance methodSignatureForSelector:@selector(setterName:)]; \
+        CHECK_RETURN_TYPE(signature, void);                                                           \
+        CHECK_ARGUMENT(signature, 0, type);                                                           \
     } while (0)
 
 /**
@@ -1210,12 +1172,6 @@ static BOOL sNeedsStackShutdown = YES;
     __auto_type * obj = [[MTRModeSelectClusterSemanticTagStruct alloc] init];
     CHECK_PROPERTY(obj, mfgCode, setMfgCode, NSNumber *);
     CHECK_PROPERTY(obj, value, setValue, NSNumber *);
-}
-
-- (void)test999_TearDown
-{
-    ResetCommissionee(GetConnectedDevice(), dispatch_get_main_queue(), self, kTimeoutInSeconds);
-    [[self class] shutdownStack];
 }
 
 @end

--- a/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
@@ -23,6 +23,11 @@
 #import "MTRTestKeys.h"
 #import "MTRTestStorage.h"
 
+// Fixture 1: chip-all-clusters-app --KVS "$(mktemp -t chip-test-kvs)" --interface-id -1
+// Fixture 2: chip-all-clusters-app --KVS "$(mktemp -t chip-test-kvs)" --interface-id -1 \
+    --dac_provider credentials/development/commissioner_dut/struct_cd_origin_pid_vid_correct/test_case_vector.json \
+    --product-id 32768 --discriminator 3839
+
 static const uint16_t kLocalPort = 5541;
 static const uint16_t kTestVendorId = 0xFFF1u;
 static const uint16_t kTestProductId1 = 0x8000u;
@@ -118,34 +123,9 @@ static BOOL sNeedsStackShutdown = YES;
 
 @implementation MTRCommissionableBrowserTests
 
-+ (void)tearDown
++ (void)setUp
 {
-    // Global teardown, runs once
-    if (sNeedsStackShutdown) {
-        [self shutdownStack];
-    }
-}
-
-- (void)setUp
-{
-    // Per-test setup, runs before each test.
     [super setUp];
-    [self setContinueAfterFailure:NO];
-
-    if (sStackInitRan == NO) {
-        [self initStack];
-    }
-}
-
-- (void)tearDown
-{
-    // Per-test teardown, runs after each test.
-    [super tearDown];
-}
-
-- (void)initStack
-{
-    sStackInitRan = YES;
 
     __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
@@ -169,17 +149,22 @@ static BOOL sNeedsStackShutdown = YES;
     sController = controller;
 }
 
-+ (void)shutdownStack
++ (void)tearDown
 {
-    sNeedsStackShutdown = NO;
-
     MTRDeviceController * controller = sController;
     XCTAssertNotNil(controller);
-
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
     [[MTRDeviceControllerFactory sharedInstance] stopControllerFactory];
+
+    [super tearDown];
+}
+
+- (void)setUp
+{
+    [super setUp];
+    [self setContinueAfterFailure:NO];
 }
 
 - (void)test001_StartBrowseAndStopBrowse
@@ -246,11 +231,6 @@ static BOOL sNeedsStackShutdown = YES;
 
     // Properly stop browsing
     XCTAssertTrue([sController stopBrowseForCommissionables]);
-}
-
-- (void)test999_TearDown
-{
-    [[self class] shutdownStack];
 }
 
 @end

--- a/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
@@ -118,9 +118,6 @@ static MTRDeviceController * sController = nil;
 @interface MTRCommissionableBrowserTests : XCTestCase
 @end
 
-static BOOL sStackInitRan = NO;
-static BOOL sNeedsStackShutdown = YES;
-
 @implementation MTRCommissionableBrowserTests
 
 + (void)setUp

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -204,10 +204,6 @@ static const uint16_t kTestVendorId = 0xFFF1u;
     dispatch_queue_t _storageQueue;
 }
 
-+ (void)tearDown
-{
-}
-
 - (void)setUp
 {
     // Per-test setup, runs before each test.

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestResetCommissioneeHelper.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestResetCommissioneeHelper.m
@@ -16,11 +16,11 @@
 
 #import "MTRTestResetCommissioneeHelper.h"
 
-void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCase * testcase, uint16_t commandTimeout)
+void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCase * testcaseUnused, uint16_t commandTimeout)
 {
     // Put the device back in the state we found it: open commissioning window, no fabrics commissioned.
     // Get our current fabric index, for later deletion.
-    XCTestExpectation * readFabricIndexExpectation = [testcase expectationWithDescription:@"Fabric index read"];
+    XCTestExpectation * readFabricIndexExpectation = [[XCTestExpectation alloc] initWithDescription:@"Fabric index read"];
 
     __block NSNumber * fabricIndex;
     __auto_type * opCredsCluster = [[MTRBaseClusterOperationalCredentials alloc] initWithDevice:device endpoint:0 queue:queue];
@@ -32,11 +32,10 @@ void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCas
             [readFabricIndexExpectation fulfill];
         }];
 
-    [testcase waitForExpectations:@[ readFabricIndexExpectation ] timeout:commandTimeout];
+    XCTAssertEqual([XCTWaiter waitForExpectations:@[ readFabricIndexExpectation ] timeout:commandTimeout], XCTWaiterResultCompleted);
 
     // Open a commissioning window.
-    XCTestExpectation * openCommissioningWindowExpectation = [testcase expectationWithDescription:@"Commissioning window opened"];
-
+    XCTestExpectation * openCommissioningWindowExpectation = [[XCTestExpectation alloc] initWithDescription:@"Commissioning window opened"];
     __auto_type * adminCommissioningCluster = [[MTRBaseClusterAdministratorCommissioning alloc] initWithDevice:device
                                                                                                       endpoint:0
                                                                                                          queue:queue];
@@ -49,10 +48,10 @@ void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCas
                                                         [openCommissioningWindowExpectation fulfill];
                                                     }];
 
-    [testcase waitForExpectations:@[ openCommissioningWindowExpectation ] timeout:commandTimeout];
+    XCTAssertEqual([XCTWaiter waitForExpectations:@[ openCommissioningWindowExpectation ] timeout:commandTimeout], XCTWaiterResultCompleted);
 
     // Remove our fabric from the device.
-    XCTestExpectation * removeFabricExpectation = [testcase expectationWithDescription:@"Fabric removed"];
+    XCTestExpectation * removeFabricExpectation = [[XCTestExpectation alloc] initWithDescription:@"Fabric removed"];
 
     __auto_type * removeParams = [[MTROperationalCredentialsClusterRemoveFabricParams alloc] init];
     removeParams.fabricIndex = fabricIndex;
@@ -66,5 +65,5 @@ void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCas
                              [removeFabricExpectation fulfill];
                          }];
 
-    [testcase waitForExpectations:@[ removeFabricExpectation ] timeout:commandTimeout];
+    XCTAssertEqual([XCTWaiter waitForExpectations:@[ removeFabricExpectation ] timeout:commandTimeout], XCTWaiterResultCompleted);
 }


### PR DESCRIPTION
Avoid relying on dummy tests that are ordered first / last.
