### PR TITLE
Add Pigweed support for Tizen

### DIFF
--- a/src/test_driver/tizen/.gn
+++ b/src/test_driver/tizen/.gn
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
 
 # The location of the build configuration file.
 buildconfig = "${build_root}/config/BUILDCONFIG.gn"
@@ -22,4 +24,16 @@ check_system_includes = true
 
 default_args = {
   target_os = "tizen"
+
+  pw_sys_io_BACKEND = "$dir_pw_sys_io_stdio"
+  pw_assert_BACKEND = "$dir_pw_assert_log"
+  pw_log_BACKEND = "$dir_pw_log_basic"
+
+  pw_unit_test_BACKEND = "$dir_pw_unit_test:light"
+
+  # TODO: Make sure only unit tests link against this
+  pw_build_LINK_DEPS = [
+    "$dir_pw_assert:impl",
+    "$dir_pw_log:impl",
+  ]
 }


### PR DESCRIPTION
Related to #29682

## Changes
Add pigweed dependencies for tizen in test_driver. 

## Testing

CI will test it. In related PR, there are changes for all platforms. The CI there passes all checks. 