### PR TITLE
Support user input for python tests in TH

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/hooks.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/hooks.py
@@ -13,6 +13,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from typing import Optional
+
 from .parser import TestStep
 
 
@@ -210,6 +212,15 @@ class TestRunnerHooks():
     async def step_manual(self):
         """
         This method is called when the step is executed manually.
+        """
+        pass
+
+    def show_prompt(self,
+                    msg: str,
+                    placeholder: Optional[str] = None,
+                    default_value: Optional[str] = None) -> None:
+        """
+        This method is called when the step needs to ask the user to perform some action or provide some value.
         """
         pass
 

--- a/src/python_testing/TC_RVCOPSTATE_2_4.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_4.py
@@ -115,47 +115,51 @@ class TC_RVCOPSTATE_2_4(MatterBaseTest):
             self.write_to_app_pipe('{"Name": "Reset"}')
 
         if self.check_pics("RVCOPSTATE.S.M.ST_ERROR"):
-            self.print_step(2, "Manually put the device in the ERROR operational state")
+            step_name = "Manually put the device in the ERROR operational state"
+            self.print_step(2, step_name)
             if self.is_ci:
                 self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "UnableToStartOrResume"}')
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(step_name)
 
             await self.read_operational_state_with_check(3, op_states.kError)
 
             await self.send_go_home_cmd_with_check(4, op_errors.kCommandInvalidInState)
 
         if self.check_pics("RVCOPSTATE.S.M.ST_CHARGING"):
-            self.print_step(5, "Manually put the device in the CHARGING operational state")
+            step_name = "Manually put the device in the CHARGING operational state"
+            self.print_step(5, step_name)
             if self.is_ci:
                 self.write_to_app_pipe('{"Name": "Reset"}')
                 self.write_to_app_pipe('{"Name": "Docked"}')
                 self.write_to_app_pipe('{"Name": "Charging"}')
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(step_name)
 
             await self.read_operational_state_with_check(6, rvc_op_states.kCharging)
 
             await self.send_go_home_cmd_with_check(7, op_errors.kCommandInvalidInState)
 
         if self.check_pics("RVCOPSTATE.S.M.ST_DOCKED"):
-            self.print_step(8, "Manually put the device in the DOCKED operational state")
+            step_name = "Manually put the device in the DOCKED operational state"
+            self.print_step(8, step_name)
             if self.is_ci:
                 self.write_to_app_pipe('{"Name": "Charged"}')
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(step_name)
 
             await self.read_operational_state_with_check(9, rvc_op_states.kDocked)
 
             await self.send_go_home_cmd_with_check(10, op_errors.kCommandInvalidInState)
 
         if self.check_pics("PICS_M_ST_SEEKING_CHARGER"):
-            self.print_step(8, "Manually put the device in the SEEKING CHARGER operational state")
+            step_name = "Manually put the device in the SEEKING CHARGER operational state"
+            self.print_step(8, step_name)
             if self.is_ci:
                 await self.send_run_change_to_mode_cmd(rvc_app_run_mode_cleaning)
                 await self.send_run_change_to_mode_cmd(rvc_app_run_mode_idle)
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(step_name)
 
             await self.read_operational_state_with_check(9, rvc_op_states.kSeekingCharger)
 

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -346,6 +346,12 @@ class InternalTestRunnerHooks(TestRunnerHooks):
         """
         pass
 
+    def show_prompt(self,
+                    msg: str,
+                    placeholder: Optional[str] = None,
+                    default_value: Optional[str] = None) -> None:
+        pass
+
 
 @dataclass
 class MatterTestConfig:
@@ -1090,6 +1096,28 @@ class MatterBaseTest(base_test.BaseTestClass):
             info.filter_value = setup_payload.long_discriminator
 
         return info
+
+    def wait_for_user_input(self,
+                            prompt_msg: str,
+                            input_msg: str = "Press Enter when done.\n",
+                            prompt_msg_placeholder: str = "Submit anything to continue",
+                            default_value: str = "y") -> str:
+        """Ask for user input and wait for it.
+
+        Args:
+            prompt_msg (str): Message for TH UI prompt. Indicates what is expected from the user.
+            input_msg (str, optional): Prompt for input function, used when running tests manually. Defaults to "Press Enter when done.\n".
+            prompt_msg_placeholder (str, optional): TH UI prompt input placeholder. Defaults to "Submit anything to continue".
+            default_value (str, optional): TH UI prompt default value. Defaults to "y".
+
+        Returns:
+            str: User input
+        """
+        if self.runner_hook:
+            self.runner_hook.show_prompt(msg=prompt_msg,
+                                         placeholder=prompt_msg_placeholder,
+                                         default_value=default_value)
+        return input(input_msg)
 
 
 def generate_mobly_test_config(matter_test_config: MatterTestConfig):


### PR DESCRIPTION
- Add support for getting user input during the execution of Python Tests in TH UI.
- Update `TC-RVCOPSTATE-2.4` as an example.

**The other tests that need user input need to be updated to use this new `wait_for_user_input` function created in this PR.**

Related TH backend PR:
- https://github.com/project-chip/certification-tool-backend/pull/73