### PR TITLE
[Linux] Fix sending reply to D-Bus release/confirm calls

### DIFF
--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -94,6 +94,7 @@ gboolean BluezAdvertisement::BluezLEAdvertisement1Release(BluezLEAdvertisement1 
     // We can use it to update the state of the advertisement in the CHIP layer.
     ChipLogDetail(DeviceLayer, "BLE advertisement stopped by BlueZ");
     mIsAdvertising = false;
+    bluez_leadvertisement1_complete_release(aAdv, aInvocation);
     BLEManagerImpl::NotifyBLEPeripheralAdvReleased();
     return TRUE;
 }

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -210,6 +210,7 @@ gboolean BluezEndpoint::BluezCharacteristicConfirm(BluezGattCharacteristic1 * aC
 {
     BluezConnection * conn = GetBluezConnectionViaDevice();
     ChipLogDetail(Ble, "Indication confirmation, %p", conn);
+    bluez_gatt_characteristic1_complete_confirm(aChar, aInvocation);
     BLEManagerImpl::HandleTXComplete(conn);
     return TRUE;
 }

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -100,8 +100,10 @@ private:
     BluezConnection * GetBluezConnectionViaDevice();
 
     gboolean BluezCharacteristicReadValue(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOptions);
-    gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOptions);
-    gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GVariant * aOptions);
+    gboolean BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GUnixFDList * aFDList,
+                                             GVariant * aOptions);
+    gboolean BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv, GUnixFDList * aFDList,
+                                              GVariant * aOptions);
     gboolean BluezCharacteristicConfirm(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInv);
 
     void RegisterGattApplicationDone(GObject * aObject, GAsyncResult * aResult);

--- a/src/platform/Linux/dbus/bluez/DbusBluez.xml
+++ b/src/platform/Linux/dbus/bluez/DbusBluez.xml
@@ -137,11 +137,13 @@
       <arg name="options" type="a{sv}" direction="in"/>
     </method>
     <method name="AcquireWrite">
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true" />
       <arg name="options" type="a{sv}" direction="in" />
       <arg name="fd" type="h" direction="out" />
       <arg name="mtu" type="q" direction="out" />
     </method>
     <method name="AcquireNotify">
+      <annotation name="org.gtk.GDBus.C.UnixFD" value="true" />
       <arg name="options" type="a{sv}" direction="in" />
       <arg name="fd" type="h" direction="out" />
       <arg name="mtu" type="q" direction="out" />


### PR DESCRIPTION
### Problem

When `org.bluez.LEAdvertisement1.Release()` or `org.bluez.GattCharacteristic1.Confirm()` is received Matter app does not send reply which might cause BlueZ to wait until timeout.

### Changes

- send confirmation to all D-Bus calls
- use `"org.gtk.GDBus.C.UnixFD"` annotation to generate UNIX compatible D-Bus stubs

### Testing

Manually tested BLE commissioning on Linux.