### PR TITLE
[Darwin] MTRDevice should support multiple delegates

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -114,7 +114,26 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *
  * The delegate will be called on the provided queue, for attribute reports, event reports, and device state changes.
  */
-- (void)setDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue;
+- (void)setDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use addDelegate:queue:interestedPaths:");
+
+/**
+ * Adds a delegate to receive asynchronous callbacks about the device.
+ *
+ * The delegate will be called on the provided queue, for attribute reports, event reports, and device state changes.
+ */
+- (void)addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue MTR_NEWLY_AVAILABLE;
+
+/**
+ * Adds a delegate to receive asynchronous callbacks about the device, and limit attribute reports to a specific set of paths.
+ *
+ * interestedAttributePaths may contain either MTRClusterPath or MTRAttributePath.
+ */
+- (void)addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedAttributePaths:(NSArray *)interestedAttributePaths MTR_NEWLY_AVAILABLE;
+
+/**
+ * Removes the delegate from
+ */
+- (void)removeDelegate:(id<MTRDeviceDelegate>)delegate MTR_NEWLY_AVAILABLE;
 
 /**
  * Read attribute in a designated attribute path.  If there is no value available
@@ -389,7 +408,7 @@ MTR_EXTERN NSString * const MTRDataVersionKey MTR_AVAILABLE(ios(17.6), macos(14.
  *
  *                The data-value dictionary also contains this key:
  *
- *                MTRDataVersionKey : NSNumber-wrapped uin32_t. Monotonically increaseing data version for the cluster.
+ *                MTRDataVersionKey : NSNumber-wrapped uin32_t.
  */
 - (void)device:(MTRDevice *)device receivedAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport;
 

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -127,11 +127,13 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * Adds a delegate to receive asynchronous callbacks about the device, and limit attribute reports to a specific set of paths.
  *
  * interestedAttributePaths may contain either MTRClusterPath or MTRAttributePath.
+ *
+ * MTRDevice does not hold a strong reference to the delegate object.
  */
-- (void)addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedAttributePaths:(NSArray *)interestedAttributePaths MTR_NEWLY_AVAILABLE;
+- (void)addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedPathsForAttributes:(NSArray *)interestedPathsForAttributes MTR_NEWLY_AVAILABLE;
 
 /**
- * Removes the delegate from
+ * Removes the delegate from receiving callbacks abou the device.
  */
 - (void)removeDelegate:(id<MTRDeviceDelegate>)delegate MTR_NEWLY_AVAILABLE;
 

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -133,7 +133,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 - (void)addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedPathsForAttributes:(NSArray *)interestedPathsForAttributes MTR_NEWLY_AVAILABLE;
 
 /**
- * Removes the delegate from receiving callbacks abou the device.
+ * Removes the delegate from receiving callbacks about the device.
  */
 - (void)removeDelegate:(id<MTRDeviceDelegate>)delegate MTR_NEWLY_AVAILABLE;
 

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -120,17 +120,25 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * Adds a delegate to receive asynchronous callbacks about the device.
  *
  * The delegate will be called on the provided queue, for attribute reports, event reports, and device state changes.
+ *
+ * MTRDevice holds a weak reference to the delegate object.
  */
 - (void)addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue MTR_NEWLY_AVAILABLE;
 
 /**
- * Adds a delegate to receive asynchronous callbacks about the device, and limit attribute reports to a specific set of paths.
+ * Adds a delegate to receive asynchronous callbacks about the device, and limit attribute and/or event reports to a specific set of paths.
  *
- * interestedAttributePaths may contain either MTRClusterPath or MTRAttributePath.
+ * interestedPathsForAttributes may contain either MTRClusterPath or MTRAttributePath to specify interested clusters and attributes, or NSNumber for endpoints.
  *
- * MTRDevice does not hold a strong reference to the delegate object.
+ * interestedPathsForAttributes may contain either MTRClusterPath or MTREventPath to specify interested clusters and events, or NSNumber for endpoints.
+ *
+ * For both interested paths arguments, if nil is specified, then no filter will be applied.
+ *
+ * Calling addDelegate: again with the same delegate object will update the interested paths for attributes and events for this delegate.
+ *
+ * MTRDevice holds a weak reference to the delegate object.
  */
