### PR TITLE
remove `zap_pregenerated_dir` from the chip_data_model GN template

### DIFF
--- a/examples/air-purifier-app/air-purifier-common/BUILD.gn
+++ b/examples/air-purifier-app/air-purifier-common/BUILD.gn
@@ -17,8 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("air-purifier-common") {
   zap_file = "air-purifier-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/air-purifier-app/zap-generated"
   is_server = true
 }

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/BUILD.gn
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/BUILD.gn
@@ -17,8 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("air-quality-sensor-common") {
   zap_file = "air-quality-sensor-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/air-quality-sensor-app/zap-generated"
   is_server = true
 }

--- a/examples/all-clusters-app/all-clusters-common/BUILD.gn
+++ b/examples/all-clusters-app/all-clusters-common/BUILD.gn
@@ -18,8 +18,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("all-clusters-common") {
   zap_file = "all-clusters-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/all-clusters-app/zap-generated"
   is_server = true
 }

--- a/examples/all-clusters-minimal-app/all-clusters-common/BUILD.gn
+++ b/examples/all-clusters-minimal-app/all-clusters-common/BUILD.gn
@@ -18,8 +18,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("all-clusters-common") {
   zap_file = "all-clusters-minimal-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/all-clusters-minimal-app/zap-generated"
   is_server = true
 }

