### PR TITLE
Add checks for localization-configuration cluster and time-format-localization cluster init callback

### DIFF
--- a/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
+++ b/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
@@ -208,7 +208,7 @@ void emberAfLocalizationConfigurationClusterServerInitCallback(EndpointId endpoi
 
         it->Release();
 
-        if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+        if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND && validLocaleCached)
         {
             // If initial value is not one of the allowed values, write the valid value it.
             status = ActiveLocale::Set(endpoint, validLocale);

--- a/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
+++ b/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
@@ -78,6 +78,12 @@ private:
 
 TimeFormatLocalizationAttrAccess gAttrAccess;
 
+bool HasFeature(EndpointId endpoint, Feature feature)
+{
+    uint32_t featureMap;
+    return FeatureMap::Get(endpoint, &featureMap) == Status::Success ? featureMap & to_underlying(feature) : false;
+}
+
 CHIP_ERROR TimeFormatLocalizationAttrAccess::ReadSupportedCalendarTypes(AttributeValueEncoder & aEncoder)
 {
     DeviceLayer::DeviceInfoProvider * provider = DeviceLayer::GetDeviceInfoProvider();
@@ -202,6 +208,10 @@ Protocols::InteractionModel::Status MatterTimeFormatLocalizationClusterServerPre
 
 void emberAfTimeFormatLocalizationClusterServerInitCallback(EndpointId endpoint)
 {
+    if (!HasFeature(endpoint, Feature::kCalendarFormat))
+    {
+        return;
+    }
     CalendarTypeEnum calendarType;
     CalendarTypeEnum validType;
     Status status = ActiveCalendarType::Get(endpoint, &calendarType);

--- a/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
+++ b/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
@@ -81,7 +81,7 @@ TimeFormatLocalizationAttrAccess gAttrAccess;
 bool HasFeature(EndpointId endpoint, Feature feature)
 {
     uint32_t featureMap;
-    return FeatureMap::Get(endpoint, &featureMap) == Status::Success ? featureMap & to_underlying(feature) : false;
+    return FeatureMap::Get(endpoint, &featureMap) == Status::Success ? (featureMap & to_underlying(feature)) : false;
 }
 
 CHIP_ERROR TimeFormatLocalizationAttrAccess::ReadSupportedCalendarTypes(AttributeValueEncoder & aEncoder)


### PR DESCRIPTION
- `emberAfTimeFormatLocalizationClusterServerInitCallback` calls `ActiveCalendarType::Get()` without checking whether the cluster supports CalendarFormat feature.
- `emberAfLocalizationConfigurationClusterServerInitCallback` tries to set `ActiveLocale` without checking `validLocaleCached`.