### PR TITLE
Fix NetworkCommissioning Cluster issues

### DIFF
--- a/examples/energy-management-app/energy-management-common/energy-management-app.matter
+++ b/examples/energy-management-app/energy-management-common/energy-management-app.matter
@@ -1770,6 +1770,7 @@ endpoint 0 {
     ram      attribute lastNetworkingStatus;
     ram      attribute lastNetworkID;
     ram      attribute lastConnectErrorValue;
+    callback attribute supportedWiFiBands;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute eventList;

--- a/examples/energy-management-app/energy-management-common/energy-management-app.zap
+++ b/examples/energy-management-app/energy-management-common/energy-management-app.zap
@@ -1453,6 +1453,22 @@
               "reportableChange": 0
             },
             {
+              "name": "SupportedWiFiBands",
+              "code": 8,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": null,
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "GeneratedCommandList",
               "code": 65528,
               "mfgCode": null,

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -1098,7 +1098,7 @@ void Instance::OnFinished(Status status, CharSpan debugText, WiFiScanResponseIte
     }
 
     // If drivers are failing to respond NetworkNotFound on empty results, force it for them.
-    bool resultsMissing = !networks || (networks && (networks->Count() == 0));
+    bool resultsMissing = (0 == CountAndRelease(networks));
     if ((status == Status::kSuccess) && mScanningWasDirected && resultsMissing)
     {
         status = Status::kNetworkNotFound;

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -26,6 +26,7 @@
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/general-commissioning-server/general-commissioning-server.h>
 #include <app/data-model/Nullable.h>
+#include <app/reporting/reporting.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 #include <credentials/CHIPCert.h>
@@ -89,6 +90,19 @@ static void EnumerateAndRelease(Iterator<T> * iterator, Func func)
     }
 }
 
+template <typename T>
+static size_t CountAndRelease(Iterator<T> * iterator)
+{
+    size_t count = 0;
+    if (iterator != nullptr)
+    {
+        count = iterator->Count();
+        iterator->Release();
+    }
+
+    return count;
+}
+
 BitFlags<Feature> WiFiFeatures(WiFiDriver * driver)
 {
     BitFlags<Feature> features = Feature::kWiFiNetworkInterface;
@@ -102,21 +116,21 @@ BitFlags<Feature> WiFiFeatures(WiFiDriver * driver)
 
 Instance::Instance(EndpointId aEndpointId, WiFiDriver * apDelegate) :
     CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Id), AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id),
-    mFeatureFlags(WiFiFeatures(apDelegate)), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate)
+    mEndpointId(aEndpointId), mFeatureFlags(WiFiFeatures(apDelegate)), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate)
 {
     mpDriver.Set<WiFiDriver *>(apDelegate);
 }
 
 Instance::Instance(EndpointId aEndpointId, ThreadDriver * apDelegate) :
     CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Id), AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id),
-    mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate)
+    mEndpointId(aEndpointId), mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate)
 {
     mpDriver.Set<ThreadDriver *>(apDelegate);
 }
 
 Instance::Instance(EndpointId aEndpointId, EthernetDriver * apDelegate) :
     CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Id), AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id),
-    mFeatureFlags(Feature::kEthernetNetworkInterface), mpWirelessDriver(nullptr), mpBaseDriver(apDelegate)
+    mEndpointId(aEndpointId), mFeatureFlags(Feature::kEthernetNetworkInterface), mpWirelessDriver(nullptr), mpBaseDriver(apDelegate)
 {}
 
 CHIP_ERROR Instance::Init()
@@ -155,6 +169,38 @@ void Instance::SendNonConcurrentConnectNetworkResponse()
     commandHandle->AddResponse(mPath, response);
 }
 #endif // CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+
