### PR TITLE
[Docker][NXP] Update Docker image for RW61X SDK

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-36 : [Silabs] Update GeckoSDK and WIFI SDK
+37 : [NXP] Update Docker image for RW61X SDK

--- a/integrations/docker/images/stage-2/chip-build-rw61x/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-rw61x/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /opt/sdk
 # Setup RW61x SDK
 RUN set -x \
     && mkdir -p rw61x \
-    && wget https://www.nxp.com/lgfiles/bsps/SDK_2_13_2_RD-RW612-BGA.zip \
-    && unzip SDK_2_13_2_RD-RW612-BGA.zip -d rw61x \
-    && rm -rf SDK_2_13_2_RD-RW612-BGA.zip \
+    && wget https://www.nxp.com/lgfiles/bsps/SDK_2_13_3_RD-RW612-BGA.zip \
+    && unzip SDK_2_13_3_RD-RW612-BGA.zip -d rw61x \
+    && rm -rf SDK_2_13_3_RD-RW612-BGA.zip \
     && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}


### PR DESCRIPTION
Updating docker image to SDK 2.13.3 support for RW61X platform.
This is a prerequisite for an upcoming PR bringing 2.13.3 SDK changes and enabling the CI workflows for RW61X platform.
