### PR TITLE
Make builder unit tests pass in vscode image.

### DIFF
--- a/scripts/build/test.py
+++ b/scripts/build/test.py
@@ -49,6 +49,8 @@ def build_actual_output(root: str, out: str, args: List[str]) -> List[str]:
         'TI_SYSCONFIG_ROOT': 'TEST_TI_SYSCONFIG_ROOT',
         'JAVA_PATH': 'TEST_JAVA_PATH',
         'GSDK_ROOT': 'TEST_GSDK_ROOT',
+        'WISECONNECT_SDK_ROOT': 'TEST_WISECONNECT_SDK_ROOT',
+        'WIFI_SDK_ROOT': 'TEST_WIFI_SDK_ROOT',
     })
 
     retval = subprocess.run([

--- a/scripts/build/testdata/dry_run_efr32-brd4161a-light-rpc-no-version.txt
+++ b/scripts/build/testdata/dry_run_efr32-brd4161a-light-rpc-no-version.txt
@@ -2,7 +2,7 @@
 cd "{root}"
 
 # Generating efr32-brd4161a-light-rpc-no-version
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/silabs '--args=silabs_board="BRD4161A" is_debug=false import("//with_pw_rpc.gni") efr32_sdk_root="TEST_GSDK_ROOT" openthread_root="TEST_GSDK_ROOT/util/third_party/openthread"' {out}/efr32-brd4161a-light-rpc-no-version
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/silabs '--args=silabs_board="BRD4161A" is_debug=false import("//with_pw_rpc.gni") efr32_sdk_root="TEST_GSDK_ROOT" openthread_root="TEST_GSDK_ROOT/util/third_party/openthread" wiseconnect_sdk_root="TEST_WISECONNECT_SDK_ROOT" wifi_sdk_root="TEST_WIFI_SDK_ROOT"' {out}/efr32-brd4161a-light-rpc-no-version
 
 # Building efr32-brd4161a-light-rpc-no-version
 ninja -C {out}/efr32-brd4161a-light-rpc-no-version


### PR DESCRIPTION
vscode image defines more environment variables. Provide overrides for these variables in unit tests, so that they pass for vscode image as well and they do not get picked up from the system env.

