### PR TITLE
DNSSD is registering, also can try dns resolve

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -629,9 +629,10 @@ bool DiscoveryImplPlatform::IsInitialized()
 
 CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId)
 {
-    // Resolve requests can only be issued once DNSSD is initialized and there is
-    // no caching currently
-    // When the DNSSD is kInitializing, can also try to resolve.
+    // It only determines that it is not in an uninitialized state, and cannot force initialization to be completed.
+    // There are differences between platforms.
+    // e.g. when a collision occurs on the Linux platform, initialization has not been completed at this time, but you can
+    // still try to parse.
     VerifyOrReturnError(mState != State::kUninitialized, CHIP_ERROR_INCORRECT_STATE);
 
     ChipLogProgress(Discovery, "Resolving " ChipLogFormatX64 ":" ChipLogFormatX64 " ...",

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -631,7 +631,8 @@ CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId)
 {
     // Resolve requests can only be issued once DNSSD is initialized and there is
     // no caching currently
-    VerifyOrReturnError(mState == State::kInitialized, CHIP_ERROR_INCORRECT_STATE);
+    // When the DNSSD is kInitializing, can also try to resolve.
+    VerifyOrReturnError(mState != State::kUninitialized, CHIP_ERROR_INCORRECT_STATE);
 
     ChipLogProgress(Discovery, "Resolving " ChipLogFormatX64 ":" ChipLogFormatX64 " ...",
                     ChipLogValueX64(peerId.GetCompressedFabricId()), ChipLogValueX64(peerId.GetNodeId()));

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -383,7 +383,8 @@ void MdnsAvahi::HandleClientState(AvahiClient * client, AvahiClientState state)
         break;
     case AVAHI_CLIENT_FAILURE:
         ChipLogError(DeviceLayer, "Avahi client failure");
-        mErrorCallback(mAsyncReturnContext, CHIP_ERROR_INTERNAL);
+	// error happend, we should to restart dnssd.
+        mErrorCallback(mAsyncReturnContext, CHIP_ERROR_FORCED_RESET);
         break;
     case AVAHI_CLIENT_S_COLLISION:
         ChipLogProgress(DeviceLayer, "Avahi collision, force to reset");

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -386,10 +386,15 @@ void MdnsAvahi::HandleClientState(AvahiClient * client, AvahiClientState state)
         mErrorCallback(mAsyncReturnContext, CHIP_ERROR_INTERNAL);
         break;
     case AVAHI_CLIENT_S_COLLISION:
-    case AVAHI_CLIENT_S_REGISTERING:
-        ChipLogProgress(DeviceLayer, "Avahi re-register required");
+        ChipLogProgress(DeviceLayer, "Avahi collision, force to reset");
         StopPublish();
         mErrorCallback(mAsyncReturnContext, CHIP_ERROR_FORCED_RESET);
+        // Should restart the resolve service of the host.
+        break;
+    case AVAHI_CLIENT_S_REGISTERING:
+        // now is registering, we should just StopPublish() without reset
+        ChipLogProgress(DeviceLayer, "Avahi registering");
+        StopPublish();
         break;
     case AVAHI_CLIENT_CONNECTING:
         ChipLogProgress(DeviceLayer, "Avahi connecting");

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -383,17 +383,14 @@ void MdnsAvahi::HandleClientState(AvahiClient * client, AvahiClientState state)
         break;
     case AVAHI_CLIENT_FAILURE:
         ChipLogError(DeviceLayer, "Avahi client failure");
-        // error happend, we should to restart dnssd.
-        mErrorCallback(mAsyncReturnContext, CHIP_ERROR_FORCED_RESET);
+        mErrorCallback(mAsyncReturnContext, CHIP_ERROR_INTERNAL);
         break;
     case AVAHI_CLIENT_S_COLLISION:
-        ChipLogProgress(DeviceLayer, "Avahi collision, force to reset");
+        ChipLogProgress(DeviceLayer, "Avahi collision");
         StopPublish();
-        mErrorCallback(mAsyncReturnContext, CHIP_ERROR_FORCED_RESET);
-        // Should restart the resolve service of the host.
+        // DNSSD does not need to be restarted, it depends on the system resolve service restarting
         break;
     case AVAHI_CLIENT_S_REGISTERING:
-        // now is registering, we should just StopPublish() without reset
         ChipLogProgress(DeviceLayer, "Avahi registering");
         StopPublish();
         break;

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -383,7 +383,7 @@ void MdnsAvahi::HandleClientState(AvahiClient * client, AvahiClientState state)
         break;
     case AVAHI_CLIENT_FAILURE:
         ChipLogError(DeviceLayer, "Avahi client failure");
-	// error happend, we should to restart dnssd.
+        // error happend, we should to restart dnssd.
         mErrorCallback(mAsyncReturnContext, CHIP_ERROR_FORCED_RESET);
         break;
     case AVAHI_CLIENT_S_COLLISION:


### PR DESCRIPTION
1. [Linux] Avahi is registering, there is no need to reset
2. [Linux] Avahi collision, needn't restart dnssd, it depends on the HOST resolve service
3. DNSSD is registering, also can try dns resolve. There are differences between platforms.

