### PR TITLE
TC-IDM-10.4: Catch feature mask errors and log

### DIFF
--- a/src/python_testing/TC_pics_checker.py
+++ b/src/python_testing/TC_pics_checker.py
@@ -164,6 +164,11 @@ class TC_PICS_Checker(MatterBaseTest, BasicCompositionTests):
                 except ValueError:
                     location = FeaturePathLocation(endpoint_id=self.endpoint_id,
                                                    cluster_id=cluster_id, feature_code=str(feature_mask))
+                    # The feature_mask is from the code generated feature masks, not the features as listed on the
+                    # device. If we get an error here, this is a problem with the codegen or spec, not with the device
+                    # under test. We still want the problem recorded, but this does not indicate a problem on the DUT.
+                    # There are two clusters with known bad features here - RvcRunMode and RvcCleanMode both have a
+                    # feature mask of kNoFeatures and an empty "mask" of 0x0.
                     self.record_warning("PICS check", location=location,
                                         problem=f"Unable to parse feature mask {feature_mask} from cluster {cluster}")
                     continue

--- a/src/python_testing/TC_pics_checker.py
+++ b/src/python_testing/TC_pics_checker.py
@@ -159,7 +159,14 @@ class TC_PICS_Checker(MatterBaseTest, BasicCompositionTests):
                 # Codegen in python uses feature masks (0x01, 0x02, 0x04 etc.)
                 # PICS uses the mask bit number (1, 2, 3)
                 # Convert the mask to a bit number so we can check the PICS.
-                feature_bit = int(math.log2(feature_mask))
+                try:
+                    feature_bit = int(math.log2(feature_mask))
+                except ValueError:
+                    location = FeaturePathLocation(endpoint_id=self.endpoint_id,
+                                                   cluster_id=cluster_id, feature_code=str(feature_mask))
+                    self.record_warning("PICS check", location=location,
+                                        problem=f"Unable to parse feature mask {feature_mask} from cluster {cluster}")
+                    continue
                 pics = feature_pics(pics_base, feature_bit)
                 if feature_mask & feature_map:
                     required = True


### PR DESCRIPTION
issue: https://github.com/project-chip/matter-test-scripts/issues/192

Tested by Yinyi during SVE: https://csamembers.slack.com/archives/C06JDQWTU6N/p1709570370147559. Also artificially tested by forcing this condition. This is related to the kNoFeatures marking for RVC.

[MatterTest] 03-04 20:01:20.421 INFO 
Problem: ProblemSeverity.WARNING
    test_name: PICS check
    location: 
        Endpoint: 1,
        Cluster:  84 (0x54) RvcRunMode,
        Feature:  Feature.kNoFeatures
    problem: Unable to parse feature mask 0 from cluster <class 'chip.clusters.Objects.RvcRunMode'>
    spec_location: 