+void Instance::SetLastNetworkingStatusValue(Attributes::LastNetworkingStatus::TypeInfo::Type networkingStatusValue)
+{
+    if (mLastNetworkingStatusValue.SetToMatch(networkingStatusValue))
+    {
+        MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id, Attributes::LastNetworkingStatus::TypeInfo::GetAttributeId());
+    }
+}
+
+void Instance::SetLastConnectErrorValue(Attributes::LastConnectErrorValue::TypeInfo::Type connectErrorValue)
+{
+    if (mLastConnectErrorValue.SetToMatch(connectErrorValue))
+    {
+        MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id, Attributes::LastConnectErrorValue::TypeInfo::GetAttributeId());
+    }
+}
+
+void Instance::SetLastNetworkId(ByteSpan lastNetworkId)
+{
+    ByteSpan prevLastNetworkId{mLastNetworkID, mLastNetworkIDLen};
+    VerifyOrReturn(lastNetworkId.size() <= kMaxNetworkIDLen);
+    VerifyOrReturn(!prevLastNetworkId.data_equal(lastNetworkId));
+
+    memcpy(mLastNetworkID, lastNetworkId.data(), lastNetworkId.size());
+    mLastNetworkIDLen = static_cast<uint8_t>(lastNetworkId.size());
+    MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id, Attributes::LastNetworkID::TypeInfo::GetAttributeId());
+}
+
+void Instance::ReportNetworksListChanged() const
+{
+    MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id, Attributes::Networks::TypeInfo::GetAttributeId());
+}
 
 void Instance::InvokeCommand(HandlerContext & ctxt)
 {
@@ -379,34 +425,34 @@ CHIP_ERROR Instance::Write(const ConcreteDataAttributePath & aPath, AttributeVal
 
 void Instance::OnNetworkingStatusChange(Status aCommissioningError, Optional<ByteSpan> aNetworkId, Optional<int32_t> aConnectStatus)
 {
-    if (aNetworkId.HasValue() && aNetworkId.Value().size() > kMaxNetworkIDLen)
-    {
-        ChipLogError(DeviceLayer, "Invalid network id received when calling OnNetworkingStatusChange");
-        return;
-    }
-    mLastNetworkingStatusValue.SetNonNull(aCommissioningError);
     if (aNetworkId.HasValue())
     {
-        memcpy(mLastNetworkID, aNetworkId.Value().data(), aNetworkId.Value().size());
-        mLastNetworkIDLen = static_cast<uint8_t>(aNetworkId.Value().size());
+        if (aNetworkId.Value().size() > kMaxNetworkIDLen)
+        {
+            ChipLogError(DeviceLayer, "Invalid network ID received when calling OnNetworkingStatusChange");
+        }
+        else
+        {
+            SetLastNetworkId(aNetworkId.Value());
+        }
     }
-    else
-    {
-        mLastNetworkIDLen = 0;
-    }
+
+    SetLastNetworkingStatusValue(MakeNullable(aCommissioningError));
     if (aConnectStatus.HasValue())
     {
-        mLastConnectErrorValue.SetNonNull(aConnectStatus.Value());
+        SetLastConnectErrorValue(MakeNullable(aConnectStatus.Value()));
     }
     else
     {
-        mLastConnectErrorValue.SetNull();
+        SetLastConnectErrorValue(NullNullable);
     }
 }
 
 void Instance::HandleScanNetworks(HandlerContext & ctx, const Commands::ScanNetworks::DecodableType & req)
 {
     MATTER_TRACE_SCOPE("HandleScanNetwork", "NetworkCommissioning");
+
+    mScanningWasDirected = false;
     if (mFeatureFlags.Has(Feature::kWiFiNetworkInterface))
     {
         ByteSpan ssid;
@@ -426,9 +472,13 @@ void Instance::HandleScanNetworks(HandlerContext & ctx, const Commands::ScanNetw
         }
         if (ssid.size() > DeviceLayer::Internal::kMaxWiFiSSIDLength)
         {
-            ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand);
+            // This should not happen, it means it's a broken driver.
+            ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError);
+            SetLastNetworkingStatusValue(MakeNullable(Status::kUnknownError));
             return;
         }
+
+        mScanningWasDirected = !ssid.empty();
         mCurrentOperationBreadcrumb = req.breadcrumb;
         mAsyncCommandHandle         = CommandHandler::Handle(&ctx.mCommandHandler);
         ctx.mCommandHandler.FlushAcksRightAwayOnSlowCommand();
@@ -436,6 +486,13 @@ void Instance::HandleScanNetworks(HandlerContext & ctx, const Commands::ScanNetw
     }
     else if (mFeatureFlags.Has(Feature::kThreadNetworkInterface))
     {
+        // Not allowed to populate SSID for Thread.
+        if (!req.ssid.HasValue())
+        {
+            ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError);
+            return;
+        }
+
         mCurrentOperationBreadcrumb = req.breadcrumb;
         mAsyncCommandHandle         = CommandHandler::Handle(&ctx.mCommandHandler);
         ctx.mCommandHandler.FlushAcksRightAwayOnSlowCommand();
@@ -483,7 +540,7 @@ void Instance::HandleAddOrUpdateWiFiNetwork(HandlerContext & ctx, const Commands
 
     if (req.ssid.empty() || req.ssid.size() > DeviceLayer::Internal::kMaxWiFiSSIDLength)
     {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand, "ssid");
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError, "ssid");
         return;
     }
 
@@ -497,7 +554,7 @@ void Instance::HandleAddOrUpdateWiFiNetwork(HandlerContext & ctx, const Commands
             return;
         }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand);
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError);
         return;
     }
 
@@ -524,7 +581,7 @@ void Instance::HandleAddOrUpdateWiFiNetwork(HandlerContext & ctx, const Commands
         {
             if (!isxdigit(req.credentials.data()[d]))
             {
-                ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand);
+                ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError);
                 return;
             }
         }
@@ -532,7 +589,7 @@ void Instance::HandleAddOrUpdateWiFiNetwork(HandlerContext & ctx, const Commands
     else
     {
         // Invalid length
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand);
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError);
         return;
     }
 
@@ -547,6 +604,7 @@ void Instance::HandleAddOrUpdateWiFiNetwork(HandlerContext & ctx, const Commands
     if (response.networkingStatus == Status::kSuccess)
     {
         UpdateBreadcrumb(req.breadcrumb);
+        ReportNetworksListChanged();
     }
 }
 
@@ -557,7 +615,7 @@ void Instance::HandleAddOrUpdateWiFiNetworkWithPDC(HandlerContext & ctx,
     // Credentials must be empty when configuring for PDC, it's only present to keep the command shape compatible.
     if (!req.credentials.empty())
     {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand, "credentials");
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError, "credentials");
         return;
     }
 
@@ -565,20 +623,20 @@ void Instance::HandleAddOrUpdateWiFiNetworkWithPDC(HandlerContext & ctx,
     if (networkIdentity.size() > kMaxCHIPCompactNetworkIdentityLength ||
         Credentials::ValidateChipNetworkIdentity(networkIdentity) != CHIP_NO_ERROR)
     {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand, "networkIdentity");
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError, "networkIdentity");
         return;
     }
 
     if (req.clientIdentifier.HasValue() && req.clientIdentifier.Value().size() != CertificateKeyId::size())
     {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand, "clientIdentifier");
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError, "clientIdentifier");
         return;
     }
 
     bool provePossession = req.possessionNonce.HasValue();
     if (provePossession && req.possessionNonce.Value().size() != kPossessionNonceSize)
     {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand, "possessionNonce");
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError, "possessionNonce");
         return;
     }
 
