### PR TITLE
[Linux] Lock CHIP stack before calling WiFi diagnostic delegate

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -98,10 +98,6 @@ namespace DeviceLayer {
 
 ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-char ConnectivityManagerImpl::sWiFiIfName[];
-#endif
-
 WiFiDriver::ScanCallback * ConnectivityManagerImpl::mpScanCallback;
 NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * ConnectivityManagerImpl::mpConnectCallback;
 uint8_t ConnectivityManagerImpl::sInterestedSSID[Internal::kMaxWiFiSSIDLength];

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -951,7 +951,7 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
     // Clean up current network if exists
     if (mWpaSupplicant.networkPath)
     {
-        g_object_unref(mWpaSupplicant.networkPath);
+        g_free(mWpaSupplicant.networkPath);
         mWpaSupplicant.networkPath = nullptr;
     }
 
@@ -991,7 +991,7 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
 
         if (mWpaSupplicant.networkPath)
         {
-            g_object_unref(mWpaSupplicant.networkPath);
+            g_free(mWpaSupplicant.networkPath);
             mWpaSupplicant.networkPath = nullptr;
         }
 
@@ -1081,7 +1081,7 @@ ConnectivityManagerImpl::_ConnectWiFiNetworkAsync(GVariant * args,
 
         if (mWpaSupplicant.networkPath)
         {
-            g_object_unref(mWpaSupplicant.networkPath);
+            g_free(mWpaSupplicant.networkPath);
             mWpaSupplicant.networkPath = nullptr;
         }
 

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -420,6 +420,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
 
                     if (delegate)
                     {
+                        chip::DeviceLayer::StackLock stackLock;
                         delegate->OnDisconnectionDetected(reason);
                         delegate->OnConnectionStatusChanged(static_cast<uint8_t>(ConnectionStatusEnum::kConnected));
                     }
@@ -459,6 +460,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
 
                         if (delegate)
                         {
+                            chip::DeviceLayer::StackLock stackLock;
                             delegate->OnAssociationFailureDetected(associationFailureCause, status);
                         }
                     }
@@ -471,6 +473,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
                 {
                     if (delegate)
                     {
+                        chip::DeviceLayer::StackLock stackLock;
                         delegate->OnConnectionStatusChanged(static_cast<uint8_t>(ConnectionStatusEnum::kNotConnected));
                     }
 

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -226,12 +226,12 @@ private:
 
     CHIP_ERROR _StartWiFiManagement();
 
-    static bool mAssociationStarted;
-    static BitFlags<ConnectivityFlags> mConnectivityFlag;
-    static GDBusWpaSupplicant mWpaSupplicant CHIP_GUARDED_BY(mWpaSupplicantMutex);
+    bool mAssociationStarted = false;
+    BitFlags<ConnectivityFlags> mConnectivityFlag;
+    GDBusWpaSupplicant mWpaSupplicant CHIP_GUARDED_BY(mWpaSupplicantMutex);
     // Access to mWpaSupplicant has to be protected by a mutex because it is accessed from
     // the CHIP event loop thread and dedicated D-Bus thread started by platform manager.
-    static std::mutex mWpaSupplicantMutex;
+    std::mutex mWpaSupplicantMutex;
 
     NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
 #endif
@@ -269,10 +269,10 @@ private:
     char sWiFiIfName[IFNAMSIZ];
 #endif
 
-    static uint8_t sInterestedSSID[Internal::kMaxWiFiSSIDLength];
-    static uint8_t sInterestedSSIDLen;
-    static NetworkCommissioning::WiFiDriver::ScanCallback * mpScanCallback;
-    static NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
+    uint8_t sInterestedSSID[Internal::kMaxWiFiSSIDLength];
+    uint8_t sInterestedSSIDLen;
+    NetworkCommissioning::WiFiDriver::ScanCallback * mpScanCallback;
+    NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
 };
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -159,16 +159,10 @@ private:
 #endif
 
 public:
-    const char * GetEthernetIfName()
-    {
-        return (mEthIfName[0] == '\0') ? nullptr : mEthIfName;
-    }
+    const char * GetEthernetIfName() { return (mEthIfName[0] == '\0') ? nullptr : mEthIfName; }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    const char * GetWiFiIfName()
-    {
-        return (sWiFiIfName[0] == '\0') ? nullptr : sWiFiIfName;
-    }
+    const char * GetWiFiIfName() { return (sWiFiIfName[0] == '\0') ? nullptr : sWiFiIfName; }
 #endif
 
 private:

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -216,12 +216,11 @@ private:
     void _OnWpaProxyReady(GObject * sourceObject, GAsyncResult * res);
     void _OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties);
     void _OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties);
-    void _OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * changedProperties,
-                                 const char * const * invalidatedProperties);
+    void _OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * properties);
+    void _OnWpaInterfaceScanDone(WpaFiW1Wpa_supplicant1Interface * proxy, gboolean success);
     void _OnWpaInterfaceReady(GObject * sourceObject, GAsyncResult * res);
     void _OnWpaInterfaceProxyReady(GObject * sourceObject, GAsyncResult * res);
     void _OnWpaBssProxyReady(GObject * sourceObject, GAsyncResult * res);
-    void _OnWpaInterfaceScanDone(GObject * sourceObject, GAsyncResult * res);
 
     bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);
 

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -165,7 +165,7 @@ public:
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    static const char * GetWiFiIfName()
+    const char * GetWiFiIfName()
     {
         return (sWiFiIfName[0] == '\0') ? nullptr : sWiFiIfName;
     }
