### PR TITLE
[Dns-sd] Added Operational Discovery and made browse delegate common

### DIFF
--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -349,10 +349,10 @@ CHIP_ERROR IncrementalResolver::Take(DiscoveredNodeData & outputData)
 
     IPAddressSorter::Sort(mCommonResolutionData.ipAddress, mCommonResolutionData.numIPs, mCommonResolutionData.interfaceId);
 
-    //Set nodeData with data specific to CommissionNodeData
+    // Set nodeData with data specific to CommissionNodeData
     outputData.Set<CommissionNodeData>(mSpecificResolutionData.Get<CommissionNodeData>());
 
-    //set the common resolution data to nodeData
+    // set the common resolution data to nodeData
     CommonResolutionData & resolutionData = outputData.Get<CommissionNodeData>();
     resolutionData                        = mCommonResolutionData;
 

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -345,14 +345,14 @@ CHIP_ERROR IncrementalResolver::OnIpAddress(Inet::InterfaceId interface, const I
 }
 
 template <class NodeType>
-CHIP_ERROR IncrementalResolver::Set(DiscoveredNodeData &output)
+CHIP_ERROR IncrementalResolver::Set(DiscoveredNodeData & output)
 {
     VerifyOrReturnError(mSpecificResolutionData.Is<NodeType>(), CHIP_ERROR_INCORRECT_STATE);
     output.Set<NodeType>();
-    auto & nodeData = output.Get<NodeType>();
-    nodeData = mSpecificResolutionData.Get<NodeType>();
+    auto & nodeData                       = output.Get<NodeType>();
+    nodeData                              = mSpecificResolutionData.Get<NodeType>();
     CommonResolutionData & resolutionData = nodeData;
-    resolutionData = mCommonResolutionData;
+    resolutionData                        = mCommonResolutionData;
     return CHIP_NO_ERROR;
 }
 
@@ -361,7 +361,6 @@ CHIP_ERROR IncrementalResolver::Take(DiscoveredNodeData & outputData)
     VerifyOrReturnError(IsActive(), CHIP_ERROR_INCORRECT_STATE);
 
     IPAddressSorter::Sort(mCommonResolutionData.ipAddress, mCommonResolutionData.numIPs, mCommonResolutionData.interfaceId);
