### PR TITLE
Add pigweed support for esp32 platform

### DIFF
--- a/config/esp32/.gn
+++ b/config/esp32/.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/build.gni")
+import("//build_overrides/pigweed.gni")
 
 # The location of the build configuration file.
 buildconfig = "${build_root}/config/BUILDCONFIG.gn"
@@ -23,6 +24,15 @@ check_system_includes = true
 default_args = {
   target_cpu = "esp32"
   target_os = "freertos"
+
+  pw_sys_io_BACKEND = dir_pw_sys_io_stdio
+  pw_assert_BACKEND = dir_pw_assert_log
+  pw_log_BACKEND = dir_pw_log_basic
+
+  pw_build_LINK_DEPS = [
+    "$dir_pw_assert:impl",
+    "$dir_pw_log:impl",
+  ]
 
   pw_build_PIP_CONSTRAINTS =
       [ "//third_party/connectedhomeip/scripts/setup/constraints.txt" ]

--- a/config/esp32/BUILD.gn
+++ b/config/esp32/BUILD.gn
@@ -36,6 +36,9 @@ group("esp32") {
   }
 
   if (chip_build_tests) {
-    deps += [ "${chip_root}/src:tests" ]
+    deps += [
+      "${chip_root}/src:tests",
+      "${chip_root}/src/lib/support:pw_tests_wrapper",
+    ]
   }
 }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -143,7 +143,7 @@ if (chip_build_tests) {
     if (chip_monolithic_tests) {
       # TODO [PW_MIGRATION] Remove this if after migartion to PW_TEST is completed for all platforms
       # TODO [PW_MIGRATION] There will be a list of already migrated platforms
-      if (false) {
+      if (chip_device_platform == "esp32") {
         deps += [ "${chip_root}/src/lib/support:pw_tests_wrapper" ]
       }
       build_monolithic_library = true

--- a/src/test_driver/esp32/main/CMakeLists.txt
+++ b/src/test_driver/esp32/main/CMakeLists.txt
@@ -45,4 +45,4 @@ target_compile_options(${COMPONENT_LIB} PUBLIC
 )
 
 target_link_directories(${COMPONENT_LIB} PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../chip/lib)
-target_link_libraries(${COMPONENT_LIB} PUBLIC -lSupportTesting)
+target_link_libraries(${COMPONENT_LIB} PUBLIC -lSupportTesting -lPWTestsWrapper)

--- a/src/test_driver/esp32/main/main_app.cpp
+++ b/src/test_driver/esp32/main/main_app.cpp
@@ -30,6 +30,7 @@
 
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/support/UnitTest.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <platform/CHIPDeviceLayer.h>
 
@@ -41,7 +42,9 @@ const char TAG[] = "CHIP-tests";
 static void tester_task(void * pvParameters)
 {
     ESP_LOGI(TAG, "Starting CHIP tests!");
+    // TODO [PW_MIGRATION] Remove NLUnit tests call after migration
     int status = RunRegisteredUnitTests();
+    status += chip::test::RunAllTests();
     ESP_LOGI(TAG, "CHIP test status: %d", status);
     exit(status);
 }


### PR DESCRIPTION
Related to #29682

## Changes
Add a call of the wrapper for running all Pigweed tests in test_driver for esp32 and link the necessary library.

## Testing

CI will test it. In related PR, there are changes for all platforms. The CI there passes all checks. 