### PR TITLE
[Linux] Fix memory leaks when handling BluezAdapter1 objects

### DIFF
--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -121,6 +121,12 @@ struct GAutoPtrDeleter<GDBusConnection>
 };
 
 template <>
+struct GAutoPtrDeleter<GDBusObjectManagerServer>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
 struct GAutoPtrDeleter<GError>
 {
     using deleter = GErrorDeleter;

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -92,9 +92,10 @@ public:
     static void HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT user_data);
     static void HandleTXComplete(BLE_CONNECTION_OBJECT user_data);
 
-    static void NotifyBLEPeripheralRegisterAppComplete(bool aIsSuccess, void * apAppstate);
-    static void NotifyBLEPeripheralAdvStartComplete(bool aIsSuccess, void * apAppstate);
-    static void NotifyBLEPeripheralAdvStopComplete(bool aIsSuccess, void * apAppstate);
+    static void NotifyBLEPeripheralRegisterAppComplete(bool aIsSuccess);
+    static void NotifyBLEPeripheralAdvStartComplete(bool aIsSuccess);
+    static void NotifyBLEPeripheralAdvStopComplete(bool aIsSuccess);
+    static void NotifyBLEPeripheralAdvReleased();
 
 private:
     // ===== Members that implement the BLEManager internal interface.

--- a/src/platform/Linux/CHIPDevicePlatformEvent.h
+++ b/src/platform/Linux/CHIPDevicePlatformEvent.h
@@ -54,7 +54,8 @@ enum InternalPlatformSpecificEventTypes
     kPlatformLinuxBLEOutOfBuffersEvent,
     kPlatformLinuxBLEPeripheralRegisterAppComplete,
     kPlatformLinuxBLEPeripheralAdvStartComplete,
-    kPlatformLinuxBLEPeripheralAdvStopComplete
+    kPlatformLinuxBLEPeripheralAdvStopComplete,
+    kPlatformLinuxBLEPeripheralAdvReleased,
 };
 
 } // namespace DeviceEventType
@@ -91,22 +92,14 @@ struct ChipDevicePlatformEvent
         struct
         {
             bool mIsSuccess;
-            void * mpAppstate;
         } BLEPeripheralRegisterAppComplete;
         struct
         {
             bool mIsSuccess;
-            void * mpAppstate;
-        } BLEPeripheralAdvConfiguredComplete;
-        struct
-        {
-            bool mIsSuccess;
-            void * mpAppstate;
         } BLEPeripheralAdvStartComplete;
         struct
         {
             bool mIsSuccess;
-            void * mpAppstate;
         } BLEPeripheralAdvStopComplete;
     };
 };

--- a/src/platform/Linux/bluez/AdapterIterator.cpp
+++ b/src/platform/Linux/bluez/AdapterIterator.cpp
@@ -84,24 +84,7 @@ bool AdapterIterator::Advance()
             continue;
         }
 
-        // PATH is of the for  BLUEZ_PATH / hci<nr>, i.e. like
-        // '/org/bluez/hci0'
-        // Index represents the number after hci
-        const char * path = g_dbus_proxy_get_object_path(G_DBUS_PROXY(adapter));
-        unsigned index    = 0;
-
-        if (sscanf(path, BLUEZ_PATH "/hci%u", &index) != 1)
-        {
-            ChipLogError(DeviceLayer, "Failed to extract HCI index from '%s'", StringOrNullMarker(path));
-            index = 0;
-        }
-
-        mCurrent.index   = index;
-        mCurrent.address = bluez_adapter1_get_address(adapter);
-        mCurrent.alias   = bluez_adapter1_get_alias(adapter);
-        mCurrent.name    = bluez_adapter1_get_name(adapter);
-        mCurrent.powered = bluez_adapter1_get_powered(adapter);
-        mCurrent.adapter.reset(adapter);
+        mCurrentAdapter.reset(adapter);
 
         mCurrentListItem = mCurrentListItem->next;
 
@@ -109,6 +92,22 @@ bool AdapterIterator::Advance()
     }
 
     return false;
+}
+
+uint32_t AdapterIterator::GetIndex() const
+{
+    // PATH is of the for  BLUEZ_PATH / hci<nr>, i.e. like '/org/bluez/hci0'
+    // Index represents the number after hci
+    const char * path = g_dbus_proxy_get_object_path(G_DBUS_PROXY(mCurrentAdapter.get()));
+    unsigned index    = 0;
+
+    if (sscanf(path, BLUEZ_PATH "/hci%u", &index) != 1)
+    {
+        ChipLogError(DeviceLayer, "Failed to extract HCI index from '%s'", StringOrNullMarker(path));
+        index = 0;
+    }
+
+    return index;
 }
 
 bool AdapterIterator::Next()

