### PR TITLE
[Python] Make all subscription callbacks async capable

### DIFF
--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1057,8 +1057,8 @@ class BaseTestHelper:
         #
         # Register async callbacks that will fire when a re-sub is attempted or succeeds.
         #
-        subscription.SetResubscriptionAttemptedCallback(OnResubscriptionAttempted, True)
-        subscription.SetResubscriptionSucceededCallback(OnResubscriptionSucceeded, True)
+        subscription.SetResubscriptionAttemptedCallback(OnResubscriptionAttempted)
+        subscription.SetResubscriptionSucceededCallback(OnResubscriptionSucceeded)
 
         #
         # Over-ride the default liveness timeout (which is set quite high to accomodate for

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -697,13 +697,12 @@ class BaseTestHelper:
         # on the sub we established previously. Since it was just marked defunct, it should return back to being
         # active and a report should get delivered.
         #
-        sawValueChange = False
+        sawValueChangeEvent = asyncio.Event()
 
         def OnValueChange(path: Attribute.TypedAttributePath, transaction: Attribute.SubscriptionTransaction) -> None:
-            nonlocal sawValueChange
             self.logger.info("Saw value change!")
             if (path.AttributeType == Clusters.UnitTesting.Attributes.Int8u and path.Path.EndpointId == 1):
-                sawValueChange = True
+                sawValueChangeEvent.set()
 
         self.logger.info("Testing CASE defunct logic")
 
@@ -720,14 +719,15 @@ class BaseTestHelper:
         # was received.
         #
         await self.devCtrl2.WriteAttribute(nodeid, [(1, Clusters.UnitTesting.Attributes.Int8u(4))])
-        await asyncio.sleep(2)
 
-        sub.Shutdown()
-
-        if sawValueChange is False:
+        try:
+            await asyncio.wait_for(sawValueChangeEvent.wait(), 2)
+        except TimeoutError:
             self.logger.error(
                 "Didn't see value change in time, likely because sub got terminated due to unexpected session eviction!")
             return False
+        finally:
+            sub.Shutdown()
 
         #
         # In this test, we're going to setup a subscription on fabric1 through devCtl, then, constantly keep
@@ -739,7 +739,7 @@ class BaseTestHelper:
         #
         self.logger.info("Testing fabric-isolated CASE eviction")
 
-        sawValueChange = False
+        sawValueChangeEvent.clear()
         sub = await self.devCtrl.ReadAttribute(nodeid, [(Clusters.UnitTesting.Attributes.Int8u)], reportInterval=(0, 1))
         sub.SetAttributeUpdateCallback(OnValueChange)
 
@@ -752,20 +752,21 @@ class BaseTestHelper:
         # was received.
         #
         await self.devCtrl2.WriteAttribute(nodeid, [(1, Clusters.UnitTesting.Attributes.Int8u(4))])
-        await asyncio.sleep(2)
 
-        sub.Shutdown()
-
-        if sawValueChange is False:
+        try:
+            await asyncio.wait_for(sawValueChangeEvent.wait(), 2)
+        except TimeoutError:
             self.logger.error("Didn't see value change in time, likely because sub got terminated due to other fabric (fabric1)")
             return False
+        finally:
+            sub.Shutdown()
 
         #
         # Do the same test again, but reversing the roles of fabric1 and fabric2.
         #
         self.logger.info("Testing fabric-isolated CASE eviction (reverse)")
 
-        sawValueChange = False
+        sawValueChangeEvent.clear()
         sub = await self.devCtrl2.ReadAttribute(nodeid, [(Clusters.UnitTesting.Attributes.Int8u)], reportInterval=(0, 1))
         sub.SetAttributeUpdateCallback(OnValueChange)
 
@@ -774,13 +775,13 @@ class BaseTestHelper:
             await self.devCtrl.ReadAttribute(nodeid, [(Clusters.BasicInformation.Attributes.ClusterRevision)])
 
         await self.devCtrl.WriteAttribute(nodeid, [(1, Clusters.UnitTesting.Attributes.Int8u(4))])
