### PR TITLE
SVE fixes: fix default and null audio track on android

### DIFF
--- a/examples/tv-app/android/java/MediaPlaybackManager.cpp
+++ b/examples/tv-app/android/java/MediaPlaybackManager.cpp
@@ -152,7 +152,7 @@ CHIP_ERROR MediaPlaybackManager::HandleGetActiveTrack(bool audio, AttributeValue
     }
     else
     {
-        err = aEncoder.EncodeNull();
+        return aEncoder.EncodeNull();
     }
 
 exit:

--- a/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/MediaPlaybackManagerStub.java
+++ b/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/MediaPlaybackManagerStub.java
@@ -35,11 +35,11 @@ public class MediaPlaybackManagerStub implements MediaPlaybackManager {
   private static int playbackMaxForwardSpeed = 10;
   private static int playbackMaxRewindSpeed = -10;
 
-  private static MediaTrack activeAudioTrack = null;
   private static MediaTrack[] audioTracks = {
     new MediaTrack("activeAudioTrackId_0", "languageCode1", "displayName1"),
     new MediaTrack("activeAudioTrackId_1", "languageCode2", "displayName2")
   };
+  private static MediaTrack activeAudioTrack = audioTracks[0];
 
   private static MediaTrack activeTextTrack = null;
   private static MediaTrack[] textTracks = {


### PR DESCRIPTION
Found during SVE
- default audio track should be set (base case for test)
- fix null track response