### PR TITLE
[nrfconnect] Improve CHIP_MEMORY_PROFILING config

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -452,10 +452,10 @@ config SHELL_STACK_SIZE
     default 2616 if CHIP_WIFI
 
 config SHELL_MINIMAL
-    default y
+    default y if !CHIP_MEMORY_PROFILING
 
 config KERNEL_SHELL
-    default n
+    default n if !CHIP_MEMORY_PROFILING
 
 config SENSOR_SHELL
     default n
@@ -482,7 +482,7 @@ config HWINFO_SHELL
     default n
 
 config OPENTHREAD_SHELL
-    default n
+    default n if !CHIP_MEMORY_PROFILING
 
 endif # SHELL
 

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -75,15 +75,20 @@ endif # CHIP_SPI_NOR
 
 config CHIP_MEMORY_PROFILING
 	bool "Enable features for tracking memory usage"
+	# Matter stack
 	select CHIP_STATISTICS
+	# Heap
 	select CHIP_MALLOC_SYS_HEAP_WATERMARKS_SUPPORT if CHIP_MALLOC_SYS_HEAP
+	select SYS_HEAP_RUNTIME_STATS if CHIP_MALLOC_SYS_HEAP	
+	# Crypto
 	select MBEDTLS_MEMORY_DEBUG if !CHIP_CRYPTO_PSA
-	select SYS_HEAP_RUNTIME_STATS if CHIP_MALLOC_SYS_HEAP
-	select KERNEL_SHELL
+	# Network
 	select NET_STATISTICS
 	select NET_SHELL
 	select NET_BUF_POOL_USAGE
 	select OPENTHREAD_SHELL if !CHIP_WIFI
+	# Zephyr
+	select KERNEL_SHELL
 	help
 	  Enables features for tracking memory usage in Matter.
 


### PR DESCRIPTION
Enabled the full SHELL option when memory profiling is enabled.


