### PR TITLE
[Silabs]Bump version string prefix to v1.3 in the build scripts.

### DIFF
--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -230,7 +230,7 @@ class Efr32Builder(GnBuilder):
                 ['git', 'describe', '--always', '--dirty', '--exclude', '*']).decode('ascii').strip()
             branchName = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).decode('ascii').strip()
             self.extra_gn_options.append(
-                'sl_matter_version_str="v1.2-%s-%s"' % (branchName, shortCommitSha))
+                'sl_matter_version_str="v1.3-%s-%s"' % (branchName, shortCommitSha))
         if enable_917_soc:
             if use_rps_extension is False:
                 self.extra_gn_options.append('use_rps_extension=false')

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -303,7 +303,7 @@ else
         {
             ShortCommitSha=$(git describe --always --dirty --exclude '*')
             branchName=$(git rev-parse --abbrev-ref HEAD)
-            optArgs+="sl_matter_version_str=\"v1.2-$branchName-$ShortCommitSha\" "
+            optArgs+="sl_matter_version_str=\"v1.3-$branchName-$ShortCommitSha\" "
         } &>/dev/null
     fi
 


### PR DESCRIPTION
Bump the version string prefix from v1.2 to v1.3 for `sl_matter_version_str` in the two build scripts available.

