### PR TITLE
Add domain names matching the DnssdServices stored in Browse Context

### DIFF
--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -368,10 +368,14 @@ void BrowseContext::DispatchSuccess()
 void BrowseContext::DispatchPartialSuccess()
 {
     sContextDispatchingSuccess = this;
-    callback(context, services.data(), services.size(), false, CHIP_NO_ERROR);
+    std::vector<DnssdService> dnsServices;
+    for (auto iter : services)
+    {
+        dnsServices.push_back(std::move(iter.first));
+    }
+    callback(context, dnsServices.data(), dnsServices.size(), false, CHIP_NO_ERROR);
     sContextDispatchingSuccess = nullptr;
     services.clear();
-    domainNames.clear();
 }
 
 void BrowseContext::OnBrowse(DNSServiceFlags flags, const char * name, const char * type, const char * domain, uint32_t interfaceId)
@@ -391,8 +395,7 @@ void BrowseContext::OnBrowseAdd(const char * name, const char * type, const char
 
     VerifyOrReturn(IsLocalDomain(domain));
     auto service = GetService(name, type, protocol, interfaceId);
-    services.push_back(service);
-    domainNames.push_back(std::make_pair(service, std::string(domain)));
+    services.push_back(std::make_pair(std::move(service), std::string(domain)));
 }
 
 void BrowseContext::OnBrowseRemove(const char * name, const char * type, const char * domain, uint32_t interfaceId)
@@ -403,17 +406,10 @@ void BrowseContext::OnBrowseRemove(const char * name, const char * type, const c
     VerifyOrReturn(name != nullptr);
     VerifyOrReturn(IsLocalDomain(domain));
 
-    domainNames.erase(std::remove_if(domainNames.begin(), domainNames.end(),
-                                     [name, type, interfaceId](const auto & domainName) {
-                                         return strcmp(domainName.first.mName, name) == 0 && domainName.first.mType == type &&
-                                             domainName.first.mInterface == chip::Inet::InterfaceId(interfaceId);
-                                     }),
-                      domainNames.end());
-
     services.erase(std::remove_if(services.begin(), services.end(),
-                                  [name, type, interfaceId](const DnssdService & service) {
-                                      return strcmp(name, service.mName) == 0 && type == GetFullType(&service) &&
-                                          service.mInterface == chip::Inet::InterfaceId(interfaceId);
+                                  [name, type, interfaceId, domain](const auto & service) {
+                                      return strcmp(name, service.first.mName) == 0 && type == GetFullType(&service.first) &&
+                                          service.first.mInterface == chip::Inet::InterfaceId(interfaceId) && strcmp(domain, service.second.c_str()) == 0;
                                   }),
                    services.end());
 }

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -406,7 +406,7 @@ void BrowseContext::OnBrowseRemove(const char * name, const char * type, const c
     domainNames.erase(std::remove_if(domainNames.begin(), domainNames.end(),
                                      [name, type, interfaceId](const auto & domainName) {
                                          return strcmp(domainName.first.mName, name) == 0 && domainName.first.mType == type &&
-                                          domainName.first.mInterface == chip::Inet::InterfaceId(interfaceId);
+                                             domainName.first.mInterface == chip::Inet::InterfaceId(interfaceId);
                                      }),
                       domainNames.end());
 

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -409,7 +409,8 @@ void BrowseContext::OnBrowseRemove(const char * name, const char * type, const c
     services.erase(std::remove_if(services.begin(), services.end(),
                                   [name, type, interfaceId, domain](const auto & service) {
                                       return strcmp(name, service.first.mName) == 0 && type == GetFullType(&service.first) &&
-                                          service.first.mInterface == chip::Inet::InterfaceId(interfaceId) && strcmp(domain, service.second.c_str()) == 0;
+                                          service.first.mInterface == chip::Inet::InterfaceId(interfaceId) &&
+                                          strcmp(domain, service.second.c_str()) == 0;
                                   }),
                    services.end());
 }

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -168,6 +168,7 @@ struct BrowseContext : public BrowseHandler
 {
     DnssdBrowseCallback callback;
     std::vector<DnssdService> services;
+    std::vector<std::pair<DnssdService, std::string>> domainNames;
 
     BrowseContext(void * cbContext, DnssdBrowseCallback cb, DnssdServiceProtocol cbContextProtocol);
 

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -167,8 +167,7 @@ struct BrowseHandler : public GenericContext
 struct BrowseContext : public BrowseHandler
 {
     DnssdBrowseCallback callback;
-    std::vector<DnssdService> services;
-    std::vector<std::pair<DnssdService, std::string>> domainNames;
+    std::vector<std::pair<DnssdService, std::string>> services;
 
     BrowseContext(void * cbContext, DnssdBrowseCallback cb, DnssdServiceProtocol cbContextProtocol);
 


### PR DESCRIPTION
This is needed to pass the domain returned from a call to Browse to the Resolve.

Fixes: #32739 

