### PR TITLE
[Darwin] Adding metrics for MTRDeviceController APIs

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -62,6 +62,7 @@ using namespace chip::Protocols::InteractionModel;
 using chip::Optional;
 using chip::SessionHandle;
 using chip::Messaging::ExchangeManager;
+using namespace chip::Metrics::DarwinFramework;
 
 NSString * const MTRAttributePathKey = @"attributePath";
 NSString * const MTRCommandPathKey = @"commandPath";
@@ -1862,12 +1863,12 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
                                             queue:(dispatch_queue_t)queue
                                        completion:(MTRDeviceOpenCommissioningWindowHandler)completion
 {
-    MATTER_LOG_METRIC_BEGIN(kMetricDarwinFrameworkOpenPairingWindow);
+    MATTER_LOG_METRIC_BEGIN(kMetricOpenPairingWindow);
 
     if (self.isPASEDevice) {
         MTR_LOG_ERROR("Can't open a commissioning window over PASE");
         dispatch_async(queue, ^{
-            MATTER_LOG_METRIC_END(kMetricDarwinFrameworkOpenPairingWindow, CHIP_ERROR_INCORRECT_STATE);
+            MATTER_LOG_METRIC_END(kMetricOpenPairingWindow, CHIP_ERROR_INCORRECT_STATE);
             completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
         });
         return;
@@ -1877,7 +1878,7 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
     if (!CanCastTo<uint16_t>(durationVal)) {
         MTR_LOG_ERROR("Error: Duration %llu is too large.", durationVal);
         dispatch_async(queue, ^{
-            MATTER_LOG_METRIC_END(kMetricDarwinFrameworkOpenPairingWindow, CHIP_ERROR_INVALID_INTEGER_VALUE);
+            MATTER_LOG_METRIC_END(kMetricOpenPairingWindow, CHIP_ERROR_INVALID_INTEGER_VALUE);
             completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE]);
         });
         return;
@@ -1888,7 +1889,7 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
     if (discriminatorVal > 0xFFF) {
         MTR_LOG_ERROR("Error: Discriminator %llu is too large. Max value %d", discriminatorVal, 0xFFF);
         dispatch_async(queue, ^{
-            MATTER_LOG_METRIC_END(kMetricDarwinFrameworkOpenPairingWindow, CHIP_ERROR_INVALID_INTEGER_VALUE);
+            MATTER_LOG_METRIC_END(kMetricOpenPairingWindow, CHIP_ERROR_INVALID_INTEGER_VALUE);
             completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE]);
         });
         return;
@@ -1900,7 +1901,7 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
         if (!CanCastTo<uint32_t>(passcodeVal) || !SetupPayload::IsValidSetupPIN(static_cast<uint32_t>(passcodeVal))) {
             MTR_LOG_ERROR("Error: Setup passcode %llu is not valid", passcodeVal);
             dispatch_async(queue, ^{
-                MATTER_LOG_METRIC_END(kMetricDarwinFrameworkOpenPairingWindow, CHIP_ERROR_INVALID_INTEGER_VALUE);
+                MATTER_LOG_METRIC_END(kMetricOpenPairingWindow, CHIP_ERROR_INVALID_INTEGER_VALUE);
                 completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE]);
             });
             return;
@@ -1913,7 +1914,7 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
             auto resultCallback = ^(CHIP_ERROR status, const SetupPayload & payload) {
                 if (status != CHIP_NO_ERROR) {
                     dispatch_async(queue, ^{
-                        MATTER_LOG_METRIC_END(kMetricDarwinFrameworkOpenPairingWindow, status);
+                        MATTER_LOG_METRIC_END(kMetricOpenPairingWindow, status);
                         completion(nil, [MTRError errorForCHIPErrorCode:status]);
                     });
                     return;
@@ -1921,14 +1922,14 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
                 auto * payloadObj = [[MTRSetupPayload alloc] initWithSetupPayload:payload];
                 if (payloadObj == nil) {
                     dispatch_async(queue, ^{
-                        MATTER_LOG_METRIC_END(kMetricDarwinFrameworkOpenPairingWindow, CHIP_ERROR_NO_MEMORY);
+                        MATTER_LOG_METRIC_END(kMetricOpenPairingWindow, CHIP_ERROR_NO_MEMORY);
                         completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_NO_MEMORY]);
                     });
                     return;
                 }
 
                 dispatch_async(queue, ^{
-                    MATTER_LOG_METRIC_END(kMetricDarwinFrameworkOpenPairingWindow, CHIP_NO_ERROR);
+                    MATTER_LOG_METRIC_END(kMetricOpenPairingWindow, CHIP_NO_ERROR);
                     completion(payloadObj, nil);
                 });
             };
