### PR TITLE
Disable QEMU ESP32 test in CI until it's fixed

### DIFF
--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -58,6 +58,8 @@ jobs:
                       build                             \
                   "
             - name: Run all tests
+              # Disabled being tracked here: https://github.com/project-chip/connectedhomeip/issues/32587
+              if: false
               run: |
                   src/test_driver/esp32/run_qemu_image.py \
                     --verbose                             \


### PR DESCRIPTION
Disabled being tracked here: https://github.com/project-chip/connectedhomeip/issues/32587

