### PR TITLE
Make chef cloudbuild checkout submodules before building

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,17 +1,28 @@
 steps:
     - name: "ghcr.io/project-chip/chip-build-vscode:41"
+      entrypoint: "bash"
+      args:
+          - "-c"
+          - |
+              git config --global --add safe.directory "*"
+              python scripts/checkout_submodules.py --shallow --recursive --platform esp32 nrfconnect silabs linux android 
+      id: Submodules
+    - name: "ghcr.io/project-chip/chip-build-vscode:41"
+      # NOTE: silabs boostrap is NOT done with the rest as it requests a conflicting
+      #       jinja2 version (asks for 3.1.3 when constraints.txt asks for 3.0.3)
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - "-c"
-          - source ./scripts/bootstrap.sh
+          - source ./scripts/bootstrap.sh -p all,esp32,nrfconnect,linux,android
       id: Bootstrap
+      waitFor:
+          - Submodules
       entrypoint: /usr/bin/bash
       volumes:
           - name: pwenv
             path: /pwenv
-      timeout: 2700s
-
+      timeout: 900s
     - name: "ghcr.io/project-chip/chip-build-vscode:41"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
smoketest did this, however chef seemed to rely on bootstrap doing the checkout.

Since #32638 it seems we do not do a submodule checkout on boostrap.