### PR TITLE
[app] Do not crash if CommandHandler fails to allocate packet

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -595,7 +595,17 @@ void CommandHandler::AddStatus(const ConcreteCommandPath & aCommandPath, const P
 {
     // Return early in case of requests targeted to a group, since they should not add a response.
     VerifyOrReturn(!IsGroupRequest());
-    VerifyOrDie(FallibleAddStatus(aCommandPath, aStatus, context) == CHIP_NO_ERROR);
+
+    CHIP_ERROR error = FallibleAddStatus(aCommandPath, aStatus, context);
+
+    if (error != CHIP_NO_ERROR)
+    {
+        ChipLogError(DataManagement, "Failed to add command status: %" CHIP_ERROR_FORMAT, error.Format());
+
+        // Do not crash if the status has not been added due to running out of packet buffers or other resources.
+        // It is better to drop a single response than to go offline and lose all sessions and subscriptions.
+        VerifyOrDie(error == CHIP_ERROR_NO_MEMORY);
+    }
 }
 
 CHIP_ERROR CommandHandler::FallibleAddStatus(const ConcreteCommandPath & path, const Protocols::InteractionModel::Status status,


### PR DESCRIPTION
CommandHandler uses VerifyOrDie when adding a status to be sent to the requestor. If the device runs out packet buffers and CommandHandler fails to allocate a packet for the status, the device crashes.

Triggering the crash requires many commands to arrive in the device around the same time, which is rare but possible.

Fixes #31791