### PR TITLE
Add Pigweed support for efr32

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -145,7 +145,8 @@ if (chip_build_tests) {
       # TODO [PW_MIGRATION] There will be a list of already migrated platforms
       if (chip_device_platform == "esp32" ||
           chip_device_platform == "nrfconnect" ||
-          chip_device_platform == "openiotsdk") {
+          chip_device_platform == "openiotsdk" ||
+          chip_device_platform == "efr32") {
         deps += [ "${chip_root}/src/lib/support:pw_tests_wrapper" ]
       }
       build_monolithic_library = true

--- a/src/test_driver/efr32/.gn
+++ b/src/test_driver/efr32/.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/build.gni")
+import("//build_overrides/pigweed.gni")
 
 # The location of the build configuration file.
 buildconfig = "${build_root}/config/BUILDCONFIG.gn"

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -80,10 +80,12 @@ silabs_executable("efr32_device_tests") {
   deps = [
     ":nl_test_service.nanopb_rpc",
     ":sdk",
+    "$dir_pw_unit_test:rpc_service",
     "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
     "${chip_root}/examples/common/pigweed:system_rpc_server",
     "${chip_root}/src:tests",
     "${chip_root}/src/lib",
+    "${chip_root}/src/lib/support:pw_tests_wrapper",
     "${chip_root}/src/lib/support:testing_nlunit",
     "${examples_common_plat_dir}/pw_sys_io:pw_sys_io_silabs",
     "${nlunit_test_root}:nlunit-test",

--- a/src/test_driver/efr32/args.gni
+++ b/src/test_driver/efr32/args.gni
@@ -30,3 +30,8 @@ openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"
 
 pw_rpc_CONFIG = "$dir_pw_rpc:disable_global_mutex"
+
+pw_assert_BACKEND = "$dir_pw_assert_log"
+pw_log_BACKEND = "$dir_pw_log_basic"
+
+pw_unit_test_BACKEND = "$dir_pw_unit_test:light"

--- a/src/test_driver/efr32/py/BUILD.gn
+++ b/src/test_driver/efr32/py/BUILD.gn
@@ -19,6 +19,7 @@ import("$dir_pw_build/python.gni")
 import("$dir_pw_build/python_dist.gni")
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 
+# TODO [PW_MIGRATION]: remove nl test runner script once transition away from nlunit-test is completed
 pw_python_package("nl_test_runner") {
   setup = [
     "pyproject.toml",
@@ -42,4 +43,28 @@ pw_python_package("nl_test_runner") {
 pw_python_wheels("nl_test_runner_wheel") {
   packages = [ ":nl_test_runner" ]
   directory = "$root_out_dir/chip_nl_test_runner_wheels"
+}
+
+pw_python_package("pw_test_runner") {
+  setup = [
+    "pw_test_runner/pyproject.toml",
+    "pw_test_runner/setup.cfg",
+    "pw_test_runner/setup.py",
+  ]
+
+  sources = [
+    "pw_test_runner/__init__.py",
+    "pw_test_runner/pw_test_runner.py",
+  ]
+
+  python_deps = [
+    "$dir_pw_hdlc/py",
+    "$dir_pw_protobuf_compiler/py",
+    "$dir_pw_rpc/py",
+  ]
+}
+
+pw_python_wheels("pw_test_runner_wheel") {
+  packages = [ ":pw_test_runner" ]
+  directory = "$root_out_dir/chip_pw_test_runner_wheels"
 }

--- a/src/test_driver/efr32/py/pw_test_runner/pw_test_runner.py
+++ b/src/test_driver/efr32/py/pw_test_runner/pw_test_runner.py
@@ -1,0 +1,118 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import serial  # type: ignore
+from pw_hdlc import rpc
+from pw_unit_test.rpc import run_tests
+
+PW_LOG = logging.getLogger(__name__)
+
+PROTO = Path(os.environ["PW_ROOT"],
+             "pw_unit_test/pw_unit_test_proto/unit_test.proto")
+
+
+class colors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+
+
+PASS_STRING = colors.OKGREEN + "\N{check mark}" + colors.ENDC
+FAIL_STRING = colors.FAIL + "FAILED" + colors.ENDC
+
+
+def _parse_args():
+    """Parses and returns the command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="CHIP on device unit test runner.")
+    parser.add_argument("-d", "--device", help="the serial port to use")
+    parser.add_argument(
+        "-b", "--baudrate", type=int, default=115200, help="the baud rate to use"
+    )
+    parser.add_argument(
+        "-f",
+        "--flash_image",
+        help="a firmware image which will be flashed berfore runnning the test",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=argparse.FileType("wb"),
+        default=sys.stdout.buffer,
+        help=(
+            "The file to which to write device output (HDLC channel 1); "
+            "provide - or omit for stdout."
+        ),
+    )
+    return parser.parse_args()
+
+
+def flash_device(device: str, flash_image: str, **kwargs):
+    """flashes the EFR32 device using commander"""
+    err = subprocess.call(
+        ["commander", "flash", "--device", "EFR32", flash_image])
+    if err:
+        raise Exception("flash failed")
+
+
+def get_hdlc_rpc_client(device: str, baudrate: int, output: Any, **kwargs):
+    """Get the HdlcRpcClient based on arguments."""
+    serial_device = serial.Serial(device, baudrate, timeout=1)
+    reader = rpc.SerialReader(serial_device, 8192)
+    write = serial_device.write
+    return rpc.HdlcRpcClient(
+        reader,
+        PROTO,
+        rpc.default_channels(write),
+        lambda data: rpc.write_to_file(data, output),
+    )
+
+
+def runner(client: rpc.HdlcRpcClient) -> int:
+    """Run the tests"""
+
+    test_records = run_tests(client.rpcs())
+
+    return len(test_records.failing_tests)
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.flash_image:
+        flash_device(**vars(args))
+        time.sleep(1)  # Give time for device to boot
+
+    with get_hdlc_rpc_client(**vars(args)) as client:
+        return runner(client)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/test_driver/efr32/py/pw_test_runner/pw_test_runner.py
+++ b/src/test_driver/efr32/py/pw_test_runner/pw_test_runner.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2021 Project CHIP Authors
+#    Copyright (c) 2024 Project CHIP Authors
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test_driver/efr32/py/pw_test_runner/pyproject.toml
+++ b/src/test_driver/efr32/py/pw_test_runner/pyproject.toml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[build-system]
+requires = ['setuptools', 'wheel']
+build-backend = 'setuptools.build_meta'

--- a/src/test_driver/efr32/py/pw_test_runner/pyproject.toml
+++ b/src/test_driver/efr32/py/pw_test_runner/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Project CHIP Authors
+# Copyright (c) 2024 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test_driver/efr32/py/pw_test_runner/setup.cfg
+++ b/src/test_driver/efr32/py/pw_test_runner/setup.cfg
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Project CHIP Authors
+# Copyright (c) 2024 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test_driver/efr32/py/pw_test_runner/setup.cfg
+++ b/src/test_driver/efr32/py/pw_test_runner/setup.cfg
@@ -1,0 +1,20 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[metadata]
+name = pw_test_runner
+version = 0.0.1
+
+[options]
+packages = find:
+zip_safe = False

--- a/src/test_driver/efr32/py/pw_test_runner/setup.py
+++ b/src/test_driver/efr32/py/pw_test_runner/setup.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import setuptools  # type: ignore
+
+setuptools.setup()  # Package definition in setup.cfg

--- a/src/test_driver/efr32/py/pw_test_runner/setup.py
+++ b/src/test_driver/efr32/py/pw_test_runner/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Project CHIP Authors
+# Copyright (c) 2024 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test_driver/efr32/src/main.cpp
+++ b/src/test_driver/efr32/src/main.cpp
@@ -25,7 +25,6 @@
 #include <cstring>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPPlatformMemory.h>
-#include <lib/support/UnitTest.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <mbedtls/platform.h>
 #include <nl_test_service/nl_test.rpc.pb.h>
@@ -57,7 +56,6 @@ public:
         nlTestSetLogger(&nl_test_logger);
 
         RunRegisteredUnitTests();
-        chip::test::RunAllTests();
 
         stream_writer = nullptr;
         writer.Finish();

--- a/src/test_driver/efr32/src/main.cpp
+++ b/src/test_driver/efr32/src/main.cpp
@@ -15,6 +15,9 @@
  *    limitations under the License.
  */
 
+// TODO To prevent config with nl headers has to be included before  nl test headers
+#include <pw_unit_test/unit_test_service.h>
+
 #include <AppConfig.h>
 #include <FreeRTOS.h>
 #include <PigweedLogger.h>
@@ -22,6 +25,7 @@
 #include <cstring>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPPlatformMemory.h>
+#include <lib/support/UnitTest.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <mbedtls/platform.h>
 #include <nl_test_service/nl_test.rpc.pb.h>
@@ -53,6 +57,7 @@ public:
         nlTestSetLogger(&nl_test_logger);
 
         RunRegisteredUnitTests();
+        chip::test::RunAllTests();
 
         stream_writer = nullptr;
         writer.Finish();
@@ -166,10 +171,11 @@ StaticTask_t sTestTaskBuffer;
 StackType_t sTestTaskStack[TEST_TASK_STACK_SIZE];
 
 chip::rpc::NlTest nl_test_service;
+pw::unit_test::UnitTestService unit_test_service;
 
 void RegisterServices(pw::rpc::Server & server)
 {
-    server.RegisterService(nl_test_service);
+    server.RegisterService(nl_test_service, unit_test_service);
 }
 
 void RunRpcService(void *)


### PR DESCRIPTION
Related to #29682

## Changes
* Add pigweed dependencies for gn 
* Add pigweed unit test service
* Create `pw_test_runner` script similar to `nl_test_runner`

## Testing
@jepenven-silabs 
I do not have the resources to test these changes. I would ask someone associated with the efr32 platform to test them and give feedback. 