### PR TITLE
[Zephyr] Make include of "zephyr/bluetooth/hci.h" explicit in src/platform/Zephyr/BLEManagerImpl.cpp

### DIFF
--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -39,6 +39,7 @@
 
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/hci.h>
 #include <zephyr/random/rand32.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>


### PR DESCRIPTION
The aim of this PR is to add an explicit include of "zephyr/bluetooth/hci.h" inside src/platform/Zephyr/BLEManagerImpl.cpp