-
 
     if (IsActiveCommissionParse())
     {

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -344,7 +344,7 @@ CHIP_ERROR IncrementalResolver::OnIpAddress(Inet::InterfaceId interface, const I
     return CHIP_NO_ERROR;
 }
 
-template <class NodeType> 
+template <class NodeType>
 CHIP_ERROR IncrementalResolver::Set(DiscoveredNodeData &output)
 {
     VerifyOrReturnError(mSpecificResolutionData.Is<NodeType>(), CHIP_ERROR_INCORRECT_STATE);
@@ -362,7 +362,7 @@ CHIP_ERROR IncrementalResolver::Take(DiscoveredNodeData & outputData)
 
     IPAddressSorter::Sort(mCommonResolutionData.ipAddress, mCommonResolutionData.numIPs, mCommonResolutionData.interfaceId);
 
-    
+
     if (IsActiveCommissionParse())
     {
         ReturnErrorOnFailure(Set<CommissionNodeData>(outputData));

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -349,10 +349,12 @@ CHIP_ERROR IncrementalResolver::Take(DiscoveredNodeData & outputData)
 
     IPAddressSorter::Sort(mCommonResolutionData.ipAddress, mCommonResolutionData.numIPs, mCommonResolutionData.interfaceId);
 
-    // Set nodeData with data specific to CommissionNodeData
+    // Set the DiscoveredNodeData with CommissionNodeData info specific to commissionable/commisssioner 
+    // node available in mSpecificResolutionData.
     outputData.Set<CommissionNodeData>(mSpecificResolutionData.Get<CommissionNodeData>());
 
-    // set the common resolution data to nodeData
+    // IncrementalResolver stored CommonResolutionData separately in mCommonResolutionData hence copy the 
+    //  CommonResolutionData info from mCommonResolutionData, to CommissionNodeData within DiscoveredNodeData
     CommonResolutionData & resolutionData = outputData.Get<CommissionNodeData>();
     resolutionData                        = mCommonResolutionData;
 

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -349,11 +349,11 @@ CHIP_ERROR IncrementalResolver::Take(DiscoveredNodeData & outputData)
 
     IPAddressSorter::Sort(mCommonResolutionData.ipAddress, mCommonResolutionData.numIPs, mCommonResolutionData.interfaceId);
 
-    // Set the DiscoveredNodeData with CommissionNodeData info specific to commissionable/commisssioner 
+    // Set the DiscoveredNodeData with CommissionNodeData info specific to commissionable/commisssioner
     // node available in mSpecificResolutionData.
     outputData.Set<CommissionNodeData>(mSpecificResolutionData.Get<CommissionNodeData>());
 
-    // IncrementalResolver stored CommonResolutionData separately in mCommonResolutionData hence copy the 
+    // IncrementalResolver stored CommonResolutionData separately in mCommonResolutionData hence copy the
     //  CommonResolutionData info from mCommonResolutionData, to CommissionNodeData within DiscoveredNodeData
     CommonResolutionData & resolutionData = outputData.Get<CommissionNodeData>();
     resolutionData                        = mCommonResolutionData;

--- a/src/lib/dnssd/IncrementalResolve.h
+++ b/src/lib/dnssd/IncrementalResolve.h
@@ -173,8 +173,6 @@ public:
     }
 
 private:
-    template <class type>
-    CHIP_ERROR Set(DiscoveredNodeData & output);
     /// Notify that a PTR record can be parsed.
     ///
     /// Input data MUST have GetType() == QType::TXT

--- a/src/lib/dnssd/IncrementalResolve.h
+++ b/src/lib/dnssd/IncrementalResolve.h
@@ -100,7 +100,7 @@ public:
     /// method.
     bool IsActive() const { return mSpecificResolutionData.Valid(); }
 
-    bool IsActiveBrowseParse() const { return mSpecificResolutionData.Is<CommissionNodeData>(); }
+    bool IsActiveCommissionParse() const { return mSpecificResolutionData.Is<CommissionNodeData>(); }
     bool IsActiveOperationalParse() const { return mSpecificResolutionData.Is<OperationalNodeData>(); }
 
     ServiceNameType GetCurrentType() const { return mServiceNameType; }
@@ -115,7 +115,8 @@ public:
     /// interested on, after which TXT and A/AAAA are looked for.
     ///
     /// If this function returns with error, the object will be in an inactive state.
-    CHIP_ERROR InitializeParsing(mdns::Minimal::SerializedQNameIterator name, const mdns::Minimal::SrvRecord & srv);
+    CHIP_ERROR InitializeParsing(mdns::Minimal::SerializedQNameIterator name, const uint64_t ttl,
+                                 const mdns::Minimal::SrvRecord & srv);
 
     /// Notify that a new record is being processed.
     /// Will handle filtering and processing of data to determine if the entry is relevant for
@@ -150,11 +151,12 @@ public:
 
     /// Take the current value of the object and clear it once returned.
     ///
-    /// Object must be in `IsActiveBrowseParse()` for this to succeed.
+    /// Object must be in `IsActive()` for this to succeed.
     /// Data will be returned (and cleared) even if not yet complete based
     /// on `GetMissingRequiredInformation()`. This method takes as much data as
     /// it was parsed so far.
     CHIP_ERROR Take(DiscoveredNodeData & outputData);
+
 
     /// Take the current value of the object and clear it once returned.
     ///
@@ -172,6 +174,8 @@ public:
     }
 
 private:
+    template <class type>
+    CHIP_ERROR Set(DiscoveredNodeData &output);
     /// Notify that a PTR record can be parsed.
     ///
     /// Input data MUST have GetType() == QType::TXT

--- a/src/lib/dnssd/IncrementalResolve.h
+++ b/src/lib/dnssd/IncrementalResolve.h
@@ -157,7 +157,6 @@ public:
     /// it was parsed so far.
     CHIP_ERROR Take(DiscoveredNodeData & outputData);
 
-
     /// Take the current value of the object and clear it once returned.
     ///
     /// Object must be in `IsActiveOperationalParse()` for this to succeed.
@@ -175,7 +174,7 @@ public:
 
 private:
     template <class type>
-    CHIP_ERROR Set(DiscoveredNodeData &output);
+    CHIP_ERROR Set(DiscoveredNodeData & output);
     /// Notify that a PTR record can be parsed.
     ///
     /// Input data MUST have GetType() == QType::TXT

--- a/src/lib/dnssd/ResolverProxy.cpp
+++ b/src/lib/dnssd/ResolverProxy.cpp
@@ -55,6 +55,13 @@ CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
     return mResolver.StartDiscovery(DiscoveryType::kCommissionerNode, filter, *mContext);
 }
 
