### PR TITLE
Fix loading of CD signing certs in chip-tool.

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -166,7 +166,8 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
             cdTrustStorePath = getenv(kCDTrustStorePathVariable);
         }
 
-        auto additionalCdCerts = chip::Credentials::LoadAllX509DerCerts(cdTrustStorePath);
+        auto additionalCdCerts =
+            chip::Credentials::LoadAllX509DerCerts(cdTrustStorePath, chip::Credentials::CertificateValidationMode::kPublicKeyOnly);
         if (cdTrustStorePath != nullptr && additionalCdCerts.size() == 0)
         {
             ChipLogError(chipTool, "Warning: no CD signing certs found in path: %s, only defaults will be used", cdTrustStorePath);

--- a/src/credentials/attestation_verifier/FileAttestationTrustStore.h
+++ b/src/credentials/attestation_verifier/FileAttestationTrustStore.h
@@ -25,17 +25,29 @@
 namespace chip {
 namespace Credentials {
 
+enum class CertificateValidationMode
+{
+    // Validate that the certificate is a valid PAA certificate.
+    kPAA,
+    // Validate just that the certificate has a public key we can extract
+    // (e.g. it's a CD signing certificate).
+    kPublicKeyOnly,
+};
+
 /**
  * @brief Load all X.509 DER certificates in a given path.
  *
- * Silently ignores non-X.509 files and X.509 files without a subject key identifier.
+ * Silently ignores non-X.509 files and X.509 files that fail validation as
+ * determined by the provided validation mode.
  *
  * Returns an empty vector if no files are found or unrecoverable errors arise.
  *
  * @param trustStorePath - path from where to search for certificates.
+ * @param validationMode - how the certificate files should be validated.
  * @return a vector of certificate DER data
  */
-std::vector<std::vector<uint8_t>> LoadAllX509DerCerts(const char * trustStorePath);
+std::vector<std::vector<uint8_t>> LoadAllX509DerCerts(const char * trustStorePath,
+                                                      CertificateValidationMode validationMode = CertificateValidationMode::kPAA);
 
 class FileAttestationTrustStore : public AttestationTrustStore
 {


### PR DESCRIPTION
We were calling a function that tried to validate that the certs are valid PAA certs, which is very much not required for CD signing certs.

Fixes https://github.com/project-chip/connectedhomeip/issues/32337
