### PR TITLE
Darwin: Clean up includes/imports

### DIFF
--- a/examples/darwin-framework-tool/commands/common/MTRError.mm
+++ b/examples/darwin-framework-tool/commands/common/MTRError.mm
@@ -19,9 +19,9 @@
 #import "MTRLogging.h"
 #import <Matter/Matter.h>
 
-#import <app/MessageDef/StatusIB.h>
-#import <inet/InetError.h>
-#import <lib/support/TypeTraits.h>
+#include <app/MessageDef/StatusIB.h>
+#include <inet/InetError.h>
+#include <lib/support/TypeTraits.h>
 
 #import <objc/runtime.h>
 

--- a/examples/darwin-framework-tool/commands/common/MTRError_Utils.h
+++ b/examples/darwin-framework-tool/commands/common/MTRError_Utils.h
@@ -16,11 +16,10 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Matter/Matter.h>
 
 #include <app/MessageDef/StatusIB.h>
 #include <lib/core/CHIPError.h>
-
-#include <Matter/Matter.h>
 
 CHIP_ERROR MTRErrorToCHIPErrorCode(NSError * error);
 id NSObjectFromCHIPTLV(chip::TLV::TLVReader * data);

--- a/src/darwin/Framework/CHIP/MTRAttributeSpecifiedCheck.h
+++ b/src/darwin/Framework/CHIP/MTRAttributeSpecifiedCheck.h
@@ -16,10 +16,6 @@
  *    limitations under the License.
  */
 
-#pragma once
-
-#import <Foundation/Foundation.h>
-
 #include <lib/core/DataModelTypes.h>
 
 BOOL MTRAttributeIsSpecified(chip::ClusterId aClusterId, chip::AttributeId aAttributeId);

--- a/src/darwin/Framework/CHIP/MTRAttributeTLVValueDecoder_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRAttributeTLVValueDecoder_Internal.h
@@ -16,8 +16,6 @@
  *    limitations under the License.
  */
 
-#pragma once
-
 #import <Foundation/Foundation.h>
 
 #include <app/ConcreteAttributePath.h>

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-
 #import <Matter/MTRCluster.h>
 #import <Matter/MTRDefines.h>
 

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -14,16 +14,18 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#import "MTRBaseDevice_Internal.h"
+
+#import <Matter/MTRCluster.h>
 #import <Matter/MTRClusterConstants.h>
-#import <Matter/MTRDefines.h>
 
 #import "MTRAttributeTLVValueDecoder_Internal.h"
-#import "MTRBaseDevice_Internal.h"
 #import "MTRBaseSubscriptionCallback.h"
 #import "MTRCallbackBridgeBase.h"
-#import "MTRCluster.h"
 #import "MTRClusterStateCacheContainer_Internal.h"
 #import "MTRCluster_Internal.h"
+#import "MTRCommandPayloads_Internal.h"
 #import "MTRDevice_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTREventTLVValueDecoder_Internal.h"
@@ -32,24 +34,22 @@
 #import "MTRSetupPayload_Internal.h"
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"
-#import "zap-generated/MTRCommandPayloads_Internal.h"
-
-#include "app/ConcreteAttributePath.h"
-#include "app/ConcreteCommandPath.h"
-#include "app/ConcreteEventPath.h"
-#include "app/StatusResponse.h"
-#include "lib/core/CHIPError.h"
-#include "lib/core/DataModelTypes.h"
 
 #include <app/AttributePathParams.h>
 #include <app/BufferedReadCallback.h>
 #include <app/ClusterStateCache.h>
+#include <app/ConcreteAttributePath.h>
+#include <app/ConcreteCommandPath.h>
+#include <app/ConcreteEventPath.h>
 #include <app/InteractionModelEngine.h>
 #include <app/ReadClient.h>
+#include <app/StatusResponse.h>
 #include <controller/CommissioningWindowOpener.h>
 #include <controller/ReadInteraction.h>
 #include <controller/WriteInteraction.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/DataModelTypes.h>
 #include <setup_payload/SetupPayload.h>
 #include <system/SystemClock.h>
 

--- a/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
@@ -15,8 +15,7 @@
  *    limitations under the License.
  */
 
-#import "MTRBaseDevice.h"
-#import <Foundation/Foundation.h>
+#import <Matter/MTRBaseDevice.h>
 
 #include <app/AttributePathParams.h>
 #include <app/ConcreteAttributePath.h>

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -14,10 +14,7 @@
  *    limitations under the License.
  */
 
-#pragma once
-
-#import "Foundation/Foundation.h"
-#import "MTRBaseDevice.h"
+#import <Matter/MTRBaseDevice.h>
 
 #include <app/BufferedReadCallback.h>
 #include <app/ClusterStateCache.h>

--- a/src/darwin/Framework/CHIP/MTRCSRInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRCSRInfo.mm
@@ -15,7 +15,8 @@
  *    limitations under the License.
  */
 
-#import "MTRCSRInfo.h"
+#import <Matter/MTRCSRInfo.h>
+
 #import "MTRFramework.h"
 #import "MTRLogging_Internal.h"
 #import "NSDataSpanConversion.h"

--- a/src/darwin/Framework/CHIP/MTRCallbackBridgeBase.h
+++ b/src/darwin/Framework/CHIP/MTRCallbackBridgeBase.h
@@ -1,4 +1,4 @@
-/*
+/**
  *
  *    Copyright (c) 2021 Project CHIP Authors
  *
@@ -15,12 +15,11 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
+#import <Matter/MTRBaseClusters.h>
 
 #import "MTRBaseDevice_Internal.h"
 #import "MTRDeviceController_Internal.h"
 #import "MTRError_Internal.h"
-#import "zap-generated/MTRBaseClusters.h"
 
 #include <app/data-model/NullObject.h>
 #include <messaging/ExchangeMgr.h>

--- a/src/darwin/Framework/CHIP/MTRCertificateInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificateInfo.mm
@@ -1,4 +1,5 @@
 /**
+ *
  *    Copyright (c) 2023 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,7 @@
  *    limitations under the License.
  */
 
-#import "MTRCertificateInfo.h"
+#import <Matter/MTRCertificateInfo.h>
 
 #import "MTRConversion.h"
 #import "MTRDefines_Internal.h"

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -14,7 +14,8 @@
  *    limitations under the License.
  */
 
-#import "MTRCertificates.h"
+#import <Matter/MTRCertificates.h>
+
 #import "MTRError_Internal.h"
 #import "MTRFramework.h"
 #import "MTRLogging_Internal.h"

