### PR TITLE
Remove comment about what should be done for batch commands on timeout

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -331,10 +331,7 @@ void CommandSender::OnResponseTimeout(Messaging::ExchangeContext * apExchangeCon
     ChipLogProgress(DataManagement, "Time out! failed to receive invoke command response from Exchange: " ChipLogFormatExchange,
                     ChipLogValueExchange(apExchangeContext));
 
-    // TODO(#30453) When timeout occurs for batch commands what should be done? Should all individual
-    // commands have a path specific error of timeout, or do we give or NoCommandResponse.
     OnErrorCallback(CHIP_ERROR_TIMEOUT);
-
     Close();
 }
 


### PR DESCRIPTION
When a timeout occurs the expected behaviour is :
* Call non-path specific error callback (`OnErrorCallback) with `CHIP_ERROR_TIMEOUT`, which is already [happening here](https://github.com/project-chip/connectedhomeip/blob/8fbe0a71deb96ade73282558a583386b80dbcd5a/src/app/CommandSender.cpp#L336)
* No further callbacks to `OnResponse`, or `OnNoResponse` occur. This is already what we are doing today since we call `Close()`  right after providing the non-path specific error. [As seen here](https://github.com/project-chip/connectedhomeip/blob/8fbe0a71deb96ade73282558a583386b80dbcd5a/src/app/CommandSender.cpp#L336-L338)

