### PR TITLE
[DiagnosticLogs] When the size of the TransferFileDesignator is 0, th…

### DIFF
--- a/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
+++ b/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
@@ -129,6 +129,8 @@ void DiagnosticLogsServer::HandleLogRequestForBdx(CommandHandler * commandObj, c
     // INVALID_COMMAND.
     VerifyOrReturn(transferFileDesignator.HasValue(), commandObj->AddStatus(path, Status::InvalidCommand));
 
+    VerifyOrReturn(transferFileDesignator.Value().size() > 0, commandObj->AddStatus(path, Status::ConstraintError));
+
     VerifyOrReturn(transferFileDesignator.Value().size() <= kMaxFileDesignatorLen,
                    commandObj->AddStatus(path, Status::ConstraintError));
 


### PR DESCRIPTION
…e server should returns CONSTRAINT_ERROR

#### Problem

[DiagnosticLogs] When the size of the TransferFileDesignator is `0`, the server should returns `CONSTRAINT_ERROR`

