### PR TITLE
[ICD] Invoke stayActive in the end of commissioning flow

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -154,6 +154,10 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
         // These Optionals must have values now.
         // The commissioner will verify these values.
         params.SetICDSymmetricKey(mICDSymmetricKey.Value());
+        if (mICDStayActiveDurationMsec.HasValue())
+        {
+            params.SetICDStayActiveDurationMsec(mICDStayActiveDurationMsec.Value());
+        }
         params.SetICDCheckInNodeId(mICDCheckInNodeId.Value());
         params.SetICDMonitoredSubject(mICDMonitoredSubject.Value());
     }
@@ -463,6 +467,12 @@ void PairingCommand::OnICDRegistrationComplete(NodeId nodeId, uint32_t icdCounte
                     " / Monitored Subject: " ChipLogFormatX64 " / Symmetric Key: %s",
                     ChipLogValueX64(nodeId), ChipLogValueX64(mICDCheckInNodeId.Value()),
                     ChipLogValueX64(mICDMonitoredSubject.Value()), icdSymmetricKeyHex);
+}
+
+void PairingCommand::OnICDStayActiveComplete(NodeId deviceId, uint32_t promisedActiveDuration)
+{
+    ChipLogProgress(chipTool, "ICD Stay Active Complete for device " ChipLogFormatX64 " / promisedActiveDuration: %u",
+                    ChipLogValueX64(deviceId), promisedActiveDuration);
 }
 
 void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -73,7 +73,7 @@ public:
                     "The monitored subject of the ICD, default: The node id used for icd-check-in-nodeid.");
         AddArgument("icd-symmetric-key", &mICDSymmetricKey, "The 16 bytes ICD symmetric key, default: randomly generated.");
         AddArgument("icd-stay-active-duration", 0, UINT32_MAX, &mICDStayActiveDurationMsec,
-                    "The active duration after LIT ICD is commissioned");
+                    "If set, a LIT ICD that is commissioned will be requested to stay active for this many milliseconds");
         switch (networkType)
         {
         case PairingNetworkType::None:

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -72,7 +72,8 @@ public:
         AddArgument("icd-monitored-subject", 0, UINT64_MAX, &mICDMonitoredSubject,
                     "The monitored subject of the ICD, default: The node id used for icd-check-in-nodeid.");
         AddArgument("icd-symmetric-key", &mICDSymmetricKey, "The 16 bytes ICD symmetric key, default: randomly generated.");
-
+        AddArgument("icd-stay-active-duration", 0, UINT32_MAX, &mICDStayActiveDurationMsec,
+                    "The active duration after LIT ICD is commissioned");
         switch (networkType)
         {
         case PairingNetworkType::None:
@@ -197,6 +198,7 @@ public:
     void OnReadCommissioningInfo(const chip::Controller::ReadCommissioningInfo & info) override;
     void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error) override;
     void OnICDRegistrationComplete(NodeId deviceId, uint32_t icdCounter) override;
+    void OnICDStayActiveComplete(NodeId deviceId, uint32_t promisedActiveDuration) override;
 
     /////////// DeviceDiscoveryDelegate Interface /////////
     void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
@@ -235,6 +237,7 @@ private:
     chip::Optional<NodeId> mICDCheckInNodeId;
     chip::Optional<chip::ByteSpan> mICDSymmetricKey;
     chip::Optional<uint64_t> mICDMonitoredSubject;
+    chip::Optional<uint32_t> mICDStayActiveDurationMsec;
     chip::app::DataModel::List<chip::app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type> mTimeZoneList;
     TypedComplexArgument<chip::app::DataModel::List<chip::app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type>>
         mComplex_TimeZones;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -265,10 +265,6 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
         // The values must be valid now.
         memcpy(mICDSymmetricKey, params.GetICDSymmetricKey().Value().data(), params.GetICDSymmetricKey().Value().size());
         mParams.SetICDSymmetricKey(ByteSpan(mICDSymmetricKey));
-        if (params.GetICDStayActiveDurationMsec().HasValue())
-        {
-            mParams.SetICDStayActiveDurationMsec(params.GetICDStayActiveDurationMsec().Value());
-        }
         mParams.SetICDCheckInNodeId(params.GetICDCheckInNodeId().Value());
         mParams.SetICDMonitoredSubject(params.GetICDMonitoredSubject().Value());
     }
@@ -500,6 +496,8 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStageInternal(Commissio
         }
         return CommissioningStage::kFindOperational;
     case CommissioningStage::kFindOperational:
