### PR TITLE
ReadClient should delay re-subscribe attempts based on delay in BUSY responses.

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -77,6 +77,7 @@ buildconfig_header("app_buildconfig") {
     "TIME_SYNC_ENABLE_TSC_FEATURE=${time_sync_enable_tsc_feature}",
     "NON_SPEC_COMPLIANT_OTA_ACTION_DELAY_FLOOR=${non_spec_compliant_ota_action_delay_floor}",
     "CHIP_DEVICE_CONFIG_DYNAMIC_SERVER=${chip_build_controller_dynamic_server}",
+    "CHIP_CONFIG_ENABLE_BUSY_HANDLING_FOR_OPERATIONAL_SESSION_SETUP=${chip_enable_busy_handling_for_operational_session_setup}",
   ]
 
   visibility = [ ":app_config" ]

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <app/AppConfig.h>
 #include <app/CASEClient.h>
 #include <app/CASEClientPool.h>
 #include <app/DeviceProxy.h>
@@ -160,6 +161,13 @@ public:
         const ScopedNodeId peerId;
         CHIP_ERROR error;
         SessionEstablishmentStage sessionStage;
+
+        // When the response was BUSY, error will be CHIP_ERROR_BUSY and
+        // requestedBusyDelay will be set, if handling of BUSY responses is
+        // enabled.
+#if CHIP_CONFIG_ENABLE_BUSY_HANDLING_FOR_OPERATIONAL_SESSION_SETUP
+        Optional<System::Clock::Milliseconds16> requestedBusyDelay;
+#endif // CHIP_CONFIG_ENABLE_BUSY_HANDLING_FOR_OPERATIONAL_SESSION_SETUP
 
         ConnnectionFailureInfo(const ScopedNodeId & peer, CHIP_ERROR err, SessionEstablishmentStage stage) :
             peerId(peer), error(err), sessionStage(stage)
@@ -306,6 +314,10 @@ private:
 
     bool mPerformingAddressUpdate = false;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES || CHIP_CONFIG_ENABLE_BUSY_HANDLING_FOR_OPERATIONAL_SESSION_SETUP
+    System::Clock::Milliseconds16 mRequestedBusyDelay = System::Clock::kZero;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES || CHIP_CONFIG_ENABLE_BUSY_HANDLING_FOR_OPERATIONAL_SESSION_SETUP
+
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
     // When we TryNextResult on the resolver, it will synchronously call back
     // into our OnNodeAddressResolved when it succeeds.  We need to track
@@ -319,8 +331,6 @@ private:
     uint8_t mAttemptsDone      = 0;
 
     uint8_t mResolveAttemptsAllowed = 0;
-
-    System::Clock::Milliseconds16 mRequestedBusyDelay = System::Clock::kZero;
 
     Callback::CallbackDeque mConnectionRetry;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
@@ -385,7 +395,12 @@ private:
                                           Callback::Cancelable & successReady, CHIP_ERROR error, SessionEstablishmentStage stage,
                                           const ScopedNodeId & peerId, bool performingAddressUpdate,
                                           Messaging::ExchangeManager * exchangeMgr,
-                                          const Optional<SessionHandle> & optionalSessionHandle);
+                                          const Optional<SessionHandle> & optionalSessionHandle,
+                                          // requestedBusyDelay will be 0 if not
+                                          // CHIP_CONFIG_ENABLE_BUSY_HANDLING_FOR_OPERATIONAL_SESSION_SETUP,
+                                          // and only has a meaningful value
+                                          // when the error is CHIP_ERROR_BUSY.
+                                          System::Clock::Milliseconds16 requestedBusyDelay);
 
     /**
      * Triggers a DNSSD lookup to find a usable peer address.

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -612,7 +612,7 @@ private:
 
     static void HandleDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr,
                                       const SessionHandle & sessionHandle);
-    static void HandleDeviceConnectionFailure(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
+    static void HandleDeviceConnectionFailure(void * context, const OperationalSessionSetup::ConnnectionFailureInfo & failureInfo);
 
     CHIP_ERROR GetMinEventNumber(const ReadPrepareParams & aReadPrepareParams, Optional<EventNumber> & aEventMin);
 
@@ -642,8 +642,12 @@ private:
     bool mForceCaseOnNextResub      = true;
     bool mIsResubscriptionScheduled = false;
 
+    // mMinimalResubscribeDelay is used to store the delay returned with a BUSY
+    // response to a Sigma1 message.
+    System::Clock::Milliseconds16 mMinimalResubscribeDelay = System::Clock::kZero;
+
     chip::Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
-    chip::Callback::Callback<OnDeviceConnectionFailure> mOnConnectionFailureCallback;
+    chip::Callback::Callback<OperationalSessionSetup::OnSetupFailure> mOnConnectionFailureCallback;
 
     ReadClient * mpNext                 = nullptr;
     InteractionModelEngine * mpImEngine = nullptr;

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -17,4 +17,8 @@ declare_args() {
   chip_app_use_echo = false
   chip_enable_read_client = true
   chip_build_controller_dynamic_server = false
+
+  # Flag that controls whether the time-to-wait from BUSY responses is
+  # communicated to OperationalSessionSetup API consumers.
+  chip_enable_busy_handling_for_operational_session_setup = true
 }


### PR DESCRIPTION
The ifdefs are to reduce the codesize costs for situations where the BUSY handling is not needed (e.g. if the application does not use ReadClient at all and does not care about handling the timeout from BUSY from OperationalSessionSetup).
