### PR TITLE
[ICD] Expose ActiveModeDuration, ActiveModeThreshold, IdleModeDuration to application

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -408,6 +408,7 @@ void PairingCommand::OnReadCommissioningInfo(const Controller::ReadCommissioning
     ChipLogProgress(AppServer, "OnReadCommissioningInfo - vendorId=0x%04X productId=0x%04X", info.basic.vendorId,
                     info.basic.productId);
 
+    VerifyOrReturn(info.icd.isICD);
     // The string in CharSpan received from the device is not null-terminated, we use std::string here for coping and
     // appending a numm-terminator at the end of the string.
     std::string userActiveModeTriggerInstruction;
@@ -426,6 +427,8 @@ void PairingCommand::OnReadCommissioningInfo(const Controller::ReadCommissioning
         ChipLogProgress(AppServer, "OnReadCommissioningInfo - LIT UserActiveModeTriggerInstruction=%s",
                         userActiveModeTriggerInstruction.c_str());
     }
+    ChipLogProgress(AppServer, "OnReadCommissioningInfo ICD - IdleModeDuration=%u activeModeDuration=%u activeModeThreshold=%u",
+                    info.icd.idleModeDuration, info.icd.activeModeDuration, info.icd.activeModeThreshold);
 }
 
 void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounter)
@@ -460,9 +463,9 @@ void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounte
     ChipLogProgress(chipTool, "Saved ICD Symmetric key for " ChipLogFormatX64, ChipLogValueX64(nodeId));
     ChipLogProgress(chipTool,
                     "ICD Registration Complete for device " ChipLogFormatX64 " / Check-In NodeID: " ChipLogFormatX64
-                    " / Monitored Subject: " ChipLogFormatX64 " / Symmetric Key: %s",
+                    " / Monitored Subject: " ChipLogFormatX64 " / Symmetric Key: %s / ICDCounter %u",
                     ChipLogValueX64(nodeId), ChipLogValueX64(mICDCheckInNodeId.Value()),
-                    ChipLogValueX64(mICDMonitoredSubject.Value()), icdSymmetricKeyHex);
+                    ChipLogValueX64(mICDMonitoredSubject.Value()), icdSymmetricKeyHex, icdCounter);
 }
 
 void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -408,7 +408,6 @@ void PairingCommand::OnReadCommissioningInfo(const Controller::ReadCommissioning
     ChipLogProgress(AppServer, "OnReadCommissioningInfo - vendorId=0x%04X productId=0x%04X", info.basic.vendorId,
                     info.basic.productId);
 
-    VerifyOrReturn(info.icd.isICD);
     // The string in CharSpan received from the device is not null-terminated, we use std::string here for coping and
     // appending a numm-terminator at the end of the string.
     std::string userActiveModeTriggerInstruction;

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -349,7 +349,6 @@ void PairingCommand::OnReadCommissioningInfo(const Controller::ReadCommissioning
     ChipLogProgress(AppServer, "OnReadCommissioningInfo - vendorId=0x%04X productId=0x%04X", info.basic.vendorId,
                     info.basic.productId);
 
-    VerifyOrReturn(info.icd.isICD);
     // The string in CharSpan received from the device is not null-terminated, we use std::string here for coping and
     // appending a numm-terminator at the end of the string.
     std::string userActiveModeTriggerInstruction;
@@ -370,7 +369,7 @@ void PairingCommand::OnReadCommissioningInfo(const Controller::ReadCommissioning
     }
 
     ChipLogProgress(AppServer, "OnReadCommissioningInfo ICD - IdleModeDuration=%u activeModeDuration=%u activeModeThreshold=%u",
-                    info.icd.IdleModeDuration, info.icd.ActiveModeDuration, info.icd.ActiveModeThreshold);
+                    info.icd.idleModeDuration, info.icd.activeModeDuration, info.icd.activeModeThreshold);
 }
 
 void PairingCommand::OnFabricCheck(NodeId matchingNodeId)

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -349,6 +349,7 @@ void PairingCommand::OnReadCommissioningInfo(const Controller::ReadCommissioning
     ChipLogProgress(AppServer, "OnReadCommissioningInfo - vendorId=0x%04X productId=0x%04X", info.basic.vendorId,
                     info.basic.productId);
 
+    VerifyOrReturn(info.icd.isICD);
     // The string in CharSpan received from the device is not null-terminated, we use std::string here for coping and
     // appending a numm-terminator at the end of the string.
     std::string userActiveModeTriggerInstruction;
@@ -367,6 +368,9 @@ void PairingCommand::OnReadCommissioningInfo(const Controller::ReadCommissioning
         ChipLogProgress(AppServer, "OnReadCommissioningInfo - LIT UserActiveModeTriggerInstruction=%s",
                         userActiveModeTriggerInstruction.c_str());
     }
+
+    ChipLogProgress(AppServer, "OnReadCommissioningInfo ICD - IdleModeDuration=%u activeModeDuration=%u activeModeThreshold=%u",
+                    info.icd.IdleModeDuration, info.icd.ActiveModeDuration, info.icd.ActiveModeThreshold);
 }
 
 void PairingCommand::OnFabricCheck(NodeId matchingNodeId)

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -740,7 +740,7 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
 
             if (mParams.GetCheckForMatchingFabric())
             {
-                chip::NodeId nodeId = mDeviceCommissioningInfo.remoteNodeId;
+                NodeId nodeId = mDeviceCommissioningInfo.remoteNodeId;
                 if (nodeId != kUndefinedNodeId)
                 {
                     mParams.SetRemoteNodeId(nodeId);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2712,11 +2712,16 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         }
 
         // Always read the active mode trigger hint attributes to notify users about it.
-        readPaths[numberOfAttributes++] = app::AttributePathParams(endpoint, IcdManagement::Id, IcdManagement::Attributes::UserActiveModeTriggerHint::Id);
-        readPaths[numberOfAttributes++] = app::AttributePathParams(endpoint, IcdManagement::Id, IcdManagement::Attributes::UserActiveModeTriggerInstruction::Id);
-        readPaths[numberOfAttributes++] = app::AttributePathParams(endpoint, IcdManagement::Id, IcdManagement::Attributes::IdleModeDuration::Id);
-        readPaths[numberOfAttributes++] = app::AttributePathParams(endpoint, IcdManagement::Id, IcdManagement::Attributes::ActiveModeDuration::Id);
-        readPaths[numberOfAttributes++] = app::AttributePathParams(endpoint, IcdManagement::Id, IcdManagement::Attributes::ActiveModeThreshold::Id);
+        readPaths[numberOfAttributes++] =
+            app::AttributePathParams(endpoint, IcdManagement::Id, IcdManagement::Attributes::UserActiveModeTriggerHint::Id);
+        readPaths[numberOfAttributes++] =
+            app::AttributePathParams(endpoint, IcdManagement::Id, IcdManagement::Attributes::UserActiveModeTriggerInstruction::Id);
+        readPaths[numberOfAttributes++] =
+            app::AttributePathParams(endpoint, IcdManagement::Id, IcdManagement::Attributes::IdleModeDuration::Id);
+        readPaths[numberOfAttributes++] =
+            app::AttributePathParams(endpoint, IcdManagement::Id, IcdManagement::Attributes::ActiveModeDuration::Id);
+        readPaths[numberOfAttributes++] =
+            app::AttributePathParams(endpoint, IcdManagement::Id, IcdManagement::Attributes::ActiveModeThreshold::Id);
         SendCommissioningReadRequest(proxy, timeout, readPaths, numberOfAttributes);
     }
     break;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2376,6 +2376,9 @@ CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
 
     if (!isICD)
     {
+        info.icd.idleModeDuration    = 0;
+        info.icd.activeModeDuration  = 0;
+        info.icd.activeModeThreshold = 0;
         return CHIP_NO_ERROR;
     }
 
