### PR TITLE
[Chef] Fix compilation error by removing printing ChipError number

### DIFF
--- a/examples/chef/common/clusters/door-lock/chef-lock-endpoint.cpp
+++ b/examples/chef/common/clusters/door-lock/chef-lock-endpoint.cpp
@@ -590,8 +590,8 @@ bool LockEndpoint::weekDayScheduleForbidsAccess(uint16_t userIndex, bool * haveS
     auto chipError = chip::System::SystemClock().GetClock_RealTimeMS(cTMs);
     if (chipError != CHIP_NO_ERROR)
     {
-        ChipLogError(Zcl, "Lock App: unable to get current time to check user schedules [endpointId=%d,error=%d (%s)]", mEndpointId,
-                     chipError.AsInteger(), chipError.AsString());
+        ChipLogError(Zcl, "Lock App: unable to get current time to check user schedules [endpointId=%d (%s)]", mEndpointId,
+                     chipError.AsString());
         return true;
     }
     time_t unixEpoch = std::chrono::duration_cast<chip::System::Clock::Seconds32>(cTMs).count();
@@ -637,8 +637,8 @@ bool LockEndpoint::yearDayScheduleForbidsAccess(uint16_t userIndex, bool * haveS
     auto chipError = chip::System::SystemClock().GetClock_RealTimeMS(cTMs);
     if (chipError != CHIP_NO_ERROR)
     {
-        ChipLogError(Zcl, "Lock App: unable to get current time to check user schedules [endpointId=%d,error=%d (%s)]", mEndpointId,
-                     chipError.AsInteger(), chipError.AsString());
+        ChipLogError(Zcl, "Lock App: unable to get current time to check user schedules [endpointId=%d (%s)]", mEndpointId,
+                     chipError.AsString());
         return true;
     }
     auto unixEpoch     = std::chrono::duration_cast<chip::System::Clock::Seconds32>(cTMs).count();


### PR DESCRIPTION
Fix Chef  compilation error by removing printing ChipError number
which may cause compilation error due to its format could be `long` (formatted as "ld")
 or `int` (formatted as "d") depending on the platform