-- (void)addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedPathsForAttributes:(NSArray *)interestedPathsForAttributes MTR_NEWLY_AVAILABLE;
+- (void)addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedPathsForAttributes:(NSArray * _Nullable)interestedPathsForAttributes interestedPathsForEvents:(NSArray * _Nullable)interestedPathsForEvents MTR_NEWLY_AVAILABLE;
 
 /**
  * Removes the delegate from receiving callbacks about the device.

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1052,7 +1052,7 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     return NO;
 }
 
-- (void)_iterateDelegatesWithBlock:(void (^)(MTRDeviceDelegateInfo * delegateInfo))block
+- (void)_iterateDelegatesWithBlock:(void (NS_NOESCAPE ^)(MTRDeviceDelegateInfo * delegateInfo))block
 {
     os_unfair_lock_assert_owner(&self->_lock);
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1834,7 +1834,7 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 }
 
 // Returns filtered set of attributes using an interestedPaths array.
-// Returns nil if no attribute reports has a path that matches the paths in the interestedPaths array.
+// Returns nil if no attribute report has a path that matches the paths in the interestedPaths array.
 - (NSArray<NSDictionary<NSString *, id> *> *)_filteredAttributes:(NSArray<NSDictionary<NSString *, id> *> *)attributes forInterestedPaths:(NSArray * _Nullable)interestedPaths
 {
     if (!interestedPaths.count) {

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -64,6 +64,7 @@ NSString * const MTRDataVersionKey = @"dataVersion";
 #pragma mark - Utility Classes
 
 // container of MTRDevice delegate weak reference, its queue, and its interested paths for attribute reports
+MTR_DIRECT_MEMBERS
 @interface MTRDeviceDelegateInfo : NSObject {
 @private
     void * _delegatePointerValue;

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1056,8 +1056,10 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     for (MTRDeviceDelegateInfo * delegateInfo in _delegates) {
         id<MTRDeviceDelegate> strongDelegate = delegateInfo.delegate;
         if (strongDelegate) {
-            @autoreleasepool {
-                block(delegateInfo);
+            if (block) {
+                @autoreleasepool {
+                    block(delegateInfo);
+                }
             }
             (void) strongDelegate; // ensure it stays alive
         } else {

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -115,11 +115,8 @@ MTR_DIRECT_MEMBERS
 
 - (BOOL)callDelegateWithBlock:(void (^)(id<MTRDeviceDelegate>))block
 {
-    if (self.delegateIsNull) {
-        return NO;
-    }
-
     id<MTRDeviceDelegate> strongDelegate = _delegate;
+    VerifyOrReturnValue(strongDelegate, NO);
     dispatch_async(_queue, ^{
         block(strongDelegate);
     });

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1063,10 +1063,12 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     // Opportunistically remove defunct delegate references on every iteration
     NSMutableSet * delegatesToRemove = [NSMutableSet set];
     for (MTRDeviceDelegateInfo * delegateInfo in _delegates) {
-        if ([delegateInfo delegateIsNull]) {
-            [delegatesToRemove addObject:delegateInfo];
-        } else {
+        id<MTRDeviceDelegate> strongDelegate = delegateInfo.delegate;
+        if (strongDelegate) {
             block(delegateInfo);
+            (void)strongDelegate; // ensure it stays alive
+        } else {
+            [delegatesToRemove addObject:delegateInfo];
         }
     }
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1047,7 +1047,7 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     os_unfair_lock_assert_owner(&self->_lock);
 
     if (!_delegates.count) {
-        MTR_LOG("%@ no delegates to iterate", self);
+        MTR_LOG_DEBUG("%@ no delegates to iterate", self);
         return NO;
     }
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -62,34 +62,90 @@ NSString * const MTRDataVersionKey = @"dataVersion";
 
 // Consider moving utility classes to their own file
 #pragma mark - Utility Classes
-// This class is for storing weak references in a container
-@interface MTRWeakReference<ObjectType> : NSObject
-+ (instancetype)weakReferenceWithObject:(ObjectType)object;
-- (instancetype)initWithObject:(ObjectType)object;
-- (ObjectType)strongObject; // returns strong object or NULL
-@end
 
-@interface MTRWeakReference () {
+// Holder of weak reference of MTRDevice delegate along with its queue
+@interface MTRDeviceDelegateInfo : NSObject {
 @private
-    __weak id _object;
+    void * _delegatePointerValue;
+    __weak id _delegate;
+    __weak dispatch_queue_t _queue;
+    NSArray * _interestedAttributePaths;
 }
+
+// Array of interested cluster paths or attribute paths, for attribute report filtering.
+@property (readonly) NSArray * interestedAttributePaths;
+
+// Pointer value for logging purpose only
+@property (readonly) void * delegatePointerValue;
+
+- (instancetype)initWithDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedAttributePaths:(NSArray * _Nullable)interestedAttributePaths;
+
+// Returns YES if delegate and queue are both non-null, and the block is scheduled to run.
+- (BOOL)callDelegateWithBlock:(void (^)(id<MTRDeviceDelegate>))block;
+
+#ifdef DEBUG
+// Only used for unit test purposes - normal delegate should not expect or handle being called back synchronously.
+- (BOOL)callDelegateSynchronouslyWithBlock:(void (^)(id<MTRDeviceDelegate>))block;
+#endif
+
+// Returns YES if the weak reference no longer points to a live object.
+- (BOOL)delegateIsNull;
+
+// Checks if the otherDelegate argument is the same object that the weak reference points to.
+- (BOOL)containsDelegate:(id<MTRDeviceDelegate>)otherDelegate;
 @end
 
-@implementation MTRWeakReference
-- (instancetype)initWithObject:(id)object
+@implementation MTRDeviceDelegateInfo
+- (instancetype)initWithDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedAttributePaths:(NSArray * _Nullable)interestedAttributePaths
 {
     if (self = [super init]) {
-        _object = object;
+        _delegate = delegate;
+        _delegatePointerValue = (__bridge void *) delegate;
+        _queue = queue;
+        _interestedAttributePaths = [interestedAttributePaths copy];
     }
     return self;
 }
-+ (instancetype)weakReferenceWithObject:(id)object
+
+- (NSString *)description
 {
-    return [[self alloc] initWithObject:object];
+    return [NSString stringWithFormat:@"<MTRDeviceDelegateInfo: %p delegate value %p interested paths count %lu>", self, _delegatePointerValue, static_cast<unsigned long>(_interestedAttributePaths.count)];
 }
-- (id)strongObject
+
+- (BOOL)callDelegateWithBlock:(void (^)(id<MTRDeviceDelegate>))block
 {
-    return _object;
+    if (self.delegateIsNull) {
+        return NO;
+    }
+
+    id<MTRDeviceDelegate> strongDelegate = _delegate;
+    dispatch_async(_queue, ^{
+        block(strongDelegate);
+    });
+    return YES;
+}
+
+#ifdef DEBUG
+- (BOOL)callDelegateSynchronouslyWithBlock:(void (^)(id<MTRDeviceDelegate>))block
+{
+    if (self.delegateIsNull) {
+        return NO;
+    }
+
+    block(_delegate);
+
+    return YES;
+}
+#endif
+
+- (BOOL)delegateIsNull
+{
+    return (!_delegate || !_queue);
+}
+
+- (BOOL)containsDelegate:(id<MTRDeviceDelegate>)otherDelegate
+{
+    return (_delegate == otherDelegate);
 }
 @end
 
@@ -321,8 +377,6 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 // and protects device calls to setUTCTime and setDSTOffset
 @property (nonatomic, readonly) os_unfair_lock timeSyncLock;
 @property (nonatomic) chip::FabricIndex fabricIndex;
-@property (nonatomic) MTRWeakReference<id<MTRDeviceDelegate>> * weakDelegate;
-@property (nonatomic) dispatch_queue_t delegateQueue;
 @property (nonatomic) NSMutableArray<NSDictionary<NSString *, id> *> * unreportedEvents;
 @property (nonatomic) BOOL receivingReport;
 @property (nonatomic) BOOL receivingPrimingReport;
@@ -445,6 +499,10 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 
     // System time change observer reference
     id _systemTimeChangeObserverToken;
+
+    NSMutableSet<MTRDeviceDelegateInfo *> * _delegates;
+    // Keep a separate entry to ensure deprecated API still works
+    MTRDeviceDelegateInfo * _legacyDelegate;
 }
 
 - (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller
@@ -469,7 +527,7 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
         _clusterDataToPersist = nil;
         _persistedClusters = [NSMutableSet set];
 
-        // If there is a data store, make sure we have an observer to
+        // If there is a data store, make sure we have an observer to monitor system clock changes, so NSDate-based write coalescing would
         if (_persistedClusterData) {
             mtr_weakify(self);
             _systemTimeChangeObserverToken = [[NSNotificationCenter defaultCenter] addObserverForName:NSSystemClockDidChangeNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull notification) {
@@ -478,6 +536,8 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
                 [self _resetStorageBehaviorState];
             }];
         }
+
+        _delegates = [NSMutableSet set];
 
         MTR_LOG_DEBUG("%@ init with hex nodeID 0x%016llX", self, _nodeID.unsignedLongLongValue);
     }
@@ -560,12 +620,12 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 
 - (void)_scheduleNextUpdate:(UInt64)nextUpdateInSeconds
 {
-    MTRWeakReference<MTRDevice *> * weakSelf = [MTRWeakReference weakReferenceWithObject:self];
+    mtr_weakify(self);
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (nextUpdateInSeconds * NSEC_PER_SEC)), self.queue, ^{
         MTR_LOG_DEBUG("%@ Timer expired, start Device Time Update", self);
-        MTRDevice * strongSelf = weakSelf.strongObject;
-        if (strongSelf) {
-            [strongSelf _performScheduledTimeUpdate];
+        mtr_strongify(self);
+        if (self) {
+            [self _performScheduledTimeUpdate];
         } else {
             MTR_LOG_DEBUG("%@ MTRDevice no longer valid. No Timer Scheduled will be scheduled for a Device Time Update.", self);
             return;
@@ -738,25 +798,67 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 - (void)setDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue
 {
     MTR_LOG("%@ setDelegate %@", self, delegate);
+    [self _addDelegate:delegate queue:queue interestedAttributePaths:nil isLegacyDelegate:YES];
+}
 
+- (void)addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue
+{
+    MTR_LOG("%@ addDelegate %@", self, delegate);
+    [self _addDelegate:delegate queue:queue interestedAttributePaths:nil isLegacyDelegate:NO];
+}
+
+- (void)addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedAttributePaths:(NSArray *)interestedPaths
+{
+    MTR_LOG("%@ addDelegate %@ with interested paths %@", self, delegate, interestedPaths);
+    [self _addDelegate:delegate queue:queue interestedAttributePaths:interestedPaths isLegacyDelegate:NO];
+}
+
+- (void)_addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedAttributePaths:(NSArray * _Nullable)interestedPaths isLegacyDelegate:(BOOL)isLegacyDelegate
+{
     std::lock_guard lock(_lock);
 
-    BOOL setUpSubscription = [self _subscriptionsAllowed];
+    // Replace delegate info with the same delegate object, and opportunistically remove defunct delegate references
+    NSMutableSet<MTRDeviceDelegateInfo *> * delegatesToRemove = [NSMutableSet set];
+    for (MTRDeviceDelegateInfo * delegateInfo in _delegates) {
+        if ([delegateInfo containsDelegate:delegate]) {
+            [delegatesToRemove addObject:delegateInfo];
+            MTR_LOG("%@ replacing delegate info for %p", self, delegate);
+        }
+        if (delegateInfo.delegateIsNull) {
+            [delegatesToRemove addObject:delegateInfo];
+            MTR_LOG("%@ removing delegate info for nil delegate %p", self, delegateInfo.delegatePointerValue);
+        }
+    }
+    if (delegatesToRemove.count) {
+        NSUInteger oldDelegatesCount = _delegates.count;
+        [_delegates minusSet:delegatesToRemove];
+        MTR_LOG("%@ addDelegate: removed %lu", self, static_cast<unsigned long>(_delegates.count - oldDelegatesCount));
+    }
+
+    MTRDeviceDelegateInfo * newDelegateInfo = [[MTRDeviceDelegateInfo alloc] initWithDelegate:delegate queue:queue interestedAttributePaths:interestedPaths];
+    [_delegates addObject:newDelegateInfo];
+    if (isLegacyDelegate) {
+        _legacyDelegate = newDelegateInfo;
+    }
+    MTR_LOG("%@ added delegate info %@", self, newDelegateInfo);
+
+    __block BOOL shouldSetUpSubscription = [self _subscriptionsAllowed];
 
     // For unit testing only. If this ever changes to not being for unit testing purposes,
     // we would need to move the code outside of where we acquire the lock above.
 #ifdef DEBUG
-    id testDelegate = delegate;
-    if ([testDelegate respondsToSelector:@selector(unitTestShouldSetUpSubscriptionForDevice:)]) {
-        setUpSubscription = [testDelegate unitTestShouldSetUpSubscriptionForDevice:self];
-    }
+    [self _callFirstDelegateSynchronouslyWithBlock:^(id testDelegate) {
+        if ([testDelegate respondsToSelector:@selector(unitTestShouldSetUpSubscriptionForDevice:)]) {
+            shouldSetUpSubscription = [testDelegate unitTestShouldSetUpSubscriptionForDevice:self];
+        }
+    }];
 #endif
 
-    _weakDelegate = [MTRWeakReference weakReferenceWithObject:delegate];
-    _delegateQueue = queue;
-
-    if (setUpSubscription) {
-        _initialSubscribeStart = [NSDate now];
+    if (shouldSetUpSubscription) {
+        // Record the time of first addDelegate call that triggers initial subscribe, and do not reset this value on subsequent addDelegate calls
+        if (!_initialSubscribeStart) {
+            _initialSubscribeStart = [NSDate now];
+        }
         if ([self _deviceUsesThread]) {
             [self _scheduleSubscriptionPoolWork:^{
                 std::lock_guard lock(self->_lock);
@@ -765,6 +867,30 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
         } else {
             [self _setupSubscriptionWithReason:@"delegate is set and subscription is needed"];
         }
+    }
+}
+
+- (void)removeDelegate:(id<MTRDeviceDelegate>)delegate
+{
+    MTR_LOG("%@ removeDelegate %@", self, delegate);
+
+    std::lock_guard lock(_lock);
+
+    NSMutableSet<MTRDeviceDelegateInfo *> * delegatesToRemove = [NSMutableSet set];
+    [self _iterateDelegatesWithBlock:^(MTRDeviceDelegateInfo * delegateInfo) {
+        if ([delegateInfo containsDelegate:delegate]) {
+            [delegatesToRemove addObject:delegateInfo];
+            MTR_LOG("%@ removing delegate info %@ for %p", self, delegateInfo, delegate);
+        }
+    }];
+    if (delegatesToRemove.count) {
+        NSUInteger oldDelegatesCount = _delegates.count;
+        [_delegates minusSet:delegatesToRemove];
+        MTR_LOG("%@ removeDelegate: removed %lu", self, static_cast<unsigned long>(_delegates.count - oldDelegatesCount));
+    }
+
+    if ([_legacyDelegate containsDelegate:delegate]) {
+        _legacyDelegate = nil;
     }
 }
 
@@ -782,7 +908,8 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 
     _state = MTRDeviceStateUnknown;
 
-    _weakDelegate = nil;
+    [_delegates removeAllObjects];
+    _legacyDelegate = nil;
 
     // Make sure we don't try to resubscribe if we have a pending resubscribe
     // attempt, since we now have no delegate.
@@ -862,20 +989,25 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 - (BOOL)_subscriptionAbleToReport
 {
     std::lock_guard lock(_lock);
-    id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (delegate == nil) {
+    if (![self _delegateExists]) {
         // No delegate definitely means no subscription.
         return NO;
     }
 
     // For unit testing only, matching logic in setDelegate
 #ifdef DEBUG
-    id testDelegate = delegate;
-    if ([testDelegate respondsToSelector:@selector(unitTestShouldSetUpSubscriptionForDevice:)]) {
-        if (![testDelegate unitTestShouldSetUpSubscriptionForDevice:self]) {
-            return NO;
+    __block BOOL useTestDelegateOverride = NO;
+    __block BOOL testDelegateShouldSetUpSubscriptionForDevice = NO;
+    [self _callFirstDelegateSynchronouslyWithBlock:^(id testDelegate) {
+        if ([testDelegate respondsToSelector:@selector(unitTestShouldSetUpSubscriptionForDevice:)]) {
+            useTestDelegateOverride = YES;
+            testDelegateShouldSetUpSubscriptionForDevice = [testDelegate unitTestShouldSetUpSubscriptionForDevice:self];
         }
+    }];
+    if (useTestDelegateOverride && !testDelegateShouldSetUpSubscriptionForDevice) {
+        return NO;
     }
+
 #endif
 
     // Subscriptions are not able to report if they are not allowed.
@@ -922,23 +1054,76 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
                                      errorHandler:nil];
 }
 
-- (BOOL)_callDelegateWithBlock:(void (^)(id<MTRDeviceDelegate>))block
+- (BOOL)_delegateExists
 {
     os_unfair_lock_assert_owner(&self->_lock);
-    id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (delegate) {
-        dispatch_async(_delegateQueue, ^{
-            block(delegate);
-        });
-        return YES;
+    for (MTRDeviceDelegateInfo * delegateInfo in _delegates) {
+        if (!delegateInfo.delegateIsNull) {
+            return YES;
+        }
     }
     return NO;
 }
 
+- (void)_iterateDelegatesWithBlock:(void (^)(MTRDeviceDelegateInfo * delegateInfo))block
+{
+    os_unfair_lock_assert_owner(&self->_lock);
+
+    if (!_delegates.count) {
+        MTR_LOG("%@ no delegates to iterate", self);
+    }
+
+    // Opportunistically remove defunct delegate references
+    NSMutableSet * delegatesToRemove = [NSMutableSet set];
+    for (MTRDeviceDelegateInfo * delegateInfo in _delegates) {
+        if ([delegateInfo delegateIsNull]) {
+            [delegatesToRemove addObject:delegateInfo];
+        } else {
+            block(delegateInfo);
+        }
+    }
+
+    if (delegatesToRemove.count) {
+        [_delegates minusSet:delegatesToRemove];
+        MTR_LOG("%@ _iterateDelegatesWithBlock: removed %lu remaining %lu", self, static_cast<unsigned long>(delegatesToRemove.count), (unsigned long) static_cast<unsigned long>(_delegates.count));
+    }
+}
+
+- (BOOL)_callDelegatesWithBlock:(void (^)(id<MTRDeviceDelegate> delegate))block
+{
+    os_unfair_lock_assert_owner(&self->_lock);
+
+    __block NSUInteger delegatesCalled = 0;
+    [self _iterateDelegatesWithBlock:^(MTRDeviceDelegateInfo * delegateInfo) {
+        if ([delegateInfo callDelegateWithBlock:block]) {
+            delegatesCalled++;
+        }
+    }];
+
+    return (delegatesCalled > 0);
+}
+
+#ifdef DEBUG
+// Only used for unit test purposes - normal delegate should not expect or handle being called back synchronously
+// Returns YES if a delegate is called
+- (void)_callFirstDelegateSynchronouslyWithBlock:(void (^)(id<MTRDeviceDelegate> delegate))block
+{
+    os_unfair_lock_assert_owner(&self->_lock);
+
+    for (MTRDeviceDelegateInfo * delegateInfo in _delegates) {
+        if (![delegateInfo delegateIsNull]) {
+            MTR_LOG("%@ _callFirstDelegateSynchronouslyWithBlock: calling %@", self, delegateInfo);
+            [delegateInfo callDelegateSynchronouslyWithBlock:block];
+            return;
+        }
+    }
+}
+#endif
+
 - (void)_callDelegateDeviceCachePrimed
 {
     os_unfair_lock_assert_owner(&self->_lock);
-    [self _callDelegateWithBlock:^(id<MTRDeviceDelegate> delegate) {
+    [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
         if ([delegate respondsToSelector:@selector(deviceCachePrimed:)]) {
             [delegate deviceCachePrimed:self];
         }
@@ -961,12 +1146,9 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
             MTR_LOG(
                 "%@ reachability state change %lu => %lu", self, static_cast<unsigned long>(lastState), static_cast<unsigned long>(state));
         }
-        id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-        if (delegate) {
-            dispatch_async(_delegateQueue, ^{
-                [delegate device:self stateChanged:state];
-            });
-        }
+        [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
+            [delegate device:self stateChanged:state];
+        }];
     } else {
         MTR_LOG(
             "%@ Not reporting reachability state change, since no change in state %lu => %lu", self, static_cast<unsigned long>(lastState), static_cast<unsigned long>(state));
@@ -983,12 +1165,11 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 
         /* BEGIN DRAGONS: This is a huge hack for a specific use case, do not rename, remove or modify behavior here */
         // TODO: This should only be called for thread devices
