### PR TITLE
[Darwin] MTRDeviceControllerStorageDelegate should support bulk store/fetch

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -236,6 +236,20 @@ static NSString * const sAttributesKey = @"attributes";
     return [[MTRDeviceClusterData alloc] initWithDataVersion:_dataVersion attributes:_attributes];
 }
 
+- (BOOL)isEqualToClusterData:(MTRDeviceClusterData *)otherClusterData
+{
+    return [_dataVersion isEqual:otherClusterData.dataVersion] && [_attributes isEqual:otherClusterData.attributes];
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if (![object isKindOfClass:[MTRDeviceClusterData class]]) {
+        return NO;
+    }
+
+    return [self isEqualToClusterData:object];
+}
+
 @end
 
 @interface MTRDevice ()
@@ -2240,6 +2254,14 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     std::lock_guard lock(_lock);
     [self _setAttributeValues:attributeValues reportChanges:reportChanges];
 }
+
+#ifdef DEBUG
+- (NSUInteger)unitTestAttributeCount
+{
+    std::lock_guard lock(_lock);
+    return _readCache.count;
+}
+#endif
 
 - (void)setClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)clusterData
 {

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -589,6 +589,22 @@ using namespace chip::Tracing::DarwinFramework;
         return NO;
     }
 
+    if (_controllerDataStore) {
+        // If the storage delegate supports the bulk read API, then a dictionary of nodeID => cluster data dictionary would be passed to the handler. Otherwise this would be a no-op, and stored attributes for MTRDevice objects will be loaded lazily in -deviceForNodeID:.
+        [_controllerDataStore startUpWithClusterDataHandler:^(NSDictionary<NSNumber *, NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *> * _Nonnull clusterDataByNode) {
+            MTR_LOG_INFO("Loaded %lu nodes from storage", static_cast<unsigned long>(clusterDataByNode.count));
+            for (NSNumber * nodeID in clusterDataByNode) {
+                MTRDevice * device = [[MTRDevice alloc] initWithNodeID:nodeID controller:self];
+                NSDictionary * clusterData = clusterDataByNode[nodeID];
+                MTR_LOG_INFO("Loaded %lu cluster data from storage for %@", static_cast<unsigned long>(clusterData.count), device);
+                if (clusterData.count) {
+                    [device setClusterData:clusterData];
+                }
+                self->_nodeIDToDeviceMap[nodeID] = device;
+            }
+        }];
+    }
+
     return YES;
 }
 
@@ -957,6 +973,18 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         MTR_LOG_ERROR("Error: Cannot remove device %p with nodeID %llu", device, nodeID.unsignedLongLongValue);
     }
 }
+
+#ifdef DEBUG
+- (NSDictionary<NSNumber *, NSNumber *> *)unitTestGetDeviceAttributeCounts
+{
+    std::lock_guard lock(_deviceMapLock);
+    NSMutableDictionary<NSNumber *, NSNumber *> * deviceAttributeCounts = [NSMutableDictionary dictionary];
+    for (NSNumber * nodeID in _nodeIDToDeviceMap) {
+        deviceAttributeCounts[nodeID] = @([_nodeIDToDeviceMap[nodeID] unitTestAttributeCount]);
+    }
+    return deviceAttributeCounts;
+}
+#endif
 
 - (void)setDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue
 {

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.h
@@ -48,6 +48,13 @@ NS_ASSUME_NONNULL_BEGIN
                             storageDelegate:(id<MTRDeviceControllerStorageDelegate>)storageDelegate
                        storageDelegateQueue:(dispatch_queue_t)storageDelegateQueue;
 
+// clusterDataByNode a dictionary: nodeID => cluster data dictionary
+typedef void (^MTRDeviceControllerDataStoreClusterDataHandler)(NSDictionary<NSNumber *, NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *> * clusterDataByNode);
+/**
+ * Asks the data store to load cluster data for nodes in bulk, if the storageDelegate supports it.
+ */
+- (void)startUpWithClusterDataHandler:(MTRDeviceControllerDataStoreClusterDataHandler)clusterDataHandler;
+
 /**
  * Resumption info APIs.
  */

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
@@ -44,6 +44,7 @@ static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
     }
 }
 
