### PR TITLE
[Silabs]Update and cleanup build_examples silabs targets and regroup wifi ncp in ci

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -122,7 +122,7 @@ jobs:
         run: |
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
             efr32 BRD4338a lock-app \
-            out/efr32-brd4338a-lock-skip-rps-generation/matter-silabs-lighting-example.out \
+            out/efr32-brd4338a-lock-skip-rps-generation/matter-silabs-lock-example.out \
             /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -65,8 +65,8 @@ jobs:
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \
                 --enable-flashbundle \
-                --target efr32-brd4187c-thermostat-openthread_mtd \
-                --target efr32-brd4187c-switch-shell-use_ot_coap_lib \
+                --target efr32-brd4187c-thermostat-openthread-mtd \
+                --target efr32-brd4187c-switch-shell-use-ot-coap-lib \
                 --target efr32-brd4187c-unit-test \
                 build \
                 --copy-artifacts-to out/artifacts \
@@ -78,9 +78,9 @@ jobs:
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \
                 --enable-flashbundle \
-                --target efr32-brd4187c-light-use_ot_lib \
+                --target efr32-brd4187c-light-use-ot-lib \
                 --target efr32-brd4187c-pump \
-                --target efr32-brd4187c-lock-shell-enable_heap_monitoring \
+                --target efr32-brd4187c-lock-shell-heap-monitoring \
                 build \
                 --copy-artifacts-to out/artifacts \
              "
@@ -91,7 +91,7 @@ jobs:
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \
                 --enable-flashbundle \
-                --target efr32-brd4187c-window-covering-additional_data_advertising \
+                --target efr32-brd4187c-window-covering-additional-data-advertising \
                 --target efr32-brd4187c-light-rpc \
                 build \
                 --copy-artifacts-to out/artifacts \
@@ -104,34 +104,39 @@ jobs:
              /tmp/bloat_reports/
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py  \
              efr32 BRD4187C window-app \
-             out/efr32-brd4187c-window-covering-additional_data_advertising/matter-silabs-window-example.out \
+             out/efr32-brd4187c-window-covering-additional-data-advertising/matter-silabs-window-example.out \
              /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out
-      - name: Build BRD4338A variants
+      - name: Build BRD4338A WiFi Soc variants
         run: |
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \
                 --enable-flashbundle \
-                --target efr32-brd4338a-light-wifi-917_soc-skip_rps_generation \
-                --target efr32-brd4338a-lock-wifi-917_soc-skip_rps_generation \
+                --target efr32-brd4338a-light-skip-rps-generation \
+                --target efr32-brd4338a-lock-skip-rps-generation \
                 build \
                 --copy-artifacts-to out/artifacts \
              "
+      - name: Prepare bloat report for brd4338a lock app
+        run: |
+          .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+            efr32 BRD4338a lock-app \
+            out/efr32-brd4338a-lock-skip-rps-generation/matter-silabs-lighting-example.out \
+            /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out
-      - name: Build example EFR32+WF200 WiFi Lock app for BRD4161A
+      - name: Build EFR32 with WiFi NCP
         run: |
-          scripts/examples/gn_silabs_example.sh examples/lock-app/silabs out/lock_app_wifi_wf200 BRD4161A is_debug=false chip_logging=false --wifi wf200 --docker
-          .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py efr32 BRD4161A+wf200 lock-app \
-            out/lock_app_wifi_wf200/BRD4161A/matter-silabs-lock-example.out /tmp/bloat_reports/
-      - name: Clean out build output
-        run: rm -rf ./out
-      - name: Build example EFR32+RS9116 WiFi Lighting app for BRD4161A
-        run: |
-          scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs out/lighting_app_wifi_rs9116 BRD4161A --wifi rs9116 --docker
-          .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py efr32 BRD4161A+rs9116 lighting-app \
-            out/lighting_app_wifi_rs9116/BRD4161A/matter-silabs-lighting-example.out /tmp/bloat_reports/
+          ./scripts/run_in_build_env.sh \
+            "./scripts/build/build_examples.py \
+                --enable-flashbundle \
+                --target efr32-brd4187c-lock-wifi-siwx917 \
+                --target efr32-brd4187c-light-wifi-rs9116 \
+                --target efr32-brd4187c-lock-wifi-wf200 \
+                build \
+                --copy-artifacts-to out/artifacts \
+            "
       - name: Clean out build output
         run: rm -rf ./out
       - name: Uploading Size Reports

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -238,7 +238,7 @@ def BuildEfr32Target():
         TargetPart('brd4186a', board=Efr32Board.BRD4186A),
         TargetPart('brd4187a', board=Efr32Board.BRD4187A),
         TargetPart('brd4304a', board=Efr32Board.BRD4304A),
