### PR TITLE
Add a lint for toplevel "using namespace" in headers.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -285,3 +285,18 @@ jobs:
               if: always()
               run: |
                   git grep -I -n 'SuccessOrExit([^=)]*(' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
+
+            # git grep exits with 0 if it finds a match, but we want
+            # to fail (exit nonzero) on match.
+            - name: Check for use of "using namespace" outside of a class/function in headers.
+              if: always()
+              run: |
+                  # Various platforms have `using namespace chip::Ble` in their BLEManager* headers; just exclude those for now.
+                  #
+                  # Exclude platform openiotsdk bits that do this in their persistent storage header.
+                  #
+                  # Also exclude examples (for now) and third_party, which have various instances of this.
+                  #
+                  # Ignore uses of `System::Clock::Literals`, because that's the only way to have things using _ms32 or whatnot
+                  # in a header file.
+                  git grep -I -n -e '^using namespace' --and --not -e 'System::Clock::Literals' -- './**/*.h' ':(exclude)src/platform/*/BLEManager*.h' ':(exclude)src/platform/openiotsdk/KVPsaPsStore.h' ':(exclude)./examples' ':(exclude)./third_party' && exit 1 || exit 0

--- a/examples/chip-tool/commands/pairing/IssueNOCChainCommand.h
+++ b/examples/chip-tool/commands/pairing/IssueNOCChainCommand.h
@@ -46,7 +46,7 @@ public:
 
     static void OnDeviceNOCChainGeneration(void * context, CHIP_ERROR status, const chip::ByteSpan & noc,
                                            const chip::ByteSpan & icac, const chip::ByteSpan & rcac,
-                                           chip::Optional<chip::IdentityProtectionKeySpan> ipk,
+                                           chip::Optional<chip::Crypto::IdentityProtectionKeySpan> ipk,
                                            chip::Optional<chip::NodeId> adminSubject)
     {
         auto command = static_cast<IssueNOCChainCommand *>(context);

--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
@@ -36,8 +36,8 @@ public:
                     "1 to use Enhanced Commissioning Method.\n  0 to use Basic Commissioning Method.");
         AddArgument("window-timeout", 0, UINT16_MAX, &mCommissioningWindowTimeout,
                     "Time, in seconds, before the commissioning window closes.");
-        AddArgument("iteration", chip::kSpake2p_Min_PBKDF_Iterations, chip::kSpake2p_Max_PBKDF_Iterations, &mIteration,
-                    "Number of PBKDF iterations to use to derive the verifier.  Ignored if 'option' is 0.");
+        AddArgument("iteration", chip::Crypto::kSpake2p_Min_PBKDF_Iterations, chip::Crypto::kSpake2p_Max_PBKDF_Iterations,
+                    &mIteration, "Number of PBKDF iterations to use to derive the verifier.  Ignored if 'option' is 0.");
         AddArgument("discriminator", 0, 4096, &mDiscriminator, "Discriminator to use for advertising.  Ignored if 'option' is 0.");
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout, "Time, in seconds, before this command is considered to have timed out.");
     }

--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -31,6 +31,7 @@
 #include "platform/ConfigurationManager.h"
 #include "platform/DiagnosticDataProvider.h"
 #include "platform/PlatformManager.h"
+#include <crypto/CHIPCryptoPAL.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
@@ -188,9 +189,9 @@ public:
 private:
     std::optional<uint16_t> mDiscriminatorOverride;
     std::optional<uint32_t> mPasscodeOverride;
-    Spake2pVerifierSerialized mVerifierBuf;
+    Crypto::Spake2pVerifierSerialized mVerifierBuf;
     std::optional<ByteSpan> mVerifierOverride;
-    uint8_t mSaltBuf[kSpake2p_Max_PBKDF_Salt_Length];
+    uint8_t mSaltBuf[Crypto::kSpake2p_Max_PBKDF_Salt_Length];
     std::optional<ByteSpan> mSaltOverride;
     std::optional<uint32_t> mIterationCountOverride;
     DeviceLayer::CommissionableDataProvider * mCommissionableDataProvider = nullptr;

--- a/examples/energy-management-app/energy-management-common/src/ElectricalPowerMeasurementDelegate.cpp
+++ b/examples/energy-management-app/energy-management-common/src/ElectricalPowerMeasurementDelegate.cpp
@@ -26,6 +26,8 @@ using namespace chip::app;
 using namespace chip::app::DataModel;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ElectricalPowerMeasurement;
