### PR TITLE
[Darwin] MTRDevice attribute cache persistent storage local test facility

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -1976,7 +1976,6 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
     MTR_LOG_DEBUG("Causing failure in subscribers on purpose");
     CauseReadClientFailure(self.deviceController, self.nodeID, queue, completion);
 }
-#endif
 
 // The following method is for unit testing purpose only
 + (id)CHIPEncodeAndDecodeNSObject:(id)object
@@ -2018,6 +2017,7 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
     }
     return decodedData.GetDecodedObject();
 }
+#endif
 
 - (void)readEventsWithEndpointID:(NSNumber * _Nullable)endpointID
                        clusterID:(NSNumber * _Nullable)clusterID

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -174,12 +174,12 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
                 return nil;
             }
 
-            id<MTRDeviceControllerStorageDelegate> storageDelegateToUse;
+            id<MTRDeviceControllerStorageDelegate> storageDelegateToUse = storageDelegate;
+#if MTR_PER_CONTROLLER_STORAGE_ENABLED
             if (MTRDeviceControllerLocalTestStorage.localTestStorageEnabled) {
                 storageDelegateToUse = [[MTRDeviceControllerLocalTestStorage alloc] initWithPassThroughStorage:storageDelegate];
-            } else {
-                storageDelegateToUse = storageDelegate;
             }
+#endif // MTR_PER_CONTROLLER_STORAGE_ENABLED
             _controllerDataStore = [[MTRDeviceControllerDataStore alloc] initWithController:self
                                                                             storageDelegate:storageDelegateToUse
                                                                        storageDelegateQueue:storageDelegateQueue];
@@ -187,6 +187,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
                 return nil;
             }
         } else {
+#if MTR_PER_CONTROLLER_STORAGE_ENABLED
             if (MTRDeviceControllerLocalTestStorage.localTestStorageEnabled) {
                 dispatch_queue_t localTestStorageQueue = dispatch_queue_create("org.csa-iot.matter.framework.devicecontroller.localteststorage", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
                 MTRDeviceControllerLocalTestStorage * localTestStorage = [[MTRDeviceControllerLocalTestStorage alloc] initWithPassThroughStorage:nil];
@@ -197,6 +198,7 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
                     return nil;
                 }
             }
+#endif // MTR_PER_CONTROLLER_STORAGE_ENABLED
         }
 
         // Ensure the otaProviderDelegate, if any, is valid.

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.h
@@ -16,8 +16,9 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <Matter/MTRDeviceControllerStorageDelegate.h>
 #import <Matter/Matter.h>
+
+#if MTR_PER_CONTROLLER_STORAGE_ENABLED
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,3 +33,5 @@ MTR_EXTERN @interface MTRDeviceControllerLocalTestStorage : NSObject<MTRDeviceCo
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // MTR_PER_CONTROLLER_STORAGE_ENABLED

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.h
@@ -16,6 +16,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Matter/MTRDeviceControllerStorageDelegate.h>
 #import <Matter/Matter.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.h
@@ -1,0 +1,33 @@
+//
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/Matter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+MTR_EXTERN @interface MTRDeviceControllerLocalTestStorage : NSObject<MTRDeviceControllerStorageDelegate>
+
+// Setting this variable only affects subsequent MTRDeviceController initializations
+@property (class, nonatomic, assign) BOOL localTestStorageEnabled;
+
+// This storage persists items to NSUserDefaults for MTRStorageSharingTypeNotShared data. Items with other sharing types will be droppped, or stored/fetched with the "passthrough storage" if one is specified.
+- (instancetype)initWithPassThroughStorage:(id<MTRDeviceControllerStorageDelegate> _Nullable)passThroughStorage;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.m
@@ -15,6 +15,8 @@
  *    limitations under the License.
  */
 
+#if MTRDeviceControllerStorageDelegate
+
 #import "MTRDeviceControllerLocalTestStorage.h"
 
 static NSString * const kLocalTestUserDefaultDomain = @"org.csa-iot.matter.darwintest";
@@ -91,3 +93,5 @@ static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
     }
 }
 @end
