### PR TITLE
Support for encoding Field IDs with an MC source

### DIFF
--- a/src/lib/support/jsontlv/JsonToTlv.cpp
+++ b/src/lib/support/jsontlv/JsonToTlv.cpp
@@ -223,7 +223,7 @@ CHIP_ERROR ParseJsonName(const std::string name, ElementContext & elementCtx, ui
         unsigned long result = strtoul(nameFields[0].c_str(), &endPtr, 10);
         VerifyOrReturnError(nameFields[0].c_str() != endPtr, CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError((errno != ERANGE && result <= UINT32_MAX), CHIP_ERROR_INVALID_ARGUMENT);
-        
+
         tagNumber   = static_cast<uint32_t>(result);
         elementType = nameFields[1].c_str();
     }
@@ -234,9 +234,9 @@ CHIP_ERROR ParseJsonName(const std::string name, ElementContext & elementCtx, ui
         char * endPtr;
         errno                = 0;
         unsigned long result = strtoul(nameFields[1].c_str(), &endPtr, 10);
-        VerifyOrReturnError(nameFields[0].c_str() != endPtr, CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(nameFields[1].c_str() != endPtr, CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError((errno != ERANGE && result <= UINT32_MAX), CHIP_ERROR_INVALID_ARGUMENT);
-        
+
         tagNumber   = static_cast<uint32_t>(result);
         elementType = nameFields[2].c_str();
     }

--- a/src/lib/support/jsontlv/JsonToTlv.cpp
+++ b/src/lib/support/jsontlv/JsonToTlv.cpp
@@ -200,7 +200,7 @@ CHIP_ERROR InternalConvertTlvTag(uint32_t tagNumber, TLV::Tag & tag, const uint3
     }
     else
     {
-        tag = TLV::ProfileTag(profileId, static_cast<uint32_t>(tagNumber));
+        tag = TLV::ProfileTag(profileId, tagNumber);
     }
     return CHIP_NO_ERROR;
 }
@@ -494,7 +494,7 @@ CHIP_ERROR JsonToTlv(const std::string & jsonString, TLV::TLVWriter & writer)
     return EncodeTlvElement(json, writer, elementCtx);
 }
 
-CHIP_ERROR ConvertTlvTag(const uint32_t tagNumber, TLV::Tag & tag)
+CHIP_ERROR ConvertTlvTag(uint32_t tagNumber, TLV::Tag & tag)
 {
     return InternalConvertTlvTag(tagNumber, tag);
 }

--- a/src/lib/support/jsontlv/JsonToTlv.cpp
+++ b/src/lib/support/jsontlv/JsonToTlv.cpp
@@ -230,11 +230,7 @@ CHIP_ERROR ParseJsonName(const std::string name, ElementContext & elementCtx, ui
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        else
-        {
-            tagNumber = static_cast<uint32_t>(result);
-        }
-
+        tagNumber   = static_cast<uint32_t>(result);
         elementType = nameFields[1].c_str();
     }
     else if (nameFields.size() == 3)
@@ -253,11 +249,7 @@ CHIP_ERROR ParseJsonName(const std::string name, ElementContext & elementCtx, ui
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        else
-        {
-            tagNumber = static_cast<uint32_t>(result);
-        }
-
+        tagNumber   = static_cast<uint32_t>(result);
         elementType = nameFields[2].c_str();
     }
     else

--- a/src/lib/support/jsontlv/JsonToTlv.cpp
+++ b/src/lib/support/jsontlv/JsonToTlv.cpp
@@ -221,15 +221,9 @@ CHIP_ERROR ParseJsonName(const std::string name, ElementContext & elementCtx, ui
         char * endPtr;
         errno                = 0;
         unsigned long result = strtoul(nameFields[0].c_str(), &endPtr, 10);
-
-        if (nameFields[0].c_str() == endPtr)
-        {
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
-        else if (errno == ERANGE || result > UINT32_MAX)
-        {
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
+        VerifyOrReturnError(nameFields[0].c_str() != endPtr, CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError((errno != ERANGE && result <= UINT32_MAX), CHIP_ERROR_INVALID_ARGUMENT);
+        
         tagNumber   = static_cast<uint32_t>(result);
         elementType = nameFields[1].c_str();
     }
@@ -240,15 +234,9 @@ CHIP_ERROR ParseJsonName(const std::string name, ElementContext & elementCtx, ui
         char * endPtr;
         errno                = 0;
         unsigned long result = strtoul(nameFields[1].c_str(), &endPtr, 10);
-
-        if (nameFields[1].c_str() == endPtr)
-        {
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
-        else if (errno == ERANGE || result > UINT32_MAX)
-        {
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
+        VerifyOrReturnError(nameFields[0].c_str() != endPtr, CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError((errno != ERANGE && result <= UINT32_MAX), CHIP_ERROR_INVALID_ARGUMENT);
+        
         tagNumber   = static_cast<uint32_t>(result);
         elementType = nameFields[2].c_str();
     }

--- a/src/lib/support/jsontlv/JsonToTlv.h
+++ b/src/lib/support/jsontlv/JsonToTlv.h
@@ -33,7 +33,7 @@ CHIP_ERROR JsonToTlv(const std::string & jsonString, MutableByteSpan & tlv);
 CHIP_ERROR JsonToTlv(const std::string & jsonString, TLV::TLVWriter & writer);
 
 /*
- * Convert a uint32_t tagNumber to a TLV tag.
+ * Convert a uint32_t tagNumber (from MEI) to a TLV tag.
  * The upper 16 bits of tag_number represent the vendor_id.
  * The lower 16 bits of tag_number represent the tag_id.
  * When the MEI prefix encodes a standard/scoped source, the tag is encoded using ContextSpecific tag if tag_id is less than or

--- a/src/lib/support/jsontlv/JsonToTlv.h
+++ b/src/lib/support/jsontlv/JsonToTlv.h
@@ -41,6 +41,6 @@ CHIP_ERROR JsonToTlv(const std::string & jsonString, TLV::TLVWriter & writer);
  * the tag is encoded using FullyQualified_6Bytes tag, the Vendor ID SHALL be set to the manufacturer code, the profile number set
  * to 0 and the tag number set to the MEI suffix.
  */
-CHIP_ERROR ConvertTlvTag(const uint32_t tagNumber, TLV::Tag & tag);
+CHIP_ERROR ConvertTlvTag(uint32_t tagNumber, TLV::Tag & tag);
 
 } // namespace chip

--- a/src/lib/support/jsontlv/JsonToTlv.h
+++ b/src/lib/support/jsontlv/JsonToTlv.h
@@ -33,10 +33,14 @@ CHIP_ERROR JsonToTlv(const std::string & jsonString, MutableByteSpan & tlv);
 CHIP_ERROR JsonToTlv(const std::string & jsonString, TLV::TLVWriter & writer);
 
 /*
- * Convert a uint64_t tagNumber to a TLV tag. When tagNumber is less than or equal to UINT8_MAX,
- * the tag is encoded using ContextTag. When tagNumber is larger than UINT8_MAX and less than or equal to UINT32_MAX,
- * the tag is encoded using an implicit profile tag.
+ * Convert a uint32_t tagNumber to a TLV tag.
+ * The upper 16 bits of tag_number represent the vendor_id.
+ * The lower 16 bits of tag_number represent the tag_id.
+ * When the MEI prefix encodes a standard/scoped source, the tag is encoded using ContextSpecific tag if tag_id is less than or
+ * equal to UINT8_MAX, and ImplicitProfile tag if tag_id is larger than UINT8_MAX. When the MEI prefix encodes a manufacturer code,
+ * the tag is encoded using FullyQualified_6Bytes tag, the Vendor ID SHALL be set to the manufacturer code, the profile number set
+ * to 0 and the tag number set to the MEI suffix.
  */
-CHIP_ERROR ConvertTlvTag(const uint64_t tagNumber, TLV::Tag & tag);
+CHIP_ERROR ConvertTlvTag(const uint32_t tagNumber, TLV::Tag & tag);
 
 } // namespace chip

--- a/src/lib/support/jsontlv/TlvToJson.cpp
+++ b/src/lib/support/jsontlv/TlvToJson.cpp
@@ -108,14 +108,12 @@ struct JsonObjectElementContext
         {
             if (TLV::ProfileIdFromTag(tag) == implicitProfileId)
             {
-                // Explicit assume implicit tags are just things we want
-                // 32-bit numbers for
                 str = std::to_string(TLV::TagNumFromTag(tag));
             }
             else
             {
-                // UNEXPECTED, create a full 64-bit number here
-                str = std::to_string(TLV::ProfileIdFromTag(tag)) + "/" + std::to_string(TLV::TagNumFromTag(tag));
+                uint32_t tagNumber = (static_cast<uint32_t>(TLV::VendorIdFromTag(tag)) << 16) | TLV::TagNumFromTag(tag);
+                str                = std::to_string(tagNumber);
             }
         }
         str = str + ":" + GetJsonElementStrFromType(type);
@@ -173,11 +171,8 @@ CHIP_ERROR TlvStructToJson(TLV::TLVReader & reader, Json::Value & jsonObj)
         TLV::Tag tag = reader.GetTag();
         VerifyOrReturnError(TLV::IsContextTag(tag) || TLV::IsProfileTag(tag), CHIP_ERROR_INVALID_TLV_TAG);
 
-        // Profile tags are expected to be implicit profile tags and they are
-        // used to encode > 8bit values from json
-        if (TLV::IsProfileTag(tag))
+        if (TLV::IsProfileTag(tag) && TLV::VendorIdFromTag(tag) == 0)
         {
-            VerifyOrReturnError(TLV::ProfileIdFromTag(tag) == reader.ImplicitProfileId, CHIP_ERROR_INVALID_TLV_TAG);
             VerifyOrReturnError(TLV::TagNumFromTag(tag) > UINT8_MAX, CHIP_ERROR_INVALID_TLV_TAG);
         }
 

--- a/src/lib/support/tests/TestJsonToTlv.cpp
+++ b/src/lib/support/tests/TestJsonToTlv.cpp
@@ -300,7 +300,7 @@ void Test32BitConvert(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite, reader.Next(TLV::AnonymousTag()) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, reader.GetType() == TLV::kTLVType_Structure);
         NL_TEST_ASSERT(inSuite, reader.EnterContainer(tlvType) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, reader.Next(TLV::ProfileTag(0xFEDCu, 0, 0xBA98u)) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.Next(TLV::ProfileTag((4275878552 >> 16) & 0xFFFF, 0, 4275878552 & 0xFFFF)) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, reader.GetType() == TLV::kTLVType_SignedInteger);
         NL_TEST_ASSERT(inSuite, reader.Get(value) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, value == 321);
@@ -310,6 +310,76 @@ void Test32BitConvert(nlTestSuite * inSuite, void * inContext)
     }
 
     // FIXME: implement
+}
+
+void TestMEIConvert(nlTestSuite * inSuite, void * inContext)
+{
+    TLV::TLVReader reader;
+    TLV::TLVType tlvType;
+    int32_t value = 0;
+
+    // Vendor ID = 1, Tag ID = 0
+    {
+        SetupWriters();
+        JsonToTlv("{\"65536:INT\": 321}", gWriter1);
+        NL_TEST_ASSERT(inSuite, gWriter1.Finalize() == CHIP_NO_ERROR);
+
+        reader.Init(gBuf1, gWriter1.GetLengthWritten());
+        reader.ImplicitProfileId = kImplicitProfileId;
+
+        NL_TEST_ASSERT(inSuite, reader.Next(TLV::AnonymousTag()) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.GetType() == TLV::kTLVType_Structure);
+        NL_TEST_ASSERT(inSuite, reader.EnterContainer(tlvType) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.Next(TLV::ProfileTag(1, 0, 0)) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.GetType() == TLV::kTLVType_SignedInteger);
+        NL_TEST_ASSERT(inSuite, reader.Get(value) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, value == 321);
+        NL_TEST_ASSERT(inSuite, reader.Next() == CHIP_END_OF_TLV);
+        NL_TEST_ASSERT(inSuite, reader.ExitContainer(tlvType) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.Next() == CHIP_END_OF_TLV);
+    }
+
+    // Vendor ID = 0xFFFF, Tag ID = 0
+    {
+        SetupWriters();
+        JsonToTlv("{\"4294901760:INT\": 123}", gWriter1);
+        NL_TEST_ASSERT(inSuite, gWriter1.Finalize() == CHIP_NO_ERROR);
+
+        reader.Init(gBuf1, gWriter1.GetLengthWritten());
+        reader.ImplicitProfileId = kImplicitProfileId;
+
+        NL_TEST_ASSERT(inSuite, reader.Next(TLV::AnonymousTag()) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.GetType() == TLV::kTLVType_Structure);
+        NL_TEST_ASSERT(inSuite, reader.EnterContainer(tlvType) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.Next(TLV::ProfileTag(0xFFFF, 0, 0)) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.GetType() == TLV::kTLVType_SignedInteger);
+        NL_TEST_ASSERT(inSuite, reader.Get(value) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, value == 123);
+        NL_TEST_ASSERT(inSuite, reader.Next() == CHIP_END_OF_TLV);
+        NL_TEST_ASSERT(inSuite, reader.ExitContainer(tlvType) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.Next() == CHIP_END_OF_TLV);
+    }
+
+    // Vendor ID = 0xFFFF, Tag ID = 0xFFFF
+    {
+        SetupWriters();
+        JsonToTlv("{\"4294967295:INT\": 123}", gWriter1);
+        NL_TEST_ASSERT(inSuite, gWriter1.Finalize() == CHIP_NO_ERROR);
+
+        reader.Init(gBuf1, gWriter1.GetLengthWritten());
+        reader.ImplicitProfileId = kImplicitProfileId;
+
+        NL_TEST_ASSERT(inSuite, reader.Next(TLV::AnonymousTag()) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.GetType() == TLV::kTLVType_Structure);
+        NL_TEST_ASSERT(inSuite, reader.EnterContainer(tlvType) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.Next(TLV::ProfileTag(0xFFFF, 0, 0xFFFF)) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.GetType() == TLV::kTLVType_SignedInteger);
+        NL_TEST_ASSERT(inSuite, reader.Get(value) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, value == 123);
+        NL_TEST_ASSERT(inSuite, reader.Next() == CHIP_END_OF_TLV);
+        NL_TEST_ASSERT(inSuite, reader.ExitContainer(tlvType) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.Next() == CHIP_END_OF_TLV);
+    }
 }
 
 int Initialize(void * apSuite)
@@ -329,6 +399,7 @@ const nlTest sTests[] =
 {
     NL_TEST_DEF("TestConverter", TestConverter),
     NL_TEST_DEF("Test32BitConvert", Test32BitConvert),
+    NL_TEST_DEF("TestMEIConvert", TestMEIConvert),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/lib/support/tests/TestJsonToTlv.cpp
+++ b/src/lib/support/tests/TestJsonToTlv.cpp
@@ -300,7 +300,7 @@ void Test32BitConvert(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite, reader.Next(TLV::AnonymousTag()) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, reader.GetType() == TLV::kTLVType_Structure);
         NL_TEST_ASSERT(inSuite, reader.EnterContainer(tlvType) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, reader.Next(TLV::ProfileTag(kImplicitProfileId, 0xFEDCBA98u)) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(inSuite, reader.Next(TLV::ProfileTag(0xFEDCu, 0, 0xBA98u)) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, reader.GetType() == TLV::kTLVType_SignedInteger);
         NL_TEST_ASSERT(inSuite, reader.Get(value) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, value == 321);

--- a/src/lib/support/tests/TestJsonToTlvToJson.cpp
+++ b/src/lib/support/tests/TestJsonToTlvToJson.cpp
@@ -703,8 +703,10 @@ void TestConverter_Array_Empty_ImplicitProfileTag4(nlTestSuite * inSuite, void *
     writer.ImplicitProfileId = kImplicitProfileId;
 
     NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, containerType));
-    NL_TEST_ASSERT(
-        gSuite, CHIP_NO_ERROR == writer.StartContainer(TLV::ProfileTag(0x000Fu, 0, 0x4240u), TLV::kTLVType_Array, containerType2));
+    NL_TEST_ASSERT(gSuite,
+                   CHIP_NO_ERROR ==
+                       writer.StartContainer(TLV::ProfileTag((1000000 >> 16) & 0xFFFF, 0, 1000000 & 0xFFFF), TLV::kTLVType_Array,
+                                             containerType2));
     NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.EndContainer(containerType2));
     NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.EndContainer(containerType));
     NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.Finalize());
@@ -1067,8 +1069,10 @@ void TestConverter_Array_Strings(nlTestSuite * inSuite, void * inContext)
     writer.ImplicitProfileId = kImplicitProfileId;
 
     NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, containerType));
