### PR TITLE
[ESP32]  Made changes to the ESP32 QEMU Dockerfile to address the QEMU CI failure.

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,2 +1,1 @@
-45 : [TI] Update Sysconfig Version to 1.18.1
-
+46 : [ESP32] Updated the QEMU Dockerfile.

--- a/integrations/docker/images/stage-3/chip-build-esp32-qemu/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-esp32-qemu/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /opt/espressif/qemu
 # Setup QEMU emulator for ESP32 platform
 RUN set -x \
     && git clone --depth 1 -b esp-develop-20210826 https://github.com/espressif/qemu.git ../qemu-src \
-    && ../qemu-src/configure --target-list=xtensa-softmmu --enable-debug --enable-sanitizers --disable-strip --disable-user --disable-capstone --disable-vnc --disable-sdl --disable-gtk \
+    && ../qemu-src/configure --target-list=xtensa-softmmu --enable-debug --disable-strip --disable-user --disable-capstone --disable-vnc --disable-sdl --disable-gtk \
     && make -j8 \
     && : # last line
 


### PR DESCRIPTION
**Problem:**
- https://github.com/project-chip/connectedhomeip/pull/32587 - The tests before disabling the QEMU tests in CI were failing.
- When we run QEMU with address sanitizers enabled ,we get following warning at the start
`WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases`!.
- For some case, this features works fine with Clang toolchain but has issues with GNU.
- I have attached the [reference Issue](https://github.com/espressif/qemu/issues/77.) here.
- Also it might consume more CPU or memory resources which might affect the CI .

**Change Overview**
- Modified the Dockerfile and built it locally and tested in the CI with the fix.



