### PR TITLE
Fix incorrectly reported NoReponse when single batch command sent to …

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -441,7 +441,8 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
             }
         }
 
-        if (!commandRef.HasValue() && !commandRefRequired && mpPendingResponseTracker != nullptr && mpPendingResponseTracker->Count() == 1)
+        if (!commandRef.HasValue() && !commandRefRequired && mpPendingResponseTracker != nullptr &&
+            mpPendingResponseTracker->Count() == 1)
         {
             // We have sent out a single invoke request. As per spec, server in this case doesn't need to provide the CommandRef
             // in the response. This is allowed to support communicating with a legacy server. In this case we assume the response

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -430,7 +430,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
                 // 2. The current InvokeResponse is for a request we never sent (based on its commandRef).
                 // Used when logging errors related to server violating spec.
                 [[maybe_unused]] ScopedNodeId remoteScopedNode;
-                if (mExchangeCtx.Get()->HasSessionHandle())
+                if (mExchangeCtx.Get() && mExchangeCtx.Get()->HasSessionHandle())
                 {
                     remoteScopedNode = mExchangeCtx.Get()->GetSessionHandle()->GetPeer();
                 }

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -31,7 +31,7 @@ namespace {
 // Gets the CommandRef if available. Error returned if we expected CommandRef and it wasn't
 // provided in the response.
 template <typename ParserT>
-CHIP_ERROR GetRef(ParserT aParser, Optional<uint16_t> & aRef, bool commandRefExpected)
+CHIP_ERROR GetRef(ParserT aParser, Optional<uint16_t> & aRef, bool commandRefRequired)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint16_t ref;
@@ -40,7 +40,7 @@ CHIP_ERROR GetRef(ParserT aParser, Optional<uint16_t> & aRef, bool commandRefExp
     VerifyOrReturnError(err == CHIP_NO_ERROR || err == CHIP_END_OF_TLV, err);
     if (err == CHIP_END_OF_TLV)
     {
-        if (commandRefExpected)
+        if (commandRefRequired)
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
@@ -364,7 +364,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
         bool hasDataResponse = false;
         TLV::TLVReader commandDataReader;
         Optional<uint16_t> commandRef;
-        bool commandRefExpected = mpPendingResponseTracker && (mpPendingResponseTracker->Count() > 1);
+        bool commandRefRequired = (mFinishedCommandCount > 1);
 
         CommandStatusIB::Parser commandStatus;
         err = aInvokeResponse.GetStatus(&commandStatus);
@@ -379,7 +379,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
             StatusIB::Parser status;
             commandStatus.GetErrorStatus(&status);
             ReturnErrorOnFailure(status.DecodeStatusIB(statusIB));
-            ReturnErrorOnFailure(GetRef(commandStatus, commandRef, commandRefExpected));
+            ReturnErrorOnFailure(GetRef(commandStatus, commandRef, commandRefRequired));
         }
         else if (CHIP_END_OF_TLV == err)
         {
@@ -391,7 +391,7 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
             ReturnErrorOnFailure(commandPath.GetClusterId(&clusterId));
             ReturnErrorOnFailure(commandPath.GetCommandId(&commandId));
             commandData.GetFields(&commandDataReader);
-            ReturnErrorOnFailure(GetRef(commandData, commandRef, commandRefExpected));
+            ReturnErrorOnFailure(GetRef(commandData, commandRef, commandRefRequired));
             err             = CHIP_NO_ERROR;
             hasDataResponse = true;
         }
@@ -439,6 +439,14 @@ CHIP_ERROR CommandSender::ProcessInvokeResponseIB(InvokeResponseIB::Parser & aIn
                              ChipLogValueScopedNodeId(remoteScopedNode), commandRef.Value());
                 return err;
             }
+        }
+
+        if (!commandRef.HasValue() && !commandRefRequired && mpPendingResponseTracker != nullptr && mpPendingResponseTracker->Count() == 1)
+        {
+            // We have sent out a single invoke request. As per spec, server in this case doesn't need to provide the CommandRef
+            // in the response. This is allowed to support communicating with a legacy server. In this case we assume the response
+            // is associated with the only command we sent out.
+            commandRef = mpPendingResponseTracker->PopPendingResponse();
         }
 
         // When using ExtendableCallbacks, we are adhering to a different API contract where path
@@ -490,8 +498,7 @@ CHIP_ERROR CommandSender::PrepareCommand(const CommandPathParams & aCommandPathP
 
     if (mpPendingResponseTracker != nullptr)
     {
-        size_t pendingCount = mpPendingResponseTracker->Count();
-        VerifyOrReturnError(pendingCount < mRemoteMaxPathsPerInvoke, CHIP_ERROR_MAXIMUM_PATHS_PER_INVOKE_EXCEEDED);
+        VerifyOrReturnError(mFinishedCommandCount < mRemoteMaxPathsPerInvoke, CHIP_ERROR_MAXIMUM_PATHS_PER_INVOKE_EXCEEDED);
     }
 
     if (mBatchCommandsEnabled)
@@ -553,6 +560,7 @@ CHIP_ERROR CommandSender::FinishCommandInternal(FinishCommandParameters & aFinis
     ReturnErrorOnFailure(commandData.EndOfCommandDataIB());
 
     MoveToState(State::AddedCommand);
+    mFinishedCommandCount++;
 
     if (mpPendingResponseTracker && aFinishCommandParams.commandRef.HasValue())
     {

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -619,6 +619,7 @@ private:
     PendingResponseTracker * mpPendingResponseTracker = nullptr;
 
     uint16_t mInvokeResponseMessageCount = 0;
+    uint16_t mFinishedCommandCount       = 0;
     uint16_t mRemoteMaxPathsPerInvoke    = 1;
 
     State mState                = State::Idle;

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -311,7 +311,8 @@ public:
     static void TestCommandHandlerWithSendEmptyCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderWithProcessReceivedMsg(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderExtendableApiWithProcessReceivedMsg(nlTestSuite * apSuite, void * apContext);
-    static void TestCommandSenderExtendableApiWithProcessReceivedMsgContainingInvalidCommandRef(nlTestSuite * apSuite, void * apContext);
+    static void TestCommandSenderExtendableApiWithProcessReceivedMsgContainingInvalidCommandRef(nlTestSuite * apSuite,
+                                                                                                void * apContext);
     static void TestCommandHandlerWithProcessReceivedNotExistCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerEncodeSimpleCommandData(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerCommandDataEncoding(nlTestSuite * apSuite, void * apContext);
@@ -472,7 +473,8 @@ void TestCommandInteraction::GenerateInvokeRequest(nlTestSuite * apSuite, void *
 }
 
 void TestCommandInteraction::GenerateInvokeResponse(nlTestSuite * apSuite, void * apContext, System::PacketBufferHandle & aPayload,
-                                                    CommandId aCommandId, ClusterId aClusterId, EndpointId aEndpointId, Optional<uint16_t> aCommandRef)
+                                                    CommandId aCommandId, ClusterId aClusterId, EndpointId aEndpointId,
+                                                    Optional<uint16_t> aCommandRef)
 
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -795,7 +797,8 @@ void TestCommandInteraction::TestCommandSenderExtendableApiWithProcessReceivedMs
                        mockCommandSenderExtendedDelegate.onErrorCalledTimes == 0);
 }
 
-void TestCommandInteraction::TestCommandSenderExtendableApiWithProcessReceivedMsgContainingInvalidCommandRef(nlTestSuite * apSuite, void * apContext)
+void TestCommandInteraction::TestCommandSenderExtendableApiWithProcessReceivedMsgContainingInvalidCommandRef(nlTestSuite * apSuite,
+                                                                                                             void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
     CHIP_ERROR err    = CHIP_NO_ERROR;
@@ -812,7 +815,8 @@ void TestCommandInteraction::TestCommandSenderExtendableApiWithProcessReceivedMs
     System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
 
     uint16_t invalidResponseCommandRef = 2;
-    GenerateInvokeResponse(apSuite, apContext, buf, kTestCommandIdWithData, kTestClusterId, kTestEndpointId, MakeOptional(invalidResponseCommandRef));
+    GenerateInvokeResponse(apSuite, apContext, buf, kTestCommandIdWithData, kTestClusterId, kTestEndpointId,
+                           MakeOptional(invalidResponseCommandRef));
     bool moreChunkedMessages = false;
     err                      = commandSender.ProcessInvokeResponse(std::move(buf), moreChunkedMessages);
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_KEY_NOT_FOUND);

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -250,6 +250,11 @@ public:
                       aResponseData.path.mClusterId, aResponseData.path.mCommandId, aResponseData.path.mEndpointId);
         onResponseCalledTimes++;
     }
+    void OnNoResponse(CommandSender * commandSender, const CommandSender::NoResponseData & aNoResponseData) override
+    {
+        ChipLogError(Controller, "NoResponse received for command associated with CommandRef %u", aNoResponseData.commandRef);
+        onNoResponseCalledTimes++;
+    }
     void OnError(const CommandSender * apCommandSender, const CommandSender::ErrorData & aErrorData) override
     {
         ChipLogError(Controller, "OnError happens with %" CHIP_ERROR_FORMAT, aErrorData.error.Format());
@@ -260,15 +265,17 @@ public:
 
     void ResetCounter()
     {
-        onResponseCalledTimes = 0;
-        onErrorCalledTimes    = 0;
-        onFinalCalledTimes    = 0;
+        onResponseCalledTimes   = 0;
+        onNoResponseCalledTimes = 0;
+        onErrorCalledTimes      = 0;
+        onFinalCalledTimes      = 0;
     }
 
-    int onResponseCalledTimes = 0;
-    int onErrorCalledTimes    = 0;
-    int onFinalCalledTimes    = 0;
-    CHIP_ERROR mError         = CHIP_NO_ERROR;
+    int onResponseCalledTimes   = 0;
+    int onNoResponseCalledTimes = 0;
+    int onErrorCalledTimes      = 0;
+    int onFinalCalledTimes      = 0;
+    CHIP_ERROR mError           = CHIP_NO_ERROR;
 } mockCommandSenderExtendedDelegate;
 
 class MockCommandHandlerCallback : public CommandHandler::Callback
@@ -297,6 +304,7 @@ public:
     static void TestCommandSenderWithSendCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithSendEmptyCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandSenderWithProcessReceivedMsg(nlTestSuite * apSuite, void * apContext);
+    static void TestCommandSenderExtendableApiWithProcessReceivedMsg(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerWithProcessReceivedNotExistCommand(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerEncodeSimpleCommandData(nlTestSuite * apSuite, void * apContext);
     static void TestCommandHandlerCommandDataEncoding(nlTestSuite * apSuite, void * apContext);
@@ -371,7 +379,7 @@ private:
     // payload will be included.  Otherwise no payload will be included.
     static void GenerateInvokeResponse(nlTestSuite * apSuite, void * apContext, System::PacketBufferHandle & aPayload,
                                        CommandId aCommandId, ClusterId aClusterId = kTestClusterId,
-                                       EndpointId aEndpointId = kTestEndpointId);
+                                       EndpointId aEndpointId = kTestEndpointId, Optional<uint16_t> aCommandRef = NullOptional);
     static void AddInvokeRequestData(nlTestSuite * apSuite, void * apContext, CommandSender * apCommandSender,
                                      CommandId aCommandId = kTestCommandIdWithData);
     static void AddInvalidInvokeRequestData(nlTestSuite * apSuite, void * apContext, CommandSender * apCommandSender,
@@ -455,7 +463,7 @@ void TestCommandInteraction::GenerateInvokeRequest(nlTestSuite * apSuite, void *
 }
 
 void TestCommandInteraction::GenerateInvokeResponse(nlTestSuite * apSuite, void * apContext, System::PacketBufferHandle & aPayload,
-                                                    CommandId aCommandId, ClusterId aClusterId, EndpointId aEndpointId)
+                                                    CommandId aCommandId, ClusterId aClusterId, EndpointId aEndpointId, Optional<uint16_t> aCommandRef)
 
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -495,6 +503,11 @@ void TestCommandInteraction::GenerateInvokeResponse(nlTestSuite * apSuite, void 
 
         err = pWriter->EndContainer(dummyType);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    }
+
+    if (aCommandRef.HasValue())
+    {
+        NL_TEST_ASSERT(apSuite, commandDataIBBuilder.Ref(aCommandRef.Value()) == CHIP_NO_ERROR);
     }
 
     commandDataIBBuilder.EndOfCommandDataIB();
@@ -706,6 +719,35 @@ void TestCommandInteraction::TestCommandSenderWithProcessReceivedMsg(nlTestSuite
     err                      = commandSender.ProcessInvokeResponse(std::move(buf), moreChunkedMessages);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(apSuite, moreChunkedMessages == false);
+}
+
+void TestCommandInteraction::TestCommandSenderExtendableApiWithProcessReceivedMsg(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(apContext);
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+
+    mockCommandSenderExtendedDelegate.ResetCounter();
+    PendingResponseTrackerImpl pendingResponseTracker;
+    app::CommandSender commandSender(kCommandSenderTestOnlyMarker, &mockCommandSenderExtendedDelegate, &ctx.GetExchangeManager(),
+                                     &pendingResponseTracker);
+
+    uint16_t mockCommandRef = 1;
+    pendingResponseTracker.Add(mockCommandRef);
+    commandSender.mFinishedCommandCount = 1;
+
+    System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+
+    GenerateInvokeResponse(apSuite, apContext, buf, kTestCommandIdWithData);
+    bool moreChunkedMessages = false;
+    err                      = commandSender.ProcessInvokeResponse(std::move(buf), moreChunkedMessages);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, moreChunkedMessages == false);
+
+    NL_TEST_ASSERT(apSuite,
+                   mockCommandSenderExtendedDelegate.onResponseCalledTimes == 1 &&
+                       mockCommandSenderExtendedDelegate.onFinalCalledTimes == 0 &&
+                       mockCommandSenderExtendedDelegate.onNoResponseCalledTimes == 0 &&
+                       mockCommandSenderExtendedDelegate.onErrorCalledTimes == 0);
 }
 
 void TestCommandInteraction::ValidateCommandHandlerEncodeInvokeResponseMessage(nlTestSuite * apSuite, void * apContext,
@@ -1930,6 +1972,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestCommandSenderWithSendCommand", chip::app::TestCommandInteraction::TestCommandSenderWithSendCommand),
     NL_TEST_DEF("TestCommandHandlerWithSendEmptyCommand", chip::app::TestCommandInteraction::TestCommandHandlerWithSendEmptyCommand),
     NL_TEST_DEF("TestCommandSenderWithProcessReceivedMsg", chip::app::TestCommandInteraction::TestCommandSenderWithProcessReceivedMsg),
+    NL_TEST_DEF("TestCommandSenderExtendableApiWithProcessReceivedMsg", chip::app::TestCommandInteraction::TestCommandSenderExtendableApiWithProcessReceivedMsg),
     NL_TEST_DEF("TestCommandHandlerEncodeSimpleCommandData", chip::app::TestCommandInteraction::TestCommandHandlerEncodeSimpleCommandData),
     NL_TEST_DEF("TestCommandHandlerCommandDataEncoding", chip::app::TestCommandInteraction::TestCommandHandlerCommandDataEncoding),
     NL_TEST_DEF("TestCommandHandlerCommandEncodeFailure", chip::app::TestCommandInteraction::TestCommandHandlerCommandEncodeFailure),


### PR DESCRIPTION
When new CommandSender APIs is used to send a single invoke request where `CommandRef` was provided in the request to a legacy device, CommandSender would incorrectly call the NoResposeCallback.

This occurs because legacy device is allowed to drop CommandRef (as it doesn't even know to look for CommandRef, nor does it know what it means).

Fix by assuming if getting a response to a single request, we assume the response matches the single pending tracked command.

fixes: https://github.com/project-chip/connectedhomeip/issues/32360
