### PR TITLE
[NXP] Update smu2 manager api

### DIFF
--- a/examples/lighting-app/nxp/k32w/k32w1/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w1/main/AppTask.cpp
@@ -236,7 +236,7 @@ void AppTask::InitServer(intptr_t arg)
 #endif
 
 #if defined(USE_SMU2_DYNAMIC)
-    VerifyOrDie(SMU2::Init(initParams.persistentStorageDelegate) == CHIP_NO_ERROR);
+    VerifyOrDie(SMU2::Init() == CHIP_NO_ERROR);
 #endif
 
     // Init ZCL Data Model and start server

--- a/src/platform/nxp/k32w/k32w1/SMU2Manager.h
+++ b/src/platform/nxp/k32w/k32w1/SMU2Manager.h
@@ -27,12 +27,11 @@
 #pragma once
 
 #include "fsl_component_mem_manager.h"
-#include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 
 namespace chip::SMU2 {
 
-CHIP_ERROR Init(PersistentStorageDelegate * storage);
+CHIP_ERROR Init();
 CHIP_ERROR Deactivate(void);
 void * Allocate(size_t size);
 


### PR DESCRIPTION
- Use KeyValueStoreManager getter instead of using an instance of persistent storage delegate to save some keys.
- Update lighting app `SMU2::Init` usage.

