### PR TITLE
tv-casting-app fixes: saving prevValue before callback

### DIFF
--- a/examples/tv-casting-app/APIs.md
+++ b/examples/tv-casting-app/APIs.md
@@ -158,9 +158,9 @@ client's lifecycle:
     the Matter specification's "Onboarding Payload" section for more details on
     commissioning data.
 
-    On Linux, define a function `InitCommissionableDataProvider` to initialize
-    initialize a `LinuxCommissionableDataProvider` that can provide the required
-    values to the `CastingApp`.
+    On Linux, define a function `InitCommissionableDataProvider` to initialize a
+    `LinuxCommissionableDataProvider` that can provide the required values to
+    the `CastingApp`.
 
     ```c
     CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & provider, LinuxDeviceOptions & options) {
@@ -917,14 +917,14 @@ On iOS refer to the following platform specific files:
 
 1. For a list of clusters, commands and attributes supported by the Matter TV
    Casting library:
-   [/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCClusterObjects.h](/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCClusterObjects.h)
+   [darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCClusterObjects.h](darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCClusterObjects.h)
 2. For the IDs and request / response types to use with the commands:
-   [/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandObjects.h](/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandObjects.h)
+   [darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandObjects.h](darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandObjects.h)
    and
-   [/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandPayloads.h](/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandPayloads.h)
+   [darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandPayloads.h](darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCCommandPayloads.h)
 3. For attribute [read operations](#read-operations) and
    [subscriptions](#subscriptions):
-   [/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCAttributeObjects.h](/darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCAttributeObjects.h)
+   [darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCAttributeObjects.h](darwin/MatterTvCastingBridge/MatterTvCastingBridge/zap-generated/MCAttributeObjects.h)
 
 ### Issuing Commands
 

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -106,6 +106,7 @@ CHIP_ERROR ProcessClusterCommand(int argc, char ** argv)
 
 int main(int argc, char * argv[])
 {
+    ChipLogProgress(AppServer, "chip_casting_simplified = 0");
     VerifyOrDie(CHIP_NO_ERROR == chip::Platform::MemoryInit());
     VerifyOrDie(CHIP_NO_ERROR == chip::DeviceLayer::PlatformMgr().InitChipStack());
 

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -106,7 +106,7 @@ CHIP_ERROR ProcessClusterCommand(int argc, char ** argv)
 
 int main(int argc, char * argv[])
 {
-    ChipLogProgress(AppServer, "chip_casting_simplified = 0");
+    ChipLogProgress(AppServer, "chip_casting_simplified = 0"); // this file is built/run only if chip_casting_simplified = 0
     VerifyOrDie(CHIP_NO_ERROR == chip::Platform::MemoryInit());
     VerifyOrDie(CHIP_NO_ERROR == chip::DeviceLayer::PlatformMgr().InitChipStack());
 

--- a/examples/tv-casting-app/linux/simple-app.cpp
+++ b/examples/tv-casting-app/linux/simple-app.cpp
@@ -130,7 +130,7 @@ public:
 
 int main(int argc, char * argv[])
 {
-    ChipLogProgress(AppServer, "chip_casting_simplified = 1");
+    ChipLogProgress(AppServer, "chip_casting_simplified = 1"); // this file is built/run only if chip_casting_simplified = 1
     // Create AppParameters that need to be passed to CastingApp.Initialize()
     AppParameters appParameters;
     RotatingDeviceIdUniqueIdProvider rotatingDeviceIdUniqueIdProvider;

--- a/examples/tv-casting-app/linux/simple-app.cpp
+++ b/examples/tv-casting-app/linux/simple-app.cpp
@@ -130,6 +130,7 @@ public:
 
 int main(int argc, char * argv[])
 {
+    ChipLogProgress(AppServer, "chip_casting_simplified = 1");
     // Create AppParameters that need to be passed to CastingApp.Initialize()
     AppParameters appParameters;
     RotatingDeviceIdUniqueIdProvider rotatingDeviceIdUniqueIdProvider;

--- a/examples/tv-casting-app/tv-casting-common/core/Attribute.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Attribute.h
@@ -97,16 +97,19 @@ public:
                                 static_cast<ReadAttributeContext<TypeInfo> *>(__context);
                             ChipLogProgress(AppServer, "<Attribute>::Read() success");
                             Attribute<TypeInfo> * __attr = static_cast<Attribute<TypeInfo> *>(__attributeContext->mAttribute);
-                            __attr->value                = response;
                             if (__attr->hasValue)
                             {
-                                __attributeContext->mSuccessCb(__attributeContext->mClientContext,
-                                                               chip::MakeOptional(__attr->value), response);
+                                typename TypeInfo::DecodableType prevValue = __attr->value;
+                                __attr->value                              = response;
+                                __attributeContext->mSuccessCb(__attributeContext->mClientContext, chip::MakeOptional(prevValue),
+                                                               __attr->value);
                             }
                             else
                             {
                                 __attr->hasValue = true;
-                                __attributeContext->mSuccessCb(__attributeContext->mClientContext, chip::NullOptional, response);
+                                __attr->value    = response;
+                                __attributeContext->mSuccessCb(__attributeContext->mClientContext, chip::NullOptional,
+                                                               __attr->value);
                             }
                             delete __attributeContext;
                         },
@@ -269,17 +272,19 @@ public:
                                 static_cast<SubscribeAttributeContext<TypeInfo> *>(__context);
                             ChipLogProgress(AppServer, "<Attribute>::Subscribe() success");
                             Attribute<TypeInfo> * __attr = static_cast<Attribute<TypeInfo> *>(__attributeContext->mAttribute);
-                            __attr->value                = response;
-                            // TODO: Save old value and then overwrite
                             if (__attr->hasValue)
                             {
-                                __attributeContext->mSuccessCb(__attributeContext->mClientContext,
-                                                               chip::MakeOptional(__attr->value), response);
+                                typename TypeInfo::DecodableType prevValue = __attr->value;
+                                __attr->value                              = response;
+                                __attributeContext->mSuccessCb(__attributeContext->mClientContext, chip::MakeOptional(prevValue),
+                                                               __attr->value);
                             }
                             else
                             {
                                 __attr->hasValue = true;
-                                __attributeContext->mSuccessCb(__attributeContext->mClientContext, chip::NullOptional, response);
+                                __attr->value    = response;
+                                __attributeContext->mSuccessCb(__attributeContext->mClientContext, chip::NullOptional,
+                                                               __attr->value);
                             }
                             delete __attributeContext;
                         },

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -58,7 +58,11 @@
 #define CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_SUBJECTS_PER_ENTRY 20
 #define CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_ENTRIES_PER_FABRIC 20
 
-// For casting, we need to allow for more binding table entries
+/**
+ * For casting, we need to allow for more binding table entries because the Casting App can connect to many Matter Casting Players,
+ * each with many Content Apps. Each Casting Player will set 1 binding per endpoint on it. A Casting Player will have 1 endpoint for
+ * every Matter Content App installed on it + 1 endpoint representing the Casting Player + 1 endpoint representing a speaker.
+ */
 #define MATTER_BINDING_TABLE_SIZE 64
 
 // Enable some test-only interaction model APIs.

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -58,6 +58,9 @@
 #define CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_SUBJECTS_PER_ENTRY 20
 #define CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_ENTRIES_PER_FABRIC 20
 
+// For casting, we need to allow for more binding table entries
+#define MATTER_BINDING_TABLE_SIZE 64
+
 // Enable some test-only interaction model APIs.
 #define CONFIG_BUILD_FOR_HOST_UNIT_TEST 1
 


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/32842

### Change summary
1. In Attribute.h, saved the prevValue of the attribute if it already had a value (from the previous read/subscribe operation) and then set the attribute to its new value.
2. Fixed a file link issue in the APIs.md file
3. Also, increased tv-casting-app's MATTER_BINDING_TABLE_SIZE to 64. For casting, we need to allow for more binding table entries because the Casting App can connect to many Matter Casting Players, each with many Content Apps. Each Casting Player will set 1 binding per endpoint on it. ACasting Player will have 1 endpoint for
every Matter Content App installed on it + 1 endpoint representing the Casting Player + 1 endpoint representing a speaker.
4. Added some debug logging to indicate which version of the Linux tv-casting-app is being run, by outputing chip_casting_simplified = 0 or 1 from the respective files (main.cpp or simple-app.cpp).

### Testing
Tested with the tv-casting-app and tv-app