### PR TITLE
[Linux] Handle BLE scan timeout in BLEManager instead of scanner class

### DIFF
--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -19,13 +19,18 @@
 #include <cstdint>
 #include <memory>
 
+#include <ble/CHIPBleServiceData.h>
 #include <lib/core/CHIPError.h>
-#include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/Linux/BlePlatformConfig.h>
 #include <platform/Linux/bluez/AdapterIterator.h>
 #include <platform/Linux/bluez/BluezObjectManager.h>
+#include <platform/Linux/bluez/ChipDeviceScanner.h>
 #include <platform/Linux/dbus/bluez/DbusBluez.h>
-#include <platform/internal/BLEManager.h>
+#include <platform/PlatformManager.h>
+#include <system/SystemClock.h>
+#include <system/SystemLayer.h>
 
 using namespace chip::DeviceLayer::Internal;
 
@@ -107,9 +112,29 @@ public:
 
     void ScannerShutdown() { mBluezObjectManager.Shutdown(); }
 
-    CHIP_ERROR ScannerStartScan(chip::System::Clock::Timeout timeout) { return mScanner.StartScan(timeout); }
+    CHIP_ERROR ScannerStartScan(chip::System::Clock::Timeout timeout)
+    {
+        CHIP_ERROR err = mScanner.StartScan();
+        VerifyOrReturnError(err == CHIP_NO_ERROR, err);
 
-    CHIP_ERROR ScannerStopScan() { return mScanner.StopScan(); }
+        err = chip::DeviceLayer::SystemLayer().StartTimer(timeout, HandleScannerTimer, this);
+        VerifyOrReturnError(err == CHIP_NO_ERROR, err, mScanner.StopScan());
+
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR ScannerStopScan()
+    {
+        chip::DeviceLayer::SystemLayer().CancelTimer(HandleScannerTimer, this);
+        return mScanner.StopScan();
+    }
+
+    static void HandleScannerTimer(chip::System::Layer *, void * appState)
+    {
+        auto * delegate = static_cast<ScannerDelegateImpl *>(appState);
+        delegate->OnScanError(CHIP_ERROR_TIMEOUT);
+        delegate->mScanner.StopScan();
+    }
 
     void OnDeviceScanned(BluezDevice1 & device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) override
     {

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -760,20 +760,20 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
     err = mDeviceScanner.Init(mAdapter.get(), this);
     VerifyOrExit(err == CHIP_NO_ERROR, {
         mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
-        ChipLogError(Ble, "Failed to create BLE device scanner: %" CHIP_ERROR_FORMAT, err.Format())
+        ChipLogError(Ble, "Failed to create BLE device scanner: %" CHIP_ERROR_FORMAT, err.Format());
     });
 
     err = mDeviceScanner.StartScan();
     VerifyOrExit(err == CHIP_NO_ERROR, {
         mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
-        ChipLogError(Ble, "Failed to start BLE scan: %" CHIP_ERROR_FORMAT, err.Format())
+        ChipLogError(Ble, "Failed to start BLE scan: %" CHIP_ERROR_FORMAT, err.Format());
     });
 
     err = DeviceLayer::SystemLayer().StartTimer(kNewConnectionScanTimeout, HandleScannerTimer, this);
     VerifyOrExit(err == CHIP_NO_ERROR, {
         mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
         mDeviceScanner.StopScan();
-        ChipLogError(Ble, "Failed to start BLE scan timeout: %" CHIP_ERROR_FORMAT, err.Format())
+        ChipLogError(Ble, "Failed to start BLE scan timeout: %" CHIP_ERROR_FORMAT, err.Format());
     });
 
 exit:

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -786,8 +786,8 @@ exit:
 void BLEManagerImpl::HandleScannerTimer(chip::System::Layer *, void * appState)
 {
     auto * manager = static_cast<BLEManagerImpl *>(appState);
-    manager->mDeviceScanner.StopScan();
     manager->OnScanError(CHIP_ERROR_TIMEOUT);
+    manager->mDeviceScanner.StopScan();
 }
 
 void BLEManagerImpl::CleanScanConfig()

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -183,13 +183,6 @@ private:
         kMaxAdvertisementDataSetSize = 31  // TODO: verify this
     };
 
-    enum class ScannerTimerState
-    {
-        kCanceled,
-        kStarted,
-        kExpired,
-    };
-
     void DriveBLEState();
     BluezAdvertisement::AdvertisingIntervals GetAdvertisingIntervals() const;
     static void HandleAdvertisingTimer(chip::System::Layer *, void * appState);
@@ -213,8 +206,6 @@ private:
 
     ChipDeviceScanner mDeviceScanner{ mBluezObjectManager };
     BLEScanConfig mBLEScanConfig;
-    // Used to track if timer has already expired and doesn't need to be canceled.
-    ScannerTimerState mBLEScanTimerState = ScannerTimerState::kCanceled;
 };
 
 /**

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -183,10 +183,18 @@ private:
         kMaxAdvertisementDataSetSize = 31  // TODO: verify this
     };
 
+    enum class ScannerTimerState
+    {
+        kCanceled,
+        kStarted,
+        kExpired,
+    };
+
     void DriveBLEState();
     BluezAdvertisement::AdvertisingIntervals GetAdvertisingIntervals() const;
     static void HandleAdvertisingTimer(chip::System::Layer *, void * appState);
     void InitiateScan(BleScanState scanType);
+    static void HandleScannerTimer(chip::System::Layer *, void * appState);
     void CleanScanConfig();
 
     CHIPoBLEServiceMode mServiceMode;
@@ -205,6 +213,8 @@ private:
 
     ChipDeviceScanner mDeviceScanner{ mBluezObjectManager };
     BLEScanConfig mBLEScanConfig;
+    // Used to track if timer has already expired and doesn't need to be canceled.
+    ScannerTimerState mBLEScanTimerState = ScannerTimerState::kCanceled;
 };
 
 /**

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -73,7 +73,7 @@ public:
     ///
     /// This method must be called while in the Matter context (from the Matter event
     /// loop, or while holding the Matter stack lock).
-    CHIP_ERROR StartScan(System::Clock::Timeout timeout);
+    CHIP_ERROR StartScan();
 
     /// Stop any currently running scan
     CHIP_ERROR StopScan();
@@ -91,16 +91,8 @@ private:
         SCANNER_SCANNING
     };
 
-    enum ScannerTimerState
-    {
-        TIMER_CANCELED,
-        TIMER_STARTED,
-        TIMER_EXPIRED
-    };
-
     CHIP_ERROR StartScanImpl();
     CHIP_ERROR StopScanImpl();
-    static void TimerExpiredCallback(chip::System::Layer * layer, void * appState);
 
     /// Check if a given device is a CHIP device and if yes, report it as discovered
     void ReportDevice(BluezDevice1 & device);
@@ -114,8 +106,6 @@ private:
 
     ChipDeviceScannerDelegate * mDelegate = nullptr;
     ChipDeviceScannerState mScannerState  = ChipDeviceScannerState::SCANNER_UNINITIALIZED;
-    /// Used to track if timer has already expired and doesn't need to be canceled.
-    ScannerTimerState mTimerState = ScannerTimerState::TIMER_CANCELED;
     GAutoPtr<GCancellable> mCancellable;
 };
 

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -78,6 +78,9 @@ public:
     /// Stop any currently running scan
     CHIP_ERROR StopScan();
 
+    /// Check if the scanner is active
+    bool IsScanning() const { return mScannerState == ChipDeviceScannerState::SCANNER_SCANNING; }
+
     /// Members that implement virtual methods on BluezObjectManagerAdapterNotificationsDelegate
     void OnDeviceAdded(BluezDevice1 & device) override;
     void OnDevicePropertyChanged(BluezDevice1 & device, GVariant * changedProps, const char * const * invalidatedProps) override;


### PR DESCRIPTION
### Problem

Scanning timeout is handler directly in the scanner class. This coupling prevents scanner restarting without restarting timer as well. In order to properly handle BlueZ restart (due to BlueZ crash), it's required to separate scan timeout and start/stop logic.

### Changes

Handle BLE scan timeout in BLEManager instead of scanner class. Just like timeout for advertisement and BLE connection.

### Testing

Tested BLE scanning timeout with `chip-tool pairing ble-wifi ...` and with `chip-repl`.

@tianfeng-yang could you verify that your use case still works as expected (fix that you've made in https://github.com/project-chip/connectedhomeip/pull/31412)?