### PR TITLE
[Linux] Reuse AdapterIterator in all places where listing managed objects

### DIFF
--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -121,6 +121,12 @@ struct GAutoPtrDeleter<GDBusConnection>
 };
 
 template <>
+struct GAutoPtrDeleter<GDBusObjectManager>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
 struct GAutoPtrDeleter<GDBusObjectManagerServer>
 {
     using deleter = GObjectDeleter;

--- a/src/platform/Linux/bluez/AdapterIterator.cpp
+++ b/src/platform/Linux/bluez/AdapterIterator.cpp
@@ -41,8 +41,8 @@ CHIP_ERROR AdapterIterator::Initialize()
     VerifyOrReturnError(mManager, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "Failed to get D-Bus object manager for listing adapters: %s", error->message));
 
-    mObjectList = BluezObjectList(mManager.get());
-    mIterator   = mObjectList.begin();
+    mObjectList.Init(mManager.get());
+    mIterator = mObjectList.begin();
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Linux/bluez/AdapterIterator.h
+++ b/src/platform/Linux/bluez/AdapterIterator.h
@@ -17,13 +17,15 @@
 
 #pragma once
 
-#include <string>
+#include <cstdint>
 
 #include <gio/gio.h>
 
 #include <lib/core/CHIPError.h>
+#include <platform/GLibTypeDeleter.h>
 #include <platform/Linux/dbus/bluez/DbusBluez.h>
 
+#include "BluezObjectList.h"
 #include "Types.h"
 
 namespace chip {
@@ -74,8 +76,8 @@ private:
     bool Advance();
 
     GDBusObjectManager * mManager = nullptr; // DBus connection
-    GList * mObjectList           = nullptr; // listing of objects on the bus
-    GList * mCurrentListItem      = nullptr; // current item viewed in the list
+    BluezObjectList mObjectList;
+    BluezObjectIterator mIterator;
     // Data valid only if Next() returns true
     GAutoPtr<BluezAdapter1> mCurrentAdapter;
 };

--- a/src/platform/Linux/bluez/AdapterIterator.h
+++ b/src/platform/Linux/bluez/AdapterIterator.h
@@ -65,7 +65,7 @@ public:
 
 private:
     /// Sets up the DBUS manager and loads the list
-    static CHIP_ERROR Initialize(AdapterIterator * self);
+    CHIP_ERROR Initialize();
 
     /// Loads the next value in the list.
     ///

