### PR TITLE
[Android] Move kotlin tlv/jsontlv out from java device controller lib

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -182,6 +182,8 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
       deps += [
         "${chip_root}/src/app/server/java",
         "${chip_root}/src/controller/java",
+        "${chip_root}/src/controller/java:tlv",
+        "${chip_root}/src/controller/java:jsontlv",
         "${chip_root}/src/controller/java:onboarding_payload",
         "${chip_root}/src/platform/android:java",
       ]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -182,9 +182,9 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
       deps += [
         "${chip_root}/src/app/server/java",
         "${chip_root}/src/controller/java",
-        "${chip_root}/src/controller/java:tlv",
         "${chip_root}/src/controller/java:jsontlv",
         "${chip_root}/src/controller/java:onboarding_payload",
+        "${chip_root}/src/controller/java:tlv",
         "${chip_root}/src/platform/android:java",
       ]
     }

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -442,8 +442,6 @@ android_library("java") {
   deps = [
     ":chipcluster",
     ":chipclusterID",
-    ":jsontlv",
-    ":tlv",
     "${chip_root}/third_party/java_deps:annotation",
   ]
 


### PR DESCRIPTION
kotlin tlv/jsontlv should not be dependency for java chip device controller jar, we need move them out.