--- a/src/platform/Linux/bluez/AdapterIterator.cpp
+++ b/src/platform/Linux/bluez/AdapterIterator.cpp
@@ -37,12 +37,6 @@ AdapterIterator::~AdapterIterator()
     {
         g_list_free_full(mObjectList, g_object_unref);
     }
-
-    if (mCurrent.adapter != nullptr)
-    {
-        g_object_unref(mCurrent.adapter);
-        mCurrent.adapter = nullptr;
-    }
 }
 
 CHIP_ERROR AdapterIterator::Initialize(AdapterIterator * self)
@@ -102,18 +96,12 @@ bool AdapterIterator::Advance()
             index = 0;
         }
 
-        if (mCurrent.adapter != nullptr)
-        {
-            g_object_unref(mCurrent.adapter);
-            mCurrent.adapter = nullptr;
-        }
-
         mCurrent.index   = index;
         mCurrent.address = bluez_adapter1_get_address(adapter);
         mCurrent.alias   = bluez_adapter1_get_alias(adapter);
         mCurrent.name    = bluez_adapter1_get_name(adapter);
         mCurrent.powered = bluez_adapter1_get_powered(adapter);
-        mCurrent.adapter = adapter;
+        mCurrent.adapter.reset(adapter);
 
         mCurrentListItem = mCurrentListItem->next;
 

--- a/src/platform/Linux/bluez/AdapterIterator.h
+++ b/src/platform/Linux/bluez/AdapterIterator.h
@@ -56,12 +56,12 @@ public:
 
     // Information about the current value. Safe to call only after
     // "Next" has returned true.
-    uint32_t GetIndex() const { return mCurrent.index; }
-    const char * GetAddress() const { return mCurrent.address.c_str(); }
-    const char * GetAlias() const { return mCurrent.alias.c_str(); }
-    const char * GetName() const { return mCurrent.name.c_str(); }
-    bool IsPowered() const { return mCurrent.powered; }
-    BluezAdapter1 * GetAdapter() const { return mCurrent.adapter.get(); }
+    uint32_t GetIndex() const;
+    const char * GetAddress() const { return bluez_adapter1_get_address(mCurrentAdapter.get()); }
+    const char * GetAlias() const { return bluez_adapter1_get_alias(mCurrentAdapter.get()); }
+    const char * GetName() const { return bluez_adapter1_get_name(mCurrentAdapter.get()); }
+    bool IsPowered() const { return bluez_adapter1_get_powered(mCurrentAdapter.get()); }
+    BluezAdapter1 * GetAdapter() const { return mCurrentAdapter.get(); }
 
 private:
     /// Sets up the DBUS manager and loads the list
@@ -73,23 +73,11 @@ private:
     /// iterate through.
     bool Advance();
 
-    static constexpr size_t kMaxAddressLength = 19; // xx:xx:xx:xx:xx:xx
-    static constexpr size_t kMaxNameLength    = 64;
-
     GDBusObjectManager * mManager = nullptr; // DBus connection
     GList * mObjectList           = nullptr; // listing of objects on the bus
     GList * mCurrentListItem      = nullptr; // current item viewed in the list
-
-    // data valid only if Next() returns true
-    struct
-    {
-        uint32_t index;
-        std::string address;
-        std::string alias;
-        std::string name;
-        bool powered;
-        GAutoPtr<BluezAdapter1> adapter;
-    } mCurrent = { 0 };
+    // Data valid only if Next() returns true
+    GAutoPtr<BluezAdapter1> mCurrentAdapter;
 };
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/AdapterIterator.h
+++ b/src/platform/Linux/bluez/AdapterIterator.h
@@ -61,7 +61,7 @@ public:
     const char * GetAlias() const { return mCurrent.alias.c_str(); }
     const char * GetName() const { return mCurrent.name.c_str(); }
     bool IsPowered() const { return mCurrent.powered; }
-    BluezAdapter1 * GetAdapter() const { return mCurrent.adapter; }
+    BluezAdapter1 * GetAdapter() const { return mCurrent.adapter.get(); }
 
 private:
     /// Sets up the DBUS manager and loads the list
