### PR TITLE
DeviceCommissioner: Track ExtendArmFailSafe conditionally and manage CASE callbacks accurately

### DIFF
--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -28,12 +28,20 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/Base64.h>
 #include <lib/support/BytesToHex.h>
+#include <lib/support/CHIPMemString.h>
+#include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
 #if ENABLE_TRACING
 #include <TracingCommandLineArgument.h> // nogncheck
+#endif
+
+#if CHIP_WITH_NLFAULTINJECTION
+#include <inet/InetFaultInjection.h>
+#include <lib/support/CHIPFaultInjection.h>
+#include <system/SystemFaultInjection.h>
 #endif
 
 using namespace chip;
@@ -93,6 +101,9 @@ enum
     kDeviceOption_WiFiSupports5g = 0x1025,
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     kDeviceOption_SubscriptionResumptionRetryIntervalSec = 0x1026,
+#endif
+#if CHIP_WITH_NLFAULTINJECTION
+    kDeviceOption_FaultInjection = 0x1027,
 #endif
 };
 
@@ -155,6 +166,9 @@ OptionDef sDeviceOptionDefs[] = {
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     { "subscription-capacity", kArgumentRequired, kDeviceOption_SubscriptionCapacity },
     { "subscription-resumption-retry-interval", kArgumentRequired, kDeviceOption_SubscriptionResumptionRetryIntervalSec },
+#endif
+#if CHIP_WITH_NLFAULTINJECTION
+    { "faults", kArgumentRequired, kDeviceOption_FaultInjection },
 #endif
     {}
 };
@@ -286,6 +300,10 @@ const char * sDeviceOptionHelp =
     "       Max number of subscriptions the device will allow\n"
     "  --subscription-resumption-retry-interval\n"
     "       subscription timeout resumption retry interval in seconds\n"
+#endif
+#if CHIP_WITH_NLFAULTINJECTION
+    "  --faults <fault-string,...>\n"
+    "       Inject specified fault(s) at runtime.\n"
 #endif
     "\n";
 
@@ -556,6 +574,20 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
     case kDeviceOption_SubscriptionResumptionRetryIntervalSec:
         LinuxDeviceOptions::GetInstance().subscriptionResumptionRetryIntervalSec = static_cast<int32_t>(atoi(aValue));
         break;
+#endif
+#if CHIP_WITH_NLFAULTINJECTION
+    case kDeviceOption_FaultInjection: {
+        constexpr nl::FaultInjection::GetManagerFn faultManagerFns[] = { FaultInjection::GetManager,
+                                                                         Inet::FaultInjection::GetManager,
+                                                                         System::FaultInjection::GetManager };
+        Platform::ScopedMemoryString mutableArg(aValue, strlen(aValue)); // ParseFaultInjectionStr may mutate
+        if (!nl::FaultInjection::ParseFaultInjectionStr(mutableArg.Get(), faultManagerFns, ArraySize(faultManagerFns)))
+        {
+            PrintArgError("%s: Invalid fault injection specification\n", aProgram);
+            retval = false;
+        }
+        break;
+    }
 #endif
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -765,7 +765,12 @@ public:
     // onSuccess nor onFailure will be called.
     bool ExtendArmFailSafe(DeviceProxy * proxy, CommissioningStage step, uint16_t armFailSafeTimeout,
                            Optional<System::Clock::Timeout> commandTimeout, OnExtendFailsafeSuccess onSuccess,
-                           OnExtendFailsafeFailure onFailure);
+                           OnExtendFailsafeFailure onFailure)
+    {
+        // If this method is called directly by a client, assume it's not tracked as a commissioning stage
+        return ExtendArmFailSafeInternal(proxy, step, armFailSafeTimeout, commandTimeout, onSuccess, onFailure,
+                                         /* useContext = */ false);
+    }
 
 private:
     DevicePairingDelegate * mPairingDelegate = nullptr;
@@ -957,11 +962,15 @@ private:
     CommissioneeDeviceProxy * FindCommissioneeDevice(const Transport::PeerAddress & peerAddress);
     void ReleaseCommissioneeDevice(CommissioneeDeviceProxy * device);
 
