### PR TITLE
[Ameba] Add clusters and modifications

### DIFF
--- a/examples/all-clusters-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-app/ameba/chip_main.cmake
@@ -153,6 +153,8 @@ endif (matter_enable_ota_requestor)
 list(
     APPEND ${list_chip_main_sources}
 
+    ${chip_dir}/src/app/clusters/microwave-oven-control-server/microwave-oven-control-server.cpp
+
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/air-quality-instance.cpp
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/concentration-measurement-instances.cpp
@@ -161,6 +163,7 @@ list(
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/energy-preference-delegate.cpp
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/fan-stub.cpp
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/oven-modes.cpp
+    ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/laundry-dryer-controls-delegate-impl.cpp
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/laundry-washer-controls-delegate-impl.cpp
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/resource-monitoring-delegates.cpp
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/rvc-modes.cpp
@@ -169,6 +172,10 @@ list(
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/static-supported-temperature-levels.cpp
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/operational-state-delegate-impl.cpp
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/rvc-operational-state-delegate-impl.cpp
+    ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/microwave-oven-mode.cpp
+    ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/oven-modes.cpp
+    ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/oven-operational-state-delegate.cpp
+
     ${chip_dir}/examples/all-clusters-app/ameba/main/chipinterface.cpp
     ${chip_dir}/examples/all-clusters-app/ameba/main/BindingHandler.cpp
     ${chip_dir}/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
@@ -177,6 +184,8 @@ list(
     ${chip_dir}/examples/all-clusters-app/ameba/main/LEDWidget.cpp
     ${chip_dir}/examples/all-clusters-app/ameba/main/ManualOperationCommand.cpp
     ${chip_dir}/examples/all-clusters-app/ameba/main/SmokeCOAlarmManager.cpp
+
+    ${chip_dir}/examples/microwave-oven-app/microwave-oven-common/src/microwave-oven-device.cpp
 
     ${chip_dir}/examples/energy-management-app/energy-management-common/src/DeviceEnergyManagementDelegateImpl.cpp
     ${chip_dir}/examples/energy-management-app/energy-management-common/src/DeviceEnergyManagementManager.cpp
@@ -228,6 +237,8 @@ target_include_directories(
     ${chip_dir}/zzz_generated/app-common
     ${chip_dir}/examples/all-clusters-app/all-clusters-common
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/include
+    ${chip_dir}/examples/microwave-oven-app/microwave-oven-common
+    ${chip_dir}/examples/microwave-oven-app/microwave-oven-common/include
     ${chip_dir}/examples/energy-management-app/energy-management-common/include
     ${chip_dir}/examples/all-clusters-app/ameba/main/include
     ${chip_dir}/examples/platform/ameba

--- a/examples/all-clusters-app/ameba/main/ManualOperationCommand.cpp
+++ b/examples/all-clusters-app/ameba/main/ManualOperationCommand.cpp
@@ -79,6 +79,7 @@ static void RegisterManualOperationCommands()
         { &ManualRVCCommandHandler, "rvc", " Usage: manual rvc <subcommand>" },
         { &ManualRefrigeratorAlarmCommandHandler, "refalm", " Usage: manual refalm <subcommand>" },
         { &ManualDishWasherAlarmCommandHandler, "dishalm", " Usage: manual dishalm <subcommand>" },
+        { &ManualOvenCavityOperationalStateCommandHandler, "oven-opstate", " Usage: manual dishalm <subcommand>" },
     };
 
     static const shell_command_t sManualOperationalStateSubCommands[] = {
@@ -123,6 +124,14 @@ static void RegisterManualOperationCommands()
         { &ManualDishWasherAlarmSetLowerCommandHandler, "lower", "lower Usage: manual dishalm lower" },
     };
 
+    static const shell_command_t sManualOvenCavityOperationalStateSubCommands[] = {
+        { &ManualOvenCavityOperationalStateCommandHelpHandler, "help", "Usage: manual oven-opstate <subcommand>" },
+        { &ManualOvenCavityOperationalStateSetStateCommandHandler, "set-state",
+          "set-state Usage: manual oven-opstate set-state <state>" },
+        { &ManualOvenCavityOperationalStateSetErrorCommandHandler, "set-error",
+          "set-error Usage: manual oven-opstate set-error <error>" },
+    };
+
     static const shell_command_t sManualOperationCommand = { &ManualOperationCommandHandler, "manual",
                                                              "Manual Operation commands. Usage: manual <subcommand>" };
 
@@ -139,6 +148,8 @@ static void RegisterManualOperationCommands()
                                                                    ArraySize(sManualRefrigeratorAlarmStateSubCommands));
     sShellManualDishWasherAlarmStateSubCommands.RegisterCommands(sManualDishWasherAlarmSubCommands,
                                                                  ArraySize(sManualDishWasherAlarmSubCommands));
+    sShellManualOvenCavityOperationalStateSubCommands.RegisterCommands(sManualOvenCavityOperationalStateSubCommands,
+                                                                       ArraySize(sManualOvenCavityOperationalStateSubCommands));
 
     Engine::Root().RegisterCommands(&sManualOperationCommand, 1);
 }

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -17,6 +17,7 @@
 
 #include <platform_stdlib.h>
 
+#include "AmebaObserver.h"
 #include "BindingHandler.h"
 #include "CHIPDeviceManager.h"
 #include "DeviceCallbacks.h"
@@ -28,13 +29,16 @@
 #include <lwip_netconf.h>
 
 #include <app/clusters/identify-server/identify-server.h>
+#include <app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-server.h>
 #include <app/clusters/laundry-washer-controls-server/laundry-washer-controls-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/af.h>
+#include <laundry-dryer-controls-delegate-impl.h>
 #include <laundry-washer-controls-delegate-impl.h>
 #include <lib/core/ErrorStr.h>
+#include <microwave-oven-device.h>
 #include <platform/Ameba/AmebaConfig.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -43,6 +47,7 @@
 #include <static-supported-temperature-levels.h>
 #include <support/CHIPMem.h>
 #if CONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER
+#include <app/clusters/smoke-co-alarm-server/SmokeCOTestEventTriggerHandler.h>
 #include <test_event_trigger/AmebaTestEventTriggerDelegate.h>
 #endif
 
@@ -140,11 +145,11 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
 
 #if CONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER
-    // TODO(#31723): Show to customers that they can do `Server::GetInstance().GetTestEventTriggerDelegate().AddHandler(xxx)`
-    // to add custom handlers during their app init, after InitServer.
     static AmebaTestEventTriggerDelegate sTestEventTriggerDelegate{ ByteSpan(sTestEventTriggerEnableKey) };
     initParams.testEventTriggerDelegate = &sTestEventTriggerDelegate;
 #endif
+    static AmebaObserver sAmebaObserver;
+    initParams.appDelegate = &sAmebaObserver;
 
     initParams.InitializeStaticResourcesBeforeServerInit();
 
@@ -166,6 +171,12 @@ static void InitServer(intptr_t context)
     InitManualOperation();
 #endif
     app::Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
+    MatterMicrowaveOvenServerInit();
+#if CONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER
+    static SmokeCOTestEventTriggerHandler sSmokeCOTestEventTriggerHandler;
+    Server::GetInstance().GetTestEventTriggerDelegate()->AddHandler(&sSmokeCOTestEventTriggerHandler);
+#endif
+    chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
 }
 
 extern "C" void ChipTest(void)
@@ -212,4 +223,10 @@ using namespace chip::app::Clusters::LaundryWasherControls;
 void emberAfLaundryWasherControlsClusterInitCallback(EndpointId endpoint)
 {
     LaundryWasherControlsServer::SetDefaultDelegate(endpoint, &LaundryWasherControlDelegate::getLaundryWasherControlDelegate());
+}
+
+using namespace chip::app::Clusters::LaundryDryerControls;
+void emberAfLaundryDryerControlsClusterInitCallback(EndpointId endpoint)
+{
+    LaundryDryerControlsServer::SetDefaultDelegate(endpoint, &LaundryDryerControlDelegate::getLaundryDryerControlDelegate());
 }

--- a/examples/all-clusters-app/ameba/main/include/AmebaObserver.h
+++ b/examples/all-clusters-app/ameba/main/include/AmebaObserver.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include <app/server/Server.h>
 #include <app/server/AppDelegate.h>
+#include <app/server/Server.h>
 #include <credentials/FabricTable.h>
 
 namespace chip {

--- a/examples/all-clusters-app/ameba/main/include/AmebaObserver.h
+++ b/examples/all-clusters-app/ameba/main/include/AmebaObserver.h
@@ -1,0 +1,47 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/server/Server.h>
+#include <app/server/AppDelegate.h>
+#include <credentials/FabricTable.h>
+
+namespace chip {
+
+class AmebaObserver : public AppDelegate, public FabricTable::Delegate
+{
+public:
+    // Commissioning Observer
+    void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) override
+    {
+        ChipLogProgress(DeviceLayer, "Ameba Observer: Commissioning error (0x%x)", err);
+        // Handle commissioning errror here
+    }
+    // Fabric Observer
+    void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override
+    {
+        ChipLogProgress(DeviceLayer, "Ameba Observer: Fabric 0x%x has been Removed", fabricIndex);
+        if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0)
+        {
+            // Customer code
+        }
+    }
+};
+
+} // namespace chip