+
+#endif // MTRDeviceControllerStorageDelegate

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.m
@@ -1,0 +1,93 @@
+//
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRDeviceControllerLocalTestStorage.h"
+
+static NSString * const kLocalTestUserDefaultDomain = @"org.csa-iot.matter.darwintest";
+static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
+
+@implementation MTRDeviceControllerLocalTestStorage {
+    id<MTRDeviceControllerStorageDelegate> _passThroughStorage;
+}
+
++ (BOOL)localTestStorageEnabled
+{
+    NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+    return [defaults boolForKey:kLocalTestUserDefaultEnabledKey];
+}
+
++ (void)setLocalTestStorageEnabled:(BOOL)localTestStorageEnabled
+{
+    NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+    [defaults setBool:localTestStorageEnabled forKey:kLocalTestUserDefaultEnabledKey];
+}
+
+- (instancetype)initWithPassThroughStorage:(id<MTRDeviceControllerStorageDelegate>)passThroughStorage
+{
+    if (self = [super init]) {
+        _passThroughStorage = passThroughStorage;
+    }
+    return self;
+}
+
+- (nullable id<NSSecureCoding>)controller:(MTRDeviceController *)controller
+                              valueForKey:(NSString *)key
+                            securityLevel:(MTRStorageSecurityLevel)securityLevel
+                              sharingType:(MTRStorageSharingType)sharingType
+{
+    if (sharingType == MTRStorageSharingTypeNotShared) {
+        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+        NSData * storedData = [defaults dataForKey:key];
+        NSError * error;
+        id value = [NSKeyedUnarchiver unarchivedObjectOfClasses:MTRDeviceControllerStorageClasses() fromData:storedData error:&error];
+        return value;
+    } else {
+        return [_passThroughStorage controller:controller valueForKey:key securityLevel:securityLevel sharingType:sharingType];
+    }
+}
+
+- (BOOL)controller:(MTRDeviceController *)controller
+        storeValue:(id<NSSecureCoding>)value
+            forKey:(NSString *)key
+     securityLevel:(MTRStorageSecurityLevel)securityLevel
+       sharingType:(MTRStorageSharingType)sharingType
+{
+    if (sharingType == MTRStorageSharingTypeNotShared) {
+        NSError * error;
+        NSData * data = [NSKeyedArchiver archivedDataWithRootObject:value requiringSecureCoding:YES error:&error];
+        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+        [defaults setObject:data forKey:key];
+        return YES;
+    } else {
+        return [_passThroughStorage controller:controller storeValue:value forKey:key securityLevel:securityLevel sharingType:sharingType];
+    }
+}
+
+- (BOOL)controller:(MTRDeviceController *)controller
+    removeValueForKey:(NSString *)key
+        securityLevel:(MTRStorageSecurityLevel)securityLevel
+          sharingType:(MTRStorageSharingType)sharingType
+{
+    if (sharingType == MTRStorageSharingTypeNotShared) {
+        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+        [defaults removeObjectForKey:key];
+        return YES;
+    } else {
+        return [_passThroughStorage controller:controller removeValueForKey:key securityLevel:securityLevel sharingType:sharingType];
+    }
+}
+@end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.m
@@ -15,9 +15,9 @@
  *    limitations under the License.
  */
 
-#if MTRDeviceControllerStorageDelegate
-
 #import "MTRDeviceControllerLocalTestStorage.h"
+
+#if MTR_PER_CONTROLLER_STORAGE_ENABLED
 
 static NSString * const kLocalTestUserDefaultDomain = @"org.csa-iot.matter.darwintest";
 static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
@@ -94,4 +94,4 @@ static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
 }
 @end
 
-#endif // MTRDeviceControllerStorageDelegate
+#endif // MTR_PER_CONTROLLER_STORAGE_ENABLED

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -118,14 +118,18 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
 @implementation MTRDeviceTests
 
+#if MTR_PER_CONTROLLER_STORAGE_ENABLED
 static BOOL slocalTestStorageEnabledBeforeUnitTest;
