### PR TITLE
[ICD] Add Check-In message at boot logic and persistent subscription checks

### DIFF
--- a/examples/all-clusters-app/esp32/main/Kconfig.projbuild
+++ b/examples/all-clusters-app/esp32/main/Kconfig.projbuild
@@ -59,6 +59,10 @@ menu "Demo"
             depends on IDF_TARGET_ESP32H2
     endchoice
 
+    config CHIP_PROJECT_CONFIG
+        string "CHIP Project Configuration file"
+        default "main/include/CHIPProjectConfig.h"
+
     choice
       prompt "Rendezvous Mode"
       default RENDEZVOUS_MODE_BLE if BT_ENABLED

--- a/examples/all-clusters-app/esp32/main/include/CHIPProjectConfig.h
+++ b/examples/all-clusters-app/esp32/main/include/CHIPProjectConfig.h
@@ -35,4 +35,4 @@
  *        that uses this flag, either appropriately conditionalize the entire test on this flag, or to exclude
  *        the compliation of that test source file entirely.
  */
-#define CONFIG_BUILD_FOR_HOST_UNIT_TEST CONFIG_BUILD_CHIP_TESTS
+#define CONFIG_BUILD_FOR_HOST_UNIT_TEST 1

--- a/examples/all-clusters-app/esp32/main/include/CHIPProjectConfig.h
+++ b/examples/all-clusters-app/esp32/main/include/CHIPProjectConfig.h
@@ -1,0 +1,38 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Example project configuration file for CHIP.
+ *
+ *          This is a place to put application or project-specific overrides
+ *          to the default configuration values for general CHIP features.
+ *
+ */
+
+#pragma once
+
+/**
+ * @def CONFIG_BUILD_FOR_HOST_UNIT_TEST
+ *
+ * @brief Defines whether we're currently building for unit testing, which enables a set of features
+ *        that are only utilized in those tests. This flag should not be enabled on devices. If you have a test
+ *        that uses this flag, either appropriately conditionalize the entire test on this flag, or to exclude
+ *        the compliation of that test source file entirely.
+ */
+#define CONFIG_BUILD_FOR_HOST_UNIT_TEST CONFIG_BUILD_CHIP_TESTS

--- a/examples/all-clusters-minimal-app/esp32/main/Kconfig.projbuild
+++ b/examples/all-clusters-minimal-app/esp32/main/Kconfig.projbuild
@@ -48,6 +48,10 @@ menu "Demo"
             depends on IDF_TARGET_ESP32C2
     endchoice
 
+    config CHIP_PROJECT_CONFIG
+        string "CHIP Project Configuration file"
+        default "main/include/CHIPProjectConfig.h"
+
     choice
       prompt "Rendezvous Mode"
       default RENDEZVOUS_MODE_BLE if BT_ENABLED

--- a/examples/all-clusters-minimal-app/esp32/main/include/CHIPProjectConfig.h
+++ b/examples/all-clusters-minimal-app/esp32/main/include/CHIPProjectConfig.h
@@ -1,0 +1,38 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Example project configuration file for CHIP.
+ *
+ *          This is a place to put application or project-specific overrides
+ *          to the default configuration values for general CHIP features.
+ *
+ */
+
+#pragma once
+
+/**
+ * @def CONFIG_BUILD_FOR_HOST_UNIT_TEST
+ *
+ * @brief Defines whether we're currently building for unit testing, which enables a set of features
+ *        that are only utilized in those tests. This flag should not be enabled on devices. If you have a test
+ *        that uses this flag, either appropriately conditionalize the entire test on this flag, or to exclude
+ *        the compliation of that test source file entirely.
+ */
+#define CONFIG_BUILD_FOR_HOST_UNIT_TEST 1

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -210,6 +210,7 @@ static_library("interaction-model") {
     ":subscription-info-provider",
     "${chip_root}/src/app/MessageDef",
     "${chip_root}/src/app/icd/server:icd-server-config",
+    "${chip_root}/src/app/icd/server:manager",
     "${chip_root}/src/app/icd/server:observer",
     "${chip_root}/src/app/util:af-types",
     "${chip_root}/src/app/util:callbacks",

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -122,7 +122,7 @@ source_set("global-attributes") {
   ]
 }
 
