### PR TITLE
[Silabs]Fix gendiag network interface attribute

### DIFF
--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -397,7 +397,7 @@ template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetPrimary802154MACAddress(uint8_t * buf)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    return ThreadStackManager().GetPrimary802154MACAddress(buf);
+    return ThreadStackMgr().GetPrimary802154MACAddress(buf);
 #else
     return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD


### PR DESCRIPTION
Fixes #32243 
Fixes #32244

The root issue for the invalid HardwareAddress was from `GenericConfigurationManagerImpl<ConfigClass>::GetPrimary802154MACAddress` using the interface class `ThreadStackManager` which doesn't have the object instead of the singleton implementation `ThreadStackMgr`. It was previously returning garbage and that fix applies to any other users of the generic `ConfigurationMgr().GetPrimary802154MACAddress`

Also, the Silabs Thread interface Ipv6 addresses were not encoded at all in the attribute read response so this PR also adds it.
Manually tested:

```
[1709242670.715664][5202:5204] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_0033 Attribute 0x0000_0000 DataVersion: 322670566
[1709242670.715799][5202:5204] CHIP:TOO:   NetworkInterfaces: 1 entries
[1709242670.716006][5202:5204] CHIP:TOO:     [1]: {
[1709242670.716051][5202:5204] CHIP:TOO:       Name: OpenThread-8046
[1709242670.716091][5202:5204] CHIP:TOO:       IsOperational: TRUE
[1709242670.716171][5202:5204] CHIP:TOO:       OffPremiseServicesReachableIPv4: null
[1709242670.716215][5202:5204] CHIP:TOO:       OffPremiseServicesReachableIPv6: null
[1709242670.716260][5202:5204] CHIP:TOO:       HardwareAddress: 9A4793C4A14BD65F
[1709242670.716305][5202:5204] CHIP:TOO:       IPv4Addresses: 0 entries
[1709242670.716358][5202:5204] CHIP:TOO:       IPv6Addresses: 4 entries
[1709242670.716408][5202:5204] CHIP:TOO:         [1]: FDCAB8F819E900014C8B3DE3AD95BD1C
[1709242670.716457][5202:5204] CHIP:TOO:         [2]: FD4421042B99E765000000FFFE00B000
[1709242670.716504][5202:5204] CHIP:TOO:         [3]: FD4421042B99E76542CC10B44A048054
[1709242670.716552][5202:5204] CHIP:TOO:         [4]: FE80000000000000984793C4A14BD65F
[1709242670.716596][5202:5204] CHIP:TOO:       Type: 4
[1709242670.716635][5202:5204] CHIP:TOO:      }
```

Confirmation that it matches the MAC addresses used for the hostname. 
```
avahi-browse -rt _matter._tcp
..
=   eth0 IPv6 64D2C0E7DD4395D9-00000000000040CC             _matter._tcp         local
   hostname = [9A4793C4A14BD65F.local]
   address = [fdca:b8f8:19e9:1:4c8b:3de3:ad95:bd1c]
   port = [5540]
   txt = ["SAT=4000" "SAI=2000" "SII=800"]
```
First IPV6 address also matches the DNS entry. I validate the rest with the ot cli ipaddr command on the device.