### PR TITLE
Set more than one DST offset in MTRDevice if the server supports that.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRTimeUtils.h
+++ b/src/darwin/Framework/CHIP/MTRTimeUtils.h
@@ -1,0 +1,34 @@
+/**
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/MTRDefines.h>
+#import <Matter/MTRStructsObjc.h>
+
+#import "MTRDefines_Internal.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Utility method to compute up to the given count of instances of
+ * MTRTimeSynchronizationClusterDSTOffsetStruct and return them.
+ *
+ * Returns nil on errors.
+ */
+MTR_EXTERN MTR_TESTABLE
+    NSArray<MTRTimeSynchronizationClusterDSTOffsetStruct *> * _Nullable MTRComputeDSTOffsets(size_t maxCount);
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRTimeUtils.mm
+++ b/src/darwin/Framework/CHIP/MTRTimeUtils.mm
@@ -1,0 +1,67 @@
+/**
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRTimeUtils.h"
+#import "MTRConversion.h"
+#import "MTRLogging_Internal.h"
+
+NSArray<MTRTimeSynchronizationClusterDSTOffsetStruct *> * _Nullable MTRComputeDSTOffsets(size_t maxCount)
+{
+    auto * tz = [NSTimeZone localTimeZone];
+    if (!tz) {
+        MTR_LOG_ERROR("Could not retrieve local time zone. Unable to determine DST offsets.");
+        return nil;
+    }
+
+    NSMutableArray<MTRTimeSynchronizationClusterDSTOffsetStruct *> * retval = [NSMutableArray arrayWithCapacity:maxCount];
+
+    auto nextOffset = tz.daylightSavingTimeOffset;
+    NSNumber * nextValidStarting = @(0);
+    auto * nextTransition = tz.nextDaylightSavingTimeTransition;
+    for (size_t offsetsAdded = 0; offsetsAdded < maxCount; ++offsetsAdded) {
+        auto offset = [[MTRTimeSynchronizationClusterDSTOffsetStruct alloc] init];
+        offset.offset = @(nextOffset);
+        offset.validStarting = nextValidStarting;
+        if (nextTransition == nil) {
+            // This one is valid forever.
+            offset.validUntil = nil;
+        } else {
+            uint64_t nextTransitionEpochUs;
+            if (!DateToMatterEpochMicroseconds(nextTransition, nextTransitionEpochUs)) {
+                // Transition is somehow before Matter epoch start.  This really
+                // should not happen, but if it does just don't pretend like we
+                // know what's going on with timezones here.
+                MTR_LOG_ERROR("Future daylight savings transition is before Matter epoch start?");
+                return nil;
+            }
+
+            offset.validUntil = @(nextTransitionEpochUs);
+        }
+
+        [retval addObject:offset];
+
+        if (offset.validUntil == nil) {
+            // Valid forever, so no need for more offsets.
+            break;
+        }
+
+        nextOffset = [tz daylightSavingTimeOffsetForDate:nextTransition];
+        nextValidStarting = offset.validUntil;
+        nextTransition = [tz nextDaylightSavingTimeTransitionAfterDate:nextTransition];
+    }
+
+    return [retval copy];
+}

--- a/src/darwin/Framework/CHIPTests/MTRDSTOffsetTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDSTOffsetTests.m
@@ -1,0 +1,57 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// module headers
+#import "MTRTimeUtils.h"
+#import <Matter/Matter.h>
+
+// system dependencies
+#import <XCTest/XCTest.h>
+
+@interface MTRDSTOffsetTests : XCTestCase
+@end
+
+@implementation MTRDSTOffsetTests
+
+- (void)test001_SingleOffset
+{
+    __auto_type * offsets = MTRComputeDSTOffsets(1);
+    // We should be able to get offsets.
+    XCTAssertNotNil(offsets);
+
+    // And there is always at least one, even if all it says is "no offset, forever".
+    XCTAssertEqual(offsets.count, 1);
+    XCTAssertEqualObjects(offsets[0].validStarting, @(0));
+}
+
+- (void)test002_TryGetting2Offsets
+{
+    __auto_type * offsets = MTRComputeDSTOffsets(2);
+    // We should be able to get offsets.
+    XCTAssertNotNil(offsets);
+
+    // And there is always at least one, even if all it says is "no offset,
+    // forever".  And we should not get too many offsets.
+    XCTAssertTrue(offsets.count >= 1);
+    XCTAssertTrue(offsets.count <= 2);
+    NSNumber * previousValidUntil = @(0);
+    for (MTRTimeSynchronizationClusterDSTOffsetStruct * offset in offsets) {
+        XCTAssertEqualObjects(previousValidUntil, offset.validStarting);
+        previousValidUntil = offset.validUntil;
+    }
+}
+
+@end

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -200,6 +200,8 @@
 		51B22C222740CB1D008D5055 /* MTRCommandPayloadsObjc.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B22C212740CB1D008D5055 /* MTRCommandPayloadsObjc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51B22C262740CB32008D5055 /* MTRStructsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C252740CB32008D5055 /* MTRStructsObjc.mm */; };
 		51B22C2A2740CB47008D5055 /* MTRCommandPayloadsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C292740CB47008D5055 /* MTRCommandPayloadsObjc.mm */; };
