### PR TITLE
[Silabs] removed a redundant include from AppTask.cpp

### DIFF
--- a/examples/window-app/silabs/src/AppTask.cpp
+++ b/examples/window-app/silabs/src/AppTask.cpp
@@ -23,7 +23,6 @@
 
 #include "WindowManager.h"
 
-#include <app/clusters/on-off-server/on-off-server.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>


### PR DESCRIPTION
Problem:
Redundant include providing error in building window app. 

Fix / solution:
Removed the redundant include from Apptask.cpp