@@ -1940,7 +1941,7 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
 
             if (errorCode != CHIP_NO_ERROR) {
                 dispatch_async(queue, ^{
-                    MATTER_LOG_METRIC_END(kMetricDarwinFrameworkOpenPairingWindow, errorCode);
+                    MATTER_LOG_METRIC_END(kMetricOpenPairingWindow, errorCode);
                     completion(nil, [MTRError errorForCHIPErrorCode:errorCode]);
                 });
                 return;
@@ -1950,7 +1951,7 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
         }
         errorHandler:^(NSError * error) {
             dispatch_async(queue, ^{
-                MATTER_LOG_METRIC_END(kMetricDarwinFrameworkOpenPairingWindow, [MTRError errorToCHIPErrorCode:error]);
+                MATTER_LOG_METRIC_END(kMetricOpenPairingWindow, [MTRError errorToCHIPErrorCode:error]);
                 completion(nil, error);
             });
         }];

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -62,7 +62,7 @@ using namespace chip::Protocols::InteractionModel;
 using chip::Optional;
 using chip::SessionHandle;
 using chip::Messaging::ExchangeManager;
-using namespace chip::Metrics::DarwinFramework;
+using namespace chip::Tracing::DarwinFramework;
 
 NSString * const MTRAttributePathKey = @"attributePath";
 NSString * const MTRCommandPathKey = @"commandPath";

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -107,7 +107,7 @@ typedef void (^SyncWorkQueueBlock)(void);
 typedef id (^SyncWorkQueueBlockWithReturnValue)(void);
 typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
 
