### PR TITLE
Switch GITHUB_TOKEN to BLOAT_REPORT since we seem to get 403 when downloading artifacts

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -49,4 +49,4 @@ jobs:
                     --github-limit-artifacts 500 \
                     --github-limit-comments 20 \
                     --github-repository project-chip/connectedhomeip \
-                    --github-api-token "${{ secrets.GITHUB_TOKEN }}"
+                    --github-api-token "${{ secrets.BLOAT_REPORT }}"


### PR DESCRIPTION
Example failed run:

https://github.com/project-chip/connectedhomeip/actions/runs/8364227298/job/22899032630

```
...
Failed to download artifact 1340243971: HTTP Error 403: Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
====Error Body====
﻿<?xml version="1.0" encoding="utf-8"?>
<Error><Code>AuthenticationFailed</Code><Message>Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
RequestId:07289831-701e-0077-34f6-7a2e96000000
Time:2024-03-20T18:40:24.1504101Z</Message></Error>
Failed to download artifact 1339152388: HTTP Error 403: Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
====Error Body====
﻿<?xml version="1.0" encoding="utf-8"?>
<Error><Code>AuthenticationFailed</Code><Message>Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
RequestId:a3e0a979-001e-001f-4ff6-7a5383000000
Time:2024-03-20T18:40:24.2809492Z</Message></Error>
Failed to download artifact 1343156229: HTTP Error 403: Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
====Error Body====
...
```