@@ -640,6 +698,7 @@ void Instance::HandleAddOrUpdateWiFiNetworkWithPDC(HandlerContext & ctx,
                 response.possessionSignature.SetValue(possessionSignature.Value().Span());
             }
 
+            ReportNetworksListChanged();
             UpdateBreadcrumb(req.breadcrumb);
         }
 
@@ -671,6 +730,7 @@ void Instance::HandleAddOrUpdateThreadNetwork(HandlerContext & ctx, const Comman
     ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
     if (response.networkingStatus == Status::kSuccess)
     {
+        ReportNetworksListChanged();
         UpdateBreadcrumb(req.breadcrumb);
     }
 }
@@ -704,7 +764,16 @@ void Instance::HandleRemoveNetwork(HandlerContext & ctx, const Commands::RemoveN
     ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
     if (response.networkingStatus == Status::kSuccess)
     {
+        ReportNetworksListChanged();
         UpdateBreadcrumb(req.breadcrumb);
+
+        // If no networks are left, clear-out errors;
+        if (CountAndRelease(mpBaseDriver->GetNetworks()) == 0)
+        {
+            SetLastNetworkId(ByteSpan{});
+            SetLastConnectErrorValue(NullNullable);
+            SetLastNetworkingStatusValue(NullNullable);
+        }
     }
 }
 
@@ -713,7 +782,7 @@ void Instance::HandleConnectNetwork(HandlerContext & ctx, const Commands::Connec
     MATTER_TRACE_SCOPE("HandleConnectNetwork", "NetworkCommissioning");
     if (req.networkID.size() > kMaxNetworkIDLen)
     {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidValue);
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError);
         return;
     }
 
@@ -754,6 +823,7 @@ void Instance::HandleReorderNetwork(HandlerContext & ctx, const Commands::Reorde
     ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
     if (response.networkingStatus == Status::kSuccess)
     {
+        ReportNetworksListChanged();
         UpdateBreadcrumb(req.breadcrumb);
     }
 }
@@ -765,7 +835,7 @@ void Instance::HandleQueryIdentity(HandlerContext & ctx, const Commands::QueryId
 
     if (req.keyIdentifier.size() != CertificateKeyId::size())
     {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand, "keyIdentifier");
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError, "keyIdentifier");
         return;
     }
     CertificateKeyId keyIdentifier(req.keyIdentifier.data());
@@ -773,7 +843,7 @@ void Instance::HandleQueryIdentity(HandlerContext & ctx, const Commands::QueryId
     bool provePossession = req.possessionNonce.HasValue();
     if (provePossession && req.possessionNonce.Value().size() != kPossessionNonceSize)
     {
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand, "possessionNonce");
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::ConstraintError, "possessionNonce");
         return;
     }
 
@@ -870,19 +940,23 @@ void Instance::OnResult(Status commissioningError, CharSpan debugText, int32_t i
     {
         DeviceLayer::DeviceControlServer::DeviceControlSvr().PostConnectedToOperationalNetworkEvent(
             ByteSpan(mLastNetworkID, mLastNetworkIDLen));
-        mLastConnectErrorValue.SetNull();
+        SetLastConnectErrorValue(NullNullable);
     }
     else
     {
         response.errorValue.SetNonNull(interfaceStatus);
-        mLastConnectErrorValue.SetNonNull(interfaceStatus);
+        SetLastConnectErrorValue(MakeNullable(interfaceStatus));
     }
 
-    mLastNetworkIDLen = mConnectingNetworkIDLen;
-    memcpy(mLastNetworkID, mConnectingNetworkID, mLastNetworkIDLen);
-    mLastNetworkingStatusValue.SetNonNull(commissioningError);
+    SetLastNetworkId(ByteSpan{mConnectingNetworkID, mConnectingNetworkIDLen});
+    SetLastNetworkingStatusValue(MakeNullable(commissioningError));
 
-#if CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+#if CONFIG_NETWORK_LAYER_BLE && !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
+    ChipLogProgress(NetworkProvisioning, "Non-concurrent mode, ConnectNetworkResponse will NOT be sent");
+    // Do not send the ConnectNetworkResponse if in non-concurrent mode
+    // TODO(#30576) raised to modify CommandHandler to notify it if no response required
+    // -----> Is this required here: commandHandle->FinishCommand();
+#else
     commandHandle->AddResponse(mPath, response);
 #endif // CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
 
@@ -904,9 +978,7 @@ void Instance::OnFinished(Status status, CharSpan debugText, ThreadScanResponseI
         return;
     }
 
-    mLastNetworkingStatusValue.SetNonNull(status);
-    mLastConnectErrorValue.SetNull();
-    mLastNetworkIDLen = 0;
+    SetLastNetworkingStatusValue(MakeNullable(status));
 
     TLV::TLVWriter * writer;
     TLV::TLVType listContainerType;
@@ -931,7 +1003,7 @@ void Instance::OnFinished(Status status, CharSpan debugText, ThreadScanResponseI
                                                TLV::TLVType::kTLVType_Array, listContainerType));
 
     // If no network was found, we encode an empty list, don't call a zero-sized alloc.
