### PR TITLE
[MatterYamlTests] Make it possible to use PICS in arguments/responses values

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -197,6 +197,7 @@ class _TestStepWithPlaceholders:
         self.event = _value_or_none(test, 'event')
         self.endpoint = _value_or_config(test, 'endpoint', config)
         self.pics = _value_or_none(test, 'PICS')
+        self.pics_checker = pics_checker
         self.is_pics_enabled = pics_checker.check(_value_or_none(test, 'PICS'))
 
         self.identity = _value_or_none(test, 'identity')
@@ -466,6 +467,10 @@ class _TestStepWithPlaceholders:
         values = container['values']
         if values is None:
             return
+
+        values = [value for value in values if value.get('PICS') is None or (
+            value.get('PICS') and self.pics_checker.check(value.get('PICS')))]
+        container['values'] = values
 
         for value in list(values):
             for key, item_value in list(value.items()):

--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -87,6 +87,7 @@ _TEST_STEP_RESPONSE_SCHEMA = {
     'constraints': dict,
     'saveAs': str,
     'saveDataVersschemaionAs': str,
+    'PICS': str,
 }
 
 _TEST_STEP_RESPONSE_CONSTRAINTS_SCHEMA = {

--- a/src/app/tests/suites/certification/Test_TC_OO_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_1_1.yaml
@@ -42,63 +42,41 @@ tests:
           constraints:
               type: int16u
 
-    - label: "Step 3a: TH reads from the DUT the FeatureMap attribute."
+    - label: "Step 3: TH reads from the DUT the FeatureMap attribute."
       command: "readAttribute"
       attribute: "FeatureMap"
-      PICS: ( !OO.S.F00 && !OO.S.F01 )
       response:
-          value: 0
-          constraints:
-              type: bitmap32
+          - values:
+                - constraints:
+                      type: bitmap32
 
-    - label:
-          "Step 3b: Given OO.S.F00(LT) ensure featuremap has the correct bit set"
-      command: "readAttribute"
-      attribute: "FeatureMap"
-      PICS: OO.S.F00
-      response:
-          constraints:
-              type: bitmap32
-              hasMasksSet: [0x1]
+                - PICS: ( !OO.S.F00 && !OO.S.F01 )
+                  value: 0
 
-    - label:
-          "Step 3c: Given OO.S.F01(DF) ensure featuremap has the correct bit set"
-      command: "readAttribute"
-      attribute: "FeatureMap"
-      PICS: OO.S.F01
-      response:
-          constraints:
-              type: bitmap32
-              hasMasksSet: [0x2]
+                - PICS: OO.S.F00
+                  constraints:
+                      hasMasksSet: [0x1]
 
-    - label: "Step 4a: TH reads from the DUT the AttributeList attribute."
-      PICS: PICS_EVENT_LIST_ENABLED
+                - PICS: OO.S.F01
+                  constraints:
+                      hasMasksSet: [0x2]
+
+    - label: "Step 4: TH reads from the DUT the AttributeList attribute."
       command: "readAttribute"
       attribute: "AttributeList"
       response:
-          constraints:
-              type: list
-              contains: [0, 65528, 65529, 65530, 65531, 65532, 65533]
+          - values:
+                - constraints:
+                      type: list
+                      contains: [0, 65528, 65529, 65531, 65532, 65533]
 
-    - label: "Step 4a: TH reads from the DUT the AttributeList attribute."
-      PICS: "!PICS_EVENT_LIST_ENABLED"
-      command: "readAttribute"
-      attribute: "AttributeList"
-      response:
-          constraints:
-              type: list
-              contains: [0, 65528, 65529, 65531, 65532, 65533]
+                - PICS: PICS_EVENT_LIST_ENABLED
+                  constraints:
+                      contains: [65530]
 
-    - label:
-          "Step 4b: TH reads the feature dependent(OO.S.F00) attribute in
-          AttributeList"
-      PICS: OO.S.F00
-      command: "readAttribute"
-      attribute: "AttributeList"
-      response:
-          constraints:
-              type: list
-              contains: [16384, 16385, 16386, 16387]
+                - PICS: OO.S.F00
+                  constraints:
+                      contains: [0x4000, 0x4001, 0x4002, 0x4003]
 
     - label: "Step 5: TH reads from the DUT the EventList attribute."
       PICS: PICS_EVENT_LIST_ENABLED
@@ -109,24 +87,18 @@ tests:
           constraints:
               type: list
 
-    - label: "Step 6a: TH reads from the DUT the AcceptedCommandList attribute."
+    - label: "Step 6: TH reads from the DUT the AcceptedCommandList attribute."
       command: "readAttribute"
       attribute: "AcceptedCommandList"
       response:
-          constraints:
-              type: list
-              contains: [0, 1, 2]
+          - values:
+                - constraints:
+                      type: list
+                      contains: [0x0, 0x1, 0x2]
 
-    - label:
-          "Step 6b: TH reads the feature dependent(OO.S.F00) commands in
-          AcceptedCommandList"
-      command: "readAttribute"
-      attribute: "AcceptedCommandList"
-      PICS: OO.S.F00
-      response:
-          constraints:
-              type: list
-              contains: [64, 65, 66]
+                - PICS: OO.S.F00
+                  constraints:
+                      contains: [0x40, 0x41, 0x42]
 
     - label: "Step 7: TH reads from the DUT the GeneratedCommandList attribute."
       command: "readAttribute"


### PR DESCRIPTION
#### Problem

A lot of test step check the response based on some PICS. While YAML provide some methods to run a test step based on a PICS code, it does not make it easy to run a single test step but check the response conditionally based on PICS.

This PR introduce such supports and updates `Test_TC_OO_1_1` to show how it can be used. 