-        await asyncio.sleep(2)
-
-        sub.Shutdown()
-
-        if sawValueChange is False:
+        try:
+            await asyncio.wait_for(sawValueChangeEvent.wait(), 2)
+        except TimeoutError:
             self.logger.error("Didn't see value change in time, likely because sub got terminated due to other fabric (fabric2)")
             return False
+        finally:
+            sub.Shutdown()
 
         return True
 

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1335,7 +1335,7 @@ class BaseTestHelper:
 
         return status == IM.Status.UnsupportedAccess
 
-    def TestSubscriptionResumption(self, nodeid: int, endpoint: int, remote_ip: str, ssh_port: int, remote_server_app: str):
+    async def TestSubscriptionResumption(self, nodeid: int, endpoint: int, remote_ip: str, ssh_port: int, remote_server_app: str):
         '''
         This test validates that the device can resume the subscriptions after restarting.
         It is executed in Linux Cirque tests and the steps of this test are:
@@ -1345,27 +1345,25 @@ class BaseTestHelper:
         '''
         desiredPath = None
         receivedUpdate = False
-        updateLock = threading.Lock()
-        updateCv = threading.Condition(updateLock)
+        updateEvent = asyncio.Event()
 
-        def OnValueReport(path: Attribute.TypedAttributePath, transaction: Attribute.SubscriptionTransaction) -> None:
-            nonlocal desiredPath, updateCv, updateLock, receivedUpdate
+        async def OnValueReport(path: Attribute.TypedAttributePath, transaction: Attribute.SubscriptionTransaction) -> None:
+            nonlocal desiredPath, updateEvent, receivedUpdate
             if path.Path != desiredPath:
                 return
 
             data = transaction.GetAttribute(path)
             logger.info(
                 f"Received report from server: path: {path.Path}, value: {data}")
-            with updateLock:
-                receivedUpdate = True
-                updateCv.notify_all()
+            receivedUpdate = True
+            updateEvent.set()
 
         try:
             desiredPath = Clusters.Attribute.AttributePath(
                 EndpointId=0, ClusterId=0x28, AttributeId=5)
             # BasicInformation Cluster, NodeLabel Attribute
-            subscription = self.devCtrl.ZCLSubscribeAttribute(
-                "BasicInformation", "NodeLabel", nodeid, endpoint, 1, 50, keepSubscriptions=True, autoResubscribe=False)
+            subscription = await self.devCtrl.ReadAttribute(nodeid, [(endpoint, Clusters.BasicInformation.Attributes.NodeLabel)], None, False, reportInterval=(1, 50),
+                                  keepSubscriptions=True, autoResubscribe=False)
             subscription.SetAttributeUpdateCallback(OnValueReport)
 
             self.logger.info("Restart remote deivce")
@@ -1374,12 +1372,11 @@ class BaseTestHelper:
             restartRemoteThread.start()
             # After device restarts, the attribute will be set dirty so the subscription can receive
             # the update
-            with updateCv:
-                while receivedUpdate is False:
-                    if not updateCv.wait(10.0):
-                        self.logger.error(
-                            "Failed to receive subscription resumption report")
-                        break
+            try:
+                await asyncio.wait_for(updateEvent.wait(), 10)
+            except TimeoutError:
+                self.logger.error(
+                    "Failed to receive subscription resumption report")
 
             restartRemoteThread.join(10.0)
 

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -720,7 +720,7 @@ class BaseTestHelper:
         # was received.
         #
         await self.devCtrl2.WriteAttribute(nodeid, [(1, Clusters.UnitTesting.Attributes.Int8u(4))])
-        time.sleep(2)
+        await asyncio.sleep(2)
 
         sub.Shutdown()
 
@@ -752,7 +752,7 @@ class BaseTestHelper:
         # was received.
         #
         await self.devCtrl2.WriteAttribute(nodeid, [(1, Clusters.UnitTesting.Attributes.Int8u(4))])
-        time.sleep(2)
+        await asyncio.sleep(2)
 
         sub.Shutdown()
 