@@ -267,7 +267,7 @@ private:
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    static char sWiFiIfName[IFNAMSIZ];
+    char sWiFiIfName[IFNAMSIZ];
 #endif
 
     static uint8_t sInterestedSSID[Internal::kMaxWiFiSSIDLength];

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -263,8 +263,10 @@ private:
     char sWiFiIfName[IFNAMSIZ];
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
     uint8_t sInterestedSSID[Internal::kMaxWiFiSSIDLength];
     uint8_t sInterestedSSIDLen;
+#endif
     NetworkCommissioning::WiFiDriver::ScanCallback * mpScanCallback;
     NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
 };

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -155,14 +155,20 @@ private:
     CHIP_ERROR _ConnectWiFiNetworkAsync(GVariant * networkArgs,
                                         NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback)
         CHIP_REQUIRES(mWpaSupplicantMutex);
-    static void _ConnectWiFiNetworkAsyncCallback(GObject * source_object, GAsyncResult * res, gpointer user_data);
+    void _ConnectWiFiNetworkAsyncCallback(GObject * sourceObject, GAsyncResult * res);
 #endif
 
 public:
-    const char * GetEthernetIfName() { return (mEthIfName[0] == '\0') ? nullptr : mEthIfName; }
+    const char * GetEthernetIfName()
+    {
+        return (mEthIfName[0] == '\0') ? nullptr : mEthIfName;
+    }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    static const char * GetWiFiIfName() { return (sWiFiIfName[0] == '\0') ? nullptr : sWiFiIfName; }
+    static const char * GetWiFiIfName()
+    {
+        return (sWiFiIfName[0] == '\0') ? nullptr : sWiFiIfName;
+    }
 #endif
 
 private:
@@ -207,16 +213,15 @@ private:
     void UpdateNetworkStatus();
     static CHIP_ERROR StopAutoScan();
 
-    static void _OnWpaProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
-    static void _OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties,
-                                       gpointer user_data);
-    static void _OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties, gpointer user_data);
-    static void _OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * changed_properties,
-                                        const gchar * const * invalidated_properties, gpointer user_data);
-    static void _OnWpaInterfaceReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
-    static void _OnWpaInterfaceProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
-    static void _OnWpaBssProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
-    static void _OnWpaInterfaceScanDone(GObject * source_object, GAsyncResult * res, gpointer user_data);
+    void _OnWpaProxyReady(GObject * sourceObject, GAsyncResult * res);
+    void _OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties);
+    void _OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties);
+    void _OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * changedProperties,
+                                 const char * const * invalidatedProperties);
+    void _OnWpaInterfaceReady(GObject * sourceObject, GAsyncResult * res);
+    void _OnWpaInterfaceProxyReady(GObject * sourceObject, GAsyncResult * res);
+    void _OnWpaBssProxyReady(GObject * sourceObject, GAsyncResult * res);
+    void _OnWpaInterfaceScanDone(GObject * sourceObject, GAsyncResult * res);
 
     static bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);
 

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -211,7 +211,7 @@ private:
     System::Clock::Timeout _GetWiFiAPIdleTimeout();
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     void UpdateNetworkStatus();
-    static CHIP_ERROR StopAutoScan();
+    CHIP_ERROR StopAutoScan();
 
     void _OnWpaProxyReady(GObject * sourceObject, GAsyncResult * res);
     void _OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties);
@@ -223,9 +223,9 @@ private:
     void _OnWpaBssProxyReady(GObject * sourceObject, GAsyncResult * res);
     void _OnWpaInterfaceScanDone(GObject * sourceObject, GAsyncResult * res);
 
-    static bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);
+    bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);
 
-    static CHIP_ERROR _StartWiFiManagement(ConnectivityManagerImpl * self);
+    CHIP_ERROR _StartWiFiManagement();
 
     static bool mAssociationStarted;
     static BitFlags<ConnectivityFlags> mConnectivityFlag;

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -108,13 +108,13 @@ gboolean WiFiIPChangeListener(GIOChannel * ch, GIOCondition /* condition */, voi
                             continue;
                         }
 
-                        if (ConnectivityManagerImpl::GetWiFiIfName() == nullptr)
+                        if (ConnectivityMgrImpl().GetWiFiIfName() == nullptr)
                         {
                             ChipLogDetail(DeviceLayer, "No wifi interface name. Ignoring IP update event.");
                             continue;
                         }
 
-                        if (strcmp(name, ConnectivityManagerImpl::GetWiFiIfName()) != 0)
+                        if (strcmp(name, ConnectivityMgrImpl().GetWiFiIfName()) != 0)
                         {
                             continue;
                         }


### PR DESCRIPTION
Fixes issue reported here: https://github.com/project-chip/connectedhomeip/issues/32033#issuecomment-1944277926

### Problem

All glib callback runs on glib thread. In order to call function which changes internal CHIP state, we need to lock CHIP stack lock beforehand. Due to changes in 86977c2a74c24dffe1dc799204fd64ee058c28fb, WiFi connection on Linux causes abort.

### Changes

- Lock CHIP stack before calling WiFi diagnostic delegate
- Fix signatures for properties-changed and scan-done callbacks
- Fix freeing char objects allocated by glib
- Convert static members/functions of `ConnectivityManagerImpl` to instance members

### Testing

Locally tested WiFi connection/disconnection during BLE commissioning.