### PR TITLE
Allow thermostat system mode to be set to dry and sleep modes

### DIFF
--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -440,7 +440,7 @@ MatterThermostatClusterServerPreAttributeChangedCallback(const app::ConcreteAttr
         }
         auto RequestedSystemMode = static_cast<SystemModeEnum>(*value);
         if (ControlSequenceOfOperation > ControlSequenceOfOperationEnum::kCoolingAndHeatingWithReheat ||
-            RequestedSystemMode > SystemModeEnum::kFanOnly)
+            RequestedSystemMode > SystemModeEnum::kSleep)
         {
             return imcode::InvalidValue;
         }


### PR DESCRIPTION
Fixes #31903 by allowing the thermostat mode to be written to `Dry` and `Sleep` modes

