### PR TITLE
Don't define __STDC_{FORMAT,LIMIT}_MACROS

### DIFF
--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -25,9 +25,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
 #include <stdint.h>
 #include <string.h>
 

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -47,9 +47,6 @@
 
 #pragma once
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
 #include <stdint.h>
 
 #include <ble/BleConfig.h>

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -27,10 +27,6 @@
 
 #pragma once
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <stdint.h>
 #include <string.h>
 

--- a/src/ble/tests/TestBleErrorStr.cpp
+++ b/src/ble/tests/TestBleErrorStr.cpp
@@ -24,14 +24,6 @@
  *
  */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <inttypes.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -25,13 +25,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 // module header, comes first
 #include <controller/CHIPDeviceController.h>
 

--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -25,10 +25,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <stddef.h>
 
 #include <credentials/CHIPCert_Internal.h>

--- a/src/credentials/CHIPCertFromX509.cpp
+++ b/src/credentials/CHIPCertFromX509.cpp
@@ -24,10 +24,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <stddef.h>
 
 #include <credentials/CHIPCert.h>

--- a/src/credentials/CHIPCertToX509.cpp
+++ b/src/credentials/CHIPCertToX509.cpp
@@ -24,10 +24,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <inttypes.h>
 #include <stddef.h>
 

--- a/src/credentials/GenerateChipX509Cert.cpp
+++ b/src/credentials/GenerateChipX509Cert.cpp
@@ -22,10 +22,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <algorithm>
 #include <initializer_list>
 #include <inttypes.h>

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -23,9 +23,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
 #include <limits>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -27,10 +27,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <inet/IPAddress.h>
 
 #include <inet/InetError.h>

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -23,10 +23,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <inet/InetInterface.h>
 
 #include <inet/IPPrefix.h>

--- a/src/inet/tests/TestInetCommon.h
+++ b/src/inet/tests/TestInetCommon.h
@@ -30,10 +30,6 @@
 
 #pragma once
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <ctype.h>
 #include <time.h>
 

--- a/src/inet/tests/TestInetCommonOptions.cpp
+++ b/src/inet/tests/TestInetCommonOptions.cpp
@@ -23,13 +23,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include "TestInetCommonOptions.h"
 
 #include <assert.h>

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -27,13 +27,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include "TestInetCommon.h"
 #include "TestInetCommonOptions.h"
 

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -24,10 +24,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <errno.h>
 #include <inttypes.h>
 #include <stdint.h>

--- a/src/inet/tests/TestInetErrorStr.cpp
+++ b/src/inet/tests/TestInetErrorStr.cpp
@@ -24,14 +24,6 @@
  *
  */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <inttypes.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -25,10 +25,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <signal.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/lib/asn1/ASN1Writer.cpp
+++ b/src/lib/asn1/ASN1Writer.cpp
@@ -24,9 +24,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
 #include <ctype.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/lib/core/ErrorStr.cpp
+++ b/src/lib/core/ErrorStr.cpp
@@ -17,10 +17,6 @@
  */
 #include <lib/core/ErrorStr.h>
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/DLLUtil.h>

--- a/src/lib/core/TLVCircularBuffer.cpp
+++ b/src/lib/core/TLVCircularBuffer.cpp
@@ -28,10 +28,6 @@
  */
 #include <lib/core/TLVCircularBuffer.h>
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <lib/core/CHIPError.h>
 #include <lib/core/TLVReader.h>
 #include <lib/core/TLVTags.h>

--- a/src/lib/core/TLVDebug.cpp
+++ b/src/lib/core/TLVDebug.cpp
@@ -17,10 +17,6 @@
  */
 #include <lib/core/TLVDebug.h>
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <inttypes.h>
 
 #include <lib/core/CHIPError.h>

--- a/src/lib/core/TLVWriter.cpp
+++ b/src/lib/core/TLVWriter.cpp
@@ -17,10 +17,6 @@
  */
 #include <lib/core/TLVWriter.h>
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/lib/core/tests/TestCHIPErrorStr.cpp
+++ b/src/lib/core/tests/TestCHIPErrorStr.cpp
@@ -24,14 +24,6 @@
  *
  */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <inttypes.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/lib/support/Base64.cpp
+++ b/src/lib/support/Base64.cpp
@@ -22,9 +22,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
 #include "Base64.h"
 
 #include <ctype.h>

--- a/src/lib/support/CHIPArgParser.cpp
+++ b/src/lib/support/CHIPArgParser.cpp
@@ -23,13 +23,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include "CHIPArgParser.hpp"
 
 #if CHIP_CONFIG_ENABLE_ARG_PARSER

--- a/src/lib/support/TimeUtils.cpp
+++ b/src/lib/support/TimeUtils.cpp
@@ -23,9 +23,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
 #include <limits>
 #include <stdint.h>
 #include <type_traits>

--- a/src/lib/support/tests/TestPersistedCounter.cpp
+++ b/src/lib/support/tests/TestPersistedCounter.cpp
@@ -23,10 +23,6 @@
  *
  */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
 #include <map>
 #include <string>
 

