### PR TITLE
Log node ID in exchanges

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -463,7 +463,7 @@
 
 /**
  *  @def CHIP_EXCHANGE_NODE_ID_LOGGING
- * 
+ *
  *  @brief
  *    If asserted (1), enable logging of node IDs in exchange context.
  */

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -462,6 +462,16 @@
 #endif // CHIP_CONFIG_ENABLE_CONDITION_LOGGING
 
 /**
+ *  @def CHIP_EXCHANGE_NODE_ID_LOGGING
+ * 
+ *  @brief
+ *    If asserted (1), enable logging of node IDs in exchange context.
+ */
+#ifndef CHIP_EXCHANGE_NODE_ID_LOGGING
+#define CHIP_EXCHANGE_NODE_ID_LOGGING 0
+#endif // CHIP_EXCHANGE_NODE_ID_LOGGING
+
+/**
  *  @def CHIP_CONFIG_TEST
  *
  *  @brief

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -268,9 +268,8 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
 #define ChipLogValueMEI(aValue) static_cast<uint16_t>(aValue >> 16), static_cast<uint16_t>(aValue)
 
 /**
- * Logging helpers for exchanges.  For now just log the exchange id and whether
- * it's an initiator or responder, but eventually we may want to log the peer
- * node id as well (especially for the responder case).  Some callsites only
+ * Logging helpers for exchanges.  Log the exchange id, whether
+ * it's an initiator or responder and the peer node id.  Some callsites only
  * have the exchange id and initiator/responder boolean, not an actual exchange,
  * so we want to have a helper for that case too.
  */

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -276,8 +276,14 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
  */
 #define ChipLogFormatExchangeId "%u%c"
 #define ChipLogValueExchangeId(id, isInitiator) id, ((isInitiator) ? 'i' : 'r')
-#define ChipLogFormatExchange ChipLogFormatExchangeId
-#define ChipLogValueExchange(ec) ChipLogValueExchangeId((ec)->GetExchangeId(), (ec)->IsInitiator())
+#define ChipLogFormateExchangeNode "[%u:" ChipLogFormatX64 "]"
+#define ChipLogValueExchangeNode(fabric, id) fabric, ChipLogValueX64(id)
+#define ChipLogFormatExchange ChipLogFormatExchangeId " to: " ChipLogFormateExchangeNode
+#define ChipLogValueExchange(ec) ChipLogValueExchangeId((ec)->GetExchangeId(), (ec)->IsInitiator()),                               \
+    ChipLogValueExchangeNode(                                                                                                      \
+        ((ec)->HasSessionHandle() ? (ec)->GetSessionHandle()->GetSubjectDescriptor().fabricIndex : kUndefinedFabricIndex),         \
+        ((ec)->HasSessionHandle() ? (ec)->GetSessionHandle()->GetSubjectDescriptor().subject : kUndefinedNodeId))   
+
 #define ChipLogValueExchangeIdFromSentHeader(payloadHeader)                                                                        \
     ChipLogValueExchangeId((payloadHeader).GetExchangeID(), (payloadHeader).IsInitiator())
 // A received header's initiator boolean is the inverse of the exchange's.

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -269,19 +269,15 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
 
 /**
  * Logging helpers for exchanges.  Log the exchange id, whether
- * it's an initiator or responder and the peer node id.  Some callsites only
+ * it's an initiator or responder and the scoped node.  Some callsites only
  * have the exchange id and initiator/responder boolean, not an actual exchange,
  * so we want to have a helper for that case too.
  */
 #define ChipLogFormatExchangeId "%u%c"
 #define ChipLogValueExchangeId(id, isInitiator) id, ((isInitiator) ? 'i' : 'r')
-#define ChipLogFormateExchangeNode "[%u:" ChipLogFormatX64 "]"
-#define ChipLogValueExchangeNode(fabric, id) fabric, ChipLogValueX64(id)
-#define ChipLogFormatExchange ChipLogFormatExchangeId " to: " ChipLogFormateExchangeNode
+#define ChipLogFormatExchange ChipLogFormatExchangeId " " ChipLogFormatScopedNodeId
 #define ChipLogValueExchange(ec) ChipLogValueExchangeId((ec)->GetExchangeId(), (ec)->IsInitiator()),                               \
