### PR TITLE
Fix threadsafety issue in MTRServerAttribute.

### DIFF
--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAttribute.mm
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAttribute.mm
@@ -34,10 +34,8 @@ using namespace chip;
 
 MTR_DIRECT_MEMBERS
 @implementation MTRServerAttribute {
-    // _lock always protects access to _deviceController, _value, and
-    // _parentCluster.  _serializedValue is protected when we are modifying it
-    // directly while we have no _deviceController.  Once we have one,
-    // _serializedValue is only modified on the Matter thread.
+    // _lock always protects access to _deviceController, _value,
+    // _serializedValue, and _parentCluster.
     os_unfair_lock _lock;
     MTRDeviceController * __weak _deviceController;
     NSDictionary<NSString *, id> * _value;
@@ -137,7 +135,7 @@ MTR_DIRECT_MEMBERS
 
     _value = [value copy];
 
-    MTR_LOG_DEFAULT("Attribute value updated: %@", self); // Logs new as part of our description.
+    MTR_LOG_DEFAULT("Attribute value updated: %@", [self _descriptionWhileLocked]); // Logs new value as part of our description.
 
     MTRDeviceController * deviceController = _deviceController;
     if (deviceController == nil) {
@@ -150,6 +148,7 @@ MTR_DIRECT_MEMBERS
         _serializedValue = serializedValue;
     } else {
         [deviceController asyncDispatchToMatterQueue:^{
+            std::lock_guard lock(self->_lock);
             auto changed = ![self->_serializedValue isEqual:serializedValue];
             self->_serializedValue = serializedValue;
             if (changed) {
@@ -185,7 +184,7 @@ MTR_DIRECT_MEMBERS
 
     _deviceController = controller;
 
-    MTR_LOG_DEFAULT("Associated %@ with controller", self);
+    MTR_LOG_DEFAULT("Associated %@ with controller", [self _descriptionWhileLocked]);
 
     return YES;
 }
@@ -216,7 +215,7 @@ MTR_DIRECT_MEMBERS
     _parentCluster = cluster;
 }
 
-- (const chip::app::ConcreteClusterPath &)parentCluster
+- (const app::ConcreteClusterPath &)parentCluster
 {
     std::lock_guard lock(_lock);
     return _parentCluster;
@@ -224,6 +223,13 @@ MTR_DIRECT_MEMBERS
 
 - (NSString *)description
 {
+    std::lock_guard lock(_lock);
+    return [self _descriptionWhileLocked];
+}
+
+- (NSString *)_descriptionWhileLocked
+{
+    os_unfair_lock_assert_owner(&_lock);
     return [NSString stringWithFormat:@"<MTRServerAttribute endpoint %u, cluster " ChipLogFormatMEI ", id " ChipLogFormatMEI ", value '%@'>", static_cast<EndpointId>(_parentCluster.mEndpointId), ChipLogValueMEI(_parentCluster.mClusterId), ChipLogValueMEI(_attributeID.unsignedLongLongValue), _value];
 }
 


### PR DESCRIPTION
An attempt to get the description could race with updates of _parentCluster.