-        id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-        if ([delegate respondsToSelector:@selector(_deviceInternalStateChanged:)]) {
-            dispatch_async(_delegateQueue, ^{
-                [(id) delegate _deviceInternalStateChanged:self];
-            });
-        }
+        [self _callDelegatesWithBlock:^(id delegate) {
+            if ([delegate respondsToSelector:@selector(_deviceInternalStateChanged:)]) {
+                [delegate _deviceInternalStateChanged:self];
+            }
+        }];
         /* END DRAGONS */
     }
 }
@@ -1070,14 +1251,15 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     os_unfair_lock_assert_owner(&self->_lock);
 
 #ifdef DEBUG
-    id testDelegate = _weakDelegate.strongObject;
-    if (testDelegate) {
-        // Note: This is a hack to allow our unit tests to test the subscription pooling behavior we have implemented for thread, so we mock devices to be a thread device
+    // Note: This is a hack to allow our unit tests to test the subscription pooling behavior we have implemented for thread, so we mock devices to be a thread device
+    __block BOOL pretendThreadEnabled = NO;
+    [self _callFirstDelegateSynchronouslyWithBlock:^(id testDelegate) {
         if ([testDelegate respondsToSelector:@selector(unitTestPretendThreadEnabled:)]) {
-            if ([testDelegate unitTestPretendThreadEnabled:self]) {
-                return YES;
-            }
+            pretendThreadEnabled = [testDelegate unitTestPretendThreadEnabled:self];
         }
+    }];
+    if (pretendThreadEnabled) {
+        return YES;
     }
 #endif
 
@@ -1103,14 +1285,11 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     MTRAsyncWorkCompletionBlock completion = self->_subscriptionPoolWorkCompletionBlock;
     if (completion) {
 #ifdef DEBUG
-        id delegate = self->_weakDelegate.strongObject;
-        if (delegate) {
-            dispatch_async(self->_delegateQueue, ^{
-                if ([delegate respondsToSelector:@selector(unitTestSubscriptionPoolWorkComplete:)]) {
-                    [delegate unitTestSubscriptionPoolWorkComplete:self];
-                }
-            });
-        }
+        [self _callDelegatesWithBlock:^(id testDelegate) {
+            if ([testDelegate respondsToSelector:@selector(unitTestSubscriptionPoolWorkComplete:)]) {
+                [testDelegate unitTestSubscriptionPoolWorkComplete:self];
+            }
+        }];
 #endif
         self->_subscriptionPoolWorkCompletionBlock = nil;
         completion(MTRAsyncWorkComplete);
@@ -1134,14 +1313,11 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
         [workItem setReadyHandler:^(id _Nonnull context, NSInteger retryCount, MTRAsyncWorkCompletionBlock _Nonnull completion) {
             os_unfair_lock_lock(&self->_lock);
 #ifdef DEBUG
-            id delegate = self->_weakDelegate.strongObject;
-            if (delegate) {
-                dispatch_async(self->_delegateQueue, ^{
-                    if ([delegate respondsToSelector:@selector(unitTestSubscriptionPoolDequeue:)]) {
-                        [delegate unitTestSubscriptionPoolDequeue:self];
-                    }
-                });
-            }
+            [self _callDelegatesWithBlock:^(id testDelegate) {
+                if ([testDelegate respondsToSelector:@selector(unitTestSubscriptionPoolDequeue:)]) {
+                    [testDelegate unitTestSubscriptionPoolDequeue:self];
+                }
+            }];
 #endif
             if (self->_subscriptionPoolWorkCompletionBlock) {
                 // This means a resubscription triggering event happened and is now in-progress
@@ -1224,8 +1400,7 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     _lastSubscriptionFailureTime = [NSDate now];
 
     // if there is no delegate then also do not retry
-    id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (!delegate) {
+    if (![self _delegateExists]) {
         // NOTE: Do not log anything here: we have been invalidated, and the
         // Matter stack might already be torn down.
         return;
@@ -1233,7 +1408,6 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 
     // don't schedule multiple retries
     if (self.reattemptingSubscription) {
-        MTR_LOG("%@ already reattempting subscription", self);
         return;
     }
 
@@ -1268,9 +1442,8 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     // Call _reattemptSubscriptionNowIfNeededWithReason when timer fires - if subscription is
     // in a better state at that time this will be a no-op.
     auto resubscriptionBlock = ^{
-        os_unfair_lock_lock(&self->_lock);
+        std::lock_guard lock(self->_lock);
         [self _reattemptSubscriptionNowIfNeededWithReason:@"got subscription reset"];
-        os_unfair_lock_unlock(&self->_lock);
     };
 
     int64_t resubscriptionDelayNs = static_cast<int64_t>(secondsToWait * NSEC_PER_SEC);
@@ -1301,14 +1474,11 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 
     [self _changeState:MTRDeviceStateReachable];
 
-    id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (delegate) {
-        dispatch_async(_delegateQueue, ^{
-            if ([delegate respondsToSelector:@selector(deviceBecameActive:)]) {
-                [delegate deviceBecameActive:self];
-            }
-        });
-    }
+    [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
+        if ([delegate respondsToSelector:@selector(deviceBecameActive:)]) {
+            [delegate deviceBecameActive:self];
+        }
+    }];
 
     // in case this is called during exponential back off of subscription
     // reestablishment, this starts the attempt right away
@@ -1375,6 +1545,12 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 {
     os_unfair_lock_assert_owner(&self->_lock);
 
+    // Sanity check
+    if (![self _dataStoreExists]) {
+        MTR_LOG_ERROR("%@ storage behavior: no data store in _persistClusterData!", self);
+        return;
+    }
+
     // Nothing to persist
     if (!_clusterDataToPersist.count) {
         return;
@@ -1403,14 +1579,11 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     _clusterDataToPersist = nil;
 
 #ifdef DEBUG
-    id delegate = _weakDelegate.strongObject;
-    if (delegate) {
-        dispatch_async(_delegateQueue, ^{
-            if ([delegate respondsToSelector:@selector(unitTestClusterDataPersisted:)]) {
-                [delegate unitTestClusterDataPersisted:self];
-            }
-        });
-    }
+    [self _callDelegatesWithBlock:^(id testDelegate) {
+        if ([testDelegate respondsToSelector:@selector(unitTestClusterDataPersisted:)]) {
+            [testDelegate unitTestClusterDataPersisted:self];
+        }
+    }];
 #endif
 }
 
@@ -1595,7 +1768,8 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     _deviceReportingExcessivelyStartTime = nil;
     _reportToPersistenceDelayCurrentMultiplier = 1;
 
-    if (_persistedClusters) {
+    // Sanity check that there is a data
+    if ([self _dataStoreExists]) {
         [self _persistClusterData];
     }
 }
@@ -1622,13 +1796,11 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     // After the handling of the report, if we detected a device configuration change, notify the delegate
     // of the same.
     if (_deviceConfigurationChanged) {
-        id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-        if (delegate) {
-            dispatch_async(_delegateQueue, ^{
-                if ([delegate respondsToSelector:@selector(deviceConfigurationChanged:)])
-                    [delegate deviceConfigurationChanged:self];
-            });
-        }
+        [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
+            if ([delegate respondsToSelector:@selector(deviceConfigurationChanged:)]) {
+                [delegate deviceConfigurationChanged:self];
+            }
+        }];
         _deviceConfigurationChanged = NO;
     }
 
@@ -1647,15 +1819,57 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 
 // For unit testing only
 #ifdef DEBUG
-    id delegate = _weakDelegate.strongObject;
-    if (delegate) {
-        dispatch_async(_delegateQueue, ^{
-            if ([delegate respondsToSelector:@selector(unitTestReportEndForDevice:)]) {
-                [delegate unitTestReportEndForDevice:self];
-            }
-        });
-    }
+    [self _callDelegatesWithBlock:^(id testDelegate) {
+        if ([testDelegate respondsToSelector:@selector(unitTestReportEndForDevice:)]) {
+            [testDelegate unitTestReportEndForDevice:self];
+        }
+    }];
 #endif
+}
+
+- (BOOL)_interestedPaths:(NSArray * _Nullable)interestedPaths includesPath:(MTRAttributePath *)attributePath
+{
+    for (id interestedPath in interestedPaths) {
+        if ([interestedPath isKindOfClass:[MTRClusterPath class]]) {
+            MTRClusterPath * interestedClusterPath = interestedPath;
+            if (interestedClusterPath.cluster.unsignedLongValue == attributePath.cluster.unsignedLongValue) {
+                return YES;
+            }
+        } else if ([interestedPath isKindOfClass:[MTRAttributePath class]]) {
+            MTRAttributePath * interestedAttributePath = interestedPath;
+            if ((interestedAttributePath.cluster.unsignedLongValue == attributePath.cluster.unsignedLongValue) && (interestedAttributePath.attribute.unsignedLongValue == attributePath.attribute.unsignedLongValue)) {
+                return YES;
+            }
+        }
+    }
+
+    return NO;
+}
+
+// Returns filtered set of attributes using an interestedPaths array.
+// Returns nil if no attribute reports has a path that matches the paths in the interestedPaths array.
+- (NSArray<NSDictionary<NSString *, id> *> *)_filteredAttributes:(NSArray<NSDictionary<NSString *, id> *> *)attributes forInterestedPaths:(NSArray * _Nullable)interestedPaths
+{
+    if (!interestedPaths.count) {
+        return attributes;
+    }
+
+    NSMutableArray * filteredAttributes = nil;
+    for (NSDictionary<NSString *, id> * responseValue in attributes) {
+        MTRAttributePath * attributePath = responseValue[MTRAttributePathKey];
+        if ([self _interestedPaths:interestedPaths includesPath:attributePath]) {
+            if (!filteredAttributes) {
+                filteredAttributes = [NSMutableArray array];
+            }
+            [filteredAttributes addObject:responseValue];
+        }
+    }
+
+    if (filteredAttributes.count && (filteredAttributes.count != attributes.count)) {
+        MTR_LOG("%@ filtered attribute report %lu => %lu", self, static_cast<unsigned long>(attributes.count), static_cast<unsigned long>(filteredAttributes.count));
+    }
+
+    return filteredAttributes;
 }
 
 // assume lock is held
@@ -1663,12 +1877,17 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 {
     os_unfair_lock_assert_owner(&self->_lock);
     if (attributes.count) {
-        id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-        if (delegate) {
-            dispatch_async(_delegateQueue, ^{
-                [delegate device:self receivedAttributeReport:attributes];
-            });
-        }
+        [self _iterateDelegatesWithBlock:^(MTRDeviceDelegateInfo * delegateInfo) {
+            // make an autorelease pool so that temporary filtered attributes reports don't bloat memory
+            @autoreleasepool {
+                NSArray<NSDictionary<NSString *, id> *> * filteredAttributes = [self _filteredAttributes:attributes forInterestedPaths:delegateInfo.interestedAttributePaths];
+                if (filteredAttributes.count) {
+                    [delegateInfo callDelegateWithBlock:^(id<MTRDeviceDelegate> delegate) {
+                        [delegate device:self receivedAttributeReport:filteredAttributes];
+                    }];
+                }
+            }
+        }];
     }
 }
 
@@ -1784,12 +2003,11 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
         MTR_LOG("%@ updated estimated start time to %@", self, _estimatedStartTime);
     }
 
-    id<MTRDeviceDelegate> delegate = _weakDelegate.strongObject;
-    if (delegate) {
+    BOOL delegatesCalled = [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
+        [delegate device:self receivedEventReport:reportToReturn];
+    }];
+    if (delegatesCalled) {
         _unreportedEvents = nil;
-        dispatch_async(_delegateQueue, ^{
-            [delegate device:self receivedEventReport:reportToReturn];
-        });
     } else {
         // save unreported events
         _unreportedEvents = reportToReturn;
@@ -2017,13 +2235,15 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     }
 
 #ifdef DEBUG
-    id delegate = _weakDelegate.strongObject;
+    __block NSNumber * delegateMin = nil;
     Optional<System::Clock::Seconds32> maxIntervalOverride;
-    if (delegate) {
-        if ([delegate respondsToSelector:@selector(unitTestMaxIntervalOverrideForSubscription:)]) {
-            NSNumber * delegateMin = [delegate unitTestMaxIntervalOverrideForSubscription:self];
-            maxIntervalOverride.Emplace(delegateMin.unsignedIntValue);
+    [self _callFirstDelegateSynchronouslyWithBlock:^(id testDelegate) {
+        if ([testDelegate respondsToSelector:@selector(unitTestMaxIntervalOverrideForSubscription:)]) {
+            delegateMin = [testDelegate unitTestMaxIntervalOverrideForSubscription:self];
         }
+    }];
+    if (delegateMin) {
+        maxIntervalOverride.Emplace(delegateMin.unsignedIntValue);
     }
 #endif
 
@@ -2036,21 +2256,23 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 
     MTR_LOG("%@ setting up subscription with reason: %@", self, reason);
 
-    bool markUnreachableAfterWait = true;
+    __block bool markUnreachableAfterWait = true;
 #ifdef DEBUG
-    if (delegate && [delegate respondsToSelector:@selector(unitTestSuppressTimeBasedReachabilityChanges:)]) {
-        markUnreachableAfterWait = ![delegate unitTestSuppressTimeBasedReachabilityChanges:self];
-    }
+    [self _callFirstDelegateSynchronouslyWithBlock:^(id testDelegate) {
+        if ([testDelegate respondsToSelector:@selector(unitTestSuppressTimeBasedReachabilityChanges:)]) {
+            markUnreachableAfterWait = ![testDelegate unitTestSuppressTimeBasedReachabilityChanges:self];
+        }
+    }];
 #endif
 
     if (markUnreachableAfterWait) {
         // Set up a timer to mark as not reachable if it takes too long to set up a subscription
-        MTRWeakReference<MTRDevice *> * weakSelf = [MTRWeakReference weakReferenceWithObject:self];
+        mtr_weakify(self);
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, static_cast<int64_t>(kSecondsToWaitBeforeMarkingUnreachableAfterSettingUpSubscription) * static_cast<int64_t>(NSEC_PER_SEC)), self.queue, ^{
-            MTRDevice * strongSelf = weakSelf.strongObject;
-            if (strongSelf != nil) {
-                std::lock_guard lock(strongSelf->_lock);
-                [strongSelf _markDeviceAsUnreachableIfNeverSubscribed];
+            mtr_strongify(self);
+            if (self != nil) {
+                std::lock_guard lock(self->_lock);
+                [self _markDeviceAsUnreachableIfNeverSubscribed];
             }
         });
     }
@@ -2254,6 +2476,20 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     NSUInteger attributesReportedSinceLastCheck = _unitTestAttributesReportedSinceLastCheck;
     _unitTestAttributesReportedSinceLastCheck = 0;
     return attributesReportedSinceLastCheck;
+}
+
+- (NSUInteger)unitTestNonnullDelegateCount
+{
+    std::lock_guard lock(self->_lock);
+
+    NSUInteger nonnullDelegateCount = 0;
+    for (MTRDeviceDelegateInfo * delegateInfo in _delegates) {
+        if (!delegateInfo.delegateIsNull) {
+            nonnullDelegateCount++;
+        }
+    }
+
+    return nonnullDelegateCount;
 }
 #endif
 
@@ -2549,14 +2785,15 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
                                                                          attributeID:attributeID];
 
-    BOOL useValueAsExpectedValue = YES;
+    __block BOOL useValueAsExpectedValue = YES;
 #ifdef DEBUG
     os_unfair_lock_lock(&self->_lock);
-    id delegate = _weakDelegate.strongObject;
+    [self _callFirstDelegateSynchronouslyWithBlock:^(id delegate) {
+        if ([delegate respondsToSelector:@selector(unitTestShouldSkipExpectedValuesForWrite:)]) {
+            useValueAsExpectedValue = ![delegate unitTestShouldSkipExpectedValuesForWrite:self];
+        }
+    }];
     os_unfair_lock_unlock(&self->_lock);
-    if ([delegate respondsToSelector:@selector(unitTestShouldSkipExpectedValuesForWrite:)]) {
-        useValueAsExpectedValue = ![delegate unitTestShouldSkipExpectedValuesForWrite:self];
-    }
 #endif
 
     uint64_t expectedValueID = 0;
@@ -2949,10 +3186,10 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
         if (waitTime < MTR_DEVICE_EXPIRATION_CHECK_TIMER_MINIMUM_WAIT_TIME) {
             waitTime = MTR_DEVICE_EXPIRATION_CHECK_TIMER_MINIMUM_WAIT_TIME;
         }
-        MTRWeakReference<MTRDevice *> * weakSelf = [MTRWeakReference weakReferenceWithObject:self];
+        mtr_weakify(self);
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (waitTime * NSEC_PER_SEC)), self.queue, ^{
-            MTRDevice * strongSelf = weakSelf.strongObject;
-            [strongSelf _performScheduledExpirationCheck];
+            mtr_strongify(self);
+            [self _performScheduledExpirationCheck];
         });
     }
 }
