### PR TITLE
[Scenes] Revision bump device types

### DIFF
--- a/data_model/device_types/ColorDimmerSwitch.xml
+++ b/data_model/device_types/ColorDimmerSwitch.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification superset="Dimmer Switch" class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/ColorTemperatureLight.xml
+++ b/data_model/device_types/ColorTemperatureLight.xml
@@ -61,6 +61,7 @@ Davis, CA 95616, USA
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
     <revision revision="3" summary="Added optional occupancy sensing"/>
+    <revision revision="4" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification superset="Dimmable Light" class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/ControlBridge.xml
+++ b/data_model/device_types/ControlBridge.xml
@@ -61,6 +61,7 @@ Davis, CA 95616, USA
 required."/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/DimmableLight.xml
+++ b/data_model/device_types/DimmableLight.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification superset="On/Off Light" class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/DimmablePlug-InUnit.xml
+++ b/data_model/device_types/DimmablePlug-InUnit.xml
@@ -61,6 +61,7 @@ Davis, CA 95616, USA
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
     <revision revision="3" summary="Added optional occupancy sensing"/>
+    <revision revision="4" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/DimmerSwitch.xml
+++ b/data_model/device_types/DimmerSwitch.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification superset="On/Off Light Switch" class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/DoorLock.xml
+++ b/data_model/device_types/DoorLock.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="Initial Matter release"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/DoorLockController.xml
+++ b/data_model/device_types/DoorLockController.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="Initial Matter release"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <clusters>

--- a/data_model/device_types/ExtendedColorLight.xml
+++ b/data_model/device_types/ExtendedColorLight.xml
@@ -61,6 +61,7 @@ Davis, CA 95616, USA
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation; integrate DM CCB 3501"/>
     <revision revision="3" summary="Added optional occupancy sensing"/>
+    <revision revision="4" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification superset="Color Temperature Light" class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/GenericSwitch.xml
+++ b/data_model/device_types/GenericSwitch.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to device type revision numbers"/>
     <revision revision="1" summary="Initial release of this document"/>
     <revision revision="2" summary="Removed requirement for Fixed Label cluster (can use TagList which was added in Descriptor cluster)"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/OnOffLight.xml
+++ b/data_model/device_types/OnOffLight.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/OnOffLightSwitch.xml
+++ b/data_model/device_types/OnOffLightSwitch.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/OnOffPlug-inUnit.xml
+++ b/data_model/device_types/OnOffPlug-inUnit.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/OnOffSensor.xml
+++ b/data_model/device_types/OnOffSensor.xml
@@ -61,6 +61,7 @@ Davis, CA 95616, USA
 required."/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/Pump.xml
+++ b/data_model/device_types/Pump.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/PumpController.xml
+++ b/data_model/device_types/PumpController.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <clusters>

--- a/data_model/device_types/RoomAirConditioner.xml
+++ b/data_model/device_types/RoomAirConditioner.xml
@@ -58,6 +58,7 @@ Davis, CA 95616, USA
 <deviceType xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="types types.xsd devicetype devicetype.xsd" id="0x0072" name="Room Air Conditioner" revision="1">
   <revisionHistory>
     <revision revision="1" summary="Initial Release"/>
+    <revision revision="2" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/Thermostat.xml
+++ b/data_model/device_types/Thermostat.xml
@@ -60,6 +60,8 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to device type revision numbers"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation, added Clusters required for Matter support, restricted legacy elements to Zigbee only"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
+    <!-- TODO Replace by: "<revision revision="3" summary="Addition of Energy Preference cluster and updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>" if the Energy Preference cluster is included in 1.3-->
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/WindowCovering.xml
+++ b/data_model/device_types/WindowCovering.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0."/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>

--- a/data_model/device_types/WindowCoveringController.xml
+++ b/data_model/device_types/WindowCoveringController.xml
@@ -60,6 +60,7 @@ Davis, CA 95616, USA
     <revision revision="0" summary="Represents device definitions prior to Zigbee 3.0"/>
     <revision revision="1" summary="Initial Zigbee 3.0 release"/>
     <revision revision="2" summary="New data model format and notation"/>
+    <revision revision="3" summary="Updated the Scenes cluster to Scenes Management with Cluster ID: 0x0062"/>
   </revisionHistory>
   <classification class="simple" scope="endpoint"/>
   <conditions/>


### PR DESCRIPTION
Bumped up the revision number for devices that list ScenesManagement in their clusters.

According to what was mentioned in: https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/8907
Fixes: https://github.com/project-chip/connectedhomeip/issues/32128

