### PR TITLE
[Silabs] Silabs fix app error

### DIFF
--- a/examples/platform/silabs/main.cpp
+++ b/examples/platform/silabs/main.cpp
@@ -71,8 +71,9 @@ int main(void)
 
 void application_start(void * unused)
 {
-    if (SilabsMatterConfig::InitMatter(BLE_DEV_NAME) != CHIP_NO_ERROR)
-        appError(CHIP_ERROR_INTERNAL);
+    CHIP_ERROR err = SilabsMatterConfig::InitMatter(BLE_DEV_NAME);
+    if (err != CHIP_NO_ERROR)
+        appError(err);
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
@@ -83,8 +84,9 @@ void application_start(void * unused)
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     SILABS_LOG("Starting App Task");
-    if (AppTask::GetAppTask().StartAppTask() != CHIP_NO_ERROR)
-        appError(CHIP_ERROR_INTERNAL);
+    err = AppTask::GetAppTask().StartAppTask();
+    if (err != CHIP_NO_ERROR)
+        appError(err);
 
     vTaskDelete(main_Task);
 }

--- a/examples/platform/silabs/silabs_utils.cpp
+++ b/examples/platform/silabs/silabs_utils.cpp
@@ -27,7 +27,7 @@ void appError(int err)
     snprintf(faultMessage, sizeof faultMessage, "App Critical Error:%d", err);
     SILABS_LOG("!!!!!!!!!!!! %s !!!!!!!!!!!", faultMessage);
     chip::DeviceLayer::Silabs::OnSoftwareFaultEventHandler(faultMessage);
-    vTaskDelay(pdMS_TO_TICKS(1000));
+    vTaskSuspendAll();
     /* Force an assert. */
     chipAbort();
 }


### PR DESCRIPTION
Two minor fixes in this PR : 
- Actually print the error if initialization fails
- Suspend the scheduler to prevent other task from using an unsafe application (in case of init failure.

