### PR TITLE
[Python] Delete BLE scanner handle in an explicit way

### DIFF
--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -113,7 +113,7 @@ public:
         }
     }
 
-    virtual void OnScanError(CHIP_ERROR error) override
+    void OnScanError(CHIP_ERROR error) override
     {
         if (mErrorCallback)
         {

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -111,8 +111,6 @@ public:
         {
             mCompleteCallback(mContext);
         }
-
-        delete this;
     }
 
     virtual void OnScanError(CHIP_ERROR error) override
@@ -133,10 +131,10 @@ private:
 
 } // namespace
 
-extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, uint32_t timeoutMs,
-                                            ScannerDelegateImpl::DeviceScannedCallback scanCallback,
-                                            ScannerDelegateImpl::ScanCompleteCallback completeCallback,
-                                            ScannerDelegateImpl::ScanErrorCallback errorCallback)
+extern "C" void * pychip_ble_scanner_start(PyObject * context, void * adapter, uint32_t timeoutMs,
+                                           ScannerDelegateImpl::DeviceScannedCallback scanCallback,
+                                           ScannerDelegateImpl::ScanCompleteCallback completeCallback,
+                                           ScannerDelegateImpl::ScanErrorCallback errorCallback)
 {
     std::unique_ptr<ScannerDelegateImpl> delegate =
         std::make_unique<ScannerDelegateImpl>(context, scanCallback, completeCallback, errorCallback);
@@ -150,4 +148,10 @@ extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, 
     VerifyOrReturnError(err == CHIP_NO_ERROR, nullptr);
 
     return delegate.release();
+}
+
+extern "C" void pychip_ble_scanner_delete(void * scanner)
+{
+    chip::DeviceLayer::StackLock lock;
+    delete static_cast<ScannerDelegateImpl *>(scanner);
 }

--- a/src/controller/python/chip/ble/darwin/Scanning.mm
+++ b/src/controller/python/chip/ble/darwin/Scanning.mm
@@ -131,7 +131,7 @@ using ScanErrorCallback = void (*)(PyObject * context, uint32_t error);
 
 @end
 
-extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, uint32_t timeout,
+extern "C" void * pychip_ble_scanner_start(PyObject * context, void * adapter, uint32_t timeout,
     DeviceScannedCallback scanCallback, ScanCompleteCallback completeCallback, ScanErrorCallback errorCallback)
 {
     // NOTE: adapter is ignored as it does not apply to mac
@@ -143,4 +143,9 @@ extern "C" void * pychip_ble_start_scanning(PyObject * context, void * adapter, 
                                                                          timeoutMs:timeout];
 
     return (__bridge_retained void *) (scanner);
+}
+
+extern "C" void pychip_ble_scanner_delete(void * scanner)
+{
+    CFRelease((CFTypeRef) scanner);
 }

--- a/src/controller/python/chip/ble/library_handle.py
+++ b/src/controller/python/chip/ble/library_handle.py
@@ -57,8 +57,10 @@ def _GetBleLibraryHandle() -> ctypes.CDLL:
         setter.Set('pychip_ble_adapter_list_get_raw_adapter',
                    VoidPointer, [VoidPointer])
 
