### PR TITLE
Fix issues in 27575

### DIFF
--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -2792,7 +2792,7 @@ endpoint 0 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0x0B;
-    ram      attribute clusterRevision default = 1;
+    ram      attribute clusterRevision default = 2;
 
     handle command SetUTCTime;
     handle command SetTrustedTimeSource;

--- a/examples/light-switch-app/light-switch-common/light-switch-app.zap
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.zap
@@ -3826,7 +3826,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "1",
+              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/src/app/clusters/time-synchronization-server/DefaultTimeSyncDelegate.cpp
+++ b/src/app/clusters/time-synchronization-server/DefaultTimeSyncDelegate.cpp
@@ -78,3 +78,13 @@ void DefaultTimeSyncDelegate::UTCTimeAvailabilityChanged(uint64_t time)
 {
     // placeholder implementation
 }
+
+void DefaultTimeSyncDelegate::TrustedTimeSourceAvailabilityChanged(bool available, GranularityEnum granularity)
+{
+    // placeholder implementation
+}
+
+void DefaultTimeSyncDelegate::NotifyTimeFailure()
+{
+    // placeholder implementation
+}

--- a/src/app/clusters/time-synchronization-server/DefaultTimeSyncDelegate.h
+++ b/src/app/clusters/time-synchronization-server/DefaultTimeSyncDelegate.h
@@ -37,6 +37,8 @@ public:
     CHIP_ERROR UpdateTimeUsingNTPFallback(const CharSpan & fallbackNTP,
                                           chip::Callback::Callback<OnFallbackNTPCompletion> * callback) override;
     void UTCTimeAvailabilityChanged(uint64_t time) override;
+    void TrustedTimeSourceAvailabilityChanged(bool available, GranularityEnum granularity) override;
+    void NotifyTimeFailure() override;
 };
 
 } // namespace TimeSynchronization

--- a/src/app/clusters/time-synchronization-server/time-synchronization-delegate.h
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-delegate.h
@@ -109,7 +109,9 @@ public:
     /**
      * @brief Signals application that UTCTime has changed through the timesync cluster.
      */
