### PR TITLE
Add pigweed support for nrfconnect

### DIFF
--- a/config/nrfconnect/chip-gn/.gn
+++ b/config/nrfconnect/chip-gn/.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
 
 # The location of the build configuration file.
 buildconfig = "${build_root}/config/BUILDCONFIG.gn"
@@ -24,6 +25,15 @@ check_system_includes = true
 default_args = {
   target_cpu = "arm"
   target_os = "zephyr"
+
+  pw_sys_io_BACKEND = dir_pw_sys_io_stdio
+  pw_assert_BACKEND = dir_pw_assert_log
+  pw_log_BACKEND = dir_pw_log_basic
+
+  pw_build_LINK_DEPS = [
+    "$dir_pw_assert:impl",
+    "$dir_pw_log:impl",
+  ]
 
   import("${chip_root}/config/nrfconnect/chip-gn/args.gni")
 }

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -143,7 +143,8 @@ if (chip_build_tests) {
     if (chip_monolithic_tests) {
       # TODO [PW_MIGRATION] Remove this if after migartion to PW_TEST is completed for all platforms
       # TODO [PW_MIGRATION] There will be a list of already migrated platforms
-      if (chip_device_platform == "esp32" || chip_device_platform == "nrfconnect") {
+      if (chip_device_platform == "esp32" ||
+          chip_device_platform == "nrfconnect") {
         deps += [ "${chip_root}/src/lib/support:pw_tests_wrapper" ]
       }
       build_monolithic_library = true

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -143,7 +143,7 @@ if (chip_build_tests) {
     if (chip_monolithic_tests) {
       # TODO [PW_MIGRATION] Remove this if after migartion to PW_TEST is completed for all platforms
       # TODO [PW_MIGRATION] There will be a list of already migrated platforms
-      if (chip_device_platform == "esp32") {
+      if (chip_device_platform == "esp32" || chip_device_platform == "nrfconnect") {
         deps += [ "${chip_root}/src/lib/support:pw_tests_wrapper" ]
       }
       build_monolithic_library = true

--- a/src/test_driver/nrfconnect/main/runner.cpp
+++ b/src/test_driver/nrfconnect/main/runner.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <lib/support/CodeUtils.h>
+#include <lib/support/UnitTest.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <platform/CHIPDeviceLayer.h>
 
@@ -35,6 +36,7 @@ extern "C" int main(void)
 
     LOG_INF("Starting CHIP tests!");
     int status = RunRegisteredUnitTests();
+    status += chip::test::RunAllTests();
     LOG_INF("CHIP test status: %d", status);
 
     _exit(status);


### PR DESCRIPTION
Related to #29682

## Changes
Add a call of the wrapper for running all Pigweed tests in test_driver for nrfconnect and link the necessary library.

## Testing

CI will test it. In related PR, there are changes for all platforms. The CI there passes all checks. 