### PR TITLE
[MWOCTRL] Add constraint error checks

### DIFF
--- a/src/python_testing/TC_MWOCTRL_2_2.py
+++ b/src/python_testing/TC_MWOCTRL_2_2.py
@@ -94,6 +94,7 @@ class TC_MWOCTRL_2_2(MatterBaseTest):
         newPowerValue = 125
         try:
             await self.send_single_cmd(cmd=commands.SetCookingParameters(powerSetting=newPowerValue), endpoint=endpoint)
+            asserts.assert_fail("Expected an exception but received none.")
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.ConstraintError, "Expected ConstraintError but received a different error.")
 

--- a/src/python_testing/TC_MWOCTRL_2_2.py
+++ b/src/python_testing/TC_MWOCTRL_2_2.py
@@ -42,6 +42,7 @@ class TC_MWOCTRL_2_2(MatterBaseTest):
             TestStep(2, "Read the PowerSetting attribute"),
             TestStep(3, "Send the SetCookingParameters command"),
             TestStep(4, "Read and verify the PowerSetting attribute"),
+            TestStep(5, "Cause constraint error response"),
         ]
         return steps
 
@@ -88,6 +89,13 @@ class TC_MWOCTRL_2_2(MatterBaseTest):
         self.step(4)
         powerValue = await self.read_mwoctrl_attribute_expect_success(endpoint=endpoint, attribute=attributes.PowerSetting)
         asserts.assert_true(powerValue == newPowerValue, "PowerSetting was not correctly set")
+
+        self.step(5)
+        newPowerValue = 125
+        try:
+            await self.send_single_cmd(cmd=commands.SetCookingParameters(powerSetting=newPowerValue), endpoint=endpoint)
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError, "Expected ConstraintError but received a difference response.")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_MWOCTRL_2_2.py
+++ b/src/python_testing/TC_MWOCTRL_2_2.py
@@ -95,7 +95,7 @@ class TC_MWOCTRL_2_2(MatterBaseTest):
         try:
             await self.send_single_cmd(cmd=commands.SetCookingParameters(powerSetting=newPowerValue), endpoint=endpoint)
         except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.ConstraintError, "Expected ConstraintError but received a difference response.")
+            asserts.assert_equal(e.status, Status.ConstraintError, "Expected ConstraintError but received a different error.")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_MWOCTRL_2_3.py
+++ b/src/python_testing/TC_MWOCTRL_2_3.py
@@ -45,6 +45,7 @@ class TC_MWOCTRL_2_3(MatterBaseTest):
             TestStep(5, "Read the PowerSetting attribute"),
             TestStep(6, "Send the SetCookingParameters command"),
             TestStep(7, "Read and verify the PowerSetting attribute"),
+            TestStep(8, "Cause constraint error response"),
         ]
         return steps
 
@@ -108,6 +109,13 @@ class TC_MWOCTRL_2_3(MatterBaseTest):
         self.step(7)
         powerValue = await self.read_mwoctrl_attribute_expect_success(endpoint=endpoint, attribute=attributes.PowerSetting)
         asserts.assert_true(powerValue == newPowerValue, "PowerSetting was not correctly set")
+
+        self.step(8)
+        newPowerValue = maxPowerValue+1
+        try:
+            await self.send_single_cmd(cmd=commands.SetCookingParameters(powerSetting=newPowerValue), endpoint=endpoint)
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.ConstraintError, "Expected ConstraintError but received a difference response.")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_MWOCTRL_2_3.py
+++ b/src/python_testing/TC_MWOCTRL_2_3.py
@@ -115,7 +115,7 @@ class TC_MWOCTRL_2_3(MatterBaseTest):
         try:
             await self.send_single_cmd(cmd=commands.SetCookingParameters(powerSetting=newPowerValue), endpoint=endpoint)
         except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.ConstraintError, "Expected ConstraintError but received a difference response.")
+            asserts.assert_equal(e.status, Status.ConstraintError, "Expected ConstraintError but received a different response.")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_MWOCTRL_2_3.py
+++ b/src/python_testing/TC_MWOCTRL_2_3.py
@@ -114,6 +114,7 @@ class TC_MWOCTRL_2_3(MatterBaseTest):
         newPowerValue = maxPowerValue+1
         try:
             await self.send_single_cmd(cmd=commands.SetCookingParameters(powerSetting=newPowerValue), endpoint=endpoint)
+            asserts.assert_fail("Expected an exception but received none.")
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.ConstraintError, "Expected ConstraintError but received a different response.")
 


### PR DESCRIPTION
The test plan was updated to check for constraint error responses.  This PR adds those checks.

Fixes #32090
Fixes #31808

