### PR TITLE
Clean up some includes in DataModelHandler

### DIFF
--- a/src/app/util/DataModelHandler.cpp
+++ b/src/app/util/DataModelHandler.cpp
@@ -17,6 +17,7 @@
 #include <app/util/DataModelHandler.h>
 
 #include <app/util/attribute-storage.h>
+#include <app/util/util.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;

--- a/src/app/util/DataModelHandler.cpp
+++ b/src/app/util/DataModelHandler.cpp
@@ -14,16 +14,9 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- * @file
- *   This file implements the handler for data model messages.
- */
-
 #include <app/util/DataModelHandler.h>
 
 #include <app/util/attribute-storage.h>
-#include <app/util/util.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip;

--- a/src/app/util/DataModelHandler.h
+++ b/src/app/util/DataModelHandler.h
@@ -14,22 +14,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- * @file
- *   This file defines the API for the handler for data model messages.
- */
-
 #pragma once
-
-#include <messaging/ExchangeContext.h>
-#include <messaging/ExchangeMgr.h>
-#include <system/SystemPacketBuffer.h>
-#include <transport/raw/MessageHeader.h>
 
 /**
  * Initialize the data model internal code to be ready to send and receive
  * data model messages.
- *
  */
 void InitDataModelHandler();


### PR DESCRIPTION
Clean up includes and useless file comment.

Overall the naming of this file is somewhat questionable as it contains a single init call. Still looking to determine if we should rename (we probably should).
