### PR TITLE
[Android]CHIP_ERROR should be handled by Long in Java/Kotlin

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -95,7 +95,7 @@ class CHIPToolActivity :
     }
   }
 
-  override fun onCommissioningComplete(code: Int, nodeId: Long) {
+  override fun onCommissioningComplete(code: Long, nodeId: Long) {
     runOnUiThread {
       Toast.makeText(this, getString(R.string.commissioning_completed, code), Toast.LENGTH_SHORT)
         .show()

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/GenericChipDeviceListener.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/GenericChipDeviceListener.kt
@@ -12,15 +12,15 @@ open class GenericChipDeviceListener : ChipDeviceController.CompletionListener {
     // No op
   }
 
-  override fun onPairingComplete(code: Int) {
+  override fun onPairingComplete(code: Long) {
     // No op
   }
 
-  override fun onPairingDeleted(code: Int) {
+  override fun onPairingDeleted(code: Long) {
     // No op
   }
 
-  override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+  override fun onCommissioningComplete(nodeId: Long, errorCode: Long) {
     // No op
   }
 
@@ -33,7 +33,7 @@ open class GenericChipDeviceListener : ChipDeviceController.CompletionListener {
     // No op
   }
 
-  override fun onCommissioningStatusUpdate(nodeId: Long, stage: String, errorCode: Int) {
+  override fun onCommissioningStatusUpdate(nodeId: Long, stage: String, errorCode: Long) {
     // No op
   }
 
@@ -57,7 +57,7 @@ open class GenericChipDeviceListener : ChipDeviceController.CompletionListener {
     // No op
   }
 
-  override fun onICDRegistrationComplete(errorCode: Int, icdDeviceInfo: ICDDeviceInfo) {
+  override fun onICDRegistrationComplete(errorCode: Long, icdDeviceInfo: ICDDeviceInfo) {
     // No op
   }
 }

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/BasicClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/BasicClientFragment.kt
@@ -98,7 +98,7 @@ class BasicClientFragment : Fragment() {
   inner class ChipControllerCallback : GenericChipDeviceListener() {
     override fun onConnectDeviceComplete() {}
 
-    override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+    override fun onCommissioningComplete(nodeId: Long, errorCode: Long) {
       Log.d(TAG, "onCommissioningComplete for nodeId $nodeId: $errorCode")
     }
 

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/GroupSettingFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/GroupSettingFragment.kt
@@ -539,7 +539,7 @@ class GroupSettingFragment : Fragment() {
   }
 
   inner class ChipControllerCallback : GenericChipDeviceListener() {
-    override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+    override fun onCommissioningComplete(nodeId: Long, errorCode: Long) {
       Log.d(TAG, "onCommissioningComplete for nodeId $nodeId: $errorCode")
     }
 

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/MultiAdminClientFragment.kt
@@ -102,7 +102,7 @@ class MultiAdminClientFragment : Fragment() {
   inner class ChipControllerCallback : GenericChipDeviceListener() {
     override fun onConnectDeviceComplete() {}
 
-    override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+    override fun onCommissioningComplete(nodeId: Long, errorCode: Long) {
       Log.d(TAG, "onCommissioningComplete for nodeId $nodeId: $errorCode")
     }
 

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OnOffClientFragment.kt
@@ -243,7 +243,7 @@ class OnOffClientFragment : Fragment() {
   inner class ChipControllerCallback : GenericChipDeviceListener() {
     override fun onConnectDeviceComplete() {}
 
-    override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+    override fun onCommissioningComplete(nodeId: Long, errorCode: Long) {
       Log.d(TAG, "onCommissioningComplete for nodeId $nodeId: $errorCode")
       showMessage("Address update complete for nodeId $nodeId with code $errorCode")
     }

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OpCredClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OpCredClientFragment.kt
@@ -76,7 +76,7 @@ class OpCredClientFragment : Fragment() {
   inner class ChipControllerCallback : GenericChipDeviceListener() {
     override fun onConnectDeviceComplete() {}
 
-    override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+    override fun onCommissioningComplete(nodeId: Long, errorCode: Long) {
       Log.d(TAG, "onCommissioningComplete for nodeId $nodeId: $errorCode")
     }
 

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OtaProviderClientFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/OtaProviderClientFragment.kt
@@ -682,7 +682,7 @@ class OtaProviderClientFragment : Fragment() {
   }
 
   inner class ChipControllerCallback : GenericChipDeviceListener() {
-    override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+    override fun onCommissioningComplete(nodeId: Long, errorCode: Long) {
       Log.d(TAG, "onCommissioningComplete for nodeId $nodeId: $errorCode")
       showMessage("Address update complete for nodeId $nodeId with code $errorCode")
     }

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/DeviceProvisioningFragment.kt
@@ -104,7 +104,7 @@ class DeviceProvisioningFragment : Fragment() {
     override fun onDeviceAttestationCompleted(
       devicePtr: Long,
       attestationInfo: AttestationInfo,
-      errorCode: Int
+      errorCode: Long
     ) {}
   }
 
@@ -249,10 +249,10 @@ class DeviceProvisioningFragment : Fragment() {
       Log.d(TAG, "Pairing status update: $status")
     }
 
-    override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+    override fun onCommissioningComplete(nodeId: Long, errorCode: Long) {
       if (errorCode == STATUS_PAIRING_SUCCESS) {
         FragmentUtil.getHost(this@DeviceProvisioningFragment, Callback::class.java)
-          ?.onCommissioningComplete(0, nodeId)
+          ?.onCommissioningComplete(0L, nodeId)
       } else {
         showMessage(R.string.rendezvous_over_ble_pairing_failure_text)
         FragmentUtil.getHost(this@DeviceProvisioningFragment, Callback::class.java)
@@ -260,7 +260,7 @@ class DeviceProvisioningFragment : Fragment() {
       }
     }
 
-    override fun onPairingComplete(code: Int) {
+    override fun onPairingComplete(code: Long) {
       Log.d(TAG, "onPairingComplete: $code")
 
       if (code != STATUS_PAIRING_SUCCESS) {
@@ -274,7 +274,7 @@ class DeviceProvisioningFragment : Fragment() {
       Log.d(TAG, String(csr))
     }
 
-    override fun onPairingDeleted(code: Int) {
+    override fun onPairingDeleted(code: Long) {
       Log.d(TAG, "onPairingDeleted: $code")
     }
 
@@ -293,7 +293,7 @@ class DeviceProvisioningFragment : Fragment() {
       )
     }
 
-    override fun onICDRegistrationComplete(errorCode: Int, icdDeviceInfo: ICDDeviceInfo) {
+    override fun onICDRegistrationComplete(errorCode: Long, icdDeviceInfo: ICDDeviceInfo) {
       Log.d(
         TAG,
         "onICDRegistrationComplete - errorCode: $errorCode, symmetricKey : ${icdDeviceInfo.symmetricKey.toHex()}, icdDeviceInfo : $icdDeviceInfo"
@@ -318,14 +318,14 @@ class DeviceProvisioningFragment : Fragment() {
   /** Callback from [DeviceProvisioningFragment] notifying any registered listeners. */
   interface Callback {
     /** Notifies that commissioning has been completed. */
-    fun onCommissioningComplete(code: Int, nodeId: Long = 0L)
+    fun onCommissioningComplete(code: Long, nodeId: Long = 0L)
   }
 
   companion object {
     private const val TAG = "DeviceProvisioningFragment"
     private const val ARG_DEVICE_INFO = "device_info"
     private const val ARG_NETWORK_CREDENTIALS = "network_credentials"
-    private const val STATUS_PAIRING_SUCCESS = 0
+    private const val STATUS_PAIRING_SUCCESS = 0L
 
     /**
      * Set for the fail-safe timer before onDeviceAttestationFailed is invoked.

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairAddressPaseCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairAddressPaseCommand.kt
@@ -30,9 +30,9 @@ class PairAddressPaseCommand(controller: ChipDeviceController, credsIssue: Crede
     PairingModeType.ADDRESS_PASE_ONLY,
     PairingNetworkType.NONE
   ) {
-  override fun onPairingComplete(errorCode: Int) {
+  override fun onPairingComplete(errorCode: Long) {
     logger.log(Level.INFO, "onPairingComplete with error code: $errorCode")
-    if (errorCode == 0) {
+    if (errorCode == 0L) {
       setSuccess()
     } else {
       setFailure("onPairingComplete failure")

--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt
@@ -127,20 +127,20 @@ abstract class PairingCommand(
     logger.log(Level.INFO, "onStatusUpdate with status: $status")
   }
 
-  override fun onPairingComplete(errorCode: Int) {
+  override fun onPairingComplete(errorCode: Long) {
     logger.log(Level.INFO, "onPairingComplete with error code: $errorCode")
-    if (errorCode != 0) {
+    if (errorCode != 0L) {
       setFailure("onPairingComplete failure")
     }
   }
 
-  override fun onPairingDeleted(errorCode: Int) {
+  override fun onPairingDeleted(errorCode: Long) {
     logger.log(Level.INFO, "onPairingDeleted with error code: $errorCode")
   }
 
-  override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+  override fun onCommissioningComplete(nodeId: Long, errorCode: Long) {
     logger.log(Level.INFO, "onCommissioningComplete with error code: $errorCode")
-    if (errorCode == 0) {
+    if (errorCode == 0L) {
       setSuccess()
     } else {
       setFailure("onCommissioningComplete failure")
@@ -156,7 +156,7 @@ abstract class PairingCommand(
     logger.log(Level.INFO, "onReadCommissioningInfo")
   }
 
-  override fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: Int) {
+  override fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: Long) {
     logger.log(Level.INFO, "onCommissioningStatusUpdate")
   }
 
@@ -186,7 +186,7 @@ abstract class PairingCommand(
       .updateCommissioningICDRegistrationInfo(ICDRegistrationInfo.newBuilder().build())
   }
 
-  override fun onICDRegistrationComplete(errorCode: Int, icdDeviceInfo: ICDDeviceInfo) {
+  override fun onICDRegistrationComplete(errorCode: Long, icdDeviceInfo: ICDDeviceInfo) {
     logger.log(
       Level.INFO,
       "onICDRegistrationComplete with errorCode: $errorCode, symmetricKey: ${icdDeviceInfo.symmetricKey.toHex()}, icdDeviceInfo: $icdDeviceInfo"

--- a/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt
+++ b/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt
@@ -127,7 +127,7 @@ abstract class PairingCommand(
 
   override fun onPairingComplete(errorCode: UInt) {
     logger.log(Level.INFO, "onPairingComplete with error code: $errorCode")
-    if (errorCode != 0) {
+    if (errorCode != 0U) {
       setFailure("onPairingComplete failure")
     }
   }
@@ -138,7 +138,7 @@ abstract class PairingCommand(
 
   override fun onCommissioningComplete(nodeId: Long, errorCode: UInt) {
     logger.log(Level.INFO, "onCommissioningComplete with error code: $errorCode")
-    if (errorCode == 0) {
+    if (errorCode == 0U) {
       setSuccess()
     } else {
       setFailure("onCommissioningComplete failure")

--- a/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt
+++ b/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt
@@ -125,20 +125,20 @@ abstract class PairingCommand(
     logger.log(Level.INFO, "onStatusUpdate with status: $status")
   }
 
-  override fun onPairingComplete(errorCode: Long) {
+  override fun onPairingComplete(errorCode: UInt) {
     logger.log(Level.INFO, "onPairingComplete with error code: $errorCode")
-    if (errorCode != 0L) {
+    if (errorCode != 0) {
       setFailure("onPairingComplete failure")
     }
   }
 
-  override fun onPairingDeleted(errorCode: Long) {
+  override fun onPairingDeleted(errorCode: UInt) {
     logger.log(Level.INFO, "onPairingDeleted with error code: $errorCode")
   }
 
-  override fun onCommissioningComplete(nodeId: Long, errorCode: Long) {
+  override fun onCommissioningComplete(nodeId: Long, errorCode: UInt) {
     logger.log(Level.INFO, "onCommissioningComplete with error code: $errorCode")
-    if (errorCode == 0L) {
+    if (errorCode == 0) {
       setSuccess()
     } else {
       setFailure("onCommissioningComplete failure")
@@ -154,7 +154,7 @@ abstract class PairingCommand(
     logger.log(Level.INFO, "onReadCommissioningInfo")
   }
 
-  override fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: Long) {
+  override fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: UInt) {
     logger.log(Level.INFO, "onCommissioningStatusUpdate")
   }
 
@@ -178,7 +178,7 @@ abstract class PairingCommand(
     logger.log(Level.INFO, "onICDRegistrationInfoRequired")
   }
 
-  override fun onICDRegistrationComplete(errorCode: Long, icdDeviceInfo: ICDDeviceInfo) {
+  override fun onICDRegistrationComplete(errorCode: UInt, icdDeviceInfo: ICDDeviceInfo) {
     logger.log(
       Level.INFO,
       "onICDRegistrationComplete with errorCode: $errorCode, symmetricKey: ${icdDeviceInfo.symmetricKey.toHex()}, icdDeviceInfo: $icdDeviceInfo"

--- a/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt
+++ b/examples/kotlin-matter-controller/java/src/com/matter/controller/commands/pairing/PairingCommand.kt
@@ -125,20 +125,20 @@ abstract class PairingCommand(
     logger.log(Level.INFO, "onStatusUpdate with status: $status")
   }
 
-  override fun onPairingComplete(errorCode: Int) {
+  override fun onPairingComplete(errorCode: Long) {
     logger.log(Level.INFO, "onPairingComplete with error code: $errorCode")
-    if (errorCode != 0) {
+    if (errorCode != 0L) {
       setFailure("onPairingComplete failure")
     }
   }
 
-  override fun onPairingDeleted(errorCode: Int) {
+  override fun onPairingDeleted(errorCode: Long) {
     logger.log(Level.INFO, "onPairingDeleted with error code: $errorCode")
   }
 
-  override fun onCommissioningComplete(nodeId: Long, errorCode: Int) {
+  override fun onCommissioningComplete(nodeId: Long, errorCode: Long) {
     logger.log(Level.INFO, "onCommissioningComplete with error code: $errorCode")
-    if (errorCode == 0) {
+    if (errorCode == 0L) {
       setSuccess()
     } else {
       setFailure("onCommissioningComplete failure")
@@ -154,7 +154,7 @@ abstract class PairingCommand(
     logger.log(Level.INFO, "onReadCommissioningInfo")
   }
 
-  override fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: Int) {
+  override fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: Long) {
     logger.log(Level.INFO, "onCommissioningStatusUpdate")
   }
 
@@ -178,7 +178,7 @@ abstract class PairingCommand(
     logger.log(Level.INFO, "onICDRegistrationInfoRequired")
   }
 
-  override fun onICDRegistrationComplete(errorCode: Int, icdDeviceInfo: ICDDeviceInfo) {
+  override fun onICDRegistrationComplete(errorCode: Long, icdDeviceInfo: ICDDeviceInfo) {
     logger.log(
       Level.INFO,
       "onICDRegistrationComplete with errorCode: $errorCode, symmetricKey: ${icdDeviceInfo.symmetricKey.toHex()}, icdDeviceInfo: $icdDeviceInfo"

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -86,10 +86,16 @@ void AndroidDeviceControllerWrapper::SetJavaObjectRef(JavaVM * vm, jobject obj)
     }
 }
 
-void AndroidDeviceControllerWrapper::CallJavaMethod(const char * methodName, jint argument)
+void AndroidDeviceControllerWrapper::CallJavaIntMethod(const char * methodName, jint argument)
 {
     JniReferences::GetInstance().CallVoidInt(JniReferences::GetInstance().GetEnvForCurrentThread(), mJavaObjectRef.ObjectRef(),
                                              methodName, argument);
+}
+
+void AndroidDeviceControllerWrapper::CallJavaLongMethod(const char * methodName, jlong argument)
+{
+    JniReferences::GetInstance().CallVoidLong(JniReferences::GetInstance().GetEnvForCurrentThread(), mJavaObjectRef.ObjectRef(),
+                                              methodName, argument);
 }
 
 AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
@@ -697,19 +703,19 @@ CHIP_ERROR AndroidDeviceControllerWrapper::SetICDCheckInDelegate(jobject checkIn
 void AndroidDeviceControllerWrapper::OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status)
 {
     chip::DeviceLayer::StackUnlock unlock;
-    CallJavaMethod("onStatusUpdate", static_cast<jint>(status));
+    CallJavaIntMethod("onStatusUpdate", static_cast<jint>(status));
 }
 
 void AndroidDeviceControllerWrapper::OnPairingComplete(CHIP_ERROR error)
 {
     chip::DeviceLayer::StackUnlock unlock;
-    CallJavaMethod("onPairingComplete", static_cast<jint>(error.AsInteger()));
+    CallJavaLongMethod("onPairingComplete", static_cast<jlong>(error.AsInteger()));
 }
 
 void AndroidDeviceControllerWrapper::OnPairingDeleted(CHIP_ERROR error)
 {
     chip::DeviceLayer::StackUnlock unlock;
-    CallJavaMethod("onPairingDeleted", static_cast<jint>(error.AsInteger()));
+    CallJavaLongMethod("onPairingDeleted", static_cast<jlong>(error.AsInteger()));
 }
 
 void AndroidDeviceControllerWrapper::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error)
@@ -727,11 +733,11 @@ void AndroidDeviceControllerWrapper::OnCommissioningComplete(NodeId deviceId, CH
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     jmethodID onCommissioningCompleteMethod;
-    CHIP_ERROR err = JniReferences::GetInstance().FindMethod(env, mJavaObjectRef.ObjectRef(), "onCommissioningComplete", "(JI)V",
+    CHIP_ERROR err = JniReferences::GetInstance().FindMethod(env, mJavaObjectRef.ObjectRef(), "onCommissioningComplete", "(JJ)V",
                                                              &onCommissioningCompleteMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error finding Java method: %" CHIP_ERROR_FORMAT, err.Format()));
     env->CallVoidMethod(mJavaObjectRef.ObjectRef(), onCommissioningCompleteMethod, static_cast<jlong>(deviceId),
-                        static_cast<jint>(error.AsInteger()));
+                        static_cast<jlong>(error.AsInteger()));
 
     if (ssidStr != nullptr)
     {
@@ -762,12 +768,12 @@ void AndroidDeviceControllerWrapper::OnCommissioningStatusUpdate(PeerId peerId, 
     JniLocalReferenceScope scope(env);
     jmethodID onCommissioningStatusUpdateMethod;
     CHIP_ERROR err = JniReferences::GetInstance().FindMethod(env, mJavaObjectRef.ObjectRef(), "onCommissioningStatusUpdate",
-                                                             "(JLjava/lang/String;I)V", &onCommissioningStatusUpdateMethod);
+                                                             "(JLjava/lang/String;J)V", &onCommissioningStatusUpdateMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error finding Java method: %" CHIP_ERROR_FORMAT, err.Format()));
 
     UtfString jStageCompleted(env, StageToString(stageCompleted));
     env->CallVoidMethod(mJavaObjectRef.ObjectRef(), onCommissioningStatusUpdateMethod, static_cast<jlong>(peerId.GetNodeId()),
-                        jStageCompleted.jniValue(), static_cast<jint>(error.AsInteger()));
+                        jStageCompleted.jniValue(), static_cast<jlong>(error.AsInteger()));
 }
 
 void AndroidDeviceControllerWrapper::OnReadCommissioningInfo(const chip::Controller::ReadCommissioningInfo & info)
@@ -800,12 +806,12 @@ void AndroidDeviceControllerWrapper::OnScanNetworksSuccess(
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
     JniLocalReferenceScope scope(env);
 
-    VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Error invoking Java callback: no JNIEnv"));
+    VerifyOrReturn(env != nullptr, ChipLogError(Controller, "Error invoking Java callback: no JNIEnv"));
 
     err = JniReferences::GetInstance().FindMethod(
         env, mJavaObjectRef.ObjectRef(), "onScanNetworksSuccess",
         "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V", &javaMethod);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error invoking Java callback: %s", ErrorStr(err)));
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error invoking Java callback: %s", ErrorStr(err)));
 
     jobject NetworkingStatus;
     std::string NetworkingStatusClassName     = "java/lang/Integer";
@@ -937,7 +943,7 @@ void AndroidDeviceControllerWrapper::OnScanNetworksSuccess(
                                                                       threadInterfaceScanResultStructClass);
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(Zcl, "Could not find class ThreadScanResult");
+                ChipLogError(Controller, "Could not find class ThreadScanResult");
                 return;
             }
             jmethodID threadInterfaceScanResultStructCtor =
@@ -946,7 +952,7 @@ void AndroidDeviceControllerWrapper::OnScanNetworksSuccess(
                                  "Integer;[BLjava/lang/Integer;Ljava/lang/Integer;)V");
             if (threadInterfaceScanResultStructCtor == nullptr)
             {
-                ChipLogError(Zcl, "Could not find ThreadScanResult constructor");
+                ChipLogError(Controller, "Could not find ThreadScanResult constructor");
                 return;
             }
 
@@ -966,7 +972,7 @@ void AndroidDeviceControllerWrapper::OnScanNetworksFailure(CHIP_ERROR error)
 {
     chip::DeviceLayer::StackUnlock unlock;
 
-    CallJavaMethod("onScanNetworksFailure", static_cast<jint>(error.AsInteger()));
+    CallJavaLongMethod("onScanNetworksFailure", static_cast<jlong>(error.AsInteger()));
 }
 
 void AndroidDeviceControllerWrapper::OnICDRegistrationInfoRequired()
@@ -1022,7 +1028,7 @@ void AndroidDeviceControllerWrapper::OnICDRegistrationComplete(chip::NodeId icdN
     jbyteArray jSymmetricKey          = nullptr;
     CHIP_ERROR methodErr =
         JniReferences::GetInstance().FindMethod(env, mJavaObjectRef.ObjectRef(), "onICDRegistrationComplete",
-                                                "(ILchip/devicecontroller/ICDDeviceInfo;)V", &onICDRegistrationCompleteMethod);
+                                                "(JLchip/devicecontroller/ICDDeviceInfo;)V", &onICDRegistrationCompleteMethod);
     VerifyOrReturn(methodErr == CHIP_NO_ERROR,
                    ChipLogError(Controller, "Error finding Java method: %" CHIP_ERROR_FORMAT, methodErr.Format()));
 
@@ -1045,7 +1051,7 @@ void AndroidDeviceControllerWrapper::OnICDRegistrationComplete(chip::NodeId icdN
         static_cast<jlong>(mAutoCommissioner.GetCommissioningParameters().GetICDMonitoredSubject().Value()),
         static_cast<jlong>(Controller()->GetFabricId()), static_cast<jint>(Controller()->GetFabricIndex()));
 
-    env->CallVoidMethod(mJavaObjectRef.ObjectRef(), onICDRegistrationCompleteMethod, static_cast<jint>(err.AsInteger()),
+    env->CallVoidMethod(mJavaObjectRef.ObjectRef(), onICDRegistrationCompleteMethod, static_cast<jlong>(err.AsInteger()),
                         icdDeviceInfoObj);
 }
 

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -86,7 +86,8 @@ public:
     }
 #endif // JAVA_MATTER_CONTROLLER_TEST
 
-    void CallJavaMethod(const char * methodName, jint argument);
+    void CallJavaIntMethod(const char * methodName, jint argument);
+    void CallJavaLongMethod(const char * methodName, jlong argument);
     CHIP_ERROR InitializeOperationalCredentialsIssuer();
 
     /**

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -161,7 +161,7 @@ void JNI_OnUnload(JavaVM * jvm, void * reserved)
     chip::Platform::MemoryShutdown();
 }
 
-JNI_METHOD(jint, onNOCChainGeneration)
+JNI_METHOD(jlong, onNOCChainGeneration)
 (JNIEnv * env, jobject self, jlong handle, jobject controllerParams)
 {
     chip::DeviceLayer::StackLock lock;
@@ -266,7 +266,7 @@ JNI_METHOD(jint, onNOCChainGeneration)
         {
             ChipLogError(Controller, "Failed to SetNocChain for the device: %" CHIP_ERROR_FORMAT, err.Format());
         }
-        return static_cast<jint>(err.AsInteger());
+        return static_cast<jlong>(err.AsInteger());
 #endif // JAVA_MATTER_CONTROLLER_TEST
     }
 exit:
@@ -274,7 +274,7 @@ exit:
     err = wrapper->GetAndroidOperationalCredentialsIssuer()->NOCChainGenerated(err, ByteSpan(), ByteSpan(), ByteSpan(), ipkOptional,
                                                                                adminSubjectOptional);
 #endif // JAVA_MATTER_CONTROLLER_TEST
-    return static_cast<jint>(err.AsInteger());
+    return static_cast<jlong>(err.AsInteger());
 }
 
 JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self, jobject controllerParams)

--- a/src/controller/java/DeviceAttestationDelegateBridge.cpp
+++ b/src/controller/java/DeviceAttestationDelegateBridge.cpp
@@ -86,7 +86,7 @@ void DeviceAttestationDelegateBridge::OnDeviceAttestationCompleted(
         {
             jmethodID onDeviceAttestationCompletedMethod;
             JniReferences::GetInstance().FindMethod(env, mDeviceAttestationDelegate.ObjectRef(), "onDeviceAttestationCompleted",
-                                                    "(JLchip/devicecontroller/AttestationInfo;I)V",
+                                                    "(JLchip/devicecontroller/AttestationInfo;J)V",
                                                     &onDeviceAttestationCompletedMethod);
             VerifyOrReturn(onDeviceAttestationCompletedMethod != nullptr,
                            ChipLogError(Controller, "Could not find deviceAttestation completed method"));

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -419,7 +419,7 @@ public class ChipDeviceController {
    * @param params
    * @return CHIP_ERROR error code (0 is no error)
    */
-  public int onNOCChainGeneration(ControllerParams params) {
+  public long onNOCChainGeneration(ControllerParams params) {
     return onNOCChainGeneration(deviceControllerPtr, params);
   }
 
@@ -555,19 +555,19 @@ public class ChipDeviceController {
     }
   }
 
-  public void onPairingComplete(int errorCode) {
+  public void onPairingComplete(long errorCode) {
     if (completionListener != null) {
       completionListener.onPairingComplete(errorCode);
     }
   }
 
-  public void onCommissioningComplete(long nodeId, int errorCode) {
+  public void onCommissioningComplete(long nodeId, long errorCode) {
     if (completionListener != null) {
       completionListener.onCommissioningComplete(nodeId, errorCode);
     }
   }
 
-  public void onCommissioningStatusUpdate(long nodeId, String stage, int errorCode) {
+  public void onCommissioningStatusUpdate(long nodeId, String stage, long errorCode) {
     if (completionListener != null) {
       completionListener.onCommissioningStatusUpdate(nodeId, stage, errorCode);
     }
@@ -581,7 +581,7 @@ public class ChipDeviceController {
     }
   }
 
-  public void onScanNetworksFailure(int errorCode) {
+  public void onScanNetworksFailure(long errorCode) {
     if (scanNetworksListener != null) {
       scanNetworksListener.onScanNetworksFailure(errorCode);
     }
@@ -604,7 +604,7 @@ public class ChipDeviceController {
     }
   }
 
-  public void onPairingDeleted(int errorCode) {
+  public void onPairingDeleted(long errorCode) {
     if (completionListener != null) {
       completionListener.onPairingDeleted(errorCode);
     }
@@ -636,7 +636,7 @@ public class ChipDeviceController {
     }
   }
 
-  public void onICDRegistrationComplete(int errorCode, ICDDeviceInfo icdDeviceInfo) {
+  public void onICDRegistrationComplete(long errorCode, ICDDeviceInfo icdDeviceInfo) {
     if (completionListener != null) {
       completionListener.onICDRegistrationComplete(errorCode, icdDeviceInfo);
     }
@@ -1576,7 +1576,7 @@ public class ChipDeviceController {
 
   private native List<ICDClientInfo> getICDClientInfo(long deviceControllerPtr, long fabricIndex);
 
-  private native int onNOCChainGeneration(long deviceControllerPtr, ControllerParams params);
+  private native long onNOCChainGeneration(long deviceControllerPtr, ControllerParams params);
 
   private native int getFabricIndex(long deviceControllerPtr);
 
@@ -1642,7 +1642,7 @@ public class ChipDeviceController {
    */
   public interface ScanNetworksListener {
     /** Notifies when scan networks call fails. */
-    void onScanNetworksFailure(int errorCode);
+    void onScanNetworksFailure(long errorCode);
 
     void onScanNetworksSuccess(
         Integer networkingStatus,
@@ -1661,20 +1661,20 @@ public class ChipDeviceController {
     void onStatusUpdate(int status);
 
     /** Notifies the completion of pairing. */
-    void onPairingComplete(int errorCode);
+    void onPairingComplete(long errorCode);
 
     /** Notifies the deletion of pairing session. */
-    void onPairingDeleted(int errorCode);
+    void onPairingDeleted(long errorCode);
 
     /** Notifies the completion of commissioning. */
-    void onCommissioningComplete(long nodeId, int errorCode);
+    void onCommissioningComplete(long nodeId, long errorCode);
 
     /** Notifies the completion of each stage of commissioning. */
     void onReadCommissioningInfo(
         int vendorId, int productId, int wifiEndpointId, int threadEndpointId);
 
     /** Notifies the completion of each stage of commissioning. */
-    void onCommissioningStatusUpdate(long nodeId, String stage, int errorCode);
+    void onCommissioningStatusUpdate(long nodeId, String stage, long errorCode);
 
     /** Notifies that the Chip connection has been closed. */
     void onNotifyChipConnectionClosed();
@@ -1695,6 +1695,6 @@ public class ChipDeviceController {
     void onICDRegistrationInfoRequired();
 
     /** Notifies when the registration flow for the ICD completes. */
-    void onICDRegistrationComplete(int errorCode, ICDDeviceInfo icdDeviceInfo);
+    void onICDRegistrationComplete(long errorCode, ICDDeviceInfo icdDeviceInfo);
   }
 }

--- a/src/controller/java/src/chip/devicecontroller/DeviceAttestationDelegate.java
+++ b/src/controller/java/src/chip/devicecontroller/DeviceAttestationDelegate.java
@@ -31,5 +31,6 @@ public interface DeviceAttestationDelegate {
    * @param attestationInfo Attestation information for the device, null is errorCode is 0.
    * @param errorCode Error code on attestation failure. 0 if succeed.
    */
-  void onDeviceAttestationCompleted(long devicePtr, AttestationInfo attestationInfo, int errorCode);
+  void onDeviceAttestationCompleted(
+      long devicePtr, AttestationInfo attestationInfo, long errorCode);
 }

--- a/src/controller/java/src/matter/controller/CompletionListenerAdapter.kt
+++ b/src/controller/java/src/matter/controller/CompletionListenerAdapter.kt
@@ -29,17 +29,17 @@ class CompletionListenerAdapter(val listener: MatterController.CompletionListene
 
   override fun onStatusUpdate(status: Int) = listener.onStatusUpdate(status)
 
-  override fun onPairingComplete(errorCode: Int) = listener.onPairingComplete(errorCode)
+  override fun onPairingComplete(errorCode: Long) = listener.onPairingComplete(errorCode.toUInt())
 
-  override fun onPairingDeleted(errorCode: Int) = listener.onPairingDeleted(errorCode)
+  override fun onPairingDeleted(errorCode: Long) = listener.onPairingDeleted(errorCode.toUInt())
 
   override fun onNotifyChipConnectionClosed() = listener.onNotifyChipConnectionClosed()
 
-  override fun onCommissioningComplete(nodeId: Long, errorCode: Int) =
-    listener.onCommissioningComplete(nodeId, errorCode)
+  override fun onCommissioningComplete(nodeId: Long, errorCode: Long) =
+    listener.onCommissioningComplete(nodeId, errorCode.toUInt())
 
-  override fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: Int) =
-    listener.onCommissioningStatusUpdate(nodeId, stage, errorCode)
+  override fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: Long) =
+    listener.onCommissioningStatusUpdate(nodeId, stage, errorCode.toUInt())
 
   override fun onReadCommissioningInfo(
     vendorId: Int,
@@ -52,10 +52,10 @@ class CompletionListenerAdapter(val listener: MatterController.CompletionListene
 
   override fun onICDRegistrationInfoRequired() = listener.onICDRegistrationInfoRequired()
 
-  override fun onICDRegistrationComplete(errorCode: Int, icdDeviceInfo: ICDDeviceInfo) =
+  override fun onICDRegistrationComplete(errorCode: Long, icdDeviceInfo: ICDDeviceInfo) =
     listener.onICDRegistrationComplete(errorCode, icdDeviceInfo)
 
-  override fun onError(error: Throwable) = listener.onError(error)
+  override fun onError(error: Throwable) = listener.onError(error.toUInt())
 
   override fun onCloseBleComplete() {
     logger.log(Level.INFO, "Not implemented, override the abstract function.")

--- a/src/controller/java/src/matter/controller/CompletionListenerAdapter.kt
+++ b/src/controller/java/src/matter/controller/CompletionListenerAdapter.kt
@@ -55,7 +55,7 @@ class CompletionListenerAdapter(val listener: MatterController.CompletionListene
   override fun onICDRegistrationComplete(errorCode: Long, icdDeviceInfo: ICDDeviceInfo) =
     listener.onICDRegistrationComplete(errorCode.toUInt(), icdDeviceInfo)
 
-  override fun onError(error: Throwable) = listener.onError(error.toUInt())
+  override fun onError(error: Throwable) = listener.onError(error)
 
   override fun onCloseBleComplete() {
     logger.log(Level.INFO, "Not implemented, override the abstract function.")

--- a/src/controller/java/src/matter/controller/CompletionListenerAdapter.kt
+++ b/src/controller/java/src/matter/controller/CompletionListenerAdapter.kt
@@ -53,7 +53,7 @@ class CompletionListenerAdapter(val listener: MatterController.CompletionListene
   override fun onICDRegistrationInfoRequired() = listener.onICDRegistrationInfoRequired()
 
   override fun onICDRegistrationComplete(errorCode: Long, icdDeviceInfo: ICDDeviceInfo) =
-    listener.onICDRegistrationComplete(errorCode, icdDeviceInfo)
+    listener.onICDRegistrationComplete(errorCode.toUInt(), icdDeviceInfo)
 
   override fun onError(error: Throwable) = listener.onError(error.toUInt())
 

--- a/src/controller/java/src/matter/controller/MatterController.kt
+++ b/src/controller/java/src/matter/controller/MatterController.kt
@@ -31,16 +31,16 @@ interface MatterController : Closeable, InteractionClient {
     fun onStatusUpdate(status: Int)
 
     /** Notifies the completion of pairing. */
-    fun onPairingComplete(errorCode: Int)
+    fun onPairingComplete(errorCode: UInt)
 
     /** Notifies the deletion of a pairing session. */
-    fun onPairingDeleted(errorCode: Int)
+    fun onPairingDeleted(errorCode: UInt)
 
     /** Notifies that the CHIP connection has been closed. */
     fun onNotifyChipConnectionClosed()
 
     /** Notifies the completion of commissioning. */
-    fun onCommissioningComplete(nodeId: Long, errorCode: Int)
+    fun onCommissioningComplete(nodeId: Long, errorCode: UInt)
 
     /** Notifies the completion of reading commissioning information. */
     fun onReadCommissioningInfo(
@@ -51,7 +51,7 @@ interface MatterController : Closeable, InteractionClient {
     )
 
     /** Notifies the completion of each stage of commissioning. */
-    fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: Int)
+    fun onCommissioningStatusUpdate(nodeId: Long, stage: String?, errorCode: UInt)
 
     /** Notifies the listener of an error. */
     fun onError(error: Throwable)
@@ -66,7 +66,7 @@ interface MatterController : Closeable, InteractionClient {
     fun onICDRegistrationInfoRequired()
 
     /** Notifies when the registration flow for the ICD completes. */
-    fun onICDRegistrationComplete(errorCode: Int, icdDeviceInfo: ICDDeviceInfo)
+    fun onICDRegistrationComplete(errorCode: UInt, icdDeviceInfo: ICDDeviceInfo)
   }
 
   /**

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -216,6 +216,22 @@ void JniReferences::CallVoidInt(JNIEnv * env, jobject object, const char * metho
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
 }
 
+void JniReferences::CallVoidLong(JNIEnv * env, jobject object, const char * methodName, jlong argument)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    jmethodID method;
+
+    err = JniReferences::FindMethod(env, object, methodName, "(J)V", &method);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Support, "Error finding Java method: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+
+    env->ExceptionClear();
+    env->CallVoidMethod(object, method, argument);
+    VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
+}
+
 void JniReferences::ReportError(JNIEnv * env, CHIP_ERROR cbErr, const char * functName)
 {
     if (cbErr == CHIP_JNI_ERROR_EXCEPTION_THROWN)

--- a/src/lib/support/JniReferences.h
+++ b/src/lib/support/JniReferences.h
@@ -132,6 +132,8 @@ public:
 
     void CallVoidInt(JNIEnv * env, jobject object, const char * methodName, jint argument);
 
+    void CallVoidLong(JNIEnv * env, jobject object, const char * methodName, jlong argument);
+
     CHIP_ERROR N2J_ByteArray(JNIEnv * env, const uint8_t * inArray, jsize inArrayLen, jbyteArray & outArray);
 
     void ReportError(JNIEnv * env, CHIP_ERROR cbErr, const char * functName);


### PR DESCRIPTION
-- CHIP_ERROR should be handled by Long in Java since CHIP_ERROR is uint32_t and Java Int cannot hold it up , fix across jni/java/kotlin

fixes: https://github.com/project-chip/connectedhomeip/issues/32560
