### PR TITLE
[Android] Fix onReport status

### DIFF
--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -281,9 +281,8 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     jobject wrapperCallback = mWrapperCallbackRef.ObjectRef();
 
     jobject nodeState = GetNodeStateObj(env, mNodeStateClassSignature, wrapperCallback);
-    if (aStatus.IsFailure())
+
     {
-        ChipLogError(Controller, "Receive bad status %s", ErrorStr(aStatus.ToChipError()));
         // Add Attribute Status to wrapperCallback
         jmethodID addAttributeStatusMethod = nullptr;
         err = JniReferences::GetInstance().FindMethod(env, nodeState, "addAttributeStatus", "(IJJILjava/lang/Integer;)V",
@@ -305,8 +304,10 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
                             static_cast<jlong>(aPath.mClusterId), static_cast<jlong>(aPath.mAttributeId),
                             static_cast<jint>(aStatus.mStatus), jClusterState);
         VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
-        return;
     }
+
+    VerifyOrReturn(aStatus.IsSuccess(), ChipLogError(Controller, "Receive bad status %s", ErrorStr(aStatus.ToChipError()));
+                   aPath.LogPath());
     VerifyOrReturn(apData != nullptr, ChipLogError(Controller, "Receive empty apData"); aPath.LogPath());
 
     TLV::TLVReader readerForJavaTLV;
@@ -415,9 +416,8 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
                    ChipLogError(Controller, "mReportCallbackRef is not valid in %s", __func__));
     jobject wrapperCallback = mWrapperCallbackRef.ObjectRef();
     jobject nodeState       = GetNodeStateObj(env, mNodeStateClassSignature, wrapperCallback);
-    if (apStatus != nullptr && apStatus->IsFailure())
+    if (apStatus != nullptr)
     {
-        ChipLogError(Controller, "Receive bad status %s", ErrorStr(apStatus->ToChipError()));
         // Add Event Status to NodeState
         jmethodID addEventStatusMethod;
         err = JniReferences::GetInstance().FindMethod(env, nodeState, "addEventStatus", "(IJJILjava/lang/Integer;)V",


### PR DESCRIPTION
Per contract in ReadClient
-- For onAttribute, we always need to report status from jni to application, if the status is failure, we would not report attribute
-- For onEvent, if status is not empty, we report status from jni to application, and not report data.