--- a/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.cpp
+++ b/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.cpp
@@ -21,6 +21,13 @@
 
 using namespace ::chip::DeviceLayer;
 
+bool AmebaHandleGlobalTestEventTrigger(uint64_t eventTrigger)
+{
+    // Customer can trigger action on the Ameba layer based on the eventTrigger
+    ChipLogProgress(Support, "[AmebaHandleGlobalTestEventTrigger] Received Event Trigger: 0x%016llx", eventTrigger);
+    return false;
+}
+
 namespace chip {
 
 bool AmebaTestEventTriggerDelegate::DoesEnableKeyMatch(const ByteSpan & enableKey) const

--- a/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.h
+++ b/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.h
@@ -34,12 +34,10 @@
  *
  * @warning *** DO NOT USE FOR STANDARD CLUSTER EVENT TRIGGERS ***
  *
- * TODO(#31723): Rename `emberAfHandleEventTrigger` to `AmebaHandleGlobalTestEventTrigger`
- *
  * @retval true on success
  * @retval false if error happened
  */
-bool emberAfHandleEventTrigger(uint64_t eventTrigger);
+bool AmebaHandleGlobalTestEventTrigger(uint64_t eventTrigger);
 
 namespace chip {
 
@@ -61,7 +59,7 @@ public:
     CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
     {
         // WARNING: LEGACY SUPPORT ONLY, DO NOT EXTEND FOR STANDARD CLUSTERS
-        return (emberAfHandleEventTrigger(eventTrigger)) ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_ARGUMENT;
+        return (AmebaHandleGlobalTestEventTrigger(eventTrigger)) ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_ARGUMENT;
     }
 
 private:

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -158,8 +158,8 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 
     char temp[32];
     uint32_t mac[ETH_ALEN];
-    char * token = strtok(temp, ":");
-    int i        = 0;
+    char * token;
+    int i = 0;
 
     error = matter_wifi_get_mac_address(temp);
     err   = AmebaUtils::MapError(error, AmebaErrorType::kWiFiError);
@@ -169,6 +169,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
         goto exit;
     }
 
+    token = strtok(temp, ":");
     while (token != NULL)
     {
         mac[i] = (uint32_t) strtol(token, NULL, 16);


### PR DESCRIPTION
+ Added AmebaObserver.h to observe failed commissioning and deleted fabric
+ Added microwave device and laundry dryer cluster in all-clusters-app
* Modified AmebaTestEventTriggerDelegate.cpp/h and chipinterface.cpp as mentioned in #31723
* Modified ConfigurationManagerImpl.cpp
* Modified ManualOperationalStateCommand.h and ManualOperationCommand.cpp to add manual operation of Oven Cavity Operational State