### PR TITLE
[VALCC] Update test scripts to match latest test plan

### DIFF
--- a/src/python_testing/TC_VALCC_4_3.py
+++ b/src/python_testing/TC_VALCC_4_3.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2023 Project CHIP Authors
+#    Copyright (c) 2024 Project CHIP Authors
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/python_testing/TC_VALCC_4_3.py
+++ b/src/python_testing/TC_VALCC_4_3.py
@@ -30,25 +30,19 @@ class TC_VALCC_4_3(MatterBaseTest):
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
 
     def desc_TC_VALCC_4_3(self) -> str:
-        return "[TC-VALCC-4.3] AutoCloseTime functionality with DUT as Server"
+        return "[TC-VALCC-4.3] AutoCloseTime functionality with (no synchronized time) DUT as Server"
 
     def steps_TC_VALCC_4_3(self) -> list[TestStep]:
         steps = [
             TestStep(1, "Commissioning, already done", is_commissioning=True),
-            TestStep(2, "Read FeatureMap attribute"),
-            TestStep(3, "Verify TimeSync feature is supported"),
-            TestStep(4, "Send Open command with duration set to 60"),
-            TestStep(5, "Read UTCTime attribute from TimeSync cluster"),
-            TestStep(6, "Read AutoCloseTime attribute"),
-            TestStep(7, "Send Close command"),
-            TestStep(8, "Read AutoCloseTime attribute"),
-            TestStep("9a", "Read DefaultOpenDuration attribute"),
-            TestStep("9b", "Write DefaultOpenDuration attribute"),
-            TestStep(10, "Send Open command"),
-            TestStep(11, "Read UTCTime attribute from TimeSync cluster"),
-            TestStep(12, "Read AutoCloseTime attribute"),
-            TestStep(13, "Send Close command"),
-            TestStep(14, "Read AutoCloseTime attribute"),
+            TestStep("2a", "Read FeatureMap attribute"),
+            TestStep("2b", "Verify TimeSync feature is supported"),
+            TestStep("3a", "Read UTCTime attribute from Time Synchronization cluster"),
+            TestStep("3b", "Verify UTCTime is null"),
+            TestStep(4, "Send Open command"),
+            TestStep(5, "Read AutoCloseTime attribute"),
+            TestStep(6, "Send Close command"),
+            TestStep(7, "Read AutoCloseTime attribute"),
         ]
         return steps
 
@@ -66,12 +60,12 @@ class TC_VALCC_4_3(MatterBaseTest):
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes
 
-        self.step(2)
+        self.step("2a")
         feature_map = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.FeatureMap)
 
         is_ts_feature_supported = feature_map & Clusters.ValveConfigurationAndControl.Bitmaps.Feature.kTimeSync
 
-        self.step(3)
+        self.step("2b")
         if not is_ts_feature_supported:
             logging.info("TimeSync feature not supported skipping test case")
 
@@ -85,82 +79,43 @@ class TC_VALCC_4_3(MatterBaseTest):
         else:
             logging.info("Test step skipped")
 
-        self.step(4)
-        try:
-            await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Open(openDuration=60), endpoint=endpoint)
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
-            pass
-
-        self.step(5)
+        self.step("3a")
         utcTime = await self.read_single_attribute_check_success(endpoint=0, cluster=Clusters.Objects.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.UTCTime)
-        asserts.assert_true(utcTime is not NullValue, "OpenDuration is null")
 
-        self.step(6)
-        auto_close_time_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.AutoCloseTime)
+        self.step("3b")
+        if utcTime is not NullValue:
+            logging.info("UTCTime is not null, skipping test case")
 
-        asserts.assert_true(auto_close_time_dut is not NullValue, "AutoCloseTime is null")
-        asserts.assert_greater_equal(auto_close_time_dut, (utcTime + 55000000),
-                                     "AutoCloseTime is not in the expected range")
-        asserts.assert_less_equal(auto_close_time_dut, (utcTime + 60000000), "AutoCloseTime is not in the expected range")
+            # Skipping all remainig steps
+            for step in self.get_test_steps(self.current_test_info.name)[self.current_step_index:]:
+                self.step(step.test_plan_number)
+                logging.info("Test step skipped")
 