--- a/src/darwin/Framework/CHIP/MTRCluster.mm
+++ b/src/darwin/Framework/CHIP/MTRCluster.mm
@@ -15,8 +15,10 @@
  *    limitations under the License.
  */
 
-#import "MTRBaseDevice.h"
 #import "MTRCluster_Internal.h"
+
+#import <Matter/MTRBaseDevice.h>
+
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"
 

--- a/src/darwin/Framework/CHIP/MTRClusterNames.h
+++ b/src/darwin/Framework/CHIP/MTRClusterNames.h
@@ -16,8 +16,6 @@
  *    limitations under the License.
  */
 
-#pragma once
-
 #import <Matter/MTRClusterConstants.h>
 #import <Matter/MTRDefines.h>
 

--- a/src/darwin/Framework/CHIP/MTRClusterStateCacheContainer+XPC.h
+++ b/src/darwin/Framework/CHIP/MTRClusterStateCacheContainer+XPC.h
@@ -16,8 +16,7 @@
  */
 
 #import <Foundation/Foundation.h>
-
-#import "MTRClusterStateCacheContainer.h"
+#import <Matter/MTRClusterStateCacheContainer.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/MTRClusterStateCacheContainer.mm
+++ b/src/darwin/Framework/CHIP/MTRClusterStateCacheContainer.mm
@@ -15,14 +15,13 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
+#import "MTRClusterStateCacheContainer_Internal.h"
+
+#import <Matter/MTRCluster.h>
 
 #import "MTRBaseDevice_Internal.h"
-#import "MTRCluster.h"
-#import "MTRClusterStateCacheContainer_Internal.h"
 #import "MTRDeviceControllerXPCConnection.h"
 #import "MTRDeviceController_Internal.h"
-#import "MTRError.h"
 #import "MTRError_Internal.h"
 #import "MTRLogging_Internal.h"
 

--- a/src/darwin/Framework/CHIP/MTRClusterStateCacheContainer_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRClusterStateCacheContainer_Internal.h
@@ -15,9 +15,10 @@
  *    limitations under the License.
  */
 
+#import <Matter/MTRClusterStateCacheContainer.h>
+
 #import <Foundation/Foundation.h>
 
-#import "MTRClusterStateCacheContainer.h"
 #import "MTRDeviceControllerOverXPC.h"
 
 #include <app/ClusterStateCache.h>

--- a/src/darwin/Framework/CHIP/MTRCluster_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRCluster_Internal.h
@@ -15,10 +15,9 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
+#import <Matter/MTRCluster.h>
 
 #import <Matter/MTRBaseDevice.h>
-#import <Matter/MTRCluster.h>
 #import <Matter/MTRDevice.h>
 
 #import "MTRBaseDevice_Internal.h"

--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
@@ -16,9 +16,11 @@
  */
 
 #import "MTRCommissionableBrowser.h"
-#import "MTRCommissionableBrowserDelegate.h"
+
+#import <Matter/MTRCommissionableBrowserDelegate.h>
+#import <Matter/MTRDeviceController.h>
+
 #import "MTRCommissionableBrowserResult_Internal.h"
-#import "MTRDeviceController.h"
 #import "MTRLogging_Internal.h"
 
 #include <controller/CHIPDeviceController.h>

--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowserResult_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowserResult_Internal.h
@@ -15,10 +15,9 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-#import <Matter/MTRDefines.h>
+#import <Matter/MTRCommissionableBrowserResult.h>
 
-#import "MTRCommissionableBrowserResult.h"
+#import <Foundation/Foundation.h>
 
 #include <controller/SetUpCodePairer.h>
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-#import "MTRCommissioningParameters.h"
+#import <Matter/MTRCommissioningParameters.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -15,35 +15,35 @@
  *    limitations under the License.
  */
 
-#import <Matter/MTRDefines.h>
-#import <os/lock.h>
+#import "MTRDevice_Internal.h"
+
+#import <Matter/MTRBaseClusters.h>
+#import <Matter/MTRCluster.h>
+#import <Matter/MTRClusterConstants.h>
 
 #import "MTRAsyncWorkQueue.h"
 #import "MTRAttributeSpecifiedCheck.h"
-#import "MTRBaseClusters.h"
 #import "MTRBaseDevice_Internal.h"
 #import "MTRBaseSubscriptionCallback.h"
-#import "MTRCluster.h"
-#import "MTRClusterConstants.h"
+#import "MTRCommandPayloads_Internal.h"
 #import "MTRCommandTimedCheck.h"
 #import "MTRConversion.h"
 #import "MTRDefines_Internal.h"
 #import "MTRDeviceController_Internal.h"
-#import "MTRDevice_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTREventTLVValueDecoder_Internal.h"
 #import "MTRLogging_Internal.h"
 #import "MTRUnfairLock.h"
-#import "zap-generated/MTRCommandPayloads_Internal.h"
 
-#include "lib/core/CHIPError.h"
-#include "lib/core/DataModelTypes.h"
-#include <app/ConcreteAttributePath.h>
+#import <os/lock.h>
 
 #include <app/AttributePathParams.h>
 #include <app/BufferedReadCallback.h>
 #include <app/ClusterStateCache.h>
+#include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelEngine.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/DataModelTypes.h>
 #include <platform/PlatformManager.h>
 
 typedef void (^MTRDeviceAttributeReportHandler)(NSArray * _Nonnull);

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
@@ -15,11 +15,11 @@
  *    limitations under the License.
  */
 
+#import <Matter/MTRDeviceAttestationDelegate.h>
+
+#include <credentials/attestation_verifier/DeviceAttestationDelegate.h>
 #include <lib/core/NodeId.h>
 #include <platform/CHIPDeviceConfig.h>
-
-#include <Matter/MTRDeviceAttestationDelegate.h>
-#include <credentials/attestation_verifier/DeviceAttestationDelegate.h>
 
 @class MTRDeviceController;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate_Internal.h
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-#import "MTRDeviceAttestationDelegate.h"
+#import <Matter/MTRDeviceAttestationDelegate.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationInfo.mm
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-#import "MTRDeviceAttestationInfo.h"
+#import <Matter/MTRDeviceAttestationInfo.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/MTRDeviceConnectionBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceConnectionBridge.h
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-#import "MTRDeviceController.h"
+#import <Matter/MTRDeviceController.h>
 
 #import <Foundation/Foundation.h>
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController+XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController+XPC.mm
@@ -15,10 +15,11 @@
  *    limitations under the License.
  */
 
-#import "MTRDeviceController+XPC.h"
+#import <Matter/MTRDeviceController+XPC.h>
 
