### PR TITLE
[Matter.framework] Add back downloadLogOfType onto MTRBaseDevice and MTRDevice

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -106,7 +106,8 @@ jobs:
               working-directory: src/darwin/Framework
               run: |
                   mkdir -p /tmp/darwin/framework-tests
-                  ../../../out/debug/chip-all-clusters-app --interface-id -1 > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
+                  echo "This is a simple log" > /tmp/darwin/framework-tests/end_user_support_log.txt
+                  ../../../out/debug/chip-all-clusters-app --interface-id -1 --end_user_support_log /tmp/darwin/framework-tests/end_user_support_log.txt > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
                   ../../../out/debug/chip-all-clusters-app --interface-id -1 --dac_provider ../../../credentials/development/commissioner_dut/struct_cd_origin_pid_vid_correct/test_case_vector.json --product-id 32768 --discriminator 3839 --secured-device-port 5539 --KVS /tmp/chip-all-clusters-app-kvs2 > >(tee /tmp/darwin/framework-tests/all-cluster-app-origin-vid.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-origin-vid-err.log >&2) &
 
                   export TEST_RUNNER_ASAN_OPTIONS=__CURRENT_VALUE__:detect_stack_use_after_return=1

--- a/examples/darwin-framework-tool/commands/bdx/DownloadLogCommand.mm
+++ b/examples/darwin-framework-tool/commands/bdx/DownloadLogCommand.mm
@@ -28,7 +28,7 @@ CHIP_ERROR DownloadLogCommand::RunCommand()
     ChipLogProgress(chipTool, "Downloading logs from node 0x" ChipLogFormatX64, ChipLogValueX64(mNodeId));
 
     MTRDeviceController * commissioner = CurrentCommissioner();
-    auto * device = [MTRDevice deviceWithNodeID:@(mNodeId) controller:commissioner];
+    auto * device = [MTRBaseDevice deviceWithNodeID:@(mNodeId) controller:commissioner];
 
     auto logType = static_cast<MTRDiagnosticLogType>(mLogType);
     auto queue = dispatch_queue_create("com.chip.bdx.downloader", DISPATCH_QUEUE_SERIAL);

--- a/examples/darwin-framework-tool/commands/bdx/DownloadLogCommand.mm
+++ b/examples/darwin-framework-tool/commands/bdx/DownloadLogCommand.mm
@@ -28,7 +28,7 @@ CHIP_ERROR DownloadLogCommand::RunCommand()
     ChipLogProgress(chipTool, "Downloading logs from node 0x" ChipLogFormatX64, ChipLogValueX64(mNodeId));
 
     MTRDeviceController * commissioner = CurrentCommissioner();
-    auto * device = [MTRBaseDevice deviceWithNodeID:@(mNodeId) controller:commissioner];
+    auto * device = [MTRDevice deviceWithNodeID:@(mNodeId) controller:commissioner];
 
     auto logType = static_cast<MTRDiagnosticLogType>(mLogType);
     auto queue = dispatch_queue_create("com.chip.bdx.downloader", DISPATCH_QUEUE_SERIAL);

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -19,6 +19,7 @@
 
 #import <Matter/MTRCluster.h>
 #import <Matter/MTRDefines.h>
+#import <Matter/MTRDiagnosticLogsType.h>
 
 @class MTRSetupPayload;
 @class MTRDeviceController;
@@ -542,6 +543,29 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
                           reportHandler:(MTRDeviceResponseHandler)reportHandler
                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
     MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+
