### PR TITLE
Remove Power Topology basic attribute test from manualTests.json

### DIFF
--- a/src/app/tests/suites/manualTests.json
+++ b/src/app/tests/suites/manualTests.json
@@ -311,7 +311,6 @@
     "AccessControlEnforcement": [],
     "OvenMode": ["Test_TC_OTCCM_1_1", "Test_TC_OTCCM_1_2"],
     "EnergyEVSE": ["Test_TC_EEVSE_1_1", "Test_TC_EEVSE_2_1"],
-    "PowerTopology": ["Test_TC_PWRTL_1_1"],
     "collection": [
         "DeviceDiscovery",
         "Groups",


### PR DESCRIPTION
This removes the basic test for Power Topology features and attributes from manualTests.json.