+        return CommissioningStage::kICDSendStayActive;
+    case CommissioningStage::kICDSendStayActive:
         return CommissioningStage::kSendComplete;
     case CommissioningStage::kSendComplete:
         return CommissioningStage::kCleanup;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -496,9 +496,24 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStageInternal(Commissio
         }
         return CommissioningStage::kFindOperational;
     case CommissioningStage::kFindOperational:
-        return CommissioningStage::kICDSendStayActive;
+        if (mActionOverCase == ActionOverCase::kICDSendStayActive)
+        {
+            return CommissioningStage::kICDSendStayActive;
+        }
+        else if (mActionOverCase == ActionOverCase::kSendComplete)
+        {
+            return CommissioningStage::kSendComplete;
+        }
+        return CommissioningStage::kError;
     case CommissioningStage::kICDSendStayActive:
-        return CommissioningStage::kSendComplete;
+        if (mActionOverCase == ActionOverCase::kSkip)
+        {
+            return CommissioningStage::kSendComplete;
+        }
+        else
+        {
+            return CommissioningStage::kFindOperational;
+        }
     case CommissioningStage::kSendComplete:
         return CommissioningStage::kCleanup;
 
@@ -752,6 +767,11 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
                 {
                     mNeedIcdRegistration = true;
                     ChipLogDetail(Controller, "AutoCommissioner: ICD supports the check-in protocol.");
+                }
+                else if (mParams.GetICDStayActiveDurationMsec().HasValue())
+                {
+                    ChipLogDetail(Controller, "AutoCommissioner: Clear ICD StayActiveDurationMsec");
+                    mParams.ClearICDStayActiveDurationMsec();
                 }
             }
             break;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -877,7 +877,7 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
 
 DeviceProxy * AutoCommissioner::GetDeviceProxyForStep(CommissioningStage nextStage)
 {
-    if (nextStage == CommissioningStage::kSendComplete ||
+    if (nextStage == CommissioningStage::kSendComplete || nextStage == CommissioningStage::kICDSendStayActive ||
         (nextStage == CommissioningStage::kCleanup && mOperationalDeviceProxy.GetDeviceId() != kUndefinedNodeId))
     {
         return &mOperationalDeviceProxy;

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -44,6 +44,8 @@ public:
     ByteSpan GetAttestationSignature() const { return ByteSpan(mAttestationSignature, mAttestationSignatureLen); }
     ByteSpan GetAttestationNonce() const { return ByteSpan(mAttestationNonce); }
 
+    void SetActionOverCase(ActionOverCase value) override { mActionOverCase = value; }
+
 protected:
     CommissioningStage GetNextCommissioningStage(CommissioningStage currentStage, CHIP_ERROR & lastErr);
     DeviceCommissioner * GetCommissioner() { return mCommissioner; }
@@ -122,8 +124,8 @@ private:
     ReadCommissioningInfo mDeviceCommissioningInfo;
     bool mNeedsDST = false;
 
-    bool mNeedIcdRegistration = false;
-
+    bool mNeedIcdRegistration      = false;
+    ActionOverCase mActionOverCase = ActionOverCase::kICDSendStayActive;
     // TODO: Why were the nonces statically allocated, but the certs dynamically allocated?
     uint8_t * mDAC   = nullptr;
     uint16_t mDACLen = 0;

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -44,8 +44,6 @@ public:
     ByteSpan GetAttestationSignature() const { return ByteSpan(mAttestationSignature, mAttestationSignatureLen); }
     ByteSpan GetAttestationNonce() const { return ByteSpan(mAttestationNonce); }
 
-    void SetActionOverCase(ActionOverCase value) override { mActionOverCase = value; }
-
 protected:
     CommissioningStage GetNextCommissioningStage(CommissioningStage currentStage, CHIP_ERROR & lastErr);
     DeviceCommissioner * GetCommissioner() { return mCommissioner; }
@@ -124,8 +122,7 @@ private:
     ReadCommissioningInfo mDeviceCommissioningInfo;
     bool mNeedsDST = false;
 
-    bool mNeedIcdRegistration      = false;
-    ActionOverCase mActionOverCase = ActionOverCase::kICDSendStayActive;
+    bool mNeedIcdRegistration = false;
     // TODO: Why were the nonces statically allocated, but the certs dynamically allocated?
     uint8_t * mDAC   = nullptr;
     uint16_t mDACLen = 0;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1201,7 +1201,7 @@ void DeviceCommissioner::OnFailedToExtendedArmFailSafeDeviceAttestation(void * c
 void DeviceCommissioner::OnICDManagementRegisterClientResponse(
     void * context, const app::Clusters::IcdManagement::Commands::RegisterClientResponse::DecodableType & data)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err                    = CHIP_NO_ERROR;
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     VerifyOrExit(commissioner != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(commissioner->mCommissioningStage == CommissioningStage::kICDRegistration, err = CHIP_ERROR_INCORRECT_STATE);
@@ -1221,17 +1221,16 @@ exit:
 void DeviceCommissioner::OnICDManagementStayActiveResponse(
     void * context, const app::Clusters::IcdManagement::Commands::StayActiveResponse::DecodableType & data)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err                    = CHIP_NO_ERROR;
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     VerifyOrExit(commissioner != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(commissioner->mCommissioningStage == CommissioningStage::kICDSendStayActive, err = CHIP_ERROR_INCORRECT_STATE);
     VerifyOrExit(commissioner->mDeviceBeingCommissioned != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-
     if (commissioner->mPairingDelegate != nullptr)
     {
         commissioner->mPairingDelegate->OnICDStayActiveComplete(commissioner->mDeviceBeingCommissioned->GetDeviceId(),
-                                                                  data.promisedActiveDuration);
+                                                                data.promisedActiveDuration);
     }
 
 exit:

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -3223,8 +3223,8 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
             return;
         }
 
+        // StayActive Command happens over CASE Connection
         IcdManagement::Commands::StayActiveRequest::Type request;
-
         request.stayActiveDuration = params.GetICDStayActiveDurationMsec().Value();
         ChipLogError(Controller, "Send ICD StayActive with Duration %u", request.stayActiveDuration);
         CHIP_ERROR err =
@@ -3239,6 +3239,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
     }
     break;
     case CommissioningStage::kSendComplete: {
+        //CommissioningComplete command happens over the CASE connection.
         GeneralCommissioning::Commands::CommissioningComplete::Type request;
         CHIP_ERROR err =
             SendCommissioningCommand(proxy, request, OnCommissioningCompleteResponse, OnBasicFailure, endpoint, timeout);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -3239,7 +3239,7 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
     }
     break;
     case CommissioningStage::kSendComplete: {
-        //CommissioningComplete command happens over the CASE connection.
+        // CommissioningComplete command happens over the CASE connection.
         GeneralCommissioning::Commands::CommissioningComplete::Type request;
         CHIP_ERROR err =
             SendCommissioningCommand(proxy, request, OnCommissioningCompleteResponse, OnBasicFailure, endpoint, timeout);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1234,6 +1234,10 @@ void DeviceCommissioner::OnICDManagementStayActiveResponse(
     }
 
 exit:
+    if (commissioner->mDefaultCommissioner != nullptr)
+    {
+        commissioner->mDefaultCommissioner->SetActionOverCase(AutoCommissioner::ActionOverCase::kSendComplete);
+    }
     CommissioningDelegate::CommissioningReport report;
     commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
 }
@@ -3219,6 +3223,8 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
     case CommissioningStage::kICDSendStayActive: {
         if (!(params.GetICDStayActiveDurationMsec().HasValue()))
         {
+            ChipLogProgress(Controller, "Skipping kICDSendStayActive since ICDStayActiveDurationMsec is not set");
+            mDefaultCommissioner->SetActionOverCase(AutoCommissioner::ActionOverCase::kSkip);
             CommissioningStageComplete(CHIP_NO_ERROR);
             return;
         }

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -921,6 +921,10 @@ private:
     static void OnICDManagementRegisterClientResponse(
         void * context, const app::Clusters::IcdManagement::Commands::RegisterClientResponse::DecodableType & data);
 
+    static void
+    OnICDManagementStayActiveResponse(void * context,
+                                      const app::Clusters::IcdManagement::Commands::StayActiveResponse::DecodableType & data);
+
     /**
      * @brief
      *   This function processes the CSR sent by the device.

--- a/src/controller/CommissioningDelegate.cpp
+++ b/src/controller/CommissioningDelegate.cpp
@@ -117,10 +117,6 @@ const char * StageToString(CommissioningStage stage)
         return "ICDRegistration";
         break;
 
-    case kICDSendStayActive:
-        return "ICDSendStayActive";
-        break;
-
     case kWiFiNetworkSetup:
         return "WiFiNetworkSetup";
         break;

--- a/src/controller/CommissioningDelegate.cpp
+++ b/src/controller/CommissioningDelegate.cpp
@@ -145,6 +145,10 @@ const char * StageToString(CommissioningStage stage)
         return "FindOperational";
         break;
 
+    case kICDSendStayActive:
+        return "ICDSendStayActive";
+        break;
+
     case kSendComplete:
         return "SendComplete";
         break;

--- a/src/controller/CommissioningDelegate.cpp
+++ b/src/controller/CommissioningDelegate.cpp
@@ -27,143 +27,114 @@ const char * StageToString(CommissioningStage stage)
     {
     case kError:
         return "Error";
-        break;
 
     case kSecurePairing:
         return "SecurePairing";
-        break;
 
     case kReadCommissioningInfo:
         return "ReadCommissioningInfo";
-        break;
 
     case kReadCommissioningInfo2:
         return "ReadCommissioningInfo2";
-        break;
 
     case kArmFailsafe:
         return "ArmFailSafe";
-        break;
 
     case kScanNetworks:
         return "ScanNetworks";
-        break;
 
     case kConfigRegulatory:
         return "ConfigRegulatory";
-        break;
 
     case kConfigureUTCTime:
         return "ConfigureUTCTime";
-        break;
 
     case kConfigureTimeZone:
         return "ConfigureTimeZone";
-        break;
 
     case kConfigureDSTOffset:
         return "ConfigureDSTOffset";
-        break;
 
     case kConfigureDefaultNTP:
         return "ConfigureDefaultNTP";
-        break;
 
     case kSendPAICertificateRequest:
         return "SendPAICertificateRequest";
-        break;
 
     case kSendDACCertificateRequest:
         return "SendDACCertificateRequest";
-        break;
 
     case kSendAttestationRequest:
         return "SendAttestationRequest";
-        break;
 
     case kAttestationVerification:
         return "AttestationVerification";
-        break;
 
     case kSendOpCertSigningRequest:
         return "SendOpCertSigningRequest";
-        break;
 
     case kValidateCSR:
         return "ValidateCSR";
-        break;
 
     case kGenerateNOCChain:
         return "GenerateNOCChain";
-        break;
 
     case kSendTrustedRootCert:
         return "SendTrustedRootCert";
-        break;
 
     case kSendNOC:
         return "SendNOC";
-        break;
 
     case kConfigureTrustedTimeSource:
         return "ConfigureTrustedTimeSource";
-        break;
 
     case kICDGetRegistrationInfo:
         return "ICDGetRegistrationInfo";
-        break;
 
     case kICDRegistration:
         return "ICDRegistration";
-        break;
 
     case kWiFiNetworkSetup:
         return "WiFiNetworkSetup";
-        break;
 
     case kThreadNetworkSetup:
         return "ThreadNetworkSetup";
-        break;
 
     case kFailsafeBeforeWiFiEnable:
         return "FailsafeBeforeWiFiEnable";
-        break;
 
     case kFailsafeBeforeThreadEnable:
         return "FailsafeBeforeThreadEnable";
-        break;
 
     case kWiFiNetworkEnable:
         return "WiFiNetworkEnable";
-        break;
 
     case kThreadNetworkEnable:
         return "ThreadNetworkEnable";
-        break;
 
-    case kFindOperational:
-        return "FindOperational";
-        break;
+    case kEvictPreviousCaseSessions:
+        return "kEvictPreviousCaseSessions";
+
+    case kFindOperationalForStayActive:
+        return "kFindOperationalForStayActive";
+
+    case kFindOperationalForCommissioningComplete:
+        return "kFindOperationalForCommissioningComplete";
 
     case kICDSendStayActive:
         return "ICDSendStayActive";
-        break;
 
     case kSendComplete:
         return "SendComplete";
-        break;
 
     case kCleanup:
         return "Cleanup";
-        break;
 
     case kNeedsNetworkCreds:
         return "NeedsNetworkCreds";
-        break;
 
     default:
         return "???";
-        break;
     }
 }
 

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -54,7 +54,6 @@ enum CommissioningStage : uint8_t
     kConfigureTrustedTimeSource, ///< Configure a trusted time source if one is required and available (must be done after SendNOC)
     kICDGetRegistrationInfo,     ///< Waiting for the higher layer to provide ICD registraion informations.
     kICDRegistration,            ///< Register for ICD management
-    kICDSendStayActive,          ///< Send Keep Alive to ICD
     kWiFiNetworkSetup,           ///< Send AddOrUpdateWiFiNetwork (0x31:2) command to the device
     kThreadNetworkSetup,         ///< Send AddOrUpdateThreadNetwork (0x31:3) command to the device
     kFailsafeBeforeWiFiEnable,   ///< Extend the fail-safe before doing kWiFiNetworkEnable
@@ -544,6 +543,13 @@ public:
         return *this;
     }
 
+    Optional<uint32_t> GetICDStayActiveDurationMsec() const { return mICDStayActiveDurationMsec; }
+    CommissioningParameters & SetICDStayActiveDurationMsec(uint32_t stayActiveDurationMsec)
+    {
+        mICDStayActiveDurationMsec = MakeOptional(stayActiveDurationMsec);
+        return *this;
+    }
+
     // Clear all members that depend on some sort of external buffer.  Can be
     // used to make sure that we are not holding any dangling pointers.
     void ClearExternalBufferDependentValues()
@@ -610,7 +616,7 @@ private:
     Optional<NodeId> mICDCheckInNodeId;
     Optional<uint64_t> mICDMonitoredSubject;
     Optional<ByteSpan> mICDSymmetricKey;
-
+    Optional<uint32_t> mICDStayActiveDurationMsec;
     ICDRegistrationStrategy mICDRegistrationStrategy = ICDRegistrationStrategy::kIgnore;
     bool mCheckForMatchingFabric                     = false;
 };

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -62,6 +62,7 @@ enum CommissioningStage : uint8_t
     kThreadNetworkEnable,        ///< Send ConnectNetwork (0x31:6) command to the device for the Thread network
     kFindOperational,            ///< Perform operational discovery and establish a CASE session with the device
     kSendComplete,               ///< Send CommissioningComplete (0x30:4) command to the device
+    kICDSendStayActive,          ///< Send Keep Alive to ICD
     kCleanup,                    ///< Call delegates with status, free memory, clear timers and state
     /// Send ScanNetworks (0x31:0) command to the device.
     /// ScanNetworks can happen anytime after kArmFailsafe.

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -775,17 +775,18 @@ public:
      * kSendOpCertSigningRequest: CSRResponse
      * kGenerateNOCChain: NocChain
      * kSendTrustedRootCert: None
-     * kSendNOC: none
+     * kSendNOC: None
      * kConfigureTrustedTimeSource: None
      * kWiFiNetworkSetup: NetworkCommissioningStatusInfo if there is an error
      * kThreadNetworkSetup: NetworkCommissioningStatusInfo if there is an error
      * kWiFiNetworkEnable: NetworkCommissioningStatusInfo if there is an error
      * kThreadNetworkEnable: NetworkCommissioningStatusInfo if there is an error
+     * kEvictPreviousCaseSessions: None
      * kFindOperationalForStayActive OperationalNodeFoundData
      * kFindOperationalForCommissioningComplete: OperationalNodeFoundData
      * kICDSendStayActive: CommissioningErrorInfo if there is an error
      * kSendComplete: CommissioningErrorInfo if there is an error
-     * kCleanup: none
+     * kCleanup: None
      */
     struct CommissioningReport
         : Variant<RequestedCertificate, AttestationResponse, CSRResponse, NocChain, OperationalNodeFoundData, ReadCommissioningInfo,

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -550,10 +550,7 @@ public:
         mICDStayActiveDurationMsec = MakeOptional(stayActiveDurationMsec);
         return *this;
     }
-    void ClearICDStayActiveDurationMsec()
-    {
-        mICDStayActiveDurationMsec.ClearValue();
-    }
+    void ClearICDStayActiveDurationMsec() { mICDStayActiveDurationMsec.ClearValue(); }
 
     // Clear all members that depend on some sort of external buffer.  Can be
     // used to make sure that we are not holding any dangling pointers.

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -550,6 +550,10 @@ public:
         mICDStayActiveDurationMsec = MakeOptional(stayActiveDurationMsec);
         return *this;
     }
+    void ClearICDStayActiveDurationMsec()
+    {
+        mICDStayActiveDurationMsec.ClearValue();
+    }
 
     // Clear all members that depend on some sort of external buffer.  Can be
     // used to make sure that we are not holding any dangling pointers.
@@ -753,6 +757,12 @@ struct NetworkCommissioningStatusInfo
 class CommissioningDelegate
 {
 public:
+    enum class ActionOverCase : uint8_t
+    {
+        kSkip,
+        kICDSendStayActive,
+        kSendComplete
+    };
     virtual ~CommissioningDelegate(){};
     /* CommissioningReport is returned after each commissioning step is completed. The reports for each step are:
      * kReadCommissioningInfo: Reported together with ReadCommissioningInfo2
@@ -792,6 +802,7 @@ public:
     virtual void SetOperationalCredentialsDelegate(OperationalCredentialsDelegate * operationalCredentialsDelegate) = 0;
     virtual CHIP_ERROR StartCommissioning(DeviceCommissioner * commissioner, CommissioneeDeviceProxy * proxy)       = 0;
     virtual CHIP_ERROR CommissioningStepFinished(CHIP_ERROR err, CommissioningReport report)                        = 0;
+    virtual void SetActionOverCase(ActionOverCase value)                                                            = 0;
 };
 
 } // namespace Controller

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -130,7 +130,7 @@ public:
     virtual void OnICDRegistrationInfoRequired() {}
 
     /**
-     * @bried
+     * @brief
      *   Called when the registration flow for the ICD completes.
      *
      * @param[in] icdNodeId    The node id of the ICD.
@@ -139,8 +139,8 @@ public:
     virtual void OnICDRegistrationComplete(NodeId icdNodeId, uint32_t icdCounter) {}
 
     /**
-     * @bried
-     *   Called when the stay active response is received in the end of the LIT ICD commissioning flow completes.
+     * @brief
+     *   Called when ICDStayActiveDuration is set and the stay active response is received in the end of the LIT ICD commissioning flow completes.
      *
      * @param[in] icdNodeId    The node id of the ICD.
      * @param[in] promisedActiveDurationMsec   The actual duration that the ICD server can stay active

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -140,7 +140,7 @@ public:
 
     /**
      * @brief
-     *   Called upon completion of the LIT ICD commissioning flow, when ICDStayActiveDuration is set 
+     *   Called upon completion of the LIT ICD commissioning flow, when ICDStayActiveDuration is set
      *   and the corresponding stayActive command response is received
      *
      * @param[in] icdNodeId    The node id of the ICD.

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -137,6 +137,16 @@ public:
      * @param[in] icdCounter   The ICD Counter received from the device.
      */
     virtual void OnICDRegistrationComplete(NodeId icdNodeId, uint32_t icdCounter) {}
+
+    /**
+     * @bried
+     *   Called when the stay active response is received in the end of the LIT ICD commissioning flow completes.
+     *
+     * @param[in] icdNodeId    The node id of the ICD.
+     * @param[in] promisedActiveDurationMsec   The actual duration that the ICD server can stay active
+     *            from the time it receives the StayActiveRequest command.
+     */
+    virtual void OnICDStayActiveComplete(NodeId icdNodeId, uint32_t promisedActiveDurationMsec) {}
 };
 
 } // namespace Controller

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -140,7 +140,8 @@ public:
 
     /**
      * @brief
-     *   Called when ICDStayActiveDuration is set and the stay active response is received in the end of the LIT ICD commissioning flow completes.
+     *   Called when ICDStayActiveDuration is set and the stay active response is received in the end of the LIT ICD commissioning
+     * flow completes.
      *
      * @param[in] icdNodeId    The node id of the ICD.
      * @param[in] promisedActiveDurationMsec   The actual duration that the ICD server can stay active

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -140,8 +140,8 @@ public:
 
     /**
      * @brief
-     *   Called when ICDStayActiveDuration is set and the stay active response is received in the end of the LIT ICD commissioning
-     * flow completes.
+     *   Called upon completion of the LIT ICD commissioning flow, when ICDStayActiveDuration is set 
+     *   and the corresponding stayActive command response is received
      *
      * @param[in] icdNodeId    The node id of the ICD.
      * @param[in] promisedActiveDurationMsec   The actual duration that the ICD server can stay active


### PR DESCRIPTION
-- StayActive is only invoked when pairing with LIT, and StayActiveDuration is set.
-- update the state machine
1.  kEvictPreviousCaseSessions to release all previous stale case session
2. kFindOperationalForStayActive to handle case session for ICD stay active
3. kFindOperationalForCommissioningComplete to handle case session for commission complete
fixes: https://github.com/project-chip/connectedhomeip/issues/29394