### PR TITLE
Add TVOC in Linux Air Quality Example README

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1440,6 +1440,7 @@ ttymxc
 ttyUSB
 TurbidityConcentrationMeasurement
 TvCasting
+TVOC
 tvOS
 TXD
 txt

--- a/examples/air-quality-sensor-app/linux/README.md
+++ b/examples/air-quality-sensor-app/linux/README.md
@@ -183,3 +183,10 @@ Generate event `Pm10ConcentrationMeasurement`, to change the PM10 value.
 ```
 echo '{"Name":"Pm10ConcentrationMeasurement","NewValue":10}' > /tmp/chip_air_quality_fifo_<PID>
 ```
+
+Generate event `TotalVolatileOrganicCompoundsConcentrationMeasurement`, to
+change the TVOC value.
+
+```
+$ echo '{"Name":"TotalVolatileOrganicCompoundsConcentrationMeasurement","NewValue":100}' > /tmp/chip_air_quality_fifo_<PID>
+```


### PR DESCRIPTION
Add TVOC in [Linux Air Quality Example README](https://github.com/project-chip/connectedhomeip/blob/master/examples/air-quality-sensor-app/linux/README.md).