@@ -2389,7 +2392,8 @@ CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
         mAttributeCache->Get<IcdManagement::Attributes::ActiveModeDuration::TypeInfo>(kRootEndpointId, info.icd.activeModeDuration);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "IcdManagement.ActiveModeDuration expected, but failed to read.");
+        ChipLogError(Controller, "IcdManagement.ActiveModeDuration expected, but failed to read: %" CHIP_ERROR_FORMAT,
+                     err.Format());
         return err;
     }
 
@@ -2397,7 +2401,8 @@ CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
                                                                                          info.icd.activeModeThreshold);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "IcdManagement.ActiveModeThreshold expected, but failed to read.");
+        ChipLogError(Controller, "IcdManagement.ActiveModeThreshold expected, but failed to read: %" CHIP_ERROR_FORMAT,
+                     err.Format());
     }
 
     return err;
@@ -2690,8 +2695,8 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         // NOTE: this array cannot have more than 9 entries, since the spec mandates that server only needs to support 9
         // See R1.1, 2.11.2 Interaction Model Limits
 
-        // Currently, we have at most 5 attributes to read in this stage.
-        app::AttributePathParams readPaths[5];
+        // Currently, we have at most 8 attributes to read in this stage.
+        app::AttributePathParams readPaths[8];
 
         // Mandatory attribute
         readPaths[numberOfAttributes++] =

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2301,14 +2301,14 @@ CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
     CHIP_ERROR err;
     IcdManagement::Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
     bool hasUserActiveModeTrigger = false;
