### PR TITLE
[Darwin] MTRDevice isCachePrimed parts list check fix

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2208,14 +2208,19 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     }
 
     // Check if we have cached descriptor clusters for each listed endpoint
-    for (NSDictionary * endpointDataValue in partsList) {
+    for (NSDictionary * endpointDictionary in partsList) {
+        NSDictionary * endpointDataValue = endpointDictionary[MTRDataKey];
+        if (![endpointDataValue isKindOfClass:[NSDictionary class]]) {
+            MTR_LOG_ERROR("%@ unexpected parts list dictionary %@ data value class %@", self, endpointDictionary, [endpointDataValue class]);
+            continue;
+        }
         if (![MTRUnsignedIntegerValueType isEqual:endpointDataValue[MTRTypeKey]]) {
-            MTR_LOG_ERROR("%@ unexpected type for parts list item %@", self, endpointDataValue);
+            MTR_LOG_ERROR("%@ unexpected parts list data value %@ item type %@", self, endpointDataValue, endpointDataValue[MTRTypeKey]);
             continue;
         }
         NSNumber * endpoint = endpointDataValue[MTRValueKey];
         if (![endpoint isKindOfClass:[NSNumber class]]) {
-            MTR_LOG_ERROR("%@ unexpected type for parts list item %@", self, endpointDataValue);
+            MTR_LOG_ERROR("%@ unexpected parts list item value class %@", self, [endpoint class]);
             continue;
         }
         NSDictionary * descriptorDeviceTypeListDataValue = _readCache[[MTRAttributePath attributePathWithEndpointID:endpoint clusterID:@(MTRClusterIDTypeDescriptorID) attributeID:@(MTRAttributeIDTypeClusterDescriptorAttributeDeviceTypeListID)]];


### PR DESCRIPTION
Turns out the parts list check was missing one level, and the bug would have caused more `-deviceCachePrimed:` delegate calls than intended. This fixes the check.