### PR TITLE
[THREAD] Bring clear all Srp Client host and Services to the GenericThreadStackManagerImpl

### DIFF
--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -125,7 +125,7 @@ public:
     /*
      * @brief Utility function to clear all thread SRP host and services established between the SRP server and client.
      * It is expected that a transaction is done between the SRP server and client so the clear request is applied on both ends
-     * 
+     *
      * A generic implementation is provided in `GenericThreadStackManagerImpl_OpenThread` with the SoC OT stack
      */
     CHIP_ERROR ClearAllSrpHostAndServices();

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -121,6 +121,9 @@ public:
     CHIP_ERROR RemoveSrpService(const char * aInstanceName, const char * aName);
     CHIP_ERROR InvalidateAllSrpServices(); ///< Mark all SRP services as invalid
     CHIP_ERROR RemoveInvalidSrpServices(); ///< Remove SRP services marked as invalid
+    CHIP_ERROR ClearAllSrpHostAndServices();
+    void WaitOnSrpClearAllComplete();
+    void NotifySrpClearAllComplete();
     CHIP_ERROR SetupSrpHost(const char * aHostName);
     CHIP_ERROR ClearSrpHost(const char * aHostName);
     CHIP_ERROR SetSrpDnsCallbacks(DnsAsyncReturnCallback aInitCallback, DnsAsyncReturnCallback aErrorCallback, void * aContext);
@@ -287,6 +290,21 @@ inline CHIP_ERROR ThreadStackManager::InvalidateAllSrpServices()
 inline CHIP_ERROR ThreadStackManager::RemoveInvalidSrpServices()
 {
     return static_cast<ImplClass *>(this)->_RemoveInvalidSrpServices();
+}
+
+inline CHIP_ERROR ThreadStackManager::ClearAllSrpHostAndServices()
+{
+    return static_cast<ImplClass *>(this)->_ClearAllSrpHostAndServices();
+}
+
+inline void ThreadStackManager::WaitOnSrpClearAllComplete()
+{
+    return static_cast<ImplClass *>(this)->_WaitOnSrpClearAllComplete();
+}
+
+inline void ThreadStackManager::NotifySrpClearAllComplete()
+{
+    return static_cast<ImplClass *>(this)->_NotifySrpClearAllComplete();
 }
 
 inline CHIP_ERROR ThreadStackManager::SetupSrpHost(const char * aHostName)

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -121,8 +121,25 @@ public:
     CHIP_ERROR RemoveSrpService(const char * aInstanceName, const char * aName);
     CHIP_ERROR InvalidateAllSrpServices(); ///< Mark all SRP services as invalid
     CHIP_ERROR RemoveInvalidSrpServices(); ///< Remove SRP services marked as invalid
+
+    /*
+     * @brief Utility function to clear all thread SRP host and services established between the SRP server and client.
+     * It is expected that a transaction is done between the SRP server and client so the clear request is applied on both ends
+     * 
+     * A generic implementation is provided in `GenericThreadStackManagerImpl_OpenThread` with the SoC OT stack
+     */
     CHIP_ERROR ClearAllSrpHostAndServices();
+
+    /*
+     * @brief Used to synchronize on the SRP server response confirming the clearing of the host and service entries
+     * Should be called in ClearAllSrpHostAndServices once the request is sent.
+     */
     void WaitOnSrpClearAllComplete();
+
+    /*
+     * @brief Notify that the SRP server confirmed the clearing of the host and service entries
+     * Should be called in the SRP Client set callback in the removal confirmation.
+     */
     void NotifySrpClearAllComplete();
     CHIP_ERROR SetupSrpHost(const char * aHostName);
     CHIP_ERROR ClearSrpHost(const char * aHostName);

--- a/src/platform/ESP32/ThreadStackManagerImpl.h
+++ b/src/platform/ESP32/ThreadStackManagerImpl.h
@@ -68,10 +68,21 @@ protected:
     void _OnCHIPoBLEAdvertisingStart();
     void _OnCHIPoBLEAdvertisingStop();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete();
