### PR TITLE
Updated Linux tv-casting-app README to include shell instructions for cluster commands.

### DIFF
--- a/examples/tv-casting-app/linux/README.md
+++ b/examples/tv-casting-app/linux/README.md
@@ -11,6 +11,9 @@ commissioned. Then it allows the user to send CHIP commands to the TV.
 -   [CHIP TV Casting App Example](#chip-tv-casting-app-example)
     -   [Building](#building)
     -   [Running the Complete Example on Linux](#running-the-complete-example-on-linux)
+        -   [Commissioning the tv-casting-app](#commissioning-the-tv-casting-app)
+        -   [Re-Running the Example on Linux with Cached Fabrics](#re-running-the-example-on-linux-with-cached-fabrics)
+        -   [Sending Arbitrary Cluster commands](#sending-arbitrary-cluster-commands)
 
 <hr>
 
@@ -44,7 +47,7 @@ commissioned. Then it allows the user to send CHIP commands to the TV.
 
         $ cd ~/connectedhomeip/examples/tv-casting-app/linux
         (delete any stored fabrics from previous runs)
-        $ rm -rf /tmp/rm -rf /tmp/chip_casting_kvs*
+        $ rm -rf /tmp/rm -rf /tmp/chip*
         $ out/debug/chip-tv-casting-app
 
     Follow the on-screen prompts on the tv-casting-app console
@@ -120,7 +123,9 @@ the current fabric.
 The tv-casting-app is able to determine the nodeId for the given fabric by
 checking its binding table since the video player sets bindings on the
 tv-casting-app for each endpoint to which the tv-casting-app is granted access
-during commissioning.
+during commissioning. Cluster commands can be invoked via command line arguments
+passed to the chip-tv-casting-app executable or via the built-in interactive
+shell by prefixing the words "cast cluster" before the command.
 
 -   Run the tv-casting-app and invoke a cluster command using default fabric,
     target video player nodeId 18446744004990074879


### PR DESCRIPTION
Updated the Linux tv-casting-app README file to include additional instructions on how cluster commands can be invoked via the built-in interactive shell. Also updated the command used to delete any stored fabrics from previous runs.

Testing
Verified that the README file still looks okay using Visual Studio Code Preview.