+/**
+ * Download log of the desired type from the device.
+ *
+ * Note: The consumer of this API should move the file that the url points to or open it for reading before the
+ * completion handler returns. Otherwise, the file will be deleted, and the data will be lost.
+ *
+ * @param type       The type of log being requested. This should correspond to a value in the enum MTRDiagnosticLogType.
+ * @param timeout    The timeout for getting the log. If the timeout expires, completion will be called with whatever
+ *                   has been retrieved by that point (which might be none or a partial log).
+ *                   If the timeout is set to 0, the request will not expire and completion will not be called until
+ *                   the log is fully retrieved or an error occurs.
+ * @param queue      The queue on which completion will be called.
+ * @param completion The completion handler that is called after attempting to retrieve the requested log.
+ *                     - In case of success, the completion handler is called with a non-nil URL and a nil error.
+ *                     - If there is an error, a non-nil error is used and the url can be non-nil too if some logs have already been downloaded.
+ */
+- (void)downloadLogOfType:(MTRDiagnosticLogType)type
+                  timeout:(NSTimeInterval)timeout
+                    queue:(dispatch_queue_t)queue
+               completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
+    MTR_NEWLY_AVAILABLE;
+
 @end
 
 /**

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -2160,6 +2160,19 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
 
     return buffer;
 }
+
+- (void)downloadLogOfType:(MTRDiagnosticLogType)type
+                  timeout:(NSTimeInterval)timeout
+                    queue:(dispatch_queue_t)queue
+               completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
+{
+    [_deviceController downloadLogFromNodeWithID:@(_nodeID)
+                                            type:type
+                                         timeout:timeout
+                                           queue:queue
+                                      completion:completion];
+}
+
 @end
 
 @implementation MTRBaseDevice (Deprecated)

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -337,6 +337,27 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  */
 - (void)removeClientDataForKey:(NSString *)key endpointID:(NSNumber *)endpointID MTR_UNSTABLE_API;
 
+/**
+ * Download log of the desired type from the device.
+ *
+ * Note: The consumer of this API should move the file that the url points to or open it for reading before the
+ * completion handler returns. Otherwise, the file will be deleted, and the data will be lost.
+ *
+ * @param type       The type of log being requested. This should correspond to a value in the enum MTRDiagnosticLogType.
+ * @param timeout    The timeout for getting the log. If the timeout expires, completion will be called with whatever
+ *                   has been retrieved by that point (which might be none or a partial log).
+ *                   If the timeout is set to 0, the request will not expire and completion will not be called until
+ *                   the log is fully retrieved or an error occurs.
+ * @param queue      The queue on which completion will be called.
+ * @param completion The completion handler that is called after attempting to retrieve the requested log.
+ *                     - In case of success, the completion handler is called with a non-nil URL and a nil error.
+ *                     - If there is an error, a non-nil error is used and the url can be non-nil too if some logs have already been downloaded.
+ */
+- (void)downloadLogOfType:(MTRDiagnosticLogType)type
+                  timeout:(NSTimeInterval)timeout
+                    queue:(dispatch_queue_t)queue
+               completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
+    MTR_NEWLY_AVAILABLE;
 @end
 
 MTR_EXTERN NSString * const MTRPreviousDataKey MTR_NEWLY_AVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -18,7 +18,6 @@
 #import <Foundation/Foundation.h>
 #import <Matter/MTRBaseDevice.h>
 #import <Matter/MTRDefines.h>
-#import <Matter/MTRDiagnosticLogsType.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -338,27 +337,6 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  */
 - (void)removeClientDataForKey:(NSString *)key endpointID:(NSNumber *)endpointID MTR_UNSTABLE_API;
 
-/**
- * Download log of the desired type from the device.
- *
- * Note: The consumer of this API should move the file that the url points to or open it for reading before the
- * completion handler returns. Otherwise, the file will be deleted, and the data will be lost.
- *
- * @param type       The type of log being requested. This should correspond to a value in the enum MTRDiagnosticLogType.
- * @param timeout    The timeout for getting the log. If the timeout expires, completion will be called with whatever
- *                   has been retrieved by that point (which might be none or a partial log).
- *                   If the timeout is set to 0, the request will not expire and completion will not be called until
- *                   the log is fully retrieved or an error occurs.
- * @param queue      The queue on which completion will be called.
- * @param completion The completion handler that is called after attempting to retrieve the requested log.
- *                     - In case of success, the completion handler is called with a non-nil URL and a nil error.
- *                     - If there is an error, a non-nil error is used and the url can be non-nil too if some logs have already been downloaded.
- */
-- (void)downloadLogOfType:(MTRDiagnosticLogType)type
-                  timeout:(NSTimeInterval)timeout
-                    queue:(dispatch_queue_t)queue
-               completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
-    MTR_NEWLY_AVAILABLE;
 @end
 
 MTR_EXTERN NSString * const MTRPreviousDataKey MTR_NEWLY_AVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1776,18 +1776,6 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     [baseDevice openCommissioningWindowWithDiscriminator:discriminator duration:duration queue:queue completion:completion];
 }
 