-        self.step(7)
-        try:
-            await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Close(), endpoint=endpoint)
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
-            pass
+            return
 
-        self.step(8)
-        auto_close_time_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.AutoCloseTime)
-
-        asserts.assert_true(auto_close_time_dut is NullValue, "AutoCloseTime is not null")
-
-        self.step("9a")
-        defaultOpenDuration = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.OpenDuration)
-
-        asserts.assert_true(auto_close_time_dut is NullValue, "AutoCloseTime is not null")
-
-        self.step("9b")
-        if defaultOpenDuration is NullValue:
-            defaultOpenDuration = 60
-
-            result = await self.default_controller.WriteAttribute(self.dut_node_id, [(endpoint, attributes.DefaultOpenDuration(defaultOpenDuration))])
-            asserts.assert_equal(result[0].Status, Status.Success, "DefaultOpenDuration write failed")
         else:
             logging.info("Test step skipped")
 
-        self.step(10)
+        self.step(4)
         try:
             await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Open(), endpoint=endpoint)
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
-        self.step(11)
-        utcTime = await self.read_single_attribute_check_success(endpoint=0, cluster=Clusters.Objects.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.UTCTime)
-
-        asserts.assert_true(utcTime is not NullValue, "OpenDuration is null")
-
-        self.step(12)
+        self.step(5)
         auto_close_time_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.AutoCloseTime)
+        asserts.assert_true(auto_close_time_dut is NullValue, "AutoCloseTime is not null")
 
-        asserts.assert_true(auto_close_time_dut is not NullValue, "AutoCloseTime is null")
-        asserts.assert_greater_equal(auto_close_time_dut, (utcTime + ((defaultOpenDuration - 5) * 1000000)),
-                                     "AutoCloseTime is not in the expected range")
-        asserts.assert_less_equal(auto_close_time_dut, (utcTime + (defaultOpenDuration * 1000000)),
-                                  "AutoCloseTime is not in the expected range")
-
-        self.step(13)
+        self.step(6)
         try:
             await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Close(), endpoint=endpoint)
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
-        self.step(14)
+        self.step(7)
         auto_close_time_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.AutoCloseTime)
-
         asserts.assert_true(auto_close_time_dut is NullValue, "AutoCloseTime is not null")
 
 

--- a/src/python_testing/TC_VALCC_4_4.py
+++ b/src/python_testing/TC_VALCC_4_4.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2023 Project CHIP Authors
+#    Copyright (c) 2024 Project CHIP Authors
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/python_testing/TC_VALCC_4_4.py
+++ b/src/python_testing/TC_VALCC_4_4.py
@@ -100,6 +100,9 @@ class TC_VALCC_4_4(MatterBaseTest):
                 asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
                 pass
 
+        else:
+            logging.info("Test step skipped")
+
         self.step(4)
         try:
             await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Open(openDuration=60), endpoint=endpoint)

--- a/src/python_testing/TC_VALCC_4_4.py
+++ b/src/python_testing/TC_VALCC_4_4.py
@@ -15,12 +15,12 @@
 #    limitations under the License.
 #
 
-import time
+import logging
 
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, utc_time_in_matter_epoch
 from mobly import asserts
 
 
@@ -30,19 +30,27 @@ class TC_VALCC_4_4(MatterBaseTest):
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
 
     def desc_TC_VALCC_4_4(self) -> str:
-        return "[TC-VALCC-4.4] Auto close functionality with DUT as Server"
+        return "[TC-VALCC-4.4] AutoCloseTime functionality with (synchronized time) DUT as Server"
 
     def steps_TC_VALCC_4_4(self) -> list[TestStep]:
         steps = [
             TestStep(1, "Commissioning, already done", is_commissioning=True),
-            TestStep(2, "Send Open command with duration set to 5"),
-            TestStep(3, "Read OpenDuration attribute"),
-            TestStep(4, "Read RemainingDuration attribute"),
-            TestStep(5, "Read CurrentState attribute"),
-            TestStep(6, "Wait 6 seconds"),
-            TestStep(7, "Read OpenDuration attribute"),
-            TestStep(8, "Read RemainingDuration attribute"),
-            TestStep(9, "Read CurrentState attribute"),
+            TestStep("2a", "Read FeatureMap attribute"),
+            TestStep("2b", "Verify TimeSync feature is supported"),
+            TestStep("3a", "Read UTCTime attribute from Time Synchronization cluster"),
+            TestStep("3b", "Set UTCTime, if null"),
+            TestStep(4, "Send Open command with duration set to 60"),
+            TestStep(5, "Read UTCTime attribute from TimeSync cluster"),
+            TestStep(6, "Read AutoCloseTime attribute"),
+            TestStep(7, "Send Close command"),
+            TestStep(8, "Read AutoCloseTime attribute"),
+            TestStep("9a", "Read DefaultOpenDuration attribute"),
+            TestStep("9b", "Write DefaultOpenDuration attribute"),
+            TestStep(10, "Send Open command"),
+            TestStep(11, "Read UTCTime attribute from TimeSync cluster"),
+            TestStep(12, "Read AutoCloseTime attribute"),
+            TestStep(13, "Send Close command"),
+            TestStep(14, "Read AutoCloseTime attribute"),
         ]
         return steps
 
@@ -60,53 +68,114 @@ class TC_VALCC_4_4(MatterBaseTest):
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes
 
-        self.step(2)
+        self.step("2a")
+        feature_map = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.FeatureMap)
+
+        is_ts_feature_supported = feature_map & Clusters.ValveConfigurationAndControl.Bitmaps.Feature.kTimeSync
+
+        self.step("2b")
+        if not is_ts_feature_supported:
+            logging.info("TimeSync feature not supported skipping test case")
+
+            # Skipping all remainig steps
+            for step in self.get_test_steps(self.current_test_info.name)[self.current_step_index:]:
+                self.step(step.test_plan_number)
+                logging.info("Test step skipped")
+
+            return
+
+        else:
+            logging.info("Test step skipped")
+
+        self.step("3a")
+        utcTime = await self.read_single_attribute_check_success(endpoint=0, cluster=Clusters.Objects.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.UTCTime)
+
+        self.step("3b")
+        if utcTime is NullValue:
+            th_utc = utc_time_in_matter_epoch()
+
+            try:
+                await self.send_single_cmd(cmd=Clusters.Objects.TimeSynchronization.Commands.SetUTCTime(UTCTime=th_utc, granularity=Clusters.Objects.TimeSynchronization.Enums.GranularityEnum.kMillisecondsGranularity), endpoint=0)
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+                pass
+
+        self.step(4)
         try:
-            await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Open(openDuration=5), endpoint=endpoint)
+            await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Open(openDuration=60), endpoint=endpoint)
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
-        self.step(3)
-        open_duration_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.OpenDuration)
-        asserts.assert_true(open_duration_dut is not NullValue, "OpenDuration is null")
-        asserts.assert_equal(open_duration_dut, 5, "OpenDuration is not the expected value")
-
-        self.step(4)
-        remaining_duration_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.RemainingDuration)
-        asserts.assert_true(remaining_duration_dut is not NullValue, "RemainingDuration is null")
-        asserts.assert_greater_equal(remaining_duration_dut, 1, "RemainingDuration is not in the expected range")
-        asserts.assert_less_equal(remaining_duration_dut, 5, "RemainingDuration is not in the expected range")
-
         self.step(5)
