### PR TITLE
[ESP32] Tracing : Added the fix of data type mismatch while registering the metrics in esp32 tracing framework.

### DIFF
--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -160,6 +160,9 @@ ALLOW: Dict[str, Set[str]] = {
     'src/tracing/json/json_tracing.cpp': {'string', 'sstream'},
     'src/tracing/json/json_tracing.h': {'fstream', 'unordered_map'},
 
+    # esp32 tracing
+    'src/tracing/esp32_trace/esp32_tracing.h': {'unordered_map'},
+
     # Not intended for embedded clients
     'src/app/PendingResponseTrackerImpl.h': {'unordered_set'},
 

--- a/src/tracing/esp32_trace/esp32_tracing.cpp
+++ b/src/tracing/esp32_trace/esp32_tracing.cpp
@@ -134,10 +134,7 @@ void RemoveHashFromPermitlist(const char * str)
 #define LOG_HEAP_INFO(label, group, entry_exit)                                                                                    \
     do                                                                                                                             \
     {                                                                                                                              \
-        ESP_DIAG_EVENT("MTR_TRC", "%s - %s - %s Min Free heap - %u - LFB - %u Start free heap - %u", entry_exit, label, group,     \
-                       heap_caps_get_minimum_free_size(MALLOC_CAP_8BIT),                                                           \
-                       heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT),                                    \
-                       heap_caps_get_free_size(MALLOC_CAP_8BIT));                                                                  \
+        ESP_DIAG_EVENT("MTR_TRC", "%s - %s - %s", entry_exit, label, group);                                                       \
     } while (0)
 
 void ESP32Backend::LogMessageReceived(MessageReceivedInfo & info) {}

--- a/src/tracing/esp32_trace/esp32_tracing.cpp
+++ b/src/tracing/esp32_trace/esp32_tracing.cpp
@@ -152,26 +152,23 @@ void ESP32Backend::TraceCounter(const char * label)
     ::Insights::ESPInsightsCounter::GetInstance(label)->ReportMetrics();
 }
 
-void ESP32Backend::RegisterMetric(const char* key, ValueType type)
+void ESP32Backend::RegisterMetric(const char * key, ValueType type)
 {
     switch (type)
     {
     case ValueType::kUInt32:
-        esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, key /* Unique key 8 */,
-                                    key /* label displayed on dashboard */, "insights.mtr" /* hierarchical path */,
-                                    ESP_DIAG_DATA_TYPE_UINT /* data_type */);
+        esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, key /* Unique key 8 */, key /* label displayed on dashboard */,
+                                  "insights.mtr" /* hierarchical path */, ESP_DIAG_DATA_TYPE_UINT /* data_type */);
         break;
 
     case ValueType::kInt32:
-        esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, key /* Unique key 8 */,
-                                    key /* label displayed on dashboard */, "insights.mtr" /* hierarchical path */,
-                                    ESP_DIAG_DATA_TYPE_INT /* data_type */);
+        esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, key /* Unique key 8 */, key /* label displayed on dashboard */,
+                                  "insights.mtr" /* hierarchical path */, ESP_DIAG_DATA_TYPE_INT /* data_type */);
         break;
 
     case ValueType::kChipErrorCode:
-        esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, key /* Unique key 8 */,
-                                    key /* label displayed on dashboard */, "insights.mtr" /* hierarchical path */,
-                                    ESP_DIAG_DATA_TYPE_UINT /* data_type */);
+        esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, key /* Unique key 8 */, key /* label displayed on dashboard */,
+                                  "insights.mtr" /* hierarchical path */, ESP_DIAG_DATA_TYPE_UINT /* data_type */);
         break;
 
     case ValueType::kUndefined:
@@ -184,8 +181,9 @@ void ESP32Backend::RegisterMetric(const char* key, ValueType type)
 
 void ESP32Backend::LogMetricEvent(const MetricEvent & event)
 {
-    
-    if (mRegisteredMetrics.find(event.key()) == mRegisteredMetrics.end()) {
+
+    if (mRegisteredMetrics.find(event.key()) == mRegisteredMetrics.end())
+    {
         RegisterMetric(event.key(), event.ValueType());
     }
 

--- a/src/tracing/esp32_trace/esp32_tracing.cpp
+++ b/src/tracing/esp32_trace/esp32_tracing.cpp
@@ -163,10 +163,6 @@ void ESP32Backend::RegisterMetric(const char * key, ValueType type)
             ESP_LOGE("SYS.MTR", "Type mismatch for metric key %s", key);
             return;
         }
-        else
-        {
-            return;
-        }
     }
 
     switch (type)