-    ChipLogValueExchangeNode(                                                                                                      \
-        ((ec)->HasSessionHandle() ? (ec)->GetSessionHandle()->GetSubjectDescriptor().fabricIndex : kUndefinedFabricIndex),         \
-        ((ec)->HasSessionHandle() ? (ec)->GetSessionHandle()->GetSubjectDescriptor().subject : kUndefinedNodeId))   
+    ChipLogValueScopedNodeId((ec)->HasSessionHandle() ? (ec)->GetSessionHandle()->GetPeer() : ScopedNodeId())
 
 #define ChipLogValueExchangeIdFromSentHeader(payloadHeader)                                                                        \
     ChipLogValueExchangeId((payloadHeader).GetExchangeID(), (payloadHeader).IsInitiator())

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -275,9 +275,15 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
  */
 #define ChipLogFormatExchangeId "%u%c"
 #define ChipLogValueExchangeId(id, isInitiator) id, ((isInitiator) ? 'i' : 'r')
-#define ChipLogFormatExchange ChipLogFormatExchangeId " " ChipLogFormatScopedNodeId
+
+#if CHIP_EXCHANGE_NODE_ID_LOGGING
+#define ChipLogFormatExchange ChipLogFormatExchangeId " with Node: " ChipLogFormatScopedNodeId
 #define ChipLogValueExchange(ec) ChipLogValueExchangeId((ec)->GetExchangeId(), (ec)->IsInitiator()),                               \
     ChipLogValueScopedNodeId((ec)->HasSessionHandle() ? (ec)->GetSessionHandle()->GetPeer() : ScopedNodeId())
+#else // CHIP_EXCHANGE_NODE_ID_LOGGING
+#define ChipLogFormatExchange ChipLogFormatExchangeId
+#define ChipLogValueExchange(ec) ChipLogValueExchangeId((ec)->GetExchangeId(), (ec)->IsInitiator())
+#endif // CHIP_EXCHANGE_NODE_ID_LOGGING
 
 #define ChipLogValueExchangeIdFromSentHeader(payloadHeader)                                                                        \
     ChipLogValueExchangeId((payloadHeader).GetExchangeID(), (payloadHeader).IsInitiator())

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -278,8 +278,9 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
 
 #if CHIP_EXCHANGE_NODE_ID_LOGGING
 #define ChipLogFormatExchange ChipLogFormatExchangeId " with Node: " ChipLogFormatScopedNodeId
-#define ChipLogValueExchange(ec) ChipLogValueExchangeId((ec)->GetExchangeId(), (ec)->IsInitiator()),                               \
-    ChipLogValueScopedNodeId((ec)->HasSessionHandle() ? (ec)->GetSessionHandle()->GetPeer() : ScopedNodeId())
+#define ChipLogValueExchange(ec)                                                                                                   \
+    ChipLogValueExchangeId((ec)->GetExchangeId(), (ec)->IsInitiator()),                                                            \
+        ChipLogValueScopedNodeId((ec)->HasSessionHandle() ? (ec)->GetSessionHandle()->GetPeer() : ScopedNodeId())
 #else // CHIP_EXCHANGE_NODE_ID_LOGGING
 #define ChipLogFormatExchange ChipLogFormatExchangeId
 #define ChipLogValueExchange(ec) ChipLogValueExchangeId((ec)->GetExchangeId(), (ec)->IsInitiator())


### PR DESCRIPTION
Previously, the SDK only recorded the exchange ID when logging information about exchanges, as illustrated by the following example:
`Failed to Send CHIP MessageCounter:68460922 on exchange 30872i sendCount: 4 max retries: 4` 
To enable more precise troubleshooting, this PR proposes to also log the peer node ID. The proposed log format change is as follows:
` Dropping unexpected message of type 0x1 with protocolId (0, 1) and MessageCounter:43669734 on exchange 11672r to: [1:0000000012344321]`
I have used the same format as here: 
https://github.com/project-chip/connectedhomeip/blob/ad14dbc9b5b1c8230bd29be4873f9367143bfc31/src/app/OperationalSessionSetup.cpp#L53

Further Context:
The HomeAssistant Matter server frequently logs the mentioned message when adding Nanoleaf Matter devices into the thread network. This situation has sparked debates regarding the source of the error – whether it is exclusive to Nanoleaf devices or  all devices relaying traffic through them, leading to timeout issues. This enhancement aims to provide clearer insights into such occurrences.