+// TODO: Add another init argument for controller so that this can support multiple-controllers.
 - (instancetype)initWithPassThroughStorage:(id<MTRDeviceControllerStorageDelegate>)passThroughStorage
 {
     if (self = [super init]) {
@@ -81,8 +82,12 @@ static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
        sharingType:(MTRStorageSharingType)sharingType
 {
     if (sharingType == MTRStorageSharingTypeNotShared) {
-        NSError * error;
+        NSError * error = nil;
         NSData * data = [NSKeyedArchiver archivedDataWithRootObject:value requiringSecureCoding:YES error:&error];
+        if (error) {
+            MTR_LOG_INFO("MTRDeviceControllerLocalTestStorage storeValue: failed to convert value object to data %@", error);
+            return NO;
+        }
         NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
         [defaults setObject:data forKey:key];
         return YES;
@@ -110,6 +115,47 @@ static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
             return [_passThroughStorage controller:controller removeValueForKey:key securityLevel:securityLevel sharingType:sharingType];
         } else {
             MTR_LOG_INFO("MTRDeviceControllerLocalTestStorage removeValueForKey: shared type but no pass-through storage");
+            return NO;
+        }
+    }
+}
+
+- (NSDictionary<NSString *, id<NSSecureCoding>> *)valuesForController:(MTRDeviceController *)controller securityLevel:(MTRStorageSecurityLevel)securityLevel sharingType:(MTRStorageSharingType)sharingType
+{
+    if (sharingType == MTRStorageSharingTypeNotShared) {
+        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+        return [defaults dictionaryRepresentation];
+    } else {
+        if (_passThroughStorage && [_passThroughStorage respondsToSelector:@selector(valuesForController:securityLevel:sharingType:)]) {
+            return [_passThroughStorage valuesForController:controller securityLevel:securityLevel sharingType:sharingType];
+        } else {
+            MTR_LOG_INFO("MTRDeviceControllerLocalTestStorage valuesForController: shared type but no pass-through storage");
+            return nil;
+        }
+    }
+}
+
+- (BOOL)controller:(MTRDeviceController *)controller storeValues:(NSDictionary<NSString *, id<NSSecureCoding>> *)values securityLevel:(MTRStorageSecurityLevel)securityLevel sharingType:(MTRStorageSharingType)sharingType
+{
+    if (sharingType == MTRStorageSharingTypeNotShared) {
+        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+        BOOL success = YES;
+        for (NSString * key in values) {
+            NSError * error = nil;
+            NSData * data = [NSKeyedArchiver archivedDataWithRootObject:values[key] requiringSecureCoding:YES error:&error];
+            if (error) {
+                MTR_LOG_INFO("MTRDeviceControllerLocalTestStorage storeValues: failed to convert value object to data %@", error);
+                success = NO;
+                continue;
+            }
+            [defaults setObject:data forKey:key];
+        }
+        return success;
+    } else {
+        if (_passThroughStorage && [_passThroughStorage respondsToSelector:@selector(controller:storeValues:securityLevel:sharingType:)]) {
+            return [_passThroughStorage controller:controller storeValues:values securityLevel:securityLevel sharingType:sharingType];
+        } else {
+            MTR_LOG_INFO("MTRDeviceControllerLocalTestStorage valuesForController: shared type but no pass-through storage");
             return NO;
         }
     }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStorageDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStorageDelegate.h
@@ -111,6 +111,34 @@ MTR_NEWLY_AVAILABLE
     removeValueForKey:(NSString *)key
         securityLevel:(MTRStorageSecurityLevel)securityLevel
           sharingType:(MTRStorageSharingType)sharingType;
+
+@optional
+/**
+ * Return all keys and values stored, if any, for the provided controller in a
+ * dictionary. Returns nil if there is no stored value.
+ *
+ * securityLevel and dataType will always be the same for any given key value
+ * and are just present here to help locate the data if storage location is
+ * separated out by security level and data type.
+ *
+ * The set of classes that might be decoded by this function is available by
+ * calling MTRDeviceControllerStorageClasses().
+ */
+- (nullable NSDictionary<NSString *, id<NSSecureCoding>> *)valuesForController:(MTRDeviceController *)controller
+                                                                 securityLevel:(MTRStorageSecurityLevel)securityLevel
+                                                                   sharingType:(MTRStorageSharingType)sharingType;
+
+/**
+ * Store a list of keys and values in the form of a dictionary. Returns whether
+ * the store succeeded.
+ *
+ * securityLevel and dataType will always be the same for any given key value
+ * and are present here as a hint to how the value should be stored.
+ */
+- (BOOL)controller:(MTRDeviceController *)controller
+       storeValues:(NSDictionary<NSString *, id<NSSecureCoding>> *)values
+     securityLevel:(MTRStorageSecurityLevel)securityLevel
+       sharingType:(MTRStorageSharingType)sharingType;
 @end
 
 // TODO: FIXME: Is this a sane place to put this API?

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -90,6 +90,10 @@ MTR_TESTABLE
 //   Currently contains data version information
 - (void)setClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)clusterData;
 
+#ifdef DEBUG
+- (NSUInteger)unitTestAttributeCount;
+#endif
+
 @end
 
 #pragma mark - Utility for clamping numbers

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -1048,7 +1048,7 @@ static const uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
 
-    __auto_type * storageDelegate = [[MTRTestPerControllerStorage alloc] initWithControllerID:[NSUUID UUID]];
+    __auto_type * storageDelegate = [[MTRTestPerControllerStorageWithBulkReadWrite alloc] initWithControllerID:[NSUUID UUID]];
 
     NSNumber * nodeID = @(123);
     NSNumber * fabricID = @(456);
@@ -1105,6 +1105,7 @@ static const uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertEqual(dataStoreValues.count, 9);
 
     // Check values
+    NSUInteger unexpectedValues = 0;
     for (NSDictionary * responseValue in dataStoreValues) {
         MTRAttributePath * path = responseValue[MTRAttributePathKey];
         XCTAssertNotNil(path);
@@ -1134,8 +1135,11 @@ static const uint16_t kTestVendorId = 0xFFF1u;
             XCTAssertEqualObjects(value, @(212));
         } else if ([path.endpoint isEqualToNumber:@(2)] && [path.cluster isEqualToNumber:@(1)] && [path.attribute isEqualToNumber:@(3)]) {
             XCTAssertEqualObjects(value, @(213));
+        } else {
+            unexpectedValues++;
         }
     }
