### PR TITLE
[Darwin] MTRDevice should persist data version by cluster

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -935,6 +935,11 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         if (attributesFromCache.count) {
             [deviceToReturn setAttributeValues:attributesFromCache reportChanges:NO];
         }
+        NSDictionary * clusterData = [_controllerDataStore getStoredClusterDataForNodeID:nodeID];
+        MTR_LOG_INFO("Loaded %lu cluster data from storage for %@", static_cast<unsigned long>(clusterData.count), deviceToReturn);
+        if (clusterData.count) {
+            [deviceToReturn setClusterData:clusterData];
+        }
     }
 
     return deviceToReturn;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 #import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceController.h>
+#import <Matter/MTRDevice_Internal.h>
 #if MTR_PER_CONTROLLER_STORAGE_ENABLED
 #import <Matter/MTRDeviceControllerStorageDelegate.h>
 #else
@@ -67,7 +68,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Storage for MTRDevice attribute read cache. This is local-only storage as an optimization. New controller devices using MTRDevice API can prime their own local cache from devices directly.
  */
 - (nullable NSArray<NSDictionary *> *)getStoredAttributesForNodeID:(NSNumber *)nodeID;
+- (nullable NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)getStoredClusterDataForNodeID:(NSNumber *)nodeID;
 - (void)storeAttributeValues:(NSArray<NSDictionary *> *)dataValues forNodeID:(NSNumber *)nodeID;
+- (void)storeClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)clusterData forNodeID:(NSNumber *)nodeID;
 - (void)clearStoredAttributesForNodeID:(NSNumber *)nodeID;
 - (void)clearAllStoredAttributes;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
@@ -398,6 +398,28 @@ static NSString * sAttributeCacheClusterIndexKeyPrefix = @"attrCacheClusterIndex
     return [self _removeAttributeCacheValueForKey:[self _clusterIndexKeyForNodeID:nodeID endpointID:endpointID]];
 }
 
+static NSString * sAttributeCacheClusterDataKeyPrefix = @"attrCacheClusterData";
+
+- (NSString *)_clusterDataKeyForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID
+{
+    return [sAttributeCacheClusterDataKeyPrefix stringByAppendingFormat:@":0x%016llX:%0x04X:0x%08lX", nodeID.unsignedLongLongValue, endpointID.unsignedShortValue, clusterID.unsignedLongValue];
+}
+
+- (nullable MTRDeviceClusterData *)_fetchClusterDataForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID
+{
+    return [self _fetchAttributeCacheValueForKey:[self _clusterDataKeyForNodeID:nodeID endpointID:endpointID clusterID:clusterID] expectedClass:[MTRDeviceClusterData class]];
+}
+
+- (BOOL)_storeClusterData:(MTRDeviceClusterData *)clusterData forNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID
+{
+    return [self _storeAttributeCacheValue:clusterData forKey:[self _clusterDataKeyForNodeID:nodeID endpointID:endpointID clusterID:clusterID]];
+}
+
+- (BOOL)_deleteClusterDataForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID
+{
+    return [self _removeAttributeCacheValueForKey:[self _clusterDataKeyForNodeID:nodeID endpointID:endpointID clusterID:clusterID]];
+}
+
 static NSString * sAttributeCacheAttributeIndexKeyPrefix = @"attrCacheAttributeIndex";
 
 - (NSString *)_attributeIndexKeyForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID
@@ -565,15 +587,21 @@ static NSString * sAttributeCacheAttributeValueKeyPrefix = @"attrCacheAttributeV
 
                 if (attributeIndex.count != attributeIndexCopy.count) {
                     BOOL success;
+                    BOOL clusterDataSuccess = YES;
                     if (attributeIndexCopy.count) {
                         success = [self _storeAttributeIndex:attributeIndexCopy forNodeID:nodeID endpointID:endpointID clusterID:clusterID];
                     } else {
                         [clusterIndexCopy removeObject:clusterID];
                         success = [self _deleteAttributeIndexForNodeID:nodeID endpointID:endpointID clusterID:clusterID];
+                        clusterDataSuccess = [self _deleteClusterDataForNodeID:nodeID endpointID:endpointID clusterID:clusterID];
                     }
                     if (!success) {
                         storeFailures++;
                         MTR_LOG_INFO("Store failed in _pruneEmptyStoredAttributesBranches for attributeIndex (%lu) @ node 0x%016llX endpoint %u cluster 0x%08lX", static_cast<unsigned long>(attributeIndexCopy.count), nodeID.unsignedLongLongValue, endpointID.unsignedShortValue, clusterID.unsignedLongValue);
+                    }
+                    if (!clusterDataSuccess) {
+                        storeFailures++;
+                        MTR_LOG_INFO("Store failed in _pruneEmptyStoredAttributesBranches for clusterData @ node 0x%016llX endpoint %u cluster 0x%08lX", nodeID.unsignedLongLongValue, endpointID.unsignedShortValue, clusterID.unsignedLongValue);
                     }
                 }
             }