+CHIP_ERROR ResolverProxy::DiscoverOperationalNodes(DiscoveryFilter filter)
+{
+    VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    return mResolver.StartDiscovery(DiscoveryType::kOperational, filter, *mContext);
+}
+
 CHIP_ERROR ResolverProxy::StopDiscovery()
 {
     VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -54,6 +54,7 @@ public:
 
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter());
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter());
+    CHIP_ERROR DiscoverOperationalNodes(DiscoveryFilter filter = DiscoveryFilter());
     CHIP_ERROR StopDiscovery();
 
 private:

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -459,7 +459,8 @@ void MinMdnsResolver::AdvancePendingResolverStates()
             {
                 DiscoveredNodeData nodeData;
                 err = resolver->Take(nodeData);
-                if (!nodeData.Is<OperationalNodeData>()) {
+                if (!nodeData.Is<OperationalNodeData>())
+                {
                     err = CHIP_ERROR_INVALID_ARGUMENT;
                 }
                 if (err != CHIP_NO_ERROR)
@@ -469,7 +470,7 @@ void MinMdnsResolver::AdvancePendingResolverStates()
                 if (mDiscoveryContext != nullptr && err == CHIP_NO_ERROR)
                 {
                     mDiscoveryContext->OnNodeDiscovered(nodeData);
-                    auto opNodeData = nodeData.Get<OperationalNodeData>();
+                    auto opNodeData                  = nodeData.Get<OperationalNodeData>();
                     nodeResolvedData.resolutionData  = static_cast<CommonResolutionData>(opNodeData);
                     nodeResolvedData.operationalData = opNodeData;
                 }

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -461,10 +461,10 @@ void MinMdnsResolver::AdvancePendingResolverStates()
             if (mActiveResolves.HasBrowseFor(chip::Dnssd::DiscoveryType::kOperational))
             {
                 DiscoveredNodeData nodeData;
-                if (err == CHIP_NO_ERROR )
+                if (err == CHIP_NO_ERROR)
                 {
                     OperationalNodeBrowseData opNodeData;
-                    opNodeData.peerId = nodeResolvedData.operationalData.peerId;
+                    opNodeData.peerId     = nodeResolvedData.operationalData.peerId;
                     opNodeData.hasZeroTTL = nodeResolvedData.operationalData.hasZeroTTL;
                     nodeData.Set<OperationalNodeBrowseData>(opNodeData);
                 }

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -454,26 +454,22 @@ void MinMdnsResolver::AdvancePendingResolverStates()
         {
             MATTER_TRACE_SCOPE("Active operational delegate call", "MinMdnsResolver");
             ResolvedNodeData nodeResolvedData;
-            CHIP_ERROR err = CHIP_ERROR_UNINITIALIZED;
-
-            err = resolver->Take(nodeResolvedData);
+            CHIP_ERROR err = resolver->Take(nodeResolvedData);
 
             if (mActiveResolves.HasBrowseFor(chip::Dnssd::DiscoveryType::kOperational))
             {
-                DiscoveredNodeData nodeData;
-                if (err == CHIP_NO_ERROR)
-                {
-                    OperationalNodeBrowseData opNodeData;
-                    opNodeData.peerId     = nodeResolvedData.operationalData.peerId;
-                    opNodeData.hasZeroTTL = nodeResolvedData.operationalData.hasZeroTTL;
-                    nodeData.Set<OperationalNodeBrowseData>(opNodeData);
-                }
                 if (err != CHIP_NO_ERROR)
                 {
                     ChipLogError(Discovery, "Failed to take discovery result: %" CHIP_ERROR_FORMAT, err.Format());
                 }
                 else if (mDiscoveryContext != nullptr)
                 {
+                    DiscoveredNodeData nodeData;
+                    OperationalNodeBrowseData opNodeData;
+
+                    opNodeData.peerId     = nodeResolvedData.operationalData.peerId;
+                    opNodeData.hasZeroTTL = nodeResolvedData.operationalData.hasZeroTTL;
+                    nodeData.Set<OperationalNodeBrowseData>(opNodeData);
                     mDiscoveryContext->OnNodeDiscovered(nodeData);
                 }
                 else

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -456,13 +456,15 @@ void MinMdnsResolver::AdvancePendingResolverStates()
             ResolvedNodeData nodeResolvedData;
             CHIP_ERROR err = resolver->Take(nodeResolvedData);
 
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Discovery, "Failed to take NodeData - result: %" CHIP_ERROR_FORMAT, err.Format());
+                continue;
+            }
+
             if (mActiveResolves.HasBrowseFor(chip::Dnssd::DiscoveryType::kOperational))
             {
-                if (err != CHIP_NO_ERROR)
-                {
-                    ChipLogError(Discovery, "Failed to take discovery result: %" CHIP_ERROR_FORMAT, err.Format());
-                }
-                else if (mDiscoveryContext != nullptr)
+                if (mDiscoveryContext != nullptr)
                 {
                     DiscoveredNodeData nodeData;
                     OperationalNodeBrowseData opNodeData;
@@ -478,12 +480,6 @@ void MinMdnsResolver::AdvancePendingResolverStates()
                     ChipLogError(Discovery, "No delegate to report operational node discovery");
 #endif
                 }
-            }
-
-            if (err != CHIP_NO_ERROR)
-            {
-                ChipLogError(Discovery, "Failed to take ResolvedNodeData - result: %" CHIP_ERROR_FORMAT, err.Format());
-                continue;
             }
 
             mActiveResolves.Complete(nodeResolvedData.operationalData.peerId);

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -207,8 +207,7 @@ struct OperationalNodeBrowseData : public OperationalNodeData
     void LogDetail() const
     {
         ChipLogDetail(Discovery, "Discovered Operational node:\r\n");
-        ChipLogDetail(Discovery, "\tNode ID: " ChipLogFormatX64 "-" ChipLogFormatX64 "\r\n",
-                      ChipLogValueX64(peerId.GetCompressedFabricId()), ChipLogValueX64(peerId.GetNodeId()));
+        ChipLogDetail(Discovery, "\tNode Instance: " ChipLogFormatPeerId, ChipLogValuePeerId(peerId));
         ChipLogDetail(Discovery, "\thasZeroTTL: %s\r\n", hasZeroTTL ? "true" : "false");
     }
 };

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -194,11 +194,15 @@ struct CommonResolutionData
 };
 
 /// Data that is specific to Operational Discovery of nodes
-struct OperationalNodeData
+struct OperationalNodeData : public CommonResolutionData
 {
     PeerId peerId;
-
-    void Reset() { peerId = PeerId(); }
+    bool hasZeroTTL;
+    void Reset()
+    {
+        CommonResolutionData::Reset();
+        peerId = PeerId();
+    }
 };
 
 inline constexpr size_t kMaxDeviceNameLen         = 32;
@@ -297,12 +301,13 @@ struct ResolvedNodeData
     }
 };
 
