### PR TITLE
[Darwin] Adding more metrics to capture BLE during setup

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
@@ -42,10 +42,13 @@ public:
 
     void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR error) override;
 
+    void SetDeviceNodeID(chip::NodeId deviceNodeId);
+
 private:
     MTRDeviceController * __weak mController;
     _Nullable id<MTRDeviceControllerDelegate> mDelegate;
     _Nullable dispatch_queue_t mQueue;
+    chip::NodeId mDeviceNodeId;
 
     MTRCommissioningStatus MapStatus(chip::Controller::DevicePairingDelegate::Status status);
 };

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -64,6 +64,13 @@ void MTRDeviceControllerDelegateBridge::OnStatusUpdate(chip::Controller::DeviceP
 {
     MTR_LOG_DEFAULT("DeviceControllerDelegate status updated: %d", status);
 
+    // If pairing failed, PASE failed. However, since OnPairingComplete(failure_code) might not be invoked in all cases, mark
+    // end of PASE with timeout as assumed failure. If OnPairingComplete is invoked, the right error code will be updated in
+    // the end event
+    if (status == chip::Controller::DevicePairingDelegate::Status::SecurePairingFailed) {
+        MATTER_LOG_METRIC_END(kMetricSetupPASESession, CHIP_ERROR_TIMEOUT);
+    }
+
     id<MTRDeviceControllerDelegate> strongDelegate = mDelegate;
     MTRDeviceController * strongController = mController;
     if (strongDelegate && mQueue && strongController) {
@@ -73,12 +80,21 @@ void MTRDeviceControllerDelegateBridge::OnStatusUpdate(chip::Controller::DeviceP
                 [strongDelegate controller:strongController statusUpdate:commissioningStatus];
             });
         }
+
+        // If PASE session setup fails and the client implements the delegate that accepts metrics, invoke the delegate
+        // to mark end of commissioning request.
+        // Since OnPairingComplete(failure_code) might not be invoked in all cases, use this opportunity to inform of failed commissioning
+        // and default the error to timeout since that is best guess in this layer.
+        if (status == chip::Controller::DevicePairingDelegate::Status::SecurePairingFailed && [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
+            OnCommissioningComplete(mDeviceNodeId, CHIP_ERROR_TIMEOUT);
+        }
     }
 }
 
 void MTRDeviceControllerDelegateBridge::OnPairingComplete(CHIP_ERROR error)
 {
     MTR_LOG_DEFAULT("DeviceControllerDelegate Pairing complete. Status %s", chip::ErrorStr(error));
+    MATTER_LOG_METRIC_END(kMetricSetupPASESession, error);
 
     id<MTRDeviceControllerDelegate> strongDelegate = mDelegate;
     MTRDeviceController * strongController = mController;
@@ -129,6 +145,7 @@ void MTRDeviceControllerDelegateBridge::OnCommissioningComplete(chip::NodeId nod
 
         // Always collect the metrics to avoid unbounded growth of the stats in the collector
         MTRMetrics * metrics = [[MTRMetricsCollector sharedInstance] metricSnapshot:TRUE];
+        MTR_LOG_INFO("Device commissioning complete with metrics %@", metrics);
 
         if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:)] ||
             [strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
@@ -156,6 +173,11 @@ void MTRDeviceControllerDelegateBridge::OnCommissioningComplete(chip::NodeId nod
             });
         }
     }
+}
+
+void MTRDeviceControllerDelegateBridge::SetDeviceNodeID(chip::NodeId deviceNodeId)
+{
+    mDeviceNodeId = deviceNodeId;
 }
 
 @implementation MTRProductIdentity

