### PR TITLE
Add data model XML files to `chip-cert-bins` docker image

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -295,7 +295,8 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-rvc-app chip-rvc
 # Stage 3.1: Setup the Matter Python environment
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/python_lib python_lib
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/python_env python_env
-COPY --from=chip-build-cert-bins /root/connectedhomeip/src/python_testing python_testing
+COPY --from=chip-build-cert-bins /root/connectedhomeip/src/python_testing python_testing/scripts/sdk
+COPY --from=chip-build-cert-bins /root/connectedhomeip/data_model python_testing/data_model
 
 COPY --from=chip-build-cert-bins /root/connectedhomeip/scripts/tests/requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt


### PR DESCRIPTION
Added data model XML files to `chip-cert-bins` docker image to be able to run some python tests.

Related TH issue:
- https://github.com/project-chip/certification-tool/issues/198
