### PR TITLE
Bump cloudbuild image version to 36

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -6,7 +6,7 @@ steps:
           - "--init"
           - "--recursive"
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:35"
+    - name: "ghcr.io/project-chip/chip-build-vscode:36"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -21,7 +21,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:35"
+    - name: "ghcr.io/project-chip/chip-build-vscode:36"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -85,7 +85,7 @@ steps:
               --target k32w-shell
               build
               --create-archives /workspace/artifacts/
-    - name: "ghcr.io/project-chip/chip-build-vscode:35"
+    - name: "ghcr.io/project-chip/chip-build-vscode:36"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "ghcr.io/project-chip/chip-build-vscode:35"
+    - name: "ghcr.io/project-chip/chip-build-vscode:36"
       entrypoint: "bash"
       args:
           - "-c"
@@ -7,7 +7,7 @@ steps:
               git config --global --add safe.directory "*"
               git submodule update --init --recursive
       id: Submodules
-    - name: "ghcr.io/project-chip/chip-build-vscode:35"
+    - name: "ghcr.io/project-chip/chip-build-vscode:36"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -22,7 +22,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:35"
+    - name: "ghcr.io/project-chip/chip-build-vscode:36"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -43,7 +43,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "ghcr.io/project-chip/chip-build-vscode:35"
+    - name: "ghcr.io/project-chip/chip-build-vscode:36"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -64,7 +64,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:35"
+    - name: "ghcr.io/project-chip/chip-build-vscode:36"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -86,7 +86,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:35"
+    - name: "ghcr.io/project-chip/chip-build-vscode:36"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -139,7 +139,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:35"
+    - name: "ghcr.io/project-chip/chip-build-vscode:36"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
Since #32171, efr32 builds require image version 36.

Update cloudbuild image to that as well, otherwise builds fail. Marking as hotfix since cloudbuild changes cannot be validated by github CI.