### PR TITLE
Correctly annotate things that are unused when logging is disabled.

### DIFF
--- a/examples/bridge-app/asr/subdevice/SubDeviceManager.cpp
+++ b/examples/bridge-app/asr/subdevice/SubDeviceManager.cpp
@@ -91,12 +91,11 @@ CHIP_ERROR RemoveDeviceEndpoint(SubDevice * dev)
     {
         if (gSubDevices[index] == dev)
         {
-            EndpointId ep      = emberAfClearDynamicEndpoint(index);
-            gSubDevices[index] = NULL;
-            ChipLogProgress(DeviceLayer, "Removed device %s from dynamic endpoint %d (index=%d)", dev->GetName(), ep, index);
             // Silence complaints about unused ep when progress logging
             // disabled.
-            UNUSED_VAR(ep);
+            [[maybe_unused]] EndpointId ep = emberAfClearDynamicEndpoint(index);
+            gSubDevices[index]             = NULL;
+            ChipLogProgress(DeviceLayer, "Removed device %s from dynamic endpoint %d (index=%d)", dev->GetName(), ep, index);
             return CHIP_NO_ERROR;
         }
     }

--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -201,12 +201,11 @@ CHIP_ERROR RemoveDeviceEndpoint(Device * dev)
     {
         if (gDevices[index] == dev)
         {
-            EndpointId ep   = emberAfClearDynamicEndpoint(index);
-            gDevices[index] = NULL;
-            ChipLogProgress(DeviceLayer, "Removed device %s from dynamic endpoint %d (index=%d)", dev->GetName(), ep, index);
             // Silence complaints about unused ep when progress logging
             // disabled.
-            UNUSED_VAR(ep);
+            [[maybe_unused]] EndpointId ep = emberAfClearDynamicEndpoint(index);
+            gDevices[index]                = NULL;
+            ChipLogProgress(DeviceLayer, "Removed device %s from dynamic endpoint %d (index=%d)", dev->GetName(), ep, index);
             return CHIP_NO_ERROR;
         }
     }

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -300,12 +300,11 @@ int RemoveDeviceEndpoint(Device * dev)
         {
             // Todo: Update this to schedule the work rather than use this lock
             DeviceLayer::StackLock lock;
-            EndpointId ep   = emberAfClearDynamicEndpoint(index);
-            gDevices[index] = nullptr;
-            ChipLogProgress(DeviceLayer, "Removed device %s from dynamic endpoint %d (index=%d)", dev->GetName(), ep, index);
             // Silence complaints about unused ep when progress logging
             // disabled.
-            UNUSED_VAR(ep);
+            [[maybe_unused]] EndpointId ep = emberAfClearDynamicEndpoint(index);
+            gDevices[index]                = nullptr;
+            ChipLogProgress(DeviceLayer, "Removed device %s from dynamic endpoint %d (index=%d)", dev->GetName(), ep, index);
             return index;
         }
         index++;

--- a/examples/bridge-app/telink/src/AppTask.cpp
+++ b/examples/bridge-app/telink/src/AppTask.cpp
@@ -224,12 +224,11 @@ CHIP_ERROR RemoveDeviceEndpoint(Device * dev)
     {
         if (gDevices[index] == dev)
         {
-            EndpointId ep   = emberAfClearDynamicEndpoint(index);
-            gDevices[index] = NULL;
-            ChipLogProgress(DeviceLayer, "Removed device %s from dynamic endpoint %d (index=%d)", dev->GetName(), ep, index);
             // Silence complaints about unused ep when progress logging
             // disabled.
-            UNUSED_VAR(ep);
+            [[maybe_unused]] EndpointId ep = emberAfClearDynamicEndpoint(index);
+            gDevices[index]                = NULL;
+            ChipLogProgress(DeviceLayer, "Removed device %s from dynamic endpoint %d (index=%d)", dev->GetName(), ep, index);
             return CHIP_NO_ERROR;
         }
     }

--- a/examples/chip-tool/commands/common/DeviceScanner.cpp
+++ b/examples/chip-tool/commands/common/DeviceScanner.cpp
@@ -218,7 +218,7 @@ void DeviceScanner::Log() const
     auto resultsCount = mDiscoveredResults.size();
     VerifyOrReturn(resultsCount > 0, ChipLogProgress(chipTool, "No device discovered."));
 
