### PR TITLE
Not call OnReadCommissioningInfo when error happens

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1983,7 +1983,7 @@ void DeviceCommissioner::ParseCommissioningInfo()
     // return.
     auto attributeCache = std::move(mAttributeCache);
 
-    if (mPairingDelegate != nullptr)
+    if (mPairingDelegate != nullptr && err == CHIP_NO_ERROR)
     {
         mPairingDelegate->OnReadCommissioningInfo(info);
     }


### PR DESCRIPTION
When there is error, the info is garbage data, we should not call OnReadCommissioningInfo
fixes: https://github.com/project-chip/connectedhomeip/issues/30992
