### PR TITLE
[Darwin] Refactor MTRMetrics to have more well formed schema

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -122,6 +122,10 @@ void MTRDeviceControllerDelegateBridge::OnCommissioningComplete(chip::NodeId nod
     id<MTRDeviceControllerDelegate> strongDelegate = mDelegate;
     MTRDeviceController * strongController = mController;
     if (strongDelegate && mQueue && strongController) {
+
+        // Always collect the metrics to avoid unbounded growth of the stats in the collector
+        MTRMetrics * metrics = [[MTRMetricsCollector sharedInstance] metricSnapshot:TRUE];
+
         if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:)] ||
             [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
             dispatch_async(mQueue, ^{
@@ -133,8 +137,6 @@ void MTRDeviceControllerDelegateBridge::OnCommissioningComplete(chip::NodeId nod
 
                 // If the client implements the metrics delegate, prefer that over others
                 if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
-                    // Create a snapshot and clear for next operation
-                    MTRMetrics * metrics = [[MTRMetricsCollector sharedInstance] metricSnapshot:TRUE];
                     [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID metrics:metrics];
                 } else {
                     [strongDelegate controller:strongController commissioningComplete:nsError nodeID:nodeID];

--- a/src/darwin/Framework/CHIP/MTRMetrics.h
+++ b/src/darwin/Framework/CHIP/MTRMetrics.h
@@ -21,6 +21,31 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ * Representation of metric data corresponding to a metric event.
+ */
+MTR_NEWLY_AVAILABLE
+@interface MTRMetricData : NSObject
+
+/**
+ * Value for the metric data. The value may be nil depending on the event emitted.
+ */
+@property (nonatomic, nullable, readonly, copy) NSNumber * value;
+
+/**
+ * Error code for the metric data. This value when valid, holds the error code value
+ * of the operation associated with the event.
+ */
+@property (nonatomic, nullable, readonly, copy) NSNumber * errorCode;
+
+/**
+ * Duration of event associated with the metric. This value may be nil depending on
+ * the event emitted.
+ */
+@property (nonatomic, nullable, readonly, copy) NSNumber * durationMicroseconds;
+
+@end
+
+/**
  * A representation of a collection of metrics data for an operation.
  */
 MTR_NEWLY_AVAILABLE
@@ -35,13 +60,13 @@ MTR_NEWLY_AVAILABLE
 @property (nonatomic, readonly, copy) NSArray<NSString *> * allKeys;
 
 /**
- * @brief Returns metric object corresponding to the metric identified by its key
+ * @brief Returns metric data corresponding to the metric identified by its key.
  *
  * @param [in] key Name of the metric
  *
- * @return An object containing the metric data, nil if key is invalid
+ * @return An object containing the metric data, nil if key is invalid.
  */
-- (nullable id)valueForKey:(NSString *)key;
+- (nullable MTRMetricData *)metricDataForKey:(NSString *)key;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRMetrics.mm
+++ b/src/darwin/Framework/CHIP/MTRMetrics.mm
@@ -21,7 +21,7 @@
 #include <Matter/MTRMetrics.h>
 
 @implementation MTRMetrics {
-    NSMutableDictionary<NSString *, id> * _metricsData;
+    NSMutableDictionary<NSString *, MTRMetricData *> * _metricsData;
 }
 
 - (instancetype)init
@@ -42,8 +42,7 @@
 {
     return [_metricsData allKeys];
 }
-
-- (nullable id)valueForKey:(NSString *)key
+- (nullable MTRMetricData *)metricDataForKey:(NSString *)key
 {
     if (!key) {
         MTR_LOG_ERROR("Cannot get metrics value for nil key");
@@ -53,7 +52,7 @@
     return _metricsData[key];
 }
 
-- (void)setValue:(id _Nullable)value forKey:(NSString *)key
+- (void)setMetricData:(MTRMetricData * _Nullable)value forKey:(NSString *)key
 {
     if (!key) {
         MTR_LOG_ERROR("Cannot set metrics value for nil key");
@@ -63,7 +62,7 @@
     [_metricsData setValue:value forKey:key];
 }
 
-- (void)removeValueForKey:(NSString *)key
+- (void)removeMetricDataForKey:(NSString *)key
 {
     if (!key) {
         MTR_LOG_ERROR("Cannot remove metrics value for nil key");

--- a/src/darwin/Framework/CHIP/MTRMetrics_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRMetrics_Internal.h
@@ -19,32 +19,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * A representation of a metric data for an operation.
- */
-@interface MTRMetricsData : NSObject
-
-// Value for the metric. This can be null if the metric is just a fire event with no value
-@property (nonatomic, nullable, readonly, copy) NSNumber * value;
-
-// Relative time point at which the metric was emitted. This may be null.
-@property (nonatomic, nullable, readonly, copy) NSNumber * timePointMicroseconds;
-
-// During for the event. This may be null.
-@property (nonatomic, nullable, readonly, copy) NSNumber * durationMicroseconds;
-
-// Convert contents to a dictionary
-- (NSDictionary *)toDictionary;
-
-@end
-
 @interface MTRMetrics ()
 
 - (instancetype)initWithCapacity:(NSUInteger)numItems;
 
-- (void)setValue:(id _Nullable)value forKey:(NSString *)key;
+- (void)setMetricData:(MTRMetricData * _Nullable)value forKey:(NSString *)key;
 
-- (void)removeValueForKey:(NSString *)key;
+- (void)removeMetricDataForKey:(NSString *)key;
 
 @end
 

--- a/src/darwin/Framework/CHIPTests/MTRMetricsTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRMetricsTests.m
@@ -50,10 +50,14 @@
 - (void)test001_TestAllKeys
 {
     MTRMetrics * metrics = [[MTRMetrics alloc] initWithCapacity:4];
-    [metrics setValue:@"metricsCounter1" forKey:@"com.matter.metrics.counter1"];
-    [metrics setValue:@"metricsCounter2" forKey:@"com.matter.metrics.counter2"];
-    [metrics setValue:@"metricsCounter3" forKey:@"com.matter.metrics.counter3"];
-    [metrics setValue:@"metricsCounter4" forKey:@"com.matter.metrics.counter4"];
+    MTRMetricData * metricData1 = [MTRMetricData new];
+    MTRMetricData * metricData2 = [MTRMetricData new];
+    MTRMetricData * metricData3 = [MTRMetricData new];
+    MTRMetricData * metricData4 = [MTRMetricData new];
+    [metrics setMetricData:metricData1 forKey:@"com.matter.metrics.counter1"];
+    [metrics setMetricData:metricData2 forKey:@"com.matter.metrics.counter2"];
+    [metrics setMetricData:metricData3 forKey:@"com.matter.metrics.counter3"];
+    [metrics setMetricData:metricData4 forKey:@"com.matter.metrics.counter4"];
 
     NSArray<NSString *> * keys = [metrics allKeys];
     XCTAssertTrue([keys count] == 4);
@@ -63,67 +67,63 @@
     XCTAssertTrue([keys containsObject:@"com.matter.metrics.counter4"]);
     XCTAssertFalse([keys containsObject:@"com.matter.metrics.counter5"]);
 }
+
 - (void)test002_TestOneKey
 {
     MTRMetrics * metrics = [[MTRMetrics alloc] initWithCapacity:1];
-    [metrics setValue:@"metricsCounter1" forKey:@"com.matter.metrics.counter1"];
+    MTRMetricData * metricData1 = [MTRMetricData new];
+    [metrics setMetricData:metricData1 forKey:@"com.matter.metrics.counter1"];
 
     NSArray<NSString *> * keys = [metrics allKeys];
     XCTAssertTrue([keys count] == 1);
     XCTAssertTrue([keys containsObject:@"com.matter.metrics.counter1"]);
 }
 
-- (void)test003_TestMultipleKeys
-{
-    MTRMetrics * metrics = [[MTRMetrics alloc] initWithCapacity:3];
-    [metrics setValue:@"metricsCounter1" forKey:@"com.matter.metrics.counter1"];
-    [metrics setValue:@"metricsCounter2" forKey:@"com.matter.metrics.counter2"];
-    [metrics setValue:[NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidState userInfo:nil] forKey:@"com.matter.metrics.counter3"];
-
-    NSArray<NSString *> * keys = [metrics allKeys];
-    XCTAssertTrue([keys count] == 3);
-    XCTAssertTrue([keys containsObject:@"com.matter.metrics.counter1"]);
-    XCTAssertTrue([keys containsObject:@"com.matter.metrics.counter2"]);
-    XCTAssertTrue([keys containsObject:@"com.matter.metrics.counter3"]);
-    XCTAssertFalse([keys containsObject:@"com.matter.metrics.counter4"]);
-}
-
-- (void)test004_TestValueForKey
+- (void)test003_TestValueForKey
 {
     MTRMetrics * metrics = [[MTRMetrics alloc] initWithCapacity:1];
-    [metrics setValue:@"metricsCounter1" forKey:@"com.matter.metrics.counter1"];
+    MTRMetricData * metricData1 = [MTRMetricData new];
+    [metrics setMetricData:metricData1 forKey:@"com.matter.metrics.counter1"];
 
-    XCTAssertEqualObjects([metrics valueForKey:@"com.matter.metrics.counter1"], @"metricsCounter1");
+    XCTAssertEqualObjects([metrics metricDataForKey:@"com.matter.metrics.counter1"], metricData1);
 }
 
-- (void)test005_TestMultipleValueForKeys
+- (void)test004_TestMultipleValueForKeys
 {
     MTRMetrics * metrics = [[MTRMetrics alloc] initWithCapacity:3];
-    [metrics setValue:@"metricsCounter1" forKey:@"com.matter.metrics.counter1"];
-    [metrics setValue:@"metricsCounter2" forKey:@"com.matter.metrics.counter2"];
-    [metrics setValue:[NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidState userInfo:nil] forKey:@"com.matter.metrics.counter3"];
+    MTRMetricData * metricData1 = [MTRMetricData new];
+    MTRMetricData * metricData2 = [MTRMetricData new];
+    MTRMetricData * metricData3 = [MTRMetricData new];
+    [metrics setMetricData:metricData1 forKey:@"com.matter.metrics.counter1"];
+    [metrics setMetricData:metricData2 forKey:@"com.matter.metrics.counter2"];
+    [metrics setMetricData:metricData3 forKey:@"com.matter.metrics.counter3"];
 
-    XCTAssertEqualObjects([metrics valueForKey:@"com.matter.metrics.counter1"], @"metricsCounter1");
-    XCTAssertEqualObjects([metrics valueForKey:@"com.matter.metrics.counter2"], @"metricsCounter2");
-    XCTAssertEqualObjects([metrics valueForKey:@"com.matter.metrics.counter3"], [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidState userInfo:nil]);
+    XCTAssertEqualObjects([metrics metricDataForKey:@"com.matter.metrics.counter1"], metricData1);
+    XCTAssertEqualObjects([metrics metricDataForKey:@"com.matter.metrics.counter2"], metricData2);
+    XCTAssertEqualObjects([metrics metricDataForKey:@"com.matter.metrics.counter3"], metricData3);
+    XCTAssertNotEqualObjects([metrics metricDataForKey:@"com.matter.metrics.counter3"], metricData2);
 }
 
-- (void)test006_TestValueRemoval
+- (void)test005_TestValueRemoval
 {
     MTRMetrics * metrics = [[MTRMetrics alloc] initWithCapacity:2];
-    [metrics setValue:@"metricsCounter1" forKey:@"com.matter.metrics.counter1"];
-    [metrics setValue:@"metricsCounter2" forKey:@"com.matter.metrics.counter2"];
+    MTRMetricData * metricData1 = [MTRMetricData new];
+    MTRMetricData * metricData2 = [MTRMetricData new];
+    [metrics setMetricData:metricData1 forKey:@"com.matter.metrics.counter1"];
+    [metrics setMetricData:metricData2 forKey:@"com.matter.metrics.counter2"];
 
     NSArray<NSString *> * keys = [metrics allKeys];
     XCTAssertTrue([keys count] == 2);
 
-    [metrics setValue:nil forKey:@"com.matter.metrics.counter2"];
+    [metrics setMetricData:nil forKey:@"com.matter.metrics.counter2"];
     keys = [metrics allKeys];
     XCTAssertTrue([keys count] == 1);
     XCTAssertTrue([keys containsObject:@"com.matter.metrics.counter1"]);
     XCTAssertFalse([keys containsObject:@"com.matter.metrics.counter2"]);
+    XCTAssertEqualObjects([metrics metricDataForKey:@"com.matter.metrics.counter1"], metricData1);
+    XCTAssertNotEqualObjects([metrics metricDataForKey:@"com.matter.metrics.counter1"], metricData2);
 
-    [metrics setValue:nil forKey:@"com.matter.metrics.counter1"];
+    [metrics setMetricData:nil forKey:@"com.matter.metrics.counter1"];
     keys = [metrics allKeys];
     XCTAssertTrue([keys count] == 0);
 }

--- a/src/tracing/metric_keys.h
+++ b/src/tracing/metric_keys.h
@@ -29,16 +29,7 @@ typedef const char * MetricKey;
 /**
  * List of supported metric keys
  */
-constexpr MetricKey kMetricDiscoveryOverBLE      = "disc-over-ble";
-constexpr MetricKey kMetricDiscoveryOnNetwork    = "disc-on-nw";
-constexpr MetricKey kMetricPASESession           = "pase-session";
-constexpr MetricKey kMetricPASESessionPair       = "pase-session-pair";
-constexpr MetricKey kMetricPASESessionBLE        = "pase-session-ble";
-constexpr MetricKey kMetricAttestationResult     = "attestation-result";
-constexpr MetricKey kMetricAttestationOverridden = "attestation-overridden";
-constexpr MetricKey kMetricCASESession           = "case-session";
-constexpr MetricKey kMetricCASESessionEstState   = "case-conn-est";
-constexpr MetricKey kMetricWiFiRSSI              = "wifi_rssi";
+constexpr MetricKey kMetricWiFiRSSI = "wifi_rssi";
 
 } // namespace Tracing
 } // namespace chip


### PR DESCRIPTION
- MTRMetrics vends MTRMetricData which has well defined schema
- Cleaned up internals of MTRMetricData
- Fixed potential unbounded growth if metrics are enabled on Darwin
- Removed stale metric keys that are not used and were meant to be removed in initial framework for metrics