-using namespace chip::Metrics::DarwinFramework;
+using namespace chip::Tracing::DarwinFramework;
 
 @implementation MTRDeviceController {
     // Atomic because it can be touched from multiple threads.

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -23,6 +23,8 @@
 #import "MTRMetricKeys.h"
 #import "MTRMetricsCollector.h"
 
+using namespace chip::Metrics::DarwinFramework;
+
 MTRDeviceControllerDelegateBridge::MTRDeviceControllerDelegateBridge(void)
     : mDelegate(nil)
 {
@@ -119,7 +121,7 @@ void MTRDeviceControllerDelegateBridge::OnReadCommissioningInfo(const chip::Cont
 void MTRDeviceControllerDelegateBridge::OnCommissioningComplete(chip::NodeId nodeId, CHIP_ERROR error)
 {
     MTR_LOG_DEFAULT("DeviceControllerDelegate Commissioning complete. NodeId %llu Status %s", nodeId, chip::ErrorStr(error));
-    MATTER_LOG_METRIC_END(kMetricDarwinFrameworkDeviceCommissioning, error);
+    MATTER_LOG_METRIC_END(kMetricDeviceCommissioning, error);
 
     id<MTRDeviceControllerDelegate> strongDelegate = mDelegate;
     MTRDeviceController * strongController = mController;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -20,6 +20,7 @@
 #import "MTRDeviceController_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTRLogging_Internal.h"
+#import "MTRMetricKeys.h"
 #import "MTRMetricsCollector.h"
 
 MTRDeviceControllerDelegateBridge::MTRDeviceControllerDelegateBridge(void)
@@ -118,6 +119,7 @@ void MTRDeviceControllerDelegateBridge::OnReadCommissioningInfo(const chip::Cont
 void MTRDeviceControllerDelegateBridge::OnCommissioningComplete(chip::NodeId nodeId, CHIP_ERROR error)
 {
     MTR_LOG_DEFAULT("DeviceControllerDelegate Commissioning complete. NodeId %llu Status %s", nodeId, chip::ErrorStr(error));
+    MATTER_LOG_METRIC_END(kMetricDarwinFrameworkDeviceCommissioning, error);
 
     id<MTRDeviceControllerDelegate> strongDelegate = mDelegate;
     MTRDeviceController * strongController = mController;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -23,7 +23,7 @@
 #import "MTRMetricKeys.h"
 #import "MTRMetricsCollector.h"
 
-using namespace chip::Metrics::DarwinFramework;
+using namespace chip::Tracing::DarwinFramework;
 
 MTRDeviceControllerDelegateBridge::MTRDeviceControllerDelegateBridge(void)
     : mDelegate(nil)

--- a/src/darwin/Framework/CHIP/MTRMetricKeys.h
+++ b/src/darwin/Framework/CHIP/MTRMetricKeys.h
@@ -52,6 +52,5 @@ constexpr Tracing::MetricKey kMetricDeviceVendorID = "dwnfw_device_vendor_id";
 constexpr Tracing::MetricKey kMetricDeviceProductID = "dwnfw_device_product_id";
 
 } // namespace DarwinFramework
-} // namespace Metrics
+} // namespace Tracing
 } // namespace chip
-

--- a/src/darwin/Framework/CHIP/MTRMetricKeys.h
+++ b/src/darwin/Framework/CHIP/MTRMetricKeys.h
@@ -18,7 +18,7 @@
 #include <tracing/metric_event.h>
 
 namespace chip {
-namespace Metrics {
+namespace Tracing {
 namespace DarwinFramework {
 
 constexpr Tracing::MetricKey kMetricDeviceCommissioning = "dwnfw_device_commissioning";

--- a/src/darwin/Framework/CHIP/MTRMetricKeys.h
+++ b/src/darwin/Framework/CHIP/MTRMetricKeys.h
@@ -14,35 +14,44 @@
  *    limitations under the License.
  */
 
+#include <lib/core/CHIPError.h>
 #include <tracing/metric_event.h>
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkDeviceCommissioning = "dwnfw_device_commissioning";
+namespace chip {
+namespace Metrics {
+namespace DarwinFramework {
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkSetupWithPayload = "dwnfw_setup_with_payload";
+constexpr Tracing::MetricKey kMetricDeviceCommissioning = "dwnfw_device_commissioning";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkPairDevice = "dwnfw_pair_device";
+constexpr Tracing::MetricKey kMetricSetupWithPayload = "dwnfw_setup_with_payload";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkSetupWithDiscovered = "dwnfw_setup_with_discovered";
+constexpr Tracing::MetricKey kMetricPairDevice = "dwnfw_pair_device";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkPreWarmCommissioning = "dwnfw_prewarm_commissioning";
+constexpr Tracing::MetricKey kMetricSetupWithDiscovered = "dwnfw_setup_with_discovered";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkStartBrowseForCommissionables = "dwnfw_start_browse_commissionables";
+constexpr Tracing::MetricKey kMetricPreWarmCommissioning = "dwnfw_prewarm_commissioning";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkStopBrowseForCommissionables = "dwnfw_stop_browse_commissionables";
+constexpr Tracing::MetricKey kMetricStartBrowseForCommissionables = "dwnfw_start_browse_commissionables";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkCancelCommissioning = "dwnfw_cancel_commissioning";
+constexpr Tracing::MetricKey kMetricStopBrowseForCommissionables = "dwnfw_stop_browse_commissionables";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkContinueCommissioningAfterAttestation =
-    "dwnfw_commission_post_attestation";
+constexpr Tracing::MetricKey kMetricCancelCommissioning = "dwnfw_cancel_commissioning";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkCommissionNode = "dwnfw_commission_node";
+constexpr Tracing::MetricKey kMetricContinueCommissioningAfterAttestation = "dwnfw_commission_post_attestation";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkDeviceBeingCommissioned = "dwnfw_dev_being_commissioned";
+constexpr Tracing::MetricKey kMetricCommissionNode = "dwnfw_commission_node";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkPASEVerifierForSetupCode = "dwnfw_pase_verifier_for_code";
+constexpr Tracing::MetricKey kMetricDeviceBeingCommissioned = "dwnfw_dev_being_commissioned";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkOpenPairingWindow = "dwnfw_pase_verifier_for_code";
+constexpr Tracing::MetricKey kMetricPASEVerifierForSetupCode = "dwnfw_pase_verifier_for_code";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkDeviceVendorID = "dwnfw_device_vendor_id";
+constexpr Tracing::MetricKey kMetricOpenPairingWindow = "dwnfw_pase_verifier_for_code";
 
-constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkDeviceProductID = "dwnfw_device_product_id";
+constexpr Tracing::MetricKey kMetricDeviceVendorID = "dwnfw_device_vendor_id";
+
+constexpr Tracing::MetricKey kMetricDeviceProductID = "dwnfw_device_product_id";
+
+} // namespace DarwinFramework
+} // namespace Metrics
+} // namespace chip
+

--- a/src/darwin/Framework/CHIP/MTRMetricKeys.h
+++ b/src/darwin/Framework/CHIP/MTRMetricKeys.h
@@ -1,0 +1,48 @@
+/**
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <tracing/metric_event.h>
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkDeviceCommissioning = "dwnfw_device_commissioning";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkSetupWithPayload = "dwnfw_setup_with_payload";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkPairDevice = "dwnfw_pair_device";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkSetupWithDiscovered = "dwnfw_setup_with_discovered";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkPreWarmCommissioning = "dwnfw_prewarm_commissioning";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkStartBrowseForCommissionables = "dwnfw_start_browse_commissionables";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkStopBrowseForCommissionables = "dwnfw_stop_browse_commissionables";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkCancelCommissioning = "dwnfw_cancel_commissioning";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkContinueCommissioningAfterAttestation =
+    "dwnfw_commission_post_attestation";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkCommissionNode = "dwnfw_commission_node";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkDeviceBeingCommissioned = "dwnfw_dev_being_commissioned";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkPASEVerifierForSetupCode = "dwnfw_pase_verifier_for_code";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkOpenPairingWindow = "dwnfw_pase_verifier_for_code";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkDeviceVendorID = "dwnfw_device_vendor_id";
+
+constexpr chip::Tracing::MetricKey kMetricDarwinFrameworkDeviceProductID = "dwnfw_device_product_id";

--- a/src/darwin/Framework/CHIP/MTRMetrics.h
+++ b/src/darwin/Framework/CHIP/MTRMetrics.h
@@ -56,6 +56,11 @@ MTR_NEWLY_AVAILABLE
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
+ * @brief Returns a unique identifier for the object
+ */
+@property (nonatomic, readonly, copy) NSUUID * uniqueIdentifier;
+
+/**
  * @brief Returns the names of all the metrics data items collected.
  */
 @property (nonatomic, readonly, copy) NSArray<NSString *> * allKeys;

--- a/src/darwin/Framework/CHIP/MTRMetrics.mm
+++ b/src/darwin/Framework/CHIP/MTRMetrics.mm
@@ -34,6 +34,7 @@
 {
     if (self = [super init]) {
         _metricsData = [NSMutableDictionary dictionaryWithCapacity:numItems];
+        _uniqueIdentifier = [NSUUID UUID];
     }
     return self;
 }
@@ -42,6 +43,7 @@
 {
     return [_metricsData allKeys];
 }
+
 - (nullable MTRMetricData *)metricDataForKey:(NSString *)key
 {
     if (!key) {

--- a/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
+++ b/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
@@ -232,13 +232,9 @@ static inline NSString * suffixNameForMetric(const MetricEvent & event)
         }
     }
 
-    [_metricsDataCollection setValue:data forKey:metricsKey];
-
-    // If the event is a begin or end event, implicitly emit a corresponding instant event
-    if (event.type() == MetricEvent::Type::kBeginEvent || event.type() == MetricEvent::Type::kEndEvent) {
-        MetricEvent instantEvent(MetricEvent::Type::kInstantEvent, event.key());
-        data = [[MTRMetricData alloc] initWithMetricEvent:instantEvent];
-        metricsKey = [NSString stringWithFormat:@"%s%@", event.key(), suffixNameForMetric(instantEvent)];
+    // If this is a Begin event, capture only the first instance of it to account for the largest duration
+    // spent on the event. For the remaining events, capture the the most recent event
+    if (event.type() != MetricEvent::Type::kBeginEvent || ![_metricsDataCollection valueForKey:metricsKey]) {
         [_metricsDataCollection setValue:data forKey:metricsKey];
     }
 }

--- a/src/darwin/Framework/CHIPTests/MTRMetricsTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRMetricsTests.m
@@ -128,4 +128,13 @@
     XCTAssertTrue([keys count] == 0);
 }
 
+- (void)test006_TestUniqueIdentifier
+{
+    MTRMetrics * metrics1 = [[MTRMetrics alloc] initWithCapacity:1];
+    MTRMetrics * metrics2 = [[MTRMetrics alloc] initWithCapacity:1];
+    XCTAssertTrue(metrics1.uniqueIdentifier != nil);
+    XCTAssertTrue(metrics2.uniqueIdentifier != nil);
+    XCTAssertTrue([metrics1.uniqueIdentifier isEqual:metrics2.uniqueIdentifier] == NO);
+}
+
 @end

--- a/src/darwin/Framework/CHIPTests/MTRMetricsTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRMetricsTests.m
@@ -132,9 +132,9 @@
 {
     MTRMetrics * metrics1 = [[MTRMetrics alloc] initWithCapacity:1];
     MTRMetrics * metrics2 = [[MTRMetrics alloc] initWithCapacity:1];
-    XCTAssertTrue(metrics1.uniqueIdentifier != nil);
-    XCTAssertTrue(metrics2.uniqueIdentifier != nil);
-    XCTAssertTrue([metrics1.uniqueIdentifier isEqual:metrics2.uniqueIdentifier] == NO);
+    XCTAssertNotNil(metrics1.uniqueIdentifier);
+    XCTAssertNotNil(metrics2.uniqueIdentifier);
+    XCTAssertNotEqualObjects(metrics1.uniqueIdentifier, metrics2.uniqueIdentifier);
 }
 
 @end

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 		75B765C12A1D71BC0014719B /* MTRAttributeSpecifiedCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = 75B765C02A1D71BC0014719B /* MTRAttributeSpecifiedCheck.h */; };
 		75B765C32A1D82D30014719B /* MTRAttributeSpecifiedCheck.mm in Sources */ = {isa = PBXBuildFile; fileRef = 75B765C22A1D82D30014719B /* MTRAttributeSpecifiedCheck.mm */; };
 		8874C1322B69C7060084BEFD /* MTRMetricsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8874C1312B69C7060084BEFD /* MTRMetricsTests.m */; };
+		88E07D612B9A89A4005FD53E /* MTRMetricKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 88E07D602B9A89A4005FD53E /* MTRMetricKeys.h */; };
 		88E6C9462B6334ED001A1FE0 /* MTRMetrics.h in Headers */ = {isa = PBXBuildFile; fileRef = 88E6C9432B6334ED001A1FE0 /* MTRMetrics.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		88E6C9472B6334ED001A1FE0 /* MTRMetrics_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 88E6C9442B6334ED001A1FE0 /* MTRMetrics_Internal.h */; };
 		88E6C9482B6334ED001A1FE0 /* MTRMetrics.mm in Sources */ = {isa = PBXBuildFile; fileRef = 88E6C9452B6334ED001A1FE0 /* MTRMetrics.mm */; };
@@ -668,6 +669,7 @@
 		75B765C02A1D71BC0014719B /* MTRAttributeSpecifiedCheck.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRAttributeSpecifiedCheck.h; sourceTree = "<group>"; };
 		75B765C22A1D82D30014719B /* MTRAttributeSpecifiedCheck.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRAttributeSpecifiedCheck.mm; sourceTree = "<group>"; };
 		8874C1312B69C7060084BEFD /* MTRMetricsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRMetricsTests.m; sourceTree = "<group>"; };
+		88E07D602B9A89A4005FD53E /* MTRMetricKeys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRMetricKeys.h; sourceTree = "<group>"; };
 		88E6C9432B6334ED001A1FE0 /* MTRMetrics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRMetrics.h; sourceTree = "<group>"; };
 		88E6C9442B6334ED001A1FE0 /* MTRMetrics_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRMetrics_Internal.h; sourceTree = "<group>"; };
 		88E6C9452B6334ED001A1FE0 /* MTRMetrics.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRMetrics.mm; sourceTree = "<group>"; };
@@ -1184,6 +1186,7 @@
 		B202528F2459E34F00F97062 /* CHIP */ = {
 			isa = PBXGroup;
 			children = (
+				88E07D602B9A89A4005FD53E /* MTRMetricKeys.h */,
 				88FA798B2B7B257100CD4B6F /* MTRMetricsCollector.h */,
 				88FA798C2B7B257100CD4B6F /* MTRMetricsCollector.mm */,
 				88E6C9442B6334ED001A1FE0 /* MTRMetrics_Internal.h */,
@@ -1558,6 +1561,7 @@
 				3CF134AB289D8DF70017A19E /* MTRDeviceAttestationInfo.h in Headers */,
 				B2E0D7B2245B0B5C003C5B48 /* MTRManualSetupPayloadParser.h in Headers */,
 				3CF134A7289D8ADA0017A19E /* MTRCSRInfo.h in Headers */,
+				88E07D612B9A89A4005FD53E /* MTRMetricKeys.h in Headers */,
 				B2E0D7B1245B0B5C003C5B48 /* Matter.h in Headers */,
 				7596A84428762729004DAE0E /* MTRDevice.h in Headers */,
 				B2E0D7B8245B0B5C003C5B48 /* MTRSetupPayload.h in Headers */,


### PR DESCRIPTION
- Adding initial set of metrics for MTRDeviceController APIs around device commissioning
- Added uniqueIdentifer to MTRMetrics
- Changed MetricsCollector to removed the end event for begin / instant event

