### PR TITLE
Fix bootstrap caching for Darwin framework jobs.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -64,6 +64,9 @@ jobs:
             - name: Build
               working-directory: src/darwin/Framework
               run: xcodebuild -target "Matter" ${{ matrix.options.arguments }}
+            # Now restore zap-cli, so that bootstrap caching does not cache the state when it's been renamed.
+            - name: Make zap-cli work again
+              run: scripts/run_in_build_env.sh 'D=$(dirname $(which zap-cli.moved)) && mv $D/zap-cli.moved $D/zap-cli'
 
     tests:
         name: Run framework tests


### PR DESCRIPTION
In https://github.com/project-chip/connectedhomeip/pull/32583 the step to put zap-cli back got lost, so when bootstrap caching caches our state it's caching the "there is no zap-cli" state.  Then restoring from cache causes `dirname $(which zap-cli)` to fail, because there is no zap-cli in the PATH.