+    XCTAssertEqual(unexpectedValues, 0);
 
     NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> * dataStoreClusterData = [controller.controllerDataStore getStoredClusterDataForNodeID:@(1001)];
     for (MTRClusterPath * path in testClusterData) {
@@ -1190,11 +1194,100 @@ static const uint16_t kTestVendorId = 0xFFF1u;
     id testNodeIndex = [storageDelegate controller:controller valueForKey:@"attrCacheNodeIndex" securityLevel:MTRStorageSecurityLevelSecure sharingType:MTRStorageSharingTypeNotShared];
     XCTAssertNil(testNodeIndex);
 
+    // Now test bulk write
+    MTRClusterPath * bulkTestClusterPath11 = [MTRClusterPath clusterPathWithEndpointID:@(1) clusterID:@(1)];
+    MTRDeviceClusterData * bulkTestClusterData11 = [[MTRDeviceClusterData alloc] init];
+    bulkTestClusterData11.dataVersion = @(11);
+    bulkTestClusterData11.attributes = @{
+        @(1) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(111) },
+        @(2) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(112) },
+        @(3) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(113) },
+    };
+    MTRClusterPath * bulkTestClusterPath12 = [MTRClusterPath clusterPathWithEndpointID:@(1) clusterID:@(2)];
+    MTRDeviceClusterData * bulkTestClusterData12 = [[MTRDeviceClusterData alloc] init];
+    bulkTestClusterData12.dataVersion = @(12);
+    bulkTestClusterData12.attributes = @{
+        @(1) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(121) },
+        @(2) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(122) },
+        @(3) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(123) },
+    };
+    MTRClusterPath * bulkTestClusterPath13 = [MTRClusterPath clusterPathWithEndpointID:@(1) clusterID:@(3)];
+    MTRDeviceClusterData * bulkTestClusterData13 = [[MTRDeviceClusterData alloc] init];
+    bulkTestClusterData13.dataVersion = @(13);
+    bulkTestClusterData13.attributes = @{
+        @(1) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(131) },
+        @(2) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(132) },
+        @(3) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(133) },
+    };
+    MTRClusterPath * bulkTestClusterPath21 = [MTRClusterPath clusterPathWithEndpointID:@(2) clusterID:@(1)];
+    MTRDeviceClusterData * bulkTestClusterData21 = [[MTRDeviceClusterData alloc] init];
+    bulkTestClusterData21.dataVersion = @(21);
+    bulkTestClusterData21.attributes = @{
+        @(1) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(211) },
+        @(2) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(212) },
+        @(3) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(213) },
+    };
+    MTRClusterPath * bulkTestClusterPath22 = [MTRClusterPath clusterPathWithEndpointID:@(2) clusterID:@(2)];
+    MTRDeviceClusterData * bulkTestClusterData22 = [[MTRDeviceClusterData alloc] init];
+    bulkTestClusterData22.dataVersion = @(22);
+    bulkTestClusterData22.attributes = @{
+        @(1) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(221) },
+        @(2) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(222) },
+        @(3) : @ { MTRTypeKey : MTRUnsignedIntegerValueType, MTRValueKey : @(223) },
+    };
+    NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> * bulkTestclusterDataDictionary = @{
+        bulkTestClusterPath11 : bulkTestClusterData11,
+        bulkTestClusterPath12 : bulkTestClusterData12,
+        bulkTestClusterPath13 : bulkTestClusterData13,
+        bulkTestClusterPath21 : bulkTestClusterData21,
+        bulkTestClusterPath22 : bulkTestClusterData22,
+    };
+
+    // Manually construct what the total dictionary should look like
+    NSDictionary<NSString *, id<NSSecureCoding>> * testBulkValues = @{
+        @"attrCacheNodeIndex" : @[ @(3001) ],
+        [controller.controllerDataStore _endpointIndexKeyForNodeID:@(3001)] : @[ @(1), @(2) ],
+        [controller.controllerDataStore _clusterIndexKeyForNodeID:@(3001) endpointID:@(1)] : @[ @(1), @(2), @(3) ],
+        [controller.controllerDataStore _clusterIndexKeyForNodeID:@(3001) endpointID:@(2)] : @[ @(1), @(2) ],
+        [controller.controllerDataStore _clusterDataKeyForNodeID:@(3001) endpointID:@(1) clusterID:@(1)] : bulkTestClusterData11,
+        [controller.controllerDataStore _clusterDataKeyForNodeID:@(3001) endpointID:@(1) clusterID:@(2)] : bulkTestClusterData12,
+        [controller.controllerDataStore _clusterDataKeyForNodeID:@(3001) endpointID:@(1) clusterID:@(3)] : bulkTestClusterData13,
+        [controller.controllerDataStore _clusterDataKeyForNodeID:@(3001) endpointID:@(2) clusterID:@(1)] : bulkTestClusterData21,
+        [controller.controllerDataStore _clusterDataKeyForNodeID:@(3001) endpointID:@(2) clusterID:@(2)] : bulkTestClusterData22,
+    };
+    // Bulk store with delegate
+    dispatch_sync(_storageQueue, ^{
+        [storageDelegate controller:controller storeValues:testBulkValues securityLevel:MTRStorageSecurityLevelSecure sharingType:MTRStorageSharingTypeNotShared];
+    });
+    // Verify that the store resluted in the correct values
+    dataStoreClusterData = [controller.controllerDataStore getStoredClusterDataForNodeID:@(3001)];
+    for (MTRClusterPath * path in dataStoreClusterData) {
+        XCTAssertEqualObjects(bulkTestclusterDataDictionary[path], dataStoreClusterData[path]);
+    }
+
+    // Now test bulk store through data store
+    [controller.controllerDataStore storeClusterData:bulkTestclusterDataDictionary forNodeID:@(3001)];
+    dataStoreClusterData = [controller.controllerDataStore getStoredClusterDataForNodeID:@(3001)];
+    for (MTRClusterPath * path in dataStoreClusterData) {
+        XCTAssertEqualObjects(bulkTestclusterDataDictionary[path], dataStoreClusterData[path]);
+    }
+
+    // Now test bulk read directly from storage delegate
+    NSDictionary<NSString *, id<NSSecureCoding>> * dataStoreBulkValues = [storageDelegate valuesForController:controller securityLevel:MTRStorageSecurityLevelSecure sharingType:MTRStorageSharingTypeNotShared];
+    XCTAssertEqualObjects(dataStoreBulkValues[[controller.controllerDataStore _endpointIndexKeyForNodeID:@(3001)]], (@[ @(1), @(2) ]));
+    XCTAssertEqualObjects(dataStoreBulkValues[[controller.controllerDataStore _clusterIndexKeyForNodeID:@(3001) endpointID:@(1)]], (@[ @(1), @(2), @(3) ]));
+    XCTAssertEqualObjects(dataStoreBulkValues[[controller.controllerDataStore _clusterIndexKeyForNodeID:@(3001) endpointID:@(2)]], (@[ @(1), @(2) ]));
+    XCTAssertEqualObjects(dataStoreBulkValues[[controller.controllerDataStore _clusterDataKeyForNodeID:@(3001) endpointID:@(1) clusterID:@(1)]], bulkTestClusterData11);
+    XCTAssertEqualObjects(dataStoreBulkValues[[controller.controllerDataStore _clusterDataKeyForNodeID:@(3001) endpointID:@(1) clusterID:@(2)]], bulkTestClusterData12);
+    XCTAssertEqualObjects(dataStoreBulkValues[[controller.controllerDataStore _clusterDataKeyForNodeID:@(3001) endpointID:@(1) clusterID:@(3)]], bulkTestClusterData13);
+    XCTAssertEqualObjects(dataStoreBulkValues[[controller.controllerDataStore _clusterDataKeyForNodeID:@(3001) endpointID:@(2) clusterID:@(1)]], bulkTestClusterData21);
+    XCTAssertEqualObjects(dataStoreBulkValues[[controller.controllerDataStore _clusterDataKeyForNodeID:@(3001) endpointID:@(2) clusterID:@(2)]], bulkTestClusterData22);
+
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 }
 
