### PR TITLE
Get some RAM savings by re-ordering some structure members based on `pahole` feedback

### DIFF
--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -116,15 +116,15 @@ public:
 private:
     struct InitParams
     {
-        NodeId nodeId                         = kUndefinedNodeId;
-        FabricId fabricId                     = kUndefinedFabricId;
-        FabricIndex fabricIndex               = kUndefinedFabricIndex;
-        CompressedFabricId compressedFabricId = kUndefinedCompressedFabricId;
-        Crypto::P256PublicKey rootPublicKey;
-        VendorId vendorId                        = VendorId::NotSpecified; /**< Vendor ID for commissioner of fabric */
+        CompressedFabricId compressedFabricId    = kUndefinedCompressedFabricId;
+        NodeId nodeId                            = kUndefinedNodeId;
+        FabricIndex fabricIndex                  = kUndefinedFabricIndex;
         Crypto::P256Keypair * operationalKeypair = nullptr;
-        bool hasExternallyOwnedKeypair           = false;
-        bool advertiseIdentity                   = false;
+        FabricId fabricId                        = kUndefinedFabricId;
+        Crypto::P256PublicKey rootPublicKey;
+        VendorId vendorId              = VendorId::NotSpecified; /**< Vendor ID for commissioner of fabric */
+        bool hasExternallyOwnedKeypair = false;
+        bool advertiseIdentity         = false;
 
         CHIP_ERROR AreValid() const
         {

--- a/src/lib/dnssd/TxtFields.h
+++ b/src/lib/dnssd/TxtFields.h
@@ -79,28 +79,28 @@ enum class TxtFieldKey : uint8_t
 namespace Internal {
 struct TxtFieldInfo
 {
-    TxtFieldKey key;
     size_t valMaxSize;
-    char keyStr[4];
+    TxtFieldKey key;
     TxtKeyUse use;
+    char keyStr[4];
 };
 
 constexpr const TxtFieldInfo txtFieldInfo[static_cast<size_t>(TxtFieldKey::kCount)] = {
-    { TxtFieldKey::kUnknown, 0, "", TxtKeyUse::kNone },
-    { TxtFieldKey::kLongDiscriminator, kKeyLongDiscriminatorMaxLength, "D", TxtKeyUse::kCommission },
-    { TxtFieldKey::kVendorProduct, kKeyVendorProductMaxLength, "VP", TxtKeyUse::kCommission },
-    { TxtFieldKey::kCommissioningMode, kKeyCommissioningModeMaxLength, "CM", TxtKeyUse::kCommission },
-    { TxtFieldKey::kDeviceType, kKeyDeviceTypeMaxLength, "DT", TxtKeyUse::kCommission },
-    { TxtFieldKey::kDeviceName, kKeyDeviceNameMaxLength, "DN", TxtKeyUse::kCommission },
-    { TxtFieldKey::kRotatingDeviceId, kKeyRotatingDeviceIdMaxLength, "RI", TxtKeyUse::kCommission },
-    { TxtFieldKey::kPairingInstruction, kKeyPairingInstructionMaxLength, "PI", TxtKeyUse::kCommission },
-    { TxtFieldKey::kPairingHint, kKeyPairingHintMaxLength, "PH", TxtKeyUse::kCommission },
-    { TxtFieldKey::kCommissionerPasscode, kKeyCommissionerPasscodeMaxLength, "CP", TxtKeyUse::kCommission },
-    { TxtFieldKey::kSessionIdleInterval, kKeySessionIdleIntervalMaxLength, "SII", TxtKeyUse::kCommon },
-    { TxtFieldKey::kSessionActiveInterval, kKeySessionActiveIntervalMaxLength, "SAI", TxtKeyUse::kCommon },
-    { TxtFieldKey::kSessionActiveThreshold, kKeySessionActiveThresholdMaxLength, "SAT", TxtKeyUse::kCommon },
-    { TxtFieldKey::kTcpSupported, kKeyTcpSupportedMaxLength, "T", TxtKeyUse::kCommon },
-    { TxtFieldKey::kLongIdleTimeICD, kKeyLongIdleTimeICDMaxLength, "ICD", TxtKeyUse::kCommon },
+    { 0, TxtFieldKey::kUnknown, TxtKeyUse::kNone, "" },
+    { kKeyLongDiscriminatorMaxLength, TxtFieldKey::kLongDiscriminator, TxtKeyUse::kCommission, "D" },
+    { kKeyVendorProductMaxLength, TxtFieldKey::kVendorProduct, TxtKeyUse::kCommission, "VP" },
+    { kKeyCommissioningModeMaxLength, TxtFieldKey::kCommissioningMode, TxtKeyUse::kCommission, "CM" },
+    { kKeyDeviceTypeMaxLength, TxtFieldKey::kDeviceType, TxtKeyUse::kCommission, "DT" },
+    { kKeyDeviceNameMaxLength, TxtFieldKey::kDeviceName, TxtKeyUse::kCommission, "DN" },
+    { kKeyRotatingDeviceIdMaxLength, TxtFieldKey::kRotatingDeviceId, TxtKeyUse::kCommission, "RI" },
+    { kKeyPairingInstructionMaxLength, TxtFieldKey::kPairingInstruction, TxtKeyUse::kCommission, "PI" },
+    { kKeyPairingHintMaxLength, TxtFieldKey::kPairingHint, TxtKeyUse::kCommission, "PH" },
+    { kKeyCommissionerPasscodeMaxLength, TxtFieldKey::kCommissionerPasscode, TxtKeyUse::kCommission, "CP" },
+    { kKeySessionIdleIntervalMaxLength, TxtFieldKey::kSessionIdleInterval, TxtKeyUse::kCommon, "SII" },
+    { kKeySessionActiveIntervalMaxLength, TxtFieldKey::kSessionActiveInterval, TxtKeyUse::kCommon, "SAI" },
+    { kKeySessionActiveThresholdMaxLength, TxtFieldKey::kSessionActiveThreshold, TxtKeyUse::kCommon, "SAT" },
+    { kKeyTcpSupportedMaxLength, TxtFieldKey::kTcpSupported, TxtKeyUse::kCommon, "T" },
+    { kKeyLongIdleTimeICDMaxLength, TxtFieldKey::kLongIdleTimeICD, TxtKeyUse::kCommon, "ICD" },
 };
 #ifdef CHIP_CONFIG_TEST
 

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -207,18 +207,18 @@ inline constexpr size_t kMaxPairingInstructionLen = 128;
 /// Data that is specific to commisionable/commissioning node discovery
 struct CommissionNodeData
 {
-    char instanceName[Commission::kInstanceNameMaxLength + 1] = {};
+    size_t rotatingIdLen                                      = 0;
+    uint32_t deviceType                                       = 0;
     uint16_t longDiscriminator                                = 0;
     uint16_t vendorId                                         = 0;
     uint16_t productId                                        = 0;
-    uint8_t commissioningMode                                 = 0;
-    uint32_t deviceType                                       = 0;
-    char deviceName[kMaxDeviceNameLen + 1]                    = {};
-    uint8_t rotatingId[kMaxRotatingIdLen]                     = {};
-    size_t rotatingIdLen                                      = 0;
     uint16_t pairingHint                                      = 0;
-    char pairingInstruction[kMaxPairingInstructionLen + 1]    = {};
+    uint8_t commissioningMode                                 = 0;
     uint8_t commissionerPasscode                              = 0;
+    uint8_t rotatingId[kMaxRotatingIdLen]                     = {};
+    char instanceName[Commission::kInstanceNameMaxLength + 1] = {};
+    char deviceName[kMaxDeviceNameLen + 1]                    = {};
+    char pairingInstruction[kMaxPairingInstructionLen + 1]    = {};
 
     CommissionNodeData() {}
 


### PR DESCRIPTION
Just randomly picked some structures, to see if going this path is even remotely worthwile.

Expectation is that RAM usage should decrease in some platforms.