-    if (networks->Count() > 0)
+    if ((status == Status::kSuccess) && (networks->Count() > 0))
     {
         VerifyOrExit(scanResponseArray.Alloc(chip::min(networks->Count(), kMaxNetworksInScanResponse)), err = CHIP_ERROR_NO_MEMORY);
         for (; networks != nullptr && networks->Next(scanResponse);)
@@ -1020,9 +1092,14 @@ void Instance::OnFinished(Status status, CharSpan debugText, WiFiScanResponseIte
         return;
     }
 
-    mLastNetworkingStatusValue.SetNonNull(status);
-    mLastConnectErrorValue.SetNull();
-    mLastNetworkIDLen = 0;
+    // If drivers are failing to respond NetworkNotFound on empty results, force it for them.
+    bool resultsMissing = !networks || (networks && (networks->Count() == 0));
+    if ((status == Status::kSuccess) && mScanningWasDirected && resultsMissing)
+    {
+        status = Status::kNetworkNotFound;
+    }
+
+    SetLastNetworkingStatusValue(MakeNullable(status));
 
     TLV::TLVWriter * writer;
     TLV::TLVType listContainerType;
@@ -1044,21 +1121,24 @@ void Instance::OnFinished(Status status, CharSpan debugText, WiFiScanResponseIte
     SuccessOrExit(err = writer->StartContainer(TLV::ContextTag(Commands::ScanNetworksResponse::Fields::kWiFiScanResults),
                                                TLV::TLVType::kTLVType_Array, listContainerType));
 
-    for (; networks != nullptr && networks->Next(scanResponse) && networksEncoded < kMaxNetworksInScanResponse; networksEncoded++)
+    // Only encode results on success, to avoid stale contents on partial failure.
+    if (status == Status::kSuccess)
     {
-        Structs::WiFiInterfaceScanResultStruct::Type result;
-        result.security = scanResponse.security;
-        result.ssid     = ByteSpan(scanResponse.ssid, scanResponse.ssidLen);
-        result.bssid    = ByteSpan(scanResponse.bssid, sizeof(scanResponse.bssid));
-        result.channel  = scanResponse.channel;
-        result.wiFiBand = scanResponse.wiFiBand;
-        result.rssi     = scanResponse.rssi;
-        SuccessOrExit(err = DataModel::Encode(*writer, TLV::AnonymousTag(), result));
+        for (; networks != nullptr && networks->Next(scanResponse) && networksEncoded < kMaxNetworksInScanResponse; networksEncoded++)
+        {
+            Structs::WiFiInterfaceScanResultStruct::Type result;
+            result.security = scanResponse.security;
+            result.ssid     = ByteSpan(scanResponse.ssid, scanResponse.ssidLen);
+            result.bssid    = ByteSpan(scanResponse.bssid, sizeof(scanResponse.bssid));
+            result.channel  = scanResponse.channel;
+            result.wiFiBand = scanResponse.wiFiBand;
+            result.rssi     = scanResponse.rssi;
+            SuccessOrExit(err = DataModel::Encode(*writer, TLV::AnonymousTag(), result));
+        }
     }
 
     SuccessOrExit(err = writer->EndContainer(listContainerType));
     SuccessOrExit(err = commandHandle->FinishCommand());
-
 exit:
     if (err != CHIP_NO_ERROR)
     {
@@ -1110,6 +1190,12 @@ void Instance::OnFailSafeTimerExpired()
     ChipLogDetail(Zcl, "Failsafe timeout, tell platform driver to revert network credentials.");
     mpWirelessDriver->RevertConfiguration();
     mAsyncCommandHandle.Release();
+
+    // Reset state on failsafe expiry.
+    ReportNetworksListChanged();
+    SetLastNetworkId(ByteSpan{});
+    SetLastConnectErrorValue(NullNullable);
+    SetLastNetworkingStatusValue(NullNullable);
 }
 
 CHIP_ERROR Instance::EnumerateAcceptedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context)

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -123,7 +123,8 @@ Instance::Instance(EndpointId aEndpointId, WiFiDriver * apDelegate) :
 
 Instance::Instance(EndpointId aEndpointId, ThreadDriver * apDelegate) :
     CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Id), AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Id),
-    mEndpointId(aEndpointId), mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(apDelegate), mpBaseDriver(apDelegate)
+    mEndpointId(aEndpointId), mFeatureFlags(Feature::kThreadNetworkInterface), mpWirelessDriver(apDelegate),
+    mpBaseDriver(apDelegate)
 {
     mpDriver.Set<ThreadDriver *>(apDelegate);
 }
@@ -174,7 +175,8 @@ void Instance::SetLastNetworkingStatusValue(Attributes::LastNetworkingStatus::Ty
 {
     if (mLastNetworkingStatusValue.SetToMatch(networkingStatusValue))
     {
-        MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id, Attributes::LastNetworkingStatus::TypeInfo::GetAttributeId());
+        MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id,
+                                               Attributes::LastNetworkingStatus::TypeInfo::GetAttributeId());
     }
 }
 