-source_set("subscription-manager") {
+source_set("subscription-info-provider") {
   sources = [ "SubscriptionsInfoProvider.h" ]
 
   public_deps = [ "${chip_root}/src/lib/core" ]
@@ -207,7 +207,7 @@ static_library("interaction-model") {
     ":app_config",
     ":constants",
     ":paths",
-    ":subscription-manager",
+    ":subscription-info-provider",
     "${chip_root}/src/app/MessageDef",
     "${chip_root}/src/app/icd/server:icd-server-config",
     "${chip_root}/src/app/icd/server:observer",

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -365,7 +365,10 @@ bool InteractionModelEngine::SubjectHasPersistedSubscription(FabricIndex aFabric
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
     auto * iterator = mpSubscriptionResumptionStorage->IterateSubscriptions();
-    // Verify that we were able to allocate an iterator. If not, assume we have a persisted subscription.
+    // Verify that we were able to allocate an iterator. If not, we are probably currently trying to resubscribe to our persisted
+    // subscriptions. As such, we assume we have a persisted subscription and return true.
+    // If we don't have a persisted subscription for the given fabric index and subjectID, we will send a Check-In message next time
+    // we transition to ActiveMode.
     VerifyOrReturnValue(iterator, true);
 
     SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -369,7 +369,7 @@ bool InteractionModelEngine::SubjectHasPersistedSubscription(FabricIndex aFabric
 
     while (iterator->Next(subscriptionInfo))
     {
-        // TODO(#31873): Persistant subscription only stores the NodeID for now. We cannot check if the CAT matches
+        // TODO(#31873): Persistent subscription only stores the NodeID for now. We cannot check if the CAT matches
         if (subscriptionInfo.mFabricIndex == aFabricIndex && subscriptionInfo.mNodeId == subjectID)
         {
             persistedSubMatches = true;

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -365,7 +365,7 @@ bool InteractionModelEngine::SubjectHasPersistedSubscription(FabricIndex aFabric
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
     auto * iterator = mpSubscriptionResumptionStorage->IterateSubscriptions();
-    // Verify that we were able t0 allocate an iterator. If not, assume we have a persisted subscription.
+    // Verify that we were able to allocate an iterator. If not, assume we have a persisted subscription.
     VerifyOrReturnValue(iterator, true);
 
     SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1926,22 +1926,22 @@ CHIP_ERROR InteractionModelEngine::ResumeSubscriptions()
     // future improvements: https://github.com/project-chip/connectedhomeip/issues/25439
 
     SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;
-    auto * iterator            = mpSubscriptionResumptionStorage->IterateSubscriptions();
-    mNumOfSubscriptionToResume = 0;
-    uint16_t minInterval       = 0;
+    auto * iterator             = mpSubscriptionResumptionStorage->IterateSubscriptions();
+    mNumOfSubscriptionsToResume = 0;
+    uint16_t minInterval        = 0;
     while (iterator->Next(subscriptionInfo))
     {
-        mNumOfSubscriptionToResume++;
+        mNumOfSubscriptionsToResume++;
         minInterval = std::max(minInterval, subscriptionInfo.mMinInterval);
     }
     iterator->Release();
 
-    if (mNumOfSubscriptionToResume)
+    if (mNumOfSubscriptionsToResume)
     {
 #if CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
         mSubscriptionResumptionScheduled = true;
 #endif
-        ChipLogProgress(InteractionModel, "Resuming %d subscriptions in %u seconds", mNumOfSubscriptionToResume, minInterval);
+        ChipLogProgress(InteractionModel, "Resuming %d subscriptions in %u seconds", mNumOfSubscriptionsToResume, minInterval);
         ReturnErrorOnFailure(mpExchangeMgr->GetSessionManager()->SystemLayer()->StartTimer(System::Clock::Seconds16(minInterval),
                                                                                            ResumeSubscriptionsTimerCallback, this));
     }
@@ -2066,15 +2066,15 @@ bool InteractionModelEngine::HasSubscriptionsToResume()
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 void InteractionModelEngine::DecrementNumSubscriptionsToResume()
 {
-    VerifyOrReturn(mNumOfSubscriptionToResume > 0);
+    VerifyOrReturn(mNumOfSubscriptionsToResume > 0);
 #if CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     VerifyOrDie(mICDManager);
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 
-    mNumOfSubscriptionToResume--;
+    mNumOfSubscriptionsToResume--;
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
-    if (!mNumOfSubscriptionToResume)
+    if (!mNumOfSubscriptionsToResume)
     {
         mICDManager->SetBootUpResumeSubscriptionExecuted();
     }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -336,16 +336,10 @@ bool InteractionModelEngine::SubjectHasActiveSubscription(FabricIndex aFabricInd
 {
     bool isActive = false;
     mReadHandlers.ForEachActiveObject([aFabricIndex, subjectID, &isActive](ReadHandler * handler) {
-        if (!handler->IsType(ReadHandler::InteractionType::Subscribe))
-        {
-            return Loop::Continue;
-        }
+        VerifyOrReturnValue(handler->IsType(ReadHandler::InteractionType::Subscribe), Loop::Continue);
 
         Access::SubjectDescriptor subject = handler->GetSubjectDescriptor();
-        if (subject.fabricIndex != aFabricIndex)
-        {
-            return Loop::Continue;
-        }
+        VerifyOrReturnValue(subject.fabricIndex == aFabricIndex, Loop::Continue);
 
         if (subject.authMode == Access::AuthMode::kCase)
         {
@@ -353,13 +347,9 @@ bool InteractionModelEngine::SubjectHasActiveSubscription(FabricIndex aFabricInd
             {
                 isActive = handler->IsActiveSubscription();
 
-                // Exit loop only if isActive is set to true
-                // Otherwise keep looking for another subscription that could
-                // match the subject
-                if (isActive)
-                {
-                    return Loop::Break;
-                }
+                // Exit loop only if isActive is set to true.
+                // Otherwise keep looking for another subscription that could match the subject.
+                VerifyOrReturnValue(!isActive, Loop::Break);
             }
         }
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -2064,12 +2064,12 @@ bool InteractionModelEngine::HasSubscriptionsToResume()
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
-void InteractionModelEngine::DecrementNumSubscriptionToResume()
+void InteractionModelEngine::DecrementNumSubscriptionsToResume()
 {
     VerifyOrReturn(mNumOfSubscriptionToResume > 0);
 #if CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     VerifyOrDie(mICDManager);
-#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 
     mNumOfSubscriptionToResume--;
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -371,8 +371,25 @@ bool InteractionModelEngine::SubjectHasActiveSubscription(FabricIndex aFabricInd
 
 bool InteractionModelEngine::SubjectHasPersistedSubscription(FabricIndex aFabricIndex, NodeId subjectID)
 {
-    // TODO(#30281) : Implement persisted sub check and verify how persistent subscriptions affects this at ICDManager::Init
-    return false;
+    bool persistedSubMatches = false;
+
+#if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
+    auto * iterator = mpSubscriptionResumptionStorage->IterateSubscriptions();
+    SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;
+
+    while (iterator->Next(subscriptionInfo))
+    {
+        // TODO(#31873): Persistant subscription only stores the NodeID for now. We cannot check if the CAT matches
+        if (subscriptionInfo.mFabricIndex == aFabricIndex && subscriptionInfo.mNodeId == subjectID)
+        {
+            persistedSubMatches = true;
+            break;
+        }
+    }
+    iterator->Release();
+#endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
+
+    return persistedSubMatches;
 }
 
 void InteractionModelEngine::OnDone(CommandResponseSender & apResponderObj)

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -330,6 +330,11 @@ public:
     bool SubjectHasPersistedSubscription(FabricIndex aFabricIndex, NodeId subjectID) override;
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
+    /**
+     * @brief Function decrements the number of subscriptions to resume counter - mNumOfSubscriptionsToResume.
+     *        This should be called after we have completed a re-subscribe attempt on a persisted subscription wether the attempt
+     *        was succesful or not.
+     */
     void DecrementNumSubscriptionsToResume();
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
@@ -681,6 +686,12 @@ private:
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
+    /**
+     * mNumOfSubscriptionsToResume tracks the number of subscriptions that the device will try to resume at its next resumption
+     * attempt. At boot up, the attempt will be at the highest min interval of all the subscriptions to resume.
+     * When the subscription timeout resumption feature is present, after the boot up attempt, the next attempt will be determined
+     * by ComputeTimeSecondsTillNextSubscriptionResumption.
+     */
     int8_t mNumOfSubscriptionsToResume = 0;
 #if CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     bool HasSubscriptionsToResume();

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -681,7 +681,7 @@ private:
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
-    int8_t mNumOfSubscriptionToResume = 0;
+    int8_t mNumOfSubscriptionsToResume = 0;
 #if CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     bool HasSubscriptionsToResume();
     uint32_t ComputeTimeSecondsTillNextSubscriptionResumption();

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed (next two includes)
+#include <lib/core/CHIPCore.h>
+
 #include <access/AccessControl.h>
 #include <app/AppConfig.h>
 #include <app/AttributePathParams.h>

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -330,7 +330,7 @@ public:
     bool SubjectHasPersistedSubscription(FabricIndex aFabricIndex, NodeId subjectID) override;
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
-    void DecrementNumSubscriptionToResume();
+    void DecrementNumSubscriptionsToResume();
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed (next two includes)
+// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed
 #include <lib/core/CHIPCore.h>
 
 #include <access/AccessControl.h>

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -821,7 +821,7 @@ void ReadHandler::PersistSubscription()
     auto * subscriptionResumptionStorage = mManagementCallback.GetInteractionModelEngine()->GetSubscriptionResumptionStorage();
     VerifyOrReturn(subscriptionResumptionStorage != nullptr);
 
-    // TODO(#31873): We need to store the CAT information to enable better interaction with ICDs
+    // TODO(#31873): We need to store the CAT information to enable better interactions with ICDs
     SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo = { .mNodeId         = GetInitiatorNodeId(),
                                                                          .mFabricIndex    = GetAccessingFabricIndex(),
                                                                          .mSubscriptionId = mSubscriptionId,

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -821,6 +821,7 @@ void ReadHandler::PersistSubscription()
     auto * subscriptionResumptionStorage = mManagementCallback.GetInteractionModelEngine()->GetSubscriptionResumptionStorage();
     VerifyOrReturn(subscriptionResumptionStorage != nullptr);
 
+    // TODO(#31873): We need to store the CAT information to enable better interaction with ICDs
     SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo = { .mNodeId         = GetInitiatorNodeId(),
                                                                          .mFabricIndex    = GetAccessingFabricIndex(),
                                                                          .mSubscriptionId = mSubscriptionId,

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -70,6 +70,7 @@ class TestReportScheduler;
 } // namespace reporting
 
 class InteractionModelEngine;
+class TestInteractionModelEngine;
 
 /**
  *  @class ReadHandler
@@ -433,6 +434,7 @@ private:
     //
     friend class chip::app::reporting::Engine;
     friend class chip::app::InteractionModelEngine;
+    friend class TestInteractionModelEngine;
 
     // The report scheduler needs to be able to access StateFlag private functions ShouldStartReporting(), CanStartReporting(),
     // ForceDirtyState() and IsDirty() to know when to schedule a run so it is declared as a friend class.

--- a/src/app/SubscriptionResumptionSessionEstablisher.cpp
+++ b/src/app/SubscriptionResumptionSessionEstablisher.cpp
@@ -91,7 +91,9 @@ void SubscriptionResumptionSessionEstablisher::HandleDeviceConnected(void * cont
     SubscriptionResumptionStorage::SubscriptionInfo & subscriptionInfo = establisher->mSubscriptionInfo;
     InteractionModelEngine * imEngine                                  = InteractionModelEngine::GetInstance();
 
-    // Decrement the number of subscriptions to resume
+    // Decrement the number of subscriptions to resume since we have completed our retry attempt for a given subscription.
+    // We do this before the readHandler creation since we do not care if the subscription has successfully been resumed or
+    // not. Counter only tracks the number of individual subscriptions we will try to resume.
     imEngine->DecrementNumSubscriptionsToResume();
 
     if (!imEngine->EnsureResourceForSubscription(subscriptionInfo.mFabricIndex, subscriptionInfo.mAttributePaths.AllocatedSize(),
@@ -129,7 +131,9 @@ void SubscriptionResumptionSessionEstablisher::HandleDeviceConnectionFailure(voi
     ChipLogError(DataManagement, "Failed to establish CASE for subscription-resumption with error '%" CHIP_ERROR_FORMAT "'",
                  error.Format());
 
-    // Decrement the number of subscriptions to resume
+    // Decrement the number of subscriptions to resume since we have completed our retry attempt for a given subscription.
+    // We do this here since we were not able to connect to the subscriber thus we have completed our resumption attempt.
+    // Counter only tracks the number of individual subscriptions we will try to resume.
     imEngine->DecrementNumSubscriptionsToResume();
 
     auto * subscriptionResumptionStorage = imEngine->GetSubscriptionResumptionStorage();

--- a/src/app/SubscriptionResumptionSessionEstablisher.cpp
+++ b/src/app/SubscriptionResumptionSessionEstablisher.cpp
@@ -90,15 +90,21 @@ void SubscriptionResumptionSessionEstablisher::HandleDeviceConnected(void * cont
     AutoDeleteEstablisher establisher(static_cast<SubscriptionResumptionSessionEstablisher *>(context));
     SubscriptionResumptionStorage::SubscriptionInfo & subscriptionInfo = establisher->mSubscriptionInfo;
     InteractionModelEngine * imEngine                                  = InteractionModelEngine::GetInstance();
+
+    // Decrement the number of subscriptions to resume
+    imEngine->DecrementNumSubscriptionToResume();
+
     if (!imEngine->EnsureResourceForSubscription(subscriptionInfo.mFabricIndex, subscriptionInfo.mAttributePaths.AllocatedSize(),
                                                  subscriptionInfo.mEventPaths.AllocatedSize()))
     {
+        // TODO - Should we keep the subscription here?
         ChipLogProgress(InteractionModel, "no resource for subscription resumption");
         return;
     }
     ReadHandler * readHandler = imEngine->mReadHandlers.CreateObject(*imEngine, imEngine->GetReportScheduler());
     if (readHandler == nullptr)
     {
+        // TODO - Should we keep the subscription here?
         ChipLogProgress(InteractionModel, "no resource for ReadHandler creation");
         return;
     }
@@ -118,10 +124,15 @@ void SubscriptionResumptionSessionEstablisher::HandleDeviceConnectionFailure(voi
                                                                              CHIP_ERROR error)
 {
     AutoDeleteEstablisher establisher(static_cast<SubscriptionResumptionSessionEstablisher *>(context));
+    InteractionModelEngine * imEngine                                  = InteractionModelEngine::GetInstance();
     SubscriptionResumptionStorage::SubscriptionInfo & subscriptionInfo = establisher->mSubscriptionInfo;
     ChipLogError(DataManagement, "Failed to establish CASE for subscription-resumption with error '%" CHIP_ERROR_FORMAT "'",
                  error.Format());
-    auto * subscriptionResumptionStorage = InteractionModelEngine::GetInstance()->GetSubscriptionResumptionStorage();
+
+    // Decrement the number of subscriptions to resume
+    imEngine->DecrementNumSubscriptionToResume();
+
+    auto * subscriptionResumptionStorage = imEngine->GetSubscriptionResumptionStorage();
     if (!subscriptionResumptionStorage)
     {
         ChipLogError(DataManagement, "Failed to get subscription resumption storage");

--- a/src/app/SubscriptionResumptionSessionEstablisher.cpp
+++ b/src/app/SubscriptionResumptionSessionEstablisher.cpp
@@ -92,7 +92,7 @@ void SubscriptionResumptionSessionEstablisher::HandleDeviceConnected(void * cont
     InteractionModelEngine * imEngine                                  = InteractionModelEngine::GetInstance();
 
     // Decrement the number of subscriptions to resume
-    imEngine->DecrementNumSubscriptionToResume();
+    imEngine->DecrementNumSubscriptionsToResume();
 
     if (!imEngine->EnsureResourceForSubscription(subscriptionInfo.mFabricIndex, subscriptionInfo.mAttributePaths.AllocatedSize(),
                                                  subscriptionInfo.mEventPaths.AllocatedSize()))
@@ -130,7 +130,7 @@ void SubscriptionResumptionSessionEstablisher::HandleDeviceConnectionFailure(voi
                  error.Format());
 
     // Decrement the number of subscriptions to resume
-    imEngine->DecrementNumSubscriptionToResume();
+    imEngine->DecrementNumSubscriptionsToResume();
 
     auto * subscriptionResumptionStorage = imEngine->GetSubscriptionResumptionStorage();
     if (!subscriptionResumptionStorage)

--- a/src/app/icd/server/BUILD.gn
+++ b/src/app/icd/server/BUILD.gn
@@ -75,9 +75,6 @@ source_set("manager") {
     ":configuration-data",
     ":notifier",
     ":observer",
-
-    # TODO : can this be in checkin?
-    "${chip_root}/src/app:subscription-manager",
     "${chip_root}/src/credentials:credentials",
     "${chip_root}/src/messaging",
   ]
@@ -87,6 +84,7 @@ source_set("manager") {
       ":monitoring-table",
       ":sender",
       "${chip_root}/src/app:app_config",
+      "${chip_root}/src/app:subscription-manager",
     ]
   }
 }

--- a/src/app/icd/server/BUILD.gn
+++ b/src/app/icd/server/BUILD.gn
@@ -22,6 +22,11 @@ buildconfig_header("icd-server-buildconfig") {
   header = "ICDServerBuildConfig.h"
   header_dir = "app/icd/server"
 
+  if (chip_enable_icd_lit || chip_enable_icd_checkin ||
+      chip_enable_icd_user_active_mode_trigger) {
+    assert(chip_enable_icd_lit)
+  }
+
   if (chip_enable_icd_lit) {
     assert(chip_enable_icd_checkin && chip_enable_icd_user_active_mode_trigger)
   }

--- a/src/app/icd/server/BUILD.gn
+++ b/src/app/icd/server/BUILD.gn
@@ -24,7 +24,7 @@ buildconfig_header("icd-server-buildconfig") {
 
   if (chip_enable_icd_lit || chip_enable_icd_checkin ||
       chip_enable_icd_user_active_mode_trigger) {
-    assert(chip_enable_icd_lit)
+    assert(chip_enable_icd_server)
   }
 
   if (chip_enable_icd_lit) {

--- a/src/app/icd/server/BUILD.gn
+++ b/src/app/icd/server/BUILD.gn
@@ -75,6 +75,8 @@ source_set("manager") {
     ":configuration-data",
     ":notifier",
     ":observer",
+
+    # TODO : can this be in checkin?
     "${chip_root}/src/app:subscription-manager",
     "${chip_root}/src/credentials:credentials",
     "${chip_root}/src/messaging",
@@ -84,6 +86,7 @@ source_set("manager") {
     public_deps += [
       ":monitoring-table",
       ":sender",
+      "${chip_root}/src/app:app_config",
     ]
   }
 }

--- a/src/app/icd/server/BUILD.gn
+++ b/src/app/icd/server/BUILD.gn
@@ -75,6 +75,7 @@ source_set("manager") {
     ":configuration-data",
     ":notifier",
     ":observer",
+    "${chip_root}/src/app:subscription-info-provider",
     "${chip_root}/src/credentials:credentials",
     "${chip_root}/src/messaging",
   ]
@@ -84,7 +85,6 @@ source_set("manager") {
       ":monitoring-table",
       ":sender",
       "${chip_root}/src/app:app_config",
-      "${chip_root}/src/app:subscription-manager",
     ]
   }
 }

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -294,10 +294,11 @@ bool ICDManager::ShouldCheckInMsgsBeSentAtActiveModeFunction(FabricIndex aFabric
 bool ICDManager::ShouldCheckInMsgsBeSentAtActiveModeFunction(FabricIndex aFabricIndex, NodeId subjectID)
 {
     bool mightHaveSubscription = mSubInfoProvider->SubjectHasActiveSubscription(aFabricIndex, subjectID);
-    if (!mightHaveSubscription && !mIsBootUpResumeSubscriptionExecuted) {
+    if (!mightHaveSubscription && !mIsBootUpResumeSubscriptionExecuted)
+    {
         mightHaveSubscription = mSubInfoProvider->SubjectHasPersistedSubscription(aFabricIndex, subjectID);
     }
-    
+
     return !mightHaveSubscription;
 }
 #endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
@@ -397,7 +398,7 @@ void ICDManager::UpdateOperationState(OperationalState state)
         // unless the device would need to send Check-In messages
         if (ICDConfigurationData::GetInstance().GetActiveModeDuration() > kZero
 #if CHIP_CONFIG_ENABLE_ICD_CIP
-            || CheckInMessagesWouldBeSent(function)
+            || CheckInMessagesWouldBeSent(sendCheckInMessagesOnActiveMode)
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
         )
         {

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -260,6 +260,12 @@ bool ICDManager::CheckInMessagesWouldBeSent(const std::function<ShouldCheckInMsg
  * @brief Implementation for when the persistent subscription and subscription timeout resumption feature are present.
  *        Function checks that there are no active or persisted subscriptions for a given fabricIndex or subjectID.
  *
+ * @note When the persistent subscription and subscription timeout resumption feature are present, we need to check for
+ *       persisted subscription at each transition to ActiveMode since there will be persisted subscriptions during normal
+ *       operation for the subscription timeout resumption feature. Once we have finished all our subscription resumption attempts
+ *       for a given subscription, the entry is deleted from persisted storage which will enable us to send Check-In messages for
+ *       the client registration. This logic avoids the device sending a Check-In message while trying to resume subscriptions.
+ *
  * @param aFabricIndex
  * @param subjectID subjectID to check. Can be an operational node id or a CAT
  *
@@ -306,6 +312,9 @@ bool ICDManager::ShouldCheckInMsgsBeSentAtActiveModeFunction(FabricIndex aFabric
 /**
  * @brief Implementation for when neither the persistent subscription nor the subscription timeout resumption features are present.
  *        Function checks that there no active sbuscriptions for a given fabricIndex and subjectId combination.
+ *
+ * @note When neither the persistent subscription nor the subscription timeout resumption features are present, we only need to
+ *       check for active subscription since we will never have any persisted subscription.
  *
  * @param aFabricIndex
  * @param subjectID subjectID to check. Can be an opperationnal node id or a CAT

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -257,8 +257,8 @@ bool ICDManager::CheckInMessagesWouldBeSent(const std::function<ShouldCheckInMsg
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 #if CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 /**
- * @brief Implementation for when the persistant subscription and subscription timeout resumption feature are present.
- *        Function checks that there no active or persisted subscriptions for a given fabricIndex or subjectID.
+ * @brief Implementation for when the persistent subscription and subscription timeout resumption feature are present.
+ *        Function checks that there are no active or persisted subscriptions for a given fabricIndex or subjectID.
  *
  * @param aFabricIndex
  * @param subjectID subjectID to check. Can be an operational node id or a CAT
@@ -273,8 +273,8 @@ bool ICDManager::ShouldCheckInMsgsBeSentAtActiveModeFunction(FabricIndex aFabric
 }
 #else
 /**
- * @brief Implementation for when the persistant subscription feature is present without the subscription timeout resumption
- * feature. Function checks that there no active subscriptions. If the boot up subscription resumption has not been completed,
+ * @brief Implementation for when the persistent subscription feature is present without the subscription timeout resumption
+ * feature. Function checks that there are no active subscriptions. If the boot up subscription resumption has not been completed,
  *        function also checks if there are persisted subscriptions.
  *
  * @note The persistent subscriptions feature tries to resume subscriptions at the highest min interval
@@ -286,26 +286,24 @@ bool ICDManager::ShouldCheckInMsgsBeSentAtActiveModeFunction(FabricIndex aFabric
  * @param subjectID subjectID to check. Can be an opperationnal node id or a CAT
  *
  * @return true Returns true if the fabricIndex and subjectId combination does not have an active subscription.
- *              If the boot up susbscription has not been completed, there must not be a persisted subscription either.
+ *              If the boot up subscription resumption has not been completed, there must not be a persisted subscription either.
  * @return false Returns false if the fabricIndex and subjectId combination has an active subscription.
- *               If the boot up susbscription has not been completed,
+ *               If the boot up subscription resumption has not been completed,
  *               returns false if the fabricIndex and subjectId combination has a persisted subscription.
  */
 bool ICDManager::ShouldCheckInMsgsBeSentAtActiveModeFunction(FabricIndex aFabricIndex, NodeId subjectID)
 {
-    bool wouldSendCheckIn = !(mSubInfoProvider->SubjectHasActiveSubscription(aFabricIndex, subjectID));
-
-    if (!mIsBootUpResumeSubscriptionExecuted)
-    {
-        wouldSendCheckIn = wouldSendCheckIn && !mSubInfoProvider->SubjectHasPersistedSubscription(aFabricIndex, subjectID);
+    bool mightHaveSubscription = mSubInfoProvider->SubjectHasActiveSubscription(aFabricIndex, subjectID);
+    if (!mightHaveSubscription && !mIsBootUpResumeSubscriptionExecuted) {
+        mightHaveSubscription = mSubInfoProvider->SubjectHasPersistedSubscription(aFabricIndex, subjectID);
     }
-
-    return wouldSendCheckIn;
+    
+    return !mightHaveSubscription;
 }
 #endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 #else
 /**
- * @brief Implementation for when neither the persistant subscription and subscription timeout resumption features are present.
+ * @brief Implementation for when neither the persistent subscription nor the subscription timeout resumption features are present.
  *        Function checks that there no active sbuscriptions for a given fabricIndex and subjectId combination.
  *
  * @param aFabricIndex
@@ -391,7 +389,7 @@ void ICDManager::UpdateOperationState(OperationalState state)
         mOperationalState = OperationalState::IdleMode;
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
-        std::function<ShouldCheckInMsgsBeSentFunction> function =
+        std::function<ShouldCheckInMsgsBeSentFunction> sendCheckInMessagesOnActiveMode =
             std::bind(&ICDManager::ShouldCheckInMsgsBeSentAtActiveModeFunction, this, std::placeholders::_1, std::placeholders::_2);
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -249,8 +249,8 @@ bool ICDManager::CheckInWouldBeSentAtActiveModeVerifier(FabricIndex aFabricIndex
     VerifyOrReturnValue(mSubInfoProvider->SubjectHasActiveSubscription(aFabricIndex, subjectID), true);
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
-    // At least one registration has a persisted entry. Do not send Check-In message.
-    // This is to cover the use-case where the subscription resumption feature is used with the Check-In message.
+    // If at least one registration has a persisted entry, do not send Check-In message.
+    // The resumption of the persisted subscription will serve the same function a check-in would have served.
     VerifyOrReturnValue(mSubInfoProvider->SubjectHasPersistedSubscription(aFabricIndex, subjectID), true);
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
     return false;

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -236,7 +236,7 @@ bool ICDManager::CheckInMessagesWouldBeSent(std::function<RegistrationVerificati
             }
 
             // At least one registration would require a Check-In message
-            VerifyOrReturnValue(RegistrationVerifier(entry.fabricIndex, entry.monitoredSubject), true);
+            VerifyOrReturnValue(!RegistrationVerifier(entry.fabricIndex, entry.monitoredSubject), true);
         }
     }
 

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -21,11 +21,11 @@
 #include <app/icd/server/ICDServerConfig.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
+#include <app/SubscriptionsInfoProvider.h>     // nogncheck
 #include <app/icd/server/ICDCheckInSender.h>   // nogncheck
 #include <app/icd/server/ICDMonitoringTable.h> // nogncheck
 #endif                                         // CHIP_CONFIG_ENABLE_ICD_CIP
 
-#include <app/SubscriptionsInfoProvider.h>
 #include <app/icd/server/ICDConfigurationData.h>
 #include <app/icd/server/ICDNotifier.h>
 #include <app/icd/server/ICDStateObserver.h>

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -135,9 +135,9 @@ public:
     /**
      * @brief Trigger the ICDManager to send Check-In message if necessary
      *
-     * @param[in] algo Verifier function to use to determine if we need to send check-in messages
+     * @param[in] function to use to determine if we need to send check-in messages
      */
-    void TriggerCheckInMessages(const std::function<ShouldCheckInMsgsBeSentFunction> & verifier);
+    void TriggerCheckInMessages(const std::function<ShouldCheckInMsgsBeSentFunction> & function);
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     /**
@@ -151,7 +151,9 @@ public:
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     void SetTestFeatureMapValue(uint32_t featureMap) { mFeatureMap = featureMap; };
+#if !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
     bool GetIsBootUpResumeSubscriptionExecuted() { return mIsBootUpResumeSubscriptionExecuted; };
+#endif // !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 #endif
 
     // Implementation of ICDListener functions.
@@ -201,7 +203,7 @@ private:
      * @return false None of the registration would require a Check-In message either because there are no registration or
      * because they all have associated subscriptions.
      */
-    bool CheckInMessagesWouldBeSent(std::function<ShouldCheckInMsgsBeSentFunction> function);
+    bool CheckInMessagesWouldBeSent(const std::function<ShouldCheckInMsgsBeSentFunction> & function);
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 
     KeepActiveFlags mKeepActiveFlags{ 0 };
@@ -214,7 +216,7 @@ private:
 #if CHIP_CONFIG_ENABLE_ICD_CIP
 #if !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
     bool mIsBootUpResumeSubscriptionExecuted = false;
-#endif // !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+#endif // !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
     PersistentStorageDelegate * mStorage           = nullptr;
     FabricTable * mFabricTable                     = nullptr;
     Messaging::ExchangeManager * mExchangeManager  = nullptr;

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -140,7 +140,7 @@ public:
     void TriggerCheckInMessages(const std::function<RegistrationVerificationFunction> & verifier);
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 
-#ifdef CONFIG_BUILD_FOR_HOST_UNIT_TEST
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     void SetTestFeatureMapValue(uint32_t featureMap) { mFeatureMap = featureMap; };
 #endif
 

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -138,10 +138,20 @@ public:
      * @param[in] algo Verifier function to use to determine if we need to send check-in messages
      */
     void TriggerCheckInMessages(const std::function<RegistrationVerificationFunction> & verifier);
+
+#if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+    /**
+     * @brief Set mSubCheckInBootCheckExecuted to true
+     *        Function allows the InteractionModelEngine to notify the ICDManager that the boot up subscription resumption has been
+     *        completed.
+     */
+    void SetBootUpResumeSubscriptionExecuted() { mIsBootUpResumeSubscriptionExecuted = true; };
+#endif // !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     void SetTestFeatureMapValue(uint32_t featureMap) { mFeatureMap = featureMap; };
+    bool GetIsBootUpResumeSubscriptionExecuted() { return mIsBootUpResumeSubscriptionExecuted; };
 #endif
 
     // Implementation of ICDListener functions.
@@ -212,6 +222,9 @@ private:
     ObjectPool<ObserverPointer, CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE> mStateObserverPool;
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
+#if !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
+    bool mIsBootUpResumeSubscriptionExecuted = false;
+#endif // !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     PersistentStorageDelegate * mStorage           = nullptr;
     FabricTable * mFabricTable                     = nullptr;
     Messaging::ExchangeManager * mExchangeManager  = nullptr;

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -85,7 +85,7 @@ public:
      *        This type can be used to implement specific verifiers that can be used in the CheckInMessagesWouldBeSent function.
      *        The goal is to avoid having multiple functions that implement the iterator loop with only the check changing.
      *
-     * @return true if at least one Check-In message wuld be sent
+     * @return true if at least one Check-In message would be sent
      *         false No Check-In messages would be sent
      */
 

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -82,9 +82,11 @@ public:
 
     /**
      * @brief Verifier template function
-     *        This type can be used to implement specific verifiers that can be used in
-     *        the CheckInMessagesWouldBeSent function. The goal is to avoid having multiple functions that implement the iterator
-     *        loop with only the check changing.
+     *        This type can be used to implement specific verifiers that can be used in the CheckInMessagesWouldBeSent function.
+     *        The goal is to avoid having multiple functions that implement the iterator loop with only the check changing.
+     *
+     * @return true if at least one Check-In message wuld be sent
+     *         false No Check-In messages would be sent
      */
 
     using RegistrationVerificationFunction = bool(FabricIndex aFabricIndex, NodeId subjectID);

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -38,9 +38,6 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <system/SystemClock.h>
 
-#define CHIP_CONFIG_ENABLE_ICD_CIP 1
-#define CHIP_CONFIG_ENABLE_ICD_LIT 1
-
 namespace chip {
 namespace Crypto {
 using SymmetricKeystore = SessionKeystore;

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -89,7 +89,7 @@ public:
      *         false No Check-In messages would be sent
      */
 
-    using RegistrationVerificationFunction = bool(FabricIndex aFabricIndex, NodeId subjectID);
+    using ShouldCheckInMsgsBeSentFunction = bool(FabricIndex aFabricIndex, NodeId subjectID);
 
     ICDManager() {}
     void Init(PersistentStorageDelegate * storage, FabricTable * fabricTable, Crypto::SymmetricKeystore * symmetricKeyStore,
@@ -137,7 +137,7 @@ public:
      *
      * @param[in] algo Verifier function to use to determine if we need to send check-in messages
      */
-    void TriggerCheckInMessages(const std::function<RegistrationVerificationFunction> & verifier);
+    void TriggerCheckInMessages(const std::function<ShouldCheckInMsgsBeSentFunction> & verifier);
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     /**
@@ -190,28 +190,18 @@ protected:
 
 private:
 #if CHIP_CONFIG_ENABLE_ICD_CIP
-    /**
-     * @brief Verifier to determine if a Check-In message would be sent on transition to ActiveMode
-     *
-     * @param aFabricIndex client fabric index
-     * @param subjectID client subject ID
-     * @return true  Check-In message would be sent on transition to ActiveMode.
-     * @return false Device has an active subscription with the subjectID.
-     *               Device is trying to resume inactive subscriptions with the client. See CHIP_CONFIG_PERSIST_SUBSCRIPTIONS and
-     *               CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
-     */
-    bool CheckInWouldBeSentAtActiveModeVerifier(FabricIndex aFabricIndex, NodeId subjectID);
+    bool ShouldCheckInMsgsBeSentAtActiveModeFunction(FabricIndex aFabricIndex, NodeId subjectID);
 
     /**
      * @brief Function checks if at least one client registration would require a Check-In message
      *
-     * @param[in] RegistrationVerifier  function to use to determine if a Check-In message would be sent for a given registration
+     * @param[in] function  function to use to determine if a Check-In message would be sent for a given registration
      *
      * @return true At least one registration would require an Check-In message if we were entering ActiveMode.
      * @return false None of the registration would require a Check-In message either because there are no registration or
      * because they all have associated subscriptions.
      */
-    bool CheckInMessagesWouldBeSent(std::function<RegistrationVerificationFunction> RegistrationVerifier);
+    bool CheckInMessagesWouldBeSent(std::function<ShouldCheckInMsgsBeSentFunction> function);
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 
     KeepActiveFlags mKeepActiveFlags{ 0 };

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -21,11 +21,11 @@
 #include <app/icd/server/ICDServerConfig.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
-#include <app/SubscriptionsInfoProvider.h>     // nogncheck
 #include <app/icd/server/ICDCheckInSender.h>   // nogncheck
 #include <app/icd/server/ICDMonitoringTable.h> // nogncheck
 #endif                                         // CHIP_CONFIG_ENABLE_ICD_CIP
 
+#include <app/SubscriptionsInfoProvider.h>
 #include <app/icd/server/ICDConfigurationData.h>
 #include <app/icd/server/ICDNotifier.h>
 #include <app/icd/server/ICDStateObserver.h>

--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -18,6 +18,9 @@
 
 #pragma once
 
+// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed (next two includes)
+#include <lib/core/CHIPCore.h>
+
 #include <app/ReadHandler.h>
 #include <app/icd/server/ICDStateObserver.h>
 #include <lib/core/CHIPError.h>

--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -213,7 +213,7 @@ public:
     /// @brief Get the number of ReadHandlers registered in the scheduler's node pool
     size_t GetNumReadHandlers() const { return mNodesPool.Allocated(); }
 
-#ifdef CONFIG_BUILD_FOR_HOST_UNIT_TEST
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     Timestamp GetMinTimestampForHandler(const ReadHandler * aReadHandler)
     {
         ReadHandlerNode * node = FindReadHandlerNode(aReadHandler);

--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed (next two includes)
+// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed
 #include <lib/core/CHIPCore.h>
 
 #include <app/ReadHandler.h>

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -450,7 +450,7 @@ void Server::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent & event)
         // We trigger Check-In messages before resuming subscriptions to avoid doing both.
         if (!mFailSafeContext.IsFailSafeArmed())
         {
-            std::function<chip::app::ICDManager::RegistrationVerificationFunction> verifier =
+            std::function<chip::app::ICDManager::ShouldCheckInMsgsBeSentFunction> verifier =
                 std::bind(&Server::CheckInWouldBeSentAtBootVerifier, this, std::placeholders::_1, std::placeholders::_2);
             mICDManager.TriggerCheckInMessages(verifier);
         }
@@ -526,7 +526,7 @@ void Server::RejoinExistingMulticastGroups()
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
-bool Server::CheckInWouldBeSentAtBootVerifier(FabricIndex aFabricIndex, NodeId subjectID)
+bool Server::ShouldCheckInMsgsBeSentAtBootFunction(FabricIndex aFabricIndex, NodeId subjectID)
 {
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
     // If at least one registration has a persisted entry, do not send Check-In message.

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -334,7 +334,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     SuccessOrExit(err);
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    chip::app::InteractionModelEngine::GetInstance()->SetICDManager(&mICDManager);
+    app::InteractionModelEngine::GetInstance()->SetICDManager(&mICDManager);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
     // ICD Init needs to be after data model init and InteractionModel Init
@@ -450,7 +450,7 @@ void Server::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent & event)
         // We trigger Check-In messages before resuming subscriptions to avoid doing both.
         if (!mFailSafeContext.IsFailSafeArmed())
         {
-            std::function<chip::app::ICDManager::ShouldCheckInMsgsBeSentFunction> function =
+            std::function<app::ICDManager::ShouldCheckInMsgsBeSentFunction> function =
                 std::bind(&Server::ShouldCheckInMsgsBeSentAtBootFunction, this, std::placeholders::_1, std::placeholders::_2);
             mICDManager.TriggerCheckInMessages(function);
         }
@@ -531,11 +531,10 @@ bool Server::ShouldCheckInMsgsBeSentAtBootFunction(FabricIndex aFabricIndex, Nod
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
     // If at least one registration has a persisted entry, do not send Check-In message.
     // The resumption of the persisted subscription will serve the same function a check-in would have served.
-    VerifyOrReturnValue(!app::InteractionModelEngine::GetInstance()->SubjectHasPersistedSubscription(aFabricIndex, subjectID),
-                        false);
-#endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
-
+    return !app::InteractionModelEngine::GetInstance()->SubjectHasPersistedSubscription(aFabricIndex, subjectID);
+#else
     return true;
+#endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 
@@ -582,7 +581,7 @@ void Server::Shutdown()
     chip::Dnssd::Resolver::Instance().Shutdown();
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    chip::app::InteractionModelEngine::GetInstance()->SetICDManager(nullptr);
+    app::InteractionModelEngine::GetInstance()->SetICDManager(nullptr);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
     mCommissioningWindowManager.Shutdown();
     mMessageCounterManager.Shutdown();

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -450,9 +450,9 @@ void Server::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent & event)
         // We trigger Check-In messages before resuming subscriptions to avoid doing both.
         if (!mFailSafeContext.IsFailSafeArmed())
         {
-            std::function<app::ICDManager::ShouldCheckInMsgsBeSentFunction> function =
+            std::function<app::ICDManager::ShouldCheckInMsgsBeSentFunction> sendCheckInMessagesOnBootUp =
                 std::bind(&Server::ShouldCheckInMsgsBeSentAtBootFunction, this, std::placeholders::_1, std::placeholders::_2);
-            mICDManager.TriggerCheckInMessages(function);
+            mICDManager.TriggerCheckInMessages(sendCheckInMessagesOnBootUp);
         }
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -450,9 +450,9 @@ void Server::OnPlatformEvent(const DeviceLayer::ChipDeviceEvent & event)
         // We trigger Check-In messages before resuming subscriptions to avoid doing both.
         if (!mFailSafeContext.IsFailSafeArmed())
         {
-            std::function<chip::app::ICDManager::ShouldCheckInMsgsBeSentFunction> verifier =
-                std::bind(&Server::CheckInWouldBeSentAtBootVerifier, this, std::placeholders::_1, std::placeholders::_2);
-            mICDManager.TriggerCheckInMessages(verifier);
+            std::function<chip::app::ICDManager::ShouldCheckInMsgsBeSentFunction> function =
+                std::bind(&Server::ShouldCheckInMsgsBeSentAtBootFunction, this, std::placeholders::_1, std::placeholders::_2);
+            mICDManager.TriggerCheckInMessages(function);
         }
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && CHIP_CONFIG_ENABLE_ICD_CIP
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -527,11 +527,11 @@ bool Server::CheckInWouldBeSentAtBootVerifier(FabricIndex aFabricIndex, NodeId s
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
     // At least one registration has a persisted entry. Do not send Check-In message.
     // This is to cover the use-case where the subscription resumption feature is used with the Check-In message.
-    VerifyOrReturnValue(chip::app::InteractionModelEngine::GetInstance()->SubjectHasPersistedSubscription(aFabricIndex, subjectID),
-                        true);
+    VerifyOrReturnValue(!chip::app::InteractionModelEngine::GetInstance()->SubjectHasPersistedSubscription(aFabricIndex, subjectID),
+                        false);
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
-    return false;
+    return true;
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -369,6 +369,18 @@ public:
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     app::ICDManager & GetICDManager() { return mICDManager; }
+
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+    /**
+     * @brief Verifier to determine if a Check-In message would be sent at Boot up
+     *
+     * @param aFabricIndex client fabric index
+     * @param subjectID client subject ID
+     * @return true Check-In message would be sent on boot up.
+     * @return false Device has a persisted subscription with the client. See CHIP_CONFIG_PERSIST_SUBSCRIPTIONS.
+     */
+    bool CheckInWouldBeSentAtBootVerifier(FabricIndex aFabricIndex, NodeId subjectID);
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
     /**

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -372,14 +372,14 @@ public:
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
     /**
-     * @brief Verifier to determine if a Check-In message would be sent at Boot up
+     * @brief Function to determine if a Check-In message would be sent at Boot up
      *
      * @param aFabricIndex client fabric index
      * @param subjectID client subject ID
      * @return true Check-In message would be sent on boot up.
      * @return false Device has a persisted subscription with the client. See CHIP_CONFIG_PERSIST_SUBSCRIPTIONS.
      */
-    bool CheckInWouldBeSentAtBootVerifier(FabricIndex aFabricIndex, NodeId subjectID);
+    bool ShouldCheckInMsgsBeSentAtBootFunction(FabricIndex aFabricIndex, NodeId subjectID);
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 

--- a/src/app/tests/TestICDManager.cpp
+++ b/src/app/tests/TestICDManager.cpp
@@ -624,27 +624,27 @@ public:
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 #if CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
-    static void TestCheckInWouldBeSentAtActiveModeVerifier(nlTestSuite * aSuite, void * aContext)
+    static void TestShouldCheckInMsgsBeSentAtActiveModeFunction(nlTestSuite * aSuite, void * aContext)
     {
         TestContext * ctx = static_cast<TestContext *>(aContext);
 
         // Test 1 - Has no ActiveSubscription & no persisted subscription
         ctx->mSubInfoProvider.SetHasActiveSubscription(false);
         ctx->mSubInfoProvider.SetHasPersistedSubscription(false);
-        NL_TEST_ASSERT(aSuite, ctx->mICDManager.CheckInWouldBeSentAtActiveModeVerifier(kTestFabricIndex1, kClientNodeId11));
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.ShouldCheckInMsgsBeSentAtActiveModeFunction(kTestFabricIndex1, kClientNodeId11));
 
         // Test 2 - Has no active subscription & a persisted subscription
         ctx->mSubInfoProvider.SetHasActiveSubscription(false);
         ctx->mSubInfoProvider.SetHasPersistedSubscription(true);
-        NL_TEST_ASSERT(aSuite, !(ctx->mICDManager.CheckInWouldBeSentAtActiveModeVerifier(kTestFabricIndex1, kClientNodeId11)));
+        NL_TEST_ASSERT(aSuite, !(ctx->mICDManager.ShouldCheckInMsgsBeSentAtActiveModeFunction(kTestFabricIndex1, kClientNodeId11)));
 
         // Test 3 - Has an active subscription & a persisted subscription
         ctx->mSubInfoProvider.SetHasActiveSubscription(true);
         ctx->mSubInfoProvider.SetHasPersistedSubscription(true);
-        NL_TEST_ASSERT(aSuite, !(ctx->mICDManager.CheckInWouldBeSentAtActiveModeVerifier(kTestFabricIndex1, kClientNodeId11)));
+        NL_TEST_ASSERT(aSuite, !(ctx->mICDManager.ShouldCheckInMsgsBeSentAtActiveModeFunction(kTestFabricIndex1, kClientNodeId11)));
     }
 #else
-    static void TestCheckInWouldBeSentAtActiveModeVerifier(nlTestSuite * aSuite, void * aContext)
+    static void TestShouldCheckInMsgsBeSentAtActiveModeFunction(nlTestSuite * aSuite, void * aContext)
     {
         TestContext * ctx = static_cast<TestContext *>(aContext);
 
@@ -652,44 +652,44 @@ public:
         ctx->mSubInfoProvider.SetHasActiveSubscription(false);
         ctx->mSubInfoProvider.SetHasPersistedSubscription(false);
         ctx->mICDManager.mIsBootUpResumeSubscriptionExecuted = false;
-        NL_TEST_ASSERT(aSuite, ctx->mICDManager.CheckInWouldBeSentAtActiveModeVerifier(kTestFabricIndex1, kClientNodeId11));
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.ShouldCheckInMsgsBeSentAtActiveModeFunction(kTestFabricIndex1, kClientNodeId11));
 
         // Test 2 - Has no active subscription and a persisted subscription at boot up
         ctx->mSubInfoProvider.SetHasActiveSubscription(false);
         ctx->mSubInfoProvider.SetHasPersistedSubscription(true);
         ctx->mICDManager.mIsBootUpResumeSubscriptionExecuted = false;
-        NL_TEST_ASSERT(aSuite, !(ctx->mICDManager.CheckInWouldBeSentAtActiveModeVerifier(kTestFabricIndex1, kClientNodeId11)));
+        NL_TEST_ASSERT(aSuite, !(ctx->mICDManager.ShouldCheckInMsgsBeSentAtActiveModeFunction(kTestFabricIndex1, kClientNodeId11)));
 
         // Test 3 - Has an active subscription and a persisted subscription during normal operations
         ctx->mSubInfoProvider.SetHasActiveSubscription(true);
         ctx->mSubInfoProvider.SetHasPersistedSubscription(true);
         ctx->mICDManager.mIsBootUpResumeSubscriptionExecuted = true;
-        NL_TEST_ASSERT(aSuite, !(ctx->mICDManager.CheckInWouldBeSentAtActiveModeVerifier(kTestFabricIndex1, kClientNodeId11)));
+        NL_TEST_ASSERT(aSuite, !(ctx->mICDManager.ShouldCheckInMsgsBeSentAtActiveModeFunction(kTestFabricIndex1, kClientNodeId11)));
 
         // Test 4 - Has no active subscription and a persisted subscription during normal operations
         ctx->mSubInfoProvider.SetHasActiveSubscription(false);
         ctx->mSubInfoProvider.SetHasPersistedSubscription(true);
         ctx->mICDManager.mIsBootUpResumeSubscriptionExecuted = true;
-        NL_TEST_ASSERT(aSuite, ctx->mICDManager.CheckInWouldBeSentAtActiveModeVerifier(kTestFabricIndex1, kClientNodeId11));
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.ShouldCheckInMsgsBeSentAtActiveModeFunction(kTestFabricIndex1, kClientNodeId11));
     }
 #endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 #else
-    static void TestCheckInWouldBeSentAtActiveModeVerifier(nlTestSuite * aSuite, void * aContext)
+    static void TestShouldCheckInMsgsBeSentAtActiveModeFunction(nlTestSuite * aSuite, void * aContext)
     {
         TestContext * ctx = static_cast<TestContext *>(aContext);
 
         // Test 1 - Has an active subscription
         ctx->mSubInfoProvider.SetHasActiveSubscription(true);
         NL_TEST_ASSERT(aSuite,
-                       ctx->mICDManager.CheckInWouldBeSentAtActiveModeVerifier(kTestFabricIndex1, kClientNodeId11) == false);
+                       ctx->mICDManager.ShouldCheckInMsgsBeSentAtActiveModeFunction(kTestFabricIndex1, kClientNodeId11) == false);
 
         // Test 2 - Has no active subscription
         ctx->mSubInfoProvider.SetHasActiveSubscription(false);
-        NL_TEST_ASSERT(aSuite, ctx->mICDManager.CheckInWouldBeSentAtActiveModeVerifier(kTestFabricIndex1, kClientNodeId11));
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.ShouldCheckInMsgsBeSentAtActiveModeFunction(kTestFabricIndex1, kClientNodeId11));
 
         // Test 3 - Make sure that the persisted subscription has no impact
         ctx->mSubInfoProvider.SetHasPersistedSubscription(true);
-        NL_TEST_ASSERT(aSuite, ctx->mICDManager.CheckInWouldBeSentAtActiveModeVerifier(kTestFabricIndex1, kClientNodeId11));
+        NL_TEST_ASSERT(aSuite, ctx->mICDManager.ShouldCheckInMsgsBeSentAtActiveModeFunction(kTestFabricIndex1, kClientNodeId11));
     }
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 };
@@ -709,7 +709,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF("TestICDMRegisterUnregisterEvents", TestICDManager::TestICDMRegisterUnregisterEvents),
     NL_TEST_DEF("TestICDCounter", TestICDManager::TestICDCounter),
     NL_TEST_DEF("TestICDStayActive", TestICDManager::TestICDMStayActive),
-    NL_TEST_DEF("TestCheckInWouldBeSentAtActiveModeVerifier", TestICDManager::TestCheckInWouldBeSentAtActiveModeVerifier),
+    NL_TEST_DEF("TestShouldCheckInMsgsBeSentAtActiveModeFunction", TestICDManager::TestShouldCheckInMsgsBeSentAtActiveModeFunction),
     NL_TEST_SENTINEL(),
 };
 

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -22,9 +22,10 @@
  *
  */
 
-#include <app/AppConfig.h>
+// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed
 #include <lib/core/CHIPCore.h>
 
+#include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/tests/MockReportScheduler.h>
 #include <app/tests/AppTestContext.h>

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -259,6 +259,9 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
 }
 
+/**
+ * @brief Test verifies the SubjectHasActiveSubscription with a single subscription with a single entry
+ */
 void TestInteractionModelEngine::TestSubjectHasActiveSubscriptionSingleSubOneEntry(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
@@ -300,6 +303,10 @@ void TestInteractionModelEngine::TestSubjectHasActiveSubscriptionSingleSubOneEnt
     NL_TEST_ASSERT(apSuite, engine->SubjectHasActiveSubscription(bobFabricIndex, bobNodeId) == false);
 }
 
+/**
+ * @brief Test verifies that the SubjectHasActiveSubscription will continue iterating till it fines at least one valid active
+ * subscription
+ */
 void TestInteractionModelEngine::TestSubjectHasActiveSubscriptionSingleSubMultipleEntries(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
@@ -354,6 +361,9 @@ void TestInteractionModelEngine::TestSubjectHasActiveSubscriptionSingleSubMultip
     engine->GetReadHandlerPool().ReleaseAll();
 }
 
+/**
+ * @brief Test validates that the SubjectHasActiveSubscription can support multiple subscriptions from different clients
+ */
 void TestInteractionModelEngine::TestSubjectHasActiveSubscriptionMultipleSubsSingleEntry(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
@@ -427,6 +437,10 @@ void TestInteractionModelEngine::TestSubjectHasActiveSubscriptionMultipleSubsSin
     NL_TEST_ASSERT(apSuite, engine->SubjectHasActiveSubscription(aliceFabricIndex, aliceNodeId) == false);
 }
 
+/**
+ * @brief Test validates that the SubjectHasActiveSubscription can find the active subscription even if there are multiple
+ * subscriptions for each client
+ */
 void TestInteractionModelEngine::TestSubjectHasActiveSubscriptionMultipleSubsMultipleEntries(nlTestSuite * apSuite,
                                                                                              void * apContext)
 {
@@ -516,6 +530,9 @@ void TestInteractionModelEngine::TestSubjectHasActiveSubscriptionMultipleSubsMul
     NL_TEST_ASSERT(apSuite, engine->SubjectHasActiveSubscription(aliceFabricIndex, aliceNodeId) == false);
 }
 
+/**
+ * @brief Verifies that SubjectHasActiveSubscription support CATs as a subject-id
+ */
 void TestInteractionModelEngine::TestSubjectHasActiveSubscriptionSubWithCAT(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx               = *reinterpret_cast<TestContext *>(apContext);
@@ -569,6 +586,9 @@ void TestInteractionModelEngine::TestSubjectHasActiveSubscriptionSubWithCAT(nlTe
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
+/**
+ * @brief Test verifies the SubjectHasPersistedSubscription with single and multiple persisted subscriptions.
+ */
 void TestInteractionModelEngine::TestSubjectHasPersistedSubscription(nlTestSuite * apSuite, void * apContext)
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -23,13 +23,14 @@
  */
 
 #include <app/AppConfig.h>
+#include <lib/core/CHIPCore.h>
+
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/tests/MockReportScheduler.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/mock/Constants.h>
 #include <app/util/mock/Functions.h>
 #include <lib/core/CASEAuthTag.h>
-#include <lib/core/CHIPCore.h>
 #include <lib/core/ErrorStr.h>
 #include <lib/core/TLV.h>
 #include <lib/core/TLVDebug.h>

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -701,7 +701,7 @@ void TestInteractionModelEngine::TestDecrementNumSubscriptionsToResume(nlTestSui
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 
     // Set number of subs
-    engine->mNumOfSubscriptionToResume = kNumberOfSubsToResume;
+    engine->mNumOfSubscriptionsToResume = kNumberOfSubsToResume;
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     // Verify mIsBootUpResumeSubscriptionExecuted has not been set
@@ -711,7 +711,7 @@ void TestInteractionModelEngine::TestDecrementNumSubscriptionsToResume(nlTestSui
     // Decrease number of subs by 1
     numberOfSubsRemaining--;
     engine->DecrementNumSubscriptionsToResume();
-    NL_TEST_ASSERT_EQUALS(apSuite, numberOfSubsRemaining, engine->mNumOfSubscriptionToResume);
+    NL_TEST_ASSERT_EQUALS(apSuite, numberOfSubsRemaining, engine->mNumOfSubscriptionsToResume);
 
     // Decrease to 0 subs remaining
     while (numberOfSubsRemaining > 0)
@@ -723,7 +723,7 @@ void TestInteractionModelEngine::TestDecrementNumSubscriptionsToResume(nlTestSui
 
         numberOfSubsRemaining--;
         engine->DecrementNumSubscriptionsToResume();
-        NL_TEST_ASSERT_EQUALS(apSuite, numberOfSubsRemaining, engine->mNumOfSubscriptionToResume);
+        NL_TEST_ASSERT_EQUALS(apSuite, numberOfSubsRemaining, engine->mNumOfSubscriptionsToResume);
     }
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
@@ -733,7 +733,7 @@ void TestInteractionModelEngine::TestDecrementNumSubscriptionsToResume(nlTestSui
 
     // Make sure we don't rollover / go negative
     engine->DecrementNumSubscriptionsToResume();
-    NL_TEST_ASSERT_EQUALS(apSuite, numberOfSubsRemaining, engine->mNumOfSubscriptionToResume);
+    NL_TEST_ASSERT_EQUALS(apSuite, numberOfSubsRemaining, engine->mNumOfSubscriptionsToResume);
 
     // Clean up
 #if CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -22,9 +22,6 @@
  *
  */
 
-// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed
-#include <lib/core/CHIPCore.h>
-
 #include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/tests/MockReportScheduler.h>

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -24,6 +24,7 @@
 
 #include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
+#include <app/icd/server/ICDServerConfig.h>
 #include <app/reporting/tests/MockReportScheduler.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/mock/Constants.h>
@@ -34,6 +35,7 @@
 #include <lib/core/TLVDebug.h>
 #include <lib/core/TLVUtilities.h>
 #include <lib/support/UnitTestContext.h>
+#include <lib/support/UnitTestExtendedAssertions.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/Flags.h>
@@ -82,6 +84,7 @@ public:
     static void TestSubjectHasActiveSubscriptionMultipleSubsSingleEntry(nlTestSuite * apSuite, void * apContext);
     static void TestSubjectHasActiveSubscriptionMultipleSubsMultipleEntries(nlTestSuite * apSuite, void * apContext);
     static void TestSubjectHasActiveSubscriptionSubWithCAT(nlTestSuite * apSuite, void * apContext);
+    static void TestDecrementNumSubscriptionToResume(nlTestSuite * apSuite, void * apContext);
 };
 
 int TestInteractionModelEngine::GetAttributePathListLength(SingleLinkedListNode<AttributePathParams> * apAttributePathParamsList)
@@ -682,6 +685,63 @@ void TestInteractionModelEngine::TestSubscriptionResumptionTimer(nlTestSuite * a
 #endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
+void TestInteractionModelEngine::TestDecrementNumSubscriptionToResume(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx                       = *static_cast<TestContext *>(apContext);
+    CHIP_ERROR err                          = CHIP_NO_ERROR;
+    InteractionModelEngine * engine         = InteractionModelEngine::GetInstance();
+    constexpr uint8_t kNumberOfSubsToResume = 5;
+    uint8_t numberOfSubsRemaining           = kNumberOfSubsToResume;
+
+    err = engine->Init(&ctx.GetExchangeManager(), &ctx.GetFabricTable(), app::reporting::GetDefaultReportScheduler());
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+    ICDManager manager;
+    engine->SetICDManager(&manager);
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+
+    // Set number of subs
+    engine->mNumOfSubscriptionToResume = kNumberOfSubsToResume;
+
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+    // Verify mIsBootUpResumeSubscriptionExecuted has not been set
+    NL_TEST_ASSERT(apSuite, !manager.GetIsBootUpResumeSubscriptionExecuted());
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+
+    // Decrease number of subs by 1
+    numberOfSubsRemaining--;
+    engine->DecrementNumSubscriptionToResume();
+    NL_TEST_ASSERT_EQUALS(apSuite, numberOfSubsRemaining, engine->mNumOfSubscriptionToResume);
+
+    // Decrease to 0 subs remaining
+    while (numberOfSubsRemaining > 0)
+    {
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+        // Verify mIsBootUpResumeSubscriptionExecuted has not been set
+        NL_TEST_ASSERT(apSuite, !manager.GetIsBootUpResumeSubscriptionExecuted());
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+
+        numberOfSubsRemaining--;
+        engine->DecrementNumSubscriptionToResume();
+        NL_TEST_ASSERT_EQUALS(apSuite, numberOfSubsRemaining, engine->mNumOfSubscriptionToResume);
+    }
+
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+    // Verify mIsBootUpResumeSubscriptionExecuted has been set
+    NL_TEST_ASSERT(apSuite, manager.GetIsBootUpResumeSubscriptionExecuted());
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+
+    // Make sure we don't rollover / go negative
+    engine->DecrementNumSubscriptionToResume();
+    NL_TEST_ASSERT_EQUALS(apSuite, numberOfSubsRemaining, engine->mNumOfSubscriptionToResume);
+
+    // Clean up
+#if CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+    engine->SetICDManager(nullptr);
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+}
+
 } // namespace app
 } // namespace chip
 
@@ -703,6 +763,7 @@ const nlTest sTests[] =
                 NL_TEST_DEF("TestSubjectHasActiveSubscriptionMultipleSubsSingleEntry", chip::app::TestInteractionModelEngine::TestSubjectHasActiveSubscriptionMultipleSubsSingleEntry),
                 NL_TEST_DEF("TestSubjectHasActiveSubscriptionMultipleSubsMultipleEntries", chip::app::TestInteractionModelEngine::TestSubjectHasActiveSubscriptionMultipleSubsMultipleEntries),
                 NL_TEST_DEF("TestSubjectHasActiveSubscriptionSubWithCAT", chip::app::TestInteractionModelEngine::TestSubjectHasActiveSubscriptionSubWithCAT),
+                NL_TEST_DEF("TestDecrementNumSubscriptionToResume", chip::app::TestInteractionModelEngine::TestDecrementNumSubscriptionToResume),
                 NL_TEST_SENTINEL()
         };
 // clang-format on

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -22,11 +22,6 @@
  *
  */
 
-// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed (next two includes)
-#include <lib/core/CHIPCore.h>
-// add a line to avoid the reorder
-#include <app/reporting/ReportScheduler.h>
-
 #include "lib/support/CHIPMem.h"
 #include <access/examples/PermissiveAccessControlDelegate.h>
 #include <app/AttributeAccessInterface.h>

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -22,7 +22,8 @@
  *
  */
 
-// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed
+// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed (next two includes)
+#include <app/reporting/ReportScheduler.h>
 #include <lib/core/CHIPCore.h>
 
 #include "lib/support/CHIPMem.h"
@@ -1372,8 +1373,7 @@ void TestReadInteraction::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void 
         public:
             DirtyingMockDelegate(AttributePathParams (&aReadPaths)[2], int & aNumAttributeResponsesWhenSetDirty,
                                  int & aNumArrayItemsWhenSetDirty) :
-                mReadPaths(aReadPaths),
-                mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
+                mReadPaths(aReadPaths), mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
                 mNumArrayItemsWhenSetDirty(aNumArrayItemsWhenSetDirty)
             {}
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -23,8 +23,9 @@
  */
 
 // TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed (next two includes)
-#include <app/reporting/ReportScheduler.h>
 #include <lib/core/CHIPCore.h>
+// add a line to avoid the reorder
+#include <app/reporting/ReportScheduler.h>
 
 #include "lib/support/CHIPMem.h"
 #include <access/examples/PermissiveAccessControlDelegate.h>
@@ -1373,8 +1374,7 @@ void TestReadInteraction::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void 
         public:
             DirtyingMockDelegate(AttributePathParams (&aReadPaths)[2], int & aNumAttributeResponsesWhenSetDirty,
                                  int & aNumArrayItemsWhenSetDirty) :
-                mReadPaths(aReadPaths),
-                mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
+                mReadPaths(aReadPaths), mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
                 mNumArrayItemsWhenSetDirty(aNumArrayItemsWhenSetDirty)
             {}
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -22,6 +22,9 @@
  *
  */
 
+// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed
+#include <lib/core/CHIPCore.h>
+
 #include "lib/support/CHIPMem.h"
 #include <access/examples/PermissiveAccessControlDelegate.h>
 #include <app/AttributeAccessInterface.h>

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1373,7 +1373,8 @@ void TestReadInteraction::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void 
         public:
             DirtyingMockDelegate(AttributePathParams (&aReadPaths)[2], int & aNumAttributeResponsesWhenSetDirty,
                                  int & aNumArrayItemsWhenSetDirty) :
-                mReadPaths(aReadPaths), mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
+                mReadPaths(aReadPaths),
+                mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
                 mNumArrayItemsWhenSetDirty(aNumArrayItemsWhenSetDirty)
             {}
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1374,7 +1374,8 @@ void TestReadInteraction::TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void 
         public:
             DirtyingMockDelegate(AttributePathParams (&aReadPaths)[2], int & aNumAttributeResponsesWhenSetDirty,
                                  int & aNumArrayItemsWhenSetDirty) :
-                mReadPaths(aReadPaths), mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
+                mReadPaths(aReadPaths),
+                mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
                 mNumArrayItemsWhenSetDirty(aNumArrayItemsWhenSetDirty)
             {}
 

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -174,6 +174,13 @@ CHIP_ERROR MessagingContext::CreateCASESessionBobToAlice()
                                                         CryptoContext::SessionRole::kInitiator);
 }
 
+CHIP_ERROR MessagingContext::CreateCASESessionBobToAlice(const CATValues & cats)
+{
+    return mSessionManager.InjectCaseSessionWithTestKey(mSessionBobToAlice, kBobKeyId, kAliceKeyId, GetBobFabric()->GetNodeId(),
+                                                        GetAliceFabric()->GetNodeId(), mBobFabricIndex, mAliceAddress,
+                                                        CryptoContext::SessionRole::kInitiator, cats);
+}
+
 CHIP_ERROR MessagingContext::CreateSessionAliceToBob()
 {
     return mSessionManager.InjectPaseSessionWithTestKey(mSessionAliceToBob, kAliceKeyId, GetBobFabric()->GetNodeId(), kBobKeyId,
@@ -185,6 +192,13 @@ CHIP_ERROR MessagingContext::CreateCASESessionAliceToBob()
     return mSessionManager.InjectCaseSessionWithTestKey(mSessionAliceToBob, kAliceKeyId, kBobKeyId, GetAliceFabric()->GetNodeId(),
                                                         GetBobFabric()->GetNodeId(), mAliceFabricIndex, mBobAddress,
                                                         CryptoContext::SessionRole::kResponder);
+}
+
+CHIP_ERROR MessagingContext::CreateCASESessionAliceToBob(const CATValues & cats)
+{
+    return mSessionManager.InjectCaseSessionWithTestKey(mSessionAliceToBob, kAliceKeyId, kBobKeyId, GetAliceFabric()->GetNodeId(),
+                                                        GetBobFabric()->GetNodeId(), mAliceFabricIndex, mBobAddress,
+                                                        CryptoContext::SessionRole::kResponder, cats);
 }
 
 CHIP_ERROR MessagingContext::CreatePASESessionCharlieToDavid()

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -19,6 +19,7 @@
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <crypto/DefaultSessionKeystore.h>
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#include <lib/core/CASEAuthTag.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
@@ -141,8 +142,10 @@ public:
 
     CHIP_ERROR CreateSessionBobToAlice(); // Creates PASE session
     CHIP_ERROR CreateCASESessionBobToAlice();
+    CHIP_ERROR CreateCASESessionBobToAlice(const CATValues & cats);
     CHIP_ERROR CreateSessionAliceToBob(); // Creates PASE session
     CHIP_ERROR CreateCASESessionAliceToBob();
+    CHIP_ERROR CreateCASESessionAliceToBob(const CATValues & cats);
     CHIP_ERROR CreateSessionBobToFriends(); // Creates PASE session
     CHIP_ERROR CreatePASESessionCharlieToDavid();
     CHIP_ERROR CreatePASESessionDavidToCharlie();

--- a/src/test_driver/esp32/main/include/CHIPProjectConfig.h
+++ b/src/test_driver/esp32/main/include/CHIPProjectConfig.h
@@ -30,4 +30,6 @@
 // Enable support functions for parsing command-line arguments
 #define CHIP_CONFIG_ENABLE_ARG_PARSER 1
 
+#define CONFIG_BUILD_FOR_HOST_UNIT_TEST 1
+
 #endif // CHIP_PROJECT_CONFIG_H


### PR DESCRIPTION
#### Description
PR adds support to send a Check-In message at boot up if the device doesn't have any subscriptions to resume.
PR also add the persistant subscription check when sending a Check-In message on transition to ActiveMode

- Implement the SubjectHasPersistedSubscription function to determine if an ICD registration has a persisted subscription counterpart
- Adds an injectable verifier function to the TriggerCheckInMessage to enable consummers to have a costum check without needing to reimplement the loops
- Adds persistant subscription check to the on ActiveMode verifier function

fixes #30281

#### Tests
- Add unit tests to validate InteractionModelEngine functions
- Some unit tests require conditonnal builds that are not run for CI. I ran each feature combination locally to make sure the unit tests pass
- Manual tests to validate the end to end behavior since we need to implement end-to-end python tests to automate full beahvior. These script will be in a follow up.