+    void _NotifySrpClearAllComplete();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    // ===== Methods that override the GenericThreadStackMa
+
 private:
     friend ThreadStackManager & ::chip::DeviceLayer::ThreadStackMgr(void);
     friend ThreadStackManagerImpl & ::chip::DeviceLayer::ThreadStackMgrImpl(void);
     static ThreadStackManagerImpl sInstance;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    TaskHandle_t mSrpClearAllRequester = nullptr;
+#endif
+
     ThreadStackManagerImpl() = default;
 };
 

--- a/src/platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.h
+++ b/src/platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.h
@@ -64,6 +64,10 @@ protected:
     bool _TryLockThreadStack(void);
     void _UnlockThreadStack(void);
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete();
+    void _NotifySrpClearAllComplete();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     // ===== Members available to the implementation subclass.
 
     SemaphoreHandle_t mThreadStackLock;
@@ -87,6 +91,10 @@ private:
 
 #if defined(CHIP_CONFIG_FREERTOS_USE_STATIC_SEMAPHORE) && CHIP_CONFIG_FREERTOS_USE_STATIC_SEMAPHORE
     StaticSemaphore_t mThreadStackLockMutex;
+#endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    TaskHandle_t mSrpClearAllRequester = nullptr;
 #endif
 };
 

--- a/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.cpp
+++ b/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.cpp
@@ -54,6 +54,14 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
     VerifyOrExit(result == WICED_SUCCESS, err = CHIP_ERROR_INTERNAL);
     otSysInit(0, NULL);
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    mSrpClearAllSemaphore = wiced_rtos_create_mutex();
+    VerifyOrExit(mSrpClearAllSemaphore != nullptr, err = CHIP_ERROR_NO_MEMORY);
+
+    result = wiced_rtos_init_mutex(mSrpClearAllSemaphore);
+    VerifyOrExit(result == WICED_SUCCESS, err = CHIP_ERROR_INTERNAL);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     err = GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(NULL);
 
 exit:
@@ -94,6 +102,21 @@ void ThreadStackManagerImpl::_UnlockThreadStack()
     const wiced_result_t result = wiced_rtos_unlock_mutex(mMutex);
     VerifyOrReturn(result == WICED_SUCCESS || result == WICED_NOT_OWNED, ChipLogError(DeviceLayer, "%s %x", __func__, result));
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+void ThreadStackManagerImpl::_WaitOnSrpClearAllComplete()
+{
+    const wiced_result_t result = wiced_rtos_lock_mutex(mSrpClearAllSemaphore);
+    VerifyOrReturn(result == WICED_SUCCESS, ChipLogError(DeviceLayer, "%s %x", __func__, result));
+}
+
+void ThreadStackManagerImpl::_NotifySrpClearAllComplete()
+{
+    const wiced_result_t result = wiced_rtos_unlock_mutex(mSrpClearAllSemaphore);
+    VerifyOrReturn(result == WICED_SUCCESS || result == WICED_NOT_OWNED, ChipLogError(DeviceLayer, "%s %x", __func__, result));
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+// ===== Methods that override the GenericThreadStackMa
 
 void ThreadStackManagerImpl::ThreadTaskMain(void)
 {

--- a/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.h
+++ b/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.h
@@ -58,6 +58,11 @@ protected:
     bool _TryLockThreadStack();
     void _UnlockThreadStack();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete();
+    void _NotifySrpClearAllComplete();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    // ===== Methods that override the GenericThreadStackMa
 private:
     // ===== Members for internal use by the following friends.
 
@@ -67,6 +72,9 @@ private:
     wiced_thread_t * mThread;
     EventFlags mEventFlags;
     wiced_mutex_t * mMutex;
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    wiced_mutex_t * mSrpClearAllSemaphore;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     static ThreadStackManagerImpl sInstance;
 
     // ===== Private members for use by this class only.

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -57,6 +57,11 @@ public:
     bool _TryLockThreadStack() { return false; }            // Intentionally left blank
     void _UnlockThreadStack() {}                            // Intentionally left blank
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete() {}
+    void _NotifySrpClearAllComplete() {}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     bool _HaveRouteToAddress(const Inet::IPAddress & destAddr);
 
     void _OnPlatformEvent(const ChipDeviceEvent * event);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -121,6 +121,7 @@ protected:
     CHIP_ERROR _RemoveSrpService(const char * aInstanceName, const char * aName);
     CHIP_ERROR _InvalidateAllSrpServices();
     CHIP_ERROR _RemoveInvalidSrpServices();
+    CHIP_ERROR _ClearAllSrpHostAndServices();
 
     CHIP_ERROR _SetupSrpHost(const char * aHostName);
     CHIP_ERROR _ClearSrpHost(const char * aHostName);
@@ -202,6 +203,8 @@ private:
     };
 
     SrpClient mSrpClient;
+
+    bool mIsSrpClearAllRequested = false;
 
     static void OnSrpClientNotification(otError aError, const otSrpClientHostInfo * aHostInfo, const otSrpClientService * aServices,
                                         const otSrpClientService * aRemovedServices, void * aContext);

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -646,6 +646,12 @@ CHIP_ERROR ThreadStackManagerImpl::_RemoveInvalidSrpServices()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ThreadStackManagerImpl::_ClearAllSrpHostAndServices()
+{
+    // TODO : could not find info on Tizen thread apis
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 void ThreadStackManagerImpl::_ThreadIpAddressCb(int index, char * ipAddr, thread_ipaddr_type_e ipAddrType, void * userData)
 {
     VerifyOrReturn(ipAddr != nullptr, ChipLogError(DeviceLayer, "FAIL: Invalid argument: Thread ipAddr not found"));

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -648,8 +648,12 @@ CHIP_ERROR ThreadStackManagerImpl::_RemoveInvalidSrpServices()
 
 CHIP_ERROR ThreadStackManagerImpl::_ClearAllSrpHostAndServices()
 {
-    // TODO : could not find info on Tizen thread apis
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    for (auto it = mSrpClientServices.begin(); it != mSrpClientServices.end();)
+    {
+        ReturnErrorOnFailure(_RemoveSrpService(it->mInstanceName, it->mName));
+        it = mSrpClientServices.erase(it);
+    }
+    return CHIP_NO_ERROR;
 }
 
 void ThreadStackManagerImpl::_ThreadIpAddressCb(int index, char * ipAddr, thread_ipaddr_type_e ipAddrType, void * userData)

--- a/src/platform/Tizen/ThreadStackManagerImpl.h
+++ b/src/platform/Tizen/ThreadStackManagerImpl.h
@@ -57,6 +57,11 @@ public:
     bool _TryLockThreadStack() { return false; }            // Intentionally left blank
     void _UnlockThreadStack() {}                            // Intentionally left blank
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete() {}
+    void _NotifySrpClearAllComplete() {}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     bool _HaveRouteToAddress(const Inet::IPAddress & destAddr);
 
     void _OnPlatformEvent(const ChipDeviceEvent * event);

--- a/src/platform/Tizen/ThreadStackManagerImpl.h
+++ b/src/platform/Tizen/ThreadStackManagerImpl.h
@@ -120,6 +120,7 @@ public:
     CHIP_ERROR _RemoveSrpService(const char * aInstanceName, const char * aName);
     CHIP_ERROR _InvalidateAllSrpServices();
     CHIP_ERROR _RemoveInvalidSrpServices();
+    CHIP_ERROR _ClearAllSrpHostAndServices();
     CHIP_ERROR _SetupSrpHost(const char * aHostName);
     CHIP_ERROR _ClearSrpHost(const char * aHostName);
     CHIP_ERROR _SetSrpDnsCallbacks(DnsAsyncReturnCallback aInitCallback, DnsAsyncReturnCallback aErrorCallback, void * aContext);

--- a/src/platform/Zephyr/ThreadStackManagerImpl.cpp
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.cpp
@@ -66,6 +66,10 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
         return MapOpenThreadError(otError);
     });
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    k_sem_init(&mSrpClearAllSemaphore, 0, 1);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     return CHIP_NO_ERROR;
 }
 
