### PR TITLE
TC-IDM-10.2: Work around conformance for color control

### DIFF
--- a/src/python_testing/spec_parsing_support.py
+++ b/src/python_testing/spec_parsing_support.py
@@ -507,6 +507,33 @@ def build_xml_clusters() -> tuple[list[XmlCluster], list[ProblemNotice]]:
             clusters[id] = new
 
     # TODO: All these fixups should be removed BEFORE SVE if at all possible
+    # Workaround for Color Control cluster - the spec uses a non-standard conformance. Set all to optional now, will need
+    # to implement either arithmetic conformance handling (once spec changes land here) or specific test
+    # https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/7808 for spec changes.
+    # see 3.2.8. Defined Primaries Information Attribute Set, affects Primary<#>X/Y/Intensity attributes.
+    cc_id = Clusters.ColorControl.id
+    cc_attr = Clusters.ColorControl.Attributes
+    affected_attributes = [cc_attr.Primary1X,
+                           cc_attr.Primary1Y,
+                           cc_attr.Primary1Intensity,
+                           cc_attr.Primary2X,
+                           cc_attr.Primary2Y,
+                           cc_attr.Primary2Intensity,
+                           cc_attr.Primary3X,
+                           cc_attr.Primary3Y,
+                           cc_attr.Primary3Intensity,
+                           cc_attr.Primary4X,
+                           cc_attr.Primary4Y,
+                           cc_attr.Primary4Intensity,
+                           cc_attr.Primary5X,
+                           cc_attr.Primary5Y,
+                           cc_attr.Primary5Intensity,
+                           cc_attr.Primary6X,
+                           cc_attr.Primary6Y,
+                           cc_attr.Primary6Intensity,
+                           ]
+    for a in affected_attributes:
+        clusters[cc_id].attributes[a.attribute_id].conformance = optional()
 
     # Workaround for temp control cluster - this is parsed incorrectly in the DM XML and is missing all its attributes
     # Remove this workaround when https://github.com/csa-data-model/projects/issues/330 is fixed


### PR DESCRIPTION
Some attributes are using a non-standard conformance marker in the spec. For now, treat all these as optional and default to the color control cluster tests to properly verify these values.

Test: Tested against the example lighting app. The app still HAS
      conformance issues, but these particular attribues are no
      longer listed as problems.

