### PR TITLE
chip-repl: Remove stale comment and validation

### DIFF
--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -283,9 +283,6 @@ PyChipError SendBatchCommandsInternal(void * appContext, DeviceProxy * device, u
         }
         SuccessOrExit(err = sender->TestOnlyFinishCommand(finishCommandParams));
 
-        // CommandSender provides us with the CommandReference for this associated command. In order to match responses
-        // we have to add CommandRef to index lookup.
-        VerifyOrExit(finishCommandParams.commandRef.HasValue(), err = CHIP_ERROR_INVALID_ARGUMENT);
         if (testOnlyCommandRefsOverride != nullptr)
         {
             // Making sure the value we used to override CommandRef was actually used.


### PR DESCRIPTION
After [this PR was merged](https://github.com/project-chip/connectedhomeip/pull/31837) this comment has become stall and incorrect
