### PR TITLE
[ESP32] Fix sntp initialization

### DIFF
--- a/examples/platform/esp32/time/TimeSync.cpp
+++ b/examples/platform/esp32/time/TimeSync.cpp
@@ -22,7 +22,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 
 static constexpr time_t kMinValidTimeStampEpoch = 1704067200; // 1 Jan 2019
-static constexpr uint32_t kSecondsInADay        = 24 * 60 * 60;
+static constexpr uint32_t kMilliSecondsInADay   = 24 * 60 * 60 * 1000;
 
 namespace {
 const uint8_t kMaxNtpServerStringSize = 128;
@@ -86,6 +86,11 @@ namespace chip {
 namespace Esp32TimeSync {
 void Init(const char * aSntpServerName, const uint16_t aSyncSntpIntervalDay)
 {
+    if (!aSyncSntpIntervalDay)
+    {
+        ChipLogError(DeviceLayer, "Invalid SNTP synchronization time interval.");
+        return;
+    }
     chip::Platform::CopyString(sSntpServerName, aSntpServerName);
     if (esp_sntp_enabled())
     {
@@ -94,9 +99,9 @@ void Init(const char * aSntpServerName, const uint16_t aSyncSntpIntervalDay)
     ChipLogProgress(DeviceLayer, "Initializing SNTP. Using the SNTP server: %s", sSntpServerName);
     esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
     esp_sntp_setservername(0, sSntpServerName);
-    esp_sntp_set_sync_interval(kSecondsInADay * aSyncSntpIntervalDay);
-    esp_sntp_init();
+    esp_sntp_set_sync_interval(kMilliSecondsInADay * aSyncSntpIntervalDay);
     sntp_set_time_sync_notification_cb(TimeSyncCallback);
+    esp_sntp_init();
 }
 } // namespace Esp32TimeSync
 } // namespace chip


### PR DESCRIPTION
Fix SNTP initialization sequence and change time synchronization interval from Seconds to MilliSeconds

Tests:
Tested energy-management-app esp32 and validated the time.