+using namespace chip::app::Clusters::ElectricalPowerMeasurement::Attributes;
+using namespace chip::app::Clusters::ElectricalPowerMeasurement::Structs;
 
 CHIP_ERROR ElectricalPowerMeasurementInstance::Init()
 {

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -71,6 +71,7 @@ using namespace chip::DeviceLayer;
 using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::app::Clusters;
+using namespace chip::Protocols::UserDirectedCommissioning;
 
 using namespace ::chip::Messaging;
 using namespace ::chip::Controller;

--- a/examples/tv-app/android/java/TVApp-JNI.cpp
+++ b/examples/tv-app/android/java/TVApp-JNI.cpp
@@ -49,6 +49,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::AppPlatform;
 using namespace chip::Credentials;
+using namespace chip::Protocols::UserDirectedCommissioning;
 
 #define JNI_METHOD(RETURN, METHOD_NAME) extern "C" JNIEXPORT RETURN JNICALL Java_com_matter_tv_server_tvapp_TvApp_##METHOD_NAME
 
@@ -204,15 +205,15 @@ class MyPincodeService : public PasscodeService
         bool foundApp = ContentAppPlatform::GetInstance().HasTargetContentApp(vendorId, productId, rotatingId, info, passcode);
         if (!foundApp)
         {
-            info.checkState = chip::Controller::TargetAppCheckState::kAppNotFound;
+            info.checkState = TargetAppCheckState::kAppNotFound;
         }
         else if (passcode != 0)
         {
-            info.checkState = chip::Controller::TargetAppCheckState::kAppFoundPasscodeReturned;
+            info.checkState = TargetAppCheckState::kAppFoundPasscodeReturned;
         }
         else
         {
-            info.checkState = chip::Controller::TargetAppCheckState::kAppFoundNoPasscode;
+            info.checkState = TargetAppCheckState::kAppFoundNoPasscode;
         }
         CommissionerDiscoveryController * cdc = GetCommissionerDiscoveryController();
         if (cdc != nullptr)

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -52,6 +52,7 @@ extern CommissionerDiscoveryController * GetCommissionerDiscoveryController();
 using namespace chip;
 using namespace chip::AppPlatform;
 using namespace chip::app::Clusters;
+using namespace chip::Protocols::UserDirectedCommissioning;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 class MyUserPrompter : public UserPrompter

--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -42,6 +42,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::AdministratorCommissioning;
 using namespace chip::Protocols;
+using namespace chip::Crypto;
 using chip::Protocols::InteractionModel::Status;
 
 class AdministratorCommissioningAttrAccess : public AttributeAccessInterface

--- a/src/app/clusters/device-energy-management-server/device-energy-management-server.h
+++ b/src/app/clusters/device-energy-management-server/device-energy-management-server.h
@@ -34,8 +34,6 @@ namespace app {
 namespace Clusters {
 namespace DeviceEnergyManagement {
 
-using namespace chip::app::Clusters::DeviceEnergyManagement::Attributes;
-
 class Delegate
 {
 public:
@@ -160,24 +158,24 @@ public:
 
     // ------------------------------------------------------------------
     // Get attribute methods
-    virtual ESATypeEnum GetESAType()                                                 = 0;
-    virtual bool GetESACanGenerate()                                                 = 0;
-    virtual ESAStateEnum GetESAState()                                               = 0;
-    virtual int64_t GetAbsMinPower()                                                 = 0;
-    virtual int64_t GetAbsMaxPower()                                                 = 0;
-    virtual PowerAdjustmentCapability::TypeInfo::Type GetPowerAdjustmentCapability() = 0;
-    virtual DataModel::Nullable<Structs::ForecastStruct::Type> GetForecast()         = 0;
-    virtual OptOutStateEnum GetOptOutState()                                         = 0;
+    virtual ESATypeEnum GetESAType()                                                             = 0;
+    virtual bool GetESACanGenerate()                                                             = 0;
+    virtual ESAStateEnum GetESAState()                                                           = 0;
+    virtual int64_t GetAbsMinPower()                                                             = 0;
+    virtual int64_t GetAbsMaxPower()                                                             = 0;
+    virtual Attributes::PowerAdjustmentCapability::TypeInfo::Type GetPowerAdjustmentCapability() = 0;
+    virtual DataModel::Nullable<Structs::ForecastStruct::Type> GetForecast()                     = 0;
+    virtual OptOutStateEnum GetOptOutState()                                                     = 0;
 
     // ------------------------------------------------------------------
     // Set attribute methods
-    virtual CHIP_ERROR SetESAType(ESATypeEnum)                                                 = 0;
-    virtual CHIP_ERROR SetESACanGenerate(bool)                                                 = 0;
-    virtual CHIP_ERROR SetESAState(ESAStateEnum)                                               = 0;
-    virtual CHIP_ERROR SetAbsMinPower(int64_t)                                                 = 0;
-    virtual CHIP_ERROR SetAbsMaxPower(int64_t)                                                 = 0;
-    virtual CHIP_ERROR SetPowerAdjustmentCapability(PowerAdjustmentCapability::TypeInfo::Type) = 0;
-    virtual CHIP_ERROR SetForecast(DataModel::Nullable<Structs::ForecastStruct::Type>)         = 0;
+    virtual CHIP_ERROR SetESAType(ESATypeEnum)                                                             = 0;
+    virtual CHIP_ERROR SetESACanGenerate(bool)                                                             = 0;
+    virtual CHIP_ERROR SetESAState(ESAStateEnum)                                                           = 0;
+    virtual CHIP_ERROR SetAbsMinPower(int64_t)                                                             = 0;
+    virtual CHIP_ERROR SetAbsMaxPower(int64_t)                                                             = 0;
+    virtual CHIP_ERROR SetPowerAdjustmentCapability(Attributes::PowerAdjustmentCapability::TypeInfo::Type) = 0;
+    virtual CHIP_ERROR SetForecast(DataModel::Nullable<Structs::ForecastStruct::Type>)                     = 0;
 
 protected:
     EndpointId mEndpointId = 0;

--- a/src/app/clusters/electrical-power-measurement-server/electrical-power-measurement-server.h
+++ b/src/app/clusters/electrical-power-measurement-server/electrical-power-measurement-server.h
@@ -29,9 +29,6 @@ namespace app {
 namespace Clusters {
 namespace ElectricalPowerMeasurement {
 
-using namespace chip::app::Clusters::ElectricalPowerMeasurement::Attributes;
-using namespace chip::app::Clusters::ElectricalPowerMeasurement::Structs;
-
 class Delegate
 {
 public:

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -55,6 +55,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::OperationalCredentials;
 using namespace chip::Credentials;
+using namespace chip::Crypto;
 using namespace chip::Protocols::InteractionModel;
 
 namespace {

--- a/src/app/icd/client/CheckInHandler.cpp
+++ b/src/app/icd/client/CheckInHandler.cpp
@@ -37,6 +37,8 @@
 
 #include <protocols/secure_channel/Constants.h>
 
+using namespace chip::Protocols::SecureChannel;
+
 namespace chip {
 namespace app {
 

--- a/src/app/icd/client/DefaultCheckInDelegate.h
+++ b/src/app/icd/client/DefaultCheckInDelegate.h
@@ -24,8 +24,6 @@
 namespace chip {
 namespace app {
 
-using namespace std;
-
 class InteractionModelEngine;
 
 /// Callbacks for check in protocol

--- a/src/app/icd/client/DefaultICDClientStorage.cpp
+++ b/src/app/icd/client/DefaultICDClientStorage.cpp
@@ -463,7 +463,7 @@ CHIP_ERROR DefaultICDClientStorage::DeleteAllEntries(FabricIndex fabricIndex)
 }
 
 CHIP_ERROR DefaultICDClientStorage::ProcessCheckInPayload(const ByteSpan & payload, ICDClientInfo & clientInfo,
-                                                          CounterType & counter)
+                                                          Protocols::SecureChannel::CounterType & counter)
 {
     uint8_t appDataBuffer[kAppDataLength];
     MutableByteSpan appData(appDataBuffer);

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -117,7 +117,8 @@ public:
      */
     CHIP_ERROR DeleteAllEntries(FabricIndex fabricIndex);
 
-    CHIP_ERROR ProcessCheckInPayload(const ByteSpan & payload, ICDClientInfo & clientInfo, CounterType & counter) override;
+    CHIP_ERROR ProcessCheckInPayload(const ByteSpan & payload, ICDClientInfo & clientInfo,
+                                     Protocols::SecureChannel::CounterType & counter) override;
 
 protected:
     enum class ClientInfoTag : uint8_t

--- a/src/app/icd/client/ICDClientStorage.h
+++ b/src/app/icd/client/ICDClientStorage.h
@@ -31,7 +31,6 @@
 namespace chip {
 namespace app {
 
-using namespace Protocols::SecureChannel;
 /**
  * The ICDClientStorage class is an abstract interface that defines the operations
  * for storing, retrieving and deleting ICD client information in persistent storage.
@@ -81,7 +80,8 @@ public:
      * @param[out] clientInfo retrieved matched clientInfo from storage
      * @param[out] counter counter value received in the check-in message
      */
-    virtual CHIP_ERROR ProcessCheckInPayload(const ByteSpan & payload, ICDClientInfo & clientInfo, CounterType & counter) = 0;
+    virtual CHIP_ERROR ProcessCheckInPayload(const ByteSpan & payload, ICDClientInfo & clientInfo,
+                                             Protocols::SecureChannel::CounterType & counter) = 0;
 
     // 4 bytes for counter + 2 bytes for ActiveModeThreshold
     static inline constexpr uint8_t kAppDataLength = 6;

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -31,6 +31,7 @@
 
 using namespace chip::app::Clusters;
 using namespace chip::System::Clock;
+using namespace chip::Crypto;
 
 using AdministratorCommissioning::CommissioningWindowStatusEnum;
 using chip::app::DataModel::MakeNullable;

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -20,6 +20,7 @@
 #include <app/data-model/Nullable.h>
 #include <app/server/AppDelegate.h>
 #include <app/server/CommissioningModeProvider.h>
+#include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/core/ClusterEnums.h>
 #include <lib/core/DataModelTypes.h>
@@ -93,7 +94,7 @@ public:
                                                                      FabricIndex fabricIndex, VendorId vendorId);
 
     CHIP_ERROR OpenEnhancedCommissioningWindow(System::Clock::Seconds16 commissioningTimeout, uint16_t discriminator,
-                                               Spake2pVerifier & verifier, uint32_t iterations, chip::ByteSpan salt,
+                                               Crypto::Spake2pVerifier & verifier, uint32_t iterations, chip::ByteSpan salt,
                                                FabricIndex fabricIndex, VendorId vendorId);
 
     void CloseCommissioningWindow();
@@ -204,7 +205,7 @@ private:
     uint8_t mFailedCommissioningAttempts = 0;
 
     bool mUseECM = false;
-    Spake2pVerifier mECMPASEVerifier;
+    Crypto::Spake2pVerifier mECMPASEVerifier;
     uint16_t mECMDiscriminator = 0;
     // mListeningForPASE is true only when we are listening for
     // PBKDFParamRequest messages or when we're in the middle of a PASE
@@ -214,7 +215,7 @@ private:
     bool mCommissioningTimeoutTimerArmed = false;
     uint32_t mECMIterations              = 0;
     uint32_t mECMSaltLength              = 0;
-    uint8_t mECMSalt[kSpake2p_Max_PBKDF_Salt_Length];
+    uint8_t mECMSalt[Crypto::kSpake2p_Max_PBKDF_Salt_Length];
 
     // For tests only, so that we can test the commissioning window timeout
     // without having to wait 3 minutes.

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -32,6 +32,8 @@
 
 #include <nlunit-test.h>
 
+using namespace chip::Crypto;
+
 using chip::CommissioningWindowAdvertisement;
 using chip::CommissioningWindowManager;
 using chip::Server;
@@ -328,9 +330,9 @@ void CheckCommissioningWindowManagerEnhancedWindowTask(intptr_t context)
     CHIP_ERROR err = chip::DeviceLayer::GetCommissionableDataProvider()->GetSetupDiscriminator(originDiscriminator);
     NL_TEST_ASSERT(suite, err == CHIP_NO_ERROR);
     uint16_t newDiscriminator = static_cast<uint16_t>(originDiscriminator + 1);
-    chip::Spake2pVerifier verifier;
-    constexpr uint32_t kIterations = chip::kSpake2p_Min_PBKDF_Iterations;
-    uint8_t salt[chip::kSpake2p_Min_PBKDF_Salt_Length];
+    Spake2pVerifier verifier;
+    constexpr uint32_t kIterations = kSpake2p_Min_PBKDF_Iterations;
+    uint8_t salt[kSpake2p_Min_PBKDF_Salt_Length];
     chip::ByteSpan saltData(salt);
 
     NL_TEST_ASSERT(suite, !sWindowStatusDirty);

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -29,6 +29,7 @@ namespace chip {
 namespace Controller {
 
 using namespace chip::app::Clusters;
+using namespace chip::Crypto;
 using chip::app::DataModel::MakeNullable;
 using chip::app::DataModel::NullNullable;
 

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -19,6 +19,7 @@
 #include <controller/CommissioneeDeviceProxy.h>
 #include <controller/CommissioningDelegate.h>
 #include <credentials/DeviceAttestationConstructor.h>
+#include <crypto/CHIPCryptoPAL.h>
 #include <protocols/secure_channel/RendezvousParameters.h>
 
 namespace chip {
@@ -70,7 +71,8 @@ private:
     ByteSpan GetDAC() const { return ByteSpan(mDAC, mDACLen); }
     ByteSpan GetPAI() const { return ByteSpan(mPAI, mPAILen); }
 
-    CHIP_ERROR NOCChainGenerated(ByteSpan noc, ByteSpan icac, ByteSpan rcac, IdentityProtectionKeySpan ipk, NodeId adminSubject);
+    CHIP_ERROR NOCChainGenerated(ByteSpan noc, ByteSpan icac, ByteSpan rcac, Crypto::IdentityProtectionKeySpan ipk,
+                                 NodeId adminSubject);
     EndpointId GetEndpoint(const CommissioningStage & stage) const;
     CommissioningStage GetNextCommissioningStageInternal(CommissioningStage currentStage, CHIP_ERROR & lastErr);
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -77,6 +77,7 @@ using namespace chip::System;
 using namespace chip::Transport;
 using namespace chip::Credentials;
 using namespace chip::app::Clusters;
+using namespace chip::Crypto;
 
 namespace chip {
 namespace Controller {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -46,6 +46,7 @@
 #include <credentials/FabricTable.h>
 #include <credentials/attestation_verifier/DeviceAttestationDelegate.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <crypto/CHIPCryptoPAL.h>
 #include <inet/InetInterface.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPCore.h>
@@ -78,8 +79,6 @@
 namespace chip {
 
 namespace Controller {
-
-using namespace chip::Protocols::UserDirectedCommissioning;
 
 inline constexpr uint16_t kNumMaxActiveDevices = CHIP_CONFIG_CONTROLLER_MAX_ACTIVE_DEVICES;
 
@@ -272,7 +271,7 @@ public:
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */
     CHIP_ERROR ComputePASEVerifier(uint32_t iterations, uint32_t setupPincode, const ByteSpan & salt,
-                                   Spake2pVerifier & outVerifier);
+                                   Crypto::Spake2pVerifier & outVerifier);
 
     void RegisterDeviceDiscoveryDelegate(DeviceDiscoveryDelegate * delegate) { mDeviceDiscoveryDelegate = delegate; }
 
@@ -720,7 +719,10 @@ public:
      *   Return the UDC Server instance
      *
      */
-    UserDirectedCommissioningServer * GetUserDirectedCommissioningServer() { return mUdcServer; }
+    Protocols::UserDirectedCommissioning::UserDirectedCommissioningServer * GetUserDirectedCommissioningServer()
+    {
+        return mUdcServer;
+    }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
     /**
@@ -785,7 +787,7 @@ private:
     ObjectPool<CommissioneeDeviceProxy, kNumMaxActiveDevices> mCommissioneeDevicePool;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable
-    UserDirectedCommissioningServer * mUdcServer = nullptr;
+    Protocols::UserDirectedCommissioning::UserDirectedCommissioningServer * mUdcServer = nullptr;
     // mUdcTransportMgr is for insecure communication (ex. user directed commissioning)
     UdcTransportMgr * mUdcTransportMgr = nullptr;
     uint16_t mUdcListenPort            = CHIP_UDC_PORT;
@@ -821,7 +823,7 @@ private:
        The function does not hold a reference to the device object.
      */
     CHIP_ERROR SendOperationalCertificate(DeviceProxy * device, const ByteSpan & nocCertBuf, const Optional<ByteSpan> & icaCertBuf,
-                                          IdentityProtectionKeySpan ipk, NodeId adminSubject,
+                                          Crypto::IdentityProtectionKeySpan ipk, NodeId adminSubject,
                                           Optional<System::Clock::Timeout> timeout);
     /* This function sends the trusted root certificate to the device.
        The function does not hold a reference to the device object.
@@ -886,7 +888,7 @@ private:
                                                            Credentials::AttestationVerificationResult result);
 
     static void OnDeviceNOCChainGeneration(void * context, CHIP_ERROR status, const ByteSpan & noc, const ByteSpan & icac,
-                                           const ByteSpan & rcac, Optional<IdentityProtectionKeySpan> ipk,
+                                           const ByteSpan & rcac, Optional<Crypto::IdentityProtectionKeySpan> ipk,
                                            Optional<NodeId> adminSubject);
     static void OnArmFailSafe(void * context,
                               const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data);

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -120,7 +120,7 @@ struct FactoryInitParams
     Inet::EndPointManager<Inet::TCPEndPoint> * tcpEndPointManager      = nullptr;
     Inet::EndPointManager<Inet::UDPEndPoint> * udpEndPointManager      = nullptr;
     FabricTable * fabricTable                                          = nullptr;
-    OperationalKeystore * operationalKeystore                          = nullptr;
+    Crypto::OperationalKeystore * operationalKeystore                  = nullptr;
     Credentials::OperationalCertificateStore * opCertStore             = nullptr;
     SessionResumptionStorage * sessionResumptionStorage                = nullptr;
 #if CONFIG_NETWORK_LAYER_BLE

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -22,6 +22,7 @@
 #include <controller/CommissioneeDeviceProxy.h>
 #include <credentials/attestation_verifier/DeviceAttestationDelegate.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <crypto/CHIPCryptoPAL.h>
 #include <lib/support/Variant.h>
 #include <system/SystemClock.h>
 
@@ -232,9 +233,9 @@ public:
     // Epoch key for the identity protection key for the node being commissioned. In the AutoCommissioner, this is set by by the
     // kGenerateNOCChain stage through the OperationalCredentialsDelegate.
     // This value must be set before calling PerformCommissioningStep for the kSendNOC step.
-    const Optional<IdentityProtectionKeySpan> GetIpk() const
+    const Optional<Crypto::IdentityProtectionKeySpan> GetIpk() const
     {
-        return mIpk.HasValue() ? Optional<IdentityProtectionKeySpan>(mIpk.Value().Span()) : Optional<IdentityProtectionKeySpan>();
+        return mIpk.HasValue() ? MakeOptional(mIpk.Value().Span()) : NullOptional;
     }
 
     // Admin subject id used for the case access control entry created if the AddNOC command succeeds. In the AutoCommissioner, this
@@ -416,9 +417,9 @@ public:
         mIcac.SetValue(icac);
         return *this;
     }
-    CommissioningParameters & SetIpk(const IdentityProtectionKeySpan ipk)
+    CommissioningParameters & SetIpk(const Crypto::IdentityProtectionKeySpan ipk)
     {
-        mIpk.SetValue(IdentityProtectionKey(ipk));
+        mIpk.SetValue(Crypto::IdentityProtectionKey(ipk));
         return *this;
     }
     CommissioningParameters & SetAdminSubject(const NodeId adminSubject)
@@ -599,7 +600,7 @@ private:
     Optional<ByteSpan> mRootCert;
     Optional<ByteSpan> mNoc;
     Optional<ByteSpan> mIcac;
-    Optional<IdentityProtectionKey> mIpk;
+    Optional<Crypto::IdentityProtectionKey> mIpk;
     Optional<NodeId> mAdminSubject;
     // Items that come from the device in commissioning steps
     Optional<ByteSpan> mAttestationElements;
@@ -651,13 +652,15 @@ struct CSRResponse
 
 struct NocChain
 {
-    NocChain(ByteSpan newNoc, ByteSpan newIcac, ByteSpan newRcac, IdentityProtectionKeySpan newIpk, NodeId newAdminSubject) :
-        noc(newNoc), icac(newIcac), rcac(newRcac), ipk(newIpk), adminSubject(newAdminSubject)
+    NocChain(ByteSpan newNoc, ByteSpan newIcac, ByteSpan newRcac, Crypto::IdentityProtectionKeySpan newIpk,
+             NodeId newAdminSubject) :
+        noc(newNoc),
+        icac(newIcac), rcac(newRcac), ipk(newIpk), adminSubject(newAdminSubject)
     {}
     ByteSpan noc;
     ByteSpan icac;
     ByteSpan rcac;
-    IdentityProtectionKeySpan ipk;
+    Crypto::IdentityProtectionKeySpan ipk;
     NodeId adminSubject;
 };
 

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -25,6 +25,7 @@
 
 using namespace chip::app::Clusters;
 using namespace chip::System::Clock;
+using namespace chip::Crypto;
 
 namespace {
 // TODO: What should the timed invoke timeout here be?
@@ -134,7 +135,7 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindowInternal(Messaging:
 
     if (mCommissioningWindowOption != CommissioningWindowOption::kOriginalSetupCode)
     {
-        chip::Spake2pVerifierSerialized serializedVerifier;
+        Spake2pVerifierSerialized serializedVerifier;
         MutableByteSpan serializedVerifierSpan(serializedVerifier);
         ReturnErrorOnFailure(mVerifier.Serialize(serializedVerifierSpan));
 

--- a/src/controller/CommissioningWindowOpener.h
+++ b/src/controller/CommissioningWindowOpener.h
@@ -139,10 +139,10 @@ private:
     NodeId mNodeId                                       = kUndefinedNodeId;
     System::Clock::Seconds16 mCommissioningWindowTimeout = System::Clock::kZero;
     CommissioningWindowOption mCommissioningWindowOption = CommissioningWindowOption::kOriginalSetupCode;
-    Spake2pVerifier mVerifier; // Used for non-basic commissioning.
+    Crypto::Spake2pVerifier mVerifier; // Used for non-basic commissioning.
     // Parameters needed for non-basic commissioning.
     uint32_t mPBKDFIterations = 0;
-    uint8_t mPBKDFSaltBuffer[kSpake2p_Max_PBKDF_Salt_Length];
+    uint8_t mPBKDFSaltBuffer[Crypto::kSpake2p_Max_PBKDF_Salt_Length];
     ByteSpan mPBKDFSalt;
 
     Callback::Callback<OnDeviceConnected> mDeviceConnected;

--- a/src/controller/java/AndroidCheckInDelegate.h
+++ b/src/controller/java/AndroidCheckInDelegate.h
@@ -25,8 +25,6 @@
 namespace chip {
 namespace app {
 
-using namespace std;
-
 class InteractionModelEngine;
 
 /// Callbacks for check in protocol

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -76,6 +76,7 @@ using namespace chip;
 using namespace chip::Inet;
 using namespace chip::Controller;
 using namespace chip::Credentials;
+using namespace chip::Crypto;
 
 #define JNI_METHOD(RETURN, METHOD_NAME)                                                                                            \
     extern "C" JNIEXPORT RETURN JNICALL Java_chip_devicecontroller_ChipDeviceController_##METHOD_NAME
@@ -2237,12 +2238,12 @@ JNI_METHOD(jobject, getICDClientInfo)(JNIEnv * env, jobject self, jlong handle, 
         }
 
         err = chip::JniReferences::GetInstance().N2J_ByteArray(env, info.aes_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>(),
-                                                               chip::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES, jIcdAesKey);
+                                                               CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES, jIcdAesKey);
         VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr,
                             ChipLogError(Controller, "ICD AES KEY N2J_ByteArray error!: %" CHIP_ERROR_FORMAT, err.Format()));
 
         err = chip::JniReferences::GetInstance().N2J_ByteArray(env, info.hmac_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>(),
-                                                               chip::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES, jIcdHmacKey);
+                                                               CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES, jIcdHmacKey);
         VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr,
                             ChipLogError(Controller, "ICD HMAC KEY N2J_ByteArray error!: %" CHIP_ERROR_FORMAT, err.Format()));
 

--- a/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
@@ -40,7 +40,7 @@ void ScriptPairingDeviceDiscoveryDelegate::OnDiscoveredDevice(const Dnssd::Disco
 
     Inet::InterfaceId interfaceId =
         nodeData.resolutionData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.resolutionData.interfaceId : Inet::InterfaceId::Null();
-    PeerAddress peerAddress = PeerAddress::UDP(nodeData.resolutionData.ipAddress[0], port, interfaceId);
+    auto peerAddress = Transport::PeerAddress::UDP(nodeData.resolutionData.ipAddress[0], port, interfaceId);
 
     RendezvousParameters keyExchangeParams = RendezvousParameters().SetSetupPINCode(mSetupPasscode).SetPeerAddress(peerAddress);
 

--- a/src/credentials/tests/CHIPCert_test_vectors.cpp
+++ b/src/credentials/tests/CHIPCert_test_vectors.cpp
@@ -28,6 +28,8 @@
 
 #include "CHIPCert_test_vectors.h"
 
+using namespace chip::Credentials;
+
 namespace chip {
 namespace TestCerts {
 

--- a/src/credentials/tests/CHIPCert_test_vectors.h
+++ b/src/credentials/tests/CHIPCert_test_vectors.h
@@ -34,8 +34,6 @@
 namespace chip {
 namespace TestCerts {
 
-using namespace chip::Credentials;
-
 enum TestCert
 {
     kNone      = 0,
@@ -78,9 +76,9 @@ extern CHIP_ERROR GetTestCertKeypair(TestCert certType, Crypto::P256SerializedKe
 extern CHIP_ERROR GetTestCertSKID(TestCert certType, ByteSpan & skid);
 extern CHIP_ERROR GetTestCertAKID(TestCert certType, ByteSpan & akid);
 
-extern CHIP_ERROR DecodeTestCert(ChipCertificateData & certData, TestCert certType);
-extern CHIP_ERROR LoadTestCert(ChipCertificateSet & certSet, TestCert certType, BitFlags<TestCertLoadFlags> certLoadFlags,
-                               BitFlags<CertDecodeFlags> decodeFlags);
+extern CHIP_ERROR DecodeTestCert(Credentials::ChipCertificateData & certData, TestCert certType);
+extern CHIP_ERROR LoadTestCert(Credentials::ChipCertificateSet & certSet, TestCert certType,
+                               BitFlags<TestCertLoadFlags> certLoadFlags, BitFlags<Credentials::CertDecodeFlags> decodeFlags);
 
 extern const TestCert gTestCerts[];
 extern const size_t gNumTestCerts;

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -77,6 +77,7 @@
 
 using namespace chip;
 using namespace chip::Crypto;
+using namespace chip::Credentials;
 using namespace chip::TLV;
 
 namespace {

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -995,7 +995,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
                                                     salt:(NSData *)salt
                                                    error:(NSError * __autoreleasing *)error
 {
-    chip::Spake2pVerifier verifier;
+    chip::Crypto::Spake2pVerifier verifier;
     CHIP_ERROR err = verifier.Generate(iterations.unsignedIntValue, AsByteSpan(salt), setupPasscode.unsignedIntValue);
 
     MATTER_LOG_METRIC_SCOPE(kMetricPASEVerifierForSetupCode, err);

--- a/src/protocols/secure_channel/CheckinMessage.cpp
+++ b/src/protocols/secure_channel/CheckinMessage.cpp
@@ -25,6 +25,8 @@
 #include <protocols/secure_channel/CheckinMessage.h>
 #include <protocols/secure_channel/Constants.h>
 
+using namespace chip::Crypto;
+
 namespace chip {
 namespace Protocols {
 namespace SecureChannel {

--- a/src/protocols/secure_channel/CheckinMessage.h
+++ b/src/protocols/secure_channel/CheckinMessage.h
@@ -30,7 +30,6 @@
 namespace chip {
 namespace Protocols {
 namespace SecureChannel {
-using namespace Crypto;
 
 using CounterType = uint32_t;
 
@@ -101,7 +100,7 @@ public:
     static size_t GetAppDataSize(const ByteSpan & payload);
 
     static constexpr uint16_t kMinPayloadSize =
-        CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES + sizeof(CounterType) + CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES;
+        Crypto::CHIP_CRYPTO_AEAD_NONCE_LENGTH_BYTES + sizeof(CounterType) + Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES;
 
 private:
     /**

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -46,19 +46,6 @@ extern const char kSpake2pR2ISessionInfo[];
 
 inline constexpr uint16_t kPBKDFParamRandomNumberSize = 32;
 
-using namespace Crypto;
-
-struct PASESessionSerialized;
-
-struct PASESessionSerializable
-{
-    uint16_t mKeLen;
-    uint8_t mKe[kMAX_Hash_Length];
-    uint8_t mPairingComplete;
-    uint16_t mLocalSessionId;
-    uint16_t mPeerSessionId;
-};
-
 class DLL_EXPORT PASESession : public Messaging::UnsolicitedMessageHandler,
                                public Messaging::ExchangeDelegate,
                                public PairingSession
@@ -94,7 +81,7 @@ public:
      *
      * @return CHIP_ERROR     The result of initialization
      */
-    CHIP_ERROR WaitForPairing(SessionManager & sessionManager, const Spake2pVerifier & verifier, uint32_t pbkdf2IterCount,
+    CHIP_ERROR WaitForPairing(SessionManager & sessionManager, const Crypto::Spake2pVerifier & verifier, uint32_t pbkdf2IterCount,
                               const ByteSpan & salt, Optional<ReliableMessageProtocolConfig> mrpLocalConfig,
                               SessionEstablishmentDelegate * delegate);
 
@@ -128,7 +115,7 @@ public:
      *
      * @return CHIP_ERROR      The result of PASE verifier generation
      */
-    static CHIP_ERROR GeneratePASEVerifier(Spake2pVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt,
+    static CHIP_ERROR GeneratePASEVerifier(Crypto::Spake2pVerifier & verifier, uint32_t pbkdf2IterCount, const ByteSpan & salt,
                                            bool useRandomPIN, uint32_t & setupPIN);
 
     /**
@@ -211,9 +198,9 @@ private:
     // mNextExpectedMsg is set when we are expecting a message.
     Optional<Protocols::SecureChannel::MsgType> mNextExpectedMsg;
 
-    Spake2p_P256_SHA256_HKDF_HMAC mSpake2p;
+    Crypto::Spake2p_P256_SHA256_HKDF_HMAC mSpake2p;
 
-    Spake2pVerifier mPASEVerifier;
+    Crypto::Spake2pVerifier mPASEVerifier;
 
     uint32_t mSetupPINCode;
 
@@ -221,7 +208,7 @@ private:
 
     uint8_t mPBKDFLocalRandomData[kPBKDFParamRandomNumberSize];
 
-    Hash_SHA256_stream mCommissioningHash;
+    Crypto::Hash_SHA256_stream mCommissioningHash;
     uint32_t mIterationCount = 0;
     uint16_t mSaltLength     = 0;
     uint8_t * mSalt          = nullptr;
@@ -232,7 +219,7 @@ private:
     };
 
 protected:
-    uint8_t mKe[kMAX_Hash_Length];
+    uint8_t mKe[Crypto::kMAX_Hash_Length];
 
     size_t mKeLen = sizeof(mKe);
 

--- a/src/protocols/secure_channel/RendezvousParameters.h
+++ b/src/protocols/secure_channel/RendezvousParameters.h
@@ -23,6 +23,7 @@
 #include <ble/Ble.h>
 #endif // CONFIG_NETWORK_LAYER_BLE
 
+#include <crypto/CHIPCryptoPAL.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ReliableMessageProtocolConfig.h>
 #include <protocols/secure_channel/PASESession.h>
@@ -67,8 +68,8 @@ public:
     }
 
     bool HasPASEVerifier() const { return mHasPASEVerifier; }
-    const Spake2pVerifier & GetPASEVerifier() const { return mPASEVerifier; }
-    RendezvousParameters & SetPASEVerifier(Spake2pVerifier & verifier)
+    const Crypto::Spake2pVerifier & GetPASEVerifier() const { return mPASEVerifier; }
+    RendezvousParameters & SetPASEVerifier(Crypto::Spake2pVerifier & verifier)
     {
         memmove(&mPASEVerifier, &verifier, sizeof(verifier));
         mHasPASEVerifier = true;
@@ -131,7 +132,7 @@ private:
     uint32_t mSetupPINCode  = 0;          ///< the target peripheral setup PIN Code
     uint16_t mDiscriminator = UINT16_MAX; ///< the target peripheral discriminator
 
-    Spake2pVerifier mPASEVerifier;
+    Crypto::Spake2pVerifier mPASEVerifier;
     bool mHasPASEVerifier = false;
 
     Optional<ReliableMessageProtocolConfig> mMRPConfig;

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -52,6 +52,7 @@ using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::Messaging;
 using namespace chip::Protocols;
+using namespace chip::Crypto;
 
 namespace chip {
 namespace {

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -33,6 +33,7 @@
 using namespace chip;
 using namespace chip::Protocols;
 using namespace chip::Protocols::SecureChannel;
+using namespace chip::Crypto;
 using TestSessionKeystoreImpl = Crypto::DefaultSessionKeystore;
 
 namespace chip {

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -51,6 +51,7 @@ using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::Messaging;
 using namespace chip::Protocols;
+using namespace chip::Crypto;
 
 namespace {
 

--- a/src/tools/spake2p/Cmd_GenVerifier.cpp
+++ b/src/tools/spake2p/Cmd_GenVerifier.cpp
@@ -36,6 +36,8 @@
 #include <protocols/secure_channel/PASESession.h>
 #include <setup_payload/SetupPayload.h>
 
+using namespace chip::Crypto;
+
 namespace {
 
 using namespace chip::ArgParser;
@@ -151,7 +153,7 @@ OptionSet *gCmdOptionSets[] =
 uint32_t gCount          = 1;
 uint32_t gPinCode        = chip::kSetupPINCodeUndefinedValue;
 uint32_t gIterationCount = 0;
-uint8_t gSalt[BASE64_MAX_DECODED_LEN(BASE64_ENCODED_LEN(chip::kSpake2p_Max_PBKDF_Salt_Length))];
+uint8_t gSalt[BASE64_MAX_DECODED_LEN(BASE64_ENCODED_LEN(kSpake2p_Max_PBKDF_Salt_Length))];
 uint8_t gSaltDecodedLen   = 0;
 uint8_t gSaltLen          = 0;
 const char * gOutFileName = nullptr;
@@ -215,7 +217,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
 
     case 'i':
         if (!ParseInt(arg, gIterationCount) ||
-            !(gIterationCount >= chip::kSpake2p_Min_PBKDF_Iterations && gIterationCount <= chip::kSpake2p_Max_PBKDF_Iterations))
+            !(gIterationCount >= kSpake2p_Min_PBKDF_Iterations && gIterationCount <= kSpake2p_Max_PBKDF_Iterations))
         {
             PrintArgError("%s: Invalid value specified for the iteration-count parameter: %s\n", progName, arg);
             return false;
@@ -223,8 +225,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
         break;
 
     case 'l':
-        if (!ParseInt(arg, gSaltLen) ||
-            !(gSaltLen >= chip::kSpake2p_Min_PBKDF_Salt_Length && gSaltLen <= chip::kSpake2p_Max_PBKDF_Salt_Length))
+        if (!ParseInt(arg, gSaltLen) || !(gSaltLen >= kSpake2p_Min_PBKDF_Salt_Length && gSaltLen <= kSpake2p_Max_PBKDF_Salt_Length))
         {
             PrintArgError("%s: Invalid value specified for salt length parameter: %s\n", progName, arg);
             return false;
@@ -232,7 +233,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
         break;
 
     case 's':
-        if (strlen(arg) > BASE64_ENCODED_LEN(chip::kSpake2p_Max_PBKDF_Salt_Length))
+        if (strlen(arg) > BASE64_ENCODED_LEN(kSpake2p_Max_PBKDF_Salt_Length))
         {
             fprintf(stderr, "%s: Salt parameter too long: %s\n", progName, arg);
             return false;
@@ -242,13 +243,13 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
 
         // The first check was just to make sure Base64Decode32 would not write beyond the buffer.
         // Now double-check if the length is correct.
-        if (gSaltDecodedLen > chip::kSpake2p_Max_PBKDF_Salt_Length)
+        if (gSaltDecodedLen > kSpake2p_Max_PBKDF_Salt_Length)
         {
             fprintf(stderr, "%s: Salt parameter too long: %s\n", progName, arg);
             return false;
         }
 
-        if (gSaltDecodedLen < chip::kSpake2p_Min_PBKDF_Salt_Length)
+        if (gSaltDecodedLen < kSpake2p_Min_PBKDF_Salt_Length)
         {
             fprintf(stderr, "%s: Salt parameter too short: %s\n", progName, arg);
             return false;
@@ -332,7 +333,7 @@ bool Cmd_GenVerifier(int argc, char * argv[])
 
     for (uint32_t i = 0; i < gCount; i++)
     {
-        uint8_t salt[chip::kSpake2p_Max_PBKDF_Salt_Length];
+        uint8_t salt[kSpake2p_Max_PBKDF_Salt_Length];
         if (gSaltDecodedLen == 0)
         {
             CHIP_ERROR err = chip::Crypto::DRBG_get_bytes(salt, gSaltLen);
@@ -347,7 +348,7 @@ bool Cmd_GenVerifier(int argc, char * argv[])
             memcpy(salt, gSalt, gSaltLen);
         }
 
-        chip::Spake2pVerifier verifier;
+        Spake2pVerifier verifier;
         CHIP_ERROR err = chip::PASESession::GeneratePASEVerifier(verifier, gIterationCount, chip::ByteSpan(salt, gSaltLen),
                                                                  (gPinCode == chip::kSetupPINCodeUndefinedValue), gPinCode);
         if (err != CHIP_NO_ERROR)
@@ -356,7 +357,7 @@ bool Cmd_GenVerifier(int argc, char * argv[])
             return false;
         }
 
-        chip::Spake2pVerifierSerialized serializedVerifier;
+        Spake2pVerifierSerialized serializedVerifier;
         chip::MutableByteSpan serializedVerifierSpan(serializedVerifier);
         err = verifier.Serialize(serializedVerifierSpan);
         if (err != CHIP_NO_ERROR)
@@ -365,12 +366,12 @@ bool Cmd_GenVerifier(int argc, char * argv[])
             return false;
         }
 
-        char saltB64[BASE64_ENCODED_LEN(chip::kSpake2p_Max_PBKDF_Salt_Length) + 1];
+        char saltB64[BASE64_ENCODED_LEN(kSpake2p_Max_PBKDF_Salt_Length) + 1];
         uint32_t saltB64Len = chip::Base64Encode32(salt, gSaltLen, saltB64);
         saltB64[saltB64Len] = '\0';
 
-        char verifierB64[BASE64_ENCODED_LEN(chip::kSpake2p_VerifierSerialized_Length) + 1];
-        uint32_t verifierB64Len = chip::Base64Encode32(serializedVerifier, chip::kSpake2p_VerifierSerialized_Length, verifierB64);
+        char verifierB64[BASE64_ENCODED_LEN(kSpake2p_VerifierSerialized_Length) + 1];
+        uint32_t verifierB64Len     = chip::Base64Encode32(serializedVerifier, kSpake2p_VerifierSerialized_Length, verifierB64);
         verifierB64[verifierB64Len] = '\0';
 
         if (fprintf(outFile, "%d,%08d,%d,%s,%s\n", i, gPinCode, gIterationCount, saltB64, verifierB64) < 0 || ferror(outFile))


### PR DESCRIPTION
We had all sorts of things using the wrong namespaces because everything was being imported into multiple namespaces if things happened to include certain headers.  Remove the "using namespace" bits in core headers, fix the resulting compile issues, add a lint so people stop doing that.