-#import "MTRBaseDevice.h"
-#import "MTRCluster.h"
+#import <Matter/MTRBaseDevice.h>
+#import <Matter/MTRCluster.h>
+
 #import "MTRDeviceControllerOverXPC.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-
 #import <Matter/MTRCommissionableBrowserDelegate.h>
 #import <Matter/MTRDefines.h>
 #import <Matter/MTROperationalCertificateIssuer.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -14,7 +14,14 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#import "MTRDeviceController_Internal.h"
+
+#import <Matter/MTRBaseClusters.h>
+#import <Matter/MTRCommissioningParameters.h>
 #import <Matter/MTRDefines.h>
+#import <Matter/MTRKeypair.h>
+#import <Matter/MTRSetupPayload.h>
 
 #if MTR_PER_CONTROLLER_STORAGE_ENABLED
 #import <Matter/MTRDeviceControllerParameters.h>
@@ -22,38 +29,26 @@
 #import "MTRDeviceControllerParameters_Wrapper.h"
 #endif // MTR_PER_CONTROLLER_STORAGE_ENABLED
 
-#import "MTRDeviceController_Internal.h"
-
 #import "MTRAttestationTrustStoreBridge.h"
 #import "MTRBaseDevice_Internal.h"
 #import "MTRCommissionableBrowser.h"
 #import "MTRCommissionableBrowserResult_Internal.h"
-#import "MTRCommissioningParameters.h"
 #import "MTRConversion.h"
+#import "MTRDeviceAttestationDelegateBridge.h"
+#import "MTRDeviceConnectionBridge.h"
 #import "MTRDeviceControllerDelegateBridge.h"
 #import "MTRDeviceControllerFactory_Internal.h"
 #import "MTRDeviceControllerLocalTestStorage.h"
-#import "MTRDeviceControllerStartupParams.h"
 #import "MTRDeviceControllerStartupParams_Internal.h"
 #import "MTRDevice_Internal.h"
 #import "MTRError_Internal.h"
-#import "MTRKeypair.h"
 #import "MTRLogging_Internal.h"
 #import "MTROperationalCredentialsDelegate.h"
 #import "MTRP256KeypairBridge.h"
 #import "MTRPersistentStorageDelegateBridge.h"
 #import "MTRServerEndpoint_Internal.h"
-#import "MTRSetupPayload.h"
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"
-#import <setup_payload/ManualSetupPayloadGenerator.h>
-#import <setup_payload/SetupPayload.h>
-#import <zap-generated/MTRBaseClusters.h>
-
-#import "MTRDeviceAttestationDelegateBridge.h"
-#import "MTRDeviceConnectionBridge.h"
-
-#include <platform/CHIPDeviceConfig.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/List.h>
@@ -67,14 +62,15 @@
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <inet/InetInterface.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
+#include <platform/CHIPDeviceConfig.h>
 #include <platform/LockTracker.h>
 #include <platform/PlatformManager.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
+#include <setup_payload/SetupPayload.h>
 #include <system/SystemClock.h>
 
-#include <atomic>
-#include <dns_sd.h>
-
+#import <atomic>
+#import <dns_sd.h>
 #import <os/lock.h>
 
 static NSString * const kErrorCommissionerInit = @"Init failure while initializing a commissioner";

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
@@ -14,10 +14,11 @@
  *    limitations under the License.
  */
 
-#include "MTRDeviceControllerDataStore.h"
+#import "MTRDeviceControllerDataStore.h"
 
 // Importing MTRBaseDevice.h for the MTRAttributePath class. Needs to change when https://github.com/project-chip/connectedhomeip/issues/31247 is fixed.
-#import "MTRBaseDevice.h"
+#import <Matter/MTRBaseDevice.h>
+
 #import "MTRLogging_Internal.h"
 
 #include <lib/core/CASEAuthTag.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-#import "MTRDeviceControllerDelegate.h"
+#import <Matter/MTRDeviceControllerDelegate.h>
 
 #include <controller/CHIPDeviceController.h>
 #include <controller/CommissioningDelegate.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -16,7 +16,7 @@
  */
 
 #import "MTRDeviceControllerDelegateBridge.h"
-#import "MTRDeviceController.h"
+
 #import "MTRDeviceController_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTRLogging_Internal.h"

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -14,10 +14,12 @@
  *    limitations under the License.
  */
 
-#import "MTRDeviceControllerFactory.h"
 #import "MTRDeviceControllerFactory_Internal.h"
 
+#import <Matter/MTRCertificates.h>
+#import <Matter/MTRClusterConstants.h>
 #import <Matter/MTRDefines.h>
+#import <Matter/MTRServerCluster.h>
 
 #if MTR_PER_CONTROLLER_STORAGE_ENABLED
 #import <Matter/MTRDeviceControllerParameters.h>
@@ -25,13 +27,7 @@
 #import "MTRDeviceControllerParameters_Wrapper.h"
 #endif // MTR_PER_CONTROLLER_STORAGE_ENABLED
 
-#import <Matter/MTRClusterConstants.h>
-#import <Matter/MTRServerCluster.h>
-
-#import "MTRCertificates.h"
 #import "MTRDemuxingStorage.h"
-#import "MTRDeviceController.h"
-#import "MTRDeviceControllerStartupParams.h"
 #import "MTRDeviceControllerStartupParams_Internal.h"
 #import "MTRDeviceController_Internal.h"
 #import "MTRDiagnosticLogsDownloader.h"

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
@@ -19,6 +19,8 @@
  * Mostly for use from MTRDeviceController.
  */
 
+#import <Matter/MTRDeviceControllerFactory.h>
+
 #import <Foundation/Foundation.h>
 #import <Matter/MTRAccessGrant.h>
 #import <Matter/MTRBaseDevice.h> // for MTRClusterPath
@@ -32,8 +34,6 @@
 #else
 #import "MTRDeviceControllerParameters_Wrapper.h"
 #endif // MTR_PER_CONTROLLER_STORAGE_ENABLED