--- a/examples/bridge-app/bridge-common/BUILD.gn
+++ b/examples/bridge-app/bridge-common/BUILD.gn
@@ -19,7 +19,6 @@ import("${chip_root}/src/app/chip_data_model.gni")
 chip_data_model("bridge-common") {
   zap_file = "bridge-app.zap"
 
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/bridge-app/zap-generated"
   is_server = true
 
   # TODO: the definition of DYNAMIC_ENDPOINT_COUNT needs find a common home!

--- a/examples/chef/linux/BUILD.gn
+++ b/examples/chef/linux/BUILD.gn
@@ -35,8 +35,6 @@ project_dir = "./.."
 
 chip_data_model("chef-data-model") {
   zap_file = "${project_dir}/devices/${sample_zap_file}"
-  zap_pregenerated_dir =
-      "${chip_root}/examples/chef/out/${sample_name}/zap-generated/"
   is_server = true
 }
 

--- a/examples/chef/silabs/BUILD.gn
+++ b/examples/chef/silabs/BUILD.gn
@@ -48,8 +48,6 @@ declare_args() {
 
 chip_data_model("chef-common") {
   zap_file = "${chef_project_dir}/devices/${sample_name}.zap"
-
-  zap_pregenerated_dir = "${chef_project_dir}/out/${sample_name}/zap-generated/"
   is_server = true
 }
 

--- a/examples/contact-sensor-app/contact-sensor-common/BUILD.gn
+++ b/examples/contact-sensor-app/contact-sensor-common/BUILD.gn
@@ -17,8 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("contact-sensor-common") {
   zap_file = "contact-sensor-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/contact-sensor-app/zap-generated"
   is_server = true
 }

--- a/examples/contact-sensor-app/nxp/zap-lit/BUILD.gn
+++ b/examples/contact-sensor-app/nxp/zap-lit/BUILD.gn
@@ -18,8 +18,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("zap-lit") {
   zap_file = "contact-sensor-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/contact-sensor-app/nxp/zap-generated"
   is_server = true
 }

--- a/examples/contact-sensor-app/nxp/zap-sit/BUILD.gn
+++ b/examples/contact-sensor-app/nxp/zap-sit/BUILD.gn
@@ -18,8 +18,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("zap-sit") {
   zap_file = "contact-sensor-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/contact-sensor-app/nxp/zap-generated"
   is_server = true
 }

--- a/examples/dishwasher-app/dishwasher-common/BUILD.gn
+++ b/examples/dishwasher-app/dishwasher-common/BUILD.gn
@@ -21,8 +21,5 @@ config("config") {
 
 chip_data_model("dishwasher-common") {
   zap_file = "dishwasher-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/dishwasher-app/zap-generated"
   is_server = true
 }

--- a/examples/energy-management-app/energy-management-common/BUILD.gn
+++ b/examples/energy-management-app/energy-management-common/BUILD.gn
@@ -22,8 +22,5 @@ config("config") {
 
 chip_data_model("energy-management-common") {
   zap_file = "energy-management-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/energy-management-app/zap-generated"
   is_server = true
 }

--- a/examples/light-switch-app/light-switch-common/BUILD.gn
+++ b/examples/light-switch-app/light-switch-common/BUILD.gn
@@ -17,9 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("light-switch-common") {
   zap_file = "light-switch-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/light-switch-app/zap-generated"
-
   is_server = true
 }

--- a/examples/light-switch-app/qpg/zap/BUILD.gn
+++ b/examples/light-switch-app/qpg/zap/BUILD.gn
@@ -17,8 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("zap") {
   zap_file = "switch.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/light-switch-app/qpg/zap-generated"
   is_server = true
 }

--- a/examples/lighting-app/bouffalolab/bl602/BUILD.gn
+++ b/examples/lighting-app/bouffalolab/bl602/BUILD.gn
@@ -90,8 +90,6 @@ bl_iot_sdk("sdk") {
 
 chip_data_model("bouffalolab-lighting") {
   zap_file = "${example_dir}/data_model/lighting-app-wifi.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/lighting-app/zap-generated"
   is_server = true
 }
 

--- a/examples/lighting-app/bouffalolab/bl702/BUILD.gn
+++ b/examples/lighting-app/bouffalolab/bl702/BUILD.gn
@@ -122,8 +122,6 @@ chip_data_model("bouffalolab-lighting") {
   } else {
     zap_file = "${example_dir}/data_model/lighting-app-ethernet.zap"
   }
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/lighting-app/zap-generated"
   is_server = true
 }
 

--- a/examples/lighting-app/bouffalolab/bl702l/BUILD.gn
+++ b/examples/lighting-app/bouffalolab/bl702l/BUILD.gn
@@ -99,8 +99,6 @@ bl_iot_sdk("sdk") {
 
 chip_data_model("bouffalolab-lighting") {
   zap_file = "${example_dir}/data_model/lighting-app-thread.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/lighting-app/zap-generated"
   is_server = true
 }
 

--- a/examples/lighting-app/lighting-common/BUILD.gn
+++ b/examples/lighting-app/lighting-common/BUILD.gn
@@ -21,8 +21,6 @@ config("config") {
 
 chip_data_model("lighting-common") {
   zap_file = "lighting-app.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/lighting-app/zap-generated"
   is_server = true
 }
 

--- a/examples/lighting-app/nxp/zap/BUILD.gn
+++ b/examples/lighting-app/nxp/zap/BUILD.gn
@@ -18,8 +18,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("zap") {
   zap_file = "lighting-on-off.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/lighting-app/nxp/zap-generated"
   is_server = true
 }

--- a/examples/lighting-app/qpg/zap/BUILD.gn
+++ b/examples/lighting-app/qpg/zap/BUILD.gn
@@ -17,8 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("zap") {
   zap_file = "light.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/lighting-app/qpg/zap-generated"
   is_server = true
 }

--- a/examples/lighting-app/silabs/data_model/BUILD.gn
+++ b/examples/lighting-app/silabs/data_model/BUILD.gn
@@ -22,7 +22,5 @@ chip_data_model("silabs-lighting") {
   } else {
     zap_file = "lighting-thread-app.zap"
   }
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/lighting-app/zap-generated"
   is_server = true
 }

--- a/examples/lit-icd-app/lit-icd-common/BUILD.gn
+++ b/examples/lit-icd-app/lit-icd-common/BUILD.gn
@@ -17,8 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("lit-icd-common") {
   zap_file = "lit-icd-server-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/lit-icd-server-app/zap-generated"
   is_server = true
 }

--- a/examples/lock-app/lock-common/BUILD.gn
+++ b/examples/lock-app/lock-common/BUILD.gn
@@ -17,8 +17,6 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("lock-common") {
   zap_file = "lock-app.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/lock-app/zap-generated"
   is_server = true
 }
 

--- a/examples/lock-app/nxp/zap/BUILD.gn
+++ b/examples/lock-app/nxp/zap/BUILD.gn
@@ -17,7 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("zap") {
   zap_file = "lock-app.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/lock-app/nxp/zap-generated"
   is_server = true
 }

--- a/examples/lock-app/qpg/zap/BUILD.gn
+++ b/examples/lock-app/qpg/zap/BUILD.gn
@@ -17,7 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("zap") {
   zap_file = "lock.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/lock-app/qpg/zap-generated"
   is_server = true
 }

--- a/examples/log-source-app/log-source-common/BUILD.gn
+++ b/examples/log-source-app/log-source-common/BUILD.gn
@@ -23,9 +23,6 @@ config("config") {
 chip_data_model("log-source-common") {
   zap_file = "log-source-app.zap"
 
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/log-source-app/zap-generated"
-
   deps = [ "${chip_root}/src/protocols/bdx" ]
 
   is_server = true

--- a/examples/microwave-oven-app/microwave-oven-common/BUILD.gn
+++ b/examples/microwave-oven-app/microwave-oven-common/BUILD.gn
@@ -21,8 +21,5 @@ config("config") {
 
 chip_data_model("microwave-oven-common") {
   zap_file = "microwave-oven-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/microwave-oven-app/zap-generated"
   is_server = true
 }

--- a/examples/network-manager-app/network-manager-common/BUILD.gn
+++ b/examples/network-manager-app/network-manager-common/BUILD.gn
@@ -17,8 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("network-manager-common") {
   zap_file = "network-manager-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/network-manager-app/zap-generated"
   is_server = true
 }

--- a/examples/ota-provider-app/ota-provider-common/BUILD.gn
+++ b/examples/ota-provider-app/ota-provider-common/BUILD.gn
@@ -23,9 +23,6 @@ config("config") {
 chip_data_model("ota-provider-common") {
   zap_file = "ota-provider-app.zap"
 
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/ota-provider-app/zap-generated"
-
   sources = [
     "BdxOtaSender.cpp",
     "BdxOtaSender.h",

--- a/examples/ota-requestor-app/ota-requestor-common/BUILD.gn
+++ b/examples/ota-requestor-app/ota-requestor-common/BUILD.gn
@@ -23,9 +23,6 @@ config("config") {
 chip_data_model("ota-requestor-common") {
   zap_file = "ota-requestor-app.zap"
 
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/ota-requestor-app/zap-generated"
-
   deps = [ "${chip_root}/src/lib" ]
 
   public_configs = [ ":config" ]

--- a/examples/placeholder/linux/apps/app1/BUILD.gn
+++ b/examples/placeholder/linux/apps/app1/BUILD.gn
@@ -17,9 +17,6 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("configuration") {
   zap_file = "config.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/placeholder/app1/zap-generated"
   is_server = true
 }
 

--- a/examples/placeholder/linux/apps/app2/BUILD.gn
+++ b/examples/placeholder/linux/apps/app2/BUILD.gn
@@ -17,9 +17,6 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("configuration") {
   zap_file = "config.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/placeholder/app2/zap-generated"
   is_server = true
 }
 

--- a/examples/pump-app/pump-common/BUILD.gn
+++ b/examples/pump-app/pump-common/BUILD.gn
@@ -18,7 +18,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("pump-common") {
   zap_file = "pump-app.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/pump-app/zap-generated"
   is_server = true
 }

--- a/examples/pump-app/silabs/data_model/BUILD.gn
+++ b/examples/pump-app/silabs/data_model/BUILD.gn
@@ -22,7 +22,5 @@ chip_data_model("silabs-pump") {
   } else {
     zap_file = "pump-thread-app.zap"
   }
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/pump-app/zap-generated"
   is_server = true
 }

--- a/examples/pump-controller-app/pump-controller-common/BUILD.gn
+++ b/examples/pump-controller-app/pump-controller-common/BUILD.gn
@@ -18,8 +18,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("pump-controller-common") {
   zap_file = "pump-controller-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/pump-controller-app/zap-generated"
   is_server = true
 }

--- a/examples/refrigerator-app/refrigerator-common/BUILD.gn
+++ b/examples/refrigerator-app/refrigerator-common/BUILD.gn
@@ -21,8 +21,5 @@ config("config") {
 
 chip_data_model("refrigerator-common") {
   zap_file = "refrigerator-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/refrigerator-app/zap-generated"
   is_server = true
 }

--- a/examples/rvc-app/rvc-common/BUILD.gn
+++ b/examples/rvc-app/rvc-common/BUILD.gn
@@ -21,7 +21,5 @@ config("config") {
 
 chip_data_model("rvc-common") {
   zap_file = "rvc-app.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/rvc-app/zap-generated"
   is_server = true
 }

--- a/examples/smoke-co-alarm-app/smoke-co-alarm-common/BUILD.gn
+++ b/examples/smoke-co-alarm-app/smoke-co-alarm-common/BUILD.gn
@@ -17,8 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("smoke-co-alarm-common") {
   zap_file = "smoke-co-alarm-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/smoke-co-alarm-app/zap-generated"
   is_server = true
 }

--- a/examples/temperature-measurement-app/temperature-measurement-common/BUILD.gn
+++ b/examples/temperature-measurement-app/temperature-measurement-common/BUILD.gn
@@ -18,8 +18,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("temperature-measurement-common") {
   zap_file = "temperature-measurement.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/temperature-measurement/zap-generated"
   is_server = true
 }

--- a/examples/thermostat/nxp/zap/BUILD.gn
+++ b/examples/thermostat/nxp/zap/BUILD.gn
@@ -28,7 +28,5 @@ chip_data_model("zap") {
     zap_file = "thermostat_matter_thread.zap"
   }
 
-  # Defining zap_pregenerated_dir is required by chip_data_model.gni in order to build IMClusterCommandHandler.cpp
-  zap_pregenerated_dir = ""
   is_server = true
 }

--- a/examples/thermostat/qpg/zap/BUILD.gn
+++ b/examples/thermostat/qpg/zap/BUILD.gn
@@ -17,8 +17,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("zap") {
   zap_file = "thermostaticRadiatorValve.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/thermostat/qpg/zap-generated"
   is_server = true
 }

--- a/examples/thermostat/thermostat-common/BUILD.gn
+++ b/examples/thermostat/thermostat-common/BUILD.gn
@@ -18,7 +18,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("thermostat-common") {
   zap_file = "thermostat.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/thermostat/zap-generated"
   is_server = true
 }

--- a/examples/tv-app/tv-common/BUILD.gn
+++ b/examples/tv-app/tv-common/BUILD.gn
@@ -19,8 +19,6 @@ import("${chip_root}/src/lib/lib.gni")
 
 chip_data_model("tv-common") {
   zap_file = "tv-app.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/tv-app/zap-generated"
   is_server = true
 }
 

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -34,9 +34,6 @@ config("config") {
 chip_data_model("tv-casting-common") {
   zap_file = "tv-casting-app.zap"
 
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/tv-casting-app/zap-generated"
-
   sources = [
     "${chip_root}/examples/chip-tool/commands/clusters/ModelCommand.h",
     "${chip_root}/examples/chip-tool/commands/common/BDXDiagnosticLogsServerDelegate.cpp",

--- a/examples/virtual-device-app/virtual-device-common/BUILD.gn
+++ b/examples/virtual-device-app/virtual-device-common/BUILD.gn
@@ -19,8 +19,5 @@ import("${chip_root}/src/lib/lib.gni")
 
 chip_data_model("virtual-device-common") {
   zap_file = "virtual-device-app.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/virtual-device-app/zap-generated"
   is_server = true
 }

--- a/examples/window-app/common/BUILD.gn
+++ b/examples/window-app/common/BUILD.gn
@@ -18,7 +18,5 @@ import("${chip_root}/src/app/chip_data_model.gni")
 
 chip_data_model("window-common") {
   zap_file = "window-app.zap"
-
-  zap_pregenerated_dir = "${chip_root}/zzz_generated/window-app/zap-generated"
   is_server = true
 }

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -23,9 +23,6 @@ _app_root = get_path_info(".", "abspath")
 # Defines a source_set for CHIP data model.
 #
 # Arguments:
-#  zap_pregenerated_dir
-#    Path to the ZAP "gen" dir.
-#
 #  zap_file
 #    Path to the ZAP input file.
 #
@@ -54,14 +51,6 @@ template("chip_data_model") {
     _idl = string_replace(invoker.zap_file, ".zap", ".matter")
   }
 
-  config("${_data_model_name}_config") {
-    include_dirs = []
-
-    if (defined(invoker.zap_pregenerated_dir)) {
-      include_dirs += [ "${invoker.zap_pregenerated_dir}/.." ]
-    }
-  }
-
   chip_zapgen("${_data_model_name}_zapgen") {
     input = rebase_path(invoker.zap_file)
     generator = "app-templates"
@@ -82,26 +71,13 @@ template("chip_data_model") {
       prune_outputs = []
     }
 
-    # TODO: It is unclear here why `zap_pregenerated_dir` has any relevance
-    #       in including IMClusterCommandHandler or not.
-    #
-    #       This logic has been carried over from previous code during compile
-    #       time codegen addition, however the rationale of why pregenerated
-    #       dir controls IMClusterCommandHandler needs to be explained and
-    #       potentially controlled by a clearer variable (is this for controllers?
-    #       is this during app compile but not others? I am unclear what
-    #       zap_pregenerated_dir is supposed to convey. Existence of a directory
-    #       does not obviously map to "need command handler cpp compiled in").
-    if (defined(invoker.zap_pregenerated_dir) &&
-        !chip_build_controller_dynamic_server) {
+    if (!chip_build_controller_dynamic_server) {
       outputs += [ "zap-generated/IMClusterCommandHandler.cpp" ]
     } else {
       if (defined(prune_outputs)) {
         prune_outputs += [ "zap-generated/IMClusterCommandHandler.cpp" ]
       }
     }
-
-    public_configs = [ ":${_data_model_name}_config" ]
 
     if (!defined(deps)) {
       deps = []
@@ -120,8 +96,6 @@ template("chip_data_model") {
       "app/cluster-init-callback.cpp",
     ]
 
-    public_configs = [ ":${_data_model_name}_config" ]
-
     if (!defined(deps)) {
       deps = []
     }
@@ -136,7 +110,6 @@ template("chip_data_model") {
     forward_variables_from(invoker,
                            "*",
                            [
-                             "zap_pregenerated_dir",
                              "zap_file",
                              "is_server",
                              "external_clusters",
@@ -390,11 +363,5 @@ template("chip_data_model") {
     if (non_spec_compliant_ota_action_delay_floor >= 0) {
       cflags += [ "-DNON_SPEC_COMPLIANT_OTA_ACTION_DELAY_FLOOR=${non_spec_compliant_ota_action_delay_floor}" ]
     }
-
-    if (!defined(public_configs)) {
-      public_configs = []
-    }
-
-    public_configs += [ ":${_data_model_name}_config" ]
   }
 }

--- a/src/controller/data_model/BUILD.gn
+++ b/src/controller/data_model/BUILD.gn
@@ -42,9 +42,5 @@ chip_codegen("cluster-tlv-metadata") {
 
 chip_data_model("data_model") {
   zap_file = "controller-clusters.zap"
-
-  zap_pregenerated_dir =
-      "${chip_root}/zzz_generated/controller-clusters/zap-generated"
-
   allow_circular_includes_from = [ "${chip_root}/src/controller" ]
 }


### PR DESCRIPTION
- this variable was ALWAYS set, to extra logic to trigger the IM dispatch CPP file building was not need
- this value was ALWAYS set to a path that does not exist anymore. our `${chip_root}/zzz_generated` is now much more minimal

This shortens code, dependencies and invalid paths.