### PR TITLE
Free up space on the github runner by deleting some tools we don't use

### DIFF
--- a/.github/actions/checkout-submodules-and-bootstrap/action.yaml
+++ b/.github/actions/checkout-submodules-and-bootstrap/action.yaml
@@ -15,6 +15,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Maximize runner disk
+      uses: ./.github/actions/maximize-runner-disk
     - name: Dump disk info
       uses: ./.github/actions/dump-disk-info
     - name: Set git safe directory for local act runs

--- a/.github/actions/maximize-runner-disk/action.yaml
+++ b/.github/actions/maximize-runner-disk/action.yaml
@@ -1,0 +1,50 @@
+name: Maximize runner disk
+description: Free up disk space on the github runner
+runs:
+  using: "composite"
+  steps:
+    - name: Free up disk space on the github runner
+      if: ${{ !env.ACT }}
+      shell: bash
+      run: |
+        # maximize-runner-disk
+        if [[ "$RUNNER_OS" == Linux ]]; then
+          # Directories to prune to free up space. Candidates:
+          #   1.6G  /usr/share/dotnet
+          #   1.1G  /usr/local/lib/android/sdk/platforms
+          #   1000M /usr/local/lib/android/sdk/build-tools
+          #   8.9G  /usr/local/lib/android/sdk
+          # This list can be amended later to change the trade-off between the amount of
+          # disk space freed up, and how long it takes to do so (deleting many files is slow).
+          prune=(/usr/share/dotnet /usr/local/lib/android/sdk/platforms /usr/local/lib/android/sdk/build-tools)
+
+          if [[ "$UID" -eq 0 && -d /__w ]]; then
+            root=/runner-root-volume
+            if [[ ! -d "$root" ]]; then
+              echo "Unable to maximize disk space, job is running inside a container and $root is not mounted"
+              exit 0
+            fi
+            function sudo() { "$@"; } # we're already root (and sudo is probably unavailable)
+          elif [[ "$UID" -ne 0 && "$RUNNER_ENVIRONMENT" == github-hosted ]]; then
+            root=
+          else
+            echo "Unable to maximize disk space, unknown runner environment"
+            exit 0
+          fi
+
+          echo "Freeing up runner disk space on ${root:-/}"
+          function avail() { df -k --output=avail "${root:-/}" | grep '^[0-9]*$'; }
+          function now() { date '+%s'; }
+          before="$(avail)" start="$(now)"
+          for dir in "${prune[@]}"; do
+            if [[ -d "${root}${dir}" ]]; then
+              echo "- $dir"
+              # du -sh -- "${root}${dir}"
+              sudo rm -rf -- "${root}${dir}"
+            else
+              echo "- $dir (not found)"
+            fi
+          done
+          after="$(avail)" end="$(now)"
+          echo "Done, freed up $(( (after - before) / 1024 ))M of disk space in $(( end - start )) seconds."
+        fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build:35
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
@@ -137,6 +138,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build:35
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
@@ -285,6 +287,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build:35
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
             options: --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
@@ -345,6 +348,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build:35
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
             options: --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
@@ -453,6 +457,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build:35
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -39,6 +39,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-android:35
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
 
         steps:

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -39,6 +39,7 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build:35
             volumes:
+                - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
 


### PR DESCRIPTION
Currently this deletes .NET tooling and parts of the Android SDK. Note that our Android CI builds bring their own Android SDK via the chip-build-android container, and do not rely on the copy that is installed in the GitHub Ubuntu image.