-    NL_TEST_ASSERT(
-        gSuite, CHIP_NO_ERROR == writer.StartContainer(TLV::ProfileTag(0x0001u, 0, 0x86A0u), TLV::kTLVType_Array, containerType2));
+    NL_TEST_ASSERT(gSuite,
+                   CHIP_NO_ERROR ==
+                       writer.StartContainer(TLV::ProfileTag((100000 >> 16) & 0xFFFF, 0, 100000 & 0xFFFF), TLV::kTLVType_Array,
+                                             containerType2));
     NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.PutString(TLV::AnonymousTag(), "ABC"));
     NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.PutString(TLV::AnonymousTag(), "Options"));
     NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.PutString(TLV::AnonymousTag(), "more"));
@@ -1826,6 +1830,40 @@ void TestConverter_JsonToTlv_ErrorCases(nlTestSuite * inSuite, void * inContext)
     }
 }
 
+// Full Qualified Profile tags, Unsigned Integer structure: {65536 = 42, 4294901760 = 17000, 4294967295 = 500000000000}
+void TestConverter_Struct_MEITags(nlTestSuite * inSuite, void * inContext)
+{
+    gSuite = inSuite;
+
+    uint8_t buf[256];
+    TLV::TLVWriter writer;
+    TLV::TLVType containerType;
+    TLV::TLVType containerType2;
+
+    writer.Init(buf);
+    writer.ImplicitProfileId = kImplicitProfileId;
+
+    NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, containerType));
+    NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.StartContainer(TLV::ContextTag(0), TLV::kTLVType_Structure, containerType2));
+    NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.Put(TLV::ProfileTag(0xFFFFu, 0, 0), static_cast<uint64_t>(17000)));
+    NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.Put(TLV::ProfileTag(0x0001u, 0, 0), static_cast<uint64_t>(42)));
+    NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.Put(TLV::ProfileTag(0xFFFFu, 0, 0xFFFFu), static_cast<uint64_t>(500000000000)));
+    NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.EndContainer(containerType2));
+    NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.EndContainer(containerType));
+    NL_TEST_ASSERT(gSuite, CHIP_NO_ERROR == writer.Finalize());
+
+    std::string jsonString = "{\n"
+                             "   \"0:STRUCT\" : {\n"
+                             "      \"65536:UINT\" : 42,\n"
+                             "      \"4294901760:UINT\" : 17000,\n"
+                             "      \"4294967295:UINT\" : \"500000000000\"\n"
+                             "   }\n"
+                             "}\n";
+
+    ByteSpan tlvSpan(buf, writer.GetLengthWritten());
+    CheckValidConversion(jsonString, tlvSpan, jsonString);
+}
+
 int Initialize(void * apSuite)
 {
     VerifyOrReturnError(chip::Platform::MemoryInit() == CHIP_NO_ERROR, FAILURE);
@@ -1891,6 +1929,7 @@ const nlTest sTests[] = {
     NL_TEST_DEF("Test Json Tlv Converter - Complex Structure from the README File", TestConverter_Structure_FromReadme),
     NL_TEST_DEF("Test Json Tlv Converter - Tlv to Json Error Cases", TestConverter_TlvToJson_ErrorCases),
     NL_TEST_DEF("Test Json Tlv Converter - Json To Tlv Error Cases", TestConverter_JsonToTlv_ErrorCases),
+    NL_TEST_DEF("Test Json Tlv Converter - Structure with MEI Elements", TestConverter_Struct_MEITags),
     NL_TEST_SENTINEL()
 };
 


### PR DESCRIPTION
Currently, we always use ImplicitProfile tag to encode field ID larger than UINT8_MAX, this is not aligned with the spec.

When the MEI prefix encodes a standard/scoped source, the tag is encoded using ContextSpecific tag if tag_id is less than or equal to UINT8_MAX, and ImplicitProfile tag if tag_id is larger than UINT8_MAX. 

When the MEI prefix encodes a manufacturer code, the tag is encoded using FullyQualified_6Bytes tag, the Vendor ID SHALL be set to the manufacturer code, the profile number set to 0 and the tag number set to the MEI suffix.
