### PR TITLE
Fix nanopb code generation

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -290,3 +290,10 @@ setuptools==68.0.0
     # via
     #   pip-tools
     #   west
+
+# Manual edits:
+
+# Higher versions depend on proto-plus, which break
+# nanopb code generation (due to name conflict of the 'proto' module)
+google-api-core==2.17.0
+


### PR DESCRIPTION
https://github.com/googleapis/python-api-core/pull/626 in the latest google-api-core pulls in `proto-plus` as a dependency and this breaks nanopb (due to conflicts in naming the `proto` crate.

Ideally we would have had fixed dependencies on all crates and I am unsure how we end up with an incomplete constraints.txt, however for now specifically only fixing this failure.

There may be more as we seem not to fix all crates we use (which is especially hard given that we may have different packages installed for different platforms)