### PR TITLE
ESP32: fix conversion error for EndpointQueueFilter

### DIFF
--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -1119,8 +1119,8 @@ void ConnectivityManagerImpl::OnStationIPv6AddressAvailable(const ip_event_got_i
         {
             uint8_t dig1               = (station_mac[i] & 0xF0) >> 4;
             uint8_t dig2               = station_mac[i] & 0x0F;
-            station_mac_str[2 * i]     = dig1 > 9 ? ('A' + dig1 - 0xA) : ('0' + dig1);
-            station_mac_str[2 * i + 1] = dig2 > 9 ? ('A' + dig2 - 0xA) : ('0' + dig2);
+            station_mac_str[2 * i]     = static_cast<char>(dig1 > 9 ? ('A' + dig1 - 0xA) : ('0' + dig1));
+            station_mac_str[2 * i + 1] = static_cast<char>(dig2 > 9 ? ('A' + dig2 - 0xA) : ('0' + dig2));
         }
         if (sEndpointQueueFilter.SetMdnsHostName(chip::CharSpan(station_mac_str)) == CHIP_NO_ERROR)
         {

--- a/src/platform/ESP32/ESP32EndpointQueueFilter.h
+++ b/src/platform/ESP32/ESP32EndpointQueueFilter.h
@@ -103,7 +103,7 @@ private:
         {
             if (hostNameLowerCase[i] <= 'F' && hostNameLowerCase[i] >= 'A')
             {
-                hostNameLowerCase[i] = 'a' + hostNameLowerCase[i] - 'A';
+                hostNameLowerCase[i] = static_cast<uint8_t>('a' + hostNameLowerCase[i] - 'A');
             }
         }
         return PayloadContains(payload, ByteSpan(mHostNameBuffer)) || PayloadContains(payload, ByteSpan(hostNameLowerCase));


### PR DESCRIPTION
The compile will fail when enable `-Werror=conversion`. Add static_cast at where compiling fails.