+#endif // MTR_PER_CONTROLLER_STORAGE_ENABLED
 
 + (void)setUp
 {
     XCTestExpectation * pairingExpectation = [[XCTestExpectation alloc] initWithDescription:@"Pairing Complete"];
 
+#if MTR_PER_CONTROLLER_STORAGE_ENABLED
     slocalTestStorageEnabledBeforeUnitTest = MTRDeviceControllerLocalTestStorage.localTestStorageEnabled;
     MTRDeviceControllerLocalTestStorage.localTestStorageEnabled = YES;
+#endif // MTR_PER_CONTROLLER_STORAGE_ENABLED
 
     __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
@@ -176,11 +180,13 @@ static BOOL slocalTestStorageEnabledBeforeUnitTest;
 {
     ResetCommissionee(GetConnectedDevice(), dispatch_get_main_queue(), nil, kTimeoutInSeconds);
 
+#if MTR_PER_CONTROLLER_STORAGE_ENABLED
     // Restore testing setting to previous state, and remove all persisted attributes
     MTRDeviceControllerLocalTestStorage.localTestStorageEnabled = slocalTestStorageEnabledBeforeUnitTest;
     [sController.controllerDataStore clearAllStoredAttributes];
     NSArray * storedAttributesAfterClear = [sController.controllerDataStore getStoredAttributesForNodeID:@(kDeviceId)];
     XCTAssertEqual(storedAttributesAfterClear.count, 0);
+#endif // MTR_PER_CONTROLLER_STORAGE_ENABLED
 
     MTRDeviceController * controller = sController;
     XCTAssertNotNil(controller);
@@ -1236,7 +1242,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     __auto_type * params = [[MTRSubscribeParams alloc] init];
     params.resubscribeAutomatically = NO;
     params.replaceExistingSubscriptions = NO; // Not strictly needed, but checking that doing this does not
-                                              // affect this subscription erroring out correctly.
+    // affect this subscription erroring out correctly.
     [device subscribeWithQueue:queue
         minInterval:1
         maxInterval:2
@@ -1606,7 +1612,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRSubscribeParams * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(1) maxInterval:@(10)];
     params.resubscribeAutomatically = NO;
     params.replaceExistingSubscriptions = NO; // Not strictly needed, but checking that doing this does not
-                                              // affect this subscription erroring out correctly.
+    // affect this subscription erroring out correctly.
     __block BOOL subscriptionEstablished = NO;
     [device subscribeToAttributesWithEndpointID:@1
         clusterID:@6
@@ -2832,6 +2838,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTAssertEqualObjects(cluster.endpointID, @(0));
 }
 
+#if MTR_PER_CONTROLLER_STORAGE_ENABLED
 - (void)test031_MTRDeviceAttributeCacheLocalTestStorage
 {
     dispatch_queue_t queue = dispatch_get_main_queue();
@@ -2888,6 +2895,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSUInteger storedAttributeCountDifferenceFromMTRDeviceReport = dataStoreValuesAfterSecondSubscription.count - attributesReportedWithSecondSubscription;
     XCTAssertTrue(storedAttributeCountDifferenceFromMTRDeviceReport > 300);
 }
+#endif // MTR_PER_CONTROLLER_STORAGE_ENABLED
 
 @end
 

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -22,6 +22,7 @@
 #import "MTRDeviceTestDelegate.h"
 #import "MTRErrorTestUtils.h"
 #import "MTRFabricInfoChecker.h"
+#import "MTRTestDeclarations.h"
 #import "MTRTestKeys.h"
 #import "MTRTestPerControllerStorage.h"
 #import "MTRTestResetCommissioneeHelper.h"
@@ -32,28 +33,6 @@ static const uint16_t kPairingTimeoutInSeconds = 10;
 static const uint16_t kTimeoutInSeconds = 3;
 static NSString * kOnboardingPayload = @"MT:-24J0AFN00KA0648G00";
 static const uint16_t kTestVendorId = 0xFFF1u;
-
-#ifdef DEBUG
-// MTRDeviceControllerDataStore.h includes C++ header, and so we need to declare the methods separately
-@protocol MTRDeviceControllerDataStoreAttributeStoreMethods
-- (nullable NSArray<NSDictionary *> *)getStoredAttributesForNodeID:(NSNumber *)nodeID;
-- (void)storeAttributeValues:(NSArray<NSDictionary *> *)dataValues forNodeID:(NSNumber *)nodeID;
-- (void)clearStoredAttributesForNodeID:(NSNumber *)nodeID;
-- (void)clearAllStoredAttributes;
-@end
-
-// Declare internal methods for testing
-@interface MTRDeviceController (Test)
-+ (void)forceLocalhostAdvertisingOnly;
-- (void)removeDevice:(MTRDevice *)device;
-@property (nonatomic, readonly, nullable) id<MTRDeviceControllerDataStoreAttributeStoreMethods> controllerDataStore;
-@end
-
-@interface MTRDevice (Test)
-- (BOOL)_attributeDataValue:(NSDictionary *)one isEqualToDataValue:(NSDictionary *)theOther;
-- (NSUInteger)unitTestAttributesReportedSinceLastCheck;
-@end
-#endif // DEBUG
 
 @interface MTRPerControllerStorageTestsControllerDelegate : NSObject <MTRDeviceControllerDelegate>
 @property (nonatomic, strong) XCTestExpectation * expectation;

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -1,0 +1,60 @@
+//
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/Matter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - Declarations for internal methods
+
+// MTRDeviceControllerDataStore.h includes C++ header, and so we need to declare the methods separately
+@protocol MTRDeviceControllerDataStoreAttributeStoreMethods
+- (nullable NSArray<NSDictionary *> *)getStoredAttributesForNodeID:(NSNumber *)nodeID;
+- (void)storeAttributeValues:(NSArray<NSDictionary *> *)dataValues forNodeID:(NSNumber *)nodeID;
+- (void)clearStoredAttributesForNodeID:(NSNumber *)nodeID;
+- (void)clearAllStoredAttributes;
+@end
+
+// Declare internal methods for testing
+@interface MTRDeviceController (Test)
++ (void)forceLocalhostAdvertisingOnly;
+- (void)removeDevice:(MTRDevice *)device;
+@property (nonatomic, readonly, nullable) id<MTRDeviceControllerDataStoreAttributeStoreMethods> controllerDataStore;
+@end
+
+@interface MTRDevice (Test)
+- (BOOL)_attributeDataValue:(NSDictionary *)one isEqualToDataValue:(NSDictionary *)theOther;
+@end
+
+#pragma mark - Declarations for items compiled only for DEBUG configuration
+
+#ifdef DEBUG
+@interface MTRBaseDevice (TestDebug)
+- (void)failSubscribers:(dispatch_queue_t)queue completion:(void (^)(void))completion;
+
+// Test function for whitebox testing
++ (id)CHIPEncodeAndDecodeNSObject:(id)object;
+@end
+
+@interface MTRDevice (TestDebug)
+- (void)unitTestInjectEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport;
+- (NSUInteger)unitTestAttributesReportedSinceLastCheck;
+@end
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -240,6 +240,8 @@
 		5ACDDD7D27CD16D200EFD68A /* MTRClusterStateCacheContainer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5ACDDD7C27CD16D200EFD68A /* MTRClusterStateCacheContainer.mm */; };
 		5ACDDD7E27CD3F3A00EFD68A /* MTRClusterStateCacheContainer_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ACDDD7B27CD14AF00EFD68A /* MTRClusterStateCacheContainer_Internal.h */; };
 		5AE6D4E427A99041001F2493 /* MTRDeviceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AE6D4E327A99041001F2493 /* MTRDeviceTests.m */; };