-    virtual void UTCTimeAvailabilityChanged(uint64_t time) = 0;
+    virtual void UTCTimeAvailabilityChanged(uint64_t time)                                         = 0;
+    virtual void TrustedTimeSourceAvailabilityChanged(bool available, GranularityEnum granularity) = 0;
+    virtual void NotifyTimeFailure()                                                               = 0;
 
     virtual ~Delegate() = default;
 

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -589,20 +589,14 @@ CHIP_ERROR TimeSynchronizationServer::SetTimeZone(const DataModel::DecodableList
         tzStore.timeZone.validAt = newTz.validAt;
         if (newTz.name.HasValue() && newTz.name.Value().size() > 0)
         {
-            size_t len = newTz.name.Value().size();
-            if (len > sizeof(tzStore.name))
-            {
-                LoadTimeZone();
-                return CHIP_IM_GLOBAL_STATUS(ConstraintError);
-            }
             memset(tzStore.name, 0, sizeof(tzStore.name));
-            chip::MutableCharSpan tempSpan(tzStore.name, len);
+            chip::MutableCharSpan tempSpan(tzStore.name);
             if (CHIP_NO_ERROR != CopyCharSpanToMutableCharSpan(newTz.name.Value(), tempSpan))
             {
                 LoadTimeZone();
                 return CHIP_IM_GLOBAL_STATUS(InvalidCommand);
             }
-            tzStore.timeZone.name.SetValue(CharSpan(tzStore.name, len));
+            tzStore.timeZone.name.SetValue(tempSpan);
         }
         else
         {

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -570,20 +570,20 @@ CHIP_ERROR TimeSynchronizationServer::SetTimeZone(const DataModel::DecodableList
         const auto & newTz = newTzL.GetValue();
         if (newTz.offset < -43200 || newTz.offset > 50400)
         {
-            ReturnErrorOnFailure(LoadTimeZone());
-            return CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_IB;
+            LoadTimeZone();
+            return CHIP_IM_GLOBAL_STATUS(ConstraintError);
         }
         // first element shall have validAt entry of 0
         if (i == 0 && newTz.validAt != 0)
         {
-            ReturnErrorOnFailure(LoadTimeZone());
-            return CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_IB;
+            LoadTimeZone();
+            return CHIP_IM_GLOBAL_STATUS(ConstraintError);
         }
         // if second element, it shall have validAt entry of non-0
         if (i != 0 && newTz.validAt == 0)
         {
-            ReturnErrorOnFailure(LoadTimeZone());
-            return CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_IB;
+            LoadTimeZone();
+            return CHIP_IM_GLOBAL_STATUS(ConstraintError);
         }
         tzStore.timeZone.offset  = newTz.offset;
         tzStore.timeZone.validAt = newTz.validAt;
@@ -592,14 +592,14 @@ CHIP_ERROR TimeSynchronizationServer::SetTimeZone(const DataModel::DecodableList
             size_t len = newTz.name.Value().size();
             if (len > sizeof(tzStore.name))
             {
-                ReturnErrorOnFailure(LoadTimeZone());
-                return CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_IB;
+                LoadTimeZone();
+                return CHIP_IM_GLOBAL_STATUS(ConstraintError);
             }
             memset(tzStore.name, 0, sizeof(tzStore.name));
             chip::MutableCharSpan tempSpan(tzStore.name, len);
             if (CHIP_NO_ERROR != CopyCharSpanToMutableCharSpan(newTz.name.Value(), tempSpan))
             {
-                ReturnErrorOnFailure(LoadTimeZone());
+                LoadTimeZone();
                 return CHIP_IM_GLOBAL_STATUS(InvalidCommand);
             }
             tzStore.timeZone.name.SetValue(CharSpan(tzStore.name, len));
@@ -612,7 +612,7 @@ CHIP_ERROR TimeSynchronizationServer::SetTimeZone(const DataModel::DecodableList
     }
     if (CHIP_NO_ERROR != newTzL.GetStatus())
     {
-        ReturnErrorOnFailure(LoadTimeZone());
+        LoadTimeZone();
         return CHIP_IM_GLOBAL_STATUS(InvalidCommand);
     }
 

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -620,7 +620,8 @@ CHIP_ERROR TimeSynchronizationServer::SetTimeZone(const DataModel::DecodableList
         {
             emit = true;
         }
-        if ((tz.name.HasValue() && lastTz.name.HasValue()) && !(tz.name.Value().data_equal(lastTz.name.Value())))
+        if (tz.name.HasValue() != lastTz.name.HasValue() ||
+            ((tz.name.HasValue() && lastTz.name.HasValue()) && !(tz.name.Value().data_equal(lastTz.name.Value()))))
         {
             emit = true;
         }

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -194,7 +194,7 @@ static bool emitTimeZoneStatusEvent(EndpointId ep)
         return false;
     }
 
-    ChipLogProgress(Zcl, "TimeZoneStatusEvent offset: %ld", tz.offset);
+    ChipLogProgress(Zcl, "TimeZoneStatusEvent offset: %d", static_cast<int>(tz.offset));
     return true;
 }
 

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -659,7 +659,7 @@ CHIP_ERROR TimeSynchronizationServer::SetDSTOffset(const DataModel::DecodableLis
     size_t items;
     VerifyOrReturnError(CHIP_NO_ERROR == dstL.ComputeSize(&items), CHIP_IM_GLOBAL_STATUS(InvalidCommand));
 
-    if (items > CHIP_CONFIG_DST_OFFSET_LIST_MAX_SIZE)
+    if (items > mDstOffsetObj.dstOffsetList.size())
     {
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
@@ -778,7 +778,7 @@ CHIP_ERROR TimeSynchronizationServer::SetUTCTime(EndpointId ep, uint64_t utcTime
     if (!(status == Status::Success || status == Status::UnsupportedAttribute))
     {
         ChipLogError(Zcl, "Writing TimeSource failed.");
-        return CHIP_IM_GLOBAL_STATUS(Failure);
+        return StatusIB(status).ToChipError();
     }
     return CHIP_NO_ERROR;
 }

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -853,7 +853,6 @@ TimeState TimeSynchronizationServer::UpdateTimeZoneState()
     }
     if (activeTzIndex != 0)
     {
-        mTimeZoneObj.validSize = tzList.size() - activeTzIndex;
         auto newTimeZoneList   = tzList.SubSpan(activeTzIndex);
         VerifyOrReturnValue(mTimeSyncDataProvider.StoreTimeZone(newTimeZoneList) == CHIP_NO_ERROR, TimeState::kInvalid);
         VerifyOrReturnValue(LoadTimeZone() == CHIP_NO_ERROR, TimeState::kInvalid);
@@ -911,7 +910,6 @@ TimeState TimeSynchronizationServer::UpdateDSTOffsetState()
     }
     if (activeDstIndex > 0)
     {
-        mDstOffsetObj.validSize = dstList.size() - activeDstIndex;
         auto newDstOffsetList   = dstList.SubSpan(activeDstIndex);
         VerifyOrReturnValue(mTimeSyncDataProvider.StoreDSTOffset(newDstOffsetList) == CHIP_NO_ERROR, TimeState::kInvalid);
         VerifyOrReturnValue(LoadDSTOffset() == CHIP_NO_ERROR, TimeState::kInvalid);

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -1095,7 +1095,7 @@ bool emberAfTimeSynchronizationClusterSetUTCTimeCallback(
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;
     }
-    if (timeSource.HasValue() && (timeSource.Value() < TimeSourceEnum::kNone || timeSource.Value() > TimeSourceEnum::kGnss))
+    if (timeSource.HasValue() && timeSource.Value() == TimeSourceEnum::kUnknownEnumValue)
     {
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return true;

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -194,7 +194,7 @@ static bool emitTimeZoneStatusEvent(EndpointId ep)
         return false;
     }
 
-    ChipLogProgress(Zcl, "TimeZoneStatusEvent offset: %d", tz.offset);
+    ChipLogProgress(Zcl, "TimeZoneStatusEvent offset: %ld", tz.offset);
     return true;
 }
 

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.h
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.h
@@ -61,12 +61,12 @@ enum class TimeState : uint8_t
  */
 enum class TimeSyncEventFlag : uint8_t
 {
-    kNone            = 0,
-    kDSTTableEmpty   = 1,
-    kDSTStatus       = 2,
-    kTimeZoneStatus  = 4,
-    kTimeFailure     = 8,
-    kMissingTTSource = 16,
+    kNone            = 0x0,
+    kDSTTableEmpty   = 0x1,
+    kDSTStatus       = 0x2,
+    kTimeZoneStatus  = 0x4,
+    kTimeFailure     = 0x8,
+    kMissingTTSource = 0x10,
 };
 
 void SetDefaultDelegate(Delegate * delegate);
@@ -109,7 +109,7 @@ public:
 
     TimeState UpdateTimeZoneState();
     TimeState UpdateDSTOffsetState();
-    TimeSyncEventFlag GetEventFlag(void);
+    BitMask<TimeSyncEventFlag> GetEventFlag(void);
     void ClearEventFlag(TimeSyncEventFlag flag);
 
     // Fabric Table delegate functions
@@ -123,6 +123,8 @@ public:
     // ReadClient::Callback functions
     void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override;
     void OnDone(ReadClient * apReadClient) override;
+
+    CHIP_ERROR AttemptToGetTimeFromTrustedNode();
 #endif
 
     // Platform event handler functions
@@ -143,7 +145,7 @@ private:
 
     TimeSyncDataProvider mTimeSyncDataProvider;
     static TimeSynchronizationServer sTimeSyncInstance;
-    TimeSyncEventFlag mEventFlag = TimeSyncEventFlag::kNone;
+    BitMask<TimeSyncEventFlag> mEventFlag;
 #if TIME_SYNC_ENABLE_TSC_FEATURE
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
@@ -166,7 +168,6 @@ private:
 
     // Called when the platform is set up - attempts to get time using the recommended source list in the spec.
     void AttemptToGetTime();
-    CHIP_ERROR AttemptToGetTimeFromTrustedNode();
     // Attempts to get fallback NTP from the delegate (last available source)
     // If successful, the function will set mGranulatiry and the time source
     // If unsuccessful, it will emit a TimeFailure event.

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.h
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.h
@@ -52,21 +52,7 @@ enum class TimeState : uint8_t
 {
     kInvalid = 0, // No valid offset available
     kActive  = 1, // An offset is currently being used
-    kChanged = 2, // An offset expired or changed to a new value
-    kStopped = 3, // Permanent item in use
-};
-
-/**
- * @brief Flags for tracking event types to emit.
- */
-enum class TimeSyncEventFlag : uint8_t
-{
-    kNone            = 0x0,
-    kDSTTableEmpty   = 0x1,
-    kDSTStatus       = 0x2,
-    kTimeZoneStatus  = 0x4,
-    kTimeFailure     = 0x8,
-    kMissingTTSource = 0x10,
+    kStopped = 2, // Permanent item in use
 };
 
 void SetDefaultDelegate(Delegate * delegate);
@@ -107,10 +93,24 @@ public:
 
     void ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action, void * aAppState);
 
+    /**
+     * @brief Updates time zone to the correct item from the time zone list.
+     * If the TimeState has changed from the previous state, the function will emit a TimeZoneStatus event.
+     *
+     * Returns kInvalid if an error occurrs.
+     * Otherwise, it returns kActive since there is always a default time zone available.
+     * kStopped is not used in this function.
+     */
     TimeState UpdateTimeZoneState();
+    /**
+     * @brief Updates DST offset to the correct item from the DSTOffset list.
+     * If the DST offset has changed from the previous state or value, the function will emit a DSTStatus event.
+     *
+     * Returns kInvalid if an error occurrs or the DSTOffset list is empty.
+     * Returns kActive if a DST offset is being used.
+     * Returns kStopped if no DST offset is applicable at the current time.
+     */
     TimeState UpdateDSTOffsetState();
-    BitMask<TimeSyncEventFlag> GetEventFlag(void);
-    void ClearEventFlag(TimeSyncEventFlag flag);
 
     // Fabric Table delegate functions
     void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override;
@@ -145,7 +145,8 @@ private:
 
     TimeSyncDataProvider mTimeSyncDataProvider;
     static TimeSynchronizationServer sTimeSyncInstance;
-    BitMask<TimeSyncEventFlag> mEventFlag;
+    TimeState mTimeZoneState  = TimeState::kInvalid;
+    TimeState mDSTOffsetState = TimeState::kInvalid;
 #if TIME_SYNC_ENABLE_TSC_FEATURE
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;

--- a/src/app/tests/suites/TestTimeSynchronization.yaml
+++ b/src/app/tests/suites/TestTimeSynchronization.yaml
@@ -196,10 +196,7 @@ tests:
       command: "readAttribute"
       attribute: "DSTOffset"
       response:
-          value:
-              [
-                  { Offset: 0, ValidStarting: 3, ValidUntil: null }
-              ]
+          value: [{ Offset: 0, ValidStarting: 3, ValidUntil: null }]
 
     - label: "Set DSTOffset with same validStarting and validUntil"
       command: "SetDSTOffset"

--- a/src/app/tests/suites/TestTimeSynchronization.yaml
+++ b/src/app/tests/suites/TestTimeSynchronization.yaml
@@ -127,9 +127,7 @@ tests:
               - name: "TimeZone"
                 value: []
       response:
-          values:
-              - name: "DSTOffsetRequired"
-                value: true
+          error: CONSTRAINT_ERROR
 
     - label: "Read Time Zone"
       command: "readAttribute"
@@ -200,8 +198,7 @@ tests:
       response:
           value:
               [
-                  { Offset: 1, ValidStarting: 1, ValidUntil: 2 },
-                  { Offset: 0, ValidStarting: 3, ValidUntil: null },
+                  { Offset: 0, ValidStarting: 3, ValidUntil: null }
               ]
 
     - label: "Set DSTOffset with same validStarting and validUntil"

--- a/src/python_testing/TC_TIMESYNC_2_1.py
+++ b/src/python_testing/TC_TIMESYNC_2_1.py
@@ -144,7 +144,7 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
                 asserts.assert_true(local_dut is NullValue, "LocalTime must be Null if the DST table is empty")
             else:
                 local_calculated = utc_dut + dst_dut[0].offset + tz_dut[0].offset
-                delta_us = abs(local_dut, local_calculated)
+                delta_us = abs(local_dut - local_calculated)
                 delta = timedelta(microseconds=delta_us)
                 toleranace = timedelta(minutes=1)
                 asserts.assert_less_equal(delta, toleranace, "Local time caluclation is not within tolerance of calculated value")


### PR DESCRIPTION
Description of issues fixed from #27575 :

- When setting time zone fails, this code was returning the error of LoadTimeZone(), if it failed, before returning ConstraintError. Fixed to return the correct error, ConstraintError, and ignore the error of LoadTimeZone(). https://github.com/project-chip/connectedhomeip/pull/26082#discussion_r1240951613
- Return ConstraintError instead of CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_IB when checking time zone constraints. https://github.com/project-chip/connectedhomeip/pull/26082#discussion_r1240951626
- Improved time zone name copying as proposed by @bzbarsky-apple https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242621779
- generate time zone status event when time zone name changes in every aspect https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242626060
- removed event flag since implementation is changed https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242627777, https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242657708 
- use actual size of buffer instead of the macro for the attribute size when comparing to incoming list size https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242630331, https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242613876
- propagate error when setting TimeSource through attribute store https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242639975
- make sure that the dst list is kept updated or expired items are dropped in every situation https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242655854
- don't encode local time when GetLocalTime errors https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242660231
- use unknown value check for enums https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242667611, https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242668186, https://github.com/project-chip/connectedhomeip/pull/26082#discussion_r1242668186
- return ConstraintError for invalid enum values https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242673209
- tighten up granularity check & set to one lower value https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242671601, https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242676471
- handle event generation in update dst and time zone functions. Only exception is when the change of state can only be detected in the ember command callbacks - https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242683543, https://github.com/project-chip/connectedhomeip/pull/26082#discussion_r1242628037
- adjust revision in the lighting app example https://github.com/project-chip/connectedhomeip/pull/26082#discussion_r1241227274
- add check for name storage and incoming before copying https://github.com/project-chip/connectedhomeip/pull/26082#discussion_r1242607150
- use CHIP_IM_GLOBAL_STATUS instead of using random error code in SetDSTOffset https://github.com/project-chip/connectedhomeip/pull/26082#discussion_r1242631916
- minor code changes https://github.com/project-chip/connectedhomeip/pull/26082/files#r1242658973, https://github.com/project-chip/connectedhomeip/pull/26082#discussion_r1242628882

Addition of delegate functions for better usability:

- TrustedTimeSourceAvailabilityChanged()
- NotifyTimeFailure()