### PR TITLE
Make gn know about ListLargeSystemExtensions.h

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -95,7 +95,6 @@ jobs:
                      --known-failure app/CommandHandler.h \
                      --known-failure app/CommandHandlerInterface.h \
                      --known-failure app/CommandSenderLegacyCallback.h \
-                     --known-failure app/data-model/ListLargeSystemExtensions.h \
                      --known-failure app/ReadHandler.h \
                      --known-failure app/reporting/reporting.cpp \
                      --known-failure app/reporting/tests/MockReportScheduler.cpp \

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -53,6 +53,7 @@ shared_library("jni") {
 
   deps = [
     "${chip_root}/examples/tv-casting-app/tv-casting-common",
+    "${chip_root}/src/app/data-model:heap",
     "${chip_root}/src/app/server/java:jni",
     "${chip_root}/src/lib",
     "${chip_root}/third_party/inipp",

--- a/src/app/data-model/BUILD.gn
+++ b/src/app/data-model/BUILD.gn
@@ -45,3 +45,12 @@ source_set("data-model") {
     "${chip_root}/src/protocols/interaction_model",
   ]
 }
+
+# Provides extensions that use heap and should be
+# used for systems that are not as constrained as
+# embedded systems typically are
+source_set("heap") {
+  sources = [ "ListLargeSystemExtensions.h" ]
+
+  deps = [ ":data-model" ]
+}


### PR DESCRIPTION
This file was previously orphaned/unknown to GN. now create a target.

This is generally only used by darwin (those files are in xcode projects, so not gn) and a single android gn dep (which I added).