+		75139A6F2B7FE5E900E3A919 /* MTRDeviceControllerLocalTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 75139A6E2B7FE5E900E3A919 /* MTRDeviceControllerLocalTestStorage.m */; };
+		75139A702B7FE68C00E3A919 /* MTRDeviceControllerLocalTestStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 75139A6D2B7FE5D600E3A919 /* MTRDeviceControllerLocalTestStorage.h */; };
 		7534F12828BFF20300390851 /* MTRDeviceAttestationDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7534F12628BFF20300390851 /* MTRDeviceAttestationDelegate.mm */; };
 		7534F12928BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7534F12728BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h */; };
 		754F3DF427FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 754F3DF327FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h */; };
@@ -633,6 +635,9 @@
 		5ACDDD7B27CD14AF00EFD68A /* MTRClusterStateCacheContainer_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRClusterStateCacheContainer_Internal.h; sourceTree = "<group>"; };
 		5ACDDD7C27CD16D200EFD68A /* MTRClusterStateCacheContainer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRClusterStateCacheContainer.mm; sourceTree = "<group>"; };
 		5AE6D4E327A99041001F2493 /* MTRDeviceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRDeviceTests.m; sourceTree = "<group>"; };
+		75139A6C2B7FE19100E3A919 /* MTRTestDeclarations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRTestDeclarations.h; sourceTree = "<group>"; };
+		75139A6D2B7FE5D600E3A919 /* MTRDeviceControllerLocalTestStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDeviceControllerLocalTestStorage.h; sourceTree = "<group>"; };
+		75139A6E2B7FE5E900E3A919 /* MTRDeviceControllerLocalTestStorage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRDeviceControllerLocalTestStorage.m; sourceTree = "<group>"; };
 		7534F12628BFF20300390851 /* MTRDeviceAttestationDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceAttestationDelegate.mm; sourceTree = "<group>"; };
 		7534F12728BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceAttestationDelegate_Internal.h; sourceTree = "<group>"; };
 		754F3DF327FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTREventTLVValueDecoder_Internal.h; sourceTree = "<group>"; };
@@ -792,9 +797,6 @@
 				039145E02993102B00257B3E /* main.mm */,
 				03F430A52994100000166449 /* controller */,
 				039547092992DB02006D42A8 /* editline */,
