### PR TITLE
TC-IDM-10.1: Fix guard around non-standard attributes

### DIFF
--- a/src/controller/python/chip/clusters/ClusterObjects.py
+++ b/src/controller/python/chip/clusters/ClusterObjects.py
@@ -301,10 +301,11 @@ class ClusterAttributeDescriptor:
         """Register a subclass."""
         super().__init_subclass__(*args, **kwargs)
         try:
-            if cls.standard_attribute and cls.cluster_id not in ALL_ATTRIBUTES:
-                ALL_ATTRIBUTES[cls.cluster_id] = {}
-            # register this clusterattribute in the ALL_ATTRIBUTES dict for quick lookups
-            ALL_ATTRIBUTES[cls.cluster_id][cls.attribute_id] = cls
+            if cls.standard_attribute:
+                if cls.cluster_id not in ALL_ATTRIBUTES:
+                    ALL_ATTRIBUTES[cls.cluster_id] = {}
+                # register this clusterattribute in the ALL_ATTRIBUTES dict for quick lookups
+                ALL_ATTRIBUTES[cls.cluster_id][cls.attribute_id] = cls
         except NotImplementedError:
             # handle case where the ClusterAttribute class is not (fully) subclassed
             # and accessing the id property throws a NotImplementedError.


### PR DESCRIPTION
Tested: Used an artificial attribute to purposefully fail test. Tested by Eve on a device with an MEI write-only attribute.