### PR TITLE
Allow multiple days to be specified in DaysMask parameter of SetWeekdaySchedule command

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -1003,7 +1003,7 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
         return;
     }
 
-    uint8_t rawDaysMask   = daysMask.Raw();
+    uint8_t rawDaysMask = daysMask.Raw();
 
     // Check that bits are within range
     if ((0 == rawDaysMask) || (rawDaysMask & 0x80))

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -1003,17 +1003,10 @@ void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler 
         return;
     }
 
-    // appclusters, 5.2.4.14 - spec does not allow setting the schedule for multiple days in the bitmask
-    int setBitsInDaysMask = 0;
     uint8_t rawDaysMask   = daysMask.Raw();
-    for (size_t i = 0; i < sizeof(rawDaysMask) * 8; ++i)
-    {
-        setBitsInDaysMask += rawDaysMask & 0x1;
-        rawDaysMask = static_cast<uint8_t>(rawDaysMask >> 1);
-    }
 
-    // TODO: Check that bits are within range
-    if (setBitsInDaysMask == 0 || setBitsInDaysMask > 1)
+    // Check that bits are within range
+    if ((0 == rawDaysMask) || (rawDaysMask & 0x80))
     {
         ChipLogProgress(Zcl,
                         "[SetWeekDaySchedule] Unable to add schedule - daysMask is out of range "

--- a/src/app/tests/suites/DL_Schedules.yaml
+++ b/src/app/tests/suites/DL_Schedules.yaml
@@ -215,7 +215,7 @@ tests:
       response:
           error: INVALID_COMMAND
 
-    - label: "Create Week Day schedule for Sunday and Monday"
+    - label: "Create Week Day schedule with Invalid day"
       command: "SetWeekDaySchedule"
       arguments:
           values:
@@ -224,28 +224,7 @@ tests:
               - name: "UserIndex"
                 value: 1
               - name: "DaysMask"
-                value: 0x3 # (Sunday and Monday)
-              - name: "StartHour"
-                value: 15
-              - name: "StartMinute"
-                value: 16
-              - name: "EndHour"
-                value: 18
-              - name: "EndMinute"
-                value: 00
-      response:
-          error: INVALID_COMMAND
-
-    - label: "Create Week Day schedule for Sunday Wednesday and Saturday"
-      command: "SetWeekDaySchedule"
-      arguments:
-          values:
-              - name: "WeekDayIndex"
-                value: 1
-              - name: "UserIndex"
-                value: 1
-              - name: "DaysMask"
-                value: 0x49 # (Sunday, Wednesday and Saturday)
+                value: 0x80 # (Not a valid day between Sunday thru Saturday)
               - name: "StartHour"
                 value: 15
               - name: "StartMinute"
@@ -1705,7 +1684,7 @@ tests:
               - name: "UserIndex"
                 value: 2
               - name: "DaysMask"
-                value: 0x40
+                value: 0x49 # (Sunday, Wednesday and Saturday)
               - name: "StartHour"
                 value: 23
               - name: "StartMinute"
@@ -1732,7 +1711,7 @@ tests:
               - name: "Status"
                 value: 0x0
               - name: "DaysMask"
-                value: 0x40
+                value: 0x49
               - name: "StartHour"
                 value: 23
               - name: "StartMinute"


### PR DESCRIPTION
Allow multiple days to be specified in DaysMask parameter of SetWeekdaySchedule command

Original SDK implementation misconstrues the spec and disallows anything but single-day schedules.

Fixes #32423


