### PR TITLE
[CI] Add --trace_decode supports when starting an accessory from a YA…

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/accessory_server_bridge.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/accessory_server_bridge.py
@@ -77,6 +77,9 @@ def _get_start_options(request):
             elif name == 'crashLogPath':
                 options.append('--crash_log')
                 options.append(str(value))
+            elif name == 'traceDecode':
+                options.append('--trace_decode')
+                options.append(str(value))
             elif name == 'registerKey':
                 pass
             else:

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/system_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/system_commands.py
@@ -33,6 +33,7 @@ _DEFINITION = '''<?xml version="1.0"?>
       <arg name="endUserSupportLogPath" type="char_string" optional="true"/>
       <arg name="networkDiagnosticsLogPath" type="char_string" optional="true"/>
       <arg name="crashLogPath" type="char_string" optional="true"/>
+      <arg name="traceDecode" type="int8u" optional="true"/>
     </command>
 
     <command source="client" code="1" name="Stop">


### PR DESCRIPTION
…ML test

#### Problem

When debugging the server responses from YAMLs ran with `./scripts/tests/run_test_suite.py` this may help to turn on `trace_decode`.

This PR adds such support to the `Start` command.