### PR TITLE
[Silabs] Add used attribute to two functions

### DIFF
--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -82,7 +82,7 @@ void OnSoftwareFaultEventHandler(const char * faultRecordString)
 /**
  * Log register contents to UART when a hard fault occurs.
  */
-extern "C" void debugHardfault(uint32_t * sp)
+extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
 {
 #if SILABS_LOG_ENABLED
     uint32_t cfsr  = SCB->CFSR;

--- a/examples/platform/silabs/heap_4_silabs.c
+++ b/examples/platform/silabs/heap_4_silabs.c
@@ -647,7 +647,7 @@ void * __wrap_realloc(void * ptr, size_t new_size)
     return pvPortRealloc(ptr, new_size);
 }
 
-void * __wrap_calloc(size_t num, size_t size)
+__attribute__((used)) void * __wrap_calloc(size_t num, size_t size)
 {
     return pvPortCalloc(num, size);
 }


### PR DESCRIPTION
mini PR to resolve linker error when using GCC LTO option.