-
-#import "MTRDeviceControllerFactory.h"
 
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/DataModelTypes.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.h
@@ -1,4 +1,3 @@
-//
 /**
  *    Copyright (c) 2023 Project CHIP Authors
  *
@@ -15,14 +14,16 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-#import <Matter/Matter.h>
+#import <Matter/MTRDeviceControllerStorageDelegate.h>
 
-#if MTR_PER_CONTROLLER_STORAGE_ENABLED
+#import "MTRDefines_Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-MTR_EXTERN @interface MTRDeviceControllerLocalTestStorage : NSObject<MTRDeviceControllerStorageDelegate>
+#if MTR_PER_CONTROLLER_STORAGE_ENABLED
+
+MTR_TESTABLE
+@interface MTRDeviceControllerLocalTestStorage : NSObject <MTRDeviceControllerStorageDelegate>
 
 // Setting this variable only affects subsequent MTRDeviceController initializations
 @property (class, nonatomic, assign) BOOL localTestStorageEnabled;
@@ -32,6 +33,6 @@ MTR_EXTERN @interface MTRDeviceControllerLocalTestStorage : NSObject<MTRDeviceCo
 
 @end
 
-NS_ASSUME_NONNULL_END
-
 #endif // MTR_PER_CONTROLLER_STORAGE_ENABLED
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
@@ -1,4 +1,3 @@
-//
 /**
  *    Copyright (c) 2023 Project CHIP Authors
  *
@@ -16,6 +15,7 @@
  */
 
 #import "MTRDeviceControllerLocalTestStorage.h"
+
 #import "MTRLogging_Internal.h"
 
 #if MTR_PER_CONTROLLER_STORAGE_ENABLED

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.mm
@@ -17,10 +17,11 @@
 
 #import "MTRDeviceControllerOverXPC_Internal.h"
 
-#import "MTRDeviceController+XPC.h"
+#import <Matter/MTRDeviceController+XPC.h>
+#import <Matter/MTRError.h>
+
 #import "MTRDeviceControllerXPCConnection.h"
 #import "MTRDeviceOverXPC.h"
-#import "MTRError.h"
 #import "MTRLogging_Internal.h"
 
 #import <Foundation/Foundation.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
@@ -16,6 +16,7 @@
  */
 
 #import "MTRDeviceControllerOverXPC.h"
+
 #import "MTRDeviceControllerXPCConnection.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerParameters_Wrapper.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerParameters_Wrapper.h
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-#include <Matter/MTRDefines.h>
+#import <Matter/MTRDefines.h>
 
 #if MTR_PER_CONTROLLER_STORAGE_ENABLED
 #error Should be including Matter/MTRDeviceControllerParameters.h

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
@@ -14,8 +14,6 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-
 #import <Matter/MTRCertificates.h>
 #import <Matter/MTRDefines.h>
 #import <Matter/MTROperationalCertificateIssuer.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -14,8 +14,10 @@
  *    limitations under the License.
  */
 
-#import "MTRDeviceControllerStartupParams.h"
-#import "MTRCertificates.h"
+#import <Matter/MTRDeviceControllerStartupParams.h>
+
+#import <Matter/MTRCertificates.h>
+
 #import "MTRConversion.h"
 #import "MTRDeviceControllerStartupParams_Internal.h"
 #import "MTRDeviceController_Internal.h"

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -14,11 +14,8 @@
  *    limitations under the License.
  */
 
-#pragma once
+#import <Matter/MTRDeviceControllerStartupParams.h>
 
-#import "MTRDeviceControllerStartupParams.h"
-#import <Foundation/Foundation.h>
-#import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceController.h>
 #if MTR_PER_CONTROLLER_STORAGE_ENABLED
 #import <Matter/MTRDeviceControllerParameters.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStorageDelegate_Wrapper.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStorageDelegate_Wrapper.h
@@ -14,7 +14,7 @@
  *    limitations under the License.
  */
 
-#include <Matter/MTRDefines.h>
+#import <Matter/MTRDefines.h>
 
 #if MTR_PER_CONTROLLER_STORAGE_ENABLED
 #error Should be including Matter/MTRDeviceControllerStorageDelegate.h

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.h
@@ -16,8 +16,7 @@
  */
 
 #import <Matter/MTRDefines.h>
-
-#import "MTRDeviceController+XPC.h"
+#import <Matter/MTRDeviceController+XPC.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -14,26 +14,10 @@
  *    limitations under the License.
  */
 
-/**
- * Parts of MTRDeviceController that are not part of the framework API.  Mostly
- * for use from MTRDeviceControllerFactory.
- */
+#import <Matter/MTRDeviceController.h>
 
-#import <Foundation/Foundation.h>
 #import <Matter/MTRAccessGrant.h>
 #import <Matter/MTRBaseDevice.h> // for MTRClusterPath
-
-#import "MTRDeviceConnectionBridge.h" // For MTRInternalDeviceConnectionCallback
-#import "MTRDeviceController.h"
-
-#include <lib/core/CHIPError.h>
-#include <lib/core/DataModelTypes.h>
-
-#import "MTRBaseDevice.h"
-#import "MTRDeviceController.h"
-#import "MTRDeviceControllerDataStore.h"
-
-#import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceControllerStartupParams.h>
 #import <Matter/MTRDiagnosticLogsType.h>
 #if MTR_PER_CONTROLLER_STORAGE_ENABLED
@@ -42,6 +26,12 @@
 #import "MTRDeviceControllerStorageDelegate_Wrapper.h"
 #endif // MTR_PER_CONTROLLER_STORAGE_ENABLED
 #import <Matter/MTROTAProviderDelegate.h>
+
+#import "MTRDeviceConnectionBridge.h" // For MTRInternalDeviceConnectionCallback
+#import "MTRDeviceControllerDataStore.h"
+
+#include <lib/core/CHIPError.h>
+#include <lib/core/DataModelTypes.h>
 
 @class MTRDeviceControllerStartupParamsInternal;
 @class MTRDeviceControllerFactory;

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
@@ -15,10 +15,9 @@
  *    limitations under the License.
  */
 
-#import <Matter/MTRDefines.h>
+#import <Matter/MTRBaseDevice.h>
+#import <Matter/MTRCluster.h> // For MTRSubscriptionEstablishedHandler
 
-#import "MTRBaseDevice.h"
-#import "MTRCluster.h" // For MTRSubscriptionEstablishedHandler
 #import "MTRDeviceControllerXPCConnection.h"
 
 @class MTRDeviceControllerOverXPC;

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.mm
@@ -17,12 +17,13 @@
 
 #import "MTRDeviceOverXPC.h"
 
-#import "MTRCluster.h"
+#import <Matter/MTRCluster.h>
+#import <Matter/MTRDeviceController+XPC.h>
+#import <Matter/MTRError.h>
+
 #import "MTRClusterStateCacheContainer+XPC.h"
-#import "MTRDeviceController+XPC.h"
 #import "MTRDeviceControllerOverXPC_Internal.h"
 #import "MTRDeviceControllerXPCConnection.h"
-#import "MTRError.h"
 #import "MTRLogging_Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/darwin/Framework/CHIP/MTRDeviceTypeMetadata.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceTypeMetadata.h