+    bool ExtendArmFailSafeInternal(DeviceProxy * proxy, CommissioningStage step, uint16_t armFailSafeTimeout,
+                                   Optional<System::Clock::Timeout> commandTimeout, OnExtendFailsafeSuccess onSuccess,
+                                   OnExtendFailsafeFailure onFailure, bool useContext = true);
+
     template <typename RequestObjectT>
     CHIP_ERROR SendCommissioningCommand(DeviceProxy * device, const RequestObjectT & request,
                                         CommandResponseSuccessCallback<typename RequestObjectT::ResponseType> successCb,
                                         CommandResponseFailureCallback failureCb, EndpointId endpoint,
-                                        Optional<System::Clock::Timeout> timeout);
+                                        Optional<System::Clock::Timeout> timeout, bool useContext = true);
     void SendCommissioningReadRequest(DeviceProxy * proxy, Optional<System::Clock::Timeout> timeout,
                                       app::AttributePathParams * readPaths, size_t readPathsSize);
     void CancelCommissioningInteractions();

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -965,6 +965,7 @@ private:
     void SendCommissioningReadRequest(DeviceProxy * proxy, Optional<System::Clock::Timeout> timeout,
                                       app::AttributePathParams * readPaths, size_t readPathsSize);
     void CancelCommissioningInteractions();
+    void CancelCASECallbacks();
 
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
     void ParseCommissioningInfo();

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -767,9 +767,9 @@ public:
                            Optional<System::Clock::Timeout> commandTimeout, OnExtendFailsafeSuccess onSuccess,
                            OnExtendFailsafeFailure onFailure)
     {
-        // If this method is called directly by a client, assume it's not tracked as a commissioning stage
+        // If this method is called directly by a client, assume it's fire-and-forget (not a commissioning stage)
         return ExtendArmFailSafeInternal(proxy, step, armFailSafeTimeout, commandTimeout, onSuccess, onFailure,
-                                         /* useContext = */ false);
+                                         /* fireAndForget = */ true);
     }
 
 private:
@@ -964,13 +964,13 @@ private:
 
     bool ExtendArmFailSafeInternal(DeviceProxy * proxy, CommissioningStage step, uint16_t armFailSafeTimeout,
                                    Optional<System::Clock::Timeout> commandTimeout, OnExtendFailsafeSuccess onSuccess,
-                                   OnExtendFailsafeFailure onFailure, bool useContext = true);
+                                   OnExtendFailsafeFailure onFailure, bool fireAndForget = false);
 
     template <typename RequestObjectT>
     CHIP_ERROR SendCommissioningCommand(DeviceProxy * device, const RequestObjectT & request,
                                         CommandResponseSuccessCallback<typename RequestObjectT::ResponseType> successCb,
                                         CommandResponseFailureCallback failureCb, EndpointId endpoint,
-                                        Optional<System::Clock::Timeout> timeout, bool useContext = true);
+                                        Optional<System::Clock::Timeout> timeout, bool fireAndForget = false);
     void SendCommissioningReadRequest(DeviceProxy * proxy, Optional<System::Clock::Timeout> timeout,
                                       app::AttributePathParams * readPaths, size_t readPathsSize);
     void CancelCommissioningInteractions();

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -964,7 +964,7 @@ private:
 
     bool ExtendArmFailSafeInternal(DeviceProxy * proxy, CommissioningStage step, uint16_t armFailSafeTimeout,
                                    Optional<System::Clock::Timeout> commandTimeout, OnExtendFailsafeSuccess onSuccess,
-                                   OnExtendFailsafeFailure onFailure, bool fireAndForget = false);
+                                   OnExtendFailsafeFailure onFailure, bool fireAndForget);
 
     template <typename RequestObjectT>
     CHIP_ERROR SendCommissioningCommand(DeviceProxy * device, const RequestObjectT & request,

--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -29,7 +29,7 @@
 // Fixture: chip-all-clusters-app --KVS "$(mktemp -t chip-test-kvs)" --interface-id -1 \
     --dac_provider credentials/development/commissioner_dut/struct_cd_origin_pid_vid_correct/test_case_vector.json \
     --product-id 32768 --discriminator 3839
-// CASE retry code paths can be tested using --faults chip_CASEServerBusy_f1 (or similar)
+// For manual testing, CASE retry code paths can be tested by adding --faults chip_CASEServerBusy_f1 (or similar)
 
 static const uint16_t kPairingTimeoutInSeconds = 10;
 static const uint16_t kTimeoutInSeconds = 3;

--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -29,6 +29,7 @@
 // Fixture: chip-all-clusters-app --KVS "$(mktemp -t chip-test-kvs)" --interface-id -1 \
     --dac_provider credentials/development/commissioner_dut/struct_cd_origin_pid_vid_correct/test_case_vector.json \
     --product-id 32768 --discriminator 3839
+// CASE retry code paths can be tested using --faults chip_CASEServerBusy_f1 (or similar)
 
 static const uint16_t kPairingTimeoutInSeconds = 10;
 static const uint16_t kTimeoutInSeconds = 3;
@@ -243,6 +244,7 @@ static MTRTestKeys * sTestKeys = nil;
 - (void)doPairingAndWaitForProgress:(NSString *)trigger
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Trigger message seen"];
+    expectation.assertForOverFulfill = NO;
     MTRSetLogCallback(MTRLogTypeDetail, ^(MTRLogType type, NSString * moduleName, NSString * message) {
         if ([message containsString:trigger]) {
             [expectation fulfill];
@@ -296,6 +298,12 @@ static MTRTestKeys * sTestKeys = nil;
 - (void)test006_pairingAfterCancellation_ConfigRegulatoryCommand
 {
     [self doPairingTestAfterCancellationAtProgress:@"Performing next commissioning step 'ConfigRegulatory'"];
+}
+
+- (void)test007_pairingAfterCancellation_FindOperational
+{
+    // Ensure CASE establishment has started by waiting for 'FindOrEstablishSession'
+    [self doPairingTestAfterCancellationAtProgress:@"FindOrEstablishSession:"];
 }
 
 @end

--- a/src/lib/support/CHIPFaultInjection.cpp
+++ b/src/lib/support/CHIPFaultInjection.cpp
@@ -53,6 +53,7 @@ static const nl::FaultInjection::Name sFaultNames[] = {
 #if CONFIG_NETWORK_LAYER_BLE
     "CHIPOBLESend",
 #endif // CONFIG_NETWORK_LAYER_BLE
+    "CASEServerBusy",
 };
 
 /**

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -71,7 +71,8 @@ typedef enum
                                         with 1 InvokeResponseMessage, dropping the response to the second request */
 #if CONFIG_NETWORK_LAYER_BLE
     kFault_CHIPOBLESend, /**< Inject a GATT error when sending the first fragment of a chip message over BLE */
-#endif                   // CONFIG_NETWORK_LAYER_BLE
+#endif
+    kFault_CASEServerBusy, /**< Respond to CASE_Sigma1 with a BUSY status */
     kFault_NumItems,
 } Id;
 

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -18,6 +18,7 @@
 #include <protocols/secure_channel/CASEServer.h>
 
 #include <lib/core/CHIPError.h>
+#include <lib/support/CHIPFaultInjection.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -79,7 +80,10 @@ CHIP_ERROR CASEServer::OnMessageReceived(Messaging::ExchangeContext * ec, const 
                                          System::PacketBufferHandle && payload)
 {
     MATTER_TRACE_SCOPE("OnMessageReceived", "CASEServer");
-    if (GetSession().GetState() != CASESession::State::kInitialized)
+
+    bool busy = GetSession().GetState() != CASESession::State::kInitialized;
+    CHIP_FAULT_INJECT(FaultInjection::kFault_CASEServerBusy, busy = true);
+    if (busy)
     {
         // We are in the middle of CASE handshake
 


### PR DESCRIPTION
Only pass a context into ExtendArmFailSafe callbacks and track them as the
current cancelable invocation when it is actually a part of the sequential
commissioning flow. Treat as "fire and forget" when the method is called by an
external client, or when we're handling CASE retries.

Fixes #32521

Also manage CASE callbacks accurately
- Ensure all callbacks are unregistered once CASE setup is done.
- Cancel CASE setup callbacks on StopPairing.

Add CASEServerBusy fault injection point and handle `--faults` in example apps when building with fault injection.
