### PR TITLE
Bump pigweed to latest version

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,6 +35,7 @@ Checks: >
   -clang-analyzer-cplusplus.Move,
   -clang-analyzer-deadcode.DeadStores,
   -clang-analyzer-nullability.NullablePassedToNonnull,
+  -clang-analyzer-optin.core.EnumCastOutOfRange,
   -clang-analyzer-optin.cplusplus.UninitializedObject,
   -clang-analyzer-optin.cplusplus.VirtualCall,
   -clang-analyzer-optin.osx.cocoa.localizability.EmptyLocalizationContextChecker,

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
@@ -302,15 +302,15 @@
             { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x7 }, /* ControlMode */                                                  \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Thermostat (server) */                                                                        \
-            { (uint16_t) 0xA28, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* OccupiedCoolingSetpoint */                             \
-            { (uint16_t) 0x7D0, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* OccupiedHeatingSetpoint */                             \
-            { (uint16_t) 0x2BC, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MinHeatSetpointLimit */                                \
-            { (uint16_t) 0xBB8, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MaxHeatSetpointLimit */                                \
-            { (uint16_t) 0x640, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MinCoolSetpointLimit */                                \
-            { (uint16_t) 0xC80, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MaxCoolSetpointLimit */                                \
-            { (uint16_t) 0x19, (uint16_t) 0x0, (uint16_t) 0x19 },        /* MinSetpointDeadBand */                                 \
-            { (uint16_t) 0x4, (uint16_t) 0x0, (uint16_t) 0x5 },          /* ControlSequenceOfOperation */                          \
-            { (uint16_t) 0x1, (uint16_t) 0x0, (uint16_t) 0x9 },          /* SystemMode */                                          \
+            { (uint16_t) 0xA28, (uint16_t) - 0x6AB3, (uint16_t) 0x7FFF }, /* OccupiedCoolingSetpoint */                            \
+            { (uint16_t) 0x7D0, (uint16_t) - 0x6AB3, (uint16_t) 0x7FFF }, /* OccupiedHeatingSetpoint */                            \
+            { (uint16_t) 0x2BC, (uint16_t) - 0x6AB3, (uint16_t) 0x7FFF }, /* MinHeatSetpointLimit */                               \
+            { (uint16_t) 0xBB8, (uint16_t) - 0x6AB3, (uint16_t) 0x7FFF }, /* MaxHeatSetpointLimit */                               \
+            { (uint16_t) 0x640, (uint16_t) - 0x6AB3, (uint16_t) 0x7FFF }, /* MinCoolSetpointLimit */                               \
+            { (uint16_t) 0xC80, (uint16_t) - 0x6AB3, (uint16_t) 0x7FFF }, /* MaxCoolSetpointLimit */                               \
+            { (uint16_t) 0x19, (uint16_t) 0x0, (uint16_t) 0x19 },         /* MinSetpointDeadBand */                                \
+            { (uint16_t) 0x4, (uint16_t) 0x0, (uint16_t) 0x5 },           /* ControlSequenceOfOperation */                         \
+            { (uint16_t) 0x1, (uint16_t) 0x0, (uint16_t) 0x9 },           /* SystemMode */                                         \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Fan Control (server) */                                                                       \
             { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x6 },  /* FanMode */                                                     \
@@ -334,14 +334,14 @@
             { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF }, /* StartUpColorTemperatureMireds */                             \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Unit Testing (server) */                                                                      \
-            { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },   /* range_restricted_int8u */                                  \
-            { (uint16_t) -0x14, (uint16_t) -0x28, (uint16_t) 0x32 }, /* range_restricted_int8s */                                  \
-            { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 },  /* range_restricted_int16u */                                 \
-            { (uint16_t) -0x64, (uint16_t) -0x96, (uint16_t) 0xC8 }, /* range_restricted_int16s */                                 \
-            { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },   /* nullable_range_restricted_int8u */                         \
-            { (uint16_t) -0x14, (uint16_t) -0x28, (uint16_t) 0x32 }, /* nullable_range_restricted_int8s */                         \
-            { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 },  /* nullable_range_restricted_int16u */                        \
-            { (uint16_t) -0x64, (uint16_t) -0x96, (uint16_t) 0xC8 }, /* nullable_range_restricted_int16s */                        \
+            { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },     /* range_restricted_int8u */                                \
+            { (uint16_t) - 0x14, (uint16_t) - 0x28, (uint16_t) 0x32 }, /* range_restricted_int8s */                                \
+            { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 },    /* range_restricted_int16u */                               \
+            { (uint16_t) - 0x64, (uint16_t) - 0x96, (uint16_t) 0xC8 }, /* range_restricted_int16s */                               \
+            { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },     /* nullable_range_restricted_int8u */                       \
+            { (uint16_t) - 0x14, (uint16_t) - 0x28, (uint16_t) 0x32 }, /* nullable_range_restricted_int8s */                       \
+            { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 },    /* nullable_range_restricted_int16u */                      \
+            { (uint16_t) - 0x64, (uint16_t) - 0x96, (uint16_t) 0xC8 }, /* nullable_range_restricted_int16s */                      \
                                                                                                                                    \
         /* Endpoint: 2, Cluster: On/Off (server) */                                                                                \
         {                                                                                                                          \

--- a/src/lib/dnssd/minimal_mdns/core/RecordWriter.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/RecordWriter.cpp
@@ -41,7 +41,7 @@ RecordWriter & RecordWriter::WriteQName(const FullQName & qname)
     size_t qNameWriteStart = mOutput->WritePos();
     bool isFullyCompressed = true;
 
-    for (uint16_t i = 0; i < static_cast<uint16_t>(qname.nameCount); i++)
+    for (size_t i = 0; i < qname.nameCount; i++)
     {
 
         // find out if the record part remaining already is located somewhere

--- a/src/lib/dnssd/minimal_mdns/core/RecordWriter.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/RecordWriter.cpp
@@ -41,7 +41,7 @@ RecordWriter & RecordWriter::WriteQName(const FullQName & qname)
     size_t qNameWriteStart = mOutput->WritePos();
     bool isFullyCompressed = true;
 
-    for (uint16_t i = 0; i < qname.nameCount; i++)
+    for (uint16_t i = 0; i < static_cast<uint16_t>(qname.nameCount); i++)
     {
 
         // find out if the record part remaining already is located somewhere

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -131,7 +131,7 @@ public:
                             nodeData.resolutionData.isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
         }
         streamer_printf(streamer_get(), "   IP addresses:\r\n");
-        for (uint8_t i = 0; i < nodeData.resolutionData.numIPs; i++)
+        for (size_t i = 0; i < nodeData.resolutionData.numIPs; i++)
         {
             streamer_printf(streamer_get(), "      %s\r\n", nodeData.resolutionData.ipAddress[i].ToString(ipAddressBuf));
         }

--- a/src/lib/support/tests/TestIniEscaping.cpp
+++ b/src/lib/support/tests/TestIniEscaping.cpp
@@ -45,7 +45,6 @@ void TestUnescaping(nlTestSuite * inSuite, void * inContext)
     // Test valid cases
     NL_TEST_ASSERT(inSuite, UnescapeKey("") == "");
     NL_TEST_ASSERT(inSuite, UnescapeKey("abcd1234,!") == "abcd1234,!");
-    std::string out = UnescapeKey("abcd1234,!");
     NL_TEST_ASSERT(inSuite, UnescapeKey("ab\\x0acd\\x20\\x3d12\\x5c34\\x7f") == "ab\ncd =12\\34\x7f");
     NL_TEST_ASSERT(inSuite, UnescapeKey("\\x20") == " ");
     NL_TEST_ASSERT(inSuite, UnescapeKey("\\x3d\\x3d\\x3d") == "===");


### PR DESCRIPTION
Minimal delta:
- bump pigweed
- this brings in a newer clangtidy, which triggers several EnumCastOutOfRange. Will fix those as followups. Removed that
- clang-format update resulted in a delta from zap-regen. Checked in that file.
- clang-tidy still had 3 minor complains which I fixed: deleted an unused std::string and updated the for loop data types for two for loops.