--- a/src/platform/Linux/bluez/AdapterIterator.h
+++ b/src/platform/Linux/bluez/AdapterIterator.h
@@ -48,8 +48,6 @@ namespace Internal {
 class AdapterIterator
 {
 public:
-    ~AdapterIterator();
-
     /// Moves to the next DBUS interface.
     ///
     /// MUST be called before any of the 'current value' methods are
@@ -75,7 +73,7 @@ private:
     /// iterate through.
     bool Advance();
 
-    GDBusObjectManager * mManager = nullptr; // DBus connection
+    GAutoPtr<GDBusObjectManager> mManager;
     BluezObjectList mObjectList;
     BluezObjectIterator mIterator;
     // Data valid only if Next() returns true

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -72,6 +72,7 @@
 #include <system/SystemPacketBuffer.h>
 
 #include "BluezConnection.h"
+#include "BluezObjectList.h"
 #include "Types.h"
 
 namespace chip {
@@ -421,15 +422,14 @@ BluezGattService1 * BluezEndpoint::CreateGattService(const char * aUUID)
     return service;
 }
 
-void BluezEndpoint::SetupAdapter()
+CHIP_ERROR BluezEndpoint::SetupAdapter()
 {
     char expectedPath[32];
     snprintf(expectedPath, sizeof(expectedPath), BLUEZ_PATH "/hci%u", mAdapterId);
 
-    GList * objects = g_dbus_object_manager_get_objects(mpObjMgr);
-    for (auto l = objects; l != nullptr && mAdapter.get() == nullptr; l = l->next)
+    for (BluezObject & object : BluezObjectList(mpObjMgr))
     {
-        GAutoPtr<BluezAdapter1> adapter(bluez_object_get_adapter1(BLUEZ_OBJECT(l->data)));
+        GAutoPtr<BluezAdapter1> adapter(bluez_object_get_adapter1(&object));
         if (adapter.get() != nullptr)
         {
             if (mpAdapterAddr == nullptr) // no adapter address provided, bind to the hci indicated by nodeid
@@ -451,7 +451,7 @@ void BluezEndpoint::SetupAdapter()
         }
     }
 
-    VerifyOrExit(mAdapter.get() != nullptr, ChipLogError(DeviceLayer, "FAIL: NULL mAdapter in %s", __func__));
+    VerifyOrReturnError(mAdapter, CHIP_ERROR_INTERNAL, ChipLogError(DeviceLayer, "FAIL: NULL mAdapter in %s", __func__));
 
     bluez_adapter1_set_powered(mAdapter.get(), TRUE);
 
@@ -460,8 +460,7 @@ void BluezEndpoint::SetupAdapter()
     // and the flag is necessary to force using LE transport.
     bluez_adapter1_set_discoverable(mAdapter.get(), FALSE);
 
-exit:
-    g_list_free_full(objects, g_object_unref);
+    return CHIP_NO_ERROR;
 }
 
 BluezConnection * BluezEndpoint::GetBluezConnection(const char * aPath)

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -85,7 +85,7 @@ public:
 private:
     CHIP_ERROR StartupEndpointBindings();
 
-    void SetupAdapter();
+    CHIP_ERROR SetupAdapter();
     void SetupGattServer(GDBusConnection * aConn);
     void SetupGattService();
 

--- a/src/platform/Linux/bluez/BluezObjectIterator.h
+++ b/src/platform/Linux/bluez/BluezObjectIterator.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <iterator>
+
 #include <glib.h>
 
 #include <platform/CHIPDeviceConfig.h>

--- a/src/platform/Linux/bluez/BluezObjectList.h
+++ b/src/platform/Linux/bluez/BluezObjectList.h
@@ -35,19 +35,25 @@ namespace Internal {
 class BluezObjectList
 {
 public:
-    explicit BluezObjectList(GDBusObjectManager * manager) { Initialize(manager); }
+    BluezObjectList() = default;
+    explicit BluezObjectList(GDBusObjectManager * manager) { Init(manager); }
 
-    ~BluezObjectList() { g_list_free_full(mObjectList, g_object_unref); }
+    ~BluezObjectList()
+    {
+        if (mObjectList != nullptr)
+            g_list_free_full(mObjectList, g_object_unref);
+    }
+
+    CHIP_ERROR Init(GDBusObjectManager * manager)
+    {
+        VerifyOrReturnError(manager != nullptr, CHIP_ERROR_INVALID_ARGUMENT,
+                            ChipLogError(DeviceLayer, "Manager is NULL in %s", __func__));
+        mObjectList = g_dbus_object_manager_get_objects(manager);
+        return CHIP_NO_ERROR;
+    }
 
     BluezObjectIterator begin() const { return BluezObjectIterator(mObjectList); }
     static BluezObjectIterator end() { return BluezObjectIterator(); }
-
-protected:
-    void Initialize(GDBusObjectManager * manager)
-    {
-        VerifyOrReturn(manager != nullptr, ChipLogError(DeviceLayer, "Manager is NULL in %s", __func__));
-        mObjectList = g_dbus_object_manager_get_objects(manager);
-    }
 
 private:
     GList * mObjectList = nullptr;

--- a/src/platform/Linux/bluez/BluezObjectList.h
+++ b/src/platform/Linux/bluez/BluezObjectList.h
@@ -40,19 +40,12 @@ public:
     ~BluezObjectList() { g_list_free_full(mObjectList, g_object_unref); }
 
     BluezObjectIterator begin() const { return BluezObjectIterator(mObjectList); }
-    BluezObjectIterator end() const { return BluezObjectIterator(); }
+    static BluezObjectIterator end() { return BluezObjectIterator(); }
 
 protected:
-    BluezObjectList() {}
-
     void Initialize(GDBusObjectManager * manager)
     {
-        if (manager == nullptr)
-        {
-            ChipLogError(DeviceLayer, "Manager is NULL in %s", __func__);
-            return;
-        }
-
+        VerifyOrReturn(manager != nullptr, ChipLogError(DeviceLayer, "Manager is NULL in %s", __func__));
         mObjectList = g_dbus_object_manager_get_objects(manager);
     }
 


### PR DESCRIPTION
### Problem

The `AdapterIterator` class provides nice RAII memory management, but it was used only in the Python binding code.

### Changes

- Reuse AdapterIterator in all places where listing managed objects

### Testing

Locally tested advertising/scanning and Python binding via `chip-repl`:
```python
>>> from chip.ble.get_adapters import GetAdapters
>>> GetAdapters()
[ AdapterInfo(index=0, address='00:15:83:E5:B0:54', name='AMD5800', alias='AMD5800', powered_on=True) ]
```