### PR TITLE
[Darwin] MTRDevice to persist data versions and use for subscription

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -475,8 +475,21 @@ public:
                                   }];
 }
 
+static NSDictionary<NSString *, id> * _MakeDataValueDictionary(NSString * type, id _Nullable value, NSNumber * _Nullable dataVersion)
+{
+    if (value && dataVersion) {
+        return @ { MTRTypeKey : type, MTRValueKey : value, MTRDataVersionKey : dataVersion };
+    } else if (value) {
+        return @ { MTRTypeKey : type, MTRValueKey : value };
+    } else if (dataVersion) {
+        return @ { MTRTypeKey : type, MTRDataVersionKey : dataVersion };
+    } else {
+        return @ { MTRTypeKey : type };
+    }
+}
+
 // Convert TLV data into data-value dictionary as described in MTRDeviceResponseHandler
-NSDictionary<NSString *, id> * _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV(chip::TLV::TLVReader * data)
+NSDictionary<NSString *, id> * _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV(chip::TLV::TLVReader * data, NSNumber * dataVersion)
 {
     chip::TLV::TLVType dataTLVType = data->GetType();
     switch (dataTLVType) {
@@ -487,8 +500,7 @@ NSDictionary<NSString *, id> * _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV
             MTR_LOG_ERROR("Error(%s): TLV signed integer decoding failed", chip::ErrorStr(err));
             return nil;
         }
-        return [NSDictionary dictionaryWithObjectsAndKeys:MTRSignedIntegerValueType, MTRTypeKey, [NSNumber numberWithLongLong:val],
-                             MTRValueKey, nil];
+        return _MakeDataValueDictionary(MTRSignedIntegerValueType, @(val), dataVersion);
     }
     case chip::TLV::kTLVType_UnsignedInteger: {
         uint64_t val;
@@ -497,8 +509,7 @@ NSDictionary<NSString *, id> * _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV
             MTR_LOG_ERROR("Error(%s): TLV unsigned integer decoding failed", chip::ErrorStr(err));
             return nil;
         }
-        return [NSDictionary dictionaryWithObjectsAndKeys:MTRUnsignedIntegerValueType, MTRTypeKey,
-                             [NSNumber numberWithUnsignedLongLong:val], MTRValueKey, nil];
+        return _MakeDataValueDictionary(MTRUnsignedIntegerValueType, @(val), dataVersion);
     }
     case chip::TLV::kTLVType_Boolean: {
         bool val;
@@ -507,15 +518,14 @@ NSDictionary<NSString *, id> * _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV
             MTR_LOG_ERROR("Error(%s): TLV boolean decoding failed", chip::ErrorStr(err));
             return nil;
         }
-        return [NSDictionary
-            dictionaryWithObjectsAndKeys:MTRBooleanValueType, MTRTypeKey, [NSNumber numberWithBool:val], MTRValueKey, nil];
+        return _MakeDataValueDictionary(MTRBooleanValueType, @(val), dataVersion);
     }
     case chip::TLV::kTLVType_FloatingPointNumber: {
         // Try float first
         float floatValue;
         CHIP_ERROR err = data->Get(floatValue);
         if (err == CHIP_NO_ERROR) {
-            return @ { MTRTypeKey : MTRFloatValueType, MTRValueKey : [NSNumber numberWithFloat:floatValue] };
+            return _MakeDataValueDictionary(MTRFloatValueType, @(floatValue), dataVersion);
         }
         double val;
         err = data->Get(val);
@@ -523,8 +533,7 @@ NSDictionary<NSString *, id> * _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV
             MTR_LOG_ERROR("Error(%s): TLV floating point decoding failed", chip::ErrorStr(err));
             return nil;
         }
-        return [NSDictionary
-            dictionaryWithObjectsAndKeys:MTRDoubleValueType, MTRTypeKey, [NSNumber numberWithDouble:val], MTRValueKey, nil];
+        return _MakeDataValueDictionary(MTRDoubleValueType, @(val), dataVersion);
     }
     case chip::TLV::kTLVType_UTF8String: {
         CharSpan stringValue;
@@ -538,7 +547,7 @@ NSDictionary<NSString *, id> * _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV
             MTR_LOG_ERROR("Error(%s): TLV UTF8String value is not actually UTF-8", err.AsString());
             return nil;
         }