@@ -15,10 +15,6 @@
  *    limitations under the License.
  */
 
-#pragma once
-
-#import <Foundation/Foundation.h>
-
 #include <lib/core/DataModelTypes.h>
 
 BOOL MTRIsKnownUtilityDeviceType(chip::DeviceTypeId aDeviceTypeId);

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -15,9 +15,9 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-#import <Matter/MTRBaseDevice.h>
 #import <Matter/MTRDevice.h>
+
+#import <Matter/MTRBaseDevice.h>
 
 #import "MTRAsyncWorkQueue.h"
 

--- a/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.mm
+++ b/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.mm
@@ -17,7 +17,7 @@
 
 #import "MTRDiagnosticLogsDownloader.h"
 
-#include <protocols/bdx/BdxTransferServerDelegate.h>
+#import <Matter/MTRClusters.h>
 
 #import "MTRDeviceControllerFactory_Internal.h"
 #import "MTRDeviceController_Internal.h"
@@ -26,7 +26,7 @@
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"
 
-#import "zap-generated/MTRClusters.h"
+#include <protocols/bdx/BdxTransferServerDelegate.h>
 
 typedef void (^AbortHandler)(NSError * error);
 

--- a/src/darwin/Framework/CHIP/MTRError.h
+++ b/src/darwin/Framework/CHIP/MTRError.h
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-
 #import <Matter/MTRDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/darwin/Framework/CHIP/MTRError.mm
+++ b/src/darwin/Framework/CHIP/MTRError.mm
@@ -15,14 +15,11 @@
  *    limitations under the License.
  */
 
-#import <Matter/MTRDefines.h>
-
-#import "MTRError.h"
 #import "MTRError_Internal.h"
 
-#import <app/MessageDef/StatusIB.h>
-#import <inet/InetError.h>
-#import <lib/support/TypeTraits.h>
+#include <app/MessageDef/StatusIB.h>
+#include <inet/InetError.h>
+#include <lib/support/TypeTraits.h>
 
 #import <objc/runtime.h>
 

--- a/src/darwin/Framework/CHIP/MTRError_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRError_Internal.h
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-#import <Matter/MTRDefines.h>
 #import <Matter/MTRError.h>
 
 #include <app/MessageDef/StatusIB.h>

--- a/src/darwin/Framework/CHIP/MTREventTLVValueDecoder_Internal.h
+++ b/src/darwin/Framework/CHIP/MTREventTLVValueDecoder_Internal.h
@@ -16,8 +16,6 @@
  *    limitations under the License.
  */
 
-#pragma once
-
 #import <Foundation/Foundation.h>
 
 #include <app/ConcreteAttributePath.h>

--- a/src/darwin/Framework/CHIP/MTRLogging_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRLogging_Internal.h
@@ -1,7 +1,6 @@
-/*
+/**
  *
  *    Copyright (c) 2020 Project CHIP Authors
- *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.mm
@@ -14,15 +14,16 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#import "MTRManualSetupPayloadParser.h"
+
+#import <Matter/MTRManualSetupPayloadParser.h>
 
 #import "MTRError_Internal.h"
 #import "MTRFramework.h"
 #import "MTRLogging_Internal.h"
 #import "MTRSetupPayload_Internal.h"
 
-#import <setup_payload/ManualSetupPayloadParser.h>
-#import <setup_payload/SetupPayload.h>
+#include <setup_payload/ManualSetupPayloadParser.h>
+#include <setup_payload/SetupPayload.h>
 
 @implementation MTRManualSetupPayloadParser {
     NSString * _decimalStringRepresentation;

--- a/src/darwin/Framework/CHIP/MTRMetrics.mm
+++ b/src/darwin/Framework/CHIP/MTRMetrics.mm
@@ -14,11 +14,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#import "MTRLogging_Internal.h"
+
 #import "MTRMetrics_Internal.h"
-#include <Foundation/Foundation.h>
-#import <Matter/MTRDefines.h>
-#include <Matter/MTRMetrics.h>
+
+#import "MTRLogging_Internal.h"
 
 @implementation MTRMetrics {
     NSMutableDictionary<NSString *, MTRMetricData *> * _metricsData;

--- a/src/darwin/Framework/CHIP/MTRMetricsCollector.h
+++ b/src/darwin/Framework/CHIP/MTRMetricsCollector.h
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#include <MTRDefines.h>
 #import <Matter/MTRMetrics.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
+++ b/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
@@ -16,10 +16,11 @@
  */
 
 #import "MTRMetricsCollector.h"
+
 #import "MTRLogging_Internal.h"
-#include "MTRMetrics_Internal.h"
-#include <MTRMetrics.h>
-#import <MTRUnfairLock.h>
+#import "MTRMetrics_Internal.h"
+#import "MTRUnfairLock.h"
+
 #include <platform/Darwin/Tracing.h>
 #include <system/SystemClock.h>
 #include <tracing/metric_event.h>

--- a/src/darwin/Framework/CHIP/MTRMetrics_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRMetrics_Internal.h
@@ -14,8 +14,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#import "MTRMetrics.h"
-#include <Foundation/Foundation.h>
+
+#import <Matter/MTRMetrics.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/MTROTAHeader.mm
+++ b/src/darwin/Framework/CHIP/MTROTAHeader.mm
@@ -15,9 +15,8 @@
  *    limitations under the License.
  */
 
-#import "MTROTAHeader.h"
+#import <Matter/MTROTAHeader.h>
 
-#import "MTRError.h"
 #import "MTRError_Internal.h"
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -16,10 +16,13 @@
  */
 
 #import "MTROTAProviderDelegateBridge.h"
-#import "MTRBaseClusters.h"
-#import "MTRCommandPayloadsObjC.h"
+
+#import <Matter/MTRBaseClusters.h>
+#import <Matter/MTRCommandPayloadsObjC.h>
+
 #import "MTRDeviceControllerFactory_Internal.h"
 #import "MTRDeviceController_Internal.h"
+#import "MTRError_Internal.h"
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"
 
@@ -27,14 +30,12 @@
 #include <controller/CHIPDeviceController.h>
 #include <lib/core/Global.h>
 #include <lib/support/TypeTraits.h>
-#include <platform/PlatformManager.h>
-#include <protocols/interaction_model/Constants.h>
-
-#include <MTRError_Internal.h>
 #include <messaging/ExchangeMgr.h>
 #include <platform/LockTracker.h>
+#include <platform/PlatformManager.h>
 #include <protocols/bdx/BdxUri.h>
 #include <protocols/bdx/TransferFacilitator.h>