-- (void)test009_TestDataStoreMTRDevice
+- (void)doDataStoreMTRDeviceTestWithStorageDelegate:(id<MTRDeviceControllerStorageDelegate>)storageDelegate
 {
     __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
@@ -1206,8 +1299,6 @@ static const uint16_t kTestVendorId = 0xFFF1u;
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
-
-    __auto_type * storageDelegate = [[MTRTestPerControllerStorage alloc] initWithControllerID:[NSUUID UUID]];
 
     NSNumber * nodeID = @(123);
     NSNumber * fabricID = @(456);
@@ -1313,7 +1404,7 @@ static const uint16_t kTestVendorId = 0xFFF1u;
     double storedAttributeDifferFromMTRDevicePercentage = storedAttributeDifferFromMTRDeviceCount * 100.0 / dataStoreValuesCount;
     XCTAssertTrue(storedAttributeDifferFromMTRDevicePercentage < 10.0);
 
-    // Now
+    // Now set up new delegate for the new device and verify that once subscription reestablishes, the data version filter loaded from storage will work
     __auto_type * newDelegate = [[MTRDeviceTestDelegate alloc] init];
 
     XCTestExpectation * newDeviceSubscriptionExpectation = [self expectationWithDescription:@"Subscription has been set up for new device"];
@@ -1337,6 +1428,61 @@ static const uint16_t kTestVendorId = 0xFFF1u;
     // Reset our commissionee.
     __auto_type * baseDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];
     ResetCommissionee(baseDevice, queue, self, kTimeoutInSeconds);
