### PR TITLE
Prioritize DNS-SD results from the network on tvOS.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -54,6 +54,11 @@ jobs:
               # Disable availability annotations, since we are not building a system
               # Matter.framework.
               run: xcodebuild -target "Matter" -sdk watchos -configuration Debug GCC_PREPROCESSOR_DEFINITIONS='${inherited} MTR_NO_AVAILABILITY=1'
+            - name: Run tvOS Build Debug
+              working-directory: src/darwin/Framework
+              # Disable availability annotations, since we are not building a system
+              # Matter.framework.
+              run: xcodebuild -target "Matter" -sdk tvos -configuration Debug GCC_PREPROCESSOR_DEFINITIONS='${inherited} MTR_NO_AVAILABILITY=1'
             - name: Run iOS Build Debug
               working-directory: src/darwin/Framework
               # Disable availability annotations, since we are not building a system

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -58,7 +58,7 @@ jobs:
               working-directory: src/darwin/Framework
               # Disable availability annotations, since we are not building a system
               # Matter.framework.
-              run: xcodebuild -target "Matter" -sdk tvos -configuration Debug GCC_PREPROCESSOR_DEFINITIONS='${inherited} MTR_NO_AVAILABILITY=1'
+              run: xcodebuild -target "Matter" -sdk appletvos -configuration Debug GCC_PREPROCESSOR_DEFINITIONS='${inherited} MTR_NO_AVAILABILITY=1'
             - name: Run iOS Build Debug
               working-directory: src/darwin/Framework
               # Disable availability annotations, since we are not building a system

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -21,6 +21,8 @@
 #include <lib/support/CHIPMemString.h>
 #include <platform/CHIPDeviceLayer.h>
 
+#include <net/if.h>
+
 using namespace chip::Dnssd;
 using namespace chip::Dnssd::Internal;
 
@@ -516,38 +518,77 @@ void ResolveContext::DispatchSuccess()
     // ChipDnssdResolveNoLongerNeeded don't find us and try to also remove us.
     bool needDelete = MdnsContexts::GetInstance().RemoveWithoutDeleting(this);
 
+#if TARGET_OS_TV
+    // On tvOS, priotize results from en0, en1, ir0 in that order, if those
+    // interfaces are present, since those will generally have more up-to-date
+    // information.
+    static const unsigned int priorityInterfaceIndices[] = {
+        if_nametoindex("en0"),
+        if_nametoindex("en1"),
+        if_nametoindex("ir0"),
+    };
+
+    for (auto interfaceIndex : priorityInterfaceIndices)
+    {
+        if (TryReportingResultsForInterfaceIndex(static_cast<uint32_t>(interfaceIndex)))
+        {
+            if (needDelete)
+            {
+                MdnsContexts::GetInstance().Delete(this);
+            }
+            return;
+        }
+    }
+#endif // TARGET_OS_TV
+
     for (auto & interface : interfaces)
     {
-        auto & ips = interface.second.addresses;
-
-        // Some interface may not have any ips, just ignore them.
-        if (ips.size() == 0)
+        if (TryReportingResultsForInterfaceIndex(interface.first))
         {
-            continue;
+            break;
         }
-
-        ChipLogProgress(Discovery, "Mdns: Resolve success on interface %" PRIu32, interface.first);
-
-        auto & service = interface.second.service;
-        auto addresses = Span<Inet::IPAddress>(ips.data(), ips.size());
-        if (nullptr == callback)
-        {
-            auto delegate = static_cast<CommissioningResolveDelegate *>(context);
-            DiscoveredNodeData nodeData;
-            service.ToDiscoveredNodeData(addresses, nodeData);
-            delegate->OnNodeDiscovered(nodeData);
-        }
-        else
-        {
-            callback(context, &service, addresses, CHIP_NO_ERROR);
-        }
-        break;
     }
 
     if (needDelete)
     {
         MdnsContexts::GetInstance().Delete(this);
     }
+}
+
+bool ResolveContext::TryReportingResultsForInterfaceIndex(uint32_t interfaceIndex)
+{
+    if (interfaceIndex == 0)
+    {
+        // Not actually an interface we have.
+        return false;
+    }
+
+    auto & interface = interfaces[interfaceIndex];
+    auto & ips       = interface.addresses;
+
+    // Some interface may not have any ips, just ignore them.
+    if (ips.size() == 0)
+    {
+        return false;
+    }
+
+    ChipLogProgress(Discovery, "Mdns: Resolve success on interface %" PRIu32, interfaceIndex);
+
+    auto & service = interface.service;
+    auto addresses = Span<Inet::IPAddress>(ips.data(), ips.size());
+    if (nullptr == callback)
+    {
+        auto delegate = static_cast<CommissioningResolveDelegate *>(context);
+        DiscoveredNodeData nodeData;
+        service.ToDiscoveredNodeData(addresses, nodeData);
+        delegate->OnNodeDiscovered(nodeData);
+    }
+    else
+    {
+        callback(context, &service, addresses, CHIP_NO_ERROR);
+    }
+
+    return true;
 }
 
 CHIP_ERROR ResolveContext::OnNewAddress(uint32_t interfaceId, const struct sockaddr * address)

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -519,7 +519,7 @@ void ResolveContext::DispatchSuccess()
     bool needDelete = MdnsContexts::GetInstance().RemoveWithoutDeleting(this);
 
 #if TARGET_OS_TV
-    // On tvOS, priotize results from en0, en1, ir0 in that order, if those
+    // On tvOS, prioritize results from en0, en1, ir0 in that order, if those
     // interfaces are present, since those will generally have more up-to-date
     // information.
     static const unsigned int priorityInterfaceIndices[] = {
@@ -527,6 +527,12 @@ void ResolveContext::DispatchSuccess()
         if_nametoindex("en1"),
         if_nametoindex("ir0"),
     };
+#else
+    // Elsewhere prioritize "lo0" over other interfaces.
+    static const unsigned int priorityInterfaceIndices[] = {
+        if_nametoindex("lo0"),
+    };
+#endif // TARGET_OS_TV
 
     for (auto interfaceIndex : priorityInterfaceIndices)
     {
@@ -539,7 +545,6 @@ void ResolveContext::DispatchSuccess()
             return;
         }
     }
-#endif // TARGET_OS_TV
 
     for (auto & interface : interfaces)
     {

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -251,6 +251,14 @@ struct ResolveContext : public GenericContext
                         const unsigned char * txtRecord);
     bool HasInterface();
     bool Matches(const char * otherInstanceName) const { return instanceName == otherInstanceName; }
+
+private:
+    /**
+     * Try reporting the results we got on the provided interface index.
+     * Returns true if information was reported, false if not (e.g. if there
+     * were no IP addresses, etc).
+     */
+    bool TryReportingResultsForInterfaceIndex(uint32_t interfaceIndex);
 };
 
 } // namespace Dnssd


### PR DESCRIPTION
Since we can only deliver results from one interface given the current state of Matter SDK APIs (see
https://github.com/project-chip/connectedhomeip/issues/32512), prioritize the interfaces that are more likely to have up-to-date results, not stale caches.
