### PR TITLE
Set extended default advertising to be 1285ms

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_DD_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_2_1.yaml
@@ -123,8 +123,9 @@ tests:
           Try NRF Connect app (https://www.nordicsemi.com/Products/Development-tools/nrf-connect-for-desktop)
           OR
           HCIDump (https://ubuntu.com/core/docs/bluez/reference/commands)
-          ->For T0 and 30s we have to get advertisement range between 20ms to 60ms
-          ->For 30s and 15mins we have to get advertisement range between 150ms to 1200ms
+          ->Between [0 .. 30s[ expect advertisement range between 20ms to 60ms.
+          ->Between [30s .. 900s[ expect advertisement range between 150ms to 1285ms. Allow +/- 10ms margin on the measured value.
+          ->Starting at 900s expect advertisement range larger or equal to 1200ms.
       disabled: true
 
     - label: "Step 6: TH does not respond to DUT. User power cycles the DUT"

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -647,28 +647,26 @@
  * CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MIN
  *
  * The minimum interval (in units of 0.625ms) at which the device will send BLE advertisements while
- * in the extended advertising mode. The minimum interval shall not be smaller than the default value
- * and should not be equal to the CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MAX.
+ * in the extended advertising mode. The minimum interval shall not be smaller than the default value.
  *
- * Defaults to 1920 (1200 ms).
+ * Defaults to 2056 (1285 ms).
  */
-#define CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MIN 1920
+#define CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MIN 2056
 
 /**
  * CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MAX
  *
  * The maximum interval (in units of 0.625ms) at which the device will send BLE advertisements while
- * in the extended advertising mode. The maximum interval should be greater and not equal to the
- * CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MIN.
+ * in the extended advertising mode. The maximum interval should be greater.
  *
- * Defaults to 1936 (1210 ms).
+ * Defaults to 2056 (1285 ms).
  */
 #ifndef CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MAX
-#define CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MAX 1936
+#define CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MAX 2056
 #endif
 
-static_assert(CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MIN < CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MAX,
-              "Max Extended Advertising Interval cannot be smaller or equal to the Min Extended Advertising Interval");
+static_assert(CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MIN <= CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MAX,
+              "Max Extended Advertising Interval cannot be larger to the Min Extended Advertising Interval");
 
 #endif
 

--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -587,7 +587,8 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     {
         ++interval_max;
     }
-    ChipLogProgress(DeviceLayer, "Starting advertising with interval_min=%u, intverval_max=%u (units of 625us)", static_cast<unsigned>(interval_min), static_cast<unsigned>(interval_max));
+    ChipLogProgress(DeviceLayer, "Starting advertising with interval_min=%u, intverval_max=%u (units of 625us)",
+                    static_cast<unsigned>(interval_min), static_cast<unsigned>(interval_max));
     ret = sl_bt_advertiser_set_timing(advertising_set_handle, interval_min, interval_max, 0, 0);
     err = MapBLEError(ret);
     SuccessOrExit(err);

--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -582,6 +582,12 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 #endif
     }
 
+    // TODO(#32274): Explain why we cannot have interval_min == interval_max.
+    if (interval_min == interval_max)
+    {
+        ++interval_max;
+    }
+    ChipLogProgress(DeviceLayer, "Starting advertising with interval_min=%u, intverval_max=%u (units of 625us)", static_cast<unsigned>(interval_min), static_cast<unsigned>(interval_max));
     ret = sl_bt_advertiser_set_timing(advertising_set_handle, interval_min, interval_max, 0, 0);
     err = MapBLEError(ret);
     SuccessOrExit(err);


### PR DESCRIPTION
- 1285ms is more reliable than 1200ms in general (https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/8965)
- Update TC-DD-2.1 script to match (https://github.com/CHIP-Specifications/chip-test-plans/pull/4020)
- Update EFR32 platform to be tolerant of min==max for advertising rate

Issue #32274
Fixes #32275

Testing done:

- Linux builds, still discoverable, extended rate 1285ms
  - Tested with nRFConnect
- EFR32 builds, still discoverable, extended rate 1285ms +/- 2ms
  - Tested with nRFConnect and xG24 Explorer kit
