### PR TITLE
[silabs] Fix 917 lock app

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -59,7 +59,6 @@ jobs:
         timeout-minutes: 30
         run: |
           scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs ./out/light-app BRD4187C --slc_generate --docker
-          scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs ./out/light-app BRD4164A --slc_generate --docker
           rm -rf ./out/
       - name: Build some BRD4187C variants (1)
         run: |
@@ -115,6 +114,7 @@ jobs:
              "./scripts/build/build_examples.py \
                 --enable-flashbundle \
                 --target efr32-brd4338a-light-wifi-917_soc-skip_rps_generation \
+                --target efr32-brd4338a-lock-wifi-917_soc-skip_rps_generation \
                 build \
                 --copy-artifacts-to out/artifacts \
              "

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -25,10 +25,12 @@
 #include "FreeRTOS.h"
 #include "event_groups.h"
 #include "sl_board_configuration.h"
+extern "C" {
 #include "sl_si91x_types.h"
 #include "sl_wifi_constants.h"
 #include "sl_wifi_types.h"
 #include "sl_wlan_config.h"
+}
 #include "task.h"
 
 #if (EXP_BOARD)
@@ -40,8 +42,10 @@
 #if SL_ICD_ENABLED && SLI_SI91X_MCU_INTERFACE
 #include "rsi_rom_power_save.h"
 #include "sl_si91x_button_pin_config.h"
+extern "C" {
 #include "sl_si91x_driver.h"
 #include "sl_si91x_m4_ps.h"
+}
 
 // TODO: should be removed once we are getting the press interrupt for button 0 with sleep
 #define BUTTON_PRESSED 1

--- a/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
+++ b/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
@@ -245,9 +245,6 @@ void wfx_dhcp_got_ipv4(uint32_t);
 void wfx_ip_changed_notify(int got_ip);
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 
-sl_status_t sl_si91x_host_process_data_frame(sl_wifi_interface_t interface, sl_wifi_buffer_t * buffer);
-void * sl_si91x_host_get_buffer_data(sl_wifi_buffer_t * buffer, uint16_t offset, uint16_t * data_length);
-
 #if SL_ICD_ENABLED
 sl_status_t wfx_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state);
 void sl_button_on_change(uint8_t btn, uint8_t btnAction);


### PR DESCRIPTION
Lock-app for 917 wasn't compiling following the change to C++

Fix the build failure and add it to the CI at the same time (removed one deprecated example as well)