+
+    [controller shutdown];
+    XCTAssertFalse([controller isRunning]);
+}
+
+- (void)test009_TestDataStoreMTRDevice
+{
+    [self doDataStoreMTRDeviceTestWithStorageDelegate:[[MTRTestPerControllerStorage alloc] initWithControllerID:[NSUUID UUID]]];
+}
+
+- (void)test010_TestDataStoreMTRDeviceWithBulkReadWrite
+{
+    __auto_type * storageDelegate = [[MTRTestPerControllerStorageWithBulkReadWrite alloc] initWithControllerID:[NSUUID UUID]];
+
+    // First do the same test as the above
+    [self doDataStoreMTRDeviceTestWithStorageDelegate:storageDelegate];
+
+    // Then restart controller with same storage and see that bulk read through MTRDevice initialization works
+
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
+    XCTAssertNotNil(factory);
+
+    __auto_type * rootKeys = [[MTRTestKeys alloc] init];
+    XCTAssertNotNil(rootKeys);
+
+    __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
+    XCTAssertNotNil(operationalKeys);
+
+    NSNumber * nodeID = @(123);
+    NSNumber * fabricID = @(456);
+
+    NSError * error;
+
+    MTRPerControllerStorageTestsCertificateIssuer * certificateIssuer;
+    MTRDeviceController * controller = [self startControllerWithRootKeys:rootKeys
+                                                         operationalKeys:operationalKeys
+                                                                fabricID:fabricID
+                                                                  nodeID:nodeID
+                                                                 storage:storageDelegate
+                                                                   error:&error
+                                                       certificateIssuer:&certificateIssuer];
+    XCTAssertNil(error);
+    XCTAssertNotNil(controller);
+    XCTAssertTrue([controller isRunning]);
+
+    XCTAssertEqualObjects(controller.controllerNodeID, nodeID);
+
+    // No need to commission device - just look at device count
+    NSDictionary<NSNumber *, NSNumber *> * deviceAttributeCounts = [controller unitTestGetDeviceAttributeCounts];
+    XCTAssertTrue(deviceAttributeCounts.count > 0);
+    NSUInteger totalAttributes = 0;
+    for (NSNumber * nodeID in deviceAttributeCounts) {
+        totalAttributes += deviceAttributeCounts[nodeID].unsignedIntegerValue;
+    }
+    XCTAssertTrue(totalAttributes > 300);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)unitTestPruneEmptyStoredAttributesBranches;
 - (NSString *)_endpointIndexKeyForNodeID:(NSNumber *)nodeID;
 - (NSString *)_clusterIndexKeyForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID;
