### PR TITLE
[Linux] Lock CHIP stack before calling WiFi diagnostic delegate

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -98,15 +98,6 @@ namespace DeviceLayer {
 
 ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-char ConnectivityManagerImpl::sWiFiIfName[];
-#endif
-
-WiFiDriver::ScanCallback * ConnectivityManagerImpl::mpScanCallback;
-NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * ConnectivityManagerImpl::mpConnectCallback;
-uint8_t ConnectivityManagerImpl::sInterestedSSID[Internal::kMaxWiFiSSIDLength];
-uint8_t ConnectivityManagerImpl::sInterestedSSIDLen;
-
 CHIP_ERROR ConnectivityManagerImpl::_Init()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
@@ -165,12 +156,6 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
-
-bool ConnectivityManagerImpl::mAssociationStarted = false;
-BitFlags<Internal::GenericConnectivityManagerImpl_WiFi<ConnectivityManagerImpl>::ConnectivityFlags>
-    ConnectivityManagerImpl::mConnectivityFlag;
-struct GDBusWpaSupplicant ConnectivityManagerImpl::mWpaSupplicant;
-std::mutex ConnectivityManagerImpl::mWpaSupplicantMutex;
 
 ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMode()
 {
@@ -313,7 +298,7 @@ CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
         ChipLogProgress(DeviceLayer, "WiFi AP mode change: %s -> %s", WiFiAPModeToStr(mWiFiAPMode), WiFiAPModeToStr(val));
         mWiFiAPMode = val;
 
-        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, nullptr);
+        DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveAPState(); });
     }
 
 exit:
@@ -326,7 +311,7 @@ void ConnectivityManagerImpl::_DemandStartWiFiAP()
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: Demand start WiFi AP");
         mLastAPDemandTime = System::SystemClock().GetMonotonicTimestamp();
-        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, nullptr);
+        DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveAPState(); });
     }
     else
     {
@@ -340,7 +325,7 @@ void ConnectivityManagerImpl::_StopOnDemandWiFiAP()
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: Demand stop WiFi AP");
         mLastAPDemandTime = System::Clock::kZero;
-        DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, nullptr);
+        DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveAPState(); });
     }
     else
     {
@@ -362,7 +347,7 @@ void ConnectivityManagerImpl::_MaintainOnDemandWiFiAP()
 void ConnectivityManagerImpl::_SetWiFiAPIdleTimeout(System::Clock::Timeout val)
 {
     mWiFiAPIdleTimeout = val;
-    DeviceLayer::SystemLayer().ScheduleWork(DriveAPState, nullptr);
+    DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveAPState(); });
 }
 
 void ConnectivityManagerImpl::UpdateNetworkStatus()
@@ -391,12 +376,11 @@ void ConnectivityManagerImpl::UpdateNetworkStatus()
         MakeOptional(GetDisconnectReason()));
 }
 