@@ -88,7 +88,7 @@ private:
         std::string alias;
         std::string name;
         bool powered;
-        BluezAdapter1 * adapter;
+        GAutoPtr<BluezAdapter1> adapter;
     } mCurrent = { 0 };
 };
 

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -93,6 +93,7 @@ gboolean BluezAdvertisement::BluezLEAdvertisement1Release(BluezLEAdvertisement1 
     // We can use it to update the state of the advertisement in the CHIP layer.
     ChipLogDetail(DeviceLayer, "BLE advertisement stopped by BlueZ");
     mIsAdvertising = false;
+    BLEManagerImpl::NotifyBLEPeripheralAdvReleased();
     return TRUE;
 }
 
@@ -235,7 +236,7 @@ void BluezAdvertisement::StartDone(GObject * aObject, GAsyncResult * aResult)
     ChipLogDetail(DeviceLayer, "RegisterAdvertisement complete");
 
 exit:
-    BLEManagerImpl::NotifyBLEPeripheralAdvStartComplete(success == TRUE, nullptr);
+    BLEManagerImpl::NotifyBLEPeripheralAdvStartComplete(success == TRUE);
 }
 
 CHIP_ERROR BluezAdvertisement::StartImpl()
@@ -293,7 +294,7 @@ void BluezAdvertisement::StopDone(GObject * aObject, GAsyncResult * aResult)
     ChipLogDetail(DeviceLayer, "UnregisterAdvertisement complete");
 
 exit:
