### PR TITLE
Bump ZAP version to v2024.02.29-nightly

### DIFF
--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,13 +8,13 @@
                 "mac-amd64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2024.01.05-nightly.1"]
+            "tags": ["version:2@v2024.02.29-nightly.1"]
         },
         {
             "_comment": "Always get the amd64 version on mac until usable arm64 zap build is available",
             "path": "fuchsia/third_party/zap/mac-amd64",
             "platforms": ["mac-arm64"],
-            "tags": ["version:2@v2024.01.05-nightly.1"]
+            "tags": ["version:2@v2024.02.29-nightly.1"]
         }
     ]
 }

--- a/scripts/setup/zap.version
+++ b/scripts/setup/zap.version
@@ -1,1 +1,1 @@
-v2024.01.05-nightly
+v2024.02.29-nightly

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2024.1.5'
+MIN_ZAP_VERSION = '2024.2.29'
 
 
 class ZapTool:


### PR DESCRIPTION
Bump ZAP version used by connectedhomeip to v2024.02.29-nightly.
https://github.com/project-chip/zap/releases

Updated using the following command: ./scripts/tools/zap/version_update.py --new-version v2024.02.29-nightly

Previous version used: v2024.01.05-nightly