### PR TITLE
[ICD] Move OnActiveModeNotification out from onCheckInComplete

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -149,9 +149,11 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
 
     ReturnErrorOnFailure(GetAttestationTrustStore(mPaaTrustStorePath.ValueOr(nullptr), &sTrustStore));
 
-    ReturnLogErrorOnFailure(sCheckInDelegate.Init(&sICDClientStorage));
+    auto engine = chip::app::InteractionModelEngine::GetInstance();
+    VerifyOrReturnError(engine != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    ReturnLogErrorOnFailure(sCheckInDelegate.Init(&sICDClientStorage, engine));
     ReturnLogErrorOnFailure(sCheckInHandler.Init(DeviceControllerFactory::GetInstance().GetSystemState()->ExchangeMgr(),
-                                                 &sICDClientStorage, &sCheckInDelegate));
+                                                 &sICDClientStorage, &sCheckInDelegate, engine));
 
     CommissionerIdentity nullIdentity{ kIdentityNull, chip::kUndefinedNodeId };
     ReturnLogErrorOnFailure(InitializeCommissioner(nullIdentity, kIdentityNullFabricId));

--- a/src/app/icd/client/CheckInHandler.cpp
+++ b/src/app/icd/client/CheckInHandler.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR CheckInHandler::Init(Messaging::ExchangeManager * exchangeManager, IC
     mpExchangeManager  = exchangeManager;
     mpICDClientStorage = clientStorage;
     mpCheckInDelegate  = delegate;
-    mpImEngine = engine;
+    mpImEngine         = engine;
     return mpExchangeManager->RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::ICD_CheckIn, this);
 }
 