-void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * changed_properties,
-                                                      const gchar * const * invalidated_properties, gpointer user_data)
+void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * changedProperties)
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    if (g_variant_n_children(changed_properties) > 0)
+    if (g_variant_n_children(changedProperties) > 0)
     {
         GAutoPtr<GVariantIter> iter;
         const gchar * key;
@@ -404,7 +388,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
 
         WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
 
-        g_variant_get(changed_properties, "a{sv}", &MakeUniquePointerReceiver(iter).Get());
+        g_variant_get(changedProperties, "a{sv}", &MakeUniquePointerReceiver(iter).Get());
 
         while (g_variant_iter_loop(iter.get(), "{&sv}", &key, &value))
         {
@@ -424,6 +408,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
 
                     if (delegate)
                     {
+                        chip::DeviceLayer::StackLock stackLock;
                         delegate->OnDisconnectionDetected(reason);
                         delegate->OnConnectionStatusChanged(static_cast<uint8_t>(ConnectionStatusEnum::kConnected));
                     }
@@ -453,7 +438,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
                             break;
                         }
 
-                        DeviceLayer::SystemLayer().ScheduleLambda([reason]() {
+                        DeviceLayer::SystemLayer().ScheduleLambda([this, reason]() {
                             if (mpConnectCallback != nullptr)
                             {
                                 mpConnectCallback->OnResult(NetworkCommissioning::Status::kUnknownError, CharSpan(), reason);
@@ -463,6 +448,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
 
                         if (delegate)
                         {
+                            chip::DeviceLayer::StackLock stackLock;
                             delegate->OnAssociationFailureDetected(associationFailureCause, status);
                         }
                     }
@@ -475,6 +461,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
                 {
                     if (delegate)
                     {
+                        chip::DeviceLayer::StackLock stackLock;
                         delegate->OnConnectionStatusChanged(static_cast<uint8_t>(ConnectionStatusEnum::kNotConnected));
                     }
 
@@ -484,7 +471,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
                 {
                     if (mAssociationStarted)
                     {
-                        DeviceLayer::SystemLayer().ScheduleLambda([]() {
+                        DeviceLayer::SystemLayer().ScheduleLambda([this]() {
                             if (mpConnectCallback != nullptr)
                             {
                                 mpConnectCallback->OnResult(NetworkCommissioning::Status::kSuccess, CharSpan(), 0);
@@ -500,7 +487,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
     }
 }
 
-void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
+void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * sourceObject, GAsyncResult * res)
 {
     // When creating D-Bus proxy object, the thread default context must be initialized. Otherwise,
     // all D-Bus signals will be delivered to the GLib global default main context.
@@ -525,8 +512,17 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object,
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to wpa_supplicant interface proxy");
 
-        g_signal_connect(mWpaSupplicant.iface, "properties-changed", G_CALLBACK(_OnWpaPropertiesChanged), NULL);
-        g_signal_connect(mWpaSupplicant.iface, "scan-done", G_CALLBACK(_OnWpaInterfaceScanDone), NULL);
+        g_signal_connect(
+            mWpaSupplicant.iface, "properties-changed",
+            G_CALLBACK(+[](WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * properties, ConnectivityManagerImpl * self) {
+                return self->_OnWpaPropertiesChanged(proxy, properties);
+            }),
+            this);
+        g_signal_connect(mWpaSupplicant.iface, "scan-done",
+                         G_CALLBACK(+[](WpaFiW1Wpa_supplicant1Interface * proxy, gboolean success, ConnectivityManagerImpl * self) {
+                             return self->_OnWpaInterfaceScanDone(proxy, success);
+                         }),
+                         this);
     }
     else
     {
@@ -537,7 +533,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object,
     }
 
     // We need to stop auto scan or it will block our network scan.
-    DeviceLayer::SystemLayer().ScheduleLambda([]() {
+    DeviceLayer::SystemLayer().ScheduleLambda([this]() {
         CHIP_ERROR errInner = StopAutoScan();
         if (errInner != CHIP_NO_ERROR)
         {
@@ -546,7 +542,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object,
     });
 }
 
-void ConnectivityManagerImpl::_OnWpaBssProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
+void ConnectivityManagerImpl::_OnWpaBssProxyReady(GObject * sourceObject, GAsyncResult * res)
 {
     // When creating D-Bus proxy object, the thread default context must be initialized. Otherwise,
     // all D-Bus signals will be delivered to the GLib global default main context.
@@ -577,7 +573,7 @@ void ConnectivityManagerImpl::_OnWpaBssProxyReady(GObject * source_object, GAsyn
     }
 }
 
-void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
+void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * sourceObject, GAsyncResult * res)
 {
     // When creating D-Bus proxy object, the thread default context must be initialized. Otherwise,
     // all D-Bus signals will be delivered to the GLib global default main context.
@@ -594,12 +590,21 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_GOT_INTERFACE_PATH;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface: %s", mWpaSupplicant.interfacePath);
 
-        wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
-                                                              mWpaSupplicant.interfacePath, nullptr, _OnWpaInterfaceProxyReady,
-                                                              nullptr);
+        wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(
+            G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, mWpaSupplicant.interfacePath, nullptr,
+            reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
+                    return self->_OnWpaInterfaceProxyReady(sourceObject_, res_);
+                }),
+            this);
 
-        wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
-                                                        mWpaSupplicant.interfacePath, nullptr, _OnWpaBssProxyReady, nullptr);
+        wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus(
+            G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, mWpaSupplicant.interfacePath, nullptr,
+            reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
+                    return self->_OnWpaBssProxyReady(sourceObject_, res_);
+                }),
+            this);
     }
     else
     {
@@ -626,12 +631,21 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
 
             Platform::CopyString(sWiFiIfName, CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME);
 
-            wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE,
-                                                                  kWpaSupplicantServiceName, mWpaSupplicant.interfacePath, nullptr,
-                                                                  _OnWpaInterfaceProxyReady, nullptr);
+            wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(
+                G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, mWpaSupplicant.interfacePath, nullptr,
+                reinterpret_cast<GAsyncReadyCallback>(
+                    +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
+                        return self->_OnWpaInterfaceProxyReady(sourceObject_, res_);
+                    }),
+                this);
 
-            wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
-                                                            mWpaSupplicant.interfacePath, nullptr, _OnWpaBssProxyReady, nullptr);
+            wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus(
+                G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, mWpaSupplicant.interfacePath, nullptr,
+                reinterpret_cast<GAsyncReadyCallback>(
+                    +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
+                        return self->_OnWpaBssProxyReady(sourceObject_, res_);
+                    }),
+                this);
         }
         else
         {
@@ -649,8 +663,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * source_object, GAsy
     }
 }
 