-    BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete(success == TRUE, nullptr);
+    BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete(success == TRUE);
 }
 
 CHIP_ERROR BluezAdvertisement::StopImpl()

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -255,7 +255,7 @@ exit:
 CHIP_ERROR BluezAdvertisement::StartImpl()
 {
     GDBusObject * adapterObject;
-    BluezLEAdvertisingManager1 * advMgr = nullptr;
+    GAutoPtr<BluezLEAdvertisingManager1> advMgr;
     GVariantBuilder optionsBuilder;
     GVariant * options;
 
@@ -265,14 +265,14 @@ CHIP_ERROR BluezAdvertisement::StartImpl()
     adapterObject = g_dbus_interface_get_object(G_DBUS_INTERFACE(mAdapter.get()));
     VerifyOrExit(adapterObject != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL adapterObject in %s", __func__));
 
-    advMgr = bluez_object_get_leadvertising_manager1(BLUEZ_OBJECT(adapterObject));
-    VerifyOrExit(advMgr != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL advMgr in %s", __func__));
+    advMgr.reset(bluez_object_get_leadvertising_manager1(BLUEZ_OBJECT(adapterObject)));
+    VerifyOrExit(advMgr.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL advMgr in %s", __func__));
 
     g_variant_builder_init(&optionsBuilder, G_VARIANT_TYPE("a{sv}"));
     options = g_variant_builder_end(&optionsBuilder);
 
     bluez_leadvertising_manager1_call_register_advertisement(
-        advMgr, mpAdvPath, options, nullptr,
+        advMgr.get(), mpAdvPath, options, nullptr,
         [](GObject * aObject, GAsyncResult * aResult, void * aData) {
             reinterpret_cast<BluezAdvertisement *>(aData)->StartDone(aObject, aResult);
         },
@@ -321,7 +321,7 @@ exit:
 CHIP_ERROR BluezAdvertisement::StopImpl()
 {
     GDBusObject * adapterObject;
-    BluezLEAdvertisingManager1 * advMgr = nullptr;
+    GAutoPtr<BluezLEAdvertisingManager1> advMgr;
 
     VerifyOrExit(mIsAdvertising, ChipLogError(DeviceLayer, "FAIL: Advertising has already been disabled in %s", __func__));
     VerifyOrExit(mAdapter.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mAdapter in %s", __func__));
@@ -329,11 +329,11 @@ CHIP_ERROR BluezAdvertisement::StopImpl()
     adapterObject = g_dbus_interface_get_object(G_DBUS_INTERFACE(mAdapter.get()));
     VerifyOrExit(adapterObject != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL adapterObject in %s", __func__));
 
-    advMgr = bluez_object_get_leadvertising_manager1(BLUEZ_OBJECT(adapterObject));
-    VerifyOrExit(advMgr != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL advMgr in %s", __func__));
+    advMgr.reset(bluez_object_get_leadvertising_manager1(BLUEZ_OBJECT(adapterObject)));
+    VerifyOrExit(advMgr.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL advMgr in %s", __func__));
 
     bluez_leadvertising_manager1_call_unregister_advertisement(
-        advMgr, mpAdvPath, nullptr,
+        advMgr.get(), mpAdvPath, nullptr,
         [](GObject * aObject, GAsyncResult * aResult, void * aData) {
             reinterpret_cast<BluezAdvertisement *>(aData)->StopDone(aObject, aResult);
         },

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -86,8 +86,8 @@ private:
     bool mIsInitialized = false;
     bool mIsAdvertising = false;
 
-    char * mpAdvPath  = nullptr;
-    char * mpAdvUUID  = nullptr;
+    char mAdvPath[64] = ""; // D-Bus path of the advertisement object
+    char mAdvUUID[64] = ""; // UUID of the service to be advertised
     char mAdvName[32] = "";
 };
 

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -81,7 +81,7 @@ private:
     // Objects (interfaces) used by LE advertisement
     GDBusObjectManagerServer * mpRoot = nullptr;
     GAutoPtr<BluezAdapter1> mAdapter;
-    BluezLEAdvertisement1 * mpAdv = nullptr;
+    GAutoPtr<BluezLEAdvertisement1> mAdv;
 
     bool mIsInitialized = false;
     bool mIsAdvertising = false;

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -80,8 +80,8 @@ private:
 
     // Objects (interfaces) used by LE advertisement
     GDBusObjectManagerServer * mpRoot = nullptr;
-    BluezAdapter1 * mpAdapter         = nullptr;
-    BluezLEAdvertisement1 * mpAdv     = nullptr;
+    GAutoPtr<BluezAdapter1> mAdapter;
+    BluezLEAdvertisement1 * mpAdv = nullptr;
 
     bool mIsInitialized = false;
     bool mIsAdvertising = false;

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -65,6 +65,9 @@ public:
     ///
     /// BLE advertising is stopped asynchronously. Application will be notified of
     /// completion via a call to BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete().
+    ///
+    /// It is also possible that the advertising is released by BlueZ. In that case,
+    /// the application will be notified by BLEManagerImpl::NotifyBLEPeripheralAdvReleased().
     CHIP_ERROR Stop();
 
 private:

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -26,6 +26,7 @@
 
 #include <ble/CHIPBleServiceData.h>
 #include <lib/core/CHIPError.h>
+#include <platform/GLibTypeDeleter.h>
 #include <platform/Linux/dbus/bluez/DbusBluez.h>
 
 #include "Types.h"
@@ -79,7 +80,7 @@ private:
     CHIP_ERROR StopImpl();
 
     // Objects (interfaces) used by LE advertisement
-    GDBusObjectManagerServer * mpRoot = nullptr;
+    GAutoPtr<GDBusObjectManagerServer> mRoot;
     GAutoPtr<BluezAdapter1> mAdapter;
     GAutoPtr<BluezLEAdvertisement1> mAdv;
 

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -60,7 +60,7 @@ gboolean BluezIsCharOnService(BluezGattCharacteristic1 * aChar, BluezGattService
 } // namespace
 
 BluezConnection::BluezConnection(const BluezEndpoint & aEndpoint, BluezDevice1 * apDevice) :
-    mpDevice(BLUEZ_DEVICE1(g_object_ref(apDevice)))
+    mpDevice(reinterpret_cast<BluezDevice1 *>(g_object_ref(apDevice)))
 {
     Init(aEndpoint);
 }
@@ -101,9 +101,9 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
 
     if (!aEndpoint.mIsCentral)
     {
-        mpService = BLUEZ_GATT_SERVICE1(g_object_ref(aEndpoint.mpService));
-        mpC1      = BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC1));
-        mpC2      = BLUEZ_GATT_CHARACTERISTIC1(g_object_ref(aEndpoint.mpC2));
+        mpService = reinterpret_cast<BluezGattService1 *>(g_object_ref(aEndpoint.mpService));
+        mpC1      = reinterpret_cast<BluezGattCharacteristic1 *>(g_object_ref(aEndpoint.mpC1));
+        mpC2      = reinterpret_cast<BluezGattCharacteristic1 *>(g_object_ref(aEndpoint.mpC2));
     }
     else
     {

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -111,9 +111,7 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
 
         for (l = objects; l != nullptr; l = l->next)
         {
-            BluezObject * object        = BLUEZ_OBJECT(l->data);
-            BluezGattService1 * service = bluez_object_get_gatt_service1(object);
-
+            BluezGattService1 * service = bluez_object_get_gatt_service1(BLUEZ_OBJECT(l->data));
             if (service != nullptr)
             {
                 if ((BluezIsServiceOnDevice(service, mpDevice)) == TRUE &&
@@ -130,9 +128,7 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
 
         for (l = objects; l != nullptr; l = l->next)
         {
-            BluezObject * object             = BLUEZ_OBJECT(l->data);
-            BluezGattCharacteristic1 * char1 = bluez_object_get_gatt_characteristic1(object);
-
+            BluezGattCharacteristic1 * char1 = bluez_object_get_gatt_characteristic1(BLUEZ_OBJECT(l->data));
             if (char1 != nullptr)
             {
                 if ((BluezIsCharOnService(char1, mpService) == TRUE) &&

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -277,17 +277,17 @@ void BluezEndpoint::RegisterGattApplicationDone(GObject * aObject, GAsyncResult 
 
 CHIP_ERROR BluezEndpoint::RegisterGattApplicationImpl()
 {
-    GDBusObject * adapter;
+    GDBusObject * adapterObject;
     BluezGattManager1 * gattMgr;
     GVariantBuilder optionsBuilder;
     GVariant * options;
 
-    VerifyOrExit(mpAdapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
+    VerifyOrExit(mAdapter.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mAdapter in %s", __func__));
 
-    adapter = g_dbus_interface_get_object(G_DBUS_INTERFACE(mpAdapter));
-    VerifyOrExit(adapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL adapter in %s", __func__));
+    adapterObject = g_dbus_interface_get_object(G_DBUS_INTERFACE(mAdapter.get()));
+    VerifyOrExit(adapterObject != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL adapterObject in %s", __func__));
 
-    gattMgr = bluez_object_get_gatt_manager1(BLUEZ_OBJECT(adapter));
+    gattMgr = bluez_object_get_gatt_manager1(BLUEZ_OBJECT(adapterObject));
     VerifyOrExit(gattMgr != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL gattMgr in %s", __func__));
 
     g_variant_builder_init(&optionsBuilder, G_VARIANT_TYPE("a{sv}"));
@@ -344,11 +344,11 @@ void BluezEndpoint::BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClie
                                                           GDBusProxy * aInterface, GVariant * aChangedProperties,
                                                           const char * const * aInvalidatedProps)
 {
-    VerifyOrReturn(mpAdapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
+    VerifyOrReturn(mAdapter.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mAdapter in %s", __func__));
     VerifyOrReturn(strcmp(g_dbus_proxy_get_interface_name(aInterface), DEVICE_INTERFACE) == 0, );
 
     BluezDevice1 * device = BLUEZ_DEVICE1(aInterface);
-    VerifyOrReturn(BluezIsDeviceOnAdapter(device, mpAdapter));
+    VerifyOrReturn(BluezIsDeviceOnAdapter(device, mAdapter.get()));
 
     UpdateConnectionTable(device);
 }
@@ -386,7 +386,7 @@ void BluezEndpoint::BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBu
     GAutoPtr<BluezDevice1> device(bluez_object_get_device1(BLUEZ_OBJECT(aObject)));
     VerifyOrReturn(device.get() != nullptr);
 
-    if (BluezIsDeviceOnAdapter(device.get(), mpAdapter) == TRUE)
+    if (BluezIsDeviceOnAdapter(device.get(), mAdapter.get()) == TRUE)
     {
         HandleNewDevice(device.get());
     }
@@ -395,7 +395,7 @@ void BluezEndpoint::BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBu
 void BluezEndpoint::BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject)
 {
     // TODO: for Device1, lookup connection, and call otPlatTobleHandleDisconnected
-    // for Adapter1: unclear, crash if this pertains to our adapter? at least null out the self->mpAdapter.
+    // for Adapter1: unclear, crash if this pertains to our adapter? at least null out the self->mAdapter.
     // for Characteristic1, or GattService -- handle here via calling otPlatTobleHandleDisconnected, or ignore.
 }
 
@@ -427,28 +427,28 @@ void BluezEndpoint::SetupAdapter()
     snprintf(expectedPath, sizeof(expectedPath), BLUEZ_PATH "/hci%u", mAdapterId);
 
     GList * objects = g_dbus_object_manager_get_objects(mpObjMgr);
-    for (auto l = objects; l != nullptr && mpAdapter == nullptr; l = l->next)
+    for (auto l = objects; l != nullptr && mAdapter.get() == nullptr; l = l->next)
     {
         BluezObject * object = BLUEZ_OBJECT(l->data);
 
         GList * interfaces = g_dbus_object_get_interfaces(G_DBUS_OBJECT(object));
         for (auto ll = interfaces; ll != nullptr; ll = ll->next)
         {
-            if (BLUEZ_IS_ADAPTER1(ll->data))
-            { // we found the adapter
-                BluezAdapter1 * adapter = BLUEZ_ADAPTER1(ll->data);
+            BluezAdapter1 * adapter = BLUEZ_ADAPTER1(ll->data);
+            if (adapter != nullptr)
+            {
                 if (mpAdapterAddr == nullptr) // no adapter address provided, bind to the hci indicated by nodeid
                 {
                     if (strcmp(g_dbus_proxy_get_object_path(G_DBUS_PROXY(adapter)), expectedPath) == 0)
                     {
-                        mpAdapter = static_cast<BluezAdapter1 *>(g_object_ref(adapter));
+                        mAdapter.reset(static_cast<BluezAdapter1 *>(g_object_ref(adapter)));
                     }
                 }
                 else
                 {
                     if (strcmp(bluez_adapter1_get_address(adapter), mpAdapterAddr) == 0)
                     {
-                        mpAdapter = static_cast<BluezAdapter1 *>(g_object_ref(adapter));
+                        mAdapter.reset(static_cast<BluezAdapter1 *>(g_object_ref(adapter)));
                     }
                 }
             }
@@ -456,14 +456,14 @@ void BluezEndpoint::SetupAdapter()
         g_list_free_full(interfaces, g_object_unref);
     }
 
-    VerifyOrExit(mpAdapter != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mpAdapter in %s", __func__));
+    VerifyOrExit(mAdapter.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mAdapter in %s", __func__));
 
-    bluez_adapter1_set_powered(mpAdapter, TRUE);
+    bluez_adapter1_set_powered(mAdapter.get(), TRUE);
 
     // Setting "Discoverable" to False on the adapter and to True on the advertisement convinces
     // Bluez to set "BR/EDR Not Supported" flag. Bluez doesn't provide API to do that explicitly
     // and the flag is necessary to force using LE transport.
-    bluez_adapter1_set_discoverable(mpAdapter, FALSE);
+    bluez_adapter1_set_discoverable(mAdapter.get(), FALSE);
 
 exit:
     g_list_free_full(objects, g_object_unref);
@@ -692,8 +692,7 @@ void BluezEndpoint::Shutdown()
         +[](BluezEndpoint * self) {
             if (self->mpObjMgr != nullptr)
                 g_object_unref(self->mpObjMgr);
-            if (self->mpAdapter != nullptr)
-                g_object_unref(self->mpAdapter);
+            self->mAdapter.reset();
             if (self->mpRoot != nullptr)
                 g_object_unref(self->mpRoot);
             if (self->mpService != nullptr)

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -268,10 +268,10 @@ void BluezEndpoint::RegisterGattApplicationDone(GObject * aObject, GAsyncResult 
 
     VerifyOrReturn(success == TRUE, {
         ChipLogError(DeviceLayer, "FAIL: RegisterApplication : %s", error->message);
-        BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(false, nullptr);
+        BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(false);
     });
 
-    BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(true, nullptr);
+    BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(true);
     ChipLogDetail(DeviceLayer, "BluezPeripheralRegisterAppDone done");
 }
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -74,7 +74,7 @@ public:
     CHIP_ERROR Init(bool aIsCentral, const char * apBleAddr);
     void Shutdown();
 
-    BluezAdapter1 * GetAdapter() const { return mpAdapter; }
+    BluezAdapter1 * GetAdapter() const { return mAdapter.get(); }
 
     CHIP_ERROR RegisterGattApplication();
     GDBusObjectManagerServer * GetGattApplicationObjectManager() const { return mpRoot; }
@@ -127,7 +127,7 @@ private:
 
     // Objects (interfaces) subscribed to by this service
     GDBusObjectManager * mpObjMgr = nullptr;
-    BluezAdapter1 * mpAdapter     = nullptr;
+    GAutoPtr<BluezAdapter1> mAdapter;
 
     // Objects (interfaces) published by this service
     GDBusObjectManagerServer * mpRoot = nullptr;

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -58,7 +58,7 @@ CHIP_ERROR ChipDeviceScanner::Init(BluezAdapter1 * adapter, ChipDeviceScannerDel
     // Make this function idempotent by shutting down previously initialized state if any.
     Shutdown();
 
-    mAdapter  = BLUEZ_ADAPTER1(g_object_ref(adapter));
+    mAdapter.reset(BLUEZ_ADAPTER1(g_object_ref(adapter)));
     mDelegate = delegate;
 
     // Create the D-Bus object manager client object on the glib thread, so that all D-Bus signals
@@ -97,8 +97,7 @@ void ChipDeviceScanner::Shutdown()
         +[](ChipDeviceScanner * self) {
             if (self->mManager != nullptr)
                 g_object_unref(self->mManager);
-            if (self->mAdapter != nullptr)
-                g_object_unref(self->mAdapter);
+            self->mAdapter.reset();
             return CHIP_NO_ERROR;
         },
         this);
@@ -205,7 +204,7 @@ CHIP_ERROR ChipDeviceScanner::MainLoopStopScan(ChipDeviceScanner * self)
         self->mInterfaceChangedSignal = 0;
     }
 
-    if (!bluez_adapter1_call_stop_discovery_sync(self->mAdapter, nullptr /* not cancellable */, &error.GetReceiver()))
+    if (!bluez_adapter1_call_stop_discovery_sync(self->mAdapter.get(), nullptr /* not cancellable */, &error.GetReceiver()))
     {
         ChipLogError(Ble, "Failed to stop discovery %s", error->message);
         return CHIP_ERROR_INTERNAL;
@@ -234,7 +233,7 @@ void ChipDeviceScanner::SignalInterfaceChanged(GDBusObjectManagerClient * manage
 
 void ChipDeviceScanner::ReportDevice(BluezDevice1 & device)
 {
-    if (strcmp(bluez_device1_get_adapter(&device), g_dbus_proxy_get_object_path(G_DBUS_PROXY(mAdapter))) != 0)
+    if (strcmp(bluez_device1_get_adapter(&device), g_dbus_proxy_get_object_path(G_DBUS_PROXY(mAdapter.get()))) != 0)
     {
         return;
     }
@@ -252,7 +251,7 @@ void ChipDeviceScanner::ReportDevice(BluezDevice1 & device)
 
 void ChipDeviceScanner::RemoveDevice(BluezDevice1 & device)
 {
-    if (strcmp(bluez_device1_get_adapter(&device), g_dbus_proxy_get_object_path(G_DBUS_PROXY(mAdapter))) != 0)
+    if (strcmp(bluez_device1_get_adapter(&device), g_dbus_proxy_get_object_path(G_DBUS_PROXY(mAdapter.get()))) != 0)
     {
         return;
     }
@@ -267,7 +266,7 @@ void ChipDeviceScanner::RemoveDevice(BluezDevice1 & device)
     const auto devicePath = g_dbus_proxy_get_object_path(G_DBUS_PROXY(&device));
     GAutoPtr<GError> error;
 
-    if (!bluez_adapter1_call_remove_device_sync(mAdapter, devicePath, nullptr, &error.GetReceiver()))
+    if (!bluez_adapter1_call_remove_device_sync(mAdapter.get(), devicePath, nullptr, &error.GetReceiver()))
     {
         ChipLogDetail(Ble, "Failed to remove device %s: %s", StringOrNullMarker(devicePath), error->message);
     }
@@ -302,7 +301,8 @@ CHIP_ERROR ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
     g_variant_builder_add(&filterBuilder, "{sv}", "Transport", g_variant_new_string("le"));
     GVariant * filter = g_variant_builder_end(&filterBuilder);
 
-    if (!bluez_adapter1_call_set_discovery_filter_sync(self->mAdapter, filter, self->mCancellable.get(), &error.GetReceiver()))
+    if (!bluez_adapter1_call_set_discovery_filter_sync(self->mAdapter.get(), filter, self->mCancellable.get(),
+                                                       &error.GetReceiver()))
     {
         // Not critical: ignore if fails
         ChipLogError(Ble, "Failed to set discovery filters: %s", error->message);
@@ -310,7 +310,7 @@ CHIP_ERROR ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
     }
 
     ChipLogProgress(Ble, "BLE initiating scan.");
-    if (!bluez_adapter1_call_start_discovery_sync(self->mAdapter, self->mCancellable.get(), &error.GetReceiver()))
+    if (!bluez_adapter1_call_start_discovery_sync(self->mAdapter.get(), self->mCancellable.get(), &error.GetReceiver()))
     {
         ChipLogError(Ble, "Failed to start discovery: %s", error->message);
         return CHIP_ERROR_INTERNAL;

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -58,7 +58,7 @@ CHIP_ERROR ChipDeviceScanner::Init(BluezAdapter1 * adapter, ChipDeviceScannerDel
     // Make this function idempotent by shutting down previously initialized state if any.
     Shutdown();
 
-    mAdapter.reset(BLUEZ_ADAPTER1(g_object_ref(adapter)));
+    mAdapter.reset(reinterpret_cast<BluezAdapter1 *>(g_object_ref(adapter)));
     mDelegate = delegate;
 
     // Create the D-Bus object manager client object on the glib thread, so that all D-Bus signals

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -27,6 +27,8 @@
 #include <platform/Linux/dbus/bluez/DbusBluez.h>
 #include <system/SystemLayer.h>
 
+#include "Types.h"
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -105,8 +107,8 @@ private:
     /// so that it can be re-discovered if it's still advertising.
     void RemoveDevice(BluezDevice1 & device);
 
-    GDBusObjectManager * mManager         = nullptr;
-    BluezAdapter1 * mAdapter              = nullptr;
+    GDBusObjectManager * mManager = nullptr;
+    GAutoPtr<BluezAdapter1> mAdapter;
     ChipDeviceScannerDelegate * mDelegate = nullptr;
     gulong mObjectAddedSignal             = 0;
     gulong mInterfaceChangedSignal        = 0;

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -73,6 +73,12 @@ struct GAutoPtrDeleter<BluezGattManager1>
 };
 
 template <>
+struct GAutoPtrDeleter<BluezLEAdvertisement1>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
 struct GAutoPtrDeleter<BluezLEAdvertisingManager1>
 {
     using deleter = GObjectDeleter;

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -66,6 +66,18 @@ struct GAutoPtrDeleter<BluezDevice1>
     using deleter = GObjectDeleter;
 };
 
+template <>
+struct GAutoPtrDeleter<BluezGattManager1>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<BluezLEAdvertisingManager1>
+{
+    using deleter = GObjectDeleter;
+};
+
 namespace DeviceLayer {
 namespace Internal {
 

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -55,6 +55,12 @@
 namespace chip {
 
 template <>
+struct GAutoPtrDeleter<BluezAdapter1>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
 struct GAutoPtrDeleter<BluezDevice1>
 {
     using deleter = GObjectDeleter;


### PR DESCRIPTION
### Problem

Explicit memory handling in glib can lead to missing unrefs. Since we've got `GAutoPtr<>` wrapper, we can use it to prevent that.

### Changes

- Use `GAutoPtr<>` to manage `BluezAdapter1` life cycle
- Properly release objects obtained with bluez_object_get_*() (such objects need to be unrefed, which was not always the case)
- Use `reinterpret_cast<>` when using `g_object_ref()` instead of glib C casting
- Fix life cycle of exported advertisement D-Bus object (we need to unexport it only on `Shutdown()`)
- Restart BLE advertisement in case of premature release (first step to make Matter SDK resilient to BlueZ restart)

### Testing

Locally tested BLE commissioning. Verified that advertisement is restarted in case of `Release()` by BlueZ without extending total advertisement time. Also, checked memory leaks with valgrind:

Before:
```
==1401615== LEAK SUMMARY:
==1401615==    definitely lost: 0 bytes in 0 blocks
==1401615==    indirectly lost: 0 bytes in 0 blocks
==1401615==      possibly lost: 960 bytes in 3 blocks
==1401615==    still reachable: 192,673 bytes in 2,486 blocks
==1401615==         suppressed: 0 bytes in 0 blocks
```

After
```
==2050877==    definitely lost: 0 bytes in 0 blocks
==2050877==    indirectly lost: 0 bytes in 0 blocks
==2050877==      possibly lost: 960 bytes in 3 blocks
==2050877==    still reachable: 185,746 bytes in 2,361 blocks
==2050877==         suppressed: 0 bytes in 0 blocks
```