### PR TITLE
Fix a few gaps in jumping between Java and C++ for Messages cluster

### DIFF
--- a/examples/tv-app/android/java/MessagesManager.cpp
+++ b/examples/tv-app/android/java/MessagesManager.cpp
@@ -74,7 +74,7 @@ void MessagesManager::InitializeWithObjects(jobject managerObject)
     }
 
     mPresentMessagesMethod =
-        env->GetMethodID(managerClass, "presentMessages", "(Ljava/lang/String;IIJILjava/lang/String;Ljava/util/HashMap;)Z");
+        env->GetMethodID(managerClass, "presentMessages", "(Ljava/lang/String;IIJJLjava/lang/String;Ljava/util/HashMap;)Z");
     if (mPresentMessagesMethod == nullptr)
     {
         ChipLogError(Zcl, "Failed to access MessagesManager 'presentMessages' method");
@@ -182,7 +182,7 @@ CHIP_ERROR MessagesManager::HandleGetMessages(AttributeValueEncoder & aEncoder)
                 message.startTime = DataModel::Nullable<uint32_t>(static_cast<uint32_t>(jstartTime));
             }
 
-            jfieldID durationField = env->GetFieldID(messageClass, "duration", "I");
+            jfieldID durationField = env->GetFieldID(messageClass, "duration", "J");
             jlong jduration        = env->GetLongField(messageObject, durationField);
             if (jduration >= 0)
             {

--- a/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/MessagesManagerStub.java
+++ b/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/MessagesManagerStub.java
@@ -36,7 +36,7 @@ public class MessagesManagerStub implements MessagesManager {
     responseOptions.put(new Long(1), "Yes");
     responseOptions.put(new Long(2), "No");
     presentMessages(
-        "31323334353637383930313233343536", 1, 1, 30, 60, "TestMessage", responseOptions);
+        "31323334353637383930313233343536", 1, 1, 30, 60000, "TestMessage", responseOptions);
     Log.d(TAG, "MessagesManagerStub: added dummy message");
   }
 


### PR DESCRIPTION
Fix dangling problems arising from uint16 seconds for duration to uint64_t milliseconds (problems introduced in https://github.com/project-chip/connectedhomeip/pull/32248 