### PR TITLE
Make it possible to dynamically set MRP parameters.

### DIFF
--- a/src/messaging/ReliableMessageProtocolConfig.cpp
+++ b/src/messaging/ReliableMessageProtocolConfig.cpp
@@ -57,18 +57,44 @@ void ClearLocalMRPConfigOverride()
 }
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
+namespace {
+
+// This is not a static member of ReliableMessageProtocolConfig because the free
+// function GetLocalMRPConfig() needs access to it.
+Optional<ReliableMessageProtocolConfig> sDynamicLocalMPRConfig;
+
+} // anonymous namespace
+
+bool ReliableMessageProtocolConfig::SetLocalMRPConfig(const Optional<ReliableMessageProtocolConfig> & localMRPConfig)
+{
+    auto oldConfig         = GetLocalMRPConfig();
+    sDynamicLocalMPRConfig = localMRPConfig;
+    return oldConfig != GetLocalMRPConfig();
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
+
 ReliableMessageProtocolConfig GetDefaultMRPConfig()
 {
     // Default MRP intervals are defined in spec <4.12.8. Parameters and Constants>
     static constexpr const System::Clock::Milliseconds32 idleRetransTimeout   = 500_ms32;
     static constexpr const System::Clock::Milliseconds32 activeRetransTimeout = 300_ms32;
     static constexpr const System::Clock::Milliseconds16 activeThresholdTime  = 4000_ms16;
+    static_assert(activeThresholdTime == kDefaultActiveTime, "Different active defaults?");
     return ReliableMessageProtocolConfig(idleRetransTimeout, activeRetransTimeout, activeThresholdTime);
 }
 
 Optional<ReliableMessageProtocolConfig> GetLocalMRPConfig()
 {
     ReliableMessageProtocolConfig config(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL, CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
+    if (sDynamicLocalMPRConfig.HasValue())
+    {
+        config = sDynamicLocalMPRConfig.Value();
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
+
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     // TODO ICD LIT shall not advertise the SII key
     // Increase local MRP retry intervals by ICD polling intervals. That is, intervals for

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -208,6 +208,25 @@ struct ReliableMessageProtocolConfig
         return mIdleRetransTimeout == that.mIdleRetransTimeout && mActiveRetransTimeout == that.mActiveRetransTimeout &&
             mActiveThresholdTime == that.mActiveThresholdTime;
     }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
+    /**
+     * Set the local MRP configuration for the node.
+     *
+     * Passing a "no value" optional resets to the compiled-in settings
+     * (CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL and
+     * CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL).
+     *
+     * Otherwise the value set via this function is used instead of the
+     * compiled-in settings, but can still be overridden by ICD configuration
+     * and other things that would override the compiled-in settings.
+     *
+     * @return whether the local MRP configuration actually changed as a result
+     *         of this call.  If it did, callers may need to reset DNS-SD
+     *         advertising to advertise the updated values.
+     */
+    static bool SetLocalMRPConfig(const Optional<ReliableMessageProtocolConfig> & localMRPConfig);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
 };
 
 /// @brief The default MRP config. The value is defined by spec, and shall be same for all implementations,

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -221,6 +221,10 @@ struct ReliableMessageProtocolConfig
      * compiled-in settings, but can still be overridden by ICD configuration
      * and other things that would override the compiled-in settings.
      *
+     * Changing the value via this function does not affect any existing
+     * sessions or exchanges, but does affect the values we communicate to our
+     * peer during future session establishments.
+     *
      * @return whether the local MRP configuration actually changed as a result
      *         of this call.  If it did, callers may need to reset DNS-SD
      *         advertising to advertise the updated values.

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -80,6 +80,11 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
 
     # Define the default number of ip addresses to discover
     chip_max_discovered_ip_addresses = 5
+
+    # Allows enabling dynamic setting of the local MRP configuration, for
+    # devices with multiple radios that have different sleep behavior for
+    # different radios.
+    chip_device_config_enable_dynamic_mrp_config = false
   }
 
   if (chip_stack_lock_tracking == "auto") {
@@ -131,6 +136,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       "CHIP_DISABLE_PLATFORM_KVS=${chip_disable_platform_kvs}",
       "CHIP_USE_TRANSITIONAL_COMMISSIONABLE_DATA_PROVIDER=${chip_use_transitional_commissionable_data_provider}",
       "CHIP_USE_TRANSITIONAL_DEVICE_INSTANCE_INFO_PROVIDER=${chip_use_transitional_device_instance_info_provider}",
+      "CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG=${chip_device_config_enable_dynamic_mrp_config}",
     ]
 
     if (chip_device_platform == "linux" || chip_device_platform == "darwin" ||


### PR DESCRIPTION
Right now MRP parameters have to be compile-time constants, except for ICDs. But in some cases the same binary might be used on different types of hardware that have different MRP requirements.  This change makes it possible to set the MRP parameters at run time, based on the actual hardware involved, not just compile time.  The new functionality is gated by a new default-off compiler flag, so only systems that really need it pay the cost for it.