-        return @ { MTRTypeKey : MTRUTF8StringValueType, MTRValueKey : stringObj };
+        return _MakeDataValueDictionary(MTRUTF8StringValueType, stringObj, dataVersion);
     }
     case chip::TLV::kTLVType_ByteString: {
         ByteSpan bytesValue;
@@ -547,10 +556,10 @@ NSDictionary<NSString *, id> * _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV
             MTR_LOG_ERROR("Error(%s): TLV ByteString decoding failed", chip::ErrorStr(err));
             return nil;
         }
-        return @ { MTRTypeKey : MTROctetStringValueType, MTRValueKey : AsData(bytesValue) };
+        return _MakeDataValueDictionary(MTROctetStringValueType, AsData(bytesValue), dataVersion);
     }
     case chip::TLV::kTLVType_Null: {
-        return [NSDictionary dictionaryWithObjectsAndKeys:MTRNullValueType, MTRTypeKey, nil];
+        return _MakeDataValueDictionary(MTRNullValueType, nil, dataVersion);
     }
     case chip::TLV::kTLVType_Structure:
     case chip::TLV::kTLVType_Array: {
@@ -606,7 +615,7 @@ NSDictionary<NSString *, id> * _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV
             MTR_LOG_ERROR("Error(%s): TLV container exiting failed", chip::ErrorStr(err));
             return nil;
         }
-        return [NSDictionary dictionaryWithObjectsAndKeys:typeName, MTRTypeKey, array, MTRValueKey, nil];
+        return _MakeDataValueDictionary(typeName, array, dataVersion);
     }
     default:
         MTR_LOG_ERROR("Error: Unsupported TLV type for conversion: %u", (unsigned) data->GetType());
