### PR TITLE
[NXP][platform][common] Fix for WiFi scenario: connect -> disconnect-> connect

### DIFF
--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -133,7 +133,8 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
         }
         else
         {
-            is_wlan_added = false;
+            /* In case network was added before, signal that it is added and that connection can start */
+            is_wlan_added = true;
         }
 
         /* At this point, the network details should be registered in the wlan driver */


### PR DESCRIPTION
Wifi network was connected previous, then a disconnect event happened, after which a connection command was issued again. In this case, the WiFi driver keeps the previous network credentials and it will not add them again. This fix allows the connection event to be called even if network was previously added.
