### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-42 : [Ameba] Update Ameba System time
+43 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -12,7 +12,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=c4dd151a1ffa96bfbd577ddc88a55c5785279514
+ARG ZEPHYR_REVISION=65dc1812431bf946dfc110682298acf83d63e27a
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**
- west.yml: Fix hal_telink sub-module building
- soc: riscv: telink_w91: Introdece Telink W91 SOC
- scripts: west_commands: runners: Add sctool support
- drivers: mbox: telink_w91: Introduce mailbox driver
- soc: riscv: telink_w91: Introduce IPC dispatcher
- drivers: dts: config: Add GPIO driver for W91
- boards: riscv: tlsr9258a: Update b95 board docs
- boards: riscv: tlsr9118: Update board docs
- soc: riscv: telink_w91: ipc: Fix driver timeout
- telink_b9x: Cleanup build system
- samples: boards: tlsr9x: Add key matrix example
- samples: boards: tlsr9x: key_matrix: Reduce resources usage
- drivers: dts: config: Add Entropy driver for W91
- samples: boards: tlsr9x: Add key pool example
- drivers: gpio: fix irq issue
- samples: boards: tlsr9x: key_*: Add keypad functionality
- drivers: ieee802154: b9x: Add the feature to read eui64 from flash area
- samples: boards: tlsr9x: Add LED pool example
- drivers: dts: config: Add pin controller driver for W91
- drivers: pwm: pwm_b9x: Rework handling inverted output
- samples: boards: tlsr9x: Add PWM pool example
- drivers: wifi: add dummy wifi driver
- samples: boards: tlsr9x: Add LED strip example
- drivers: spi: spi_b9x: Added spi pin configuration
- drivers: i2c: added I2C for W91 platform
- drivers: spi: spi_b9x: Fixed the wrong base clk selection
- soc: riscv: telink_w91: create icmsg workqueue instead of system

**Testing**
Tested manually.

**Steps:**
- Build image
- Run docker
- Check if Telink examples able to be built successfully