-using DiscoveredNodeData = Variant<CommissionNodeData>;
+using DiscoveredNodeData = Variant<CommissionNodeData, OperationalNodeData>;
 
-/// Callbacks for discovering nodes advertising non-operational status:
+/// Callbacks for discovering nodes advertising both operational and non-operational status:
 ///   - Commissioners
 ///   - Nodes in commissioning modes over IP (e.g. ethernet devices, devices already
 ///     connected to thread/wifi or devices with a commissioning window open)
+///   - Operational nodes
 class DiscoverNodeDelegate
 {
 public:

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -208,7 +208,7 @@ struct OperationalNodeBrowseData : public OperationalNodeData
     {
         ChipLogDetail(Discovery, "Discovered Operational node:\r\n");
         ChipLogDetail(Discovery, "\tNode ID: " ChipLogFormatX64 "-" ChipLogFormatX64 "\r\n",
-                            ChipLogValueX64(peerId.GetCompressedFabricId()), 
+                            ChipLogValueX64(peerId.GetCompressedFabricId()),
                             ChipLogValueX64(peerId.GetNodeId()));
         ChipLogDetail(Discovery, "\thasZeroTTL: %s\r\n", hasZeroTTL ? "true" : "false");
     }

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -194,14 +194,23 @@ struct CommonResolutionData
 };
 
 /// Data that is specific to Operational Discovery of nodes
