### PR TITLE
[ESP32] Remove dead code and __func__ from error logging

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -44,15 +44,6 @@ namespace DeviceLayer {
 
 using namespace ::chip::DeviceLayer::Internal;
 
-namespace {
-
-enum
-{
-    kChipProduct_Connect = 0x0016
-};
-
-} // unnamed namespace
-
 // TODO: Define a Singleton instance of CHIP Group Key Store here (#1266)
 
 ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -1462,7 +1462,7 @@ void BLEManagerImpl::HandleC3CharRead(struct ble_gatt_char_context * param)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to generate TLV encoded Additional Data (%s)", __func__);
+        ChipLogError(DeviceLayer, "Failed to generate TLV encoded Additional Data, err:%" CHIP_ERROR_FORMAT, err.Format());
     }
     return;
 }


### PR DESCRIPTION
Removing because:
- `kChipProduct_Connect ` is unused
- `__func__` in error log is flash size overhead.