+		51C659D92BA3787500C54922 /* MTRTimeUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 51C659D72BA3787500C54922 /* MTRTimeUtils.h */; };
+		51C659DA2BA3787500C54922 /* MTRTimeUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51C659D82BA3787500C54922 /* MTRTimeUtils.mm */; };
 		51C8E3F82825CDB600D47D00 /* MTRTestKeys.m in Sources */ = {isa = PBXBuildFile; fileRef = 51C8E3F72825CDB600D47D00 /* MTRTestKeys.m */; };
 		51C984622A61CE2A00B0AD9A /* MTRFabricInfoChecker.m in Sources */ = {isa = PBXBuildFile; fileRef = 51C984602A61CE2A00B0AD9A /* MTRFabricInfoChecker.m */; };
 		51D0B1272B617246006E3511 /* MTRServerEndpoint.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51D0B1252B617246006E3511 /* MTRServerEndpoint.mm */; };
@@ -214,6 +216,7 @@
 		51D0B1402B61B3A4006E3511 /* MTRServerCluster.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D0B13E2B61B3A3006E3511 /* MTRServerCluster.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51D0B1412B61B3A4006E3511 /* MTRServerCluster.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51D0B13F2B61B3A3006E3511 /* MTRServerCluster.mm */; };
 		51D10D2E2808E2CA00E8CA3D /* MTRTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 51D10D2D2808E2CA00E8CA3D /* MTRTestStorage.m */; };
+		51D9CB0B2BA37DCE0049D6DB /* MTRDSTOffsetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51D9CB0A2BA37DCE0049D6DB /* MTRDSTOffsetTests.m */; };
 		51E0FC102ACBBF230001E197 /* MTRSwiftDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E0FC0F2ACBBF230001E197 /* MTRSwiftDeviceTests.swift */; };
 		51E24E73274E0DAC007CCF6E /* MTRErrorTestUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E24E72274E0DAC007CCF6E /* MTRErrorTestUtils.mm */; };
 		51E51FBF282AD37A00FC978D /* MTRDeviceControllerStartupParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E51FBC282AD37A00FC978D /* MTRDeviceControllerStartupParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -600,6 +603,8 @@
 		51B22C252740CB32008D5055 /* MTRStructsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRStructsObjc.mm; sourceTree = "<group>"; };
 		51B22C292740CB47008D5055 /* MTRCommandPayloadsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCommandPayloadsObjc.mm; sourceTree = "<group>"; };
 		51B6C5C72AD85B47003F4D3A /* MTRCommandPayloads_Internal.zapt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = MTRCommandPayloads_Internal.zapt; sourceTree = "<group>"; };
+		51C659D72BA3787500C54922 /* MTRTimeUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRTimeUtils.h; sourceTree = "<group>"; };
+		51C659D82BA3787500C54922 /* MTRTimeUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRTimeUtils.mm; sourceTree = "<group>"; };
 		51C8E3F72825CDB600D47D00 /* MTRTestKeys.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRTestKeys.m; sourceTree = "<group>"; };
 		51C984602A61CE2A00B0AD9A /* MTRFabricInfoChecker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRFabricInfoChecker.m; sourceTree = "<group>"; };
 		51C984612A61CE2A00B0AD9A /* MTRFabricInfoChecker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRFabricInfoChecker.h; sourceTree = "<group>"; };
@@ -615,6 +620,7 @@
 		51D0B13E2B61B3A3006E3511 /* MTRServerCluster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRServerCluster.h; sourceTree = "<group>"; };
 		51D0B13F2B61B3A3006E3511 /* MTRServerCluster.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRServerCluster.mm; sourceTree = "<group>"; };
 		51D10D2D2808E2CA00E8CA3D /* MTRTestStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRTestStorage.m; sourceTree = "<group>"; };
+		51D9CB0A2BA37DCE0049D6DB /* MTRDSTOffsetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRDSTOffsetTests.m; sourceTree = "<group>"; };
 		51E0FC0F2ACBBF230001E197 /* MTRSwiftDeviceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MTRSwiftDeviceTests.swift; sourceTree = "<group>"; };
 		51E24E72274E0DAC007CCF6E /* MTRErrorTestUtils.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRErrorTestUtils.mm; sourceTree = "<group>"; };
 		51E51FBC282AD37A00FC978D /* MTRDeviceControllerStartupParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceControllerStartupParams.h; sourceTree = "<group>"; };
@@ -1320,6 +1326,8 @@
 				2C8C8FBE253E0C2100797F05 /* MTRStorage.h */,
 				997DED172695344800975E97 /* MTRThreadOperationalDataset.h */,
 				997DED152695343400975E97 /* MTRThreadOperationalDataset.mm */,