-struct OperationalNodeData : public CommonResolutionData
+struct OperationalNodeData
 {
     PeerId peerId;
     bool hasZeroTTL;
-    void Reset()
+    void Reset() { peerId = PeerId(); }
+};
+
+struct OperationalNodeBrowseData : public OperationalNodeData
+{
+    OperationalNodeBrowseData() { Reset(); };
+    void LogDetail() const
     {
-        CommonResolutionData::Reset();
-        peerId = PeerId();
+        ChipLogDetail(Discovery, "Discovered Operational node:\r\n");
+        ChipLogDetail(Discovery, "\tNode ID: " ChipLogFormatX64 "-" ChipLogFormatX64 "\r\n",
+                            ChipLogValueX64(peerId.GetCompressedFabricId()), 
+                            ChipLogValueX64(peerId.GetNodeId()));
+        ChipLogDetail(Discovery, "\thasZeroTTL: %s\r\n", hasZeroTTL ? "true" : "false");
     }
 };
 
@@ -301,7 +310,7 @@ struct ResolvedNodeData
     }
 };
 
-using DiscoveredNodeData = Variant<CommissionNodeData, OperationalNodeData>;
+using DiscoveredNodeData = Variant<CommissionNodeData, OperationalNodeBrowseData>;
 
 /// Callbacks for discovering nodes advertising both operational and non-operational status:
 ///   - Commissioners

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -208,8 +208,7 @@ struct OperationalNodeBrowseData : public OperationalNodeData
     {
         ChipLogDetail(Discovery, "Discovered Operational node:\r\n");
         ChipLogDetail(Discovery, "\tNode ID: " ChipLogFormatX64 "-" ChipLogFormatX64 "\r\n",
-                            ChipLogValueX64(peerId.GetCompressedFabricId()),
-                            ChipLogValueX64(peerId.GetNodeId()));
+                      ChipLogValueX64(peerId.GetCompressedFabricId()), ChipLogValueX64(peerId.GetNodeId()));
         ChipLogDetail(Discovery, "\thasZeroTTL: %s\r\n", hasZeroTTL ? "true" : "false");
     }
 };

--- a/src/lib/dnssd/tests/TestIncrementalResolve.cpp
+++ b/src/lib/dnssd/tests/TestIncrementalResolve.cpp
@@ -20,6 +20,7 @@
 
 #include <string.h>
 
+#include <lib/dnssd/ServiceNaming.h>
 #include <lib/dnssd/minimal_mdns/core/tests/QNameStrings.h>
 #include <lib/dnssd/minimal_mdns/records/IP.h>
 #include <lib/dnssd/minimal_mdns/records/Ptr.h>
@@ -161,7 +162,7 @@ TEST(TestIncrementalResolve, TestCreation)
     IncrementalResolver resolver;
 
     EXPECT_FALSE(resolver.IsActive());
-    EXPECT_FALSE(resolver.IsActiveBrowseParse());
+    EXPECT_FALSE(resolver.IsActiveCommissionParse());
     EXPECT_FALSE(resolver.IsActiveOperationalParse());
     EXPECT_TRUE(
         resolver.GetMissingRequiredInformation().HasOnly(IncrementalResolver::RequiredInformationBitFlags::kSrvInitialization));
@@ -177,10 +178,10 @@ TEST(TestIncrementalResolve, TestInactiveResetOnInitError)
     PreloadSrvRecord(srvRecord);
 
     // test host name is not a 'matter' name
