### PR TITLE
Remove PoolCommon::ResetObject

### DIFF
--- a/src/lib/support/Pool.h
+++ b/src/lib/support/Pool.h
@@ -104,18 +104,6 @@ private:
     std::atomic<tBitChunkType> * mUsage;
 };
 
-template <class T>
-class PoolCommon
-{
-public:
-    template <typename... Args>
-    void ResetObject(T * element, Args &&... args)
-    {
-        element->~T();
-        new (element) T(std::forward<Args>(args)...);
-    }
-};
-
 template <typename T, typename Function>
 class LambdaProxy
 {
@@ -211,7 +199,7 @@ struct HeapObjectList : HeapObjectListNode
  *  @tparam     N   a positive integer max number of elements the pool provides.
  */
 template <class T, size_t N>
-class BitMapObjectPool : public internal::StaticAllocatorBitmap, public internal::PoolCommon<T>
+class BitMapObjectPool : public internal::StaticAllocatorBitmap
 {
 public:
     BitMapObjectPool() : StaticAllocatorBitmap(mData.mMemory, mUsage, N, sizeof(T)) {}
@@ -314,7 +302,7 @@ private:
  *  @tparam     T   type to be allocated.
  */
 template <class T>
-class HeapObjectPool : public internal::Statistics, public internal::PoolCommon<T>, public HeapObjectPoolExitHandling
+class HeapObjectPool : public internal::Statistics, public HeapObjectPoolExitHandling
 {
 public:
     HeapObjectPool() {}

--- a/src/lib/support/PoolWrapper.h
+++ b/src/lib/support/PoolWrapper.h
@@ -36,7 +36,6 @@ public:
     virtual U * CreateObject(ConstructorArguments... args)              = 0;
     virtual void ReleaseObject(U * element)                             = 0;
     virtual void ReleaseAll()                                           = 0;
-    virtual void ResetObject(U * element, ConstructorArguments... args) = 0;
 
     template <typename Function>
     Loop ForEachActiveObject(Function && function)
@@ -81,11 +80,6 @@ public:
     void ReleaseObject(U * element) override { Impl().ReleaseObject(static_cast<T *>(element)); }
 
     void ReleaseAll() override { Impl().ReleaseAll(); }
-
-    void ResetObject(U * element, ConstructorArguments... args) override
-    {
-        return Impl().ResetObject(static_cast<T *>(element), std::move(args)...);
-    }
 
 protected:
     Loop ForEachActiveObjectInner(void * context, typename PoolInterface<U, ConstructorArguments...>::Lambda lambda) override

--- a/src/lib/support/PoolWrapper.h
+++ b/src/lib/support/PoolWrapper.h
@@ -33,9 +33,9 @@ public:
 
     virtual ~PoolInterface() {}
 
-    virtual U * CreateObject(ConstructorArguments... args)              = 0;
-    virtual void ReleaseObject(U * element)                             = 0;
-    virtual void ReleaseAll()                                           = 0;
+    virtual U * CreateObject(ConstructorArguments... args) = 0;
+    virtual void ReleaseObject(U * element)                = 0;
+    virtual void ReleaseAll()                              = 0;
 
     template <typename Function>
     Loop ForEachActiveObject(Function && function)

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -278,7 +278,7 @@ private:
     CHIP_ERROR AllocEntry(UnauthenticatedSession::SessionRole sessionRole, NodeId ephemeralInitiatorNodeID,
                           const ReliableMessageProtocolConfig & config, UnauthenticatedSession *& entry)
     {
-        EntryType entryType = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
+        auto entryType = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
         if (entryType != nullptr)
         {
             entry = entryType;

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -278,10 +278,10 @@ private:
     CHIP_ERROR AllocEntry(UnauthenticatedSession::SessionRole sessionRole, NodeId ephemeralInitiatorNodeID,
                           const ReliableMessageProtocolConfig & config, UnauthenticatedSession *& entry)
     {
-        auto entryType = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
+        auto entryToUse = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
         if (entryType != nullptr)
         {
-            entry = entryType;
+            entry = entryToUse;
             return CHIP_NO_ERROR;
         }
 
@@ -289,20 +289,20 @@ private:
         // permanent failure if heap was insufficient
         return CHIP_ERROR_NO_MEMORY;
 #else
-        entryType = FindLeastRecentUsedEntry();
-        VerifyOrReturnError(entryType != nullptr, CHIP_ERROR_NO_MEMORY);
+        entryToUse = FindLeastRecentUsedEntry();
+        VerifyOrReturnError(entryToUse != nullptr, CHIP_ERROR_NO_MEMORY);
 
         // clean the least recent entry to allow for a new alloc
-        mEntries.ReleaseObject(entryType);
-        entryType = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
+        mEntries.ReleaseObject(entryToUse);
+        entryToUse = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
 
-        if (entryType == nullptr)
+        if (entryToUse == nullptr)
         {
             // this is NOT expected: we freed an object to have space
             return CHIP_ERROR_INTERNAL;
         }
 
-        entry = entryType;
+        entry = entryToUse;
         return CHIP_NO_ERROR;
 #endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
     }

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -294,7 +294,7 @@ private:
         VerifyOrReturnError(entry != nullptr, CHIP_ERROR_NO_MEMORY);
 
         // make sure a clean reset is done
-        mEntries.ReleaseObject(entry);
+        mEntries.ReleaseObject(static_cast<EntryType*>(entry));
         entry = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
 
         // entry being null is not expected as we released an object that could be reclaimed

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -271,6 +271,8 @@ private:
     /**
      * Allocates a new session out of the internal resource pool.
      *
+     * On failure, the output `entry` will be set to nullptr
+     *
      * @returns CHIP_NO_ERROR if new session created. May fail if maximum session count has been reached (with
      * CHIP_ERROR_NO_MEMORY).
      */

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -279,7 +279,7 @@ private:
                           const ReliableMessageProtocolConfig & config, UnauthenticatedSession *& entry)
     {
         auto entryToUse = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
-        if (entryType != nullptr)
+        if (entryToUse != nullptr)
         {
             entry = entryToUse;
             return CHIP_NO_ERROR;

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -294,7 +294,7 @@ private:
         VerifyOrReturnError(entry != nullptr, CHIP_ERROR_NO_MEMORY);
 
         // make sure a clean reset is done
-        mEntries.ReleaseObject(static_cast<EntryType*>(entry));
+        mEntries.ReleaseObject(static_cast<EntryType *>(entry));
         entry = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
 
         // entry being null is not expected as we released an object that could be reclaimed

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -292,7 +292,7 @@ private:
         entryToUse = FindLeastRecentUsedEntry();
         VerifyOrReturnError(entryToUse != nullptr, CHIP_ERROR_NO_MEMORY);
 
-        // clean the least recent entry to allow for a new alloc
+        // Drop the least recent entry to allow for a new alloc.
         mEntries.ReleaseObject(entryToUse);
         entryToUse = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
 

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -271,8 +271,6 @@ private:
     /**
      * Allocates a new session out of the internal resource pool.
      *
-     * On failure, the output `entry` will be set to nullptr
-     *
      * @returns CHIP_NO_ERROR if new session created. May fail if maximum session count has been reached (with
      * CHIP_ERROR_NO_MEMORY).
      */
@@ -280,9 +278,10 @@ private:
     CHIP_ERROR AllocEntry(UnauthenticatedSession::SessionRole sessionRole, NodeId ephemeralInitiatorNodeID,
                           const ReliableMessageProtocolConfig & config, UnauthenticatedSession *& entry)
     {
-        entry = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
-        if (entry != nullptr)
+        EntryType entryType = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
+        if (entryType != nullptr)
         {
+            entry = entryType;
             return CHIP_NO_ERROR;
         }
 
@@ -290,16 +289,20 @@ private:
         // permanent failure if heap was insufficient
         return CHIP_ERROR_NO_MEMORY;
 #else
-        entry = FindLeastRecentUsedEntry();
-        VerifyOrReturnError(entry != nullptr, CHIP_ERROR_NO_MEMORY);
+        entryType = FindLeastRecentUsedEntry();
+        VerifyOrReturnError(entryType != nullptr, CHIP_ERROR_NO_MEMORY);
 
-        // make sure a clean reset is done
-        mEntries.ReleaseObject(static_cast<EntryType *>(entry));
-        entry = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
+        // clean the least recent entry to allow for a new alloc
+        mEntries.ReleaseObject(entryType);
+        entryType = mEntries.CreateObject(sessionRole, ephemeralInitiatorNodeID, config, *this);
 
-        // entry being null is not expected as we released an object that could be reclaimed
-        VerifyOrReturnError(entry != nullptr, CHIP_ERROR_INTERNAL);
+        if (entryType == nullptr)
+        {
+            // this is NOT expected: we freed an object to have space
+            return CHIP_ERROR_INTERNAL;
+        }
 
+        entry = entryType;
         return CHIP_NO_ERROR;
 #endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
     }


### PR DESCRIPTION
This class had a catch-all name (common) and implemented only a single method that should not have been a class method to start with (it does not depend on the class).

Rather than implementing the ResetObject as a global method, I replaced its one single usage with a free + alloc. This is slightly slower, however it should be much more readable.