### PR TITLE
Remove unnecessary include from OperationalSessionSetupPool.h

### DIFF
--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -30,8 +30,6 @@
 
 namespace chip {
 
-class OperationalSessionSetupPoolDelegate;
-
 struct CASESessionManagerConfig
 {
     CASEClientInitParams sessionInitParams;

--- a/src/app/OperationalSessionSetupPool.h
+++ b/src/app/OperationalSessionSetupPool.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <app/CASESessionManager.h>
 #include <app/OperationalSessionSetup.h>
 #include <lib/support/Pool.h>
 #include <transport/Session.h>


### PR DESCRIPTION
Without this, `CASESessionManager` includes `OperationalSessionSetupPool` and vice-versa. This seems odd.

![image](https://github.com/project-chip/connectedhomeip/assets/1832280/aa91716c-aecb-44bd-8798-142713704e17)
