### PR TITLE
Properly namespace nullptr_t.

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -62,7 +62,7 @@ void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Cal
 }
 
 void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
-                                                nullptr_t
+                                                std::nullptr_t
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
                                                 ,
                                                 uint8_t attemptCount, Callback::Callback<OnDeviceConnectionRetry> * onRetry

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -135,7 +135,7 @@ public:
      * @param attemptCount The number of retry attempts if session setup fails (default is 1).
      * @param onRetry A callback to be called on a retry attempt (enabled by a config flag).
      */
-    void FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection, nullptr_t
+    void FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection, std::nullptr_t
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
                                 ,
                                 uint8_t attemptCount = 1, Callback::Callback<OnDeviceConnectionRetry> * onRetry = nullptr


### PR DESCRIPTION
nullptr_t is in namespace std, not just at global level.  Fixes https://github.com/project-chip/connectedhomeip/issues/32749
