### PR TITLE
Fix compiler error on tip of tree

### DIFF
--- a/src/controller/AbstractDnssdDiscoveryController.cpp
+++ b/src/controller/AbstractDnssdDiscoveryController.cpp
@@ -34,10 +34,11 @@ void AbstractDnssdDiscoveryController::OnNodeDiscovered(const chip::Dnssd::Disco
         {
             continue;
         }
-        // TODO Check if IP address are the same. Must account for `numIPs` in the list of `ipAddress`.
+        // TODO(#32576) Check if IP address are the same. Must account for `numIPs` in the list of `ipAddress`.
         // Additionally, must NOT assume that the ordering is consistent.
         if (strcmp(discoveredNode.resolutionData.hostName, nodeData.resolutionData.hostName) == 0 &&
-            discoveredNode.resolutionData.port == nodeData.resolutionData.port)
+            discoveredNode.resolutionData.port == nodeData.resolutionData.port &&
+            discoveredNode.resolutionData.numIPs == nodeData.resolutionData.numIPs)
         {
             discoveredNode = nodeData;
             if (mDeviceDiscoveryDelegate != nullptr)

--- a/src/controller/AbstractDnssdDiscoveryController.cpp
+++ b/src/controller/AbstractDnssdDiscoveryController.cpp
@@ -34,9 +34,10 @@ void AbstractDnssdDiscoveryController::OnNodeDiscovered(const chip::Dnssd::Disco
         {
             continue;
         }
+        // TODO Check if IP address are the same. Must account for `numIPs` in the list of `ipAddress`.
+        // Additionally, must NOT assume that the ordering is consistent.
         if (strcmp(discoveredNode.resolutionData.hostName, nodeData.resolutionData.hostName) == 0 &&
-            discoveredNode.resolutionData.port == nodeData.resolutionData.port &&
-            discoveredNode.resolutionData.ipAddress == nodeData.resolutionData.ipAddress)
+            discoveredNode.resolutionData.port == nodeData.resolutionData.port)
         {
             discoveredNode = nodeData;
             if (mDeviceDiscoveryDelegate != nullptr)


### PR DESCRIPTION
Compiling chip-tool on tip of tree fails with:

Issue was introduced in https://github.com/project-chip/connectedhomeip/pull/32459. I don't have the time to properly forward fix so just going with revert of section of code that was problematic with a TODO

```
2024-03-14 17:46:51 INFO    ../../examples/chip-tool/third_party/connectedhomeip/src/controller/AbstractDnssdDiscoveryController.cpp: In member function ‘virtual void chip::Controller::AbstractDnssdDiscoveryCont
roller::OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData&)’:
2024-03-14 17:46:51 INFO    ../../examples/chip-tool/third_party/connectedhomeip/src/controller/AbstractDnssdDiscoveryController.cpp:39:53: error: comparison between two arrays [-Werror=array-compare]
2024-03-14 17:46:51 INFO       39 |             discoveredNode.resolutionData.ipAddress == nodeData.resolutionData.ipAddress)
```

