### PR TITLE
Use `curl` to download github artifacts during bloat report

### DIFF
--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -50,4 +50,4 @@ jobs:
                     --github-limit-artifacts 500 \
                     --github-limit-comments 20 \
                     --github-repository project-chip/connectedhomeip \
-                    --github-api-token "${{ secrets.BLOAT_REPORT }}"
+                    --github-api-token "${{ secrets.GITHUB_TOKEN }}"

--- a/scripts/tools/memory/memdf/util/github.py
+++ b/scripts/tools/memory/memdf/util/github.py
@@ -175,9 +175,6 @@ class Gh:
         try:
             assert self.ghapi
 
-            # TODO: custom artifact download?
-            ar = self.ghapi.actions.get_artifact(artifact_id)
-
             # It seems like github artifact download is at least partially broken
             # (see https://github.com/project-chip/connectedhomeip/issues/32656)
             #

--- a/scripts/tools/memory/memdf/util/github.py
+++ b/scripts/tools/memory/memdf/util/github.py
@@ -25,6 +25,8 @@ import dateutil.parser  # type: ignore
 import ghapi.all  # type: ignore
 from memdf import Config, ConfigDescription
 
+import subprocess
+
 
 def postprocess_config(config: Config, _key: str, _info: Mapping) -> None:
     """Postprocess --github-repository."""
@@ -173,7 +175,35 @@ class Gh:
         logging.debug('Downloading artifact %d', artifact_id)
         try:
             assert self.ghapi
-            return self.ghapi.actions.download_artifact(artifact_id, 'zip')
+
+            # TODO: custom artifact download?
+            ar = self.ghapi.actions.get_artifact(artifact_id)
+
+            # It seems like github artifact download is at least partially broken
+            # (see https://github.com/project-chip/connectedhomeip/issues/32656)
+            #
+            # This makes `self.ghapi.actions.download_artifact` not work
+            #
+            # Oddly enough downloading via CURL seems ok
+            owner = self.config['github.owner']
+            repo = self.config['github.repo']
+            token = self.config['github.token']
+
+            download_url = f"https://api.github.com/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip"
+
+
+            # Follow https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#download-an-artifact
+            return subprocess.check_output(
+                    [
+                        'curl',
+                        '-L',
+                        '-H', 'Accept: application/vnd.github+json',
+                        '-H', f'Authorization: Bearer {token}',
+                        '-H', 'X-GitHub-Api-Version: 2022-11-28',
+                        '--output', '-',
+                        download_url
+                    ]
+            )
         except Exception as e:
             logging.error('Failed to download artifact %d: %s', artifact_id, e)
         return None

--- a/scripts/tools/memory/memdf/util/github.py
+++ b/scripts/tools/memory/memdf/util/github.py
@@ -18,14 +18,13 @@
 import itertools
 import logging
 import os
+import subprocess
 from typing import Iterable, Mapping, Optional
 
 import dateutil  # type: ignore
 import dateutil.parser  # type: ignore
 import ghapi.all  # type: ignore
 from memdf import Config, ConfigDescription
-
-import subprocess
 
 
 def postprocess_config(config: Config, _key: str, _info: Mapping) -> None:
@@ -191,18 +190,17 @@ class Gh:
 
             download_url = f"https://api.github.com/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip"
 
-
             # Follow https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#download-an-artifact
             return subprocess.check_output(
-                    [
-                        'curl',
-                        '-L',
-                        '-H', 'Accept: application/vnd.github+json',
-                        '-H', f'Authorization: Bearer {token}',
-                        '-H', 'X-GitHub-Api-Version: 2022-11-28',
-                        '--output', '-',
-                        download_url
-                    ]
+                [
+                    'curl',
+                    '-L',
+                    '-H', 'Accept: application/vnd.github+json',
+                    '-H', f'Authorization: Bearer {token}',
+                    '-H', 'X-GitHub-Api-Version: 2022-11-28',
+                    '--output', '-',
+                    download_url
+                ]
             )
         except Exception as e:
             logging.error('Failed to download artifact %d: %s', artifact_id, e)


### PR DESCRIPTION
This fixes #32656 

I am unsure why the ghapi does not work, however that is a 3rd party library so there may be bugs.
I tried to report a bug to github and during that I wanted to describe reproduction steps in terms of what they documented in https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#download-an-artifact ... however it turns out curl actually worked.

Since curl works, just started using that instead.