-        current_state_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentState)
-        asserts.assert_true(current_state_dut is not NullValue, "CurrentState is null")
-
-        while current_state_dut is Clusters.Objects.ValveConfigurationAndControl.Enums.ValveStateEnum.kTransitioning:
-            time.sleep(1)
-
-            current_state_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentState)
-            asserts.assert_true(current_state_dut is not NullValue, "CurrentState is null")
-
-        asserts.assert_equal(current_state_dut, Clusters.Objects.ValveConfigurationAndControl.Enums.ValveStateEnum.kOpen,
-                             "CurrentState is not the expected value")
+        utcTime = await self.read_single_attribute_check_success(endpoint=0, cluster=Clusters.Objects.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.UTCTime)
 
         self.step(6)
-        time.sleep(6)
+        auto_close_time_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.AutoCloseTime)
+
+        asserts.assert_true(auto_close_time_dut is not NullValue, "AutoCloseTime is null")
+        asserts.assert_greater_equal(auto_close_time_dut, (utcTime + 55000000),
+                                     "AutoCloseTime is not in the expected range")
+        asserts.assert_less_equal(auto_close_time_dut, (utcTime + 60000000), "AutoCloseTime is not in the expected range")
 
         self.step(7)
-        open_duration_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.OpenDuration)
-        asserts.assert_true(open_duration_dut is NullValue, "OpenDuration is not null")
+        try:
+            await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Close(), endpoint=endpoint)
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
 
         self.step(8)
-        remaining_duration_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.RemainingDuration)
-        asserts.assert_true(remaining_duration_dut is NullValue, "RemainingDuration is not null")
+        auto_close_time_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.AutoCloseTime)
 
