### PR TITLE
fix crash caused by lacking null pointer check and wrong cluster id usage

### DIFF
--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -214,6 +214,7 @@ public:
               ScenesManagement::ScenesServer::Instance().IsHandlerRegistered(endpoint, LevelControlServer::GetSceneHandler())))
 #endif
         {
+            VerifyOrReturnError(mTransitionTimeInterface.sceneEventControl(endpoint) != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
             OnOffServer::Instance().scheduleTimerCallbackMs(mTransitionTimeInterface.sceneEventControl(endpoint), timeMs);
         }
 
@@ -221,7 +222,7 @@ public:
     }
 
 private:
-    OnOffTransitionTimeInterface mTransitionTimeInterface = OnOffTransitionTimeInterface(Attributes::OnOff::Id, sceneOnOffCallback);
+    OnOffTransitionTimeInterface mTransitionTimeInterface = OnOffTransitionTimeInterface(OnOff::Id, sceneOnOffCallback);
 };
 static DefaultOnOffSceneHandler sOnOffSceneHandler;
 


### PR DESCRIPTION
Crash detected while executing recall-scene for onoff cluster

- crash caused by lacking null pointer check in timer callback
- this was caused by using wrong cluster id in the transition time implementation
- fixes https://github.com/project-chip/connectedhomeip/issues/32338