-    EXPECT_NE(resolver.InitializeParsing(kTestHostName.Serialized(), srvRecord), CHIP_NO_ERROR);
+    EXPECT_NE(resolver.InitializeParsing(kTestHostName.Serialized(), 0, srvRecord), CHIP_NO_ERROR);
 
     EXPECT_FALSE(resolver.IsActive());
-    EXPECT_FALSE(resolver.IsActiveBrowseParse());
+    EXPECT_FALSE(resolver.IsActiveCommissionParse());
     EXPECT_FALSE(resolver.IsActiveOperationalParse());
 }
 
@@ -193,10 +194,10 @@ TEST(TestIncrementalResolve, TestStartOperational)
     SrvRecord srvRecord;
     PreloadSrvRecord(srvRecord);
 
-    EXPECT_EQ(resolver.InitializeParsing(kTestOperationalName.Serialized(), srvRecord), CHIP_NO_ERROR);
+    EXPECT_EQ(resolver.InitializeParsing(kTestOperationalName.Serialized(), 1, srvRecord), CHIP_NO_ERROR);
 
     EXPECT_TRUE(resolver.IsActive());
-    EXPECT_FALSE(resolver.IsActiveBrowseParse());
+    EXPECT_FALSE(resolver.IsActiveCommissionParse());
     EXPECT_TRUE(resolver.IsActiveOperationalParse());
     EXPECT_TRUE(resolver.GetMissingRequiredInformation().HasOnly(IncrementalResolver::RequiredInformationBitFlags::kIpAddress));
     EXPECT_EQ(resolver.GetTargetHostName(), kTestHostName.Serialized());
@@ -211,10 +212,10 @@ TEST(TestIncrementalResolve, TestStartCommissionable)
     SrvRecord srvRecord;
     PreloadSrvRecord(srvRecord);
 
-    EXPECT_EQ(resolver.InitializeParsing(kTestCommissionableNode.Serialized(), srvRecord), CHIP_NO_ERROR);
+    EXPECT_EQ(resolver.InitializeParsing(kTestCommissionableNode.Serialized(), 0, srvRecord), CHIP_NO_ERROR);
 
     EXPECT_TRUE(resolver.IsActive());
-    EXPECT_TRUE(resolver.IsActiveBrowseParse());
+    EXPECT_TRUE(resolver.IsActiveCommissionParse());
     EXPECT_FALSE(resolver.IsActiveOperationalParse());
     EXPECT_TRUE(resolver.GetMissingRequiredInformation().HasOnly(IncrementalResolver::RequiredInformationBitFlags::kIpAddress));
     EXPECT_EQ(resolver.GetTargetHostName(), kTestHostName.Serialized());
@@ -229,10 +230,10 @@ TEST(TestIncrementalResolve, TestStartCommissioner)
     SrvRecord srvRecord;
     PreloadSrvRecord(srvRecord);
 
-    EXPECT_EQ(resolver.InitializeParsing(kTestCommissionerNode.Serialized(), srvRecord), CHIP_NO_ERROR);
+    EXPECT_EQ(resolver.InitializeParsing(kTestCommissionerNode.Serialized(), 0, srvRecord), CHIP_NO_ERROR);
 
     EXPECT_TRUE(resolver.IsActive());
-    EXPECT_TRUE(resolver.IsActiveBrowseParse());
+    EXPECT_TRUE(resolver.IsActiveCommissionParse());
     EXPECT_FALSE(resolver.IsActiveOperationalParse());
     EXPECT_TRUE(resolver.GetMissingRequiredInformation().HasOnly(IncrementalResolver::RequiredInformationBitFlags::kIpAddress));
     EXPECT_EQ(resolver.GetTargetHostName(), kTestHostName.Serialized());
@@ -247,7 +248,7 @@ TEST(TestIncrementalResolve, TestParseOperational)
     SrvRecord srvRecord;
     PreloadSrvRecord(srvRecord);
 
