### PR TITLE
Fix incorrect snapshotting of MRP config by CASE client.

### DIFF
--- a/src/app/CASEClient.cpp
+++ b/src/app/CASEClient.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <app/CASEClient.h>
+#include <messaging/ReliableMessageProtocolConfig.h>
 
 namespace chip {
 
@@ -49,10 +50,12 @@ CHIP_ERROR CASEClient::EstablishSession(const CASEClientInitParams & params, con
     Messaging::ExchangeContext * exchange = params.exchangeMgr->NewContext(session.Value(), &mCASESession);
     VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_INTERNAL);
 
+    const Optional<ReliableMessageProtocolConfig> & mrpLocalConfig =
+        params.mrpLocalConfig.HasValue() ? params.mrpLocalConfig : GetLocalMRPConfig();
     mCASESession.SetGroupDataProvider(params.groupDataProvider);
     ReturnErrorOnFailure(mCASESession.EstablishSession(*params.sessionManager, params.fabricTable, peer, exchange,
                                                        params.sessionResumptionStorage, params.certificateValidityPolicy, delegate,
-                                                       params.mrpLocalConfig));
+                                                       mrpLocalConfig));
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/CASEClient.cpp
+++ b/src/app/CASEClient.cpp
@@ -50,10 +50,9 @@ CHIP_ERROR CASEClient::EstablishSession(const CASEClientInitParams & params, con
     VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_INTERNAL);
 
     mCASESession.SetGroupDataProvider(params.groupDataProvider);
-    // EstablishSession defaults to using the local MRP config, which is what we want.
     ReturnErrorOnFailure(mCASESession.EstablishSession(*params.sessionManager, params.fabricTable, peer, exchange,
                                                        params.sessionResumptionStorage, params.certificateValidityPolicy, delegate,
-                                                       NullOptional));
+                                                       params.mrpLocalConfig));
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/CASEClient.cpp
+++ b/src/app/CASEClient.cpp
@@ -50,9 +50,10 @@ CHIP_ERROR CASEClient::EstablishSession(const CASEClientInitParams & params, con
     VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_INTERNAL);
 
     mCASESession.SetGroupDataProvider(params.groupDataProvider);
+    // EstablishSession defaults to using the local MRP config, which is what we want.
     ReturnErrorOnFailure(mCASESession.EstablishSession(*params.sessionManager, params.fabricTable, peer, exchange,
                                                        params.sessionResumptionStorage, params.certificateValidityPolicy, delegate,
-                                                       params.mrpLocalConfig));
+                                                       NullOptional));
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -34,7 +34,6 @@ struct CASEClientInitParams
     Messaging::ExchangeManager * exchangeMgr                           = nullptr;
     FabricTable * fabricTable                                          = nullptr;
     Credentials::GroupDataProvider * groupDataProvider                 = nullptr;
-    Optional<ReliableMessageProtocolConfig> mrpLocalConfig             = Optional<ReliableMessageProtocolConfig>::Missing();
 
     CHIP_ERROR Validate() const
     {

--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -35,6 +35,11 @@ struct CASEClientInitParams
     FabricTable * fabricTable                                          = nullptr;
     Credentials::GroupDataProvider * groupDataProvider                 = nullptr;
 
+    // mrpLocalConfig should not generally be set to anything other than
+    // NullOptional.  Doing that can lead to different parts of the system
+    // claiming different MRP parameters for the same node.
+    Optional<ReliableMessageProtocolConfig> mrpLocalConfig = NullOptional;
+
     CHIP_ERROR Validate() const
     {
         // sessionResumptionStorage can be nullptr when resumption is disabled.

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -313,7 +313,6 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
             .exchangeMgr       = &mExchangeMgr,
             .fabricTable       = &mFabrics,
             .groupDataProvider = mGroupsProvider,
-            .mrpLocalConfig    = GetLocalMRPConfig(),
         },
         .clientPool            = &mCASEClientPool,
         .sessionSetupPool      = &mSessionSetupPool,

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -313,6 +313,9 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
             .exchangeMgr       = &mExchangeMgr,
             .fabricTable       = &mFabrics,
             .groupDataProvider = mGroupsProvider,
+            // Don't provide an MRP local config, so each CASE initiation will use
+            // the then-current value.
+            .mrpLocalConfig = NullOptional,
         },
         .clientPool            = &mCASEClientPool,
         .sessionSetupPool      = &mSessionSetupPool,

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -270,7 +270,6 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         .exchangeMgr               = stateParams.exchangeMgr,
         .fabricTable               = stateParams.fabricTable,
         .groupDataProvider         = stateParams.groupDataProvider,
-        .mrpLocalConfig            = GetLocalMRPConfig(),
     };
 
     CASESessionManagerConfig sessionManagerConfig = {

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -270,6 +270,9 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         .exchangeMgr               = stateParams.exchangeMgr,
         .fabricTable               = stateParams.fabricTable,
         .groupDataProvider         = stateParams.groupDataProvider,
+        // Don't provide an MRP local config, so each CASE initiation will use
+        // the then-current value.
+        .mrpLocalConfig = NullOptional,
     };
 
     CASESessionManagerConfig sessionManagerConfig = {


### PR DESCRIPTION
Right now, we snapshot the MRP config as part of the CASEClientInitParams during stack startup.

After that, we will use that snapshotted config whenever we are the CASE initiator.

This config will not match the parameters we use as CASE responder or advertise over DNS-SD if the local MRP configuration ever changes.  Which for an ICD it can.

The fix is to stop the incorrect snapshotting and get the information we need from the right source of truth when we need it.