-void ConnectivityManagerImpl::_OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties,
-                                                   gpointer user_data)
+void ConnectivityManagerImpl::_OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties)
 {
     // When creating D-Bus proxy object, the thread default context must be initialized. Otherwise,
     // all D-Bus signals will be delivered to the GLib global default main context.
@@ -669,17 +682,25 @@ void ConnectivityManagerImpl::_OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * prox
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_GOT_INTERFACE_PATH;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface added: %s", mWpaSupplicant.interfacePath);
 
-        wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
-                                                              mWpaSupplicant.interfacePath, nullptr, _OnWpaInterfaceProxyReady,
-                                                              nullptr);
+        wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(
+            G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, mWpaSupplicant.interfacePath, nullptr,
+            reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
+                    return self->_OnWpaInterfaceProxyReady(sourceObject_, res_);
+                }),
+            this);
 
-        wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
-                                                        mWpaSupplicant.interfacePath, nullptr, _OnWpaBssProxyReady, nullptr);
+        wpa_fi_w1_wpa_supplicant1_bss_proxy_new_for_bus(
+            G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, mWpaSupplicant.interfacePath, nullptr,
+            reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
+                    return self->_OnWpaBssProxyReady(sourceObject_, res_);
+                }),
+            this);
     }
 }
 
-void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties,
-                                                     gpointer user_data)
+void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties)
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
@@ -716,7 +737,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * pr
     }
 }
 
-void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data)
+void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * sourceObject, GAsyncResult * res)
 {
     // When creating D-Bus proxy object, the thread default context must be initialized. Otherwise,
     // all D-Bus signals will be delivered to the GLib global default main context.
@@ -732,11 +753,24 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncRe
         mWpaSupplicant.state = GDBusWpaSupplicant::WPA_CONNECTED;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to wpa_supplicant proxy");
 
-        g_signal_connect(mWpaSupplicant.proxy, "interface-added", G_CALLBACK(_OnWpaInterfaceAdded), NULL);
+        g_signal_connect(
+            mWpaSupplicant.proxy, "interface-added",
+            G_CALLBACK(+[](WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties,
+                           ConnectivityManagerImpl * self) { return self->_OnWpaInterfaceAdded(proxy, path, properties); }),
+            this);
+        g_signal_connect(
+            mWpaSupplicant.proxy, "interface-removed",
+            G_CALLBACK(+[](WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties,
+                           ConnectivityManagerImpl * self) { return self->_OnWpaInterfaceRemoved(proxy, path, properties); }),
+            this);
 
-        g_signal_connect(mWpaSupplicant.proxy, "interface-removed", G_CALLBACK(_OnWpaInterfaceRemoved), NULL);
-
-        wpa_fi_w1_wpa_supplicant1_call_get_interface(mWpaSupplicant.proxy, sWiFiIfName, nullptr, _OnWpaInterfaceReady, nullptr);
+        wpa_fi_w1_wpa_supplicant1_call_get_interface(
+            mWpaSupplicant.proxy, sWiFiIfName, nullptr,
+            reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
+                    return self->_OnWpaInterfaceReady(sourceObject_, res_);
+                }),
+            this);
     }
     else
     {
@@ -753,7 +787,8 @@ void ConnectivityManagerImpl::StartWiFiManagement()
     mConnectivityFlag.ClearAll();
     mWpaSupplicant = GDBusWpaSupplicant{};
 
-    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(_StartWiFiManagement, this);
+    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](ConnectivityManagerImpl * self) { return self->_StartWiFiManagement(); }, this);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Failed to start WiFi management"));
 }
 