-        TargetPart('brd4338a', board=Efr32Board.BRD4338A),
+        TargetPart('brd4338a', board=Efr32Board.BRD4338A, enable_wifi=True, enable_917_soc=True),
     ])
 
     # apps
@@ -257,26 +257,26 @@ def BuildEfr32Target():
     target.AppendModifier('icd', enable_icd=True)
     target.AppendModifier('low-power', enable_low_power=True).OnlyIfRe('-icd')
     target.AppendModifier('shell', chip_build_libshell=True)
-    target.AppendModifier('no_logging', chip_logging=False)
-    target.AppendModifier('openthread_mtd', chip_openthread_ftd=False)
-    target.AppendModifier('enable_heap_monitoring',
+    target.AppendModifier('no-logging', chip_logging=False)
+    target.AppendModifier('openthread-mtd', chip_openthread_ftd=False)
+    target.AppendModifier('heap-monitoring',
                           enable_heap_monitoring=True)
-    target.AppendModifier('no_openthread_cli', enable_openthread_cli=False)
+    target.AppendModifier('no-openthread-cli', enable_openthread_cli=False)
     target.AppendModifier(
-        'show_qr_code', show_qr_code=True).ExceptIfRe('-low-power')
+        'show-qr-code', show_qr_code=True).ExceptIfRe('-low-power')
     target.AppendModifier('wifi', enable_wifi=True)
-    target.AppendModifier('rs911x', enable_rs911x=True).OnlyIfRe('-wifi')
+    target.AppendModifier('rs9116', enable_rs9116=True).OnlyIfRe('-wifi')
     target.AppendModifier('wf200', enable_wf200=True).OnlyIfRe('-wifi')
-    target.AppendModifier('wifi_ipv4', enable_wifi_ipv4=True).OnlyIfRe('-wifi')
-    target.AppendModifier('917_soc', enable_917_soc=True).OnlyIfRe('-wifi')
-    target.AppendModifier('additional_data_advertising',
+    target.AppendModifier('siwx917', enable_917_ncp=True).OnlyIfRe('-wifi')
+    target.AppendModifier('ipv4', enable_wifi_ipv4=True).OnlyIfRe('-wifi')
+    target.AppendModifier('additional-data-advertising',
                           enable_additional_data_advertising=True)
-    target.AppendModifier('use_ot_lib', enable_ot_lib=True).ExceptIfRe(
-        '-(wifi|use_ot_coap_lib)')
-    target.AppendModifier('use_ot_coap_lib', enable_ot_coap_lib=True).ExceptIfRe(
-        '-(wifi|use_ot_lib)')
+    target.AppendModifier('use-ot-lib', enable_ot_lib=True).ExceptIfRe(
+        '-(wifi|use-ot-coap-lib)')
+    target.AppendModifier('use-ot-coap-lib', enable_ot_coap_lib=True).ExceptIfRe(
+        '-(wifi|use-ot-lib)')
     target.AppendModifier('no-version', no_version=True)
-    target.AppendModifier('skip_rps_generation', use_rps_extension=False).OnlyIfRe('-wifi')
+    target.AppendModifier('skip-rps-generation', use_rps_extension=False)
 
     return target
 

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -146,8 +146,9 @@ class Efr32Builder(GnBuilder):
                  enable_icd: bool = False,
                  enable_low_power: bool = False,
                  enable_wifi: bool = False,
-                 enable_rs911x: bool = False,
+                 enable_rs9116: bool = False,
                  enable_wf200: bool = False,
+                 enable_917_ncp: bool = False,
                  enable_wifi_ipv4: bool = False,
                  enable_additional_data_advertising: bool = False,
                  enable_ot_lib: bool = False,
@@ -196,19 +197,22 @@ class Efr32Builder(GnBuilder):
 
         if enable_wifi:
             self.dotfile += self.root + '/build_for_wifi_gnfile.gn'
-            if board == Efr32Board.BRD4161A:
-                self.extra_gn_options.append('is_debug=false chip_logging=false')
-            else:
-                self.extra_gn_options.append('disable_lcd=true use_external_flash=false')
-
-            if enable_rs911x:
-                self.extra_gn_options.append('use_rs911x=true')
-            elif enable_wf200:
-                self.extra_gn_options.append('use_wf200=true')
-            elif enable_917_soc:
+            if enable_917_soc:
+                # Wifi SoC platform
                 self.extra_gn_options.append('chip_device_platform=\"SiWx917\"')
             else:
-                raise Exception('Wifi usage: ...-wifi-[rs911x|wf200]-...')
+                # EFR32 + WiFi NCP combos
+                if board == Efr32Board.BRD4161A:
+                    self.extra_gn_options.append('is_debug=false chip_logging=false')
+
+                if enable_rs9116:
+                    self.extra_gn_options.append('use_rs9116=true chip_device_platform =\"efr32\"')
+                elif enable_wf200:
+                    self.extra_gn_options.append('use_wf200=true chip_device_platform =\"efr32\"')
+                elif enable_917_ncp:
+                    self.extra_gn_options.append('use_SiWx917=true chip_device_platform =\"efr32\"')
+                else:
+                    raise Exception('Wifi usage: ...-wifi-[rs9116|wf200|siwx917]-...')
 
         if enable_wifi_ipv4:
             self.extra_gn_options.append('chip_enable_wifi_ipv4=true')
@@ -231,9 +235,9 @@ class Efr32Builder(GnBuilder):
             branchName = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).decode('ascii').strip()
             self.extra_gn_options.append(
                 'sl_matter_version_str="v1.3-%s-%s"' % (branchName, shortCommitSha))