@@ -84,6 +88,18 @@ void ThreadStackManagerImpl::_UnlockThreadStack()
 {
     openthread_api_mutex_unlock(openthread_get_default_context());
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+void ThreadStackManagerImpl::_WaitOnSrpClearAllComplete()
+{
+    k_sem_take(&mSrpClearAllSemaphore, K_SECONDS(2));
+}
+
+void ThreadStackManagerImpl::_NotifySrpClearAllComplete()
+{
+    k_sem_give(&mSrpClearAllSemaphore);
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Zephyr/ThreadStackManagerImpl.h
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.h
@@ -71,6 +71,10 @@ protected:
     bool _TryLockThreadStack();
     void _UnlockThreadStack();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete();
+    void _NotifySrpClearAllComplete();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     // ===== Methods that override the GenericThreadStackManagerImpl_OpenThread abstract interface.
 
     void _ProcessThreadActivity() {}
@@ -82,6 +86,10 @@ private:
 
     friend ThreadStackManager & ::chip::DeviceLayer::ThreadStackMgr(void);
     friend ThreadStackManagerImpl & ::chip::DeviceLayer::ThreadStackMgrImpl(void);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    k_sem mSrpClearAllSemaphore;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
     static ThreadStackManagerImpl sInstance;
 

--- a/src/platform/silabs/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/ConfigurationManagerImpl.cpp
@@ -272,7 +272,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-    ThreadStackMgrImpl().RemoveAllSrpServices();
+    ThreadStackMgr().ClearAllSrpHostAndServices();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     ChipLogProgress(DeviceLayer, "Clearing Thread provision");
     ThreadStackMgr().ErasePersistentInfo();

--- a/src/platform/silabs/ThreadStackManagerImpl.h
+++ b/src/platform/silabs/ThreadStackManagerImpl.h
@@ -72,19 +72,11 @@ public:
 
     using ThreadStackManager::InitThreadStack;
     CHIP_ERROR InitThreadStack(otInstance * otInst);
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-    void RemoveAllSrpServices();
-#endif
 
 private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-    static void OnSrpClientRemoveCallback(otError aError, const otSrpClientHostInfo * aHostInfo,
-                                          const otSrpClientService * aServices, const otSrpClientService * aRemovedServices,
-                                          void * aContext);
-#endif
     // ===== Members for internal use by the following friends.
 
     friend ThreadStackManager & ::chip::DeviceLayer::ThreadStackMgr(void);
@@ -94,9 +86,6 @@ private:
     static ThreadStackManagerImpl sInstance;
 
     static bool IsInitialized();
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-    TaskHandle_t srpRemoveRequester = nullptr;
-#endif
 
     // ===== Private members for use by this class only.
 

--- a/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ThreadStackManagerImpl.cpp
@@ -66,58 +66,6 @@ bool ThreadStackManagerImpl::IsInitialized()
     return sInstance.mThreadStackLock != NULL;
 }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-/*
- * @brief Notifies `RemoveAllSrpServices` that the Srp Client removal has completed
- *        and unblock the calling task.
- *
- *  No data is processed.
- */
-void ThreadStackManagerImpl::OnSrpClientRemoveCallback(otError aError, const otSrpClientHostInfo * aHostInfo,
-                                                       const otSrpClientService * aServices,
-                                                       const otSrpClientService * aRemovedServices, void * aContext)
-{
-    if (ThreadStackMgrImpl().srpRemoveRequester)
-    {
-        xTaskNotifyGive(ThreadStackMgrImpl().srpRemoveRequester);
-    }
-}
-
-/*
- * @brief This is a utility function to remove all Thread client Srp services
- * established between the device and the srp server (in most cases the OTBR).
- * The calling task is blocked until OnSrpClientRemoveCallback.
- *
- * Note: This function is meant to be used during the factory reset sequence.
- *       It overrides the generic SrpClient callback `OnSrpClientNotification` with
- *       OnSrpClientRemoveCallback which doesn't process any of the callback data.
- *
- *       If there is a usecase where this function would be needed in a non-Factory reset context,
- *       OnSrpClientRemoveCallback should be extended and tied back with the GenericThreadStackManagerImpl_OpenThread
- *       management of the srp clients.
- */
-void ThreadStackManagerImpl::RemoveAllSrpServices()
-{
-    // This check ensure that only one srp services removal is running
-    if (ThreadStackMgrImpl().srpRemoveRequester == nullptr)
-    {
-        srpRemoveRequester = xTaskGetCurrentTaskHandle();
-        otSrpClientSetCallback(OTInstance(), &OnSrpClientRemoveCallback, nullptr);
-        InvalidateAllSrpServices();
-        if (RemoveInvalidSrpServices() == CHIP_NO_ERROR)
-        {
-            // Wait for the OnSrpClientRemoveCallback.
-            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(2000));
-        }
-        else
-        {
-            ChipLogError(DeviceLayer, "Failed to remove srp services");
-        }
-        ThreadStackMgrImpl().srpRemoveRequester = nullptr;
-    }
-}
-#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
-
 } // namespace DeviceLayer
 } // namespace chip
 

