### PR TITLE
Introduce AttributeAccessInterface lookup cache

### DIFF
--- a/src/app/AttributeAccessInterfaceCache.h
+++ b/src/app/AttributeAccessInterfaceCache.h
@@ -1,0 +1,146 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <stddef.h>
+
+#include <app/AttributeAccessInterface.h>
+#include <lib/core/DataModelTypes.h>
+
+namespace chip {
+namespace app {
+
+/**
+ * @brief Cache to make look-up of AttributeAccessInterface (AAI) instances faster.
+ *
+ * @tparam N - The size of the cache (current suggested value == 1)
+ *
+ * This cache makes use of the fact that looking-up AttributeAccessInterface
+ * instances is usually done in loops, during read/subscription wildcard
+ * expansion, and there is a significant amount of locality.
+ *
+ * This cache records both "used" (i.e. uses AAI) and the single last
+ * "unused" (i.e. does NOT use AAI) entries. Combining positive/negative
+ * lookup led to factor of ~10 reduction of AAI lookups in total for wildcard
+ * reads on chip-all-clusters-app, with a cache size of 1. The size did not
+ * significantly improve the performance, but `N` is left to support better
+ * hashing/storage algorithms in the future if needed.
+ */
+template <size_t N>
+class AttributeAccessInterfaceCache
+{
+  public:
+    AttributeAccessInterfaceCache() { Invalidate(); }
+
+    /**
+     * @brief Invalidate the whole cache. Must be called every time list of AAI registrations changes.
+     */
+    void Invalidate()
+    {
+        for (auto & entry : mCacheSlots)
+        {
+          entry.Invalidate();
+        }
+        mLastUnusedEntry.Invalidate();
+    }
+
+    /**
+     * @brief Mark that we know a given <`endpointId`, `clusterId`> uses AAI, with instance `attrInterface`
+     */
+    void MarkUsed(EndpointId endpointId, ClusterId clusterId, AttributeAccessInterface *attrInterface)
+    {
+        GetCacheSlot(endpointId, clusterId)->Set(endpointId, clusterId, attrInterface);
+    }
+
+    /**
+     * @brief Mark that we know a given <`endpointId`, `clusterId`> does NOT use AAI.
+     */
+    void MarkUnused(EndpointId endpointId, ClusterId clusterId)
+    {
+        mLastUnusedEntry.Set(endpointId, clusterId, nullptr);
+
+    }
+
+    /**
+     * @brief Get the AttributeAccessInterface instance for a given <`endpointId`, `clusterId`>, if present in cache.
+     *
+     * @param endpointId - Endpoint ID to look-up.
+     * @param clusterId - Cluster ID to look-up.
+     * @return the instance pointer on cache hit, or nullptr on cache miss.
+     */
+    AttributeAccessInterface * Get(EndpointId endpointId, ClusterId clusterId)
+    {
+        AttributeAccessCacheEntry * cacheSlot = GetCacheSlot(endpointId, clusterId);
+        if (cacheSlot->Matches(endpointId, clusterId) && (cacheSlot->accessor != nullptr))
+        {
+          return cacheSlot->accessor;
+        }
+
+        return nullptr;
+    }
+
+    /**
+     * @brief returns true if <`endpointId`, `clusterId`> was last marked as NOT to using AAI.
+     *
+     * May return false even though it doesn't use AAI, on cache miss of unused slot.
+     */
+    bool IsUnused(EndpointId endpointId, ClusterId clusterId) const
+    {
+        return mLastUnusedEntry.Matches(endpointId, clusterId);
+    }
+
+  private:
+    struct AttributeAccessCacheEntry
+    {
+        EndpointId endpointId = kInvalidEndpointId;
+        ClusterId clusterId = kInvalidClusterId;
+        AttributeAccessInterface * accessor = nullptr;
+
+        void Invalidate()
+        {
+            endpointId = kInvalidEndpointId;
+            clusterId = kInvalidClusterId;
+            accessor = nullptr;
+        }
+
+        void Set(EndpointId theEndpointId, ClusterId theClusterId, AttributeAccessInterface *theAccessor)
+        {
+            endpointId = theEndpointId;
+            clusterId = theClusterId;
+            accessor = theAccessor;
+        }
+
+        bool Matches(EndpointId theEndpointId, ClusterId theClusterId) const
+        {
+            return (endpointId == theEndpointId) && (clusterId == theClusterId);
+        }
+    };
+
+    AttributeAccessCacheEntry * GetCacheSlot(EndpointId endpointId, ClusterId clusterId)
+    {
+        // A future implementation may use a better method.
+        size_t slotId = (clusterId ^ endpointId) & (N - 1);
+        return &mCacheSlots[slotId];
+    }
+
+    AttributeAccessCacheEntry mCacheSlots[N];
+    AttributeAccessCacheEntry mLastUnusedEntry;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/AttributeAccessInterfaceCache.h
+++ b/src/app/AttributeAccessInterfaceCache.h
@@ -41,10 +41,11 @@ namespace app {
 class AttributeAccessInterfaceCache
 {
 public:
-    enum class CacheResult {
-      kCacheMiss,
-      kDefinitelyUnused,
-      kDefinitelyUsed
+    enum class CacheResult
+    {
+        kCacheMiss,
+        kDefinitelyUnused,
+        kDefinitelyUsed
     };
 
     AttributeAccessInterfaceCache() { Invalidate(); }
@@ -74,7 +75,6 @@ public:
      */
     void MarkUnused(EndpointId endpointId, ClusterId clusterId) { mLastUnusedEntry.Set(endpointId, clusterId, nullptr); }
 
-
     /**
      * @brief Get the AttributeAccessInterface instance for a given <`endpointId`, `clusterId`>, if present in cache.
      *
@@ -95,7 +95,7 @@ public:
         {
             if (outAttributeAccess != nullptr)
             {
-                *outAttributeAccess =cacheSlot->accessor;
+                *outAttributeAccess = cacheSlot->accessor;
             }
             return CacheResult::kDefinitelyUsed;
         }
@@ -132,8 +132,8 @@ private:
 
     AttributeAccessCacheEntry * GetCacheSlot(EndpointId endpointId, ClusterId clusterId)
     {
-        (void)endpointId;
-        (void)clusterId;
+        (void) endpointId;
+        (void) clusterId;
         return &mCacheSlots[0];
     }
 

--- a/src/app/AttributeAccessInterfaceCache.h
+++ b/src/app/AttributeAccessInterfaceCache.h
@@ -44,7 +44,7 @@ namespace app {
 template <size_t N>
 class AttributeAccessInterfaceCache
 {
-  public:
+public:
     AttributeAccessInterfaceCache() { Invalidate(); }
 
     /**
@@ -54,7 +54,7 @@ class AttributeAccessInterfaceCache
     {
         for (auto & entry : mCacheSlots)
         {
-          entry.Invalidate();
+            entry.Invalidate();
         }
         mLastUnusedEntry.Invalidate();
     }
@@ -62,7 +62,7 @@ class AttributeAccessInterfaceCache
     /**
      * @brief Mark that we know a given <`endpointId`, `clusterId`> uses AAI, with instance `attrInterface`
      */
-    void MarkUsed(EndpointId endpointId, ClusterId clusterId, AttributeAccessInterface *attrInterface)
+    void MarkUsed(EndpointId endpointId, ClusterId clusterId, AttributeAccessInterface * attrInterface)
     {
         GetCacheSlot(endpointId, clusterId)->Set(endpointId, clusterId, attrInterface);
     }
@@ -70,11 +70,7 @@ class AttributeAccessInterfaceCache
     /**
      * @brief Mark that we know a given <`endpointId`, `clusterId`> does NOT use AAI.
      */
-    void MarkUnused(EndpointId endpointId, ClusterId clusterId)
-    {
-        mLastUnusedEntry.Set(endpointId, clusterId, nullptr);
-
-    }
+    void MarkUnused(EndpointId endpointId, ClusterId clusterId) { mLastUnusedEntry.Set(endpointId, clusterId, nullptr); }
 
     /**
      * @brief Get the AttributeAccessInterface instance for a given <`endpointId`, `clusterId`>, if present in cache.
@@ -88,7 +84,7 @@ class AttributeAccessInterfaceCache
         AttributeAccessCacheEntry * cacheSlot = GetCacheSlot(endpointId, clusterId);
         if (cacheSlot->Matches(endpointId, clusterId) && (cacheSlot->accessor != nullptr))
         {
-          return cacheSlot->accessor;
+            return cacheSlot->accessor;
         }
 
         return nullptr;
@@ -99,30 +95,27 @@ class AttributeAccessInterfaceCache
      *
      * May return false even though it doesn't use AAI, on cache miss of unused slot.
      */
-    bool IsUnused(EndpointId endpointId, ClusterId clusterId) const
-    {
-        return mLastUnusedEntry.Matches(endpointId, clusterId);
-    }
+    bool IsUnused(EndpointId endpointId, ClusterId clusterId) const { return mLastUnusedEntry.Matches(endpointId, clusterId); }
 
-  private:
+private:
     struct AttributeAccessCacheEntry
     {
-        EndpointId endpointId = kInvalidEndpointId;
-        ClusterId clusterId = kInvalidClusterId;
+        EndpointId endpointId               = kInvalidEndpointId;
+        ClusterId clusterId                 = kInvalidClusterId;
         AttributeAccessInterface * accessor = nullptr;
 
         void Invalidate()
         {
             endpointId = kInvalidEndpointId;
-            clusterId = kInvalidClusterId;
-            accessor = nullptr;
+            clusterId  = kInvalidClusterId;
+            accessor   = nullptr;
         }
 
-        void Set(EndpointId theEndpointId, ClusterId theClusterId, AttributeAccessInterface *theAccessor)
+        void Set(EndpointId theEndpointId, ClusterId theClusterId, AttributeAccessInterface * theAccessor)
         {
             endpointId = theEndpointId;
-            clusterId = theClusterId;
-            accessor = theAccessor;
+            clusterId  = theClusterId;
+            accessor   = theAccessor;
         }
 
         bool Matches(EndpointId theEndpointId, ClusterId theClusterId) const

--- a/src/app/AttributeAccessInterfaceCache.h
+++ b/src/app/AttributeAccessInterfaceCache.h
@@ -35,7 +35,7 @@ namespace app {
  * This cache records both "used" (i.e. uses AAI) and the single last
  * "unused" (i.e. does NOT use AAI) entries. Combining positive/negative
  * lookup led to factor of ~10 reduction of AAI lookups in total for wildcard
- * reads on chip-all-clusters-app, with a cache size of 1. The size did not
+ * reads on chip-all-clusters-app, with a cache size of 1. Increasing the size did not
  * significantly improve the performance.
  */
 class AttributeAccessInterfaceCache

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -250,6 +250,7 @@ static_library("app") {
 
   sources = [
     "AttributeAccessInterface.cpp",
+    "AttributeAccessInterfaceCache.h",
     "AttributePathExpandIterator.cpp",
     "AttributePathExpandIterator.h",
     "AttributePersistenceProvider.h",

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -125,6 +125,7 @@ chip_test_suite_using_nltest("tests") {
 
   test_sources = [
     "TestAclEvent.cpp",
+    "TestAttributeAccessInterfaceCache.cpp",
     "TestAttributePathExpandIterator.cpp",
     "TestAttributePersistenceProvider.cpp",
     "TestAttributeValueDecoder.cpp",

--- a/src/app/tests/TestAttributeAccessInterfaceCache.cpp
+++ b/src/app/tests/TestAttributeAccessInterfaceCache.cpp
@@ -26,7 +26,6 @@ using namespace chip::app;
 
 namespace {
 
-
 void TestBasicLifecycle(nlTestSuite * inSuite, void * inContext)
 {
     using CacheResult = AttributeAccessInterfaceCache::CacheResult;

--- a/src/app/tests/TestAttributeAccessInterfaceCache.cpp
+++ b/src/app/tests/TestAttributeAccessInterfaceCache.cpp
@@ -1,0 +1,105 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceCache.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <nlunit-test.h>
+
+using namespace chip;
+using namespace chip::app;
+
+namespace {
+
+void TestBasicLifecycle(nlTestSuite * inSuite, void * inContext)
+{
+    int data1 = 1;
+    int data2 = 2;
+
+    // We alias the pointers to given locations to avoid needing to implement anything
+    // since the AttributeAccessInterfaceCache only deals in pointers, and never calls
+    // the API itself.
+    AttributeAccessInterface * accessor1 = reinterpret_cast<AttributeAccessInterface *>(&data1);
+    AttributeAccessInterface * accessor2 = reinterpret_cast<AttributeAccessInterface *>(&data2);
+
+    AttributeAccessInterfaceCache<1> cache;
+
+    // Cache can keep track of at least 1 entry,
+    NL_TEST_ASSERT(inSuite, cache.Get(1, 1) == nullptr);
+    NL_TEST_ASSERT(inSuite, !cache.IsUnused(1, 1));
+    cache.MarkUsed(1, 1, accessor1);
+
+    NL_TEST_ASSERT(inSuite, cache.Get(1, 1) == accessor1);
+    NL_TEST_ASSERT(inSuite, cache.Get(1, 2) == nullptr);
+    NL_TEST_ASSERT(inSuite, cache.Get(2, 1) == nullptr);
+
+    cache.MarkUsed(1, 2, accessor1);
+    NL_TEST_ASSERT(inSuite, cache.Get(1, 2) == accessor1);
+    NL_TEST_ASSERT(inSuite, cache.Get(2, 1) == nullptr);
+
+    cache.MarkUsed(1, 2, accessor2);
+    NL_TEST_ASSERT(inSuite, cache.Get(1, 2) == accessor2);
+
+    cache.Invalidate();
+    NL_TEST_ASSERT(inSuite, cache.Get(1, 1) == nullptr);
+    NL_TEST_ASSERT(inSuite, cache.Get(1, 2) == nullptr);
+    NL_TEST_ASSERT(inSuite, cache.Get(2, 1) == nullptr);
+
+    // Marking unused works, keeps single entry, and is invalidated when invalidated fully.
+    NL_TEST_ASSERT(inSuite, !cache.IsUnused(2, 2));
+    NL_TEST_ASSERT(inSuite, !cache.IsUnused(3, 3));
+    cache.MarkUnused(2, 2);
+    NL_TEST_ASSERT(inSuite, cache.IsUnused(2, 2));
+    NL_TEST_ASSERT(inSuite, !cache.IsUnused(3, 3));
+
+    cache.MarkUnused(3, 3);
+    NL_TEST_ASSERT(inSuite, !cache.IsUnused(2, 2));
+    NL_TEST_ASSERT(inSuite, cache.IsUnused(3, 3));
+
+    cache.Invalidate();
+    NL_TEST_ASSERT(inSuite, !cache.IsUnused(3, 3));
+}
+
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("Basic AttributeAccessInterfaceCache lifecycle works", TestBasicLifecycle),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+} // namespace
+
+int TestAttributeAccessInterfaceCache()
+{
+    // clang-format off
+    nlTestSuite theSuite =
+    {
+        "Test for AttributeAccessInterface cache utility",
+        &sTests[0],
+        nullptr,
+        nullptr
+    };
+    // clang-format on
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestAttributeAccessInterfaceCache)

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1394,27 +1394,27 @@ app::AttributeAccessInterface * GetAttributeAccessOverride(EndpointId endpointId
     using CacheResult = AttributeAccessInterfaceCache::CacheResult;
 
     AttributeAccessInterface * cached = nullptr;
-    CacheResult result = gAttributeAccessInterfaceCache.Get(endpointId, clusterId, &cached);
+    CacheResult result                = gAttributeAccessInterfaceCache.Get(endpointId, clusterId, &cached);
     switch (result)
     {
-      case CacheResult::kDefinitelyUnused:
-          return nullptr;
-      case CacheResult::kDefinitelyUsed:
-          return cached;
-      case CacheResult::kCacheMiss:
-      default:
-          // Did not cache yet, search set of AAI registered, and cache if found.
-          for (app::AttributeAccessInterface * cur = gAttributeAccessOverrides; cur; cur = cur->GetNext())
-          {
-              if (cur->Matches(endpointId, clusterId))
-              {
-                  gAttributeAccessInterfaceCache.MarkUsed(endpointId, clusterId, cur);
-                  return cur;
-              }
-          }
+    case CacheResult::kDefinitelyUnused:
+        return nullptr;
+    case CacheResult::kDefinitelyUsed:
+        return cached;
+    case CacheResult::kCacheMiss:
+    default:
+        // Did not cache yet, search set of AAI registered, and cache if found.
+        for (app::AttributeAccessInterface * cur = gAttributeAccessOverrides; cur; cur = cur->GetNext())
+        {
+            if (cur->Matches(endpointId, clusterId))
+            {
+                gAttributeAccessInterfaceCache.MarkUsed(endpointId, clusterId, cur);
+                return cur;
+            }
+        }
 
-          // Did not find AAI registered: mark as definitely not using.
-          gAttributeAccessInterfaceCache.MarkUnused(endpointId, clusterId);
+        // Did not find AAI registered: mark as definitely not using.
+        gAttributeAccessInterfaceCache.MarkUnused(endpointId, clusterId);
     }
 
     return nullptr;

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1393,7 +1393,7 @@ app::AttributeAccessInterface * GetAttributeAccessOverride(EndpointId endpointId
     // If endpoint/cluster is definitely not for AttributeAccessInterface, immediately skip all searches.
     if (gAttributeAccessInterfaceCache.IsUnused(endpointId, clusterId))
     {
-      return nullptr;
+        return nullptr;
     }
 
     // Find in cache, hope for a match.


### PR DESCRIPTION
- Running TC_DeviceBasicComposition test caused, for a single Wildcard read, 44622 iterations through the AttributeAccessInterface (AAI) lookup loop. This is significant runtime cost on embedded devices, when a wildcard subscription is established or when trying to iterate over changes of attributes.
- Instrumented analysis showed that significant locality exists within the lookup, which could be exploited by a cache.
- This PR introduces a cache, and its use, in AAI lookups. On same workload as the initial investigation, the total number of iterations of the costly loop went from 44622 --> 4864, a factor of almost 10, for very little additional RAM usage (single entry in cache).

Issue #31405

Testing done:
- Added unit tests
- Integration tests still pass
- TC_BasicDeviceComposition still succeeds