@@ -3232,7 +3469,11 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             }
 
             previousValue = [self _cachedAttributeValueForPath:attributePath];
+#ifdef DEBUG
+            __block BOOL readCacheValueChanged = ![self _attributeDataValue:attributeDataValue isEqualToDataValue:previousValue];
+#else
             BOOL readCacheValueChanged = ![self _attributeDataValue:attributeDataValue isEqualToDataValue:previousValue];
+#endif
             // Now that we have grabbed previousValue, update our cache with the attribute value.
             if (readCacheValueChanged) {
                 if (dataVersion) {
@@ -3254,12 +3495,11 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 #ifdef DEBUG
             // Unit test only code.
             if (!readCacheValueChanged) {
-                id delegate = _weakDelegate.strongObject;
-                if (delegate) {
+                [self _callFirstDelegateSynchronouslyWithBlock:^(id delegate) {
                     if ([delegate respondsToSelector:@selector(unitTestForceAttributeReportsIfMatchingCache:)]) {
                         readCacheValueChanged = [delegate unitTestForceAttributeReportsIfMatchingCache:self];
                     }
-                }
+                }];
             }
 #endif // DEBUG
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -126,11 +126,10 @@ MTR_DIRECT_MEMBERS
 #ifdef DEBUG
 - (BOOL)callDelegateSynchronouslyWithBlock:(void (^)(id<MTRDeviceDelegate>))block
 {
-    if (self.delegateIsNull) {
-        return NO;
-    }
-
-    block(_delegate);
+    id<MTRDeviceDelegate> strongDelegate = _delegate;
+    VerifyOrReturnValue(strongDelegate, NO);
+    
+    block(strongDelegate);
 
     return YES;
 }

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -69,7 +69,7 @@ MTR_DIRECT_MEMBERS
 @private
     void * _delegatePointerValue;
     __weak id _delegate;
-    __weak dispatch_queue_t _queue;
+    dispatch_queue_t _queue;
     NSArray * _interestedPathsForAttributes;
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceStorageBehaviorConfiguration.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceStorageBehaviorConfiguration.h
@@ -20,7 +20,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Class that configures how MTRDevice objects persist its attributes to storage, so as to not
+ * Class that configures how MTRDevice objects persist their attributes to storage, so as to not
  * overwhelm the underlying storage system.
  */
 MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
@@ -79,7 +79,7 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
  * be used to replace all of them:
  *
  * reportToPersistenceDelayTimeDefault (15)
- * reportToPersistenceDelayTimeMaxDefault (20 * kReportToPersistenceDelayTimeDefault)
+ * reportToPersistenceDelayTimeMaxDefault (20 * 15)
  * recentReportTimesMaxCountDefault (12)
  * timeBetweenReportsTooShortThresholdDefault (15)
  * timeBetweenReportsTooShortMinThresholdDefault (5)

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -4185,7 +4185,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTestExpectation * gotReportEnd4again = [self expectationWithDescription:@"Report end for delegate 4 again"];
     delegate4.onReportEnd = ^{
         [gotReportEnd4again fulfill];
-        __strong __auto_type strongDelegate = weakDelegate3;
+        __strong __auto_type strongDelegate = weakDelegate4;
         strongDelegate.onReportEnd = nil;
     };
 

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -3929,6 +3929,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     [device addDelegate:delegate1 queue:queue];
 
+    // Use autoreleasepool to dealloc a second delegate upon exiting the scope
     @autoreleasepool {
         // Test that a second delegate can also receive attribute reports
         XCTestExpectation * gotAReport2 = [self expectationWithDescription:@"Report end  for delegate 2"];
@@ -3951,7 +3952,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     [self waitForExpectations:@[ gotReportEnd1 ] timeout:60];
 
-    // Verify that once the entire report comes in from all-clusters, that delegate2 has been dealloced, and MTRDevice no longer sees it
+    // Verify that once the entire report comes in from all-clusters, that delegate2 had been dealloced, and MTRDevice no longer sees it
     XCTAssertEqual([device unitTestNonnullDelegateCount], 1);
 }
 
@@ -4008,7 +4009,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         [MTRAttributePath attributePathWithEndpointID:@(2) clusterID:@(21) attributeID:@(212)],
         [MTRClusterPath clusterPathWithEndpointID:@(2) clusterID:@(21)],
     ];
-    [device addDelegate:delegate1 queue:queue interestedAttributePaths:interestedPaths1];
+    [device addDelegate:delegate1 queue:queue interestedPathsForAttributes:interestedPaths1];
 
     // Test that a second delegate can also receive attribute reports
     XCTestExpectation * gotReportEnd2 = [self expectationWithDescription:@"Report end for delegate 2"];
@@ -4031,7 +4032,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         [MTRClusterPath clusterPathWithEndpointID:@(3) clusterID:@(32)],
         [MTRClusterPath clusterPathWithEndpointID:@(3) clusterID:@(33)],
     ];