@@ -719,9 +747,11 @@ static NSString * sAttributeCacheAttributeValueKeyPrefix = @"attrCacheAttributeV
 {
     NSUInteger endpointsClearAttempts = 0;
     NSUInteger clustersClearAttempts = 0;
+    NSUInteger clusterDataClearAttempts = 0;
     NSUInteger attributesClearAttempts = 0;
     NSUInteger endpointsCleared = 0;
     NSUInteger clustersCleared = 0;
+    NSUInteger clusterDataCleared = 0;
     NSUInteger attributesCleared = 0;
 
     // Fetch endpoint index
@@ -733,6 +763,7 @@ static NSString * sAttributeCacheAttributeValueKeyPrefix = @"attrCacheAttributeV
         NSArray<NSNumber *> * clusterIndex = [self _fetchClusterIndexForNodeID:nodeID endpointID:endpointID];
 
         clustersClearAttempts += clusterIndex.count;
+        clusterDataClearAttempts += clusterIndex.count; // Assuming every cluster has cluster data
         for (NSNumber * clusterID in clusterIndex) {
             // Fetch attribute index
             NSArray<NSNumber *> * attributeIndex = [self _fetchAttributeIndexForNodeID:nodeID endpointID:endpointID clusterID:clusterID];
@@ -753,6 +784,13 @@ static NSString * sAttributeCacheAttributeValueKeyPrefix = @"attrCacheAttributeV
             } else {
                 clustersCleared++;
             }
+
+            success = [self _deleteClusterDataForNodeID:nodeID endpointID:endpointID clusterID:clusterID];
+            if (!success) {
+                MTR_LOG_INFO("Delete failed for clusterData @ node 0x%016llX endpoint %u cluster 0x%08lX", nodeID.unsignedLongLongValue, endpointID.unsignedShortValue, clusterID.unsignedLongValue);
+            } else {
+                clusterDataCleared++;
+            }
         }
 
         BOOL success = [self _deleteClusterIndexForNodeID:nodeID endpointID:endpointID];
@@ -768,7 +806,7 @@ static NSString * sAttributeCacheAttributeValueKeyPrefix = @"attrCacheAttributeV
         MTR_LOG_INFO("Delete failed for endpointrIndex @ node 0x%016llX", nodeID.unsignedLongLongValue);
     }
 
-    MTR_LOG_INFO("clearStoredAttributesForNodeID: deleted endpoints %lu/%lu clusters %lu/%lu attributes %lu/%lu", static_cast<unsigned long>(endpointsCleared), static_cast<unsigned long>(endpointsClearAttempts), static_cast<unsigned long>(clustersCleared), static_cast<unsigned long>(clustersClearAttempts), static_cast<unsigned long>(attributesCleared), static_cast<unsigned long>(attributesClearAttempts));
+    MTR_LOG_INFO("clearStoredAttributesForNodeID: deleted endpoints %lu/%lu clusters %lu/%lu clusterData %lu/%lu attributes %lu/%lu", static_cast<unsigned long>(endpointsCleared), static_cast<unsigned long>(endpointsClearAttempts), static_cast<unsigned long>(clustersCleared), static_cast<unsigned long>(clustersClearAttempts), static_cast<unsigned long>(clusterDataCleared), static_cast<unsigned long>(clusterDataClearAttempts), static_cast<unsigned long>(attributesCleared), static_cast<unsigned long>(attributesClearAttempts));
 }
 
 - (void)clearStoredAttributesForNodeID:(NSNumber *)nodeID