-    bool isICD = false;
+    bool isICD                    = false;
     err = mAttributeCache->Get<IcdManagement::Attributes::FeatureMap::TypeInfo>(kRootEndpointId, featureMap);
     if (err == CHIP_NO_ERROR)
     {
         info.icd.isLIT                  = !!(featureMap & to_underlying(IcdManagement::Feature::kLongIdleTimeSupport));
         info.icd.checkInProtocolSupport = !!(featureMap & to_underlying(IcdManagement::Feature::kCheckInProtocolSupport));
         hasUserActiveModeTrigger        = !!(featureMap & to_underlying(IcdManagement::Feature::kUserActiveModeTrigger));
-        isICD = true;
+        isICD                           = true;
     }
     else if (err == CHIP_ERROR_KEY_NOT_FOUND)
     {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2301,14 +2301,14 @@ CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
     CHIP_ERROR err;
     IcdManagement::Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
     bool hasUserActiveModeTrigger = false;
-
+    bool isICD = false;
     err = mAttributeCache->Get<IcdManagement::Attributes::FeatureMap::TypeInfo>(kRootEndpointId, featureMap);
     if (err == CHIP_NO_ERROR)
     {
         info.icd.isLIT                  = !!(featureMap & to_underlying(IcdManagement::Feature::kLongIdleTimeSupport));
         info.icd.checkInProtocolSupport = !!(featureMap & to_underlying(IcdManagement::Feature::kCheckInProtocolSupport));
         hasUserActiveModeTrigger        = !!(featureMap & to_underlying(IcdManagement::Feature::kUserActiveModeTrigger));
-        info.icd.isICD                  = true;
+        isICD = true;
     }
     else if (err == CHIP_ERROR_KEY_NOT_FOUND)
     {
@@ -2335,7 +2335,7 @@ CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
     }
 
     ReturnErrorOnFailure(err);
-    if (!(info.icd.isICD))
+    if (!isICD)
     {
         return CHIP_NO_ERROR;
     }

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -74,7 +74,7 @@ enum CommissioningStage : uint8_t
     kNeedsNetworkCreds,
 };
 
-enum ICDRegistrationStrategy : uint8_t
+enum class ICDRegistrationStrategy : uint8_t
 {
     kIgnore,         ///< Do not check whether the device is an ICD during commissioning
     kBeforeComplete, ///< Do commissioner self-registration or external controller registration,
@@ -686,12 +686,20 @@ struct GeneralCommissioningInfo
 // the ICD Management cluster, and is used to communicate that information.
 struct ICDManagementClusterInfo
 {
+    bool isICD = false;
     // Whether the ICD is capable of functioning as a LIT device.  If false, the ICD can only be a SIT device.
-    bool isLIT;
+    bool isLIT = false;
     // Whether the ICD supports the check-in protocol.  LIT devices have to support it, but SIT devices
     // might or might not.
-    bool checkInProtocolSupport;
-
+    bool checkInProtocolSupport = false;
+    // Indicate the maximum interval in seconds the server can stay in idle mode.
+    uint32_t idleModeDuration = 0;
+    // Indicate the minimum interval in milliseconds the server typically will stay in active mode after initial transition out of
+    // idle mode.
+    uint32_t activeModeDuration = 0;
+    // Indicate the minimum amount of time in milliseconds the server typically will stay active after network activity when in
+    // active mode.
+    uint16_t activeModeThreshold = 0;
     // userActiveModeTriggerHint indicates which user action(s) will trigger the ICD to switch to Active mode.
     // For a LIT: The device is required to provide a value for the bitmap.
     // For a SIT: The device may not provide a value.  In that case, none of the bits will be set.

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -686,7 +686,6 @@ struct GeneralCommissioningInfo
 // the ICD Management cluster, and is used to communicate that information.
 struct ICDManagementClusterInfo
 {
-    bool isICD = false;
     // Whether the ICD is capable of functioning as a LIT device.  If false, the ICD can only be a SIT device.
     bool isLIT = false;
     // Whether the ICD supports the check-in protocol.  LIT devices have to support it, but SIT devices


### PR DESCRIPTION
--Expose ActiveModeDuration, ActiveModeThreshold, IdleModeDuration to application, and let user decide how to use them, for example, when user tries to interact with lit icd and have the queue, and UI can prompt user with the estimate waiting time window, if that waiting time is very long, user can decide whether to manually wakeup the device immediately.