@@ -774,7 +774,7 @@ class BaseTestHelper:
             await self.devCtrl.ReadAttribute(nodeid, [(Clusters.BasicInformation.Attributes.ClusterRevision)])
 
         await self.devCtrl.WriteAttribute(nodeid, [(1, Clusters.UnitTesting.Attributes.Int8u(4))])
-        time.sleep(2)
+        await asyncio.sleep(2)
 
         sub.Shutdown()
 

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1241,62 +1241,60 @@ class BaseTestHelper:
             return False
         return True
 
-    def TestSubscription(self, nodeid: int, endpoint: int):
+    async def TestSubscription(self, nodeid: int, endpoint: int):
         desiredPath = None
         receivedUpdate = 0
-        updateLock = threading.Lock()
-        updateCv = threading.Condition(updateLock)
+        updateEvent = asyncio.Event()
 
-        def OnValueChange(path: Attribute.TypedAttributePath, transaction: Attribute.SubscriptionTransaction) -> None:
-            nonlocal desiredPath, updateCv, updateLock, receivedUpdate
+        async def OnValueChange(path: Attribute.TypedAttributePath, transaction: Attribute.SubscriptionTransaction) -> None:
+            nonlocal desiredPath, updateEvent, receivedUpdate
             if path.Path != desiredPath:
                 return
 
             data = transaction.GetAttribute(path)
             logger.info(
                 f"Received report from server: path: {path.Path}, value: {data}")
-            with updateLock:
-                receivedUpdate += 1
-                updateCv.notify_all()
+            receivedUpdate += 1
+            updateEvent.set()
 
-        class _conductAttributeChange(threading.Thread):
-            def __init__(self, devCtrl: ChipDeviceCtrl.ChipDeviceController, nodeid: int, endpoint: int):
-                super(_conductAttributeChange, self).__init__()
-                self.nodeid = nodeid
-                self.endpoint = endpoint
-                self.devCtrl = devCtrl
-
-            def run(self):
-                for i in range(5):
-                    time.sleep(3)
-                    self.devCtrl.ZCLSend(
-                        "OnOff", "Toggle", self.nodeid, self.endpoint, 0, {})
+        async def _conductAttributeChange(devCtrl: ChipDeviceCtrl.ChipDeviceController, nodeid: int, endpoint: int):
+            for i in range(5):
+                await asyncio.sleep(3)
+                await self.devCtrl.SendCommand(nodeid, endpoint, Clusters.OnOff.Commands.Toggle())
 
         try:
             desiredPath = Clusters.Attribute.AttributePath(
                 EndpointId=1, ClusterId=6, AttributeId=0)
             # OnOff Cluster, OnOff Attribute
-            subscription = self.devCtrl.ZCLSubscribeAttribute(
-                "OnOff", "OnOff", nodeid, endpoint, 1, 10)
+            subscription = await self.devCtrl.ReadAttribute(nodeid, [(endpoint, Clusters.OnOff.Attributes.OnOff)], None, False, reportInterval=(1, 10),
+                                              keepSubscriptions=False, autoResubscribe=True)
             subscription.SetAttributeUpdateCallback(OnValueChange)
-            changeThread = _conductAttributeChange(
-                self.devCtrl, nodeid, endpoint)
             # Reset the number of subscriptions received as subscribing causes a callback.
-            changeThread.start()
-            with updateCv:
-                while receivedUpdate < 5:
-                    # We should observe 5 attribute changes
-                    # The changing thread will change the value after 3 seconds. If we're waiting more than 10, assume something
-                    # is really wrong and bail out here with some information.
-                    if not updateCv.wait(10.0):
-                        self.logger.error(
-                            "Failed to receive subscription update")
-                        break
+            loop = asyncio.get_running_loop()
+            taskAttributeChange = loop.create_task(_conductAttributeChange(self.devCtrl, nodeid, endpoint))
+
+            while receivedUpdate < 5:
+                # We should observe 5 attribute changes
+                # The changing thread will change the value after 3 seconds. If we're waiting more than 10, assume something
+                # is really wrong and bail out here with some information.
+                try:
+                    await asyncio.wait_for(updateEvent.wait(), 10)
+                    updateEvent.clear()
+                except TimeoutError:
+                    self.logger.error(
+                        "Failed to receive subscription update")
+                    break
 
             # thread changes 5 times, and sleeps for 3 seconds in between.
             # Add an additional 3 seconds of slack. Timeout is in seconds.