@@ -805,6 +843,140 @@ static NSString * sAttributeCacheAttributeValueKeyPrefix = @"attrCacheAttributeV
         BOOL success = [self _deleteNodeIndex];
         if (!success) {
             MTR_LOG_INFO("Delete failed for nodeIndex");
+        }
+    });
+}
+
+- (nullable NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)getStoredClusterDataForNodeID:(NSNumber *)nodeID
+{
+    __block NSMutableDictionary<MTRClusterPath *, MTRDeviceClusterData *> * clusterDataToReturn = nil;
+    dispatch_sync(_storageDelegateQueue, ^{
+        // Fetch node index
+        NSArray<NSNumber *> * nodeIndex = [self _fetchNodeIndex];
+
+#if ATTRIBUTE_CACHE_VERBOSE_LOGGING
+        MTR_LOG_INFO("Fetch got %lu values for nodeIndex", static_cast<unsigned long>(nodeIndex.count));
+#endif
+
+        if (![nodeIndex containsObject:nodeID]) {
+            // Sanity check and delete if nodeID exists in index
+            NSArray<NSNumber *> * endpointIndex = [self _fetchEndpointIndexForNodeID:nodeID];
+            if (endpointIndex) {
+                MTR_LOG_ERROR("Persistent attribute cache contains orphaned entry for nodeID %@ - deleting", nodeID);
+                [self clearStoredAttributesForNodeID:nodeID];
+            }
+
+            MTR_LOG_INFO("Fetch got no value for endpointIndex @ node 0x%016llX", nodeID.unsignedLongLongValue);
+            clusterDataToReturn = nil;
+            return;
+        }
+
+        // Fetch endpoint index
+        NSArray<NSNumber *> * endpointIndex = [self _fetchEndpointIndexForNodeID:nodeID];
+
+#if ATTRIBUTE_CACHE_VERBOSE_LOGGING
+        MTR_LOG_INFO("Fetch got %lu values for endpointIndex @ node 0x%016llX", static_cast<unsigned long>(endpointIndex.count), nodeID.unsignedLongLongValue);
+#endif
+
+        for (NSNumber * endpointID in endpointIndex) {
+            // Fetch endpoint index
+            NSArray<NSNumber *> * clusterIndex = [self _fetchClusterIndexForNodeID:nodeID endpointID:endpointID];
+
+#if ATTRIBUTE_CACHE_VERBOSE_LOGGING
+            MTR_LOG_INFO("Fetch got %lu values for clusterIndex @ node 0x%016llX %u", static_cast<unsigned long>(clusterIndex.count), nodeID.unsignedLongLongValue, endpointID.unsignedShortValue);
+#endif
+
+            for (NSNumber * clusterID in clusterIndex) {
+                // Fetch cluster data
+                MTRDeviceClusterData * clusterData = [self _fetchClusterDataForNodeID:nodeID endpointID:endpointID clusterID:clusterID];
+                if (!clusterData) {
+                    MTR_LOG_INFO("Fetch got no value for clusterData @ node 0x%016llX endpoint %u cluster 0x%08lX", nodeID.unsignedLongLongValue, endpointID.unsignedShortValue, clusterID.unsignedLongValue);
+                    continue;
+                }
+
+#if ATTRIBUTE_CACHE_VERBOSE_LOGGING
+                MTR_LOG_INFO("Fetch got clusterData @ node 0x%016llX endpoint %u cluster 0x%08lX", nodeID.unsignedLongLongValue, endpointID.unsignedShortValue, clusterID.unsignedLongValue);
+#endif
+
+                MTRClusterPath * path = [MTRClusterPath clusterPathWithEndpointID:endpointID clusterID:clusterID];
+                if (!clusterDataToReturn) {
+                    clusterDataToReturn = [NSMutableDictionary dictionary];
+                }
+                clusterDataToReturn[path] = clusterData;
+            }
+        }
+    });
+
+    return clusterDataToReturn;
+}
+
+- (void)storeClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)clusterData forNodeID:(NSNumber *)nodeID
+{
+    dispatch_async(_storageDelegateQueue, ^{
+        NSUInteger storeFailures = 0;
+
+        for (MTRClusterPath * path in clusterData) {
+            MTRDeviceClusterData * data = clusterData[path];
+
+#if ATTRIBUTE_CACHE_VERBOSE_LOGGING
+            MTR_LOG_INFO("Attempt to store clusterData @ node 0x%016llX endpoint %u cluster 0x%08lX", nodeID.unsignedLongLongValue, path.endpoint.unsignedShortValue, path.cluster.unsignedLongValue);
+#endif
+
+            BOOL storeFailed = NO;
+            // Ensure node index exists
+            NSArray<NSNumber *> * nodeIndex = [self _fetchNodeIndex];
+            if (!nodeIndex) {
+                nodeIndex = [NSArray arrayWithObject:nodeID];
+                storeFailed = ![self _storeNodeIndex:nodeIndex];
+            } else if (![nodeIndex containsObject:nodeID]) {
+                storeFailed = ![self _storeNodeIndex:[nodeIndex arrayByAddingObject:nodeID]];
+            }
+            if (storeFailed) {
+                storeFailures++;
+                MTR_LOG_INFO("Store failed for nodeIndex");
+                continue;
+            }
+
+            // Ensure endpoint index exists
+            NSArray<NSNumber *> * endpointIndex = [self _fetchEndpointIndexForNodeID:nodeID];
+            if (!endpointIndex) {
+                endpointIndex = [NSArray arrayWithObject:path.endpoint];
+                storeFailed = ![self _storeEndpointIndex:endpointIndex forNodeID:nodeID];
+            } else if (![endpointIndex containsObject:path.endpoint]) {
+                storeFailed = ![self _storeEndpointIndex:[endpointIndex arrayByAddingObject:path.endpoint] forNodeID:nodeID];
+            }
+            if (storeFailed) {
+                storeFailures++;
+                MTR_LOG_INFO("Store failed for endpointIndex @ node 0x%016llX", nodeID.unsignedLongLongValue);
+                continue;
+            }
+
+            // Ensure cluster index exists
+            NSArray<NSNumber *> * clusterIndex = [self _fetchClusterIndexForNodeID:nodeID endpointID:path.endpoint];
+            if (!clusterIndex) {
+                clusterIndex = [NSArray arrayWithObject:path.cluster];
+                storeFailed = ![self _storeClusterIndex:clusterIndex forNodeID:nodeID endpointID:path.endpoint];
+            } else if (![clusterIndex containsObject:path.cluster]) {
+                storeFailed = ![self _storeClusterIndex:[clusterIndex arrayByAddingObject:path.cluster] forNodeID:nodeID endpointID:path.endpoint];
+            }
+            if (storeFailed) {
+                storeFailures++;
+                MTR_LOG_INFO("Store failed for clusterIndex @ node 0x%016llX endpoint %u", nodeID.unsignedLongLongValue, path.endpoint.unsignedShortValue);
+                continue;
+            }
+
+            // Store cluster data
+            storeFailed = ![self _storeClusterData:data forNodeID:nodeID endpointID:path.endpoint clusterID:path.cluster];
+            if (storeFailed) {
+                storeFailures++;
+                MTR_LOG_INFO("Store failed for clusterDAta @ node 0x%016llX endpoint %u cluster 0x%08lX", nodeID.unsignedLongLongValue, path.endpoint.unsignedShortValue, path.cluster.unsignedLongValue);
+            }
+        }
+
+        // In the rare event that store fails, allow all attribute store attempts to go through and prune empty branches at the end altogether.
+        if (storeFailures) {
+            [self _pruneEmptyStoredAttributesBranches];
+            MTR_LOG_ERROR("Store failed in -storeAttributeValues:forNodeID: failure count %lu", static_cast<unsigned long>(storeFailures));
         }
     });
 }