-        setter.Set('pychip_ble_start_scanning', VoidPointer, [
-            py_object, VoidPointer, c_uint32, DeviceScannedCallback, ScanDoneCallback, ScanErrorCallback
+        setter.Set('pychip_ble_scanner_start', VoidPointer, [
+            py_object, VoidPointer, c_uint32, DeviceScannedCallback,
+            ScanDoneCallback, ScanErrorCallback,
         ])
+        setter.Set('pychip_ble_scanner_delete', None, [VoidPointer])
 
     return handle

--- a/src/controller/python/chip/ble/scan_devices.py
+++ b/src/controller/python/chip/ble/scan_devices.py
@@ -27,17 +27,17 @@ from chip.ble.types import DeviceScannedCallback, ScanDoneCallback, ScanErrorCal
 @DeviceScannedCallback
 def ScanFoundCallback(closure, address: str, discriminator: int, vendor: int,
                       product: int):
-    closure.DeviceFound(address, discriminator, vendor, product)
+    closure.OnDeviceScanned(address, discriminator, vendor, product)
 
 
 @ScanDoneCallback
 def ScanDoneCallback(closure):
-    closure.ScanCompleted()
+    closure.OnScanComplete()
 
 
 @ScanErrorCallback
 def ScanErrorCallback(closure, errorCode: int):
-    closure.ScanErrorCallback(errorCode)
+    closure.OnScanError(errorCode)
 
 
 @dataclass
@@ -59,13 +59,13 @@ class _DeviceInfoReceiver:
     def __init__(self):
         self.queue = Queue()
 
-    def DeviceFound(self, address, discriminator, vendor, product):
+    def OnDeviceScanned(self, address, discriminator, vendor, product):
         self.queue.put(DeviceInfo(address, discriminator, vendor, product))
 
-    def ScanCompleted(self):
+    def OnScanComplete(self):
         self.queue.put(None)
 
-    def ScanError(self, errorCode):
+    def OnScanError(self, errorCode):
         # TODO need to determine what we do with this error. Most of the time this
         # error is just a timeout introduced in PR #24873, right before we get a
         # ScanCompleted.

--- a/src/controller/python/chip/ble/scan_devices.py
+++ b/src/controller/python/chip/ble/scan_devices.py
@@ -54,8 +54,11 @@ def DiscoverAsync(timeoutMs: int, scanCallback, doneCallback, errorCallback, ada
                     a string with the adapter address. If None, the first
                     adapter on the system is used.
     """
-    if adapter and not isinstance(adapter, str):
-        adapter = adapter.address
+    if adapter:
+        if isinstance(adapter, str):
+            adapter = adapter.upper()
+        else:
+            adapter = adapter.address
 
     handle = _GetBleLibraryHandle()
 

--- a/src/controller/python/chip/ble/scan_devices.py
+++ b/src/controller/python/chip/ble/scan_devices.py
@@ -140,8 +140,6 @@ def DiscoverSync(timeoutMs: int, adapter=None) -> Generator[DeviceInfo, None, No
 
     Args:
       timeoutMs:    scan will complete after this time
-      scanCallback: callback when a device is found
-      doneCallback: callback when the scan is complete
       adapter:      what adapter to choose. Either an AdapterInfo object or
                     a string with the adapter address. If None, the first
                     adapter on the system is used.

--- a/src/platform/Linux/bluez/AdapterIterator.cpp
+++ b/src/platform/Linux/bluez/AdapterIterator.cpp
@@ -47,6 +47,18 @@ CHIP_ERROR AdapterIterator::Initialize()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR AdapterIterator::Shutdown()
+{
+    // Release resources on the glib thread to synchronize with potential signal handlers
+    // attached to the manager client object that may run on the glib thread.
+    return PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](AdapterIterator * self) {
+            self->mManager.reset();
+            return CHIP_NO_ERROR;
+        },
+        this);
+}
+
 bool AdapterIterator::Advance()
 {
     for (; mIterator != BluezObjectList::end(); ++mIterator)

--- a/src/platform/Linux/bluez/AdapterIterator.h
+++ b/src/platform/Linux/bluez/AdapterIterator.h
@@ -48,6 +48,9 @@ namespace Internal {
 class AdapterIterator
 {
 public:
+    AdapterIterator() = default;
+    ~AdapterIterator() { Shutdown(); }
+
     /// Moves to the next DBUS interface.
     ///
     /// MUST be called before any of the 'current value' methods are
@@ -66,6 +69,8 @@ public:
 private:
     /// Sets up the DBUS manager and loads the list
     CHIP_ERROR Initialize();
+    /// Destroys the DBUS manager
+    CHIP_ERROR Shutdown();
 
     /// Loads the next value in the list.
     ///


### PR DESCRIPTION
### Problem

Currently, when starting BLE scanning via Python binding, the scanner object is created in Python code, and then it's destroyed in C++ code by the scanner itself (on complete callback). Such design causes lots of issues, where the lifetime of the object is hard to maintain.

### Changes

- Delete BLE scanner handle in an explicit way in Python code
- Normalize BT MAC letter case passed to DiscoverAsync/Sync
- Unref manager client on glib thread (unrefing it on Matter thread caused glib critical warnings from time to time - race condition in glib)

### Testing:

Darwin platform **was not tested** as I do not have access to platform with macOS!
If anyone with Mac could verify BLE scanning via Python binding I'd be glad.

Manually tested BLE scanner in Python bindings on Linux:
```python
>>> from chip.ble.scan_devices import DiscoverAsync, DiscoverSync
>>> DiscoverAsync(1000, lambda a,b,c,d: print(a,b,c,d), lambda: print('Done'), lambda x: print(x))
b'B8:27:EB:5E:BA:83' 3840 32769 65521
Done
>>> list(DiscoverSync(1000))
[
   DeviceInfo(
      address=b'B8:27:EB:5E:BA:83',
      discriminator=3840,
      vendor=32769,
      product=65521
   )
]

```
