### PR TITLE
Move isIdentifying out of util.cpp

### DIFF
--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -40,6 +40,19 @@ using namespace app::Clusters::Groups;
 using namespace chip::Credentials;
 using Protocols::InteractionModel::Status;
 
+// Is the device identifying?
+static bool emberAfIsDeviceIdentifying(EndpointId endpoint)
+{
+#ifdef ZCL_USING_IDENTIFY_CLUSTER_SERVER
+    uint16_t identifyTime;
+    Status status = app::Clusters::Identify::Attributes::IdentifyTime::Get(endpoint, &identifyTime);
+    return (status == Status::Success && 0 < identifyTime);
+#else
+    return false;
+#endif
+}
+
+
 /**
  * @brief Checks if group-endpoint association exist for the given fabric
  */

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -52,7 +52,6 @@ static bool emberAfIsDeviceIdentifying(EndpointId endpoint)
 #endif
 }
 
-
 /**
  * @brief Checks if group-endpoint association exist for the given fabric
  */

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -196,21 +196,6 @@ bool emberAfIsTypeSigned(EmberAfAttributeType dataType);
 
 /** @} END Attribute Storage */
 
-/** @name Device Control */
-// @{
-
-/**
- * @brief Function that checks if endpoint is identifying
- *
- * This function returns true if device at a given endpoint is
- * identifying.
- *
- * @param endpoint Zigbee endpoint number
- */
-bool emberAfIsDeviceIdentifying(chip::EndpointId endpoint);
-
-/** @} END Device Control */
-
 /** @name Miscellaneous */
 // @{
 

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -32,25 +32,9 @@
 // TODO: figure out a clear path for compile-time codegen
 #include <app/PluginApplicationCallbacks.h>
 
-#ifdef MATTER_DM_PLUGIN_GROUPS_SERVER
-#include <app/clusters/groups-server/groups-server.h>
-#endif // MATTER_DM_PLUGIN_GROUPS_SERVER
-
 using namespace chip;
 
 using chip::Protocols::InteractionModel::Status;
-
-// Is the device identifying?
-bool emberAfIsDeviceIdentifying(EndpointId endpoint)
-{
-#ifdef ZCL_USING_IDENTIFY_CLUSTER_SERVER
-    uint16_t identifyTime;
-    Status status = app::Clusters::Identify::Attributes::IdentifyTime::Get(endpoint, &identifyTime);
-    return (status == Status::Success && 0 < identifyTime);
-#else
-    return false;
-#endif
-}
 
 // Calculates difference. See EmberAfDifferenceType for the maximum data size
 // that this function will support.


### PR DESCRIPTION
Looking to minimize the API surface that depends on generated code. IsIdentifying is only used in one place currently and seems not too complex to implement if really needed somewhere else.