@@ -895,6 +1067,7 @@ NSSet<Class> * MTRDeviceControllerStorageClasses()
         [NSDictionary class],
         [NSString class],
         [MTRAttributePath class],
+        [MTRDeviceClusterData class],
     ]];
     return sStorageClasses;
 }

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -20,14 +20,22 @@
 #import <Matter/MTRDevice.h>
 
 #import "MTRAsyncWorkQueue.h"
-
-#include <app/DeviceProxy.h>
+#import "MTRDefines_Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class MTRAsyncWorkQueue;
 
 typedef void (^MTRDevicePerformAsyncBlock)(MTRBaseDevice * baseDevice);
+
+/**
+ * Information about a cluster, currently is just data version
+ */
+MTR_TESTABLE
+@interface MTRDeviceClusterData : NSObject <NSSecureCoding>
+@property (nonatomic) NSNumber * dataVersion;
+// TODO: add cluster attributes in this object, and remove direct attribute storage
+@end
 
 @interface MTRDevice ()
 - (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;
@@ -72,6 +80,10 @@ typedef void (^MTRDevicePerformAsyncBlock)(MTRBaseDevice * baseDevice);
 //   attributeValues : array of response-value dictionaries with non-null MTRAttributePathKey value
 //   reportChanges : if set to YES, attribute reports will also sent to the delegate if new values are different
 - (void)setAttributeValues:(NSArray<NSDictionary *> *)attributeValues reportChanges:(BOOL)reportChanges;
+
+// Method to insert cluster data
+//   Currently contains data version information
+- (void)setClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)clusterData;
 
 @end
 

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -20,6 +20,7 @@
 #import <XCTest/XCTest.h>
 
 #import "MTRDeviceTestDelegate.h"
