### PR TITLE
[Scenes] TC_S_2_6 Split Overloads

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_S_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_6.yaml
@@ -101,7 +101,7 @@ tests:
           CHIP:TOO:    }
       disabled: true
 
-    - label: "Step 1b: Repeat Step 1a with TH2 and TH3."
+    - label: "Step 1b: Repeat Step 1a with TH2."
       PICS: S.S.C03.Rsp
       verification: |
           ./chip-tool scenesmanagement remove-all-scenes 0x0000 2 1 --commissioner-name beta
@@ -116,7 +116,11 @@ tests:
           [1700826575.191974][15971:15973] CHIP:TOO:     status: 0
           [1700826575.191985][15971:15973] CHIP:TOO:     groupID: 0
           [1700826575.191995][15971:15973] CHIP:TOO:    }
+      disabled: true
 
+    - label: "Step 1C: Repeat Step 1a with TH3."
+      PICS: S.S.C03.Rsp
+      verification: |
           ./chip-tool scenesmanagement remove-all-scenes 0x0000 3 1 --commissioner-name gamma
 
           Verify the RemoveAllScenesResponse with following fields:
@@ -282,10 +286,10 @@ tests:
           [1701242801.625919][7636:7638] CHIP:TOO:       RemainingCapacity: 7
           [1701242801.625930][7636:7638] CHIP:TOO:       FabricIndex: 2
           [1701242801.625941][7636:7638] CHIP:TOO:      }
+      disabled: true
 
-
-          TH3:
-
+    - label: "Step 2e:  Repeat Step 2b and 2c with TH3."
+      verification: |
           Please use Interactive mode to Verify the subscription of an event
           Here the command to enter interactive mode:--
           ./chip-tool interactive start
@@ -966,11 +970,11 @@ tests:
       disabled: true
 
     - label:
-          Verify that the DUT sends a report data to TH2 for FabricSceneInfo
-          after the MinIntervalFloor time; store the RemainingCapacity field
-          from this fabric’s entry reported in FabricSceneInfo into
-          Remaining2ndCapacity; verify Remaining2ndCapacity equals
-          (MaxRemainingCapacity).
+          "Step 10b: Verify that the DUT sends a report data to TH2 for
+          FabricSceneInfo after the MinIntervalFloor time; store the
+          RemainingCapacity field from this fabric’s entry reported in
+          FabricSceneInfo into Remaining2ndCapacity; verify Remaining2ndCapacity
+          equals (MaxRemainingCapacity)."
       verification: |
           ./chip-tool scenesmanagement subscribe fabric-scene-info 100 200 2 1 --commissioner-name beta
 
@@ -988,4 +992,38 @@ tests:
           [1705915866.717635][21433:21435] CHIP:TOO:       FabricIndex: 2
           [1705915866.717640][21433:21435] CHIP:TOO:      }
 
+      disabled: true
+
+    - label:
+          "Step 11a: TH1 removes the TH2 fabric by sending the RemoveFabric
+          command to the DUT with the FabricIndex set to th2FabricIndex"
+      verification: |
+          ./chip-tool operationalcredentials remove-fabric th2FabricIndex 1 0
+
+          On TH1(chip-tool) verify the success with the nocresponse with statuscode is success(0)
+
+          [1784416866.004187][21433:21435] CHIP:DMG: Received Command Response Data, Endpoint=0 Cluster=0x0000_003E Command=0x0000_0008
+          [1784416866.004214][21433:21435] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_003E Command 0x0000_0008
+          [1784416866.004236][21433:21435] CHIP:TOO:   NOCResponse: {
+          [1784416866.004250][21433:21435] CHIP:TOO:     statusCode: 0
+          [1784416866.004255][21433:21435] CHIP:TOO:     fabricIndex: th2FabricIndex
+          [1784416866.004259][21433:21435] CHIP:TOO:    }
+          [1784416866.004270][21433:21435] CHIP:DMG: ICR moving to [AwaitingDe]
+      disabled: true
+
+    - label:
+          "Step 11b: TH1 removes the TH3 fabric by sending the RemoveFabric
+          command to the DUT with the FabricIndex set to th3FabricIndex"
+      verification: |
+          ./chip-tool operationalcredentials remove-fabric th3FabricIndex 1 0
+
+          On TH1(chip-tool) verify the success with the nocresponse with statuscode is success(0)
+
+          [1784416866.004187][21433:21435] CHIP:DMG: Received Command Response Data, Endpoint=0 Cluster=0x0000_003E Command=0x0000_0008
+          [1784416866.004214][21433:21435] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_003E Command 0x0000_0008
+          [1784416866.004236][21433:21435] CHIP:TOO:   NOCResponse: {
+          [1784416866.004250][21433:21435] CHIP:TOO:     statusCode: 0
+          [1784416866.004255][21433:21435] CHIP:TOO:     fabricIndex: th3FabricIndex
+          [1784416866.004259][21433:21435] CHIP:TOO:    }
+          [1784416866.004270][21433:21435] CHIP:DMG: ICR moving to [AwaitingDe]
       disabled: true


### PR DESCRIPTION
Split overloaded steps 1b and 2d in 2_6 and added fabric removal for TH2 and TH3 at the end.

Fixes: https://github.com/project-chip/matter-test-scripts/issues/160
Fixes: https://github.com/project-chip/connectedhomeip/issues/32125
Fixes: https://github.com/project-chip/connectedhomeip/issues/32127