+#include <protocols/interaction_model/Constants.h>
 
 using namespace chip;
 using namespace chip::app;

--- a/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.mm
@@ -15,10 +15,11 @@
  *    limitations under the License.
  */
 
-#import "MTROnboardingPayloadParser.h"
-#import "MTRManualSetupPayloadParser.h"
-#import "MTRQRCodeSetupPayloadParser.h"
-#import "MTRSetupPayload.h"
+#import <Matter/MTROnboardingPayloadParser.h>
+
+#import <Matter/MTRManualSetupPayloadParser.h>
+#import <Matter/MTRQRCodeSetupPayloadParser.h>
+#import <Matter/MTRSetupPayload.h>
 
 @implementation MTROnboardingPayloadParser
 

--- a/src/darwin/Framework/CHIP/MTROperationalBrowser.h
+++ b/src/darwin/Framework/CHIP/MTROperationalBrowser.h
@@ -14,10 +14,9 @@
  *    limitations under the License.
  */
 
-#pragma once
-
 #import <Foundation/Foundation.h>
 #import <Matter/MTRDeviceControllerFactory.h>
+
 #import <dns_sd.h>
 
 class MTROperationalBrowser

--- a/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCertificateIssuer.mm
@@ -14,9 +14,7 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-
-#import "MTROperationalCertificateIssuer.h"
+#import <Matter/MTROperationalCertificateIssuer.h>
 
 @implementation MTROperationalCertificateChain
 

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
@@ -15,22 +15,23 @@
  *    limitations under the License.
  */
 
-#include <memory>
+#import <Matter/MTRDeviceController.h>
+#import <Matter/MTRKeypair.h>
+#import <Matter/MTROperationalCertificateIssuer.h>
+
+#import "MTRError_Internal.h"
+#import "MTRP256KeypairBridge.h"
+#import "MTRPersistentStorageDelegateBridge.h"
 
 #import <Foundation/Foundation.h>
 #import <Security/Security.h>
-
-#import "MTRDeviceController.h"
-#import "MTRError_Internal.h"
-#import "MTRKeypair.h"
-#import "MTROperationalCertificateIssuer.h"
-#import "MTRP256KeypairBridge.h"
-#import "MTRPersistentStorageDelegateBridge.h"
 
 #include <controller/CHIPDeviceController.h>
 #include <controller/OperationalCredentialsDelegate.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CASEAuthTag.h>
+
+#include <memory>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
@@ -15,17 +15,16 @@
  *    limitations under the License.
  */
 
-#include <algorithm>
-
 #import "MTROperationalCredentialsDelegate.h"
 
-#import <Security/Security.h>
+#import <Matter/MTRCertificates.h>
 
-#import "MTRCertificates.h"
 #import "MTRConversion.h"
 #import "MTRDeviceController_Internal.h"
 #import "MTRLogging_Internal.h"
 #import "NSDataSpanConversion.h"
+
+#import <Security/Security.h>
 
 #include <controller/CommissioningDelegate.h>
 #include <credentials/CHIPCert.h>
@@ -36,6 +35,8 @@
 #include <lib/core/TLV.h>
 #include <lib/support/PersistentStorageMacros.h>
 #include <platform/LockTracker.h>
+
+#include <algorithm>
 
 using namespace chip;
 using namespace TLV;

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.h
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.h
@@ -15,9 +15,10 @@
  *    limitations under the License.
  */
 
-#import "MTRKeypair.h"
+#import <Matter/MTRKeypair.h>
 
 #import "MTRError_Internal.h"
+
 #include <crypto/CHIPCryptoPAL.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
@@ -16,13 +16,15 @@
  */
 
 #import "MTRP256KeypairBridge.h"
+
+#import <Matter/MTRKeypair.h>
+
+#import "MTRLogging_Internal.h"
 #import "NSDataSpanConversion.h"
 
 #import <Security/Security.h>
-#include <string>
 
-#import "MTRKeypair.h"
-#import "MTRLogging_Internal.h"
+#include <string>
 
 using namespace chip::Crypto;
 

--- a/src/darwin/Framework/CHIP/MTRPersistentStorageDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRPersistentStorageDelegateBridge.h
@@ -15,9 +15,10 @@
  *    limitations under the License.
  */
 
-#import "MTRStorage.h"
+#import <Matter/MTRStorage.h>
 
 #import "MTRError_Internal.h"
+
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.mm
@@ -15,14 +15,15 @@
  *    limitations under the License.
  */
 
-#import "MTRQRCodeSetupPayloadParser.h"
+#import <Matter/MTRQRCodeSetupPayloadParser.h>
+
 #import "MTRError_Internal.h"
 #import "MTRFramework.h"
 #import "MTRLogging_Internal.h"
 #import "MTRSetupPayload_Internal.h"
 
