### PR TITLE
[NXP] Fix pw RPC build for k32w1 lighting app

### DIFF
--- a/config/nxp/lib/pw_rpc/BUILD.gn
+++ b/config/nxp/lib/pw_rpc/BUILD.gn
@@ -24,7 +24,6 @@ static_library("pw_rpc") {
     "$dir_pw_rpc:server",
     "$dir_pw_rpc/nanopb:echo_service",
     "${chip_root}/examples/platform/nxp/pw_sys_io:pw_sys_io_nxp",
-    "${dir_pigweed}/pw_hdlc:pw_rpc",
     dir_pw_assert,
     dir_pw_hdlc,
     dir_pw_log,

--- a/examples/platform/nxp/Rpc.cpp
+++ b/examples/platform/nxp/Rpc.cpp
@@ -66,7 +66,7 @@ public:
 class NxpDevice final : public Device
 {
 public:
-    pw::Status Reboot(const pw_protobuf_Empty & request, pw_protobuf_Empty & response) override
+    pw::Status Reboot(const chip_rpc_RebootRequest & request, pw_protobuf_Empty & response) override
     {
         mRebootTimer = xTimerCreate("Reboot", kRebootTimerPeriodTicks, false, nullptr, RebootHandler);
         xTimerStart(mRebootTimer, pdMS_TO_TICKS(0));

--- a/examples/platform/nxp/pw_sys_io/BUILD.gn
+++ b/examples/platform/nxp/pw_sys_io/BUILD.gn
@@ -28,14 +28,13 @@ config("default_config") {
 
 pw_source_set("pw_sys_io_nxp") {
   sources = [
-    "${chip_root}/src/lib/shell/streamer_nxp.cpp",
     "sys_io_nxp.cc",
   ]
 
   deps = [
     "$dir_pw_sys_io:default_putget_bytes",
     "$dir_pw_sys_io:facade",
-    "${nxp_sdk_build_root}/${nxp_sdk_name}:nxp_sdk",
+    "${chip_root}/src/lib/shell:shell"
   ]
 
   public_configs = [ ":default_config" ]

--- a/examples/platform/nxp/pw_sys_io/BUILD.gn
+++ b/examples/platform/nxp/pw_sys_io/BUILD.gn
@@ -27,14 +27,12 @@ config("default_config") {
 }
 
 pw_source_set("pw_sys_io_nxp") {
-  sources = [
-    "sys_io_nxp.cc",
-  ]
+  sources = [ "sys_io_nxp.cc" ]
 
   deps = [
     "$dir_pw_sys_io:default_putget_bytes",
     "$dir_pw_sys_io:facade",
-    "${chip_root}/src/lib/shell:shell"
+    "${chip_root}/src/lib/shell:shell",
   ]
 
   public_configs = [ ":default_config" ]


### PR DESCRIPTION
Bring NXP pigweed RPC integration up to date. Seems like a gn target was removed from the `pw_hdlc` component. Currently, pw RPC can be enabled on k32w1 lighting app.