-        self.step(9)
-        current_state_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentState)
-        asserts.assert_true(current_state_dut is not NullValue, "CurrentState is null")
-        asserts.assert_equal(current_state_dut, Clusters.Objects.ValveConfigurationAndControl.Enums.ValveStateEnum.kClosed,
-                             "CurrentState is not the expected value")
+        asserts.assert_true(auto_close_time_dut is NullValue, "AutoCloseTime is not null")
+
+        self.step("9a")
+        defaultOpenDuration = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.OpenDuration)
+
+        asserts.assert_true(auto_close_time_dut is NullValue, "AutoCloseTime is not null")
+
+        self.step("9b")
+        if defaultOpenDuration is NullValue:
+            defaultOpenDuration = 60
+
+            result = await self.default_controller.WriteAttribute(self.dut_node_id, [(endpoint, attributes.DefaultOpenDuration(defaultOpenDuration))])
+            asserts.assert_equal(result[0].Status, Status.Success, "DefaultOpenDuration write failed")
+        else:
+            logging.info("Test step skipped")
+
+        self.step(10)
+        try:
+            await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Open(), endpoint=endpoint)
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
+
+        self.step(11)
+        utcTime = await self.read_single_attribute_check_success(endpoint=0, cluster=Clusters.Objects.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.UTCTime)
+
+        asserts.assert_true(utcTime is not NullValue, "OpenDuration is null")
+
+        self.step(12)
+        auto_close_time_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.AutoCloseTime)
+
+        asserts.assert_true(auto_close_time_dut is not NullValue, "AutoCloseTime is null")
+        asserts.assert_greater_equal(auto_close_time_dut, (utcTime + ((defaultOpenDuration - 5) * 1000000)),
+                                     "AutoCloseTime is not in the expected range")
+        asserts.assert_less_equal(auto_close_time_dut, (utcTime + (defaultOpenDuration * 1000000)),
+                                  "AutoCloseTime is not in the expected range")
+
+        self.step(13)
+        try:
+            await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Close(), endpoint=endpoint)
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
+
+        self.step(14)
+        auto_close_time_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.AutoCloseTime)
+
+        asserts.assert_true(auto_close_time_dut is NullValue, "AutoCloseTime is not null")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_VALCC_4_5.py
+++ b/src/python_testing/TC_VALCC_4_5.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2023 Project CHIP Authors
+#    Copyright (c) 2024 Project CHIP Authors
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/python_testing/TC_VALCC_4_5.py
+++ b/src/python_testing/TC_VALCC_4_5.py
@@ -1,0 +1,113 @@
+#
+#    Copyright (c) 2023 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import time
+
+import chip.clusters as Clusters
+from chip.clusters.Types import NullValue
+from chip.interaction_model import InteractionModelError, Status
+from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+
+
+class TC_VALCC_4_5(MatterBaseTest):
+    async def read_valcc_attribute_expect_success(self, endpoint, attribute):
+        cluster = Clusters.Objects.ValveConfigurationAndControl
+        return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
+
+    def desc_TC_VALCC_4_5(self) -> str:
+        return "[TC-VALCC-4.5] Auto close functionality with DUT as Server"
+
+    def steps_TC_VALCC_4_5(self) -> list[TestStep]:
+        steps = [
+            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(2, "Send Open command with duration set to 5"),
+            TestStep(3, "Read OpenDuration attribute"),
+            TestStep(4, "Read RemainingDuration attribute"),
+            TestStep(5, "Read CurrentState attribute"),
+            TestStep(6, "Wait 6 seconds"),
+            TestStep(7, "Read OpenDuration attribute"),
+            TestStep(8, "Read RemainingDuration attribute"),
+            TestStep(9, "Read CurrentState attribute"),
+        ]
+        return steps
+
+    def pics_TC_VALCC_4_5(self) -> list[str]:
+        pics = [
+            "VALCC.S",
+        ]
+        return pics
+
+    @async_test_body
+    async def test_TC_VALCC_4_5(self):
+
+        endpoint = self.user_params.get("endpoint", 1)
+
+        self.step(1)
+        attributes = Clusters.ValveConfigurationAndControl.Attributes
+
+        self.step(2)
+        try:
+            await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Open(openDuration=5), endpoint=endpoint)
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
+
+        self.step(3)
+        open_duration_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.OpenDuration)
+        asserts.assert_true(open_duration_dut is not NullValue, "OpenDuration is null")
+        asserts.assert_equal(open_duration_dut, 5, "OpenDuration is not the expected value")
+
+        self.step(4)
+        remaining_duration_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.RemainingDuration)
+        asserts.assert_true(remaining_duration_dut is not NullValue, "RemainingDuration is null")
+        asserts.assert_greater_equal(remaining_duration_dut, 1, "RemainingDuration is not in the expected range")
+        asserts.assert_less_equal(remaining_duration_dut, 5, "RemainingDuration is not in the expected range")
+
+        self.step(5)
+        current_state_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentState)
+        asserts.assert_true(current_state_dut is not NullValue, "CurrentState is null")
+
+        while current_state_dut is Clusters.Objects.ValveConfigurationAndControl.Enums.ValveStateEnum.kTransitioning:
+            time.sleep(1)
+
+            current_state_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentState)
+            asserts.assert_true(current_state_dut is not NullValue, "CurrentState is null")
+
+        asserts.assert_equal(current_state_dut, Clusters.Objects.ValveConfigurationAndControl.Enums.ValveStateEnum.kOpen,
+                             "CurrentState is not the expected value")
+
+        self.step(6)
+        time.sleep(6)
+
+        self.step(7)
+        open_duration_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.OpenDuration)
+        asserts.assert_true(open_duration_dut is NullValue, "OpenDuration is not null")
+
+        self.step(8)
+        remaining_duration_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.RemainingDuration)
+        asserts.assert_true(remaining_duration_dut is NullValue, "RemainingDuration is not null")
+
+        self.step(9)
+        current_state_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentState)
+        asserts.assert_true(current_state_dut is not NullValue, "CurrentState is null")
+        asserts.assert_equal(current_state_dut, Clusters.Objects.ValveConfigurationAndControl.Enums.ValveStateEnum.kClosed,
+                             "CurrentState is not the expected value")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()


### PR DESCRIPTION
This PR updates the Valve Configuration and Control test scripts to match the latest test plan (https://github.com/CHIP-Specifications/chip-test-plans/pull/3921)

The there has been added a test script to verify the case Time Sync has not happened and it was requested to have this as the first test, which resulted in a reordering of 4.3 -> 4.4 and 4.4 -> 4.5, hence why the diff does look a bit strange.