### PR TITLE
[MatterYamlTests] Allow enum names in YAML instead of raw values

### DIFF
--- a/scripts/py_matter_yamltests/BUILD.gn
+++ b/scripts/py_matter_yamltests/BUILD.gn
@@ -55,6 +55,7 @@ pw_python_package("matter_yamltests") {
     "test_pics_checker.py",
     "test_parser_builder.py",
     "test_pseudo_clusters.py",
+    "test_yaml_parser.py",
     "test_yaml_loader.py",
   ]
 

--- a/scripts/py_matter_yamltests/matter_yamltests/errors.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/errors.py
@@ -232,7 +232,7 @@ class TestStepEnumError(TestStepError):
         - enum_name_or_value (str|int): The name (str) or value (int) of the enumeration in the step.
           If a string is provided, it is considered the name of the enumeration; if an integer is provided, it is considered the value of the enumeration.
         - enum_candidates (dict): A dictionary mapping enumeration names (as strings) to their corresponding values
-          (as integers). This dictionary represents all possible candidates of the enumeration.
+          (as integers). This dictionary represents all known values of the enumeration.
     """
 
     def __init__(self, enum_name_or_value, enum_candidates: dict):

--- a/scripts/py_matter_yamltests/matter_yamltests/errors.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/errors.py
@@ -222,3 +222,45 @@ class TestStepSaveAsNameError(TestStepError):
         self.tag_key_with_error(content, 'attribute')
         response = content.get('response')
         self.tag_key_with_error(response, 'saveAs')
+
+
+class TestStepEnumError(TestStepError):
+    """
+    Raise when an enum value or an enum name is not found in the definitions.
+
+    Parameters:
+        - enum_name_or_value (str|int): The name (str) or value (int) of the enumeration in the step.
+          If a string is provided, it is considered the name of the enumeration; if an integer is provided, it is considered the value of the enumeration.
+        - enum_candidates (dict): A dictionary mapping enumeration names (as strings) to their corresponding values
+          (as integers). This dictionary represents all possible candidates of the enumeration.
+    """
+
+    def __init__(self, enum_name_or_value, enum_candidates: dict):
+        if type(enum_name_or_value) is str:
+            message = f'Unknown enum name: "{enum_name_or_value}". The possible values are: "{enum_candidates}"'
+
+            for enum_name in enum_candidates:
+                if enum_name.lower() == enum_name_or_value.lower():
+                    message = f'Unknown enum name: "{enum_name_or_value}". Did you mean "{enum_name}" ?'
+                    break
+
+        else:
+            message = f'Unknown enum value: "{enum_name_or_value}". The possible values are: "{enum_candidates}"'
+
+        super().__init__(message)
+
+
+class TestStepEnumSpecifierNotUnknownError(TestStepError):
+    """Raise when an enum value declared as unknown is in fact a known enum value from the definitions."""
+
+    def __init__(self, specified_value, enum_name):
+        message = f'The value "{specified_value}" is not unknown. It is the value of "{enum_name}"'
+        super().__init__(message)
+
+
+class TestStepEnumSpecifierWrongError(TestStepError):
+    """Raise when an enum value is specified for a given enum name but it does not match the enum value from the definitions."""
+
+    def __init__(self, specified_value, enum_name, enum_value):
+        message = f'The value "{specified_value}" is not the value of "{enum_name}({enum_value})"'
+        super().__init__(message)

--- a/src/app/tests/suites/DL_UsersAndCredentials.yaml
+++ b/src/app/tests/suites/DL_UsersAndCredentials.yaml
@@ -562,7 +562,7 @@ tests:
               - name: "UserUniqueID"
                 value: 0xBABA
               - name: "UserStatus"
-                value: 2
+                value: UserStatusEnum.UnknownEnumValue(2)
               - name: "UserType"
                 value: null
               - name: "CredentialRule"
@@ -1031,7 +1031,7 @@ tests:
               - name: "UserIndex"
                 value: null
               - name: "UserStatus"
-                value: 2
+                value: UserStatusEnum.UnknownEnumValue(2)
               - name: "UserType"
                 value: null
       response:

--- a/src/app/tests/suites/TestAccessControlConstraints.yaml
+++ b/src/app/tests/suites/TestAccessControlConstraints.yaml
@@ -130,7 +130,7 @@ tests:
                   {
                       FabricIndex: 0,
                       Privilege: 3,
-                      AuthMode: 4, # INVALID
+                      AuthMode: AccessControlEntryAuthModeEnum.UnknownEnumValue,
                       Subjects: [],
                       Targets: null,
                   },
@@ -231,7 +231,7 @@ tests:
                   },
                   {
                       FabricIndex: 0,
-                      Privilege: 6, # INVALID
+                      Privilege: AccessControlEntryPrivilegeEnum.UnknownEnumValue,
                       AuthMode: 2, # CASE
                       Subjects: null,
                       Targets: null,

--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -1066,7 +1066,7 @@ tests:
               - name: "arg1"
                 value: 20003
               - name: "arg2"
-                value: 101
+                value: SimpleEnum.UnknownEnumValue
       response:
           # Attempting to echo back the invalid enum value should fail.
           error: FAILURE
@@ -2814,7 +2814,7 @@ tests:
       command: "writeAttribute"
       attribute: "nullable_enum_attr"
       arguments:
-          value: 255
+          value: SimpleEnum.UnknownEnumValue(255)
       response:
           error: CONSTRAINT_ERROR
 

--- a/src/app/tests/suites/TestDiagnosticLogs.yaml
+++ b/src/app/tests/suites/TestDiagnosticLogs.yaml
@@ -443,7 +443,7 @@ tests:
       arguments:
           values:
               - name: "Intent"
-                value: 128 # undefined value
+                value: IntentEnum.UnknownEnumValue(128)
               - name: "RequestedProtocol"
                 value: 0 # ResponsePayload
       response:
@@ -456,7 +456,7 @@ tests:
               - name: "Intent"
                 value: 0 # EndUserSupport
               - name: "RequestedProtocol"
-                value: 128 # undefined value
+                value: TransferProtocolEnum.UnknownEnumValue(128)
       response:
           error: "INVALID_COMMAND"
 

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
@@ -1164,7 +1164,7 @@ tests:
                       FabricIndex: CurrentFabricIndexValue,
                   },
                   {
-                      Privilege: 6,
+                      Privilege: AccessControlEntryPrivilegeEnum.UnknownEnumValue,
                       AuthMode: 2,
                       Subjects: null,
                       Targets: null,
@@ -1192,7 +1192,7 @@ tests:
                   },
                   {
                       Privilege: 3,
-                      AuthMode: 4,
+                      AuthMode: AccessControlEntryAuthModeEnum.UnknownEnumValue,
                       Subjects: null,
                       Targets: null,
                       FabricIndex: CurrentFabricIndexValue,

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_9.yaml
@@ -66,8 +66,8 @@ tests:
           value:
               [
                   {
-                      Privilege: "4",
-                      AuthMode: "2",
+                      Privilege: AccessControlEntryPrivilegeEnum.Manage,
+                      AuthMode: AccessControlEntryAuthModeEnum.CASE,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
                       FabricIndex: CurrentFabricIndexValue,
@@ -94,8 +94,8 @@ tests:
           value:
               [
                   {
-                      Privilege: "5",
-                      AuthMode: "2",
+                      Privilege: AccessControlEntryPrivilegeEnum.Administer,
+                      AuthMode: AccessControlEntryAuthModeEnum.CASE,
                       Subjects: [CommissionerNodeId],
                       Targets: null,
                       FabricIndex: CurrentFabricIndexValue,

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_9.yaml
@@ -167,7 +167,7 @@ tests:
               - name: "UserIndex"
                 value: null
               - name: "UserStatus"
-                value: 5
+                value: UserStatusEnum.UnknownEnumValue(5)
               - name: "UserType"
                 value: 10
       response:

--- a/src/app/tests/suites/certification/Test_TC_DRYERCTRL_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRYERCTRL_2_1.yaml
@@ -60,7 +60,7 @@ tests:
           constraints:
               type: enum8
               minValue: 0
-              maxValue: 15
+              maxValue: 3
 
     - label:
           "Step 4:TH writes a supported SelectedDrynessLevel attribute that is

--- a/src/app/tests/suites/certification/Test_TC_ILL_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ILL_2_1.yaml
@@ -86,4 +86,4 @@ tests:
           constraints:
               type: enum8
               minValue: 0
-              maxValue: 254
+              maxValue: LightSensorTypeEnum.UnknownEnumValue(254)

--- a/src/app/tests/suites/certification/Test_TC_I_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_I_2_3.yaml
@@ -237,7 +237,7 @@ tests:
               - name: "EffectIdentifier"
                 value: 0
               - name: "EffectVariant"
-                value: 66
+                value: EffectVariantEnum.UnknownEnumValue(66)
 
     - label: "Check DUT executes a blink effect."
       cluster: "LogCommands"

--- a/src/app/tests/suites/certification/Test_TC_LTIME_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LTIME_3_1.yaml
@@ -336,7 +336,7 @@ tests:
       command: "writeAttribute"
       attribute: "ActiveCalendarType"
       arguments:
-          value: 50
+          value: CalendarTypeEnum.UnknownEnumValue(50)
       response:
           error: CONSTRAINT_ERROR
 
@@ -345,6 +345,6 @@ tests:
       command: "writeAttribute"
       attribute: "HourFormat"
       arguments:
-          value: 5
+          value: HourFormatEnum.UnknownEnumValue(5)
       response:
           error: CONSTRAINT_ERROR

--- a/src/app/tests/suites/certification/Test_TC_LUNIT_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LUNIT_3_1.yaml
@@ -94,6 +94,6 @@ tests:
       arguments:
           # Per spec, if [TEMP] feature is enabled, then this attribute can be
           # one of 0 (Farenheit), 1 (Celsius) or 2 (Kelvin)
-          value: 5 # INVALID
+          value: TempUnitEnum.UnknownEnumValue(5)
       response:
           error: CONSTRAINT_ERROR

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
@@ -468,8 +468,12 @@ tests:
       response:
           constraints:
               type: enum8
-              minValue: 0
-              maxValue: 9
+              anyOf:
+                  [
+                      ThermostatRunningModeEnum.Off(0),
+                      ThermostatRunningModeEnum.Cool(3),
+                      ThermostatRunningModeEnum.Heat(4),
+                  ]
 
     - label: "Step 27: TH reads the StartOfWeek attribute from the DUT"
       PICS: TSTAT.S.F03


### PR DESCRIPTION
#### Problem

When writing tests using YAML, when a test specify an enum value it can not be used as if, one would need to write the raw value. As a result there are often steps where the "name" of the enum value is added next to the raw value.

This PR allows names to be specified instead of raw values. It also introduce a `UnknownEnumValue` that is automatically calculated based on the values from the enum definitions.
Some tests may want to specify the invalid value they want to use, for those case writing `EnumName.UnknownEnumValue(66)` is allowed if the invalid value is `66`.

For now using an enum name is not enforced but I think we should ultimately do it when used in a as it make the test clearer and matches the test plan better.


The PR also updates some tests. Most of them are just valid tests that does not fit the new syntax but for 2 of them that looks like errors:
 - src/app/tests/suites/certification/Test_TC_TSTAT_2_1.yaml
 - src/app/tests/suites/certification/Test_TC_DRYERCTRL_2_1.yaml
