### PR TITLE
[Silabs] Fix header guard since 2 headers had the same

### DIFF
--- a/src/platform/silabs/rs911x/rsi_ble_config.h
+++ b/src/platform/silabs/rs911x/rsi_ble_config.h
@@ -14,9 +14,7 @@
  * sections of the MSLA applicable to Source Code.
  *
  ******************************************************************************/
-
-#ifndef RSI_BLE_CONFIG_H
-#define RSI_BLE_CONFIG_H
+#pragma once
 
 #include "rsi_ble_apis.h"
 #if (SIWX_917 | EXP_BOARD)
@@ -316,5 +314,3 @@ typedef struct rsi_ble_s
     uint16_t att_rec_list_count;
     rsi_ble_att_list_t att_rec_list[NO_OF_VAL_ATT];
 } rsi_ble_t;
-
-#endif


### PR DESCRIPTION
Fix header guards that caused compilation problems on some machine.

Real cause of the issue : 


`src/platforms/silabs/rs911x/rsi_ble_config.h` is also present under the name `src/platforms/silabs/rs911x/ble_config.h`
Both headers file are exactly the same because `ble_config.h` is actually a symbolic link to `rsi_ble_config.h`. Since they share the same header guard under the form of `#ifndef XXXX` well depending on the machine building the binary this could cause the `rsi_ble_config.h` to be used and `ble_config.h` to be useless thus causing a build failure with `undefined reference to XXXX` 

While this is far from fixing the real underlying issue, it will allow compilations on all machines.