### PR TITLE
[devcontainer] forcing devcontainer to execute docker build script us…

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
     ],
-    "initializeCommand": ".devcontainer/build.sh --tag matter-dev-environment:local --version 22",
+    "initializeCommand": "bash .devcontainer/build.sh --tag matter-dev-environment:local --version 22",
     "image": "matter-dev-environment:local",
     "remoteUser": "vscode",
     "customizations": {


### PR DESCRIPTION
Fixes #29898,  #31231 and #30704 

## The error:

`[2024-02-17T13:10:28.070Z] Start: Run: C:\WINDOWS\system32\cmd.exe /c .devcontainer/build.sh --tag matter-dev-environment:local --version 22
[2024-02-17T13:10:28.476Z] '.devcontainer' is not recognized as an internal or external command,
operable program or batch file.`

## To reproduce the issue:

- follow "Windows Only" steps in [VSCode Guide](https://github.com/project-chip/connectedhomeip/blob/master/docs/VSCODE_DEVELOPMENT.md).

- The repo should be cloned on windows and not WSL (I assume this what is expected).
- Build the container using VSCode Dev Container
- No way was found to let the devcontainer CLI execute the "initializeCommand" using bash, it will only execute it using cmd.exe  "(it seems that the devcontainer CLI that executes initializeCommand works independently from VSCode terminal settings ) 

## Solution

- Is my solution acceptable? prefixing the command with a bash it should also work when using VSCode on Ubuntu natively. So It shouldn't break anything.