+- (NSString *)_clusterDataKeyForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID;
 - (NSString *)_attributeIndexKeyForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID;
 - (NSString *)_attributeValueKeyForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID attributeID:(NSNumber *)attributeID;
 @end
@@ -52,6 +53,10 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Declarations for items compiled only for DEBUG configuration
 
 #ifdef DEBUG
+@interface MTRDeviceController (TestDebug)
+- (NSDictionary<NSNumber *, NSNumber *> *)unitTestGetDeviceAttributeCounts;
+@end
+
 @interface MTRBaseDevice (TestDebug)
 - (void)failSubscribers:(dispatch_queue_t)queue completion:(void (^)(void))completion;
 

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestPerControllerStorage.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestPerControllerStorage.h
@@ -42,6 +42,17 @@ NS_ASSUME_NONNULL_BEGIN
           sharingType:(MTRStorageSharingType)sharingType;
 @end
 
+@interface MTRTestPerControllerStorageWithBulkReadWrite : MTRTestPerControllerStorage
+- (nullable NSDictionary<NSString *, id<NSSecureCoding>> *)valuesForController:(MTRDeviceController *)controller
+                                                                 securityLevel:(MTRStorageSecurityLevel)securityLevel
+                                                                   sharingType:(MTRStorageSharingType)sharingType;
+- (BOOL)controller:(MTRDeviceController *)controller
+       storeValues:(NSDictionary<NSString *, id<NSSecureCoding>> *)values
+     securityLevel:(MTRStorageSecurityLevel)securityLevel
+       sharingType:(MTRStorageSharingType)sharingType;
+
+@end
+
 NS_ASSUME_NONNULL_END
 
 #endif // MTR_PER_CONTROLLER_STORAGE_ENABLED

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestPerControllerStorage.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestPerControllerStorage.m
@@ -86,4 +86,35 @@
 
 @end
 
+@implementation MTRTestPerControllerStorageWithBulkReadWrite
+
+- (NSDictionary<NSString *, id<NSSecureCoding>> *)valuesForController:(MTRDeviceController *)controller securityLevel:(MTRStorageSecurityLevel)securityLevel sharingType:(MTRStorageSharingType)sharingType
+{
+    XCTAssertEqualObjects(self.controllerID, controller.uniqueIdentifier);
+
+    if (!self.storage.count) {
+        return nil;
+    }
+
+    NSMutableDictionary * valuesToReturn = [NSMutableDictionary dictionary];
+    for (NSString * key in self.storage) {
+        valuesToReturn[key] = [self controller:controller valueForKey:key securityLevel:securityLevel sharingType:sharingType];
+    }
+
+    return valuesToReturn;
+}
+
+- (BOOL)controller:(MTRDeviceController *)controller storeValues:(NSDictionary<NSString *, id<NSSecureCoding>> *)values securityLevel:(MTRStorageSecurityLevel)securityLevel sharingType:(MTRStorageSharingType)sharingType
+{
+    XCTAssertEqualObjects(self.controllerID, controller.uniqueIdentifier);
+
+    for (NSString * key in values) {
+        [self controller:controller storeValue:values[key] forKey:key securityLevel:securityLevel sharingType:sharingType];
+    }
+
+    return YES;
+}
+
+@end
+
 #endif // MTR_PER_CONTROLLER_STORAGE_ENABLED


### PR DESCRIPTION
This adds bulk store/fetch in the MTRDeviceControllerStorageDelegate, and the MTRDevice attribute storage implementation is changed to use it for bulk reads and writes if the storage delegate supports it.