@@ -182,24 +184,27 @@ void Instance::SetLastConnectErrorValue(Attributes::LastConnectErrorValue::TypeI
 {
     if (mLastConnectErrorValue.SetToMatch(connectErrorValue))
     {
-        MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id, Attributes::LastConnectErrorValue::TypeInfo::GetAttributeId());
+        MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id,
+                                               Attributes::LastConnectErrorValue::TypeInfo::GetAttributeId());
     }
 }
 
 void Instance::SetLastNetworkId(ByteSpan lastNetworkId)
 {
-    ByteSpan prevLastNetworkId{mLastNetworkID, mLastNetworkIDLen};
+    ByteSpan prevLastNetworkId{ mLastNetworkID, mLastNetworkIDLen };
     VerifyOrReturn(lastNetworkId.size() <= kMaxNetworkIDLen);
     VerifyOrReturn(!prevLastNetworkId.data_equal(lastNetworkId));
 
     memcpy(mLastNetworkID, lastNetworkId.data(), lastNetworkId.size());
     mLastNetworkIDLen = static_cast<uint8_t>(lastNetworkId.size());
-    MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id, Attributes::LastNetworkID::TypeInfo::GetAttributeId());
+    MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id,
+                                           Attributes::LastNetworkID::TypeInfo::GetAttributeId());
 }
 
 void Instance::ReportNetworksListChanged() const
 {
-    MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id, Attributes::Networks::TypeInfo::GetAttributeId());
+    MatterReportingAttributeChangeCallback(mEndpointId, Clusters::NetworkCommissioning::Id,
+                                           Attributes::Networks::TypeInfo::GetAttributeId());
 }
 
 void Instance::InvokeCommand(HandlerContext & ctxt)
@@ -478,7 +483,7 @@ void Instance::HandleScanNetworks(HandlerContext & ctx, const Commands::ScanNetw
             return;
         }
 
-        mScanningWasDirected = !ssid.empty();
+        mScanningWasDirected        = !ssid.empty();
         mCurrentOperationBreadcrumb = req.breadcrumb;
         mAsyncCommandHandle         = CommandHandler::Handle(&ctx.mCommandHandler);
         ctx.mCommandHandler.FlushAcksRightAwayOnSlowCommand();
@@ -948,7 +953,7 @@ void Instance::OnResult(Status commissioningError, CharSpan debugText, int32_t i
         SetLastConnectErrorValue(MakeNullable(interfaceStatus));
     }
 
-    SetLastNetworkId(ByteSpan{mConnectingNetworkID, mConnectingNetworkIDLen});
+    SetLastNetworkId(ByteSpan{ mConnectingNetworkID, mConnectingNetworkIDLen });
     SetLastNetworkingStatusValue(MakeNullable(commissioningError));
 
 #if CONFIG_NETWORK_LAYER_BLE && !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
