### PR TITLE
[ICD] Store ICD Idle/Active parameters

### DIFF
--- a/src/app/icd/client/DefaultICDClientStorage.cpp
+++ b/src/app/icd/client/DefaultICDClientStorage.cpp
@@ -274,6 +274,18 @@ CHIP_ERROR DefaultICDClientStorage::Load(FabricIndex fabricIndex, std::vector<IC
         memcpy(clientInfo.hmac_key_handle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(), hmacBuf.data(),
                sizeof(Crypto::Symmetric128BitsKeyByteArray));
 
+        // Idle Mode Duration
+        ReturnErrorOnFailure(reader.Next(TLV::ContextTag(ClientInfoTag::kIdleModeDuration)));
+        ReturnErrorOnFailure(reader.Get(clientInfo.idle_mode_duration));
+
+        // Active Mode Duration
+        ReturnErrorOnFailure(reader.Next(TLV::ContextTag(ClientInfoTag::kActiveModeDuration)));
+        ReturnErrorOnFailure(reader.Get(clientInfo.active_mode_duration));
+
+        // Active Mode Threshold
+        ReturnErrorOnFailure(reader.Next(TLV::ContextTag(ClientInfoTag::kActiveModeThreshold)));
+        ReturnErrorOnFailure(reader.Get(clientInfo.active_mode_threshold));
+
         ReturnErrorOnFailure(reader.ExitContainer(ICDClientInfoType));
         clientInfoVector.push_back(clientInfo);
     }
@@ -327,6 +339,9 @@ CHIP_ERROR DefaultICDClientStorage::SerializeToTlv(TLV::TLVWriter & writer, cons
         ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kAesKeyHandle), aesBuf));
         ByteSpan hmacBuf(clientInfo.hmac_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());
         ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kHmacKeyHandle), hmacBuf));
+        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kIdleModeDuration), clientInfo.idle_mode_duration));
+        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kActiveModeDuration), clientInfo.active_mode_duration));
+        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kActiveModeThreshold), clientInfo.active_mode_threshold));
         ReturnErrorOnFailure(writer.EndContainer(ICDClientInfoContainerType));
     }
     return writer.EndContainer(arrayType);

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -122,13 +122,16 @@ public:
 protected:
     enum class ClientInfoTag : uint8_t
     {
-        kPeerNodeId       = 1,
-        kFabricIndex      = 2,
-        kStartICDCounter  = 3,
-        kOffset           = 4,
-        kMonitoredSubject = 5,
-        kAesKeyHandle     = 6,
-        kHmacKeyHandle    = 7,
+        kPeerNodeId          = 1,
+        kFabricIndex         = 2,
+        kStartICDCounter     = 3,
+        kOffset              = 4,
+        kMonitoredSubject    = 5,
+        kAesKeyHandle        = 6,
+        kHmacKeyHandle       = 7,
+        kIdleModeDuration    = 8,
+        kActiveModeDuration  = 9,
+        kActiveModeThreshold = 10
     };
 
     enum class CounterTag : uint8_t
@@ -155,8 +158,11 @@ protected:
     static constexpr size_t MaxICDClientInfoSize()
     {
         // All the fields added together
-        return TLV::EstimateStructOverhead(sizeof(NodeId), sizeof(FabricIndex), sizeof(uint32_t), sizeof(uint32_t),
-                                           sizeof(uint64_t), sizeof(Crypto::Symmetric128BitsKeyByteArray));
+        return TLV::EstimateStructOverhead(
+            sizeof(NodeId), sizeof(FabricIndex), sizeof(uint32_t) /*start_icd_counter*/, sizeof(uint32_t) /*offset*/,
+            sizeof(uint64_t) /*monitored_subject*/, sizeof(Crypto::Symmetric128BitsKeyByteArray) /*aes_key_handle*/,
+            sizeof(Crypto::Symmetric128BitsKeyByteArray) /*hmac_key_handle*/, sizeof(uint32_t) /*idle_mode_duration*/,
+            sizeof(uint32_t) /*active_mode_duration*/, sizeof(uint16_t) /*active_mode_threshold*/);
     }
 
     static constexpr size_t MaxICDCounterSize()