-    EXPECT_EQ(resolver.InitializeParsing(kTestOperationalName.Serialized(), srvRecord), CHIP_NO_ERROR);
+    EXPECT_EQ(resolver.InitializeParsing(kTestOperationalName.Serialized(), 1, srvRecord), CHIP_NO_ERROR);
 
     // once initialized, parsing should be ready however no IP address is available
     EXPECT_TRUE(resolver.IsActiveOperationalParse());
@@ -304,6 +305,7 @@ TEST(TestIncrementalResolve, TestParseOperational)
     // validate data as it was passed in
     EXPECT_EQ(nodeData.operationalData.peerId,
               PeerId().SetCompressedFabricId(0x1234567898765432LL).SetNodeId(0xABCDEFEDCBAABCDELL));
+    EXPECT_FALSE(nodeData.operationalData.hasZeroTTL);
     EXPECT_EQ(nodeData.resolutionData.numIPs, 1u);
     EXPECT_EQ(nodeData.resolutionData.port, 0x1234);
     EXPECT_FALSE(nodeData.resolutionData.supportsTcp);
@@ -324,10 +326,10 @@ TEST(TestIncrementalResolve, TestParseCommissionable)
     SrvRecord srvRecord;
     PreloadSrvRecord(srvRecord);
 
-    EXPECT_EQ(resolver.InitializeParsing(kTestCommissionableNode.Serialized(), srvRecord), CHIP_NO_ERROR);
+    EXPECT_EQ(resolver.InitializeParsing(kTestCommissionableNode.Serialized(), 0, srvRecord), CHIP_NO_ERROR);
 
     // once initialized, parsing should be ready however no IP address is available
-    EXPECT_TRUE(resolver.IsActiveBrowseParse());
+    EXPECT_TRUE(resolver.IsActiveCommissionParse());
     EXPECT_TRUE(resolver.GetMissingRequiredInformation().HasOnly(IncrementalResolver::RequiredInformationBitFlags::kIpAddress));
     EXPECT_EQ(resolver.GetTargetHostName(), kTestHostName.Serialized());
 

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -109,7 +109,7 @@ public:
 
         char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1];
         Encoding::BytesToUppercaseHexString(nodeData.rotatingId, nodeData.rotatingIdLen, rotatingId, sizeof(rotatingId));
-        
+
         streamer_printf(streamer_get(), "DNS browse succeeded: \r\n");
         streamer_printf(streamer_get(), "   Hostname: %s\r\n", nodeData.hostName);
         streamer_printf(streamer_get(), "   Vendor ID: %u\r\n", nodeData.vendorId);

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -86,8 +86,7 @@ public:
     void LogOperationalNodeDiscovered(const Dnssd::OperationalNodeBrowseData & nodeData)
     {
         streamer_printf(streamer_get(), "DNS browse operational succeeded: \r\n");
-        streamer_printf(streamer_get(), "   Node ID: " ChipLogFormatX64 "-" ChipLogFormatX64 "\r\n",
-                        ChipLogValueX64(nodeData.peerId.GetCompressedFabricId()), ChipLogValueX64(nodeData.peerId.GetNodeId()));
+        streamer_printf(streamer_get(), "   Node Instance: " ChipLogFormatPeerId, ChipLogValuePeerId(nodeData.peerId));
         streamer_printf(streamer_get(), "   hasZeroTTL: %s\r\n", nodeData.hasZeroTTL ? "true" : "false");
     }
 

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -104,14 +104,14 @@ public:
             return;
         }
 
-        if (discNodeData.Is<Dnssd::OperationalNodeData>()) 
+        if (discNodeData.Is<Dnssd::OperationalNodeData>())
         {
             LogOperationalNodeDiscovered(discNodeData.Get<Dnssd::OperationalNodeData>());
             return;
-        } 
+        }
 
         auto nodeData = discNodeData.Get<Dnssd::CommissionNodeData>();
-         
+
         if (!nodeData.IsValid())
         {
             streamer_printf(streamer_get(), "DNS browse failed - not found valid services \r\n");


### PR DESCRIPTION
Added support for operational node browse/discovery. Also, updated existing browse/discover interface in Resolver class to a common interface for all types of node browse and made the delegates common for all browse(commissionable, commissioner and operational)

This is continuation of work in #26718.