+#import "MTRDevice_Internal.h"
 #import "MTRErrorTestUtils.h"
 #import "MTRFabricInfoChecker.h"
 #import "MTRTestDeclarations.h"
@@ -1082,6 +1083,19 @@ static const uint16_t kTestVendorId = 0xFFF1u;
     [controller.controllerDataStore storeAttributeValues:testAttributes forNodeID:@(1002)];
     [controller.controllerDataStore storeAttributeValues:testAttributes forNodeID:@(1003)];
 
+    MTRDeviceClusterData * testClusterData1 = [[MTRDeviceClusterData alloc] init];
+    testClusterData1.dataVersion = @(1);
+    MTRDeviceClusterData * testClusterData2 = [[MTRDeviceClusterData alloc] init];
+    testClusterData2.dataVersion = @(2);
+    MTRDeviceClusterData * testClusterData3 = [[MTRDeviceClusterData alloc] init];
+    testClusterData3.dataVersion = @(3);
+    NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> * testClusterData = @{
+        [MTRClusterPath clusterPathWithEndpointID:@(1) clusterID:@(1)] : testClusterData1,
+        [MTRClusterPath clusterPathWithEndpointID:@(1) clusterID:@(2)] : testClusterData2,
+        [MTRClusterPath clusterPathWithEndpointID:@(1) clusterID:@(3)] : testClusterData3,
+    };
+    [controller.controllerDataStore storeClusterData:testClusterData forNodeID:@(1001)];
+
     // Check values are written and can be fetched
     NSArray * dataStoreValues = [controller.controllerDataStore getStoredAttributesForNodeID:@(1001)];
     XCTAssertEqual(dataStoreValues.count, 9);
@@ -1121,6 +1135,11 @@ static const uint16_t kTestVendorId = 0xFFF1u;
         } else if ([path.endpoint isEqualToNumber:@(2)] && [path.cluster isEqualToNumber:@(1)] && [path.attribute isEqualToNumber:@(3)]) {
             XCTAssertEqualObjects(value, @(213));
         }
+    }
+
+    NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> * dataStoreClusterData = [controller.controllerDataStore getStoredClusterDataForNodeID:@(1001)];
+    for (MTRClusterPath * path in testClusterData) {
+        XCTAssertEqualObjects(testClusterData[path].dataVersion, dataStoreClusterData[path].dataVersion);
     }
 
     [controller.controllerDataStore clearStoredAttributesForNodeID:@(1001)];

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -22,10 +22,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Declarations for internal methods
 
+@class MTRDeviceClusterData;
 // MTRDeviceControllerDataStore.h includes C++ header, and so we need to declare the methods separately
 @protocol MTRDeviceControllerDataStoreAttributeStoreMethods
 - (nullable NSArray<NSDictionary *> *)getStoredAttributesForNodeID:(NSNumber *)nodeID;
+- (nullable NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)getStoredClusterDataForNodeID:(NSNumber *)nodeID;
 - (void)storeAttributeValues:(NSArray<NSDictionary *> *)dataValues forNodeID:(NSNumber *)nodeID;
+- (void)storeClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)clusterData forNodeID:(NSNumber *)nodeID;
 - (void)clearStoredAttributesForNodeID:(NSNumber *)nodeID;
 - (void)clearAllStoredAttributes;
 - (void)unitTestPruneEmptyStoredAttributesBranches;


### PR DESCRIPTION
The initial implementation for the attribute cache storage made a mistaken assumption about how data versions work. This change moves the data version stored from by-attribute to by-cluster.