### PR TITLE
device  will not react to ethernet change,as #32696 reported

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -269,6 +269,12 @@ LinuxCommissionableDataProvider gCommissionableDataProvider;
 
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
+
+void ConnectivityChnagedtimerCallback(System::Layer *, void * callbackContext)
+{
+    app::DnssdServer::Instance().StartServer();
+}
+
 void EventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
     (void) arg;
@@ -278,8 +284,9 @@ void EventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
     }
     else if ((event->Type == chip::DeviceLayer::DeviceEventType::kInternetConnectivityChange))
     {
-        // Restart the server on connectivity change
-        app::DnssdServer::Instance().StartServer();
+        // Restart the server on connectivity change,because recieving a netlink router event doesn't guarantee immediate network reachablility,specially ethernet,so we daly 1200 millis to start dnssd server
+         DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(1200),ConnectivityChnagedtimerCallback , nullptr);
+       
     }
 }
 

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -270,7 +270,7 @@ LinuxCommissionableDataProvider gCommissionableDataProvider;
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 
-void ConnectivityChnagedtimerCallback(System::Layer *, void * callbackContext)
+void UpdateDnssdServiceCallback(System::Layer *, void * callbackContext)
 {
     app::DnssdServer::Instance().StartServer();
 }
@@ -284,8 +284,10 @@ void EventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
     }
     else if ((event->Type == chip::DeviceLayer::DeviceEventType::kInternetConnectivityChange))
     {
-        // Restart the server on connectivity change,because recieving a netlink router event doesn't guarantee immediate network reachablility,specially ethernet,so we daly 1200 millis to start dnssd server
-         DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(1200),ConnectivityChnagedtimerCallback , nullptr);
+          //Restart the server with a timer delay on connectivity change.
+        // When kInternetConnectivityChange happens,it doesn't guarantee immediate network reachablility,
+        //which restart dnssd server will fail with some low layer fail,so a delay timer  will be needed.
+         DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(UPDATE_DNS_SD_SERVICE_DELAY_VALUE),UpdateDnssdServiceCallback , nullptr);
        
     }
 }

--- a/examples/platform/linux/AppMain.h
+++ b/examples/platform/linux/AppMain.h
@@ -30,6 +30,8 @@
 
 #include "Options.h"
 
+static constexpr uint16_t UPDATE_DNS_SD_SERVICE_DELAY_VALUE = 1;
+
 // Applications can optionally provide the endpoint id of a secondary network
 // commissioning endpoint, if one is supported.
 int ChipLinuxAppInit(int argc, char * const argv[], chip::ArgParser::OptionSet * customOptions = nullptr,

--- a/examples/platform/linux/AppMain.h
+++ b/examples/platform/linux/AppMain.h
@@ -30,7 +30,7 @@
 
 #include "Options.h"
 
-static constexpr uint16_t UPDATE_DNS_SD_SERVICE_DELAY_VALUE = 1;
+static constexpr uint16_t UPDATE_DNS_SD_SERVICE_DELAY_VALUE = 1200;
 
 // Applications can optionally provide the endpoint id of a secondary network
 // commissioning endpoint, if one is supported.

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -108,14 +108,10 @@ gboolean IPChangeListener(GIOChannel * ch, GIOCondition /* condition */, void * 
                             continue;
                         }
 
-                        if (ConnectivityMgrImpl().GetWiFiIfName() == nullptr && ConnectivityMgrImpl().GetEthernetIfName() == nullptr)
-                        {
-                            ChipLogDetail(DeviceLayer, "No wifi interface name or etherInterface name. Ignoring IP update event.");
-                            continue;
-                        }
-
-                        if (strcmp(name, ConnectivityMgrImpl().GetWiFiIfName()) != 0 && strcmp(name, ConnectivityMgrImpl().GetEthernetIfName()) != 0)
-                        {
+                        bool wifi_matched = ConnectivityMgrImpl().GetWiFiIfName()!= nullptr && strcmp(name, ConnectivityMgrImpl().GetWiFiIfName()) == 0;
+                        bool ethernet_matched = ConnectivityMgrImpl().GetEthernetIfName() != nullptr && strcmp(name, ConnectivityMgrImpl().GetEthernetIfName()) == 0;
+                        if(!wifi_matched && !ethernet_matched){
+                             ChipLogDetail(DeviceLayer, "No wifi interface name or ethernet interface name match the router info interface name . Ignoring IP update event.");
                             continue;
                         }
 

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -69,7 +69,7 @@ void * GLibMainLoopThread(void * userData)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
-gboolean WiFiIPChangeListener(GIOChannel * ch, GIOCondition /* condition */, void * /* userData */)
+gboolean IPChangeListener(GIOChannel * ch, GIOCondition /* condition */, void * /* userData */)
 {
 
     char buffer[4096];
@@ -108,13 +108,13 @@ gboolean WiFiIPChangeListener(GIOChannel * ch, GIOCondition /* condition */, voi
                             continue;
                         }
 
-                        if (ConnectivityMgrImpl().GetWiFiIfName() == nullptr)
+                        if (ConnectivityMgrImpl().GetWiFiIfName() == nullptr && ConnectivityMgrImpl().GetEthernetIfName() == nullptr)
                         {
-                            ChipLogDetail(DeviceLayer, "No wifi interface name. Ignoring IP update event.");
+                            ChipLogDetail(DeviceLayer, "No wifi interface name or etherInterface name. Ignoring IP update event.");
                             continue;
                         }
 
-                        if (strcmp(name, ConnectivityMgrImpl().GetWiFiIfName()) != 0)
+                        if (strcmp(name, ConnectivityMgrImpl().GetWiFiIfName()) != 0 && strcmp(name, ConnectivityMgrImpl().GetEthernetIfName()) != 0)
                         {
                             continue;
                         }
@@ -155,7 +155,7 @@ gboolean WiFiIPChangeListener(GIOChannel * ch, GIOCondition /* condition */, voi
 
 // The temporary hack for getting IP address change on linux for network provisioning in the rendezvous session.
 // This should be removed or find a better place once we deprecate the rendezvous session.
-CHIP_ERROR RunWiFiIPChangeListener()
+CHIP_ERROR RunIPChangeListener()
 {
     int sock;
     if ((sock = socket(PF_NETLINK, SOCK_RAW, NETLINK_ROUTE)) == -1)
@@ -178,7 +178,7 @@ CHIP_ERROR RunWiFiIPChangeListener()
 
     GIOChannel * ch       = g_io_channel_unix_new(sock);
     GSource * watchSource = g_io_create_watch(ch, G_IO_IN);
-    g_source_set_callback(watchSource, G_SOURCE_FUNC(WiFiIPChangeListener), nullptr, nullptr);
+    g_source_set_callback(watchSource, G_SOURCE_FUNC(IPChangeListener), nullptr, nullptr);
     g_io_channel_set_close_on_unref(ch, TRUE);
     g_io_channel_set_encoding(ch, nullptr, nullptr);
 
@@ -231,7 +231,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    ReturnErrorOnFailure(RunWiFiIPChangeListener());
+    ReturnErrorOnFailure(RunIPChangeListener());
 #endif
 
     // Initialize the configuration system.


### PR DESCRIPTION
this is a pull request to `Fixes #32696` .

it post all the ip change event to application layer,which originally only post when wifi ip change event.
and in appmain, it will handle these events, at the same time, with my test, if ethernet ip change, the application will not able to access network right away, so ,i set a 1200 milliseconds to update dns-sd .

by the way, in may repo test, all the workflows passed ,only darwin action failed, but  i am sure it is nothing to do with my pull request, i guess it is because of action script itself?