@@ -829,7 +864,7 @@ void ConnectivityManagerImpl::DriveAPState()
                 // Compute the amount of idle time before the AP should be deactivated and
                 // arm a timer to fire at that time.
                 System::Clock::Timeout apTimeout = (mLastAPDemandTime + mWiFiAPIdleTimeout) - now;
-                err                              = DeviceLayer::SystemLayer().StartTimer(apTimeout, DriveAPState, nullptr);
+                err                              = DeviceLayer::SystemLayer().StartTimer(apTimeout, DriveAPState, this);
                 SuccessOrExit(err);
                 ChipLogProgress(DeviceLayer, "Next WiFi AP timeout in %" PRIu32 " s",
                                 std::chrono::duration_cast<System::Clock::Seconds32>(apTimeout).count());
@@ -916,7 +951,7 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
     // Clean up current network if exists
     if (mWpaSupplicant.networkPath)
     {
-        g_object_unref(mWpaSupplicant.networkPath);
+        g_free(mWpaSupplicant.networkPath);
         mWpaSupplicant.networkPath = nullptr;
     }
 
@@ -956,7 +991,7 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
 
         if (mWpaSupplicant.networkPath)
         {
-            g_object_unref(mWpaSupplicant.networkPath);
+            g_free(mWpaSupplicant.networkPath);
             mWpaSupplicant.networkPath = nullptr;
         }
 
@@ -977,7 +1012,7 @@ void ConnectivityManagerImpl::ChangeWiFiAPState(WiFiAPState newState)
 
 void ConnectivityManagerImpl::DriveAPState(::chip::System::Layer * aLayer, void * aAppState)
 {
-    sInstance.DriveAPState();
+    reinterpret_cast<ConnectivityManagerImpl *>(aAppState)->DriveAPState();
 }
 
 CHIP_ERROR
@@ -1030,8 +1065,14 @@ ConnectivityManagerImpl::_ConnectWiFiNetworkAsync(GVariant * args,
         wpa_fi_w1_wpa_supplicant1_interface_call_disconnect_sync(mWpaSupplicant.iface, nullptr, nullptr);
         ChipLogProgress(DeviceLayer, "wpa_supplicant: added network: %s", mWpaSupplicant.networkPath);
 
-        wpa_fi_w1_wpa_supplicant1_interface_call_select_network(mWpaSupplicant.iface, mWpaSupplicant.networkPath, nullptr,
-                                                                _ConnectWiFiNetworkAsyncCallback, this);
+        wpa_fi_w1_wpa_supplicant1_interface_call_select_network(
+            mWpaSupplicant.iface, mWpaSupplicant.networkPath, nullptr,
+            reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
+                    return self->_ConnectWiFiNetworkAsyncCallback(sourceObject_, res_);
+                }),
+            this);
+
         mpConnectCallback = apCallback;
     }
     else
