### PR TITLE
TC-DA-1.2: refine steps descriptions, remove PICS

### DIFF
--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -324,6 +324,8 @@ class TC_DA_1_2(MatterBaseTest):
             asserts.assert_equal(dac_pid, origin_pid, "Origin Product ID in the CD does not match the Product ID in the DAC")
             if pai_pid:
                 asserts.assert_equal(pai_pid, origin_pid, "Origin Product ID in the CD does not match the Product ID in the PAI")
+        else:
+            self.mark_current_step_skipped()
 
         self.step("7.3")
         if not has_origin_vid:
@@ -332,6 +334,8 @@ class TC_DA_1_2(MatterBaseTest):
             asserts.assert_in(dac_pid, product_id_array, "Product ID from the DAC is not present in the PID list in the CD")
             if pai_pid:
                 asserts.assert_in(pai_pid, product_id_array, "Product ID from the PAI is not present in the PID list in the CD")
+        else:
+            self.mark_current_step_skipped()
 
         self.step(8)
         has_paa_list = 11 in cd.keys()
@@ -341,6 +345,8 @@ class TC_DA_1_2(MatterBaseTest):
             asserts.assert_equal(len(akids), 1, "PAI requires exactly one AuthorityKeyIdentifier")
             paa_authority_list = cd[11]
             asserts.assert_in(akids[0], paa_authority_list, "PAI AKID not found in the authority list")
+        else:
+            self.mark_current_step_skipped()
 
         self.step(9)
         signature_cd = bytes(signer_info['signature'])
@@ -374,6 +380,8 @@ class TC_DA_1_2(MatterBaseTest):
                 int(decoded[4], 16)
             except ValueError:
                 asserts.fail("Firmware is not an octet string")
+        else:
+            self.mark_current_step_skipped()
 
         self.step(12)
         proxy = self.default_controller.GetConnectedDeviceSync(self.dut_node_id, False)