-- (void)downloadLogOfType:(MTRDiagnosticLogType)type
-                  timeout:(NSTimeInterval)timeout
-                    queue:(dispatch_queue_t)queue
-               completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
-{
-    [_deviceController downloadLogFromNodeWithID:_nodeID
-                                            type:type
-                                         timeout:timeout
-                                           queue:queue
-                                      completion:completion];
-}
-
 #pragma mark - Cache management
 
 // assume lock is held

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1776,6 +1776,18 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     [baseDevice openCommissioningWindowWithDiscriminator:discriminator duration:duration queue:queue completion:completion];
 }
 
+- (void)downloadLogOfType:(MTRDiagnosticLogType)type
+                  timeout:(NSTimeInterval)timeout
+                    queue:(dispatch_queue_t)queue
+               completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
+{
+    auto * baseDevice = [self newBaseDevice];
+    [baseDevice downloadLogOfType:type
+                          timeout:timeout
+                            queue:queue
+                       completion:completion];
+}
+
 #pragma mark - Cache management
 
 // assume lock is held

--- a/src/darwin/Framework/CHIP/MTRDeviceController+XPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController+XPC.h
@@ -20,6 +20,7 @@
 #import <Matter/MTRCluster.h>
 #import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceController.h>
+#import <Matter/MTRDiagnosticLogsType.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -182,6 +183,15 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
                                clusterId:(NSNumber * _Nullable)clusterId
                              attributeId:(NSNumber * _Nullable)attributeId
                               completion:(MTRValuesHandler)completion;
+
+/**
+ * Requests downloading some logs
+ */
+- (void)downloadLogWithController:(id _Nullable)controller
+                           nodeId:(NSNumber *)nodeId
+                             type:(MTRDiagnosticLogType)type
+                          timeout:(NSTimeInterval)timeout
+                       completion:(void (^)(NSString * _Nullable url, NSError * _Nullable error))completion MTR_NEWLY_AVAILABLE;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController+XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController+XPC.mm
@@ -220,6 +220,10 @@ static void decodeReadParams(NSDictionary<NSString *, id> * inParams, MTRReadPar
                  forSelector:@selector(readAttributeCacheWithController:nodeId:endpointId:clusterId:attributeId:completion:)
                argumentIndex:0
                      ofReply:YES];
+    [xpcInterface setClasses:GetXPCAllowedClasses()
+                 forSelector:@selector(downloadLogWithController:nodeId:type:timeout:completion:)
+               argumentIndex:0
+                     ofReply:YES];
     return xpcInterface;
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
@@ -427,6 +427,17 @@ typedef void (^MTRFetchProxyHandleCompletion)(MTRDeviceControllerXPCProxyHandle 
     });
 }
 
+- (void)downloadLogOfType:(MTRDiagnosticLogType)type
+                  timeout:(NSTimeInterval)timeout
+                    queue:(dispatch_queue_t)queue
+               completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
+{
+    MTR_LOG_ERROR("MTRBaseDevice doesn't support downloadLogOfType over XPC");
+    dispatch_async(queue, ^{
+        completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidState userInfo:nil]);
+    });
+}
+
 - (void)fetchProxyHandleWithQueue:(dispatch_queue_t)queue completion:(MTRFetchProxyHandleCompletion)completion
 {
     if (self.controllerID != nil) {

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
@@ -432,10 +432,31 @@ typedef void (^MTRFetchProxyHandleCompletion)(MTRDeviceControllerXPCProxyHandle 
                     queue:(dispatch_queue_t)queue
                completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
 {
-    MTR_LOG_ERROR("MTRBaseDevice doesn't support downloadLogOfType over XPC");
-    dispatch_async(queue, ^{
-        completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidState userInfo:nil]);
-    });
+    MTR_LOG_DEBUG("Downloading log ...");
+
+    __auto_type workBlock = ^(MTRDeviceControllerXPCProxyHandle * _Nullable handle, NSError * _Nullable error) {
+        if (error != nil) {
+            completion(nil, error);
+            return;
+        }
+
+        [handle.proxy downloadLogWithController:self.controllerID
+                                         nodeId:self.nodeID
+                                           type:type
+                                        timeout:timeout
+                                     completion:^(NSString * _Nullable url, NSError * _Nullable error) {
+                                         dispatch_async(queue, ^{
+                                             MTR_LOG_DEBUG("Download log");
+                                             completion([NSURL URLWithString:url], error);
+                                             // The following captures the proxy handle in the closure so that the
+                                             // handle won't be released prior to block call.
+                                             __auto_type handleRetainer = handle;
+                                             (void) handleRetainer;
+                                         });
+                                     }];
+    };
+
+    [self fetchProxyHandleWithQueue:queue completion:workBlock];
 }
 
 - (void)fetchProxyHandleWithQueue:(dispatch_queue_t)queue completion:(MTRFetchProxyHandleCompletion)completion

--- a/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.mm
+++ b/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.mm
@@ -165,7 +165,6 @@ private:
                     // data in the logs that the caller may find useful. For this reason, fileURL is passed in even
                     // when there is an error but fileHandle is not nil.
                     completion(strongSelf->_fileHandle ? fileURL : nil, bdxError);
-                    [strongSelf deleteFile];
 
                     done(strongSelf);
                 }

