### PR TITLE
Fix bug in level control move [bug fix]

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -952,6 +952,12 @@ static void moveHandler(app::CommandHandler * commandObj, const app::ConcreteCom
         goto send_default_response;
     }
 
+    if (rate == 0) {
+      status = Status::Success;
+      goto send_default_response;
+    }
+
+
     if (!shouldExecuteIfOff(endpoint, commandId, optionsMask, optionsOverride))
     {
         status = Status::Success;


### PR DESCRIPTION
Command `chip-tool levelcontrol move 0 0 1 1 42 2` throws error `Stop reason: signal SIGFPE: integer divide by zero` because of division by zero in rate handling in LevelControl cluster. This PR checks if rate equal to zero, and if it is, consider it to be null.