--- a/src/app/icd/client/CheckInHandler.cpp
+++ b/src/app/icd/client/CheckInHandler.cpp
@@ -45,7 +45,7 @@ inline constexpr uint32_t kKeyRefreshLimit   = (1U << 31);
 CheckInHandler::CheckInHandler() {}
 
 CHIP_ERROR CheckInHandler::Init(Messaging::ExchangeManager * exchangeManager, ICDClientStorage * clientStorage,
-                                CheckInDelegate * delegate)
+                                CheckInDelegate * delegate, InteractionModelEngine * engine)
 {
     VerifyOrReturnError(exchangeManager != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(clientStorage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -55,7 +55,7 @@ CHIP_ERROR CheckInHandler::Init(Messaging::ExchangeManager * exchangeManager, IC
     mpExchangeManager  = exchangeManager;
     mpICDClientStorage = clientStorage;
     mpCheckInDelegate  = delegate;
-
+    mpImEngine = engine;
     return mpExchangeManager->RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::ICD_CheckIn, this);
 }
 
@@ -128,9 +128,7 @@ CHIP_ERROR CheckInHandler::OnMessageReceived(Messaging::ExchangeContext * ec, co
     else
     {
         mpCheckInDelegate->OnCheckInComplete(clientInfo);
-        #if CHIP_CONFIG_ENABLE_READ_CLIENT
-        InteractionModelEngine::GetInstance()->OnActiveModeNotification(clientInfo.peer_node);
-        #endif
+        mpImEngine->OnActiveModeNotification(clientInfo.peer_node);
     }
 
     return CHIP_NO_ERROR;

--- a/src/app/icd/client/CheckInHandler.cpp
+++ b/src/app/icd/client/CheckInHandler.cpp
@@ -130,7 +130,7 @@ CHIP_ERROR CheckInHandler::OnMessageReceived(Messaging::ExchangeContext * ec, co
         mpCheckInDelegate->OnCheckInComplete(clientInfo);
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
         mpImEngine->OnActiveModeNotification(clientInfo.peer_node);
-#endif //CHIP_CONFIG_ENABLE_READ_CLIENT
+#endif // CHIP_CONFIG_ENABLE_READ_CLIENT
     }
 
     return CHIP_NO_ERROR;

--- a/src/app/icd/client/CheckInHandler.cpp
+++ b/src/app/icd/client/CheckInHandler.cpp
@@ -128,7 +128,9 @@ CHIP_ERROR CheckInHandler::OnMessageReceived(Messaging::ExchangeContext * ec, co
     else
     {
         mpCheckInDelegate->OnCheckInComplete(clientInfo);
+#if CHIP_CONFIG_ENABLE_READ_CLIENT
         mpImEngine->OnActiveModeNotification(clientInfo.peer_node);
+#endif //CHIP_CONFIG_ENABLE_READ_CLIENT
     }
 
     return CHIP_NO_ERROR;

--- a/src/app/icd/client/CheckInHandler.cpp
+++ b/src/app/icd/client/CheckInHandler.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <app/InteractionModelEngine.h>
 #include <app/InteractionModelTimeout.h>
 #include <app/icd/client/CheckInHandler.h>
 #include <app/icd/client/RefreshKeySender.h>
@@ -127,6 +128,9 @@ CHIP_ERROR CheckInHandler::OnMessageReceived(Messaging::ExchangeContext * ec, co
     else
     {
         mpCheckInDelegate->OnCheckInComplete(clientInfo);
+        #if CHIP_CONFIG_ENABLE_READ_CLIENT
+        InteractionModelEngine::GetInstance()->OnActiveModeNotification(clientInfo.peer_node);
+        #endif
     }
 
     return CHIP_NO_ERROR;

--- a/src/app/icd/client/CheckInHandler.cpp
+++ b/src/app/icd/client/CheckInHandler.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/InteractionModelTimeout.h>
 #include <app/icd/client/CheckInHandler.h>

--- a/src/app/icd/client/CheckInHandler.h
+++ b/src/app/icd/client/CheckInHandler.h
@@ -41,7 +41,8 @@ class CheckInHandler : public Messaging::ExchangeDelegate, public Messaging::Uns
 {
 
 public:
-    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeManager, ICDClientStorage * clientStorage, CheckInDelegate * delegate, InteractionModelEngine *engine);
+    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeManager, ICDClientStorage * clientStorage, CheckInDelegate * delegate,
+                    InteractionModelEngine * engine);
     void Shutdown();
 
     CheckInHandler();
@@ -87,7 +88,7 @@ private:
     Messaging::ExchangeManager * mpExchangeManager = nullptr;
     CheckInDelegate * mpCheckInDelegate            = nullptr;
     ICDClientStorage * mpICDClientStorage          = nullptr;
-    InteractionModelEngine *mpImEngine             = nullptr;
+    InteractionModelEngine * mpImEngine            = nullptr;
 };
 
 } // namespace app

--- a/src/app/icd/client/CheckInHandler.h
+++ b/src/app/icd/client/CheckInHandler.h
@@ -36,12 +36,12 @@
 
 namespace chip {
 namespace app {
-
+class InteractionModelEngine;
 class CheckInHandler : public Messaging::ExchangeDelegate, public Messaging::UnsolicitedMessageHandler
 {
 
 public:
-    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeManager, ICDClientStorage * clientStorage, CheckInDelegate * delegate);
+    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeManager, ICDClientStorage * clientStorage, CheckInDelegate * delegate, InteractionModelEngine *engine);
     void Shutdown();
 
     CheckInHandler();
@@ -87,6 +87,7 @@ private:
     Messaging::ExchangeManager * mpExchangeManager = nullptr;
     CheckInDelegate * mpCheckInDelegate            = nullptr;
     ICDClientStorage * mpICDClientStorage          = nullptr;
+    InteractionModelEngine *mpImEngine             = nullptr;
 };
 
 } // namespace app

--- a/src/app/icd/client/DefaultCheckInDelegate.cpp
+++ b/src/app/icd/client/DefaultCheckInDelegate.cpp
@@ -28,7 +28,7 @@ CHIP_ERROR DefaultCheckInDelegate::Init(ICDClientStorage * storage, InteractionM
 {
     VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mpStorage == nullptr, CHIP_ERROR_INCORRECT_STATE);
-    mpStorage = storage;
+    mpStorage  = storage;
     mpImEngine = engine;
     return CHIP_NO_ERROR;
 }

--- a/src/app/icd/client/DefaultCheckInDelegate.cpp
+++ b/src/app/icd/client/DefaultCheckInDelegate.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#include <app/InteractionModelEngine.h>
 #include <app/icd/client/DefaultCheckInDelegate.h>
 #include <app/icd/client/RefreshKeySender.h>
 #include <crypto/CHIPCryptoPAL.h>
@@ -38,9 +37,6 @@ void DefaultCheckInDelegate::OnCheckInComplete(const ICDClientInfo & clientInfo)
     ChipLogProgress(
         ICD, "Check In Message processing complete: start_counter=%" PRIu32 " offset=%" PRIu32 " nodeid=" ChipLogFormatScopedNodeId,
         clientInfo.start_icd_counter, clientInfo.offset, ChipLogValueScopedNodeId(clientInfo.peer_node));
-#if CHIP_CONFIG_ENABLE_READ_CLIENT
-    InteractionModelEngine::GetInstance()->OnActiveModeNotification(clientInfo.peer_node);
-#endif
 }
 
 RefreshKeySender * DefaultCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & clientInfo, ICDClientStorage * clientStorage)

