### PR TITLE
[Linux] Dispatch BlueZ signals in BluezObjectManager

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -37,6 +37,7 @@
 
 #include <ble/BleError.h>
 #include <ble/CHIPBleServiceData.h>
+#include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -257,6 +258,22 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
     ChipLogDetail(DeviceLayer, "HandlePlatformSpecificBLEEvent %d", apEvent->Type);
     switch (apEvent->Type)
     {
+    case DeviceEventType::kPlatformLinuxBLEAdapterAdded:
+        ChipLogDetail(DeviceLayer, "BLE adapter added: id=%u address=%s", apEvent->Platform.BLEAdapter.mAdapterId,
+                      apEvent->Platform.BLEAdapter.mAdapterAddress);
+        if (apEvent->Platform.BLEAdapter.mAdapterId == mAdapterId)
+        {
+            // TODO: Handle adapter added
+        }
+        break;
+    case DeviceEventType::kPlatformLinuxBLEAdapterRemoved:
+        ChipLogDetail(DeviceLayer, "BLE adapter removed: id=%u address=%s", apEvent->Platform.BLEAdapter.mAdapterId,
+                      apEvent->Platform.BLEAdapter.mAdapterAddress);
+        if (apEvent->Platform.BLEAdapter.mAdapterId == mAdapterId)
+        {
+            // TODO: Handle adapter removed
+        }
+        break;
     case DeviceEventType::kPlatformLinuxBLECentralConnected:
         if (mBLEScanConfig.mBleScanState == BleScanState::kConnecting)
         {
@@ -790,6 +807,24 @@ CHIP_ERROR BLEManagerImpl::CancelConnection()
     else if (mBLEScanConfig.mBleScanState != BleScanState::kNotScanning)
         mDeviceScanner.StopScan();
     return CHIP_NO_ERROR;
+}
+
+void BLEManagerImpl::NotifyBLEAdapterAdded(unsigned int aAdapterId, const char * aAdapterAddress)
+{
+    ChipDeviceEvent event;
+    event.Type                           = DeviceEventType::kPlatformLinuxBLEAdapterAdded;
+    event.Platform.BLEAdapter.mAdapterId = aAdapterId;
+    Platform::CopyString(event.Platform.BLEAdapter.mAdapterAddress, aAdapterAddress);
+    PlatformMgr().PostEventOrDie(&event);
+}
+
+void BLEManagerImpl::NotifyBLEAdapterRemoved(unsigned int aAdapterId, const char * aAdapterAddress)
+{
+    ChipDeviceEvent event;
+    event.Type                           = DeviceEventType::kPlatformLinuxBLEAdapterRemoved;
+    event.Platform.BLEAdapter.mAdapterId = aAdapterId;
+    Platform::CopyString(event.Platform.BLEAdapter.mAdapterAddress, aAdapterAddress);
+    PlatformMgr().PostEventOrDie(&event);
 }
 
 void BLEManagerImpl::NotifyBLEPeripheralRegisterAppComplete(CHIP_ERROR error)

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -93,6 +93,8 @@ public:
     static void HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT user_data);
     static void HandleTXComplete(BLE_CONNECTION_OBJECT user_data);
 
+    static void NotifyBLEAdapterAdded(unsigned int aAdapterId, const char * aAdapterAddress);
+    static void NotifyBLEAdapterRemoved(unsigned int aAdapterId, const char * aAdapterAddress);
     static void NotifyBLEPeripheralRegisterAppComplete(CHIP_ERROR error);
     static void NotifyBLEPeripheralAdvStartComplete(CHIP_ERROR error);
     static void NotifyBLEPeripheralAdvStopComplete(CHIP_ERROR error);

