### PR TITLE
Add a keybinding to darwin-framework-tool to call exit(0).

### DIFF
--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -23,8 +23,12 @@
 #include <platform/logging/LogV.h>
 
 #include <editline.h>
+#include <stdlib.h>
 
-constexpr char kInteractiveModePrompt[] = "Stop and restart stack: [Ctrl+_] & [Ctrl+^] \nQuit Interactive: 'quit()'\n>>> ";
+constexpr char kInteractiveModePrompt[] = "Stop and restart stack: [Ctrl+_] & [Ctrl+^]\n"
+                                          "Trigger exit(0): [Ctrl+@]\n"
+                                          "Quit Interactive: 'quit()'\n"
+                                          ">>> ";
 constexpr char kInteractiveModeHistoryFilePath[] = "/tmp/darwin_framework_tool_history";
 constexpr char kInteractiveModeStopCommand[] = "quit()";
 constexpr char kCategoryError[] = "Error";
@@ -296,6 +300,12 @@ el_status_t StopFunction()
     return CSstay;
 }
 
+el_status_t ExitFunction()
+{
+    exit(0);
+    return CSstay;
+}
+
 CHIP_ERROR InteractiveStartCommand::RunCommand()
 {
     read_history(kInteractiveModeHistoryFilePath);
@@ -304,8 +314,13 @@ CHIP_ERROR InteractiveStartCommand::RunCommand()
     // is dumped to stdout while the user is typing a command.
     chip::Logging::SetLogRedirectCallback(LoggingCallback);
 
+    // The valid keys to bind are listed at
+    // https://github.com/troglobit/editline/blob/425584840c09f83bb8fedbf76b599d3a917621ba/src/editline.c#L1941
+    // but note that some bindings (like Ctrl+Q) might be captured by terminals
+    // and not make their way to this code.
     el_bind_key(CTL('^'), RestartFunction);
     el_bind_key(CTL('_'), StopFunction);
+    el_bind_key(CTL('@'), ExitFunction);
 
     char * command = nullptr;
     int status;


### PR DESCRIPTION
Can be useful to test behavior if an application using the framework decides to exit().
