### PR TITLE
[Linux] Handle BLE adapter re-appearance due to BlueZ restart

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -184,6 +184,7 @@ private:
     };
 
     void DriveBLEState();
+    void DisableBLEService(CHIP_ERROR err);
     BluezAdvertisement::AdvertisingIntervals GetAdvertisingIntervals() const;
     void InitiateScan(BleScanState scanType);
     void CleanScanConfig();

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -185,10 +185,12 @@ private:
 
     void DriveBLEState();
     BluezAdvertisement::AdvertisingIntervals GetAdvertisingIntervals() const;
-    static void HandleAdvertisingTimer(chip::System::Layer *, void * appState);
     void InitiateScan(BleScanState scanType);
-    static void HandleScannerTimer(chip::System::Layer *, void * appState);
     void CleanScanConfig();
+
+    static void HandleAdvertisingTimer(chip::System::Layer *, void * appState);
+    static void HandleScanTimer(chip::System::Layer *, void * appState);
+    static void HandleConnectTimer(chip::System::Layer *, void * appState);
 
     CHIPoBLEServiceMode mServiceMode;
     BitFlags<Flags> mFlags;

--- a/src/platform/Linux/bluez/BluezObjectManager.cpp
+++ b/src/platform/Linux/bluez/BluezObjectManager.cpp
@@ -193,6 +193,12 @@ void BluezObjectManager::OnObjectAdded(GDBusObjectManager * aMgr, BluezObject * 
     // Verify that the adapter is properly initialized - the class property must be set.
     // BlueZ can export adapter objects on the bus before it is fully initialized. Such
     // adapter objects are not usable and must be ignored.
+    //
+    // TODO: Find a better way to determine whether the adapter interface exposed by
+    //       BlueZ D-Bus service is fully functional. The current approach is based on
+    //       the assumption that the class property is non-zero, which is true only
+    //       for BR/EDR + LE adapters. LE-only adapters do not have HCI command to read
+    //       the class property and BlueZ sets it to 0 as a default value.
     if (adapter && bluez_adapter1_get_class(adapter.get()) != 0)
     {
         NotifyAdapterAdded(adapter.get());

--- a/src/platform/Linux/bluez/BluezObjectManager.h
+++ b/src/platform/Linux/bluez/BluezObjectManager.h
@@ -89,9 +89,9 @@ private:
     using NotificationsDelegates = std::vector<BluezObjectManagerAdapterNotificationsDelegate *>;
     NotificationsDelegates GetDeviceNotificationsDelegates(BluezDevice1 * device);
 
-    void OnObjectAdded(GDBusObjectManager * aMgr, GDBusObject * aObj);
-    void OnObjectRemoved(GDBusObjectManager * aMgr, GDBusObject * aObj);
-    void OnInterfacePropertiesChanged(GDBusObjectManagerClient * aMgr, GDBusObjectProxy * aObj, GDBusProxy * aIface,
+    void OnObjectAdded(GDBusObjectManager * aMgr, BluezObject * aObj);
+    void OnObjectRemoved(GDBusObjectManager * aMgr, BluezObject * aObj);
+    void OnInterfacePropertiesChanged(GDBusObjectManagerClient * aMgr, BluezObject * aObj, GDBusProxy * aIface,
                                       GVariant * aChangedProps, const char * const * aInvalidatedProps);
 
     GAutoPtr<GDBusConnection> mConnection;


### PR DESCRIPTION
### Problem

In case of BlueZ restart (e.g. due to a crash and restart by systemd), all D-Bus proxy objects need to be refreshed (they keep unique name of watched D-Bus client). Otherwise, BLE functionality will be permanently broken in Matter SDK, until restart of the application.

### Changes

Implement logic for `kPlatformLinuxBLEAdapterAdded` and `kPlatformLinuxBLEAdapterRemoved` signals. In case of adapter disappearance, BlueZ integration is shutdown and BLE subsystem is disabled. Later when the adapter appears again, the BLE state machine re-registers with BlueZ in order to get new D-Bus unique name. The shutdown procedure does not stop timers, so the overall timeouts for BLE-related actions are not affected by adapter re-appearance.

### Testing

Manually tested LE advertising after BlueZ restart:
1. Restart BlueZ in the middle of advertising - overall advertising time is still 15 minutes.
2. Restart BlueZ after advertising is stopped - advertising is not started again.