### PR TITLE
Improve "need a custom toolchain" message to log more information.

### DIFF
--- a/build/config/BUILDCONFIG.gn
+++ b/build/config/BUILDCONFIG.gn
@@ -127,7 +127,9 @@ if (_chip_defaults.custom_toolchain != "") {
            "Unsupported target_cpu: ${current_cpu}. Shall be arm for webOS")
   }
 } else {
-  assert(false, "No toolchain specified, please specify custom_toolchain")
+  assert(
+      false,
+      "No toolchain specified, please specify custom_toolchain for host_os='${host_os}', target_os='${target_os}', host_cpu='${host_cpu}', target_cpu='${target_cpu}'")
 }
 
 set_default_toolchain(_default_toolchain)


### PR DESCRIPTION
Logging what gn thinks is going on for the host/target OS and cpu can help diagnose why we didn't find toolchain in the big if cascade.
