### PR TITLE
Create workflow yaml file to trigger CI check for Linux tv-casting-app and Linux tv-app.

### DIFF
--- a/.github/workflows/examples-linux-tv-casting-app.yaml
+++ b/.github/workflows/examples-linux-tv-casting-app.yaml
@@ -1,0 +1,68 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test TV Casting Example
+
+on:
+    push:
+    pull_request:
+    merge_group:
+
+concurrency:
+    group:
+        ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name ==
+        'pull_request' && github.event.number) || (github.event_name ==
+        'workflow_dispatch' && github.run_number) || github.sha }}
+    cancel-in-progress: true
+
+jobs:
+    Linux-test:
+        name: Linux Test
+
+        runs-on: ubuntu-latest
+        if: github.actor != 'restyled-io[bot]'
+
+        container:
+            image: ghcr.io/project-chip/chip-build:41
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Checkout submodules & Bootstrap
+              uses: ./.github/actions/checkout-submodules-and-bootstrap
+              with:
+                  platform: linux
+
+            - name: Set Up Environment for Size Reports
+              uses: ./.github/actions/setup-size-reports
+              if: ${{ !env.ACT }}
+              with:
+                  gh-context: ${{ toJson(github) }}
+
+            - name: Build Linux tv-app
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                    "scripts/examples/gn_build_example.sh examples/tv-app/linux/ out/tv-app"
+
+            - name: Build Linux tv-casting-app
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                    "scripts/examples/gn_build_example.sh examples/tv-casting-app/linux/ out/tv-casting-app"
+
+            - name: Uploading Size Reports
+              uses: ./.github/actions/upload-size-reports
+              if: ${{ !env.ACT }}
+              with:
+                  platform-name: Linux


### PR DESCRIPTION
Fixes [#32787](https://github.com/project-chip/connectedhomeip/issues/32787)

**Problem**
There is currently no automated testing available to verify that the Linux tv-casting-app continues to work with the Linux tv-app. Without having a CI check in place, the existing Matter casting experience of the Linux tv-casting-app and the Linux tv-app can unknowingly break whenever a PR is merged.

**Solution Overview**
Create a CI check to verify that the Linux tv-casting-app continues to work with the Linux tv-app whenever a PR is created. The configurations of the workflow yaml file will use the existing workflow files as reference. For now, the workflow will just be building the Linux tv-casting-app and the Linux tv-app. In follow up PRs, the testing script will be created with specific commands and test scenarios to test for. See [#32787](https://github.com/project-chip/connectedhomeip/issues/32787) for reference.

**Testing**
- Verify that a new CI check is created using the workflow yaml file. The CI check is called: Build example - Linux TV Casting App and Linux TV App / Linux TV Casting App and Linux TV App.
- Verify that the new CI check and the existing CI checks pass.