@@ -1124,7 +1129,8 @@ void Instance::OnFinished(Status status, CharSpan debugText, WiFiScanResponseIte
     // Only encode results on success, to avoid stale contents on partial failure.
     if (status == Status::kSuccess)
     {
-        for (; networks != nullptr && networks->Next(scanResponse) && networksEncoded < kMaxNetworksInScanResponse; networksEncoded++)
+        for (; networks != nullptr && networks->Next(scanResponse) && networksEncoded < kMaxNetworksInScanResponse;
+             networksEncoded++)
         {
             Structs::WiFiInterfaceScanResultStruct::Type result;
             result.security = scanResponse.security;

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -1098,7 +1098,7 @@ void Instance::OnFinished(Status status, CharSpan debugText, WiFiScanResponseIte
     }
 
     // If drivers are failing to respond NetworkNotFound on empty results, force it for them.
-    bool resultsMissing = (0 == CountAndRelease(networks));
+    bool resultsMissing = !networks || (networks && (networks->Count() == 0));
     if ((status == Status::kSuccess) && mScanningWasDirected && resultsMissing)
     {
         status = Status::kNetworkNotFound;

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -81,7 +81,7 @@ private:
     void SendNonConcurrentConnectNetworkResponse();
 #endif
 
-    EndpointId mEndpointId;
+    EndpointId mEndpointId = kInvalidEndpointId;
     const BitFlags<Feature> mFeatureFlags;
 
     DeviceLayer::NetworkCommissioning::Internal::WirelessDriver * const mpWirelessDriver;

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -77,10 +77,11 @@ private:
     static void OnPlatformEventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     void OnCommissioningComplete();
     void OnFailSafeTimerExpired();
-
 #if !CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
     void SendNonConcurrentConnectNetworkResponse();
 #endif
+
+    EndpointId mEndpointId;
     const BitFlags<Feature> mFeatureFlags;
 
     DeviceLayer::NetworkCommissioning::Internal::WirelessDriver * const mpWirelessDriver;
@@ -96,14 +97,19 @@ private:
     // Setting these values don't have to care about parallel requests, since we will reject other requests when there is another
     // request ongoing.
     // These values can be updated via OnNetworkingStatusChange callback, ScanCallback::OnFinished and ConnectCallback::OnResult.
-    DataModel::Nullable<NetworkCommissioningStatusEnum> mLastNetworkingStatusValue;
+    Attributes::LastNetworkingStatus::TypeInfo::Type mLastNetworkingStatusValue;
     Attributes::LastConnectErrorValue::TypeInfo::Type mLastConnectErrorValue;
     uint8_t mConnectingNetworkID[DeviceLayer::NetworkCommissioning::kMaxNetworkIDLen];
     uint8_t mConnectingNetworkIDLen = 0;
     uint8_t mLastNetworkID[DeviceLayer::NetworkCommissioning::kMaxNetworkIDLen];
     uint8_t mLastNetworkIDLen = 0;
-
     Optional<uint64_t> mCurrentOperationBreadcrumb;
+    bool mScanningWasDirected = false;
+
+    void SetLastNetworkingStatusValue(Attributes::LastNetworkingStatus::TypeInfo::Type networkingStatusValue);
+    void SetLastConnectErrorValue(Attributes::LastConnectErrorValue::TypeInfo::Type connectErrorValue);
+    void SetLastNetworkId(ByteSpan lastNetworkId);
+    void ReportNetworksListChanged() const;
 
     // Commits the breadcrumb value saved in mCurrentOperationBreadcrumb to the breadcrumb attribute in GeneralCommissioning
     // cluster. Will set mCurrentOperationBreadcrumb to NullOptional.

--- a/src/app/data-model/Nullable.h
+++ b/src/app/data-model/Nullable.h
@@ -80,6 +80,16 @@ struct Nullable : protected Optional<T>
         return true;
     }
 
+    // Set the nullable to the `other` nullable, returning true if something actually changed.
+    // This can be used to determine if changes occurred on assignment, so that reporting can be triggered
+    // only on actual changes.
+    constexpr bool SetToMatch(const Nullable<T> & other)
+    {
+        bool changed = *this != other;
+        *this = other;
+        return changed;
+    }
+
     // The only fabric-scoped objects in the spec are commands, events and structs inside lists, and none of those can be nullable.
     static constexpr bool kIsFabricScoped = false;
 

--- a/src/app/data-model/Nullable.h
+++ b/src/app/data-model/Nullable.h
@@ -83,10 +83,13 @@ struct Nullable : protected Optional<T>
     // Set the nullable to the `other` nullable, returning true if something actually changed.
     // This can be used to determine if changes occurred on assignment, so that reporting can be triggered
     // only on actual changes.
-    constexpr bool SetToMatch(const Nullable<T> & other)
+    constexpr bool Update(const Nullable<T> & other)
     {
         bool changed = *this != other;
-        *this        = other;
+        if (changed)
+        {
+            *this = other;
+        }
         return changed;
     }
 

--- a/src/app/data-model/Nullable.h
+++ b/src/app/data-model/Nullable.h
@@ -86,7 +86,7 @@ struct Nullable : protected Optional<T>
     constexpr bool SetToMatch(const Nullable<T> & other)
     {
         bool changed = *this != other;
-        *this = other;
+        *this        = other;
         return changed;
     }
 

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -143,6 +143,7 @@ chip_test_suite_using_nltest("tests") {
     "TestFabricScopedEventLogging.cpp",
     "TestInteractionModelEngine.cpp",
     "TestMessageDef.cpp",
+    "TestNullable.cpp",
     "TestNumericAttributeTraits.cpp",
     "TestOperationalStateClusterObjects.cpp",
     "TestPendingNotificationMap.cpp",

--- a/src/app/tests/TestNullable.cpp
+++ b/src/app/tests/TestNullable.cpp
@@ -1,0 +1,309 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <array>
+#include <inttypes.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <app/data-model/Nullable.h>
+#include <lib/support/Span.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <nlunit-test.h>
+
+using namespace chip;
+using namespace chip::app::DataModel;
+
+struct Count
+{
+    Count(int i) : m(i) { ++created; }
+    ~Count() { ++destroyed; }
+
+    Count(const Count & o) : m(o.m) { ++created; }
+    Count & operator=(const Count &) = default;
+
+    Count(Count && o) : m(o.m) { ++created; }
+    Count & operator=(Count &&) = default;
+
+    bool operator==(const Count & o) const { return m == o.m; }
+
+    int m;
+
+    static void ResetCounter()
+    {
+        created   = 0;
+        destroyed = 0;
+    }
+
+    static int created;
+    static int destroyed;
+};
+
+struct CountMovable : public Count
+{
+public:
+    CountMovable(int i) : Count(i) {}
+
+    CountMovable(const CountMovable & o)           = delete;
+    CountMovable & operator=(const CountMovable &) = delete;
+
+    CountMovable(CountMovable && o)           = default;
+    CountMovable & operator=(CountMovable &&) = default;
+};
+
+int Count::created;
+int Count::destroyed;
+
+static void TestBasic(nlTestSuite * inSuite, void * inContext)
+{
+    // Set up our test Count objects, which will mess with counts, before we reset the
+    // counts.
+    Count c100(100), c101(101), c102(102);
+
+    Count::ResetCounter();
+
+    {
+        auto testNullable = MakeNullable<Count>(100);
+        NL_TEST_ASSERT(inSuite, Count::created == 1 && Count::destroyed == 0);
+        NL_TEST_ASSERT(inSuite, !testNullable.IsNull() && testNullable.Value().m == 100);
+        NL_TEST_ASSERT(inSuite, testNullable == c100);
+        NL_TEST_ASSERT(inSuite, testNullable != c101);
+        NL_TEST_ASSERT(inSuite, testNullable != c102);
+
+        testNullable.SetNull();
+        NL_TEST_ASSERT(inSuite, Count::created == 1 && Count::destroyed == 1);
+        NL_TEST_ASSERT(inSuite, !!testNullable.IsNull());
+        NL_TEST_ASSERT(inSuite, testNullable != c100);
+        NL_TEST_ASSERT(inSuite, testNullable != c101);
+        NL_TEST_ASSERT(inSuite, testNullable != c102);
+
+        testNullable.SetNonNull(Count(101));
+        NL_TEST_ASSERT(inSuite, Count::created == 3 && Count::destroyed == 2);
+        NL_TEST_ASSERT(inSuite, !testNullable.IsNull() && testNullable.Value().m == 101);
+        NL_TEST_ASSERT(inSuite, testNullable != c100);
+        NL_TEST_ASSERT(inSuite, testNullable == c101);
+        NL_TEST_ASSERT(inSuite, testNullable != c102);
+
+        testNullable.SetNonNull(102);
+        NL_TEST_ASSERT(inSuite, Count::created == 4 && Count::destroyed == 3);
+        NL_TEST_ASSERT(inSuite, !testNullable.IsNull() && testNullable.Value().m == 102);
+        NL_TEST_ASSERT(inSuite, testNullable != c100);
+        NL_TEST_ASSERT(inSuite, testNullable != c101);
+        NL_TEST_ASSERT(inSuite, testNullable == c102);
+    }
+
+    // Our test Count objects are still in scope here.
+    NL_TEST_ASSERT(inSuite, Count::created == 4 && Count::destroyed == 4);
+}
+
+static void TestMake(nlTestSuite * inSuite, void * inContext)
+{
+    Count::ResetCounter();
+
+    {
+        auto testNullable = MakeNullable<Count>(200);
+        NL_TEST_ASSERT(inSuite, Count::created == 1 && Count::destroyed == 0);
+        NL_TEST_ASSERT(inSuite, !testNullable.IsNull() && testNullable.Value().m == 200);
+    }
+
+    NL_TEST_ASSERT(inSuite, Count::created == 1 && Count::destroyed == 1);
+}
+
+static void TestCopy(nlTestSuite * inSuite, void * inContext)
+{
+    Count::ResetCounter();
+
+    {
+        auto testSrc = MakeNullable<Count>(300);
+        NL_TEST_ASSERT(inSuite, Count::created == 1 && Count::destroyed == 0);
+        NL_TEST_ASSERT(inSuite, !testSrc.IsNull() && testSrc.Value().m == 300);
+
+        {
+            Nullable<Count> testDst(testSrc);
+            NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 0);
+            NL_TEST_ASSERT(inSuite, !testDst.IsNull() && testDst.Value().m == 300);
+        }
+        NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 1);
+
+        {
+            Nullable<Count> testDst;
+            NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 1);
+            NL_TEST_ASSERT(inSuite, !!testDst.IsNull());
+
+            testDst = testSrc;
+            NL_TEST_ASSERT(inSuite, Count::created == 3 && Count::destroyed == 1);
+            NL_TEST_ASSERT(inSuite, !testDst.IsNull() && testDst.Value().m == 300);
+        }
+        NL_TEST_ASSERT(inSuite, Count::created == 3 && Count::destroyed == 2);
+    }
+    NL_TEST_ASSERT(inSuite, Count::created == 3 && Count::destroyed == 3);
+}
+
+static void TestMove(nlTestSuite * inSuite, void * inContext)
+{
+    Count::ResetCounter();
+
+    {
+        auto testSrc = MakeNullable<CountMovable>(400);
+        Nullable<CountMovable> testDst(std::move(testSrc));
+        NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 1);
+        NL_TEST_ASSERT(inSuite, !testDst.IsNull() && testDst.Value().m == 400);
+    }
+    NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 2);
+
+    {
+        Nullable<CountMovable> testDst;
+        NL_TEST_ASSERT(inSuite, Count::created == 2 && Count::destroyed == 2);
+        NL_TEST_ASSERT(inSuite, !!testDst.IsNull());
+
+        auto testSrc = MakeNullable<CountMovable>(401);
+        testDst      = std::move(testSrc);
+        NL_TEST_ASSERT(inSuite, Count::created == 4 && Count::destroyed == 3);
+        NL_TEST_ASSERT(inSuite, !testDst.IsNull() && testDst.Value().m == 401);
+    }
+    NL_TEST_ASSERT(inSuite, Count::created == 4 && Count::destroyed == 4);
+}
+
+static void TestSetToMatch(nlTestSuite * inSuite, void * inContext)
+{
+    using SmallArray = std::array<uint8_t, 3>;
+    // Arrays
+    {
+        auto nullable1 = MakeNullable<SmallArray>({1,2,3});
+        auto nullable2 = MakeNullable<SmallArray>({1,2,3});
+
+        NL_TEST_ASSERT(inSuite, !nullable1.IsNull());
+        NL_TEST_ASSERT(inSuite, !nullable2.IsNull());
+        NL_TEST_ASSERT(inSuite, nullable1 == nullable2);
+
+        // No-op on change to same.
+        NL_TEST_ASSERT(inSuite, nullable1.SetToMatch(nullable2) == false);
+        NL_TEST_ASSERT(inSuite, nullable1 == nullable2);
+
+        nullable1.Value()[0] = 100;
+
+        NL_TEST_ASSERT(inSuite, nullable1 != nullable2);
+        NL_TEST_ASSERT(inSuite, nullable2.SetToMatch(nullable1) == true);
+        NL_TEST_ASSERT(inSuite, nullable1 == nullable2);
+    }
+
+    // Structs
+    {
+        struct SomeObject
+        {
+            uint8_t a;
+            uint8_t b;
+
+            bool operator==(const SomeObject & other) const {
+              return (a == other.a) && (b == other.b);
+            }
+        };
+
+        auto nullable1 = MakeNullable<SomeObject>({1, 2});
+        auto nullable2 = MakeNullable<SomeObject>({1, 2});
+
+        NL_TEST_ASSERT(inSuite, !nullable1.IsNull());
+        NL_TEST_ASSERT(inSuite, !nullable2.IsNull());
+        NL_TEST_ASSERT(inSuite, nullable1 == nullable2);
+
+        // No-op on change to same.
+        NL_TEST_ASSERT(inSuite, nullable1.SetToMatch(nullable2) == false);
+        NL_TEST_ASSERT(inSuite, nullable1 == nullable2);
+
+        nullable1.Value().a = 100;
+
+        NL_TEST_ASSERT(inSuite, nullable1 != nullable2);
+        NL_TEST_ASSERT(inSuite, nullable2.SetToMatch(nullable1) == true);
+        NL_TEST_ASSERT(inSuite, nullable1 == nullable2);
+    }
+
+    // Scalar cases
+    {
+        auto nullable1 = MakeNullable(static_cast<uint8_t>(1));
+
+        NL_TEST_ASSERT(inSuite, !nullable1.IsNull());
+
+        // Non-null to non-null same value
+        NL_TEST_ASSERT(inSuite, nullable1.SetToMatch(nullable1) == false);
+        NL_TEST_ASSERT(inSuite, !nullable1.IsNull());
+
+        // Non-null to null
+        NL_TEST_ASSERT(inSuite, nullable1.SetToMatch(NullNullable) == true);
+        NL_TEST_ASSERT(inSuite, nullable1.IsNull());
+
+        // Null to null
+        NL_TEST_ASSERT(inSuite, nullable1.SetToMatch(NullNullable) == false);
+        NL_TEST_ASSERT(inSuite, nullable1.IsNull());
+
+        // Null to non-null
+        NL_TEST_ASSERT(inSuite, nullable1.SetToMatch(MakeNullable(static_cast<uint8_t>(1))) == true);
+        NL_TEST_ASSERT(inSuite, !nullable1.IsNull());
+        NL_TEST_ASSERT(inSuite, nullable1.Value() == 1);
+
+        // Non-null to non-null different value
+        NL_TEST_ASSERT(inSuite, nullable1.SetToMatch(MakeNullable(static_cast<uint8_t>(2))) == true);
+        NL_TEST_ASSERT(inSuite, !nullable1.IsNull());
+        NL_TEST_ASSERT(inSuite, nullable1.Value() == 2);
+
+        // Non-null to extent of range --> changes to "invalid" value in range.
+        NL_TEST_ASSERT(inSuite, nullable1.SetToMatch(MakeNullable(static_cast<uint8_t>(255))) == true);
+        NL_TEST_ASSERT(inSuite, !nullable1.IsNull());
+        NL_TEST_ASSERT(inSuite, nullable1.Value() == 255);
+    }
+}
+
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("NullableBasic", TestBasic),
+    NL_TEST_DEF("NullableMake", TestMake),
+    NL_TEST_DEF("NullableCopy", TestCopy),
+    NL_TEST_DEF("NullableMove", TestMove),
+    NL_TEST_DEF("Nullable SetToMatch operation", TestSetToMatch),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestNullable_Setup(void * inContext)
+{
+    return SUCCESS;
+}
+
+int TestNullable_Teardown(void * inContext)
+{
+    return SUCCESS;
+}
+
+int TestNullable()
+{
+    // clang-format off
+    nlTestSuite theSuite =
+    {
+        "Test for Nullable abstraction",
+        &sTests[0],
+        TestNullable_Setup,
+        TestNullable_Teardown
+    };
+    // clang-format on
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestNullable)

