### PR TITLE
Move `ReadPrepareparams.h` to app:interaction-model.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -98,7 +98,6 @@ jobs:
                      --known-failure app/CommandSenderLegacyCallback.h \
                      --known-failure app/data-model/ListLargeSystemExtensions.h \
                      --known-failure app/ReadHandler.h \
-                     --known-failure app/ReadPrepareParams.h \
                      --known-failure app/reporting/tests/MockReportScheduler.cpp \
                      --known-failure app/reporting/tests/MockReportScheduler.h \
                      --known-failure app/TestEventTriggerDelegate.h \

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -171,6 +171,7 @@ static_library("interaction-model") {
     "PendingResponseTrackerImpl.h",
     "ReadClient.h",  # TODO: cpp is only included conditionally. Needs logic
                      # fixing
+    "ReadPrepareParams.h",
     "RequiredPrivilege.h",
     "StatusResponse.cpp",
     "StatusResponse.h",


### PR DESCRIPTION
Within src/app, only interaction-model files include this header (specifically DeviceProxy.cpp and ReadClient.h). No need for this header to be orphaned.

![image](https://github.com/project-chip/connectedhomeip/assets/1832280/78fa69ae-302b-4903-be3d-710e13d56b94)