--- a/src/platform/Linux/CHIPDevicePlatformEvent.h
+++ b/src/platform/Linux/CHIPDevicePlatformEvent.h
@@ -45,6 +45,8 @@ enum PublicPlatformSpecificEventTypes
 enum InternalPlatformSpecificEventTypes
 {
     kPlatformLinuxEvent = kRange_InternalPlatformSpecific,
+    kPlatformLinuxBLEAdapterAdded,
+    kPlatformLinuxBLEAdapterRemoved,
     kPlatformLinuxBLECentralConnected,
     kPlatformLinuxBLECentralConnectFailed,
     kPlatformLinuxBLEWriteComplete,
@@ -67,6 +69,11 @@ struct ChipDevicePlatformEvent
 {
     union
     {
+        struct
+        {
+            unsigned int mAdapterId;
+            char mAdapterAddress[18];
+        } BLEAdapter;
         struct
         {
             BLE_CONNECTION_OBJECT mConnection;

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -45,22 +45,22 @@ namespace {
 gboolean BluezIsServiceOnDevice(BluezGattService1 * aService, BluezDevice1 * aDevice)
 {
     const auto * servicePath = bluez_gatt_service1_get_device(aService);
-    const auto * devicePath  = g_dbus_proxy_get_object_path(G_DBUS_PROXY(aDevice));
+    const auto * devicePath  = g_dbus_proxy_get_object_path(reinterpret_cast<GDBusProxy *>(aDevice));
     return strcmp(servicePath, devicePath) == 0 ? TRUE : FALSE;
 }
 
 gboolean BluezIsCharOnService(BluezGattCharacteristic1 * aChar, BluezGattService1 * aService)
 {
     const auto * charPath    = bluez_gatt_characteristic1_get_service(aChar);
-    const auto * servicePath = g_dbus_proxy_get_object_path(G_DBUS_PROXY(aService));
+    const auto * servicePath = g_dbus_proxy_get_object_path(reinterpret_cast<GDBusProxy *>(aService));
     ChipLogDetail(DeviceLayer, "Char %s on service %s", charPath, servicePath);
     return strcmp(charPath, servicePath) == 0 ? TRUE : FALSE;
 }
 
 } // namespace
 
-BluezConnection::BluezConnection(const BluezEndpoint & aEndpoint, BluezDevice1 * apDevice) :
-    mDevice(reinterpret_cast<BluezDevice1 *>(g_object_ref(apDevice)))
+BluezConnection::BluezConnection(const BluezEndpoint & aEndpoint, BluezDevice1 & aDevice) :
+    mDevice(reinterpret_cast<BluezDevice1 *>(g_object_ref(&aDevice)))
 {
     Init(aEndpoint);
 }

--- a/src/platform/Linux/bluez/BluezConnection.h
+++ b/src/platform/Linux/bluez/BluezConnection.h
@@ -39,7 +39,7 @@ class BluezEndpoint;
 class BluezConnection
 {
 public:
-    BluezConnection(const BluezEndpoint & aEndpoint, BluezDevice1 * apDevice);
+    BluezConnection(const BluezEndpoint & aEndpoint, BluezDevice1 & aDevice);
     ~BluezConnection() = default;
 
     const char * GetPeerAddress() const;

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -81,9 +81,9 @@ public:
     void CancelConnect();
 
     // Members that implement virtual methods on BluezObjectManagerAdapterNotificationsDelegate
-    void OnDeviceAdded(BluezDevice1 * device) override;
-    void OnDevicePropertyChanged(BluezDevice1 * device, GVariant * changedProps, const char * const * invalidatedProps) override;
-    void OnDeviceRemoved(BluezDevice1 * device) override;
+    void OnDeviceAdded(BluezDevice1 & device) override;
+    void OnDevicePropertyChanged(BluezDevice1 & device, GVariant * changedProps, const char * const * invalidatedProps) override;
+    void OnDeviceRemoved(BluezDevice1 & device) override;
 
 private:
     CHIP_ERROR SetupEndpointBindings();
@@ -94,8 +94,8 @@ private:
     BluezGattCharacteristic1 * CreateGattCharacteristic(BluezGattService1 * aService, const char * aCharName, const char * aUUID,
                                                         const char * const * aFlags);
 
-    void HandleNewDevice(BluezDevice1 * aDevice);
-    void UpdateConnectionTable(BluezDevice1 * aDevice);
+    void HandleNewDevice(BluezDevice1 & aDevice);
+    void UpdateConnectionTable(BluezDevice1 & aDevice);
     BluezConnection * GetBluezConnection(const char * aPath);
     BluezConnection * GetBluezConnectionViaDevice();
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -65,7 +65,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-class BluezEndpoint
+class BluezEndpoint : public BluezObjectManagerAdapterNotificationsDelegate
 {
 public:
     BluezEndpoint(BluezObjectManager & aObjectManager) : mObjectManager(aObjectManager) {}
@@ -79,6 +79,11 @@ public:
 
     CHIP_ERROR ConnectDevice(BluezDevice1 & aDevice);
     void CancelConnect();
+
+    // Members that implement virtual methods on BluezObjectManagerAdapterNotificationsDelegate
+    void OnDeviceAdded(BluezDevice1 * device) override;
+    void OnDevicePropertyChanged(BluezDevice1 * device, GVariant * changedProps, const char * const * invalidatedProps) override;
+    void OnDeviceRemoved(BluezDevice1 * device) override;
 
 private:
     CHIP_ERROR SetupEndpointBindings();
@@ -98,12 +103,6 @@ private:
     gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOptions);
     gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOptions);
     gboolean BluezCharacteristicConfirm(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv);
-
-    void BluezSignalOnObjectAdded(GDBusObjectManager * aManager, GDBusObject * aObject);
-    void BluezSignalOnObjectRemoved(GDBusObjectManager * aManager, GDBusObject * aObject);
-    void BluezSignalInterfacePropertiesChanged(GDBusObjectManagerClient * aManager, GDBusObjectProxy * aObject,
-                                               GDBusProxy * aInterface, GVariant * aChangedProperties,
-                                               const char * const * aInvalidatedProps);
 
     void RegisterGattApplicationDone(GObject * aObject, GAsyncResult * aResult);
     CHIP_ERROR RegisterGattApplicationImpl();

--- a/src/platform/Linux/bluez/BluezObjectManager.cpp
+++ b/src/platform/Linux/bluez/BluezObjectManager.cpp
@@ -192,7 +192,7 @@ void BluezObjectManager::OnObjectAdded(GDBusObjectManager * aMgr, GDBusObject * 
         {
             if (IsDeviceOnAdapter(device.get(), adapterPath))
             {
-                delegate->OnDeviceAdded(device.get());
+                delegate->OnDeviceAdded(*device.get());
             }
         }
     }
@@ -216,7 +216,7 @@ void BluezObjectManager::OnObjectRemoved(GDBusObjectManager * aMgr, GDBusObject 
         {
             if (IsDeviceOnAdapter(device.get(), adapterPath))
             {
-                delegate->OnDeviceRemoved(device.get());
+                delegate->OnDeviceRemoved(*device.get());
             }
         }
     }
@@ -233,7 +233,7 @@ void BluezObjectManager::OnInterfacePropertiesChanged(GDBusObjectManagerClient *
         {
             if (IsDeviceOnAdapter(device.get(), adapterPath))
             {
-                delegate->OnDevicePropertyChanged(device.get(), aChangedProps, aInvalidatedProps);
+                delegate->OnDevicePropertyChanged(*device.get(), aChangedProps, aInvalidatedProps);
             }
         }
     }

--- a/src/platform/Linux/bluez/BluezObjectManager.h
+++ b/src/platform/Linux/bluez/BluezObjectManager.h
@@ -17,17 +17,33 @@
 
 #pragma once
 
+#include <mutex>
+#include <string>
+#include <vector>
+
 #include <gio/gio.h>
 #include <glib.h>
 
 #include <lib/core/CHIPError.h>
 #include <platform/GLibTypeDeleter.h>
+#include <system/SystemMutex.h>
 
 #include "BluezObjectList.h"
 
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
+
+/// Delegate for receiving notifications about various events on the Adapter1
+/// interface managed by the BlueZ object manager.
+class BluezObjectManagerAdapterNotificationsDelegate
+{
+public:
+    virtual ~BluezObjectManagerAdapterNotificationsDelegate() {}
+    virtual void OnDeviceAdded(BluezDevice1 * device)                                                                           = 0;
+    virtual void OnDevicePropertyChanged(BluezDevice1 * device, GVariant * changedProps, const char * const * invalidatedProps) = 0;
+    virtual void OnDeviceRemoved(BluezDevice1 * device)                                                                         = 0;
+};
 
 class BluezObjectManager
 {
@@ -54,13 +70,33 @@ public:
     // Get the adapter with the given Bluetooth address.
     BluezAdapter1 * GetAdapter(const char * aAdapterAddress);
 
+    // Subscribe to notifications associated with the given adapter.
+    // In case when the adapter is removed, the subscription will be automatically canceled.
+    CHIP_ERROR SubscribeDeviceNotifications(BluezAdapter1 * adapter, BluezObjectManagerAdapterNotificationsDelegate * delegate);
+
+    // Unsubscribe from notifications associated with the given adapter.
+    CHIP_ERROR UnsubscribeDeviceNotifications(BluezAdapter1 * adapter, BluezObjectManagerAdapterNotificationsDelegate * delegate);
+
 private:
     CHIP_ERROR SetupDBusConnection();
     CHIP_ERROR SetupObjectManager();
     CHIP_ERROR SetupAdapter(BluezAdapter1 * aAdapter);
 
+    void NotifyAdapterAdded(BluezAdapter1 * aAdapter);
+    void NotifyAdapterRemoved(BluezAdapter1 * aAdapter);
+    void RemoveAdapterSubscriptions(BluezAdapter1 * aAdapter);
+
+    void OnObjectAdded(GDBusObjectManager * aMgr, GDBusObject * aObj);
+    void OnObjectRemoved(GDBusObjectManager * aMgr, GDBusObject * aObj);
+    void OnInterfacePropertiesChanged(GDBusObjectManagerClient * aMgr, GDBusObjectProxy * aObj, GDBusProxy * aIface,
+                                      GVariant * aChangedProps, const char * const * aInvalidatedProps);
+
     GAutoPtr<GDBusConnection> mConnection;
     GAutoPtr<GDBusObjectManager> mObjectManager;
+
+    std::mutex mSubscriptionsMutex;
+    std::vector<std::pair<std::string, BluezObjectManagerAdapterNotificationsDelegate *>>
+        mSubscriptions CHIP_GUARDED_BY(mSubscriptionsMutex);
 };
 
 // Helper function to convert glib error returned by bluez_*_call_*() functions to CHIP_ERROR.

--- a/src/platform/Linux/bluez/BluezObjectManager.h
+++ b/src/platform/Linux/bluez/BluezObjectManager.h
@@ -40,9 +40,9 @@ class BluezObjectManagerAdapterNotificationsDelegate
 {
 public:
     virtual ~BluezObjectManagerAdapterNotificationsDelegate() {}
-    virtual void OnDeviceAdded(BluezDevice1 * device)                                                                           = 0;
-    virtual void OnDevicePropertyChanged(BluezDevice1 * device, GVariant * changedProps, const char * const * invalidatedProps) = 0;
-    virtual void OnDeviceRemoved(BluezDevice1 * device)                                                                         = 0;
+    virtual void OnDeviceAdded(BluezDevice1 & device)                                                                           = 0;
+    virtual void OnDevicePropertyChanged(BluezDevice1 & device, GVariant * changedProps, const char * const * invalidatedProps) = 0;
+    virtual void OnDeviceRemoved(BluezDevice1 & device)                                                                         = 0;
 };
 
 class BluezObjectManager

--- a/src/platform/Linux/bluez/BluezObjectManager.h
+++ b/src/platform/Linux/bluez/BluezObjectManager.h
@@ -86,6 +86,9 @@ private:
     void NotifyAdapterRemoved(BluezAdapter1 * aAdapter);
     void RemoveAdapterSubscriptions(BluezAdapter1 * aAdapter);
 
+    using NotificationsDelegates = std::vector<BluezObjectManagerAdapterNotificationsDelegate *>;
+    NotificationsDelegates GetDeviceNotificationsDelegates(BluezDevice1 * device);
+
     void OnObjectAdded(GDBusObjectManager * aMgr, GDBusObject * aObj);
     void OnObjectRemoved(GDBusObjectManager * aMgr, GDBusObject * aObj);
     void OnInterfacePropertiesChanged(GDBusObjectManagerClient * aMgr, GDBusObjectProxy * aObj, GDBusProxy * aIface,

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -188,15 +188,15 @@ CHIP_ERROR ChipDeviceScanner::StopScanImpl()
     return CHIP_NO_ERROR;
 }
 
-void ChipDeviceScanner::OnDeviceAdded(BluezDevice1 * device)
+void ChipDeviceScanner::OnDeviceAdded(BluezDevice1 & device)
 {
-    ReportDevice(*device);
+    ReportDevice(device);
 }
 
-void ChipDeviceScanner::OnDevicePropertyChanged(BluezDevice1 * device, GVariant * changedProps,
+void ChipDeviceScanner::OnDevicePropertyChanged(BluezDevice1 & device, GVariant * changedProps,
                                                 const char * const * invalidatedProps)
 {
-    ReportDevice(*device);
+    ReportDevice(device);
 }
 
 void ChipDeviceScanner::ReportDevice(BluezDevice1 & device)

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -53,7 +53,7 @@ public:
 /// Allows scanning for CHIP devices
 ///
 /// Will perform scan operations and call back whenever a device is discovered.
-class ChipDeviceScanner
+class ChipDeviceScanner : public BluezObjectManagerAdapterNotificationsDelegate
 {
 public:
     ChipDeviceScanner(BluezObjectManager & aObjectManager) : mObjectManager(aObjectManager) {}
@@ -78,6 +78,11 @@ public:
     /// Stop any currently running scan
     CHIP_ERROR StopScan();
 
+    /// Members that implement virtual methods on BluezObjectManagerAdapterNotificationsDelegate
+    void OnDeviceAdded(BluezDevice1 * device) override;
+    void OnDevicePropertyChanged(BluezDevice1 * device, GVariant * changedProps, const char * const * invalidatedProps) override;
+    void OnDeviceRemoved(BluezDevice1 * device) override {}
+
 private:
     enum ChipDeviceScannerState
     {
@@ -97,10 +102,6 @@ private:
     CHIP_ERROR StopScanImpl();
     static void TimerExpiredCallback(chip::System::Layer * layer, void * appState);
 
-    void SignalObjectAdded(GDBusObjectManager * aManager, GDBusObject * aObject);
-    void SignalInterfacePropertiesChanged(GDBusObjectManagerClient * aManager, GDBusObjectProxy * aObject, GDBusProxy * aInterface,
-                                          GVariant * aChangedProperties, const char * const * aInvalidatedProps);
-
     /// Check if a given device is a CHIP device and if yes, report it as discovered
     void ReportDevice(BluezDevice1 & device);
 
@@ -111,10 +112,8 @@ private:
     BluezObjectManager & mObjectManager;
     GAutoPtr<BluezAdapter1> mAdapter;
 
-    ChipDeviceScannerDelegate * mDelegate  = nullptr;
-    unsigned long mObjectAddedSignal       = 0;
-    unsigned long mPropertiesChangedSignal = 0;
-    ChipDeviceScannerState mScannerState   = ChipDeviceScannerState::SCANNER_UNINITIALIZED;
+    ChipDeviceScannerDelegate * mDelegate = nullptr;
+    ChipDeviceScannerState mScannerState  = ChipDeviceScannerState::SCANNER_UNINITIALIZED;
     /// Used to track if timer has already expired and doesn't need to be canceled.
     ScannerTimerState mTimerState = ScannerTimerState::TIMER_CANCELED;
     GAutoPtr<GCancellable> mCancellable;

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -79,9 +79,9 @@ public:
     CHIP_ERROR StopScan();
 
     /// Members that implement virtual methods on BluezObjectManagerAdapterNotificationsDelegate
-    void OnDeviceAdded(BluezDevice1 * device) override;
-    void OnDevicePropertyChanged(BluezDevice1 * device, GVariant * changedProps, const char * const * invalidatedProps) override;
-    void OnDeviceRemoved(BluezDevice1 * device) override {}
+    void OnDeviceAdded(BluezDevice1 & device) override;
+    void OnDevicePropertyChanged(BluezDevice1 & device, GVariant * changedProps, const char * const * invalidatedProps) override;
+    void OnDeviceRemoved(BluezDevice1 & device) override {}
 
 private:
     enum ChipDeviceScannerState


### PR DESCRIPTION
### Problem

BlueZ signals dispatching is done in `BluezEndpoint` and `ChipDeviceScanner`. This can be simplified by moving BlueZ management related logic to the `BluezObjectManager` class. Also, this way we can handle (in the future) adapter added/removed events.

### Changes

- Dispatch BlueZ signals in BluezObjectManager
- Notification facility for BLE adapter added/removed for future use (it will be used in the follow-up PR)

### Testing

Locally tested BLE commissioning on Linux with `chip-tool` and lighting app.
