### PR TITLE
Add GN arg to enable logging of node Id in exchange context

### DIFF
--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -48,6 +48,7 @@ buildconfig_header("chip_buildconfig") {
     "CHIP_AUTOMATION_LOGGING=${chip_automation_logging}",
     "CHIP_PW_TOKENIZER_LOGGING=${chip_pw_tokenizer_logging}",
     "CHIP_USE_PW_LOGGING=${chip_use_pw_logging}",
+    "CHIP_EXCHANGE_NODE_ID_LOGGING=${chip_exchange_node_id_logging}",
     "CHIP_CONFIG_SHORT_ERROR_STR=${chip_config_short_error_str}",
     "CHIP_CONFIG_ENABLE_ARG_PARSER=${chip_config_enable_arg_parser}",
     "CHIP_TARGET_STYLE_UNIX=${chip_target_style_unix}",

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -462,16 +462,6 @@
 #endif // CHIP_CONFIG_ENABLE_CONDITION_LOGGING
 
 /**
- *  @def CHIP_EXCHANGE_NODE_ID_LOGGING
- *
- *  @brief
- *    If asserted (1), enable logging of node IDs in exchange context.
- */
-#ifndef CHIP_EXCHANGE_NODE_ID_LOGGING
-#define CHIP_EXCHANGE_NODE_ID_LOGGING 0
-#endif // CHIP_EXCHANGE_NODE_ID_LOGGING
-
-/**
  *  @def CHIP_CONFIG_TEST
  *
  *  @brief

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -47,6 +47,10 @@ declare_args() {
   # Configure chip logging to output through pigweed logging.
   chip_use_pw_logging = false
 
+  # Enable logging of node Id in exchange context log messages.
+  # Will cause increase in code size and is therefore disabled by default.
+  chip_exchange_node_id_logging = false
+
   # Configure chip logging to output through external logging implementation.
   # External code will need to provide implementation for CHIP log output
   # function (LogV), which is defined in "src/platform/logging/LogV.h".


### PR DESCRIPTION
#32550 added the logging of the node ID to the logging of the exchange context. Since the code size increase caused by this was rather large, this has been made optional. This PR adds the option to enable the logging of the node ID when compiling using the arg `chip_exchange_node_id_logging=true`