-        if enable_917_soc:
-            if use_rps_extension is False:
-                self.extra_gn_options.append('use_rps_extension=false')
+
+        if use_rps_extension is False:
+            self.extra_gn_options.append('use_rps_extension=false')
 
         if "GSDK_ROOT" in os.environ:
             # EFR32 SDK is very large. If the SDK path is already known (the
@@ -244,11 +248,11 @@ class Efr32Builder(GnBuilder):
         if "GSDK_ROOT" in os.environ and not enable_wifi:
             self.extra_gn_options.append(f"openthread_root=\"{sdk_path}/util/third_party/openthread\"")
 
-        if "WISECONNECT_SDK_ROOT" in os.environ and enable_rs911x:
+        if "WISECONNECT_SDK_ROOT" in os.environ:
             wiseconnect_sdk_path = shlex.quote(os.environ['WISECONNECT_SDK_ROOT'])
             self.extra_gn_options.append(f"wiseconnect_sdk_root=\"{wiseconnect_sdk_path}\"")
 
-        if "WIFI_SDK_ROOT" in os.environ and enable_917_soc:
+        if "WIFI_SDK_ROOT" in os.environ:
             wifi_sdk_path = shlex.quote(os.environ['WIFI_SDK_ROOT'])
             self.extra_gn_options.append(f"wifi_sdk_root=\"{wifi_sdk_path}\"")
 

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -6,7 +6,7 @@ cc32xx-{lock,air-purifier}
 ti-cc13x2x7_26x2x7-{lighting,lock,pump,pump-controller}[-mtd]
 ti-cc13x4_26x4-{all-clusters,lighting,lock,pump,pump-controller}[-mtd][-ftd]
 cyw30739-cyw930739m2evb_01-{light,lock,ota-requestor,switch}
-efr32-{brd4161a,brd4187c,brd4186c,brd4163a,brd4164a,brd4166a,brd4170a,brd4186a,brd4187a,brd4304a,brd4338a}-{window-covering,switch,unit-test,light,lock,thermostat,pump}[-rpc][-with-ota-requestor][-icd][-low-power][-shell][-no_logging][-openthread_mtd][-enable_heap_monitoring][-no_openthread_cli][-show_qr_code][-wifi][-rs911x][-wf200][-wifi_ipv4][-917_soc][-additional_data_advertising][-use_ot_lib][-use_ot_coap_lib][-no-version][-skip_rps_generation]
+efr32-{brd4161a,brd4187c,brd4186c,brd4163a,brd4164a,brd4166a,brd4170a,brd4186a,brd4187a,brd4304a,brd4338a}-{window-covering,switch,unit-test,light,lock,thermostat,pump}[-rpc][-with-ota-requestor][-icd][-low-power][-shell][-no-logging][-openthread-mtd][-heap-monitoring][-no-openthread-cli][-show-qr-code][-wifi][-rs9116][-wf200][-siwx917][-ipv4][-additional-data-advertising][-use-ot-lib][-use-ot-coap-lib][-no-version][-skip-rps-generation]
 esp32-{m5stack,c3devkit,devkitc,qemu}-{all-clusters,all-clusters-minimal,energy-management,ota-provider,ota-requestor,shell,light,lock,bridge,temperature-measurement,ota-requestor,tests}[-rpc][-ipv6only][-tracing]
 genio-lighting-app
 linux-fake-tests[-mbedtls][-boringssl][-asan][-tsan][-ubsan][-libfuzzer][-ossfuzz][-coverage][-dmalloc][-clang]


### PR DESCRIPTION
Target changes
- Standardize the Append modifier. e.g.: replace all `_` by `-`
- Add option for siwx917 as ncp build.
- Reduce the needed modifiers for 917 soc build.
- Simplify some conditional statements

Workflow changes
- Update build command with target changes mentioned above
- Add bloat check for Wifi soc build
- Regroup EFR32 with WiFi ncp in one ci run with build_example command