### PR TITLE
[Linux] Fix BLE infinite advertising

### DIFF
--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -65,7 +65,7 @@ BluezLEAdvertisement1 * BluezAdvertisement::CreateLEAdvertisement()
     // Bluez to set "BR/EDR Not Supported" flag. Bluez doesn't provide API to do that explicitly
     // and the flag is necessary to force using LE transport.
     bluez_leadvertisement1_set_discoverable(adv, TRUE);
-    bluez_leadvertisement1_set_discoverable_timeout(adv, 0 /* infinite */);
+    // empty discoverable timeout for infinite discoverability
 
     // empty includes
     bluez_leadvertisement1_set_local_name(adv, mAdvName);

--- a/src/platform/Linux/dbus/bluez/DbusBluez.xml
+++ b/src/platform/Linux/dbus/bluez/DbusBluez.xml
@@ -108,6 +108,10 @@
     </method>
   </interface>
 
+  <!--
+  This interface shall be exported by Matter GATT application and registered
+  with org.bluez.GattManager1.RegisterApplication method.
+  -->
   <interface name="org.bluez.GattService1">
     <property name="UUID" type="s" access="read" />
     <property name="Device" type="o" access="read" />
@@ -115,6 +119,10 @@
     <!-- <property name="Includes" type="ao" access="read" /> -->
   </interface>
 
+  <!--
+  This interface shall be exported by Matter GATT application and linked
+  with org.bluez.GattService1 object via the Service property.
+  -->
   <interface name="org.bluez.GattCharacteristic1">
     <method name="ReadValue">
       <arg name="options" type="a{sv}" direction="in"/>
@@ -152,6 +160,10 @@
     <property name="NotifyAcquired" type="b" access="read" />
   </interface>
 
+  <!--
+  This interface shall be exported by Matter GATT application and linked
+  with org.bluez.GattCharacteristic1 object via the Characteristic property.
+  -->
   <interface name="org.bluez.GattDescriptor1">
     <method name="ReadValue">
       <arg name="options" type="a{sv}" direction="in"/>
@@ -172,6 +184,10 @@
     </property>
   </interface>
 
+  <!--
+  This interface shall be exported by Matter GATT application and registered
+  with org.bluez.LEAdvertisingManager1.RegisterAdvertisement method.
+  -->
   <interface name="org.bluez.LEAdvertisement1">
     <method name="Release"/>
     <property name="Type" type="s" access="read"/>
@@ -183,13 +199,33 @@
     <property name="ServiceData" type="a{sv}" access="read"/>
     <property name="Data" type="a{yay}" access="read"/>
     <property name="Discoverable" type="b" access="read"/>
+    <!--
+    Do not expose discoverable timeout property, so BlueZ will set it
+    internally to zero, effectively disabling the timeout. Becase of BlueZ
+    bug, which is not fixed until BlueZ 5.73, exposing discoverable timeout
+    as zero will timout the advertisement immediately.
+
     <property name="DiscoverableTimeout" type="q" access="read"/>
+    -->
     <property name="Includes" type="as" access="read"/>
     <property name="LocalName" type="s" access="read"/>
     <property name="Appearance" type="q" access="read"/>
-    <!-- <property name="Duration" type="q" access="read"/> -->
-    <!-- <property name="Timeout" type="q" access="read"/> -->
-    <!-- <property name="SecondaryChannel" type="s" access="read"/> -->
+    <!--
+    Do not expose duration, so BlueZ will use the internal default value.
+
+    <property name="Duration" type="q" access="read"/>
+    -->
+    <!--
+    Do not expose timeout property, so BlueZ will not call the Release()
+    method after a timeout.
+
+    <property name="Timeout" type="q" access="read"/>
+    -->
+    <!--
+    We are not using SecondaryChannel property, so we do not expose it.
+
+    <property name="SecondaryChannel" type="s" access="read"/>
+    -->
     <property name="MinInterval" type="u" access="read"/>
     <property name="MaxInterval" type="u" access="read"/>
   </interface>


### PR DESCRIPTION
### Problem

According to BlueZ documentation, discoverable timeout of 0 should disable the timeout. However, due to a bug on RPi, setting timeout to 0 stops advertising immediately after sending ADV frame. Also, we can not set this property to a big value, because it is `uint16` which can count only 65535 seconds which is ~18.2 hours (not enough for 48 h extended advertising).

Regression introduced in bd6c4aba209923587717ec195fc8f9446e6b0d23

Fixes #32033

### Changes

- remove `DiscoverableTimeout` property, so BlueZ will set it internally to 0

### Testing

Tested connection between `linux-x64-chip-tool` and `linux-arm64-all-clusters-clang`.