### PR TITLE
[ThreadDiag]Encode an empty list as no ActiveNetworkFault are tracked

### DIFF
--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
@@ -670,16 +670,9 @@ CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, a
     break;
 
     case Attributes::ActiveNetworkFaultsList::Id: {
-        err = encoder.EncodeList([](const auto & aEncoder) -> CHIP_ERROR {
-            // TODO activeNetworkFaultsList isn't tracked. Encode the list of 4 entries at 0 none the less
-            NetworkFaultEnum activeNetworkFaultsList[4] = { NetworkFaultEnum(0) };
-            for (auto fault : activeNetworkFaultsList)
-            {
-                ReturnErrorOnFailure(aEncoder.Encode(fault));
-            }
-
-            return CHIP_NO_ERROR;
-        });
+        // activeNetworkFaults are not tracked by the thread stack nor the ThreadStackManager.
+        // Encode an emptyList to indicate there are currently no active faults.
+        err = encoder.EncodeEmptyList();
     }
     break;
 


### PR DESCRIPTION
fixes #32292
Attribute value was not respecting the spec.  Encode an empty list as there is no active fault (none are tracked)


Result:
```
[1709244937.426632][5801:5803] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_0035 Attribute 0x0000_003E DataVersion: 953547807
[1709244937.426760][5801:5803] CHIP:TOO:   ActiveNetworkFaultsList: 0 entries
```