### PR TITLE
[Darwin] The data value comparison function in MTRDevice incorrectly complains about nil comparison

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2008,7 +2008,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
         return YES;
     }
     if (!one || !theOther) {
-        MTR_LOG_ERROR("%@ attribute data-value comparison does not expect a dictionary to be nil: %@ %@", self, one, theOther);
+        // Comparing against nil is expected, and should return NO quietly
         return NO;
     }
 


### PR DESCRIPTION
This minor logging fix removes a log line that incorrectly states a nil comparison is unexpected.