--- a/src/darwin/Framework/CHIP/MTRMetricKeys.h
+++ b/src/darwin/Framework/CHIP/MTRMetricKeys.h
@@ -21,35 +21,65 @@ namespace chip {
 namespace Tracing {
 namespace DarwinFramework {
 
+// Tracks overall commissioning via one of the setup APIs
 constexpr Tracing::MetricKey kMetricDeviceCommissioning = "dwnfw_device_commissioning";
 
+// Tracks portion related to starting setup with a payload
 constexpr Tracing::MetricKey kMetricSetupWithPayload = "dwnfw_setup_with_payload";
 
+// Tracks portion related to legacy setup APIs
 constexpr Tracing::MetricKey kMetricPairDevice = "dwnfw_pair_device";
 
+// Tracks portion related to starting setup with a discovered device
 constexpr Tracing::MetricKey kMetricSetupWithDiscovered = "dwnfw_setup_with_discovered";
 
+// Tracks PASE session during setup of a device
+constexpr Tracing::MetricKey kMetricSetupPASESession = "dwnfw_setup_pase_session";
+
+// Marks the request to prewarm for commissioning
 constexpr Tracing::MetricKey kMetricPreWarmCommissioning = "dwnfw_prewarm_commissioning";
 
+// Marks the request to start browsing for commissionable devices
 constexpr Tracing::MetricKey kMetricStartBrowseForCommissionables = "dwnfw_start_browse_commissionables";
 
+// Marks the request to stop browsing for commissionable devices
 constexpr Tracing::MetricKey kMetricStopBrowseForCommissionables = "dwnfw_stop_browse_commissionables";
 
+// Marks the request to cancel commissioning a device
 constexpr Tracing::MetricKey kMetricCancelCommissioning = "dwnfw_cancel_commissioning";
 
+// Marks the request to continue or cancel after attestation failure
 constexpr Tracing::MetricKey kMetricContinueCommissioningAfterAttestation = "dwnfw_commission_post_attestation";
 
+// Tracks request to commission device with a node ID
 constexpr Tracing::MetricKey kMetricCommissionNode = "dwnfw_commission_node";
 
+// Marks the request to get device being commissioned
 constexpr Tracing::MetricKey kMetricDeviceBeingCommissioned = "dwnfw_dev_being_commissioned";
 
+// Tracks the request to generate PASE verifier for a given setup code
 constexpr Tracing::MetricKey kMetricPASEVerifierForSetupCode = "dwnfw_pase_verifier_for_code";
 
+// Marks the request to open pairing window
 constexpr Tracing::MetricKey kMetricOpenPairingWindow = "dwnfw_pase_verifier_for_code";
 
+// Device Vendor ID
 constexpr Tracing::MetricKey kMetricDeviceVendorID = "dwnfw_device_vendor_id";
 
+// Device Product ID
 constexpr Tracing::MetricKey kMetricDeviceProductID = "dwnfw_device_product_id";
+
+// Counter of number of devices discovered on the network during setup
+constexpr Tracing::MetricKey kMetricOnNetworkDevicesAdded = "dwnfw_onnet_devices_added";
+
+// Counter of number of devices removed from the network during setup
+constexpr Tracing::MetricKey kMetricOnNetworkDevicesRemoved = "dwnfw_onnet_devices_removed";
+
+// Counter of number of BLE devices discovered during setup
+constexpr Tracing::MetricKey kMetricBLEDevicesAdded = "dwnfw_ble_devices_added";
+
+// Counter of number of BLE devices removed during setup
+constexpr Tracing::MetricKey kMetricBLEDevicesRemoved = "dwnfw_ble_devices_removed";
 
 } // namespace DarwinFramework
 } // namespace Tracing

--- a/src/darwin/Framework/CHIP/MTRMetrics.mm
+++ b/src/darwin/Framework/CHIP/MTRMetrics.mm
@@ -76,7 +76,7 @@
 
 - (NSString *)description
 {
-    return [_metricsData description];
+    return [NSString stringWithFormat:@"<MTRMetrics: uuid = %@, data = %@>", _uniqueIdentifier, [_metricsData description]];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRMetricsCollector.h
+++ b/src/darwin/Framework/CHIP/MTRMetricsCollector.h
@@ -54,6 +54,11 @@ void ShutdownMetricsCollection();
  */
 - (MTRMetrics *)metricSnapshot:(BOOL)resetCollection;
 
+/**
+ * @brief This method clears any metrics collected.
+ */
+- (void)resetMetrics;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -71,6 +71,7 @@ static_library("Darwin") {
     "NetworkCommissioningDriver.h",
     "PlatformManagerImpl.cpp",
     "PlatformManagerImpl.h",
+    "PlatformMetricKeys.h",
     "PosixConfig.cpp",
     "PosixConfig.h",
     "SystemPlatformConfig.h",
@@ -101,6 +102,7 @@ static_library("Darwin") {
     "${chip_root}/src/lib/dnssd:platform_header",
     "${chip_root}/src/platform/logging:headers",
     "${chip_root}/src/setup_payload",
+    "${chip_root}/src/tracing",
   ]
 
   public_deps = [

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -35,10 +35,13 @@
 #include <platform/Darwin/BleScannerDelegate.h>
 #include <platform/LockTracker.h>
 #include <setup_payload/SetupPayload.h>
+#include <tracing/metric_event.h>
 
+#import "PlatformMetricKeys.h"
 #import "UUIDHelper.h"
 
 using namespace chip::Ble;
+using namespace chip::Tracing::DarwinPlatform;
 
 constexpr uint64_t kScanningWithDiscriminatorTimeoutInSeconds = 60;
 constexpr uint64_t kScanningWithoutDelegateTimeoutInSeconds = 120;
@@ -222,6 +225,8 @@ namespace DeviceLayer {
 } // namespace chip
 
 @interface BleConnection ()
+@property (nonatomic, readonly) int32_t totalDevicesAdded;
+@property (nonatomic, readonly) int32_t totalDevicesRemoved;
 @end
 
 @implementation BleConnection
@@ -237,6 +242,7 @@ namespace DeviceLayer {
         _found = false;
         _cachedPeripherals = [[NSMutableDictionary alloc] init];
         _currentMode = kUndefined;
+        [self _resetCounters];
     }
 
     return self;
@@ -330,6 +336,8 @@ namespace DeviceLayer {
 
 - (void)centralManagerDidUpdateState:(CBCentralManager *)central
 {
+    MATTER_LOG_METRIC(kMetricBLECentralManagerState, static_cast<uint32_t>(central.state));
+
     switch (central.state) {
     case CBManagerStatePoweredOn:
         ChipLogDetail(Ble, "CBManagerState: ON");
@@ -374,6 +382,8 @@ namespace DeviceLayer {
     }
 
     NSNumber * isConnectable = [advertisementData objectForKey:CBAdvertisementDataIsConnectable];
+    MATTER_LOG_METRIC_END(kMetricBLEDiscoveredPeripheral, [isConnectable boolValue]);
+
     if ([isConnectable boolValue] == NO) {
         ChipLogError(Ble, "A device (%p) with a matching Matter UUID has been discovered but it is not connectable.", peripheral);
         return;
@@ -389,6 +399,7 @@ namespace DeviceLayer {
             "A device (%p) with a matching Matter UUID has been discovered but the service data len does not match our expectation "
             "(serviceData = %s)",
             peripheral, [hexString UTF8String]);
+        MATTER_LOG_METRIC(kMetricBLEBadServiceDataLength, static_cast<uint32_t>([serviceData length]));
         return;
     }
 
@@ -398,6 +409,7 @@ namespace DeviceLayer {
             "A device (%p) with a matching Matter UUID has been discovered but the service data opCode not match our expectation "
             "(opCode = %u).",
             peripheral, opCode);
+        MATTER_LOG_METRIC(kMetricBLEBadOpCode, opCode);
         return;
     }
 
@@ -409,9 +421,11 @@ namespace DeviceLayer {
                 "A device (%p) with a matching Matter UUID has been discovered but the service data discriminator not match our "
                 "expectation (discriminator = %u).",
                 peripheral, discriminator);
+            MATTER_LOG_METRIC(kMetricBLEMismatchedDiscriminator);
             return;
         }
 
+        MATTER_LOG_METRIC_BEGIN(kMetricBLEDiscoveredMatchingPeripheral);
         ChipLogProgress(Ble, "Connecting to device %p with discriminator: %d", peripheral, discriminator);
         [self connect:peripheral];
         [self stopScanning];
@@ -427,6 +441,8 @@ namespace DeviceLayer {
 
 - (void)centralManager:(CBCentralManager *)central didConnectPeripheral:(CBPeripheral *)peripheral
 {
+    MATTER_LOG_METRIC_END(kMetricBLEConnectPeripheral);
+    MATTER_LOG_METRIC_BEGIN(kMetricBLEDiscoveredServices);
     [peripheral setDelegate:self];
     [peripheral discoverServices:nil];
 }
@@ -441,8 +457,11 @@ namespace DeviceLayer {
         ChipLogError(Ble, "BLE:Error finding Chip Service in the device: [%s]", [error.localizedDescription UTF8String]);
     }
 
+    MATTER_LOG_METRIC_END(kMetricBLEDiscoveredServices, CHIP_ERROR(chip::ChipError::Range::kOS, static_cast<uint32_t>(error.code)));
+
     for (CBService * service in peripheral.services) {
         if ([service.UUID.data isEqualToData:_shortServiceUUID.data] && !self.found) {
+            MATTER_LOG_METRIC_BEGIN(kMetricBLEDiscoveredCharacteristics);
             [peripheral discoverCharacteristics:nil forService:service];
             self.found = true;
             break;
@@ -451,12 +470,15 @@ namespace DeviceLayer {
 
     if (!self.found || error != nil) {
         ChipLogError(Ble, "Service not found on the device.");
+        MATTER_LOG_METRIC(kMetricBLEDiscoveredServices, CHIP_ERROR_INCORRECT_STATE);
         [self dispatchConnectionError:CHIP_ERROR_INCORRECT_STATE];
     }
 }
 
 - (void)peripheral:(CBPeripheral *)peripheral didDiscoverCharacteristicsForService:(CBService *)service error:(NSError *)error
 {
+    MATTER_LOG_METRIC_END(kMetricBLEDiscoveredCharacteristics, CHIP_ERROR(chip::ChipError::Range::kOS, static_cast<uint32_t>(error.code)));
+
     if (nil != error) {
         ChipLogError(
             Ble, "BLE:Error finding Characteristics in Chip service on the device: [%s]", [error.localizedDescription UTF8String]);
@@ -481,6 +503,7 @@ namespace DeviceLayer {
         ChipLogError(
             Ble, "BLE:Error writing Characteristics in Chip service on the device: [%s]", [error.localizedDescription UTF8String]);
         dispatch_async(_chipWorkQueue, ^{
+            MATTER_LOG_METRIC(kMetricBLEWriteChrValueFailed, BLE_ERROR_GATT_WRITE_FAILED);
             _mBleLayer->HandleConnectionError((__bridge void *) peripheral, BLE_ERROR_GATT_WRITE_FAILED);
         });
     }
@@ -509,10 +532,12 @@ namespace DeviceLayer {
             [error.localizedDescription UTF8String]);
         dispatch_async(_chipWorkQueue, ^{
             if (isNotifying) {
+                MATTER_LOG_METRIC(kMetricBLEUpdateNotificationStateForChrFailed, BLE_ERROR_GATT_WRITE_FAILED);
                 // we're still notifying, so we must failed the unsubscription
                 _mBleLayer->HandleConnectionError((__bridge void *) peripheral, BLE_ERROR_GATT_UNSUBSCRIBE_FAILED);
             } else {
                 // we're not notifying, so we must failed the subscription
+                MATTER_LOG_METRIC(kMetricBLEUpdateNotificationStateForChrFailed, BLE_ERROR_GATT_SUBSCRIBE_FAILED);
                 _mBleLayer->HandleConnectionError((__bridge void *) peripheral, BLE_ERROR_GATT_SUBSCRIBE_FAILED);
             }
         });
@@ -535,17 +560,20 @@ namespace DeviceLayer {
 
             if (msgBuf.IsNull()) {
                 ChipLogError(Ble, "Failed at allocating buffer for incoming BLE data");
+                MATTER_LOG_METRIC(kMetricBLEUpdateValueForChrFailed, CHIP_ERROR_NO_MEMORY);
                 _mBleLayer->HandleConnectionError((__bridge void *) peripheral, CHIP_ERROR_NO_MEMORY);
             } else if (!_mBleLayer->HandleIndicationReceived((__bridge void *) peripheral, &svcId, &charId, std::move(msgBuf))) {
                 // since this error comes from device manager core
                 // we assume it would do the right thing, like closing the connection
                 ChipLogError(Ble, "Failed at handling incoming BLE data");
+                MATTER_LOG_METRIC(kMetricBLEUpdateValueForChrFailed, CHIP_ERROR_INCORRECT_STATE);
             }
         });
     } else {
         ChipLogError(
             Ble, "BLE:Error receiving indication of Characteristics on the device: [%s]", [error.localizedDescription UTF8String]);
         dispatch_async(_chipWorkQueue, ^{
+            MATTER_LOG_METRIC(kMetricBLEUpdateValueForChrFailed, BLE_ERROR_GATT_INDICATE_FAILED);
             _mBleLayer->HandleConnectionError((__bridge void *) peripheral, BLE_ERROR_GATT_INDICATE_FAILED);
         });
     }
@@ -558,6 +586,7 @@ namespace DeviceLayer {
     // If a peripheral has already been found, try to connect to it once BLE starts,
     // otherwise start scanning to find the peripheral to connect to.
     if (_peripheral != nil) {
+        MATTER_LOG_METRIC_BEGIN(kMetricBLEDiscoveredMatchingPeripheral);
         [self connect:_peripheral];
     } else {
         [self startScanning];
@@ -597,11 +626,22 @@ namespace DeviceLayer {
     });
 }
 
+- (void)_resetCounters
+{
+    _totalDevicesAdded = 0;
+    _totalDevicesRemoved = 0;
+}
+
 - (void)startScanning
 {
     if (!_centralManager) {
         return;
     }
+
+    MATTER_LOG_METRIC_BEGIN(kMetricBLEScan);
+    MATTER_LOG_METRIC_BEGIN(kMetricBLEDiscoveredPeripheral);
+    MATTER_LOG_METRIC_BEGIN(kMetricBLEDiscoveredMatchingPeripheral);
+    [self _resetCounters];
 
     auto scanOptions = @{ CBCentralManagerScanOptionAllowDuplicatesKey : @YES };
     [_centralManager scanForPeripheralsWithServices:@[ _shortServiceUUID ] options:scanOptions];
@@ -613,6 +653,9 @@ namespace DeviceLayer {
         return;
     }
 
+    MATTER_LOG_METRIC_END(kMetricBLEScan);
+    [self _resetCounters];
+
     [self clearTimer];
     [_centralManager stopScan];
 }
@@ -623,6 +666,8 @@ namespace DeviceLayer {
         return;
     }
 
+    MATTER_LOG_METRIC_END(kMetricBLEDiscoveredMatchingPeripheral);
+    MATTER_LOG_METRIC_BEGIN(kMetricBLEConnectPeripheral);
     _peripheral = peripheral;
     [_centralManager connectPeripheral:peripheral options:nil];
 }
@@ -669,6 +714,7 @@ namespace DeviceLayer {
     [self removePeripheralsFromCache];
 
     if (peripheral) {
+        MATTER_LOG_METRIC_BEGIN(kMetricBLEDiscoveredMatchingPeripheral);
         ChipLogProgress(Ble, "Connecting to cached device: %p", peripheral);
         [self connect:peripheral];
         [self stopScanning];
@@ -682,6 +728,7 @@ namespace DeviceLayer {
     _scannerDelegate = nil;
     _currentMode = kConnecting;
 
+    MATTER_LOG_METRIC_BEGIN(kMetricBLEDiscoveredMatchingPeripheral);
     ChipLogProgress(Ble, "Connecting to device: %p", peripheral);
     [self connect:peripheral];
     [self stopScanning];
@@ -713,6 +760,7 @@ namespace DeviceLayer {
 
         timeoutTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _workQueue);
         dispatch_source_set_event_handler(timeoutTimer, ^{
+            MATTER_LOG_METRIC(kMetricBLEPeripheralRemoved, ++self->_totalDevicesRemoved);
             [self removePeripheralFromCache:peripheral];
         });
         dispatch_resume(timeoutTimer);
@@ -720,6 +768,11 @@ namespace DeviceLayer {
 
     auto timeout = static_cast<int64_t>(kCachePeripheralTimeoutInSeconds * NSEC_PER_SEC);
     dispatch_source_set_timer(timeoutTimer, dispatch_walltime(nullptr, timeout), DISPATCH_TIME_FOREVER, 5 * NSEC_PER_SEC);
+
+    // Add only unique count of devices found
+    if (!_cachedPeripherals[peripheral]) {
+        MATTER_LOG_METRIC(kMetricBLEPeripheralAdded, ++_totalDevicesAdded);
+    }
 
     _cachedPeripherals[peripheral] = @{
         @"data" : data,

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <tracing/metric_macros.h>
 
 #if !CHIP_DISABLE_PLATFORM_KVS
 #include <platform/Darwin/DeviceInstanceInfoProviderImpl.h>
@@ -36,6 +37,10 @@
 #include <platform/internal/GenericPlatformManagerImpl.ipp>
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <tracing/metric_event.h>
+
+#import "PlatformMetricKeys.h"
+using namespace chip::Tracing::DarwinPlatform;
 
 namespace chip {
 namespace DeviceLayer {
@@ -188,7 +193,7 @@ bool PlatformManagerImpl::IsWorkQueueCurrentQueue() const
 CHIP_ERROR PlatformManagerImpl::StartBleScan(BleScannerDelegate * delegate)
 {
 #if CONFIG_NETWORK_LAYER_BLE
-    ReturnErrorOnFailure(Internal::BLEMgrImpl().StartScan(delegate));
+    ReturnErrorOnFailureWithMetric(kMetricBLEScan, Internal::BLEMgrImpl().StartScan(delegate));
 #endif // CONFIG_NETWORK_LAYER_BLE
     return CHIP_NO_ERROR;
 }
@@ -196,7 +201,7 @@ CHIP_ERROR PlatformManagerImpl::StartBleScan(BleScannerDelegate * delegate)
 CHIP_ERROR PlatformManagerImpl::StopBleScan()
 {
 #if CONFIG_NETWORK_LAYER_BLE
-    ReturnErrorOnFailure(Internal::BLEMgrImpl().StopScan());
+    ReturnErrorOnFailureWithMetric(kMetricBLEScan, Internal::BLEMgrImpl().StopScan());
 #endif // CONFIG_NETWORK_LAYER_BLE
     return CHIP_NO_ERROR;
 }
@@ -204,7 +209,7 @@ CHIP_ERROR PlatformManagerImpl::StopBleScan()
 CHIP_ERROR PlatformManagerImpl::PrepareCommissioning()
 {
 #if CONFIG_NETWORK_LAYER_BLE
-    ReturnErrorOnFailure(Internal::BLEMgrImpl().StartScan());
+    ReturnErrorOnFailureWithMetric(kMetricBLEStartPreWarmScan, Internal::BLEMgrImpl().StartScan());
 #endif // CONFIG_NETWORK_LAYER_BLE
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Darwin/PlatformMetricKeys.h
+++ b/src/platform/Darwin/PlatformMetricKeys.h
@@ -1,0 +1,74 @@
+/**
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/core/CHIPError.h>
+#include <tracing/metric_keys.h>
+
+namespace chip {
+namespace Tracing {
+namespace DarwinPlatform {
+
+// BLE Scan duration
+constexpr Tracing::MetricKey kMetricBLEScan = "dwnpm_ble_scan";
+
+// Number of peripherals added to the cache during a scan operation
+constexpr Tracing::MetricKey kMetricBLEPeripheralAdded = "dwnpm_ble_peripheral_added";
+
+// Number of peripherals removed from the cache during a scan operation
+constexpr Tracing::MetricKey kMetricBLEPeripheralRemoved = "dwnpm_ble_peripheral_removed";
+
+// Request to prewarm scan
+constexpr Tracing::MetricKey kMetricBLEStartPreWarmScan = "dwnpm_ble_start_prewarm_scan";
+
+// Captures the last known state of the BLE Central manager during a commissioning attempt
+constexpr Tracing::MetricKey kMetricBLECentralManagerState = "dwnpm_ble_cbmgr_state";
+
+// Discovered a peripheral after a request to scan
+constexpr Tracing::MetricKey kMetricBLEDiscoveredPeripheral = "dwnpm_ble_discovered_peripheral";
+
+// Discovered a peripheral matching scanned from QR Code
+constexpr Tracing::MetricKey kMetricBLEDiscoveredMatchingPeripheral = "dwnpm_ble_discovered_matching_peripheral";
+
+// Unexpected length of Matter BLE service data
+constexpr Tracing::MetricKey kMetricBLEBadServiceDataLength = "dwnpm_ble_bad_service_data";
+
+// Unexpected OpCode in Matter BLE service data
+constexpr Tracing::MetricKey kMetricBLEBadOpCode = "dwnpm_ble_bad_opcode";
+
+// Mismatched discriminator when connecting to a peripheral
+constexpr Tracing::MetricKey kMetricBLEMismatchedDiscriminator = "dwnpm_ble_mismatched_discriminator";
+
+// Attempt to connect to discovered peripheral
+constexpr Tracing::MetricKey kMetricBLEConnectPeripheral = "dwnpm_ble_connect_peripheral";
+
+// Discover services on connected peripheral
+constexpr Tracing::MetricKey kMetricBLEDiscoveredServices = "dwnpm_ble_discovered_svs";
+
+// Discover characteristics on connected peripheral
+constexpr Tracing::MetricKey kMetricBLEDiscoveredCharacteristics = "dwnpm_ble_discovered_chrs";
+
+// Failed to write charateristic value
+constexpr Tracing::MetricKey kMetricBLEWriteChrValueFailed = "dwnpm_ble_write_chr_val_failed";
+
+// Failed to update notification state change for charateristic
+constexpr Tracing::MetricKey kMetricBLEUpdateNotificationStateForChrFailed = "dwnpm_ble_chr_nfy_state_failed";
+
+// Failed to update value for charateristic
+constexpr Tracing::MetricKey kMetricBLEUpdateValueForChrFailed = "dwnpm_ble_upd_chr_val_failed";
+
+} // namespace DarwinPlatform
+} // namespace Tracing
+} // namespace chip


### PR DESCRIPTION
- Added more metrics across BLE phase in Darwin
- Fixed MetricsCollector to only capture first event of any kind
- Reset metrics before any API is started
- Fixed bug where duration was not being calculated correctly

