### PR TITLE
MTR_EXTERN should not imply MTR_EXPORT.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDefines.h
+++ b/src/darwin/Framework/CHIP/MTRDefines.h
@@ -51,9 +51,9 @@
 #define MTR_EXPORT __attribute__((visibility("default")))
 
 #ifdef __cplusplus
-#define MTR_EXTERN extern "C" MTR_EXPORT
+#define MTR_EXTERN extern "C"
 #else
-#define MTR_EXTERN extern MTR_EXPORT
+#define MTR_EXTERN extern
 #endif
 
 #if __has_attribute(__swift_attr__)

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.h
@@ -22,7 +22,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-MTR_EXTERN @interface MTRDeviceControllerLocalTestStorage : NSObject<MTRDeviceControllerStorageDelegate>
+MTR_EXTERN MTR_EXPORT @interface MTRDeviceControllerLocalTestStorage : NSObject<MTRDeviceControllerStorageDelegate>
 
 // Setting this variable only affects subsequent MTRDeviceController initializations
 @property (class, nonatomic, assign) BOOL localTestStorageEnabled;


### PR DESCRIPTION
Most things using MTR_EXTERN had availability annotations anyway, which imply MTR_EXPORT.
