### PR TITLE
Define explicit `data_model` sub-targets for generated files

### DIFF
--- a/build/chip/chip_codegen.gni
+++ b/build/chip/chip_codegen.gni
@@ -35,7 +35,7 @@ template("_chip_build_time_codegen") {
     include_dirs = [ target_gen_dir ]
   }
 
-  pw_python_action("${_name}_codegen") {
+  pw_python_action("${_name}_generate") {
     script = "${chip_root}/scripts/codegen.py"
 
     # TODO: this seems to touch internals. Is this ok? speeds up builds!
@@ -99,7 +99,7 @@ template("_chip_build_time_codegen") {
     if (!defined(deps)) {
       deps = []
     }
-    deps += [ ":${_name}_codegen" ]
+    deps += [ ":${_name}_generate" ]
   }
 }
 
@@ -152,7 +152,7 @@ template("_chip_build_time_zapgen") {
     _output_subdir = "zap-generated"
   }
 
-  pw_python_action("${_name}_zap") {
+  pw_python_action("${_name}_generate") {
     script = "${chip_root}/scripts/tools/zap/generate.py"
 
     # TODO: this seems to touch internals. Is this ok? speeds up builds!
@@ -211,7 +211,7 @@ template("_chip_build_time_zapgen") {
     if (!defined(public_deps)) {
       public_deps = []
     }
-    public_deps += [ ":${_name}_zap" ]
+    public_deps += [ ":${_name}_generate" ]
   }
 }
 

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/access.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/access.h
@@ -20,7 +20,7 @@
 // Prevent multiple inclusion
 #pragma once
 
-#include <app/util/privilege-storage.h>
+#include <app/util/privilege-constants.h>
 
 // Prevent changing generated format
 // clang-format off

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/access.h
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/access.h
@@ -20,7 +20,7 @@
 // Prevent multiple inclusion
 #pragma once
 
-#include <app/util/privilege-storage.h>
+#include <app/util/privilege-constants.h>
 
 // Prevent changing generated format
 // clang-format off

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -229,6 +229,7 @@ static_library("interaction-model") {
       "dynamic_server/AccessControl.cpp",
       "dynamic_server/AccessControl.h",
       "dynamic_server/DynamicDispatcher.cpp",
+      "util/privilege-constants.h",
       "util/privilege-storage.cpp",
       "util/privilege-storage.h",
     ]

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -158,21 +158,23 @@ template("chip_data_model") {
     }
   }
 
-  source_set("${_data_model_name}-command-dispatch") {
-    sources = [ "${_zapgen_gen_dir}/zap-generated/IMClusterCommandHandler.cpp" ]
-
-    deps = [
-      "${chip_root}/src/app",
-      "${chip_root}/src/app:interaction-model",
-      "${chip_root}/src/app/common:cluster-objects",
-      "${chip_root}/src/app/common:enums",
-      "${chip_root}/src/app/common:ids",
-      "${chip_root}/src/lib/core",
-      "${chip_root}/src/lib/support",
-    ]
-
-    if (chip_code_pre_generated_directory == "") {
-      deps += [ ":${_data_model_name}_zapgen_generate" ]
+  if (!chip_build_controller_dynamic_server) {
+    source_set("${_data_model_name}-command-dispatch") {
+      sources = [ "${_zapgen_gen_dir}/zap-generated/IMClusterCommandHandler.cpp" ]
+    
+      deps = [
+        "${chip_root}/src/app",
+        "${chip_root}/src/app:interaction-model",
+        "${chip_root}/src/app/common:cluster-objects",
+        "${chip_root}/src/app/common:enums",
+        "${chip_root}/src/app/common:ids",
+        "${chip_root}/src/lib/core",
+        "${chip_root}/src/lib/support",
+      ]
+    
+      if (chip_code_pre_generated_directory == "") {
+        deps += [ ":${_data_model_name}_zapgen_generate" ]
+      }
     }
   }
 

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -160,8 +160,9 @@ template("chip_data_model") {
 
   if (!chip_build_controller_dynamic_server) {
     source_set("${_data_model_name}-command-dispatch") {
-      sources = [ "${_zapgen_gen_dir}/zap-generated/IMClusterCommandHandler.cpp" ]
-    
+      sources =
+          [ "${_zapgen_gen_dir}/zap-generated/IMClusterCommandHandler.cpp" ]
+
       deps = [
         "${chip_root}/src/app",
         "${chip_root}/src/app:interaction-model",
@@ -171,7 +172,7 @@ template("chip_data_model") {
         "${chip_root}/src/lib/core",
         "${chip_root}/src/lib/support",
       ]
-    
+
       if (chip_code_pre_generated_directory == "") {
         deps += [ ":${_data_model_name}_zapgen_generate" ]
       }

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -132,11 +132,14 @@ template("chip_data_model") {
       "${_zapgen_gen_dir}/zap-generated/gen_config.h",
     ]
 
-    deps = [
-      ":${_data_model_name}_codegen_codegen",
-      ":${_data_model_name}_zapgen_zap",
-      "${chip_root}/src/lib/core:chip_config_header",
-    ]
+    deps = [ "${chip_root}/src/lib/core:chip_config_header" ]
+
+    if (chip_code_pre_generated_directory == "") {
+      deps += [
+        ":${_data_model_name}_codegen_generate",
+        ":${_data_model_name}_zapgen_generate",
+      ]
+    }
   }
 
   source_set("${_data_model_name}-callbacks") {
@@ -144,17 +147,21 @@ template("chip_data_model") {
       "${_codegen_gen_dir}/app/callback-stub.cpp",
       "${_codegen_gen_dir}/app/cluster-init-callback.cpp",
     ]
+
     deps = [
-      ":${_data_model_name}_codegen_codegen",
       "${chip_root}/src/lib/support:span",
       "${chip_root}/src/protocols/interaction_model",
     ]
+
+    if (chip_code_pre_generated_directory == "") {
+      deps += [ ":${_data_model_name}_codegen_generate" ]
+    }
   }
 
   source_set("${_data_model_name}-command-dispatch") {
     sources = [ "${_zapgen_gen_dir}/zap-generated/IMClusterCommandHandler.cpp" ]
+
     deps = [
-      ":${_data_model_name}_zapgen_zap",
       "${chip_root}/src/app",
       "${chip_root}/src/app:interaction-model",
       "${chip_root}/src/app/common:cluster-objects",
@@ -163,6 +170,10 @@ template("chip_data_model") {
       "${chip_root}/src/lib/core",
       "${chip_root}/src/lib/support",
     ]
+
+    if (chip_code_pre_generated_directory == "") {
+      deps += [ ":${_data_model_name}_zapgen_generate" ]
+    }
   }
 
   source_set(_data_model_name) {

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -32,6 +32,26 @@ _app_root = get_path_info(".", "abspath")
 #
 # Forwards all the remaining variables to the source_set.
 #
+#
+#
+# Additional underlying source sets that will be provided
+#
+#   - ${name}-endpoint-metadata
+#     contains HEADERS that define endpoint metadata from zap/matter files:
+#        - zap-generated/gen_config.h
+#        - zap-generated/endpoint_config.h
+#        - zap-generated/access.h
+#        - PluginApplicationCallbacks.h
+#   - ${name}-callbacks
+#     contains the callback implementation for cluster init:
+#        - cluster-init-callback.cpp
+#        - callback-stub.cpp (contains __weak__ implementations. TODO: we should not be using
+#          weak linkage over time at all)
+#   - ${name}-command-dispatch:
+#     contains the implementation of `DispatchServerCommand` which forwards data to
+#     `emberAf....Cluster...Callback` callbacks
+#        - zap-generated/IMClusterCommandHandler.cpp
+#
 template("chip_data_model") {
   _data_model_name = target_name
 
@@ -84,6 +104,48 @@ template("chip_data_model") {
     deps += [
       ":${_data_model_name}_zapgen",
       "${chip_root}/src/app/common:cluster-objects",
+    ]
+  }
+
+  # Fixed source sets for allowing reasonable dependencies on things:
+  source_set("${_data_model_name}-endpoint-metadata") {
+    sources = [
+      "app/PluginApplicationCallbacks.h",
+      "zap-generated/access.h",
+      "zap-generated/endpoint_config.h",
+      "zap-generated/gen_config.h",
+    ]
+
+    deps = [
+      ":${_data_model_name}_codegen",
+      ":${_data_model_name}_zapgen",
+      "${chip_root}/src/lib/core:chip_config_header",
+    ]
+  }
+
+  source_set("${_data_model_name}-callbacks") {
+    sources = [
+      "app/callback-stub.cpp",
+      "app/cluster-init-callback.cpp",
+    ]
+    deps = [
+      ":${_data_model_name}_codegen",
+      "${chip_root}/src/protocols/interaction_model",
+      "${chip_root}/src/support:span",
+    ]
+  }
+
+  source_set("${_data_model_name}-command-dispatch") {
+    sources = [ "zap-generated/IMClusterCommandHandler.cpp" ]
+    deps = [
+      ":${_data_model_name}_codegen",
+      "${chip_root}/src/app",
+      "${chip_root}/src/app:interaction-model",
+      "${chip_root}/src/app/common:cluster-objects",
+      "${chip_root}/src/app/common:enums",
+      "${chip_root}/src/app/common:ids",
+      "${chip_root}/src/core",
+      "${chip_root}/src/support",
     ]
   }
 

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -149,6 +149,7 @@ template("chip_data_model") {
     ]
 
     deps = [
+      "${chip_root}/src/app/common:ids",
       "${chip_root}/src/lib/support:span",
       "${chip_root}/src/protocols/interaction_model",
     ]

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -107,45 +107,61 @@ template("chip_data_model") {
     ]
   }
 
+  # where generated files reside
+  # TODO: where can this reside?
+  if (chip_code_pre_generated_directory == "") {
+    _zapgen_gen_dir = "${target_gen_dir}/zapgen"
+    _codegen_gen_dir = "${target_gen_dir}"
+  } else {
+    # NOTE: if zap and matter file will reside in different locations
+    #       this path will change between zapgen and codegen
+    _pregen_dir =
+        chip_code_pre_generated_directory + "/" +
+        string_replace(rebase_path(invoker.zap_file, chip_root), ".zap", "")
+
+    _zapgen_gen_dir = "${_pregen_dir}/zap/app-templates"
+    _codegen_gen_dir = "${_pregen_dir}/codegen/cpp-app"
+  }
+
   # Fixed source sets for allowing reasonable dependencies on things:
   source_set("${_data_model_name}-endpoint-metadata") {
     sources = [
-      "app/PluginApplicationCallbacks.h",
-      "zap-generated/access.h",
-      "zap-generated/endpoint_config.h",
-      "zap-generated/gen_config.h",
+      "${_codegen_gen_dir}/app/PluginApplicationCallbacks.h",
+      "${_zapgen_gen_dir}/zap-generated/access.h",
+      "${_zapgen_gen_dir}/zap-generated/endpoint_config.h",
+      "${_zapgen_gen_dir}/zap-generated/gen_config.h",
     ]
 
     deps = [
-      ":${_data_model_name}_codegen",
-      ":${_data_model_name}_zapgen",
+      ":${_data_model_name}_codegen_codegen",
+      ":${_data_model_name}_zapgen_zap",
       "${chip_root}/src/lib/core:chip_config_header",
     ]
   }
 
   source_set("${_data_model_name}-callbacks") {
     sources = [
-      "app/callback-stub.cpp",
-      "app/cluster-init-callback.cpp",
+      "${_codegen_gen_dir}/app/callback-stub.cpp",
+      "${_codegen_gen_dir}/app/cluster-init-callback.cpp",
     ]
     deps = [
-      ":${_data_model_name}_codegen",
+      ":${_data_model_name}_codegen_codegen",
+      "${chip_root}/src/lib/support:span",
       "${chip_root}/src/protocols/interaction_model",
-      "${chip_root}/src/support:span",
     ]
   }
 
   source_set("${_data_model_name}-command-dispatch") {
-    sources = [ "zap-generated/IMClusterCommandHandler.cpp" ]
+    sources = [ "${_zapgen_gen_dir}/zap-generated/IMClusterCommandHandler.cpp" ]
     deps = [
-      ":${_data_model_name}_codegen",
+      ":${_data_model_name}_zapgen_zap",
       "${chip_root}/src/app",
       "${chip_root}/src/app:interaction-model",
       "${chip_root}/src/app/common:cluster-objects",
       "${chip_root}/src/app/common:enums",
       "${chip_root}/src/app/common:ids",
-      "${chip_root}/src/core",
-      "${chip_root}/src/support",
+      "${chip_root}/src/lib/core",
+      "${chip_root}/src/lib/support",
     ]
   }
 

--- a/src/app/util/privilege-constants.h
+++ b/src/app/util/privilege-constants.h
@@ -1,0 +1,23 @@
+/**
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+inline constexpr int kMatterAccessPrivilegeView       = 0;
+inline constexpr int kMatterAccessPrivilegeOperate    = 1;
+inline constexpr int kMatterAccessPrivilegeManage     = 2;
+inline constexpr int kMatterAccessPrivilegeAdminister = 3;
+inline constexpr int kMatterAccessPrivilegeMaxValue   = kMatterAccessPrivilegeAdminister;

--- a/src/app/util/privilege-storage.h
+++ b/src/app/util/privilege-storage.h
@@ -16,13 +16,8 @@
  */
 #pragma once
 
+#include <app/util/privilege-constants.h>
 #include <lib/core/DataModelTypes.h>
-
-inline constexpr int kMatterAccessPrivilegeView       = 0;
-inline constexpr int kMatterAccessPrivilegeOperate    = 1;
-inline constexpr int kMatterAccessPrivilegeManage     = 2;
-inline constexpr int kMatterAccessPrivilegeAdminister = 3;
-inline constexpr int kMatterAccessPrivilegeMaxValue   = kMatterAccessPrivilegeAdminister;
 
 int MatterGetAccessPrivilegeForReadAttribute(chip::ClusterId cluster, chip::AttributeId attribute);
 int MatterGetAccessPrivilegeForWriteAttribute(chip::ClusterId cluster, chip::AttributeId attribute);

--- a/src/app/zap-templates/templates/app/access.zapt
+++ b/src/app/zap-templates/templates/app/access.zapt
@@ -3,7 +3,7 @@
 // Prevent multiple inclusion
 #pragma once
 
-#include <app/util/privilege-storage.h>
+#include <app/util/privilege-constants.h>
 
 // Prevent changing generated format
 // clang-format off


### PR DESCRIPTION
we currently code-generate across all layers, both config headers (that generally define endpoint composition) and cpp implementations like init callback stubs and data dispatch. As a result we cannot have a "data model target" as a stand-alone since this would imply a full monolith of src/app.

This PR contains two changes:
   - define separate targets for data_model that can be used in the future for GN dependencies
   - split out constants for privileges so that codegen can be independent from privilege-storage
   
This is what codegen we have for app (orange red bits):

![image](https://github.com/project-chip/connectedhomeip/assets/1832280/961ab7d3-1ae4-4161-ab74-e9007d5cedc5)

Additional this is the constant include move for privilege-storage. Existing code would force me to combine generated code and non-generated:

![image](https://github.com/project-chip/connectedhomeip/assets/1832280/eb43454b-6eac-43da-9767-76448b219857)

Where as new code breaks that dependency into 2:

![image](https://github.com/project-chip/connectedhomeip/assets/1832280/a4d60d2d-dfbf-451c-88eb-1efccc2bcbb0)

After the PR, this is what targets could exist (they do not as there is still no GN linkage ... I will need to include some form of `data_model_BACKEND` that differs across each app):

![image](https://github.com/project-chip/connectedhomeip/assets/1832280/c5888729-d98e-4df3-8bb9-b81be085afa8)


