### PR TITLE
Place `endpoint-config-defines.h` into `app/util:types`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -116,7 +116,6 @@ jobs:
                      --known-failure app/util/DataModelHandler.h \
                      --known-failure app/util/ember-compatibility-functions.cpp \
                      --known-failure app/util/endpoint-config-api.h \
-                     --known-failure app/util/endpoint-config-defines.h \
                      --known-failure app/util/generic-callbacks.h \
                      --known-failure app/util/generic-callback-stubs.cpp \
                      --known-failure app/util/im-client-callbacks.h \

--- a/src/app/util/BUILD.gn
+++ b/src/app/util/BUILD.gn
@@ -22,6 +22,7 @@ source_set("types") {
     "basic-types.h",
     "ember-strings.cpp",
     "ember-strings.h",
+    "endpoint-config-defines.h",
     "types_stub.h",
   ]
 


### PR DESCRIPTION
The util:types source set seems to be the lowest level source set. endpoint-config-defines are defines used by generated code. It looks reasonable for generated code to have access to all ember types, so placing this file to be tracked by gn.