### PR TITLE
Remove redundant SetValue() for Optional ExchangeHandle in CASESession.cpp

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -2106,7 +2106,6 @@ CHIP_ERROR CASESession::ValidateReceivedMessage(ExchangeContext * ec, const Payl
     }
     else
     {
-        mExchangeCtxt.SetValue(ExchangeHandle(*ec));
         mExchangeCtxt.Emplace(*ec);
     }
     mExchangeCtxt.Value()->UseSuggestedResponseTimeout(kExpectedHighProcessingTime);


### PR DESCRIPTION
This is an addendum to PR #32499.

Fix for #32498. 