-    [device addDelegate:delegate2 queue:queue interestedAttributePaths:interestedPaths2];
+    [device addDelegate:delegate2 queue:queue interestedPathsForAttributes:interestedPaths2];
 
     // Test that a second delegate can also receive attribute reports
     XCTestExpectation * gotReportEnd3 = [self expectationWithDescription:@"Report end for delegate 3"];

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -3905,6 +3905,213 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     delegate.onClusterDataPersisted = nil;
 }
 
+- (void)test037_MTRDeviceMultipleDelegatesGetReports
+{
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    // First start with clean slate by removing the MTRDevice and clearing the persisted cache
+    __auto_type * device = [MTRDevice deviceWithNodeID:@(kDeviceId) controller:sController];
+    [sController removeDevice:device];
+    [sController.controllerDataStore clearAllStoredClusterData];
+    NSDictionary * storedClusterDataAfterClear = [sController.controllerDataStore getStoredClusterDataForNodeID:@(kDeviceId)];
+    XCTAssertEqual(storedClusterDataAfterClear.count, 0);
+
+    // Now recreate device and get subscription primed
+    device = [MTRDevice deviceWithNodeID:@(kDeviceId) controller:sController];
+    XCTestExpectation * gotReportEnd1 = [self expectationWithDescription:@"Report end  for delegate 1"];
+    __auto_type * delegate1 = [[MTRDeviceTestDelegate alloc] init];
+    __weak __auto_type weakDelegate1 = delegate1;
+    delegate1.onReportEnd = ^{
+        [gotReportEnd1 fulfill];
+        __strong __auto_type strongDelegate = weakDelegate1;
+        strongDelegate.onReportEnd = nil;
+    };
+
+    [device addDelegate:delegate1 queue:queue];
+
+    @autoreleasepool {
+        // Test that a second delegate can also receive attribute reports
+        XCTestExpectation * gotAReport2 = [self expectationWithDescription:@"Report end  for delegate 2"];
+        __auto_type * delegate2 = [[MTRDeviceTestDelegate alloc] init];
+        __weak __auto_type weakDelegate2 = delegate2;
+        delegate2.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * data) {
+            [gotAReport2 fulfill];
+            __strong __auto_type strongDelegate = weakDelegate2;
+            strongDelegate.onAttributeDataReceived = nil;
+        };
+
+        [device addDelegate:delegate2 queue:queue];
+
+        // Wait just long enough for 1 report
+        [self waitForExpectations:@[ gotAReport2 ] timeout:60];
+
+        // Verify that at this point MTRDevice is still seeing 2 delegates
+        XCTAssertEqual([device unitTestNonnullDelegateCount], 2);
+    }
+
+    [self waitForExpectations:@[ gotReportEnd1 ] timeout:60];
+
+    // Verify that once the entire report comes in from all-clusters, that delegate2 has been dealloced, and MTRDevice no longer sees it
+    XCTAssertEqual([device unitTestNonnullDelegateCount], 1);
+}
+
+- (NSDictionary<NSString *, id> *)_testAttributeResponseValueWithEndpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID attributeID:(NSNumber *)attributeID value:(unsigned int)testValue
+{
+    return @{
+        MTRAttributePathKey : [MTRAttributePath attributePathWithEndpointID:endpointID clusterID:clusterID attributeID:attributeID],
+        MTRDataKey : @ {
+            MTRDataVersionKey : @(testValue),
+            MTRTypeKey : MTRUnsignedIntegerValueType,
+            MTRValueKey : @(testValue),
+        }
+    };
+}
+
+- (void)test038_MTRDeviceMultipleDelegatesInterestedPaths
+{
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    // First start with clean slate by removing the MTRDevice and clearing the persisted cache
+    __auto_type * device = [MTRDevice deviceWithNodeID:@(kDeviceId) controller:sController];
+    [sController removeDevice:device];
+    [sController.controllerDataStore clearAllStoredClusterData];
+    NSDictionary * storedClusterDataAfterClear = [sController.controllerDataStore getStoredClusterDataForNodeID:@(kDeviceId)];
+    XCTAssertEqual(storedClusterDataAfterClear.count, 0);
+
+    // Now recreate device and get subscription primed
+    device = [MTRDevice deviceWithNodeID:@(kDeviceId) controller:sController];
+    XCTestExpectation * gotReportEnd1 = [self expectationWithDescription:@"Report end for delegate 1"];
+
+    __auto_type * delegate1 = [[MTRDeviceTestDelegateWithSubscriptionSetupOverride alloc] init];
+    delegate1.skipSetupSubscription = YES;
+    __weak __auto_type weakDelegate1 = delegate1;
+    __block NSUInteger attributesReceived1 = 0;
+    delegate1.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * data) {
+        attributesReceived1 += data.count;
+    };
+    delegate1.onReportEnd = ^{
+        [gotReportEnd1 fulfill];
+        __strong __auto_type strongDelegate = weakDelegate1;
+        strongDelegate.onReportEnd = nil;
+    };
+
+    // All 9 attributes from endpoint 1, plus 3 from endpoint 2
+    NSArray * interestedPaths1 = @[
+        [MTRAttributePath attributePathWithEndpointID:@(1) clusterID:@(11) attributeID:@(111)],
+        [MTRAttributePath attributePathWithEndpointID:@(1) clusterID:@(11) attributeID:@(112)],
+        [MTRAttributePath attributePathWithEndpointID:@(1) clusterID:@(11) attributeID:@(113)],
+        [MTRAttributePath attributePathWithEndpointID:@(1) clusterID:@(12) attributeID:@(121)],
+        [MTRAttributePath attributePathWithEndpointID:@(1) clusterID:@(12) attributeID:@(122)],
+        [MTRAttributePath attributePathWithEndpointID:@(1) clusterID:@(12) attributeID:@(123)],
+        [MTRClusterPath clusterPathWithEndpointID:@(1) clusterID:@(13)],
+        [MTRAttributePath attributePathWithEndpointID:@(2) clusterID:@(21) attributeID:@(211)],
+        [MTRAttributePath attributePathWithEndpointID:@(2) clusterID:@(21) attributeID:@(212)],
+        [MTRClusterPath clusterPathWithEndpointID:@(2) clusterID:@(21)],
+    ];
+    [device addDelegate:delegate1 queue:queue interestedAttributePaths:interestedPaths1];
+
+    // Test that a second delegate can also receive attribute reports
+    XCTestExpectation * gotReportEnd2 = [self expectationWithDescription:@"Report end for delegate 2"];
+    __auto_type * delegate2 = [[MTRDeviceTestDelegateWithSubscriptionSetupOverride alloc] init];
+    delegate2.skipSetupSubscription = YES;
+    __weak __auto_type weakDelegate2 = delegate2;
+    __block NSUInteger attributesReceived2 = 0;
+    delegate2.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * data) {
+        attributesReceived2 += data.count;
+    };
+    delegate2.onReportEnd = ^{
+        [gotReportEnd2 fulfill];
+        __strong __auto_type strongDelegate = weakDelegate2;
+        strongDelegate.onReportEnd = nil;
+    };
+
+    // All 9 attributes from endpoint 3
+    NSArray * interestedPaths2 = @[
+        [MTRClusterPath clusterPathWithEndpointID:@(3) clusterID:@(31)],
+        [MTRClusterPath clusterPathWithEndpointID:@(3) clusterID:@(32)],
+        [MTRClusterPath clusterPathWithEndpointID:@(3) clusterID:@(33)],
+    ];
+    [device addDelegate:delegate2 queue:queue interestedAttributePaths:interestedPaths2];
+
+    // Test that a second delegate can also receive attribute reports
+    XCTestExpectation * gotReportEnd3 = [self expectationWithDescription:@"Report end for delegate 3"];
+    __auto_type * delegate3 = [[MTRDeviceTestDelegateWithSubscriptionSetupOverride alloc] init];
+    delegate3.skipSetupSubscription = YES;
+    __weak __auto_type weakDelegate3 = delegate3;
+    __block NSUInteger attributesReceived3 = 0;
+    delegate3.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * data) {
+        attributesReceived3 += data.count;
+    };
+    delegate3.onReportEnd = ^{
+        [gotReportEnd3 fulfill];
+        __strong __auto_type strongDelegate = weakDelegate3;
+        strongDelegate.onReportEnd = nil;
+    };
+
+    // Test a third delegate that receives everything will get all the reports
+    [device addDelegate:delegate3 queue:queue];
+
+    // Now inject attributes and check that each delegate gets the right set of attributes
+    NSMutableArray * attributeReport = [NSMutableArray array];
+    // Construct 27 attributes with endpoints 1~3, clusters 11 ~ 33, and attributes 111~333
+    for (int i = 1; i <= 3; i++) {
+        for (int j = 1; j <= 3; j++) {
+            for (int k = 1; k <= 3; k++) {
+                int endpointID = i;
+                int clusterID = i * 10 + j;
+                int attributeID = i * 100 + j * 10 + k;
+                int value = attributeID + 10000;
+                [attributeReport addObject:[self _testAttributeResponseValueWithEndpointID:@(endpointID) clusterID:@(clusterID) attributeID:@(attributeID) value:value]];
+            }
+        }
+    }
+    [device unitTestInjectAttributeReport:attributeReport fromSubscription:YES];
+
+    [self waitForExpectations:@[ gotReportEnd1, gotReportEnd2, gotReportEnd3 ] timeout:60];
+
+    XCTAssertEqual(attributesReceived1, 12);
+    XCTAssertEqual(attributesReceived2, 9);
+    XCTAssertEqual(attributesReceived3, 27);
+
+    // Now reset the counts, remove delegate1 and verify that only delegate2 and delegate3 got reports
+    attributesReceived1 = 0;
+    attributesReceived2 = 0;
+    attributesReceived3 = 0;
+    [device removeDelegate:delegate1];
+
+    XCTestExpectation * gotReportEnd2again = [self expectationWithDescription:@"Report end for delegate 2 again"];
+    delegate2.onReportEnd = ^{
+        [gotReportEnd2again fulfill];
+        __strong __auto_type strongDelegate = weakDelegate2;
+        strongDelegate.onReportEnd = nil;
+    };
+    XCTestExpectation * gotReportEnd3again = [self expectationWithDescription:@"Report end for delegate 3 again"];
+    delegate3.onReportEnd = ^{
+        [gotReportEnd3again fulfill];
+        __strong __auto_type strongDelegate = weakDelegate3;
+        strongDelegate.onReportEnd = nil;
+    };
+
+    // Construct 27 new attributes with new values / data versions
+    for (int i = 1; i <= 3; i++) {
+        for (int j = 1; j <= 3; j++) {
+            for (int k = 1; k <= 3; k++) {
+                int endpointID = i;
+                int clusterID = i * 10 + j;
+                int attributeID = i * 100 + j * 10 + k;
+                int value = attributeID + 20000;
+                [attributeReport addObject:[self _testAttributeResponseValueWithEndpointID:@(endpointID) clusterID:@(clusterID) attributeID:@(attributeID) value:value]];
+            }
+        }
+    }
+    [device unitTestInjectAttributeReport:attributeReport fromSubscription:YES];
+    [self waitForExpectations:@[ gotReportEnd2again, gotReportEnd3again ] timeout:60];
+
+    XCTAssertEqual(attributesReceived1, 0);
+    XCTAssertEqual(attributesReceived2, 9);
+    XCTAssertEqual(attributesReceived3, 27);
+}
+
 @end
 
 @interface MTRDeviceEncoderTests : XCTestCase

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -78,6 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
           reportToPersistenceDelayMaxMultiplier:(double)reportToPersistenceDelayMaxMultiplier
     deviceReportingExcessivelyIntervalThreshold:(NSTimeInterval)deviceReportingExcessivelyIntervalThreshold;
 - (void)unitTestSetMostRecentReportTimes:(NSMutableArray<NSDate *> *)mostRecentReportTimes;
+- (NSUInteger)unitTestNonnullDelegateCount;
 @end
 #endif
 


### PR DESCRIPTION
This PR adds multiple delegate support for MTRDevice, and a unit test for it.

Also includes some comment fixes, logging additions, and MTRDevice os_unfair_lock usage cleanup for straight-forward lock/unlock situations.