--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -105,62 +105,54 @@ def parse_ids_from_certs(dac: x509.Certificate, pai: x509.Certificate) -> tuple(
 class TC_DA_1_2(MatterBaseTest):
     def steps_TC_DA_1_2(self):
         return [TestStep(0, "Commission DUT if not done", is_commissioning=True),
-                TestStep(1, "TH1 generates 32-byte AttestationNonce", ""),
-                TestStep(2, "TH1 sends AttestationRequest Command with a random 32 bytes AttestationNonce` to the DUT."),
-                TestStep(
-                    "3a", "", "Verify that the DUT generates the Attestation Information and that it is sent to TH1 using AttestationResponse Command"),
-                TestStep("3b", "TH1 sends CertificateChainRequest Command with CertificateType field set to DACCertificate (1) to DUT to obtain DAC"),
-                TestStep("3c", "TH1 saves DAC certificate",
+                TestStep(1, "TH1 generates 32-byte AttestationNonce and saves as `nonce", ""),
+                TestStep(2, "TH1 sends AttestationRequest Command to the DUT with AttestationNonce set to `nonce`",
+                         "Verify AttestationResponse is received"),
+                TestStep("3a", "TH1 sends CertificateChainRequest Command with CertificateType field set to DACCertificate (1) to DUT to obtain DAC",
                          "DUT responds with CertificateChainResponse the DAC certificate in X.509v3 format with size ⇐ 600 bytes"),
-                TestStep("3d", "TH1 sends CertificateChainRequest Command with CertificateType field set to PAICertificate (2) to DUT to obtain PAI",
+                TestStep("3b", "TH1 sends CertificateChainRequest Command with CertificateType field set to PAICertificate (2) to DUT to obtain PAI",
                          "DUT responds with CertificateChainResponse the PAI certificate in X.509v3 format with size ⇐ 600 bytes"),
-                TestStep("3e", "TH1 saves PAI certificate", ""),
                 TestStep("4a", "TH1 Reads the VendorID attribute of the Basic Information cluster and saves it as `basic_info_vendor_id`"),
                 TestStep("4b", "TH1 Reads the ProductID attribute of the Basic Information cluster and saves it as `basic_info_product_id`"),
-                TestStep(5, "Extract the attestation_elements_message structure fields from the AttestationResponse Command received by TH1 from DUT"),
-                TestStep(6, "Verify that the DUT generated the AttestationResponse has the following fields: AttestationElements, AttestationSignature"),
-                TestStep(7, "Read the attestation_elements_message structure fields"),
-                TestStep(8, "", "Verify that the attestation_elements_message structure fields satisfy the following conditions:"),
-                TestStep("8.1", "", "AttestationElements field size should not be greater than RESP_MAX(900 bytes)"),
-                TestStep("8.2", "", "certification_declaration is present and is an octet string representation CMS-format certification declaration, as described in section 6.3.1"),
-                TestStep("8.3", "", ("Verify the following for contents of the CD:\n"
-                                     "\n"
-                                     "* format_version = 1\n"
-                                     "* The vendor_id field matches the one saved as `basic_info_vendor_id` saved earlier\n"
-                                     "* The product_id_array field contains the value of basic_info_product_id saved earlier\n"
-                                     "* device_type_id has a value between 0 and (2^31 - 1)\n"
-                                     "* certificate_id has a length of 19\n"
-                                     "* security level = 0\n"
-                                     "* security_information = 0\n"
-                                     "* version_number is an integer in range 0..65535\n"
-                                     "* certification_type has a value between 1..2\n")),
+                TestStep(5, "Extract the attestation_elements_message structure fields from the AttestationResponse"),
+                TestStep("5.1", "Verify AttestationElements field size",
+                         "AttestationElements field size should not be greater than RESP_MAX(900 bytes)"),
+                TestStep("5.2", "Verify certification_declaration format",
+                         "certification_declaration is present and is an octet string representation CMS-format certification declaration, as described in section 6.3.1"),
+                TestStep("6.1", "Verify CD format_version", "format_version = 1"),
+                TestStep("6.2", "Verify CD vendor_id",
+                         "vendor_id field matches `basic_info_vendor_id` and is in the standard vendor ID range"),
+                TestStep("6.3", "Verify CD product_id_array", "product_id_array field contains `basic_info_product_id`"),
+                TestStep("6.4", "Verify CD device_type_id", "device_type_id has a value between 0 and (2^31 - 1)"),
+                TestStep("6.5", "Verify CD certificate_id", "certificate_id has a length of 19"),
+                TestStep("6.6", "Verify CD security level", "security level = 0"),
+                TestStep("6.7", "Verify CD security_information", "security_information = 0"),
+                TestStep("6.8", "Verify CD version_number", "version_number is an integer in range 0..65535"),
+                TestStep("6.9", "Verify CD certification_type", "certification_type has a value between 1..2"),
                 TestStep(
-                    "8.4", "", "Confirm that both the fields dac_origin_vendor_id and dac_origin_product_id are present in Certification Declaration"),
+                    "7.1", "", "Confirm that both the fields dac_origin_vendor_id and dac_origin_product_id are present in Certification Declaration"),
                 TestStep(
-                    "8.5", "", "Or confirm both the fields dac_origin_vendor_id and dac_origin_product_id are not present in the Certification Declaration"),
-                TestStep("8.6", "", ("If the Certification Declaration has both the dac_origin_vendor_id and the dac_origin_product_id fields then check for the following conditions:\n"
-                                     "\n"
-                                     "* The Vendor ID (VID) in the DAC subject and PAI subject are the same as the dac_origin_vendor_id field in the Certification Declaration.\n"
-                                     "* The Product ID (PID) in the DAC subject is same as the dac_origin_product_id field in the Certification Declaration.\n"
-                                     "* If it is present in the PAI certificate, the Product ID (PID) in the subject is same as the dac_origin_product_id field in the Certification Declaration.\n")),
-                TestStep("8.7", "", ("If the Certification Declaration has neither the dac_origin_vendor_id nor the dac_origin_product_id fields then check for the following conditions:\n"
-                                     "\n"
-                                     "* The Vendor ID (VID) in the DAC subject and PAI subject are the same as the vendor_id field in the Certification Declaration.\n"
-                                     "* The Product ID (PID) subject DN in the DAC is contained in the product_id_array field in the Certification Declaration.\n"
-                                     "* If it is present in the PAI certificate, the Product ID (PID) in the subject is contained in the product_id_array field in the Certification Declaration.\n")),
-                TestStep("8.8", "", ("If the Certification Declaration has authorized_paa_list then check for the following conditions:\n"
-                                     "\n"
-                                     "* The authority key id extension of the PAI certificate matches the one found in the authorized_paa_list\n")),
-                TestStep("8.9", "", "Verify that the certification_declaration CMS enveloped can be verified with the well-known Certification Declaration public key used to originally sign the Certification Declaration\n"),
-                TestStep(9, "", ("* attestation_nonce is present in the attestation_elements_message structure\n"
-                                 "* attestation_nonce value matches the AttestationNonce field value sent in the AttestationRequest Command sent by the commissioner\n"
-                                 "* attestation_nonce is a 32 byte-long octet string\n")),
-                TestStep(10, "", ("* firmware_information is optional, may be present\n"
-                                  "* if firmware_information field is present it is a octet string\n")),
-                TestStep(11, "", "Using Crypto_Verify cryptographic primitive, validate that the AttestationSignature from the AttestationResponse Command is valid if verified against a message constructed by concatenating AttestationElements with the attestation challenge associated with the secure session over which the AttestationResponse was obtained, using the subject public key found in the DAC."),
-                TestStep(12, "TH1 sends AttestationRequest Command with Invalid AttestationNonce (size > 32 bytes) as the field to the DUT.",
+                    "7.2", "", "Or confirm both the fields dac_origin_vendor_id and dac_origin_product_id are not present in the Certification Declaration"),
+                TestStep("7.3", "If the Certification Declaration has both the dac_origin_vendor_id and the dac_origin_product_id fields, verify dac_origin fields",
+                         ("* The Vendor ID (VID) in the DAC subject and PAI subject are the same as the dac_origin_vendor_id field in the Certification Declaration.\n"
+                          "* The Product ID (PID) in the DAC subject is same as the dac_origin_product_id field in the Certification Declaration.\n"
+                          "* If it is present in the PAI certificate, the Product ID (PID) in the subject is same as the dac_origin_product_id field in the Certification Declaration.\n")),
+                TestStep("7.4", "If the Certification Declaration has neither the dac_origin_vendor_id nor the dac_origin_product_id fields, verify the vendor_id and product_id_array fields",
+                         ("* The Vendor ID (VID) in the DAC subject and PAI subject are the same as the vendor_id field in the Certification Declaration.\n"
+                          "* The Product ID (PID) subject DN in the DAC is contained in the product_id_array field in the Certification Declaration.\n"
+                          "* If it is present in the PAI certificate, the Product ID (PID) in the subject is contained in the product_id_array field in the Certification Declaration.\n")),
+                TestStep(8, "If the Certification Declaration has authorized_paa_list, check that the authority_key_id extension of the PAI matches one found in the authorized_paa_list",
+                         "PAA from PAI authority_key_id extension matches one found in authorized_paa_list"),
+                TestStep(9, "Verify that the certification_declaration CMS enveloped can be verified with the well-known Certification Declaration public key used to originally sign the Certification Declaration", "Signature verification passes"),
+                TestStep(10, "Verify attestation_nonce", ("* attestation_nonce is present in the attestation_elements_message structure\n"
+                                                          "* attestation_nonce value matches the AttestationNonce field value sent in the AttestationRequest Command sent by the commissioner\n"
+                                                          "* attestation_nonce is a 32 byte-long octet string\n")),
+                TestStep(11, "If firmware_information is present, verify firmware information type",
+                         "firmware_information is an octet string"),
+                TestStep(12, "Using Crypto_Verify cryptographic primitive, validate that the AttestationSignature from the AttestationResponse Command is valid if verified against a message constructed by concatenating AttestationElements with the attestation challenge associated with the secure session over which the AttestationResponse was obtained, using the subject public key found in the DAC.", "Signature is valid"),
+                TestStep(13, "TH1 sends AttestationRequest Command with Invalid AttestationNonce (size > 32 bytes) as the field to the DUT.",
                          "Verify DUT responds w/ status INVALID_COMMAND(0x85)"),
-                TestStep(13, "TH1 sends AttestationRequest Command with invalid AttestationNonce (size < 32 bytes) as the field to the DUT.",
+                TestStep(14, "TH1 sends AttestationRequest Command with invalid AttestationNonce (size < 32 bytes) as the field to the DUT.",
                          "Verify that the DUT reports an INVALID_COMMAND error"),
                 ]
 
@@ -188,16 +180,12 @@ class TC_DA_1_2(MatterBaseTest):
 
         self.step(2)
         attestation_resp = await self.send_single_cmd(cmd=opcreds.Commands.AttestationRequest(attestationNonce=nonce))
-
-        self.step("3a")
         asserts.assert_true(type_matches(attestation_resp, opcreds.Commands.AttestationResponse),
                             "DUT returned invalid response to AttestationRequest")
 
-        self.step("3b")
+        self.step("3a")
         type = opcreds.Enums.CertificateChainTypeEnum.kDACCertificate
         dac_resp = await self.send_single_cmd(cmd=opcreds.Commands.CertificateChainRequest(certificateType=type))
-
-        self.step("3c")
         asserts.assert_true(type_matches(dac_resp, opcreds.Commands.CertificateChainResponse),
                             "DUT returned invalid response to CertificateChainRequest")
         der_dac = dac_resp.certificate
@@ -209,7 +197,7 @@ class TC_DA_1_2(MatterBaseTest):
             asserts.assert_true(False, "Unable to parse certificate from CertificateChainResponse")
         asserts.assert_equal(parsed_dac.version, x509.Version.v3, "DUT returned incorrect certificate type")
 
-        self.step("3d")
+        self.step("3b")
         type = opcreds.Enums.CertificateChainTypeEnum.kPAICertificate
         pai_resp = await self.send_single_cmd(cmd=opcreds.Commands.CertificateChainRequest(certificateType=type))
         asserts.assert_true(type_matches(pai_resp, opcreds.Commands.CertificateChainResponse),
@@ -223,9 +211,6 @@ class TC_DA_1_2(MatterBaseTest):
             asserts.assert_true(False, "Unable to parse certificate from CertificateChainResponse")
         asserts.assert_equal(parsed_pai.version, x509.Version.v3, "DUT returned incorrect certificate type")
 
-        self.step("3e")
-        # already saved above
-
         self.step("4a")
         basic_info_vendor_id = await self.read_single_attribute_check_success(basic, basic.Attributes.VendorID)
 
@@ -234,22 +219,12 @@ class TC_DA_1_2(MatterBaseTest):
 
         self.step(5)
         elements = attestation_resp.attestationElements
-
-        self.step(6)
-        # OK, it's a bit weird that we're doing this after extracting the elements already, but sure.
-        # We type checked earlier, but let's grab the signature here.
         signature_attestation_raw = attestation_resp.attestationSignature
 
-        self.step(7)
-        # Already done
-
-        self.step(8)
-        # Not sure why this is a separate step, but I'm ready...let's check.
-
-        self.step("8.1")
+        self.step("5.1")
         asserts.assert_less_equal(len(elements), 900, "AttestationElements field is more than 900 bytes")
 
-        self.step("8.2")
+        self.step("5.2")
         decoded = TLVReader(elements).get()["Any"]
         # Certification declaration is tag 1
         asserts.assert_in(1, decoded.keys(), "CD is not present in the attestation elements")
@@ -290,7 +265,7 @@ class TC_DA_1_2(MatterBaseTest):
         # There should be only one signer info
         asserts.assert_equal(len(signed_data['signerInfos']), 1, "Too many signer infos provided")
 
-        # version shoule be 3
+        # version should be 3
         signer_info = dict(signed_data['signerInfos'][0])
         asserts.assert_equal(signer_info['version'], 3, "Incorrect version on signer info")
 
@@ -306,7 +281,7 @@ class TC_DA_1_2(MatterBaseTest):
         algo_id = dict(signer_info['signatureAlgorithm'])
         asserts.assert_equal(algo_id['algorithm'], id_ecdsa_with_sha256, "Incorrect signature algorithm")
 
-        self.step("8.3")
+        self.step("6.1")
         # First, lets parse it
         cd = TLVReader(cd_tlv).get()["Any"]
         format_version = cd[0]
@@ -320,33 +295,40 @@ class TC_DA_1_2(MatterBaseTest):
         certification_type = cd[8]
 
         asserts.assert_equal(format_version, 1, "Format version is incorrect")
+        self.step("6.2")
         asserts.assert_equal(vendor_id, basic_info_vendor_id, "Vendor ID is incorrect")
         if not is_ci:
             asserts.assert_in(vendor_id, range(1, 0xfff0), "Vendor ID is out of range")
+        self.step("6.3")
         asserts.assert_true(basic_info_product_id in product_id_array, "Product ID not found in CD product array")
+        self.step("6.4")
         asserts.assert_in(device_type_id, range(0, (2**31)-1), "Device type ID is out of range")
+        self.step("6.5")
         asserts.assert_equal(len(certificate_id), 19, "Certificate id is the incorrect length")
+        self.step("6.6")
         asserts.assert_equal(security_level, 0, "Incorrect value for security level")
+        self.step("6.7")
         asserts.assert_equal(security_info, 0, "Incorrect value for security information")
+        self.step("6.8")
         asserts.assert_in(version_number, range(0, 65535), "Version number out of range")
+        self.step("6.9")
         if is_ci:
             asserts.assert_in(certification_type, [0, 1, 2], "Certification type is out of range")
         else:
             asserts.assert_in(certification_type, [1, 2], "Certification type is out of range")
 
-        self.step("8.4")
+        self.step("7.1")
         if not is_ci and pics_origin_vid:
             asserts.assert_in(9, cd.keys(), "Origin vendor ID not found in cert")
             asserts.assert_in(10, cd.keys(), "Origin product ID not found in cert")
 
-        self.step("8.5")
+        self.step("7.2")
         if not is_ci and not pics_origin_vid:
             asserts.assert_not_in(9, cd.keys(), "Origin vendor ID found in cert")
             asserts.assert_not_in(10, cd.keys(), "Origin product ID found in cert")
 
         dac_vid, dac_pid, pai_vid, pai_pid = parse_ids_from_certs(parsed_dac, parsed_pai)
 
-        self.step("8.6")
         has_origin_vid = 9 in cd.keys()
         has_origin_pid = 10 in cd.keys()
         if not is_ci and has_origin_vid != pics_origin_vid:
@@ -357,6 +339,7 @@ class TC_DA_1_2(MatterBaseTest):
             asserts.fail("Found one of origin PID or VID in CD but not both")
 
         # If this is the CI, ignore the PICS, we're going to try many cases.
+        self.step("7.3")
         if has_origin_vid:
             origin_vid = cd[9]
             origin_pid = cd[10]
@@ -367,7 +350,7 @@ class TC_DA_1_2(MatterBaseTest):
             if pai_pid:
                 asserts.assert_equal(pai_pid, origin_pid, "Origin Product ID in the CD does not match the Product ID in the PAI")
 
-        self.step("8.7")
+        self.step("7.4")
         if not has_origin_vid:
             asserts.assert_equal(dac_vid, vendor_id, "Vendor ID in the CD does not match the Vendor ID in the DAC")
             asserts.assert_equal(pai_vid, vendor_id, "Vendor ID in the CD does not match the Vendor ID in the PAI")
@@ -375,7 +358,7 @@ class TC_DA_1_2(MatterBaseTest):
             if pai_pid:
                 asserts.assert_in(pai_pid, product_id_array, "Product ID from the PAI is not present in the PID list in the CD")
 
-        self.step("8.8")
+        self.step(8)
         has_paa_list = 11 in cd.keys()
         if not is_ci and pics_paa_list != has_paa_list:
             asserts.fail("PAA list does not match PICS")
@@ -386,7 +369,7 @@ class TC_DA_1_2(MatterBaseTest):
             paa_authority_list = cd[11]
             asserts.assert_in(akids[0], paa_authority_list, "PAI AKID not found in the authority list")
 
-        self.step("8.9")
+        self.step(9)
         signature_cd = bytes(signer_info['signature'])
         certs = {}
         for filename in os.listdir(cd_cert_dir):
@@ -405,13 +388,13 @@ class TC_DA_1_2(MatterBaseTest):
         except InvalidSignature:
             asserts.fail("Failed to verify CD signature against known CD public key")
 
-        self.step(9)
+        self.step(10)
         asserts.assert_in(2, decoded.keys(), "Attestation nonce is not present in the attestation elements")
         returned_nonce = decoded[2]
         asserts.assert_equal(returned_nonce, nonce, "Returned attestation nonce does not match request nonce")
         asserts.assert_equal(len(returned_nonce), 32, "Returned nonce is incorrect size")
 
-        self.step(10)
+        self.step(11)
         has_firmware_information = 4 in decoded.keys()
         if not is_ci and has_firmware_information != pics_firmware_info:
             asserts.fail("PICS for firmware information does not match returned value")
@@ -421,7 +404,7 @@ class TC_DA_1_2(MatterBaseTest):
             except ValueError:
                 asserts.fail("Firmware is not an octet string")
 
-        self.step(11)
+        self.step(12)
         proxy = self.default_controller.GetConnectedDeviceSync(self.dut_node_id, False)
         asserts.assert_equal(len(proxy.attestationChallenge), 16, "Attestation challenge is the wrong length")
         attestation_tbs = elements + proxy.attestationChallenge
@@ -437,7 +420,7 @@ class TC_DA_1_2(MatterBaseTest):
         parsed_dac.public_key().verify(signature=signature_attestation, data=attestation_tbs,
                                        signature_algorithm=ec.ECDSA(hashes.SHA256()))
 
-        self.step(12)
+        self.step(13)
         nonce = random.randbytes(33)
         try:
             await self.send_single_cmd(cmd=opcreds.Commands.AttestationRequest(attestationNonce=nonce))
@@ -445,7 +428,7 @@ class TC_DA_1_2(MatterBaseTest):
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.InvalidCommand, "Received incorrect error from AttestationRequest command")
 
-        self.step(13)
+        self.step(14)
         nonce = random.randbytes(31)
         try:
             await self.send_single_cmd(cmd=opcreds.Commands.AttestationRequest(attestationNonce=nonce))

--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -27,7 +27,7 @@ from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, utils
 from ecdsa.curves import curve_by_name
-from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main, hex_from_bytes, type_matches, TestStep
+from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, hex_from_bytes, type_matches
 from mobly import asserts
 from pyasn1.codec.der.decoder import decode as der_decoder
 from pyasn1.error import PyAsn1Error

--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -103,6 +103,9 @@ def parse_ids_from_certs(dac: x509.Certificate, pai: x509.Certificate) -> tuple(
 
 
 class TC_DA_1_2(MatterBaseTest):
+    def desc_TC_DA_1_2(self):
+        return "Device Attestation Request Validation [DUT - Commissionee]"
+
     def steps_TC_DA_1_2(self):
         return [TestStep(0, "Commission DUT if not done", is_commissioning=True),
                 TestStep(1, "TH1 generates 32-byte AttestationNonce and saves as `nonce", ""),

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -648,6 +648,7 @@ def hex_from_bytes(b: bytes) -> str:
 class TestStep:
     test_plan_number: typing.Union[int, str]
     description: str
+    expectation: str = ""
     is_commissioning: bool = False
 
 


### PR DESCRIPTION
This PR does not include any functional changes besides the removal of the PICS. The test steps have been refined so they can be used to auto-generate the test plan, and so they appear in the TH. 

Please see the individual commits to see smaller change sets, starting with adding the test steps directly from the current test plan, then refining the steps, removing pics and adding skip markers and descriptions.

This PR was tested using test_TC_DA_1_2.