### PR TITLE
Remove redundant checks from the operational state impl in all-clusters-app.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/operational-state-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/operational-state-delegate-impl.cpp
@@ -55,15 +55,6 @@ CHIP_ERROR GenericOperationalStateDelegateImpl::GetOperationalPhaseAtIndex(size_
 
 void GenericOperationalStateDelegateImpl::HandlePauseStateCallback(GenericOperationalError & err)
 {
-    OperationalState::OperationalStateEnum state =
-        static_cast<OperationalState::OperationalStateEnum>(GetInstance()->GetCurrentOperationalState());
-
-    if (state == OperationalState::OperationalStateEnum::kStopped || state == OperationalState::OperationalStateEnum::kError)
-    {
-        err.Set(to_underlying(OperationalState::ErrorStateEnum::kCommandInvalidInState));
-        return;
-    }
-
     // placeholder implementation
     auto error = GetInstance()->SetOperationalState(to_underlying(OperationalState::OperationalStateEnum::kPaused));
     if (error == CHIP_NO_ERROR)
@@ -78,15 +69,6 @@ void GenericOperationalStateDelegateImpl::HandlePauseStateCallback(GenericOperat
 
 void GenericOperationalStateDelegateImpl::HandleResumeStateCallback(GenericOperationalError & err)
 {
-    OperationalState::OperationalStateEnum state =
-        static_cast<OperationalState::OperationalStateEnum>(GetInstance()->GetCurrentOperationalState());
-
-    if (state == OperationalState::OperationalStateEnum::kStopped || state == OperationalState::OperationalStateEnum::kError)
-    {
-        err.Set(to_underlying(OperationalState::ErrorStateEnum::kCommandInvalidInState));
-        return;
-    }
-
     // placeholder implementation
     auto error = GetInstance()->SetOperationalState(to_underlying(OperationalStateEnum::kRunning));
     if (error == CHIP_NO_ERROR)


### PR DESCRIPTION
The cluster implementation does those checks.