+				51C659D72BA3787500C54922 /* MTRTimeUtils.h */,
+				51C659D82BA3787500C54922 /* MTRTimeUtils.mm */,
 				3D843710294977000070D20A /* NSDataSpanConversion.h */,
 				3D84370E294977000070D20A /* NSStringSpanConversion.h */,
 				5117DD3729A931AE00FFA1AA /* MTROperationalBrowser.h */,
@@ -1342,6 +1350,7 @@
 				3DFCB3282966684500332B35 /* MTRCertificateInfoTests.m */,
 				99C65E0F267282F1003402F6 /* MTRControllerTests.m */,
 				5AE6D4E327A99041001F2493 /* MTRDeviceTests.m */,
+				51D9CB0A2BA37DCE0049D6DB /* MTRDSTOffsetTests.m */,
 				3D0C484A29DA4FA0006D811F /* MTRErrorTests.m */,
 				5A6FEC9C27B5E48800F25F42 /* MTRXPCProtocolTests.m */,
 				5A7947DD27BEC3F500434CF2 /* MTRXPCListenerSampleTests.m */,
@@ -1589,6 +1598,7 @@
 				1EC4CE6425CC276600D7304F /* MTRBaseClusters.h in Headers */,
 				3D843712294977000070D20A /* MTRCallbackBridgeBase.h in Headers */,
 				3DECCB742934C21B00585AEC /* MTRDefines.h in Headers */,
+				51C659D92BA3787500C54922 /* MTRTimeUtils.h in Headers */,
 				75139A702B7FE68C00E3A919 /* MTRDeviceControllerLocalTestStorage.h in Headers */,
 				2C5EEEF6268A85C400CAE3D3 /* MTRDeviceConnectionBridge.h in Headers */,
 				2C8C8FC0253E0C2100797F05 /* MTRPersistentStorageDelegateBridge.h in Headers */,
@@ -1928,6 +1938,7 @@
 				3DA1A3562ABAB3B4004F0BB9 /* MTRAsyncWorkQueue.mm in Sources */,
 				51D0B1272B617246006E3511 /* MTRServerEndpoint.mm in Sources */,
 				3DECCB722934AFE200585AEC /* MTRLogging.mm in Sources */,
+				51C659DA2BA3787500C54922 /* MTRTimeUtils.mm in Sources */,
 				7596A84528762729004DAE0E /* MTRDevice.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1970,6 +1981,7 @@
 				519498322A25581C00B3BABE /* MTRSetupPayloadSerializerTests.m in Sources */,
 				51A2F1322A00402A00F03298 /* MTRDataValueParserTests.m in Sources */,
 				51E95DF82A78110900A434F0 /* MTRPerControllerStorageTests.m in Sources */,
+				51D9CB0B2BA37DCE0049D6DB /* MTRDSTOffsetTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This way when the next DST transition happens, the device won't be confused about the local time.