--- a/src/tracing/esp32_trace/esp32_tracing.cpp
+++ b/src/tracing/esp32_trace/esp32_tracing.cpp
@@ -157,32 +157,58 @@ void ESP32Backend::TraceCounter(const char * label)
 
 void ESP32Backend::LogMetricEvent(const MetricEvent & event)
 {
+    using ValueType = MetricEvent::Value::Type;
     if (!mRegistered)
     {
-        esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, event.key() /* Unique key 8 */,
-                                  event.key() /* label displayed on dashboard */, "insights.mtr" /* hierarchical path */,
-                                  ESP_DIAG_DATA_TYPE_INT /* data_type */);
+
+        switch (event.ValueType())
+        {
+        case ValueType::kUInt32:
+            esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, event.key() /* Unique key 8 */,
+                                      event.key() /* label displayed on dashboard */, "insights.mtr" /* hierarchical path */,
+                                      ESP_DIAG_DATA_TYPE_UINT /* data_type */);
+            break;
+
+        case ValueType::kInt32:
+            esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, event.key() /* Unique key 8 */,
+                                      event.key() /* label displayed on dashboard */, "insights.mtr" /* hierarchical path */,
+                                      ESP_DIAG_DATA_TYPE_INT /* data_type */);
+            break;
+
+        case ValueType::kChipErrorCode:
+            esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, event.key() /* Unique key 8 */,
+                                      event.key() /* label displayed on dashboard */, "insights.mtr" /* hierarchical path */,
+                                      ESP_DIAG_DATA_TYPE_UINT /* data_type */);
+            break;
+
+        case ValueType::kUndefined:
+            ESP_LOGE("mtr", "failed to register %s as its value is undefined", event.key());
+            break;
+        }
         mRegistered = true;
     }
 
-    using ValueType = MetricEvent::Value::Type;
     switch (event.ValueType())
     {
     case ValueType::kInt32:
         ESP_LOGI("mtr", "The value of %s is %ld ", event.key(), event.ValueInt32());
         esp_diag_metrics_add_int(event.key(), event.ValueInt32());
         break;
+
     case ValueType::kUInt32:
         ESP_LOGI("mtr", "The value of %s is %lu ", event.key(), event.ValueUInt32());
         esp_diag_metrics_add_uint(event.key(), event.ValueUInt32());
         break;
+
     case ValueType::kChipErrorCode:
         ESP_LOGI("mtr", "The value of %s is error with code %lu ", event.key(), event.ValueErrorCode());
         esp_diag_metrics_add_uint(event.key(), event.ValueErrorCode());
         break;
+
     case ValueType::kUndefined:
         ESP_LOGI("mtr", "The value of %s is undefined", event.key());
         break;
+
     default:
         ESP_LOGI("mtr", "The value of %s is of an UNKNOWN TYPE", event.key());
         break;

--- a/src/tracing/esp32_trace/esp32_tracing.cpp
+++ b/src/tracing/esp32_trace/esp32_tracing.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <algorithm>
+#include <esp_err.h>
 #include <esp_heap_caps.h>
 #include <esp_insights.h>
 #include <esp_log.h>
@@ -154,6 +155,20 @@ void ESP32Backend::TraceCounter(const char * label)
 
 void ESP32Backend::RegisterMetric(const char * key, ValueType type)
 {
+    // Check for the same key will not have two different types.
+    if (mRegisteredMetrics.find(key) != mRegisteredMetrics.end())
+    {
+        if (mRegisteredMetrics[key] != type)
+        {
+            ESP_LOGE("SYS.MTR", "Type mismatch for metric key %s", key);
+            return;
+        }
+        else
+        {
+            return;
+        }
+    }
+
     switch (type)
     {
     case ValueType::kUInt32:
@@ -181,7 +196,6 @@ void ESP32Backend::RegisterMetric(const char * key, ValueType type)
 
 void ESP32Backend::LogMetricEvent(const MetricEvent & event)
 {
-
     if (mRegisteredMetrics.find(event.key()) == mRegisteredMetrics.end())
     {
         RegisterMetric(event.key(), event.ValueType());

--- a/src/tracing/esp32_trace/esp32_tracing.h
+++ b/src/tracing/esp32_trace/esp32_tracing.h
@@ -1,7 +1,7 @@
 #include <lib/core/CHIPError.h>
 #include <tracing/backend.h>
-#include <unordered_map>
 #include <tracing/metric_event.h>
+#include <unordered_map>
 
 #include <memory>
 namespace chip {
@@ -43,8 +43,7 @@ public:
 private:
     using ValueType = MetricEvent::Value::Type;
     std::unordered_map<const char *, ValueType> mRegisteredMetrics;
-    void RegisterMetric(const char *key, ValueType type);
-
+    void RegisterMetric(const char * key, ValueType type);
 };
 
 } // namespace Insights

--- a/src/tracing/esp32_trace/esp32_tracing.h
+++ b/src/tracing/esp32_trace/esp32_tracing.h
@@ -1,5 +1,7 @@
 #include <lib/core/CHIPError.h>
 #include <tracing/backend.h>
+#include <unordered_map>
+#include <tracing/metric_event.h>
 
 #include <memory>
 namespace chip {
@@ -39,7 +41,10 @@ public:
     void LogMetricEvent(const MetricEvent &) override;
 
 private:
-    bool mRegistered = false;
+    using ValueType = MetricEvent::Value::Type;
+    std::unordered_map<const char *, ValueType> mRegisteredMetrics;
+    void RegisterMetric(const char *key, ValueType type);
+
 };
 
 } // namespace Insights


### PR DESCRIPTION
**Problem**
- Testing the merged PR #32223 for esp32 showed failure to report metric data to esp32 tracing framework due to data type mismatch.

**Change Overview:**
- Added the fix for the metric reporting.
- Removed the heap diagnostic metrics in the traces due to framework built in support.

**Testing**
- Tested the esp32 lighting app with the fix and verified the metric report.