--- a/src/lwip/standalone/arch/cc.h
+++ b/src/lwip/standalone/arch/cc.h
@@ -52,10 +52,6 @@
 #ifndef __ARCH_CC_H__
 #define __ARCH_CC_H__
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 /* Include some files for defining library routines */
 #include <inttypes.h>
 #include <limits.h>

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -20,13 +20,6 @@
  *      This file implements the ExchangeContext class.
  *
  */
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
 
 #include <inttypes.h>
 #include <stdint.h>

--- a/src/messaging/ExchangeMessageDispatch.cpp
+++ b/src/messaging/ExchangeMessageDispatch.cpp
@@ -20,14 +20,6 @@
  *      This file provides implementation of ExchangeMessageDispatch class.
  */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <errno.h>
 #include <inttypes.h>
 #include <memory>

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -21,14 +21,6 @@
  *
  */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <cstring>
 #include <inttypes.h>
 #include <stddef.h>

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -23,10 +23,6 @@
  *      mechanisms for manipulating packets of octet-serialized
  *      data.
  */
-// Include standard C library limit macros
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
 
 // Include module header
 #include <system/SystemPacketBuffer.h>
@@ -614,7 +610,7 @@ void PacketBuffer::Free(PacketBuffer * aPacket)
 #elif CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
             chip::Platform::MemoryFree(aPacket);
 #endif
-            aPacket       = lNextPacket;
+            aPacket = lNextPacket;
         }
         else
         {

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -610,7 +610,7 @@ void PacketBuffer::Free(PacketBuffer * aPacket)
 #elif CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP
             chip::Platform::MemoryFree(aPacket);
 #endif
-            aPacket = lNextPacket;
+            aPacket       = lNextPacket;
         }
         else
         {

--- a/src/system/SystemStats.h
+++ b/src/system/SystemStats.h
@@ -24,11 +24,6 @@
 
 #pragma once
 
-// Include standard C library limit macros
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 // Include configuration headers
 #include <inet/InetConfig.h>
 #include <lib/core/CHIPConfig.h>

--- a/src/system/tests/TestSystemClock.cpp
+++ b/src/system/tests/TestSystemClock.cpp
@@ -15,10 +15,6 @@
  *    limitations under the License.
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <system/SystemConfig.h>
 
 #include <lib/core/ErrorStr.h>

--- a/src/system/tests/TestSystemErrorStr.cpp
+++ b/src/system/tests/TestSystemErrorStr.cpp
@@ -24,14 +24,6 @@
  *
  */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <inttypes.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -23,10 +23,6 @@
  *      structure for network packet buffer management.
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -23,10 +23,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <system/SystemConfig.h>
 
 #include <lib/core/ErrorStr.h>

--- a/src/system/tests/TestSystemWakeEvent.cpp
+++ b/src/system/tests/TestSystemWakeEvent.cpp
@@ -21,10 +21,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <system/SystemConfig.h>
 
 #include <lib/core/ErrorStr.h>

--- a/src/system/tests/TestTimeSource.cpp
+++ b/src/system/tests/TestTimeSource.cpp
@@ -21,10 +21,6 @@
  *    the ability to compile and use the test implementation of the time source.
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <system/SystemConfig.h>
 
 #include <lib/core/ErrorStr.h>

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -24,8 +24,6 @@
  *
  */
 
-#define __STDC_FORMAT_MACROS
-
 #include "chip-cert.h"
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/BytesToHex.h>

--- a/src/tools/chip-cert/Cmd_GenAttCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenAttCert.cpp
@@ -23,10 +23,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include "chip-cert.h"
 
 #include <lib/support/SafeInt.h>

--- a/src/tools/chip-cert/Cmd_GenCD.cpp
+++ b/src/tools/chip-cert/Cmd_GenCD.cpp
@@ -23,10 +23,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include "chip-cert.h"
 
 #include <credentials/CertificationDeclaration.h>

--- a/src/tools/chip-cert/Cmd_GenCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenCert.cpp
@@ -24,10 +24,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include "chip-cert.h"
 
 namespace {

--- a/src/tools/chip-cert/Cmd_ResignCert.cpp
+++ b/src/tools/chip-cert/Cmd_ResignCert.cpp
@@ -24,10 +24,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include "chip-cert.h"
 
 namespace {

--- a/src/tools/spake2p/Cmd_GenVerifier.cpp
+++ b/src/tools/spake2p/Cmd_GenVerifier.cpp
@@ -23,10 +23,6 @@
  *
  */
 
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include "spake2p.h"
 
 #include <errno.h>

--- a/src/transport/raw/tests/TestPeerAddress.cpp
+++ b/src/transport/raw/tests/TestPeerAddress.cpp
@@ -17,14 +17,6 @@
  *    limitations under the License.
  */
 
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS
-#endif
-
-#ifndef __STDC_LIMIT_MACROS
-#define __STDC_LIMIT_MACROS
-#endif
-
 #include <inttypes.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
The need for this workaround was removed in glibc years ago.

See https://sourceware.org/bugzilla/show_bug.cgi?id=15366
