### PR TITLE
Allow manual bloat check for testing purposes, to not wait 5 minutes to test bloat report

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -14,6 +14,7 @@
 
 name: Bloat Check
 on:
+    workflow_dispatch:
     schedule:
         - cron: "*/5 * * * *"
 


### PR DESCRIPTION
There is no reason to not allow manual invocation of this one.