### PR TITLE
Android: Fix memory leak in DnssdImpl.cpp ChipDnssdStopBrowse()

### DIFF
--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -224,6 +224,7 @@ CHIP_ERROR ChipDnssdStopBrowse(intptr_t browseIdentifier)
         ChipLogError(Discovery, "Java exception in ChipDnssdStopBrowse");
         env->ExceptionDescribe();
         env->ExceptionClear();
+        chip::Platform::Delete(ctx);
         return CHIP_JNI_ERROR_EXCEPTION_THROWN;
     }
     chip::Platform::Delete(ctx);

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -219,15 +219,14 @@ CHIP_ERROR ChipDnssdStopBrowse(intptr_t browseIdentifier)
 
     env->CallVoidMethod(sBrowserObject.ObjectRef(), sStopBrowseMethod, reinterpret_cast<jlong>(ctx->callback));
 
+    chip::Platform::Delete(ctx);
     if (env->ExceptionCheck())
     {
         ChipLogError(Discovery, "Java exception in ChipDnssdStopBrowse");
         env->ExceptionDescribe();
         env->ExceptionClear();
-        chip::Platform::Delete(ctx);
         return CHIP_JNI_ERROR_EXCEPTION_THROWN;
     }
-    chip::Platform::Delete(ctx);
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
**Change Summary** 

Fixing context memory lean in connectedhomeip/src/platform/android/DnssdImpl.cpp ChipDnssdStopBrowse() pointed out by bzbarsky-apple in previous PR [32801](https://github.com/project-chip/connectedhomeip/pull/32801) after it merged. Leak would occur if the call to the Java method failed, threw an exception. 

**Testing**

Verified and tested locally with the Android tv-casting-app example app. By calling the stop discovery API form the tv-casting-app app GUI, we are able to stop NsdManagerDiscovery discovery, prior to timeout triggered stop discovery.
