### PR TITLE
Make it possible to dynamically set the "sender boost" for MRP.

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -47,6 +47,10 @@ using namespace chip::System::Clock::Literals;
 namespace chip {
 namespace Messaging {
 
+#if CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
+Optional<System::Clock::Milliseconds64> ReliableMessageMgr::sAdditionalMRPBackoffTime;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
+
 ReliableMessageMgr::RetransTableEntry::RetransTableEntry(ReliableMessageContext * rc) :
     ec(*rc->GetExchangeContext()), nextRetransTime(0), sendCount(0)
 {
@@ -263,7 +267,11 @@ System::Clock::Timestamp ReliableMessageMgr::GetBackoff(System::Clock::Timestamp
     mrpBackoffTime += ICDConfigurationData::GetInstance().GetFastPollingInterval();
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
+    mrpBackoffTime += sAdditionalMRPBackoffTime.ValueOr(CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST);
+#else
     mrpBackoffTime += CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
 
     return mrpBackoffTime;
 }

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 
 #include <lib/core/CHIPError.h>
+#include <lib/core/Optional.h>
 #include <lib/support/BitFlags.h>
 #include <lib/support/Pool.h>
 #include <messaging/ExchangeContext.h>
@@ -205,6 +206,26 @@ public:
     }
 #endif // CHIP_CONFIG_TEST
 
+#if CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
+    /**
+     * Set the value to add to the MRP backoff time we compute.  This is meant to
+     * account for high network latency on the sending side (us) that can't be
+     * known to the message recipient and hence is not captured in the MRP
+     * parameters the message recipient communicates to us.
+     *
+     * If set to NullOptional falls back to the compile-time
+     * CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST.
+     *
+     * This is a static, not a regular member, because API consumers may need to
+     * set this before actually bringing up the stack and having access to a
+     * ReliableMessageMgr.
+     */
+    static void SetAdditionaMRPBackoffTime(const Optional<System::Clock::Milliseconds64> & additionalTime)
+    {
+        sAdditionalMRPBackoffTime = additionalTime;
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
+
 private:
     /**
      * Calculates the next retransmission time for the entry
@@ -233,6 +254,10 @@ private:
     ObjectPool<RetransTableEntry, CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE> mRetransTable;
 
     SessionUpdateDelegate * mSessionUpdateDelegate = nullptr;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
+    static Optional<System::Clock::Milliseconds64> sAdditionalMRPBackoffTime;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG
 };
 
 } // namespace Messaging


### PR DESCRIPTION
CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST is a compile-time constant meant to capture the fact that we might be on a high-latency radio connection.  But the same binary might be used on different types of hardware that have different MRP requirements.  This change makes it possible to control the behavior CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST is used for at run time, based on the actual hardware involved, not just at compile time.  The new functionality is gated by the default-off CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG compiler flag, so only systems that really need it pay the cost for it.