-				039546AD2991E193006D42A8 /* log */,
-				039546B12991E194006D42A8 /* system */,
-				039546A72991E185006D42A8 /* delay */,
 				039546A22991E132006D42A8 /* interaction_model */,
 				039546972991DFC4006D42A8 /* lib_json */,
 				039546872991C400006D42A8 /* chip-tool */,
@@ -815,7 +817,6 @@
 				03FB93DA2A46200A0048CB35 /* discover */,
 				037C3D7C2991BD4F00B7EEE2 /* pairing */,
 				037C3D852991BD4F00B7EEE2 /* clusters */,
-				037C3D8B2991BD4F00B7EEE2 /* tests */,
 				037C3D8D2991BD4F00B7EEE2 /* provider */,
 				037C3D932991BD4F00B7EEE2 /* payload */,
 				037C3D972991BD4F00B7EEE2 /* storage */,
@@ -1105,6 +1106,7 @@
 				51C984602A61CE2A00B0AD9A /* MTRFabricInfoChecker.m */,
 				75B0D01C2B71B46F002074DD /* MTRDeviceTestDelegate.h */,
 				75B0D01D2B71B47F002074DD /* MTRDeviceTestDelegate.m */,
+				75139A6C2B7FE19100E3A919 /* MTRTestDeclarations.h */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -1238,6 +1240,8 @@
 				5136661228067D550025EDAE /* MTRDeviceControllerFactory.h */,
 				5136661128067D540025EDAE /* MTRDeviceControllerFactory_Internal.h */,
 				5136661028067D540025EDAE /* MTRDeviceControllerFactory.mm */,
+				75139A6D2B7FE5D600E3A919 /* MTRDeviceControllerLocalTestStorage.h */,
+				75139A6E2B7FE5E900E3A919 /* MTRDeviceControllerLocalTestStorage.m */,
 				5A6FEC8D27B5624E00F25F42 /* MTRDeviceControllerOverXPC.h */,
 				5A830D6B27CFCF590053B85D /* MTRDeviceControllerOverXPC_Internal.h */,
 				5A6FEC8F27B563D900F25F42 /* MTRDeviceControllerOverXPC.mm */,
@@ -1555,6 +1559,7 @@
 				1EC4CE6425CC276600D7304F /* MTRBaseClusters.h in Headers */,
 				3D843712294977000070D20A /* MTRCallbackBridgeBase.h in Headers */,
 				3DECCB742934C21B00585AEC /* MTRDefines.h in Headers */,
+				75139A702B7FE68C00E3A919 /* MTRDeviceControllerLocalTestStorage.h in Headers */,
 				2C5EEEF6268A85C400CAE3D3 /* MTRDeviceConnectionBridge.h in Headers */,
 				2C8C8FC0253E0C2100797F05 /* MTRPersistentStorageDelegateBridge.h in Headers */,
 				51FE72352ACDB40000437032 /* MTRCommandPayloads_Internal.h in Headers */,
