### PR TITLE
Add check for calendar format feature when initializing time format localization cluster

### DIFF
--- a/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
+++ b/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
@@ -202,9 +202,18 @@ Protocols::InteractionModel::Status MatterTimeFormatLocalizationClusterServerPre
 
 void emberAfTimeFormatLocalizationClusterServerInitCallback(EndpointId endpoint)
 {
+    uint32_t featureMap = 0;
+    Status status       = FeatureMap::Get(endpoint, &featureMap);
+
+    VerifyOrReturn(Status::Success == status,
+                   ChipLogError(Zcl, "Failed to read the time format lozalization feature map, err:0x%02x", to_underlying(status)));
+
+    // Check for calendar format feature, becuase we only read/write the calendar related attributes below
+    VerifyOrReturn(featureMap & to_underlying(Feature::kCalendarFormat));
+
     CalendarTypeEnum calendarType;
     CalendarTypeEnum validType;
-    Status status = ActiveCalendarType::Get(endpoint, &calendarType);
+    status = ActiveCalendarType::Get(endpoint, &calendarType);
 
     VerifyOrReturn(Status::Success == status,
                    ChipLogError(Zcl, "Failed to read calendar type with error: 0x%02x", to_underlying(status)));


### PR DESCRIPTION
`supported-calendar-types` and `active-calendar-type` from time format localization cluster should be enabled only if `Calendar Format` feature is enabled. Otherwise the cluster init routine try to read them and put up the error prints.

```
E (3766) chip[ZCL]: Failed to read calendar type with error: 0x86
```