--- a/src/app/icd/client/ICDClientInfo.h
+++ b/src/app/icd/client/ICDClientInfo.h
@@ -35,7 +35,9 @@ struct ICDClientInfo
     uint64_t monitored_subject               = static_cast<uint64_t>(0);
     Crypto::Aes128KeyHandle aes_key_handle   = Crypto::Aes128KeyHandle();
     Crypto::Hmac128KeyHandle hmac_key_handle = Crypto::Hmac128KeyHandle();
-
+    uint32_t idle_mode_duration              = 0;
+    uint32_t active_mode_duration            = 0;
+    uint16_t active_mode_threshold           = 0;
     ICDClientInfo() {}
     ICDClientInfo(const ICDClientInfo & other) { *this = other; }
 
@@ -51,6 +53,9 @@ struct ICDClientInfo
         ByteSpan hmac_buf(other.hmac_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());
         memcpy(hmac_key_handle.AsMutable<Crypto::Symmetric128BitsKeyByteArray>(), hmac_buf.data(),
                sizeof(Crypto::Symmetric128BitsKeyByteArray));
+        idle_mode_duration    = other.idle_mode_duration;
+        active_mode_duration  = other.active_mode_duration;
+        active_mode_threshold = other.active_mode_threshold;
         return *this;
     }
 };

--- a/src/app/tests/TestDefaultICDClientStorage.cpp
+++ b/src/app/tests/TestDefaultICDClientStorage.cpp
@@ -217,9 +217,14 @@ void TestProcessCheckInPayload(nlTestSuite * apSuite, void * apContext)
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     // Populate clientInfo
     ICDClientInfo clientInfo;
-    clientInfo.peer_node = ScopedNodeId(nodeId, fabricId);
-
-    err = manager.SetKey(clientInfo, ByteSpan(kKeyBuffer1));
+    clientInfo.peer_node             = ScopedNodeId(nodeId, fabricId);
+    clientInfo.start_icd_counter     = 1;
+    clientInfo.offset                = 2;
+    clientInfo.monitored_subject     = 3;
+    clientInfo.idle_mode_duration    = 4;
+    clientInfo.active_mode_duration  = 5;
+    clientInfo.active_mode_threshold = 6;
+    err                              = manager.SetKey(clientInfo, ByteSpan(kKeyBuffer1));
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     err = manager.StoreEntry(clientInfo);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -237,6 +242,12 @@ void TestProcessCheckInPayload(nlTestSuite * apSuite, void * apContext)
     ByteSpan payload{ buffer->Start(), buffer->DataLength() };
     err = manager.ProcessCheckInPayload(payload, decodeClientInfo, checkInCounter);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, decodeClientInfo.start_icd_counter == 1);
+    NL_TEST_ASSERT(apSuite, decodeClientInfo.offset == 2);
+    NL_TEST_ASSERT(apSuite, decodeClientInfo.monitored_subject == 3);
+    NL_TEST_ASSERT(apSuite, decodeClientInfo.idle_mode_duration == 4);
+    NL_TEST_ASSERT(apSuite, decodeClientInfo.active_mode_duration == 5);
+    NL_TEST_ASSERT(apSuite, decodeClientInfo.active_mode_threshold == 6);
 
     // 2. Use a key not available in the storage for encoding
     err = manager.SetKey(clientInfo, ByteSpan(kKeyBuffer2));


### PR DESCRIPTION
--Store ActiveModeDuration, ActiveModeThreshold, IdleModeDuration in ICDClientStorage, and let user decide how to use them, for example, when user tries to interact with lit icd and have the queue, and UI can prompt user with the estimate waiting time window, if that waiting time is very long, user can decide whether to manually wakeup the device immediately.