@@ -1753,7 +1758,6 @@
 				B45373EF2A9FEBFE00807602 /* ops-raw-skt.c in Sources */,
 				516411332B6BF77700E67C05 /* MTRServerAccessControl.mm in Sources */,
 				037C3DD52991C2E200B7EEE2 /* CHIPCommandBridge.mm in Sources */,
-				039546BC2991E1CB006D42A8 /* LogCommands.cpp in Sources */,
 				516411312B6BF70300E67C05 /* DataModelHandler.cpp in Sources */,
 				B45373E12A9FEB7F00807602 /* ops-h1.c in Sources */,
 				B45373EB2A9FEBDB00807602 /* ops-listen.c in Sources */,
@@ -1766,13 +1770,11 @@
 				B45373E62A9FEBA400807602 /* header.c in Sources */,
 				B45374002A9FEC4F00807602 /* unix-init.c in Sources */,
 				B45373DF2A9FEB6F00807602 /* system.c in Sources */,
-				039546BD2991E1CB006D42A8 /* SystemCommands.cpp in Sources */,
 				B45373FC2A9FEC4F00807602 /* unix-caps.c in Sources */,
 				B4E262162AA0CF1C00DBA5BC /* RemoteDataModelLogger.mm in Sources */,
 				B45373ED2A9FEBEC00807602 /* ops-pipe.c in Sources */,
 				B45373C02A9FEA9100807602 /* output.c in Sources */,
 				0395470F2992DB37006D42A8 /* complete.c in Sources */,
-				039546BE2991E1CB006D42A8 /* DelayCommands.cpp in Sources */,
 				B4E2621B2AA0D02000DBA5BC /* SleepCommand.mm in Sources */,
 				B45373FF2A9FEC4F00807602 /* unix-misc.c in Sources */,
 				B45373D92A9FEB3800807602 /* poll.c in Sources */,
@@ -1840,6 +1842,7 @@
 				75B765C32A1D82D30014719B /* MTRAttributeSpecifiedCheck.mm in Sources */,
 				AF5F90FF2878D351005503FA /* MTROTAProviderDelegateBridge.mm in Sources */,
 				516415FF2B6B132200D5CE11 /* DataModelHandler.cpp in Sources */,
+				75139A6F2B7FE5E900E3A919 /* MTRDeviceControllerLocalTestStorage.m in Sources */,
 				51E95DFC2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.mm in Sources */,
 				514C79ED2B62ADCD00DD6D7B /* ember-compatibility-functions.cpp in Sources */,
 				7534F12828BFF20300390851 /* MTRDeviceAttestationDelegate.mm in Sources */,

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -241,7 +241,7 @@
 		5ACDDD7E27CD3F3A00EFD68A /* MTRClusterStateCacheContainer_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ACDDD7B27CD14AF00EFD68A /* MTRClusterStateCacheContainer_Internal.h */; };
 		5AE6D4E427A99041001F2493 /* MTRDeviceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AE6D4E327A99041001F2493 /* MTRDeviceTests.m */; };
 		75139A6F2B7FE5E900E3A919 /* MTRDeviceControllerLocalTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 75139A6E2B7FE5E900E3A919 /* MTRDeviceControllerLocalTestStorage.m */; };
-		75139A702B7FE68C00E3A919 /* MTRDeviceControllerLocalTestStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 75139A6D2B7FE5D600E3A919 /* MTRDeviceControllerLocalTestStorage.h */; };
+		75139A702B7FE68C00E3A919 /* MTRDeviceControllerLocalTestStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 75139A6D2B7FE5D600E3A919 /* MTRDeviceControllerLocalTestStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		7534F12828BFF20300390851 /* MTRDeviceAttestationDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7534F12628BFF20300390851 /* MTRDeviceAttestationDelegate.mm */; };
 		7534F12928BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7534F12728BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h */; };
 		754F3DF427FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 754F3DF327FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h */; };


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/31966

But mainly this PR adds a facility to test MTRDevice attribute cache persistent storage when the MTRDeviceController does not have a per controller storage delegate.

On macOS the storage can be turned on with the command:
```
defaults write org.csa-iot.matter.darwintest enableTestStorage -bool yes
```
and turned off with:
```
defaults delete org.csa-iot.matter.darwintest enableTestStorage
```