--- a/src/platform/telink/ThreadStackManagerImpl.cpp
+++ b/src/platform/telink/ThreadStackManagerImpl.cpp
@@ -68,6 +68,10 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
         return MapOpenThreadError(otError);
     });
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    k_sem_init(&mSrpClearAllSemaphore, 0, 1);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     return CHIP_NO_ERROR;
 }
 
@@ -86,6 +90,18 @@ void ThreadStackManagerImpl::_UnlockThreadStack()
 {
     openthread_api_mutex_unlock(openthread_get_default_context());
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+void ThreadStackManagerImpl::_WaitOnSrpClearAllComplete()
+{
+    k_sem_take(&mSrpClearAllSemaphore, K_SECONDS(2));
+}
+
+void ThreadStackManagerImpl::_NotifySrpClearAllComplete()
+{
+    k_sem_give(&mSrpClearAllSemaphore);
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
 CHIP_ERROR
 ThreadStackManagerImpl::_AttachToThreadNetwork(const Thread::OperationalDataset & dataset,

--- a/src/platform/telink/ThreadStackManagerImpl.h
+++ b/src/platform/telink/ThreadStackManagerImpl.h
@@ -74,6 +74,10 @@ protected:
     bool _TryLockThreadStack();
     void _UnlockThreadStack();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete();
+    void _NotifySrpClearAllComplete();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     // ===== Methods that override the GenericThreadStackManagerImpl_OpenThread abstract interface.
 
     void _ProcessThreadActivity() {}
@@ -94,6 +98,10 @@ private:
     // ===== Private members for use by this class only.
     bool mRadioBlocked;
     bool mReadyToAttach;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    k_sem mSrpClearAllSemaphore;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
     NetworkCommissioning::ThreadDriver::ScanCallback * mpScanCallback;
 };

--- a/src/platform/webos/ThreadStackManagerImpl.h
+++ b/src/platform/webos/ThreadStackManagerImpl.h
@@ -50,6 +50,11 @@ public:
     bool _TryLockThreadStack() { return false; }            // Intentionally left blank
     void _UnlockThreadStack() {}                            // Intentionally left blank
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete() {}
+    void _NotifySrpClearAllComplete() {}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     bool _HaveRouteToAddress(const Inet::IPAddress & destAddr);
 
     void _OnPlatformEvent(const ChipDeviceEvent * event);


### PR DESCRIPTION
This PR brings #31606 feature to The GenericThreadStackManagerImpl. 
The functionality remains the same (with the addition of deleting the client key lease also).

However, this requires each platform that uses it, to provide a synchronization mechanism.

I created the Templates `_WaitOnSrpClearAllComplete` and `_NotifySrpClearAllComplete` and I provided an implementation for all platforms using the GenericThreadStackManagerImpl. (It is left unimplemented for others)

The synchronization mechanism I chose for Zephyr platforms (nordic/telink) and Infineon might not be optional so suggestions are welcome.

The functionality was only tested on the Silabs platform and is currently only used on it also. I am confident it works for all FreeRTOS-based platforms. 

I suggest all other thread platform owners take some time to test and use `ClearAllSrpHostAndServices` during their factory-reset sequence.