--- a/src/app/tests/TestNullable.cpp
+++ b/src/app/tests/TestNullable.cpp
@@ -70,7 +70,7 @@ public:
     MovableCtorDtorCounter & operator=(MovableCtorDtorCounter &&) = default;
 };
 
-int CtorDtorCounter::created = 0;
+int CtorDtorCounter::created   = 0;
 int CtorDtorCounter::destroyed = 0;
 
 } // namespace

--- a/src/app/tests/TestNullable.cpp
+++ b/src/app/tests/TestNullable.cpp
@@ -184,8 +184,8 @@ static void TestSetToMatch(nlTestSuite * inSuite, void * inContext)
     using SmallArray = std::array<uint8_t, 3>;
     // Arrays
     {
-        auto nullable1 = MakeNullable<SmallArray>({1,2,3});
-        auto nullable2 = MakeNullable<SmallArray>({1,2,3});
+        auto nullable1 = MakeNullable<SmallArray>({ 1, 2, 3 });
+        auto nullable2 = MakeNullable<SmallArray>({ 1, 2, 3 });
 
         NL_TEST_ASSERT(inSuite, !nullable1.IsNull());
         NL_TEST_ASSERT(inSuite, !nullable2.IsNull());
@@ -209,13 +209,11 @@ static void TestSetToMatch(nlTestSuite * inSuite, void * inContext)
             uint8_t a;
             uint8_t b;
 
-            bool operator==(const SomeObject & other) const {
-              return (a == other.a) && (b == other.b);
-            }
+            bool operator==(const SomeObject & other) const { return (a == other.a) && (b == other.b); }
         };
 
-        auto nullable1 = MakeNullable<SomeObject>({1, 2});
-        auto nullable2 = MakeNullable<SomeObject>({1, 2});
+        auto nullable1 = MakeNullable<SomeObject>({ 1, 2 });
+        auto nullable2 = MakeNullable<SomeObject>({ 1, 2 });
 
         NL_TEST_ASSERT(inSuite, !nullable1.IsNull());
         NL_TEST_ASSERT(inSuite, !nullable2.IsNull());


### PR DESCRIPTION
This PR addresses several NetworkCommissioning issues which are all inter-related:

- Attributes are never reported on change.
- ScanNetworks used to modify attributes that should not be modified
- LastNetworkStatus was not set where required
- Thread network scanning did not report error on SSID field provided
- All ConstraintErrors actually were reported as InvalidCommand
- Lacking results of directed scanning did not report NetworkNotFound

All fixed issues:
- Fixes #32024
- Fixes #32022
- Fixes #32021
- Fixes #32019
- Fixes #32018
- Fixes #31870

Testing done:
- TC-CNET-4.4 pass on ESP32 and Linux
- Commissioning works on ESP32 and Linux
- Manual testing of all attribute changes validated with chip-repl
  - Automated test beyond TC-CNET-4.4 coming as a follow-up