-            changeThread.join(18.0)
+            await asyncio.wait_for(taskAttributeChange, 3)
 
+            return True if receivedUpdate == 5 else False
+
+        except Exception as ex:
+            self.logger.exception(f"Failed to finish API test: {ex}")
+            return False
+        finally:
             #
             # Clean-up by shutting down the sub. Otherwise, we're going to get callbacks through
             # OnValueChange on what will soon become an invalid
@@ -1304,16 +1302,6 @@ class BaseTestHelper:
             #
             subscription.Shutdown()
 
-            if changeThread.is_alive():
-                # Thread join timed out
-                self.logger.error("Failed to join change thread")
-                return False
-
-            return True if receivedUpdate == 5 else False
-
-        except Exception as ex:
-            self.logger.exception(f"Failed to finish API test: {ex}")
-            return False
 
         return True
 

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -141,11 +141,11 @@ def TestDatamodel(test: BaseTestHelper, device_nodeid: int):
               "Failed to test Read Basic Attributes")
 
     logger.info("Testing subscription")
-    FailIfNot(test.TestSubscription(nodeid=device_nodeid, endpoint=LIGHTING_ENDPOINT_ID),
+    FailIfNot(asyncio.run(test.TestSubscription(nodeid=device_nodeid, endpoint=LIGHTING_ENDPOINT_ID)),
               "Failed to subscribe attributes.")
 
     logger.info("Testing another subscription that kills previous subscriptions")
-    FailIfNot(test.TestSubscription(nodeid=device_nodeid, endpoint=LIGHTING_ENDPOINT_ID),
+    FailIfNot(asyncio.run(test.TestSubscription(nodeid=device_nodeid, endpoint=LIGHTING_ENDPOINT_ID)),
               "Failed to subscribe attributes.")
 
     logger.info("Testing re-subscription")

--- a/src/controller/python/test/test_scripts/subscription_resumption_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_test.py
@@ -19,6 +19,7 @@
 
 # Commissioning test.
 
+import asyncio
 import os
 import sys
 from optparse import OptionParser
@@ -115,8 +116,8 @@ def main():
         "Failed on on-network commissioing")
 
     FailIfNot(
-        test.TestSubscriptionResumption(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
-                                        TEST_SSH_PORT, options.remoteServerApp), "Failed to resume subscription")
+        asyncio.run(test.TestSubscriptionResumption(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
+                                        TEST_SSH_PORT, options.remoteServerApp), "Failed to resume subscription"))
 
     timeoutTicker.stop()
 


### PR DESCRIPTION
Support asyncio coroutines as callback arguments. This allows to write asyncio code easily. Still support regular callbacks.

This changes on what thread some of the callbacks are being made. So far, some of the callbacks have been made directly (from the Matter SDK thread), and some from the callee thread (from the event loop thread learned via `asyncio.get_running_loop()`).

- SetResubscriptionAttemptedCallback -> even loop thread
- SetResubscriptionSucceededCallback -> even loop thread
- SetAttributeUpdateCallback -> SDK thread
- SetEventUpdateCallback -> SDK thread
- SetErrorCallback -> even loop thread

~~With this PR, all callbacks are done in the even loop thread, no matter if coroutines are used or regular routines.~~

Calling all callbacks in the event loop thread causes issues for the `ZCLSubscribeAttribute`  (legacy?) API. This PR now simply makes all callbacks asyncio capable. Coroutines as callback can only be used when using the new `WriteAttribute()`/`ReadAttribute()` API.

This also addresses at least one bug where `create_task()` is used on the even loop from the SDK thread. `create_task()` is not thread safe. This PR uses the thread safe alternative `run_coroutine_threadsafe()`.

It also speeds up the tests slightly by avoiding fixed sleeps in `TestCaseEviction`.