-    uint16_t index = 0;
+    [[maybe_unused]] uint16_t index = 0;
     for (auto & instance : mDiscoveredResults)
     {
         ChipLogProgress(chipTool, "Instance Name: %s ", instance.first.c_str());

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
@@ -29,7 +29,7 @@ CHIP_ERROR DiscoverCommissionersCommand::RunCommand()
 
 void DiscoverCommissionersCommand::Shutdown()
 {
-    int commissionerCount = 0;
+    [[maybe_unused]] int commissionerCount = 0;
     for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; i++)
     {
         const Dnssd::DiscoveredNodeData * commissioner = mCommissionableNodeController.GetDiscoveredCommissioner(i);

--- a/examples/common/websocket-server/WebSocketServer.cpp
+++ b/examples/common/websocket-server/WebSocketServer.cpp
@@ -24,9 +24,9 @@
 #include <deque>
 #include <mutex>
 
-constexpr uint16_t kDefaultWebSocketServerPort = 9002;
-constexpr uint16_t kMaxMessageBufferLen        = 8192;
-constexpr char kWebSocketServerReadyMessage[]  = "== WebSocket Server Ready";
+constexpr uint16_t kDefaultWebSocketServerPort                 = 9002;
+constexpr uint16_t kMaxMessageBufferLen                        = 8192;
+[[maybe_unused]] constexpr char kWebSocketServerReadyMessage[] = "== WebSocket Server Ready";
 
 namespace {
 lws * gWebSocketInstance = nullptr;

--- a/examples/light-switch-app/genio/src/main.cpp
+++ b/examples/light-switch-app/genio/src/main.cpp
@@ -51,8 +51,6 @@ using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer;
 
-#define UNUSED_PARAMETER(a) (a = a)
-
 volatile int apperror_cnt;
 
 /***************************************************************************

--- a/examples/lighting-app/genio/src/AppTask.cpp
+++ b/examples/lighting-app/genio/src/AppTask.cpp
@@ -66,8 +66,6 @@
 #error "Must have portYIELD_FROM_ISR or portEND_SWITCHING_ISR"
 #endif
 
-#define UNUSED_PARAMETER(a) (a = a)
-
 #if defined(ENABLE_CHIP_SHELL)
 using chip::Shell::Engine;
 using chip::Shell::PrintCommandHelp;

--- a/examples/lighting-app/genio/src/main.cpp
+++ b/examples/lighting-app/genio/src/main.cpp
@@ -51,8 +51,6 @@ using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer;
 
-#define UNUSED_PARAMETER(a) (a = a)
-
 volatile int apperror_cnt;
 
 /***************************************************************************

--- a/examples/lock-app/genio/src/AppTask.cpp
+++ b/examples/lock-app/genio/src/AppTask.cpp
@@ -60,8 +60,6 @@
 #error "Must have portYIELD_FROM_ISR or portEND_SWITCHING_ISR"
 #endif
 
-#define UNUSED_PARAMETER(a) (a = a)
-
 namespace {
 
 TimerHandle_t sFunctionTimer; // FreeRTOS app sw timer.

--- a/examples/lock-app/genio/src/main.cpp
+++ b/examples/lock-app/genio/src/main.cpp
@@ -51,8 +51,6 @@ using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer;
 
-#define UNUSED_PARAMETER(a) (a = a)
-
 volatile int apperror_cnt;
 
 /***************************************************************************

--- a/examples/ota-requestor-app/genio/src/AppTask.cpp
+++ b/examples/ota-requestor-app/genio/src/AppTask.cpp
@@ -53,8 +53,6 @@
 #error "Must have portYIELD_FROM_ISR or portEND_SWITCHING_ISR"
 #endif
 
-#define UNUSED_PARAMETER(a) (a = a)
-
 namespace {
 
 TaskHandle_t sAppTaskHandle;

--- a/examples/ota-requestor-app/genio/src/main.cpp
+++ b/examples/ota-requestor-app/genio/src/main.cpp
@@ -53,8 +53,6 @@ using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer;
 
-#define UNUSED_PARAMETER(a) (a = a)
-
 volatile int apperror_cnt;
 
 static void OTAEventsHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)

--- a/examples/platform/silabs/efr32/rs911x/hal/efx32_ncp_host.c
+++ b/examples/platform/silabs/efr32/rs911x/hal/efx32_ncp_host.c
@@ -57,11 +57,9 @@ LDMA_TransferCfg_t ldmaRXConfig;
 
 static osSemaphoreId_t transfer_done_semaphore = NULL;
 
-static bool dma_callback(unsigned int channel, unsigned int sequenceNo, void * userParam)
+static bool dma_callback([[maybe_unused]] unsigned int channel, [[maybe_unused]] unsigned int sequenceNo,
+                         [[maybe_unused]] void * userParam)
 {
-    UNUSED_PARAMETER(channel);
-    UNUSED_PARAMETER(sequenceNo);
-    UNUSED_PARAMETER(userParam);
 #if defined(SL_CATLOG_POWER_MANAGER_PRESENT)
     sl_power_manager_remove_em_requirement(SL_POWER_MANAGER_EM1);
 #endif
@@ -69,10 +67,8 @@ static bool dma_callback(unsigned int channel, unsigned int sequenceNo, void * u
     return false;
 }
 
-static void gpio_interrupt(uint8_t interrupt_number)
+static void gpio_interrupt([[maybe_unused]] uint8_t interrupt_number)
 {
-    UNUSED_PARAMETER(interrupt_number);
-
     if (NULL != init_config.rx_irq)
     {
         init_config.rx_irq();

--- a/examples/platform/silabs/efr32/rs911x/hal/efx_spi.c
+++ b/examples/platform/silabs/efr32/rs911x/hal/efx_spi.c
@@ -171,10 +171,7 @@ void sl_wfx_host_reset_chip(void)
     vTaskDelay(pdMS_TO_TICKS(3));
 }
 
-void gpio_interrupt(uint8_t interrupt_number)
-{
-    UNUSED_PARAMETER(interrupt_number);
-}
+void gpio_interrupt([[maybe_unused]] uint8_t interrupt_number) {}
 
 /*****************************************************************
  * @fn   void rsi_hal_board_init(void)

--- a/examples/thermostat/genio/src/main.cpp
+++ b/examples/thermostat/genio/src/main.cpp
@@ -51,8 +51,6 @@ using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer;
 
-#define UNUSED_PARAMETER(a) (a = a)
-
 volatile int apperror_cnt;
 
 /***************************************************************************

--- a/examples/tv-casting-app/linux/CastingUtils.cpp
+++ b/examples/tv-casting-app/linux/CastingUtils.cpp
@@ -105,7 +105,7 @@ void InitCommissioningFlow(intptr_t commandArg)
             commissioner->LogDetail();
             if (associatedConnectableVideoPlayer.HasValue())
             {
-                TargetVideoPlayerInfo * targetVideoPlayerInfo = associatedConnectableVideoPlayer.Value();
+                [[maybe_unused]] TargetVideoPlayerInfo * targetVideoPlayerInfo = associatedConnectableVideoPlayer.Value();
                 ChipLogProgress(AppServer, "Previously connected with nodeId 0x" ChipLogFormatX64 " fabricIndex: %d",
                                 ChipLogValueX64(targetVideoPlayerInfo->GetNodeId()), targetVideoPlayerInfo->GetFabricIndex());
             }
@@ -305,7 +305,7 @@ void PrintFabrics()
             ChipLogError(AppServer, " -- Not initialized");
             continue;
         }
-        NodeId myNodeId = fb.GetNodeId();
+        [[maybe_unused]] NodeId myNodeId = fb.GetNodeId();
         ChipLogProgress(NotSpecified,
                         "---- Current Fabric nodeId=0x" ChipLogFormatX64 " fabricId=0x" ChipLogFormatX64 " fabricIndex=%d",
                         ChipLogValueX64(myNodeId), ChipLogValueX64(fb.GetFabricId()), fabricIndex);

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -257,7 +257,7 @@ void CastingPlayer::LogDetail() const
     {
         for (unsigned j = 0; j < mAttributes.numIPs; j++)
         {
-            char * ipAddressOut = mAttributes.ipAddresses[j].ToString(buf);
+            [[maybe_unused]] char * ipAddressOut = mAttributes.ipAddresses[j].ToString(buf);
             ChipLogDetail(AppServer, "\tIP Address #%d: %s", j + 1, ipAddressOut);
         }
     }

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -695,7 +695,7 @@ void CastingServer::SetDefaultFabricIndex(std::function<void(TargetVideoPlayerIn
             ChipLogError(AppServer, " -- Not initialized");
             continue;
         }
-        NodeId myNodeId = fb.GetNodeId();
+        [[maybe_unused]] NodeId myNodeId = fb.GetNodeId();
         ChipLogProgress(NotSpecified,
                         "---- Current Fabric nodeId=0x" ChipLogFormatX64 " fabricId=0x" ChipLogFormatX64 " fabricIndex=%d",
                         ChipLogValueX64(myNodeId), ChipLogValueX64(fb.GetFabricId()), fabricIndex);

--- a/examples/tv-casting-app/tv-casting-common/src/ZCLCallbacks.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/ZCLCallbacks.cpp
@@ -38,8 +38,8 @@ using namespace ::chip::app::Clusters;
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
-    ClusterId clusterId     = attributePath.mClusterId;
-    AttributeId attributeId = attributePath.mAttributeId;
+    [[maybe_unused]] ClusterId clusterId     = attributePath.mClusterId;
+    [[maybe_unused]] AttributeId attributeId = attributePath.mAttributeId;
     ChipLogProgress(Zcl, "AttributeChangeCallback cluster: " ChipLogFormatMEI " attribute:" ChipLogFormatMEI,
                     ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId));
 }

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -237,13 +237,12 @@ EndpointId ContentAppPlatform::RemoveContentApp(ContentApp * app)
         if (mContentApps[index] == app)
         {
             EndpointId curEndpoint = app->GetEndpointId();
-            EndpointId ep          = emberAfClearDynamicEndpoint(index);
-            mContentApps[index]    = nullptr;
-            ChipLogProgress(DeviceLayer, "Removed device %d from dynamic endpoint %d (index=%d)",
-                            app->GetApplicationBasicDelegate()->HandleGetVendorId(), ep, index);
             // Silence complaints about unused ep when progress logging
             // disabled.
-            UNUSED_VAR(ep);
+            /*[[maybe_unused]]*/ EndpointId ep = emberAfClearDynamicEndpoint(index);
+            mContentApps[index]                = nullptr;
+            ChipLogProgress(DeviceLayer, "Removed device %d from dynamic endpoint %d (index=%d)",
+                            app->GetApplicationBasicDelegate()->HandleGetVendorId(), ep, index);
             if (curEndpoint == mCurrentAppEndpointId)
             {
                 mCurrentAppEndpointId = kNoCurrentEndpointId;

--- a/src/app/server/DefaultAclStorage.cpp
+++ b/src/app/server/DefaultAclStorage.cpp
@@ -138,7 +138,7 @@ CHIP_ERROR DefaultAclStorage::Init(PersistentStorageDelegate & persistentStorage
 
     CHIP_ERROR err;
 
-    size_t count = 0;
+    [[maybe_unused]] size_t count = 0;
 
     for (auto it = first; it != last; ++it)
     {

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -167,12 +167,6 @@ typedef struct
 } EmberEventControl;
 
 /**
- * @description Useful macro for avoiding compiler warnings related to unused
- * function arguments or unused variables.
- */
-#define UNUSED_VAR(x) (void) (x)
-
-/**
  * @brief Returns the value of the bitmask \c bits within
  * the register or byte \c reg.
  */

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -475,7 +475,7 @@ void TestReadInteraction::TestReadSubscribeAttributeResponseWithCache(nlTestSuit
     //
     app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(&gTestReadInteraction);
 
-    int testId = 0;
+    [[maybe_unused]] int testId = 0;
 
     // Read of E2C3A1(dedup), E*C3A1(E1C3A1 not exit, E2C3A1 exist), E2C3A* (5 supported attributes)
     // Expect no versions would be cached.

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -2715,7 +2715,7 @@ static void TestVIDPID_StringExtraction(nlTestSuite * inSuite, void * inContext)
     };
     // clang-format on
 
-    int caseIdx = 0;
+    [[maybe_unused]] int caseIdx = 0;
     for (const auto & testCase : kTestCases)
     {
         AttestationCertVidPid vidpid;


### PR DESCRIPTION
We don't seem to have very good CI coverage for the logging-disabled configurations.

Also removes UNUSED_VAR and UNUSED_PARAMETER use in favor of the standard [[maybe_unused]].

Fixes https://github.com/project-chip/connectedhomeip/issues/32113
