### PR TITLE
[Darwin] Remove StartupMetricsCollection from fw init

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -84,7 +84,11 @@ static NSString * const kErrorCertStoreInit = @"Init failure while initializing 
 static NSString * const kErrorSessionKeystoreInit = @"Init failure while initializing session keystore";
 
 static bool sExitHandlerRegistered = false;
-static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stopControllerFactory]; }
+static void ShutdownOnExit()
+{
+    MTR_LOG_INFO("ShutdownOnExit invoked on exit");
+    [[MTRDeviceControllerFactory sharedInstance] stopControllerFactory];
+}
 
 @interface MTRDeviceControllerFactory () {
     MTRServerEndpoint * _otaProviderEndpoint;
@@ -323,6 +327,8 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
 
 - (void)cleanupStartupObjects
 {
+    MTR_LOG_INFO("Cleaning startup objects in controller factory");
+
     // Make sure the deinit order here is the reverse of the init order in
     // startControllerFactory:
     _certificationDeclarationCertificates = nil;
@@ -562,7 +568,7 @@ static void ShutdownOnExit() { [[MTRDeviceControllerFactory sharedInstance] stop
         [_controllers[0] shutdown];
     }
 
-    MTR_LOG_DEBUG("Shutting down the Matter controller factory");
+    MTR_LOG_INFO("Shutting down the Matter controller factory");
     _controllerFactory->Shutdown();
 
     [self cleanupStartupObjects];

--- a/src/darwin/Framework/CHIP/MTRFramework.mm
+++ b/src/darwin/Framework/CHIP/MTRFramework.mm
@@ -15,7 +15,6 @@
  */
 
 #import "MTRFramework.h"
-#import "MTRMetricsCollector.h"
 
 #include <dispatch/dispatch.h>
 #include <lib/support/CHIPMem.h>
@@ -35,8 +34,5 @@ void MTRFrameworkInit()
         // Suppress CHIP logging until we actually need it for redirection
         // (see MTRSetLogCallback()). Logging to os_log is always enabled.
         chip::Logging::SetLogFilter(chip::Logging::kLogCategory_None);
-
-        // Startup metrics collection and tracing framework
-        StartupMetricsCollection();
     });
 }


### PR DESCRIPTION
- MTRFrameworkInit was initializing metrics collector but if controller factory is never created tracing backend will crash on system exit.
- Remove the unbalanced init and rely on controller to register and unregister the backend
- Added more logging on shutdown

