### PR TITLE
Add a way for a client to know if the device cache is primed in Darwin

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -70,7 +70,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * This verifies that both the MTRDeviceController has a storage delegate, and a subscription has been set up and the resulting state has been cached. If this is true this means most state is ready to cache and will not require a round trip to the accessory.
  *
  */
-@property (nonatomic, readonly) BOOL deviceCachePrimed;
+@property (readonly) BOOL deviceCachePrimed;
 
 /**
  * The estimated device system start time.

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -65,6 +65,14 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @property (nonatomic, readonly) MTRDeviceState state;
 
 /**
+ * Is the state cache primed for this device?
+ * 
+ * This verifies that both the MTRDeviceController has a storage delegate, and a subscription has been set up and the resulting state has been cached. If this is true this means most state is ready to cache and will not require a round trip to the accessory.
+ *
+ */
+@property (nonatomic, readonly) BOOL deviceCachePrimed;
+
+/**
  * The estimated device system start time.
  *
  * A device can report its events with either calendar time or time since system start time. When events are reported with time

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -66,7 +66,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 
 /**
  * Is the state cache primed for this device?
- * 
+ *
  * This verifies that both the MTRDeviceController has a storage delegate, and a subscription has been set up and the resulting state has been cached. If this is true this means most state is ready to cache and will not require a round trip to the accessory.
  *
  */

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -28,6 +28,7 @@
 #import "MTRCommandTimedCheck.h"
 #import "MTRConversion.h"
 #import "MTRDefines_Internal.h"
+#import "MTRUnfairLock.h"
 #import "MTRDeviceController_Internal.h"
 #import "MTRDevice_Internal.h"
 #import "MTRError_Internal.h"

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2019,15 +2019,8 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
 - (BOOL)deviceCachePrimed
 {
-    BOOL isPrimed = NO;
-
-    os_unfair_lock_lock(&self->_lock);
-
-    isPrimed = [self _isCachePrimedWithInitialConfigurationData];
-
-    os_unfair_lock_unlock(&self->_lock);
-
-    return isPrimed;
+    std::lock_guard lock(_lock);
+    return [self _isCachePrimedWithInitialConfigurationData];
 }
 
 // If value is non-nil, associate with expectedValueID

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2017,6 +2017,18 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     os_unfair_lock_unlock(&self->_lock);
 }
 
+- (BOOL)deviceCachePrimed {
+    BOOL isPrimed = NO;
+    
+    os_unfair_lock_lock(&self->_lock);
+
+    isPrimed = [self _isCachePrimedWithInitialConfigurationData];
+
+    os_unfair_lock_unlock(&self->_lock);
+
+    return isPrimed;
+}
+
 // If value is non-nil, associate with expectedValueID
 // If value is nil, remove only if expectedValueID matches
 // previousValue is an out parameter

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2019,7 +2019,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
 - (BOOL)deviceCachePrimed {
     BOOL isPrimed = NO;
-    
+
     os_unfair_lock_lock(&self->_lock);
 
     isPrimed = [self _isCachePrimedWithInitialConfigurationData];

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -28,12 +28,12 @@
 #import "MTRCommandTimedCheck.h"
 #import "MTRConversion.h"
 #import "MTRDefines_Internal.h"
-#import "MTRUnfairLock.h"
 #import "MTRDeviceController_Internal.h"
 #import "MTRDevice_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTREventTLVValueDecoder_Internal.h"
 #import "MTRLogging_Internal.h"
+#import "MTRUnfairLock.h"
 #import "zap-generated/MTRCommandPayloads_Internal.h"
 
 #include "lib/core/CHIPError.h"

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2017,7 +2017,8 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     os_unfair_lock_unlock(&self->_lock);
 }
 
-- (BOOL)deviceCachePrimed {
+- (BOOL)deviceCachePrimed
+{
     BOOL isPrimed = NO;
 
     os_unfair_lock_lock(&self->_lock);


### PR DESCRIPTION
Right now clients are called back when the cache is primed, but they have no way to know if it already was.