--- a/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
@@ -116,6 +116,8 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 @property (readwrite, strong) void (^handleReadClusterStateCache)
     (id controller, NSNumber * nodeId, NSNumber * _Nullable endpointId, NSNumber * _Nullable clusterId,
         NSNumber * _Nullable attributeId, void (^completion)(id _Nullable values, NSError * _Nullable error));
+@property (readwrite, strong) void (^handleDownloadLog)(id controller, NSNumber * nodeId, MTRDiagnosticLogType type, NSTimeInterval timeout,
+    void (^completion)(NSString * _Nullable url, NSError * _Nullable error));
 
 @end
 
@@ -274,6 +276,18 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     });
 }
 
+- (void)downloadLogWithController:(id)controller
+                           nodeId:(NSNumber *)nodeId
+                             type:(MTRDiagnosticLogType)type
+                          timeout:(NSTimeInterval)timeout
+                       completion:(void (^)(NSString * _Nullable url, NSError * _Nullable error))completion
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        XCTAssertNotNil(self.handleDownloadLog);
+        self.handleDownloadLog(controller, nodeId, type, timeout, completion);
+    });
+}
+
 - (void)setUp
 {
     [self setContinueAfterFailure:NO];
@@ -298,6 +312,44 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     [_xpcListener suspend];
     _xpcListener = nil;
     _xpcDisconnectExpectation = nil;
+}
+
+- (void)testDownloadLogSuccess
+{
+    uint64_t myNodeId = 9876543210;
+    NSString * myBdxURL = @"bdx://foo";
+    NSTimeInterval myTimeout = 10;
+
+    XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
+    XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
+
+    __auto_type uuid = self.controllerUUID;
+    _handleDownloadLog = ^(id controller, NSNumber * nodeId, MTRDiagnosticLogType type, NSTimeInterval timeout,
+        void (^completion)(NSString * _Nullable url, NSError * _Nullable error)) {
+        XCTAssertTrue([controller isEqualToString:uuid]);
+        XCTAssertEqual([nodeId unsignedLongLongValue], myNodeId);
+        [callExpectation fulfill];
+        completion(myBdxURL, nil);
+    };
+
+    __auto_type * device = [MTRBaseDevice deviceWithNodeID:@(myNodeId) controller:_remoteDeviceController];
+    NSLog(@"Device acquired. Downloading...");
+    [device downloadLogOfType:MTRDiagnosticLogTypeEndUserSupport
+                      timeout:myTimeout
+                        queue:dispatch_get_main_queue()
+                   completion:^(NSURL * _Nullable url, NSError * _Nullable error) {
+                       NSLog(@"Read url: %@", url);
+                       XCTAssertNotNil(url);
+                       XCTAssertNil(error);
+                       [responseExpectation fulfill];
+                       self.xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+                   }];
+
+    [self waitForExpectations:[NSArray arrayWithObjects:callExpectation, responseExpectation, nil] timeout:kTimeoutInSeconds];
+
+    // When download is done, connection should have been released
+    [self waitForExpectations:[NSArray arrayWithObject:_xpcDisconnectExpectation] timeout:kTimeoutInSeconds];
+    XCTAssertNil(_xpcConnection);
 }
 
 - (void)testReadAttributeSuccess


### PR DESCRIPTION
Add back what has been reverted in https://github.com/project-chip/connectedhomeip/pull/32319 and expose the API to `MTRDevice` as well.