@@ -1040,7 +1081,7 @@ ConnectivityManagerImpl::_ConnectWiFiNetworkAsync(GVariant * args,
 
         if (mWpaSupplicant.networkPath)
         {
-            g_object_unref(mWpaSupplicant.networkPath);
+            g_free(mWpaSupplicant.networkPath);
             mWpaSupplicant.networkPath = nullptr;
         }
 
@@ -1191,9 +1232,8 @@ CHIP_ERROR ConnectivityManagerImpl::ConnectWiFiNetworkWithPDCAsync(
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
 
-void ConnectivityManagerImpl::_ConnectWiFiNetworkAsyncCallback(GObject * source_object, GAsyncResult * res, gpointer user_data)
+void ConnectivityManagerImpl::_ConnectWiFiNetworkAsyncCallback(GObject * sourceObject, GAsyncResult * res)
 {
-    ConnectivityManagerImpl * this_ = reinterpret_cast<ConnectivityManagerImpl *>(user_data);
     GAutoPtr<GError> err;
 
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
@@ -1204,12 +1244,12 @@ void ConnectivityManagerImpl::_ConnectWiFiNetworkAsyncCallback(GObject * source_
         if (!result)
         {
             ChipLogError(DeviceLayer, "Failed to perform connect network: %s", err == nullptr ? "unknown error" : err->message);
-            DeviceLayer::SystemLayer().ScheduleLambda([this_]() {
+            DeviceLayer::SystemLayer().ScheduleLambda([this]() {
                 if (mpConnectCallback != nullptr)
                 {
                     // TODO(#14175): Replace this with actual thread attach result.
-                    this_->mpConnectCallback->OnResult(NetworkCommissioning::Status::kUnknownError, CharSpan(), 0);
-                    this_->mpConnectCallback = nullptr;
+                    mpConnectCallback->OnResult(NetworkCommissioning::Status::kUnknownError, CharSpan(), 0);
+                    mpConnectCallback = nullptr;
                 }
                 mpConnectCallback = nullptr;
             });
@@ -1796,7 +1836,7 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
     return true;
 }
 
-void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(GObject * source_object, GAsyncResult * res, gpointer user_data)
+void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(WpaFiW1Wpa_supplicant1Interface * proxy, gboolean success)
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
@@ -1806,7 +1846,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(GObject * source_object, G
     if (bsss == nullptr)
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: no network found");
-        DeviceLayer::SystemLayer().ScheduleLambda([]() {
+        DeviceLayer::SystemLayer().ScheduleLambda([this]() {
             if (mpScanCallback != nullptr)
             {
                 mpScanCallback->OnFinished(Status::kSuccess, CharSpan(), nullptr);
@@ -1833,7 +1873,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(GObject * source_object, G
         }
     }
 
-    DeviceLayer::SystemLayer().ScheduleLambda([networkScanned]() {
+    DeviceLayer::SystemLayer().ScheduleLambda([this, networkScanned]() {
         // Note: We cannot post a event in ScheduleLambda since std::vector is not trivial copiable. This results in the use of
         // const_cast but should be fine for almost all cases, since we actually handled the ownership of this element to this
         // lambda.
@@ -1850,15 +1890,19 @@ void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(GObject * source_object, G
     g_strfreev(oldBsss);
 }
 
-CHIP_ERROR ConnectivityManagerImpl::_StartWiFiManagement(ConnectivityManagerImpl * self)
+CHIP_ERROR ConnectivityManagerImpl::_StartWiFiManagement()
 {
     // When creating D-Bus proxy object, the thread default context must be initialized. Otherwise,
     // all D-Bus signals will be delivered to the GLib global default main context.
     VerifyOrDie(g_main_context_get_thread_default() != nullptr);
 
     ChipLogProgress(DeviceLayer, "wpa_supplicant: Start WiFi management");
-    wpa_fi_w1_wpa_supplicant1_proxy_new_for_bus(G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName,
-                                                kWpaSupplicantObjectPath, nullptr, self->_OnWpaProxyReady, nullptr);
+    wpa_fi_w1_wpa_supplicant1_proxy_new_for_bus(
+        G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, kWpaSupplicantServiceName, kWpaSupplicantObjectPath, nullptr,
+        reinterpret_cast<GAsyncReadyCallback>(+[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
+            return self->_OnWpaProxyReady(sourceObject_, res_);
+        }),
+        this);
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -155,14 +155,14 @@ private:
     CHIP_ERROR _ConnectWiFiNetworkAsync(GVariant * networkArgs,
                                         NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback)
         CHIP_REQUIRES(mWpaSupplicantMutex);
-    static void _ConnectWiFiNetworkAsyncCallback(GObject * source_object, GAsyncResult * res, gpointer user_data);
+    void _ConnectWiFiNetworkAsyncCallback(GObject * sourceObject, GAsyncResult * res);
 #endif
 
 public:
     const char * GetEthernetIfName() { return (mEthIfName[0] == '\0') ? nullptr : mEthIfName; }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    static const char * GetWiFiIfName() { return (sWiFiIfName[0] == '\0') ? nullptr : sWiFiIfName; }
+    const char * GetWiFiIfName() { return (sWiFiIfName[0] == '\0') ? nullptr : sWiFiIfName; }
 #endif
 
 private:
@@ -205,29 +205,27 @@ private:
     System::Clock::Timeout _GetWiFiAPIdleTimeout();
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     void UpdateNetworkStatus();
-    static CHIP_ERROR StopAutoScan();
+    CHIP_ERROR StopAutoScan();
 
-    static void _OnWpaProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
-    static void _OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties,
-                                       gpointer user_data);
-    static void _OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * proxy, const gchar * path, GVariant * properties, gpointer user_data);
-    static void _OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * changed_properties,
-                                        const gchar * const * invalidated_properties, gpointer user_data);
-    static void _OnWpaInterfaceReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
-    static void _OnWpaInterfaceProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
-    static void _OnWpaBssProxyReady(GObject * source_object, GAsyncResult * res, gpointer user_data);
-    static void _OnWpaInterfaceScanDone(GObject * source_object, GAsyncResult * res, gpointer user_data);
+    void _OnWpaProxyReady(GObject * sourceObject, GAsyncResult * res);
+    void _OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties);
+    void _OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties);
+    void _OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * properties);
+    void _OnWpaInterfaceScanDone(WpaFiW1Wpa_supplicant1Interface * proxy, gboolean success);
+    void _OnWpaInterfaceReady(GObject * sourceObject, GAsyncResult * res);
+    void _OnWpaInterfaceProxyReady(GObject * sourceObject, GAsyncResult * res);
+    void _OnWpaBssProxyReady(GObject * sourceObject, GAsyncResult * res);
 
-    static bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);
+    bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);
 
-    static CHIP_ERROR _StartWiFiManagement(ConnectivityManagerImpl * self);
+    CHIP_ERROR _StartWiFiManagement();
 
-    static bool mAssociationStarted;
-    static BitFlags<ConnectivityFlags> mConnectivityFlag;
-    static GDBusWpaSupplicant mWpaSupplicant CHIP_GUARDED_BY(mWpaSupplicantMutex);
+    bool mAssociationStarted = false;
+    BitFlags<ConnectivityFlags> mConnectivityFlag;
+    GDBusWpaSupplicant mWpaSupplicant CHIP_GUARDED_BY(mWpaSupplicantMutex);
     // Access to mWpaSupplicant has to be protected by a mutex because it is accessed from
     // the CHIP event loop thread and dedicated D-Bus thread started by platform manager.
-    static std::mutex mWpaSupplicantMutex;
+    std::mutex mWpaSupplicantMutex;
 
     NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
 #endif
@@ -262,13 +260,15 @@ private:
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    static char sWiFiIfName[IFNAMSIZ];
+    char sWiFiIfName[IFNAMSIZ];
 #endif
 
-    static uint8_t sInterestedSSID[Internal::kMaxWiFiSSIDLength];
-    static uint8_t sInterestedSSIDLen;
-    static NetworkCommissioning::WiFiDriver::ScanCallback * mpScanCallback;
-    static NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+    uint8_t sInterestedSSID[Internal::kMaxWiFiSSIDLength];
+    uint8_t sInterestedSSIDLen;
+#endif
+    NetworkCommissioning::WiFiDriver::ScanCallback * mpScanCallback;
+    NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * mpConnectCallback;
 };
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -108,13 +108,13 @@ gboolean WiFiIPChangeListener(GIOChannel * ch, GIOCondition /* condition */, voi
                             continue;
                         }
 
-                        if (ConnectivityManagerImpl::GetWiFiIfName() == nullptr)
+                        if (ConnectivityMgrImpl().GetWiFiIfName() == nullptr)
                         {
                             ChipLogDetail(DeviceLayer, "No wifi interface name. Ignoring IP update event.");
                             continue;
                         }
 
-                        if (strcmp(name, ConnectivityManagerImpl::GetWiFiIfName()) != 0)
+                        if (strcmp(name, ConnectivityMgrImpl().GetWiFiIfName()) != 0)
                         {
                             continue;
                         }


### PR DESCRIPTION
Fixes issue reported here: https://github.com/project-chip/connectedhomeip/issues/32033#issuecomment-1944277926

### Problem

All glib callback runs on glib thread. In order to call function which changes internal CHIP state, we need to lock CHIP stack lock beforehand. Due to changes in 86977c2a74c24dffe1dc799204fd64ee058c28fb, WiFi connection on Linux causes abort.

### Changes

- Lock CHIP stack before calling WiFi diagnostic delegate
- Fix signatures for properties-changed and scan-done callbacks
- Fix freeing char objects allocated by glib
- Convert static members/functions of `ConnectivityManagerImpl` to instance members

### Testing

Locally tested WiFi connection/disconnection during BLE commissioning.