--- a/src/app/icd/client/DefaultCheckInDelegate.cpp
+++ b/src/app/icd/client/DefaultCheckInDelegate.cpp
@@ -24,11 +24,12 @@
 namespace chip {
 namespace app {
 
-CHIP_ERROR DefaultCheckInDelegate::Init(ICDClientStorage * storage)
+CHIP_ERROR DefaultCheckInDelegate::Init(ICDClientStorage * storage, InteractionModelEngine * engine)
 {
     VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mpStorage == nullptr, CHIP_ERROR_INCORRECT_STATE);
     mpStorage = storage;
+    mpImEngine = engine;
     return CHIP_NO_ERROR;
 }
 
@@ -51,7 +52,7 @@ RefreshKeySender * DefaultCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & cl
         return nullptr;
     }
 
-    auto refreshKeySender = Platform::New<RefreshKeySender>(this, clientInfo, clientStorage, newKey);
+    auto refreshKeySender = Platform::New<RefreshKeySender>(this, clientInfo, clientStorage, mpImEngine, newKey);
     if (refreshKeySender == nullptr)
     {
         return nullptr;

--- a/src/app/icd/client/DefaultCheckInDelegate.h
+++ b/src/app/icd/client/DefaultCheckInDelegate.h
@@ -26,18 +26,21 @@ namespace app {
 
 using namespace std;
 
+class InteractionModelEngine;
+
 /// Callbacks for check in protocol
 class DefaultCheckInDelegate : public CheckInDelegate
 {
 public:
     virtual ~DefaultCheckInDelegate() {}
-    CHIP_ERROR Init(ICDClientStorage * storage);
+    CHIP_ERROR Init(ICDClientStorage * storage, InteractionModelEngine * engine);
     void OnCheckInComplete(const ICDClientInfo & clientInfo) override;
     RefreshKeySender * OnKeyRefreshNeeded(ICDClientInfo & clientInfo, ICDClientStorage * clientStorage) override;
     void OnKeyRefreshDone(RefreshKeySender * refreshKeySender, CHIP_ERROR error) override;
 
 private:
     ICDClientStorage * mpStorage = nullptr;
+    InteractionModelEngine * mpImEngine             = nullptr;
 };
 
 } // namespace app

--- a/src/app/icd/client/DefaultCheckInDelegate.h
+++ b/src/app/icd/client/DefaultCheckInDelegate.h
@@ -39,8 +39,8 @@ public:
     void OnKeyRefreshDone(RefreshKeySender * refreshKeySender, CHIP_ERROR error) override;
 
 private:
-    ICDClientStorage * mpStorage = nullptr;
-    InteractionModelEngine * mpImEngine             = nullptr;
+    ICDClientStorage * mpStorage        = nullptr;
+    InteractionModelEngine * mpImEngine = nullptr;
 };
 
 } // namespace app

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -65,7 +65,9 @@ CHIP_ERROR RefreshKeySender::RegisterClientWithNewKey(Messaging::ExchangeManager
         }
 
         mpCheckInDelegate->OnCheckInComplete(mICDClientInfo);