-#import <setup_payload/QRCodeSetupPayloadParser.h>
-#import <setup_payload/SetupPayload.h>
+#include <setup_payload/QRCodeSetupPayloadParser.h>
+#include <setup_payload/SetupPayload.h>
 
 @implementation MTRQRCodeSetupPayloadParser {
     NSString * _base38Representation;

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -15,14 +15,16 @@
  *    limitations under the License.
  */
 
-#import "MTRError.h"
+#import "MTRSetupPayload_Internal.h"
+
+#import <Matter/MTROnboardingPayloadParser.h>
+
 #import "MTRError_Internal.h"
 #import "MTRFramework.h"
-#import "MTROnboardingPayloadParser.h"
-#import "MTRSetupPayload_Internal.h"
-#import "setup_payload/ManualSetupPayloadGenerator.h"
-#import "setup_payload/QRCodeSetupPayloadGenerator.h"
-#import <setup_payload/SetupPayload.h>
+
+#include <setup_payload/ManualSetupPayloadGenerator.h>
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <setup_payload/SetupPayload.h>
 
 @implementation MTROptionalQRCodeInfo
 @end

--- a/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
@@ -1,17 +1,25 @@
-//
-//  MTRSetupPayload_Internal.h
-//  MTR
-//
-//  Copyright © 2021 CHIP. All rights reserved.
-//
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
-#import <Foundation/Foundation.h>
-
-#import "MTRSetupPayload.h"
+#import <Matter/MTRSetupPayload.h>
 
 #ifdef __cplusplus
-#import <lib/core/Optional.h>
-#import <setup_payload/SetupPayload.h>
+#include <lib/core/Optional.h>
+#include <setup_payload/SetupPayload.h>
 #endif
 
 @interface MTRSetupPayload ()

--- a/src/darwin/Framework/CHIP/MTRThreadOperationalDataset.mm
+++ b/src/darwin/Framework/CHIP/MTRThreadOperationalDataset.mm
@@ -15,10 +15,11 @@
  *    limitations under the License.
  */
 
-#import "MTRThreadOperationalDataset.h"
+#import <Matter/MTRThreadOperationalDataset.h>
+
+#import "MTRLogging_Internal.h"
 #import "NSDataSpanConversion.h"
 
-#include "MTRLogging_Internal.h"
 #include <lib/support/Span.h>
 #include <lib/support/ThreadOperationalDataset.h>
 

--- a/src/darwin/Framework/CHIP/NSDataSpanConversion.h
+++ b/src/darwin/Framework/CHIP/NSDataSpanConversion.h
@@ -14,8 +14,6 @@
  *    limitations under the License.
  */
 
-#pragma once
-
 #import <Foundation/Foundation.h>
 
 #include <lib/support/Span.h>

--- a/src/darwin/Framework/CHIP/NSStringSpanConversion.h
+++ b/src/darwin/Framework/CHIP/NSStringSpanConversion.h
@@ -14,8 +14,6 @@
  *    limitations under the License.
  */
 
-#pragma once
-
 #import <Foundation/Foundation.h>
 
 #include <lib/support/Span.h>

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAttribute_Internal.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAttribute_Internal.h
@@ -14,10 +14,9 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
+#import <Matter/MTRServerAttribute.h>
 
 #import <Matter/MTRDeviceController.h>
-#import <Matter/MTRServerAttribute.h>
 
 #include <app/ConcreteClusterPath.h>
 

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.h
@@ -14,7 +14,6 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
 #import <Matter/MTRAccessGrant.h>
 #import <Matter/MTRDefines.h>
 #import <Matter/MTRServerAttribute.h>

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster_Internal.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster_Internal.h
@@ -14,16 +14,14 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-
-#import <Matter/MTRDeviceController.h>
 #import <Matter/MTRServerCluster.h>
 
 #include <lib/core/DataModelTypes.h>
-
 // TODO: These attribute-*.h and Span bits are a hack that should eventually go away.
 #include <app/util/attribute-metadata.h>
 #include <lib/support/Span.h>
+
+@class MTRDeviceController;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint.h
@@ -14,7 +14,6 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
 #import <Matter/MTRAccessGrant.h>
 #import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceTypeRevision.h>

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint_Internal.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint_Internal.h
@@ -14,9 +14,9 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-#import <Matter/MTRDeviceController.h>
 #import <Matter/MTRServerEndpoint.h>
+
+#import <Matter/MTRDeviceController.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
@@ -2,7 +2,8 @@
 
 #import "MTRAttributeTLVValueDecoder_Internal.h"
 
-#import "MTRStructsObjc.h"
+#import <Matter/MTRStructsObjc.h>
+
 #import "NSStringSpanConversion.h"
 #import "NSDataSpanConversion.h"
 

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -1,18 +1,18 @@
 {{> header excludeZapComment=true}}
 
-#import <Foundation/Foundation.h>
-
 #import "MTRBaseClusters_Internal.h"
+
+#import <Matter/MTRCommandPayloadsObjc.h>
+#import <Matter/MTRStructsObjc.h>
+
 #import "MTRBaseDevice_Internal.h"
 #import "MTRCallbackBridgeBase.h"
 #import "MTRCluster_Internal.h"
 #import "MTRClusterStateCacheContainer_Internal.h"
-#import "MTRCommandPayloadsObjc.h"
+#import "MTRDefines_Internal.h"
 #import "MTRDevice_Internal.h"
-#import "MTRStructsObjc.h"
 #import "NSStringSpanConversion.h"
 #import "NSDataSpanConversion.h"
-#import "MTRDefines_Internal.h"
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/util/im-client-callbacks.h>

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters_Internal.zapt
@@ -1,9 +1,8 @@
 {{> header excludeZapComment=true}}
 
 #import <Foundation/Foundation.h>
-
-#import "MTRBaseClusters.h"
-#import "MTRBaseDevice.h"
+#import <Matter/MTRBaseClusters.h>
+#import <Matter/MTRBaseDevice.h>
 
 // Nothing here for now, but leaving this file in place in case we need to add
 // something.

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -1,13 +1,13 @@
 {{> header excludeZapComment=true}}
 
-#import <Foundation/Foundation.h>
+#import "MTRClusters_Internal.h"
 
-#import "MTRClusterConstants.h"
+#import <Matter/MTRClusterConstants.h>
+#import <Matter/MTRCommandPayloadsObjc.h>
+#import <Matter/MTRStructsObjc.h>
+
 #import "MTRDevice_Internal.h"
 #import "MTRCluster_Internal.h"
-#import "MTRClusters_Internal.h"
-#import "MTRStructsObjc.h"
-#import "MTRCommandPayloadsObjc.h"
 #import "MTRLogging_Internal.h"
 #import "MTRDefines_Internal.h"
 

--- a/src/darwin/Framework/CHIP/templates/MTRClusters_Internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_Internal.zapt
@@ -1,10 +1,6 @@
 {{> header excludeZapComment=true}}
 
-#import <Foundation/Foundation.h>
-
-#import "MTRClusters.h"
-#import "MTRDevice.h"
-#import "MTRDevice_Internal.h"
+#import <Matter/MTRClusters.h>
 
 // Nothing here for now, but leaving this file in place in case we need to add
 // something.

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
@@ -1,6 +1,8 @@
 {{> header excludeZapComment=true}}
 
-#import "MTRCommandPayloadsObjc.h"
+#import <Matter/MTRBackwardsCompatShims.h>
+#import <Matter/MTRCommandPayloadsObjc.h>
+
 #import "MTRCommandPayloads_Internal.h"
 #import "MTRCommandPayloadExtensions_Internal.h"
 #import "MTRBaseDevice_Internal.h"
@@ -8,10 +10,9 @@
 #import "MTRLogging_Internal.h"
 #import "NSStringSpanConversion.h"
 #import "NSDataSpanConversion.h"
-#import "MTRBackwardsCompatShims.h"
 
-#include <app/data-model/Decode.h>
 #include <lib/core/TLV.h>
+#include <app/data-model/Decode.h>
 #include <app/data-model/ListLargeSystemExtensions.h>
 #include <lib/support/CodeUtils.h>
 #include <system/TLVPacketBufferBackingStore.h>

--- a/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
@@ -2,7 +2,8 @@
 
 #import "MTREventTLVValueDecoder_Internal.h"
 
-#import "MTRStructsObjc.h"
+#import <Matter/MTRStructsObjc.h>
+
 #import "NSStringSpanConversion.h"
 #import "NSDataSpanConversion.h"
 

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
@@ -1,6 +1,6 @@
 {{> header excludeZapComment=true}}
 
-#import "MTRStructsObjc.h"
+#import <Matter/MTRStructsObjc.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
@@ -17,7 +17,8 @@
 
 #import "MTRAttributeTLVValueDecoder_Internal.h"
 
-#import "MTRStructsObjc.h"
+#import <Matter/MTRStructsObjc.h>
+
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters_Internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters_Internal.h
@@ -16,9 +16,8 @@
  */
 
 #import <Foundation/Foundation.h>
-
-#import "MTRBaseClusters.h"
-#import "MTRBaseDevice.h"
+#import <Matter/MTRBaseClusters.h>
+#import <Matter/MTRBaseDevice.h>
 
 // Nothing here for now, but leaving this file in place in case we need to add
 // something.

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -15,16 +15,16 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-
-#import "MTRClusterConstants.h"
-#import "MTRCluster_Internal.h"
 #import "MTRClusters_Internal.h"
-#import "MTRCommandPayloadsObjc.h"
+
+#import <Matter/MTRClusterConstants.h>
+#import <Matter/MTRCommandPayloadsObjc.h>
+#import <Matter/MTRStructsObjc.h>
+
+#import "MTRCluster_Internal.h"
 #import "MTRDefines_Internal.h"
 #import "MTRDevice_Internal.h"
 #import "MTRLogging_Internal.h"
-#import "MTRStructsObjc.h"
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <platform/CHIPDeviceLayer.h>

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters_Internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters_Internal.h
@@ -15,11 +15,7 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-
-#import "MTRClusters.h"
-#import "MTRDevice.h"
-#import "MTRDevice_Internal.h"
+#import <Matter/MTRClusters.h>
 
 // Nothing here for now, but leaving this file in place in case we need to add
 // something.

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -15,8 +15,9 @@
  *    limitations under the License.
  */
 
-#import "MTRCommandPayloadsObjc.h"
-#import "MTRBackwardsCompatShims.h"
+#import <Matter/MTRBackwardsCompatShims.h>
+#import <Matter/MTRCommandPayloadsObjc.h>
+
 #import "MTRBaseDevice_Internal.h"
 #import "MTRCommandPayloadExtensions_Internal.h"
 #import "MTRCommandPayloads_Internal.h"

--- a/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
@@ -17,7 +17,8 @@
 
 #import "MTREventTLVValueDecoder_Internal.h"
 
-#import "MTRStructsObjc.h"
+#import <Matter/MTRStructsObjc.h>
+
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -15,7 +15,7 @@
  *    limitations under the License.
  */
 
-#import "MTRStructsObjc.h"
+#import <Matter/MTRStructsObjc.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -18,10 +18,6 @@
  *    limitations under the License.
  */
 
-// module headers
-#import <Matter/MTRBaseClusters.h>
-#import <Matter/MTRBaseDevice.h>
-#import <Matter/MTRClusterStateCacheContainer.h>
 #import <Matter/Matter.h>
 
 #import "MTRCommandPayloadExtensions_Internal.h"

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
@@ -1,6 +1,3 @@
-//
-//  MTRSetupPayloadParserTests.m
-//  MTRQRCodeReaderTests
 /**
  *
  *    Copyright (c) 2020 Project CHIP Authors
@@ -17,13 +14,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-// module headers
-#import "MTRSetupPayload.h"
 
-// additional includes
-#import "MTRError.h"
-
-// system dependencies
+#import <Matter/Matter.h>
 #import <XCTest/XCTest.h>
 
 @interface MTRSetupPayloadParserTests : XCTestCase

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadSerializerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadSerializerTests.m
@@ -13,13 +13,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-// module headers
-#import "MTRSetupPayload.h"
 
-// additional includes
-#import "MTRError.h"
-
-// system dependencies
+#import <Matter/Matter.h>
 #import <XCTest/XCTest.h>
 
 @interface MTRSetupPayloadSerializerTests : XCTestCase

--- a/src/darwin/Framework/CHIPTests/MTRThreadOperationalDatasetTests.mm
+++ b/src/darwin/Framework/CHIPTests/MTRThreadOperationalDatasetTests.mm
@@ -1,6 +1,3 @@
-//
-//  MTRControllerTests.m
-//  MTRControllerTests
 /**
  *
  *    Copyright (c) 2021 Project CHIP Authors
@@ -19,8 +16,6 @@
  */
 
 #import <Matter/Matter.h>
-
-// system dependencies
 #import <XCTest/XCTest.h>
 
 @interface MTRThreadOperationalDatasetTests : XCTestCase

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestResetCommissioneeHelper.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestResetCommissioneeHelper.h
@@ -14,10 +14,7 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
 #import <Matter/Matter.h>
 #import <XCTest/XCTest.h>
-
-#pragma once
 
 void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCase * testcase, uint16_t commandTimeout);

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -244,7 +244,7 @@
 		5ACDDD7E27CD3F3A00EFD68A /* MTRClusterStateCacheContainer_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ACDDD7B27CD14AF00EFD68A /* MTRClusterStateCacheContainer_Internal.h */; };
 		5AE6D4E427A99041001F2493 /* MTRDeviceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AE6D4E327A99041001F2493 /* MTRDeviceTests.m */; };
 		75139A6F2B7FE5E900E3A919 /* MTRDeviceControllerLocalTestStorage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 75139A6E2B7FE5E900E3A919 /* MTRDeviceControllerLocalTestStorage.mm */; };
-		75139A702B7FE68C00E3A919 /* MTRDeviceControllerLocalTestStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 75139A6D2B7FE5D600E3A919 /* MTRDeviceControllerLocalTestStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		75139A702B7FE68C00E3A919 /* MTRDeviceControllerLocalTestStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 75139A6D2B7FE5D600E3A919 /* MTRDeviceControllerLocalTestStorage.h */; };
 		7534F12828BFF20300390851 /* MTRDeviceAttestationDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7534F12628BFF20300390851 /* MTRDeviceAttestationDelegate.mm */; };
 		7534F12928BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7534F12728BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h */; };
 		754F3DF427FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 754F3DF327FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h */; };


### PR DESCRIPTION
Import public headers via #import <Matter/Foo.h>
Import project headers via #import "Foo.h"
Include C++ SDK headers via #include <foo/bar.h>
Import counterpart header first in implementation file Import public header first in _Internal headers
Don't use #pragma once in ObjC(++)

Make MTRDeviceControllerLocalTestStorage.h a project header.