@@ -815,7 +824,7 @@ template <typename DecodableValueType>
 class BufferedReadClientCallback final : public app::ReadClient::Callback {
 public:
     using OnSuccessAttributeCallbackType
-        = std::function<void(const ConcreteAttributePath & aPath, const DecodableValueType & aData)>;
+        = std::function<void(const ConcreteDataAttributePath & aPath, const DecodableValueType & aData)>;
     using OnSuccessEventCallbackType = std::function<void(const EventHeader & aEventHeader, const DecodableValueType & aData)>;
     using OnErrorCallbackType = std::function<void(
         const app::ConcreteAttributePath * attributePath, const app::ConcreteEventPath * eventPath, CHIP_ERROR aError)>;
@@ -1028,6 +1037,16 @@ private:
                      queue:(dispatch_queue_t)queue
                 completion:(MTRDeviceResponseHandler)completion
 {
+    [self readAttributePaths:attributePaths eventPaths:eventPaths params:params includeDataVersion:NO queue:queue completion:completion];
+}
+
+- (void)readAttributePaths:(NSArray<MTRAttributeRequestPath *> * _Nullable)attributePaths
+                eventPaths:(NSArray<MTREventRequestPath *> * _Nullable)eventPaths
+                    params:(MTRReadParams * _Nullable)params
+        includeDataVersion:(BOOL)includeDataVersion
+                     queue:(dispatch_queue_t)queue
+                completion:(MTRDeviceResponseHandler)completion
+{
     if ((attributePaths == nil || [attributePaths count] == 0) && (eventPaths == nil || [eventPaths count] == 0)) {
         // No paths, just return an empty array.
         dispatch_async(queue, ^{
@@ -1056,11 +1075,20 @@ private:
 
             auto resultArray = [[NSMutableArray alloc] init];
             auto onAttributeSuccessCb
-                = [resultArray](const ConcreteAttributePath & aAttributePath, const MTRDataValueDictionaryDecodableType & aData) {
-                      [resultArray addObject:@ {
-                          MTRAttributePathKey : [[MTRAttributePath alloc] initWithPath:aAttributePath],
-                          MTRDataKey : aData.GetDecodedObject()
-                      }];
+                = [resultArray, includeDataVersion](const ConcreteDataAttributePath & aAttributePath, const MTRDataValueDictionaryDecodableType & aData) {
+                      // TODO: move this logic into MTRDataValueDictionaryDecodableType
+                      if (includeDataVersion && aAttributePath.mDataVersion.HasValue()) {
+                          NSDictionary * dataValue = aData.GetDecodedObject();
+                          [resultArray addObject:@{
+                              MTRAttributePathKey : [[MTRAttributePath alloc] initWithPath:aAttributePath],
+                              MTRDataKey : _MakeDataValueDictionary(dataValue[MTRTypeKey], dataValue[MTRValueKey], @(aAttributePath.mDataVersion.Value()))
+                          }];
+                      } else {
+                          [resultArray addObject:@ {
+                              MTRAttributePathKey : [[MTRAttributePath alloc] initWithPath:aAttributePath],
+                              MTRDataKey : aData.GetDecodedObject()
+                          }];
+                      }
                   };
 
             auto onEventSuccessCb

--- a/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
@@ -185,6 +185,16 @@ static inline MTRTransportType MTRMakeTransportType(chip::Transport::Type type)
                                     queue:(dispatch_queue_t)queue
                                completion:(void (^)(id _Nullable value, NSError * _Nullable error))completion;
 
+/**
+ * Same as the public -readAttributePaths:eventPaths:params:queue:completion: except also include the data version in the data-value dictionary in the response dictionary, if the includeDataVersion argument is set to YES.
+ */
+- (void)readAttributePaths:(NSArray<MTRAttributeRequestPath *> * _Nullable)attributePaths
+                eventPaths:(NSArray<MTREventRequestPath *> * _Nullable)eventPaths
+                    params:(MTRReadParams * _Nullable)params
+        includeDataVersion:(BOOL)includeDataVersion
+                     queue:(dispatch_queue_t)queue
+                completion:(MTRDeviceResponseHandler)completion;
+
 @end
 
 @interface MTRClusterPath ()
@@ -228,7 +238,7 @@ static inline MTRTransportType MTRMakeTransportType(chip::Transport::Type type)
 
 // Exported utility function
 // Convert TLV data into data-value dictionary as described in MTRDeviceResponseHandler
-NSDictionary<NSString *, id> * _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV(chip::TLV::TLVReader * data);
+NSDictionary<NSString *, id> * _Nullable MTRDecodeDataValueDictionaryFromCHIPTLV(chip::TLV::TLVReader * data, NSNumber * _Nullable dataVersion = nil);
 
 // Convert a data-value dictionary as described in MTRDeviceResponseHandler into
 // TLV Data with an anonymous tag.  This method assumes the encoding of the

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
@@ -111,9 +111,9 @@ void MTRBaseSubscriptionCallback::OnDeallocatePaths(ReadPrepareParams && aReadPr
     }
 
     VerifyOrDie((aReadPrepareParams.mDataVersionFilterListSize == 0 && aReadPrepareParams.mpDataVersionFilterList == nullptr)
-        || (aReadPrepareParams.mDataVersionFilterListSize == 1 && aReadPrepareParams.mpDataVersionFilterList != nullptr));
+        || (aReadPrepareParams.mDataVersionFilterListSize > 0 && aReadPrepareParams.mpDataVersionFilterList != nullptr));
     if (aReadPrepareParams.mpDataVersionFilterList != nullptr) {
-        delete aReadPrepareParams.mpDataVersionFilterList;
+        delete[] aReadPrepareParams.mpDataVersionFilterList;
     }
 
     VerifyOrDie((aReadPrepareParams.mEventPathParamsListSize == 0 && aReadPrepareParams.mpEventPathParamsList == nullptr)

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -350,6 +350,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @end
 
 MTR_EXTERN NSString * const MTRPreviousDataKey MTR_NEWLY_AVAILABLE;
+MTR_EXTERN NSString * const MTRDataVersionKey MTR_NEWLY_AVAILABLE;
 
 @protocol MTRDeviceDelegate <NSObject>
 @required
@@ -366,6 +367,10 @@ MTR_EXTERN NSString * const MTRPreviousDataKey MTR_NEWLY_AVAILABLE;
  *                In addition to MTRDataKey, each response-value dictionary in the array may also have this key:
  *
  *                MTRPreviousDataKey : Same data-value dictionary format as the object for MTRDataKey. This is included when the previous value is known for an attribute.
+ *
+ *                The data-value dictionary also contains this key:
+ *
+ *                MTRDataVersionKey : NSNumber-wrapped uin32_t. Monotonically increaseing data version for the cluster.
  */
 - (void)device:(MTRDevice *)device receivedAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
@@ -139,6 +139,16 @@ typedef void (^MTRFetchProxyHandleCompletion)(MTRDeviceControllerXPCProxyHandle 
                      queue:(dispatch_queue_t)queue
                 completion:(MTRDeviceResponseHandler)completion
 {
+    [self readAttributePaths:attributePaths eventPaths:eventPaths params:params includeDataVersion:NO queue:queue completion:completion];
+}
+
+- (void)readAttributePaths:(NSArray<MTRAttributeRequestPath *> * _Nullable)attributePaths
+                eventPaths:(NSArray<MTREventRequestPath *> * _Nullable)eventPaths
+                    params:(MTRReadParams * _Nullable)params
+        includeDataVersion:(BOOL)includeDataVersion
+                     queue:(dispatch_queue_t)queue
+                completion:(MTRDeviceResponseHandler)completion
+{
     if (attributePaths == nil || eventPaths != nil) {
         MTR_LOG_ERROR("MTRBaseDevice doesn't support reading event paths over XPC");
         dispatch_async(queue, ^{

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -51,6 +51,7 @@ static const uint16_t kTestVendorId = 0xFFF1u;
 
 @interface MTRDevice (Test)
 - (BOOL)_attributeDataValue:(NSDictionary *)one isEqualToDataValue:(NSDictionary *)theOther;
+- (NSUInteger)unitTestAttributesReportedSinceLastCheck;
 @end
 #endif // DEBUG
 
@@ -1235,20 +1236,45 @@ static const uint16_t kTestVendorId = 0xFFF1u;
     [controller removeDevice:device];
 
     // Verify the new device is initialized with the same values
-    __auto_type * deviceNew = [MTRDevice deviceWithNodeID:deviceID controller:controller];
-    BOOL storedAttributeDifferFromMTRDevice = NO;
+    __auto_type * newDevice = [MTRDevice deviceWithNodeID:deviceID controller:controller];
+    NSUInteger storedAttributeDifferFromMTRDeviceCount = 0;
     for (NSDictionary * responseValue in dataStoreValues) {
         MTRAttributePath * path = responseValue[MTRAttributePathKey];
         XCTAssertNotNil(path);
         NSDictionary * dataValue = responseValue[MTRDataKey];
         XCTAssertNotNil(dataValue);
 
-        NSDictionary * dataValueFromMTRDevice = [deviceNew readAttributeWithEndpointID:path.endpoint clusterID:path.cluster attributeID:path.attribute params:nil];
-        if (![deviceNew _attributeDataValue:dataValue isEqualToDataValue:dataValueFromMTRDevice]) {
-            storedAttributeDifferFromMTRDevice = YES;
+        NSDictionary * dataValueFromMTRDevice = [newDevice readAttributeWithEndpointID:path.endpoint clusterID:path.cluster attributeID:path.attribute params:nil];
+        if (![newDevice _attributeDataValue:dataValue isEqualToDataValue:dataValueFromMTRDevice]) {
+            storedAttributeDifferFromMTRDeviceCount++;
         }
     }
-    XCTAssertTrue(storedAttributeDifferFromMTRDevice);
+
+    // Only test that 90% of attributes are the same because there are some changing attributes each time (UTC time, for example)
+    //   * With all-clusters-app as of 2024-02-10, about 1.476% of attributes change.
+    double storedAttributeDifferFromMTRDevicePercentage = storedAttributeDifferFromMTRDeviceCount * 100.0 / dataStoreValues.count;
+    XCTAssertTrue(storedAttributeDifferFromMTRDevicePercentage < 10.0);
+
+    // Now
+    __auto_type * newDelegate = [[MTRDeviceTestDelegate alloc] init];
+
+    XCTestExpectation * newDeviceSubscriptionExpectation = [self expectationWithDescription:@"Subscription has been set up for new device"];
+
+    newDelegate.onReportEnd = ^{
+        [newDeviceSubscriptionExpectation fulfill];
+    };
+
+    [newDevice setDelegate:newDelegate queue:queue];
+
+    [self waitForExpectations:@[ newDeviceSubscriptionExpectation ] timeout:60];
+    newDelegate.onReportEnd = nil;
+
+    // 1) MTRDevice actually gets some attributes reported more than once
+    // 2) Some attributes do change on resubscribe
+    //   * With all-clusts-app as of 2024-02-10, out of 1287 persisted attributes, still 450 attributes were reported with filter
+    // And so conservatively, assert that data version filters save at least 300 entries.
+    NSUInteger storedAttributeCountDifferenceFromMTRDeviceReport = dataStoreValues.count - [device unitTestAttributesReportedSinceLastCheck];
+    XCTAssertTrue(storedAttributeCountDifferenceFromMTRDeviceReport > 300);
 
     // Reset our commissionee.
     __auto_type * baseDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];


### PR DESCRIPTION
This PR includes:
1. Add attribute data versions to the MTRDevice read cache, which gets persisted with the per-controller storage when available.
2. MTRDevice subscriptions now makes use of data version filter list .
3. Unit test for testing that data versions is restored and applied when new MTRDevice object is created.