+#if CHIP_CONFIG_ENABLE_READ_CLIENT
         mpImEngine->OnActiveModeNotification(mICDClientInfo.peer_node);
+#endif //CHIP_CONFIG_ENABLE_READ_CLIENT
         mpCheckInDelegate->OnKeyRefreshDone(this, CHIP_NO_ERROR);
     };
 

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -19,6 +19,7 @@
 #include "CheckInDelegate.h"
 #include "controller/InvokeInteraction.h"
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/AppConfig.h>
 #include <app/CommandPathParams.h>
 #include <app/InteractionModelEngine.h>
 #include <app/OperationalSessionSetup.h>

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -28,10 +28,11 @@ namespace chip {
 namespace app {
 
 RefreshKeySender::RefreshKeySender(CheckInDelegate * checkInDelegate, const ICDClientInfo & icdClientInfo,
-                                   ICDClientStorage * icdClientStorage, InteractionModelEngine *engine, const RefreshKeyBuffer & refreshKeyBuffer) :
-    mpCheckInDelegate(checkInDelegate), mICDClientInfo(icdClientInfo),
-    mpICDClientStorage(icdClientStorage), mpImEngine(engine), mOnConnectedCallback(HandleDeviceConnected, this),
-    mOnConnectionFailureCallback(HandleDeviceConnectionFailure, this)
+                                   ICDClientStorage * icdClientStorage, InteractionModelEngine * engine,
+                                   const RefreshKeyBuffer & refreshKeyBuffer) :
+    mpCheckInDelegate(checkInDelegate),
+    mICDClientInfo(icdClientInfo), mpICDClientStorage(icdClientStorage), mpImEngine(engine),
+    mOnConnectedCallback(HandleDeviceConnected, this), mOnConnectionFailureCallback(HandleDeviceConnectionFailure, this)
 
 {
     mNewKey = refreshKeyBuffer;

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -64,6 +64,9 @@ CHIP_ERROR RefreshKeySender::RegisterClientWithNewKey(Messaging::ExchangeManager
         }
 
         mpCheckInDelegate->OnCheckInComplete(mICDClientInfo);
+#if CHIP_CONFIG_ENABLE_READ_CLIENT
+        InteractionModelEngine::GetInstance()->OnActiveModeNotification(mICDClientInfo.peer_node);
+#endif
         mpCheckInDelegate->OnKeyRefreshDone(this, CHIP_NO_ERROR);
     };
 

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -67,7 +67,7 @@ CHIP_ERROR RefreshKeySender::RegisterClientWithNewKey(Messaging::ExchangeManager
         mpCheckInDelegate->OnCheckInComplete(mICDClientInfo);
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
         mpImEngine->OnActiveModeNotification(mICDClientInfo.peer_node);
-#endif //CHIP_CONFIG_ENABLE_READ_CLIENT
+#endif // CHIP_CONFIG_ENABLE_READ_CLIENT
         mpCheckInDelegate->OnKeyRefreshDone(this, CHIP_NO_ERROR);
     };
 

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -28,9 +28,9 @@ namespace chip {
 namespace app {
 
 RefreshKeySender::RefreshKeySender(CheckInDelegate * checkInDelegate, const ICDClientInfo & icdClientInfo,
-                                   ICDClientStorage * icdClientStorage, const RefreshKeyBuffer & refreshKeyBuffer) :
-    mICDClientInfo(icdClientInfo),
-    mpICDClientStorage(icdClientStorage), mpCheckInDelegate(checkInDelegate), mOnConnectedCallback(HandleDeviceConnected, this),
+                                   ICDClientStorage * icdClientStorage, InteractionModelEngine *engine, const RefreshKeyBuffer & refreshKeyBuffer) :
+    mpCheckInDelegate(checkInDelegate), mICDClientInfo(icdClientInfo),
+    mpICDClientStorage(icdClientStorage), mpImEngine(engine), mOnConnectedCallback(HandleDeviceConnected, this),
     mOnConnectionFailureCallback(HandleDeviceConnectionFailure, this)
 
 {
@@ -64,9 +64,7 @@ CHIP_ERROR RefreshKeySender::RegisterClientWithNewKey(Messaging::ExchangeManager
         }
 
         mpCheckInDelegate->OnCheckInComplete(mICDClientInfo);
-#if CHIP_CONFIG_ENABLE_READ_CLIENT
-        InteractionModelEngine::GetInstance()->OnActiveModeNotification(mICDClientInfo.peer_node);
-#endif
+        mpImEngine->OnActiveModeNotification(mICDClientInfo.peer_node);
         mpCheckInDelegate->OnKeyRefreshDone(this, CHIP_NO_ERROR);
     };
 

--- a/src/app/icd/client/RefreshKeySender.h
+++ b/src/app/icd/client/RefreshKeySender.h
@@ -44,7 +44,7 @@ public:
     typedef Crypto::SensitiveDataBuffer<Crypto::kAES_CCM128_Key_Length> RefreshKeyBuffer;
 
     RefreshKeySender(CheckInDelegate * checkInDelegate, const ICDClientInfo & icdClientInfo, ICDClientStorage * icdClientStorage,
-    InteractionModelEngine *engine, const RefreshKeyBuffer & refreshKeyBuffer);
+                     InteractionModelEngine * engine, const RefreshKeyBuffer & refreshKeyBuffer);
 
     /**
      * @brief Sets up a CASE session to the peer for re-registering a client with the peer when a key refresh is required to avoid
@@ -82,10 +82,10 @@ private:
      */
     CHIP_ERROR RegisterClientWithNewKey(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
 
-    CheckInDelegate * mpCheckInDelegate   = nullptr;
+    CheckInDelegate * mpCheckInDelegate = nullptr;
     ICDClientInfo mICDClientInfo;
     ICDClientStorage * mpICDClientStorage = nullptr;
-    InteractionModelEngine *mpImEngine    = nullptr;
+    InteractionModelEngine * mpImEngine   = nullptr;
     RefreshKeyBuffer mNewKey;
     Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
     Callback::Callback<OnDeviceConnectionFailure> mOnConnectionFailureCallback;

--- a/src/app/icd/client/RefreshKeySender.h
+++ b/src/app/icd/client/RefreshKeySender.h
@@ -34,7 +34,7 @@ namespace chip {
 namespace app {
 
 class CheckInDelegate;
-
+class InteractionModelEngine;
 /**
  * @brief RefreshKeySender contains all the data and methods needed for key refresh and re-registration of an ICD client.
  */
@@ -44,7 +44,7 @@ public:
     typedef Crypto::SensitiveDataBuffer<Crypto::kAES_CCM128_Key_Length> RefreshKeyBuffer;
 
     RefreshKeySender(CheckInDelegate * checkInDelegate, const ICDClientInfo & icdClientInfo, ICDClientStorage * icdClientStorage,
-                     const RefreshKeyBuffer & refreshKeyBuffer);
+    InteractionModelEngine *engine, const RefreshKeyBuffer & refreshKeyBuffer);
 
     /**
      * @brief Sets up a CASE session to the peer for re-registering a client with the peer when a key refresh is required to avoid
@@ -82,9 +82,10 @@ private:
      */
     CHIP_ERROR RegisterClientWithNewKey(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle);
 
+    CheckInDelegate * mpCheckInDelegate   = nullptr;
     ICDClientInfo mICDClientInfo;
     ICDClientStorage * mpICDClientStorage = nullptr;
-    CheckInDelegate * mpCheckInDelegate   = nullptr;
+    InteractionModelEngine *mpImEngine    = nullptr;
     RefreshKeyBuffer mNewKey;
     Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
     Callback::Callback<OnDeviceConnectionFailure> mOnConnectionFailureCallback;


### PR DESCRIPTION
-- This PR does not have logic change, and just move OnActiveModeNotification out from onCheckInComplete, and into CheckInHandler and refreshKeySender, since OnActiveModeNotification is not responsibility for onCheckInComplete
-- When implementing darin/android CheckInDelegate, we should not call OnActiveModeNotification again.
