### PR TITLE
Mark ServerEndpoint Darwin objects as Sendable in Swift.

### DIFF
--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRAccessGrant.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRAccessGrant.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  * An access grant, which can be represented as an entry in the Matter Access
  * Control cluster.
  */
+NS_SWIFT_SENDABLE
 MTR_NEWLY_AVAILABLE
 @interface MTRAccessGrant : NSObject <NSCopying>
 

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRDeviceTypeRevision.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRDeviceTypeRevision.h
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  * A representation of a "device type revision" in the sense used in the Matter
  * specification.  This has an identifier and a version number.
  */
+NS_SWIFT_SENDABLE
 MTR_NEWLY_AVAILABLE
 @interface MTRDeviceTypeRevision : NSObject <NSCopying>
 

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAttribute.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAttribute.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  * MTRDeviceController.  An attribute has an identifier and a value, and may or
  * may not be writable.
  */
+NS_SWIFT_SENDABLE
 MTR_NEWLY_AVAILABLE
 @interface MTRServerAttribute : NSObject
 

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A representation of a server cluster implemented by an MTRDeviceController.
  */
+NS_SWIFT_SENDABLE
 MTR_NEWLY_AVAILABLE
 @interface MTRServerCluster : NSObject
 

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A representation of an endpoint implemented by an MTRDeviceController.
  */
+NS_SWIFT_SENDABLE
 MTR_NEWLY_AVAILABLE
 @interface MTRServerEndpoint : NSObject
 


### PR DESCRIPTION
These are allowed to be accessed concurrently from multiple threads, so are Sendable.
