### PR TITLE
Refactored mDNS Browse Interface

### DIFF
--- a/examples/chip-tool/commands/common/DeviceScanner.cpp
+++ b/examples/chip-tool/commands/common/DeviceScanner.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR DeviceScanner::Stop()
 
 void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
 {
-    auto & commissionData = nodeData.commissionData;
+    auto & commissionData = nodeData.nodeData;
 
     auto discriminator = commissionData.longDiscriminator;
     auto vendorId      = static_cast<VendorId>(commissionData.vendorId);

--- a/examples/chip-tool/commands/common/DeviceScanner.h
+++ b/examples/chip-tool/commands/common/DeviceScanner.h
@@ -42,7 +42,7 @@ struct DeviceScannerResult
     chip::Optional<chip::Dnssd::CommonResolutionData> mResolutionData;
 };
 
-class DeviceScanner : public chip::Dnssd::CommissioningResolveDelegate,
+class DeviceScanner : public chip::Dnssd::DiscoverNodeDelegate,
                       public chip::Dnssd::DnssdBrowseDelegate
 #if CONFIG_NETWORK_LAYER_BLE
     ,
@@ -56,7 +56,7 @@ public:
     CHIP_ERROR Get(uint16_t index, chip::Dnssd::CommonResolutionData & resolutionData);
     void Log() const;
 
-    /////////// CommissioningResolveDelegate Interface /////////
+    /////////// DiscoverNodeDelegate Interface /////////
     void OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
 
     /////////// DnssdBrowseDelegate Interface /////////

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -209,7 +209,7 @@ CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::DiscoveredNodeData & nodeDat
     VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
 
     auto & resolutionData = nodeData.resolutionData;
-    auto & commissionData = nodeData.commissionData;
+    auto & commissionData = nodeData.nodeData;
 
     if (!chip::CanCastTo<uint8_t>(resolutionData.numIPs))
     {

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -482,7 +482,7 @@ void PairingCommand::OnICDStayActiveComplete(NodeId deviceId, uint32_t promisedA
 void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
 {
     // Ignore nodes with closed commissioning window
-    VerifyOrReturn(nodeData.commissionData.commissioningMode != 0);
+    VerifyOrReturn(nodeData.nodeData.commissioningMode != 0);
 
     auto & resolutionData = nodeData.resolutionData;
 

--- a/examples/platform/linux/ControllerShellCommands.cpp
+++ b/examples/platform/linux/ControllerShellCommands.cpp
@@ -124,8 +124,8 @@ static CHIP_ERROR display(bool printHeader)
         else
         {
             streamer_printf(sout, "  Entry %d instanceName=%s host=%s longDiscriminator=%d vendorId=%d productId=%d\r\n", i,
-                            next->commissionData.instanceName, next->resolutionData.hostName,
-                            next->commissionData.longDiscriminator, next->commissionData.vendorId, next->commissionData.productId);
+                            next->nodeData.instanceName, next->resolutionData.hostName, next->nodeData.longDiscriminator,
+                            next->nodeData.vendorId, next->nodeData.productId);
         }
     }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
@@ -324,53 +324,50 @@ CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscovered
     jstring jInstanceName         = static_cast<jstring>(env->GetObjectField(jDiscoveredNodeData, getInstanceNameField));
     if (jInstanceName != nullptr)
     {
-        chip::Platform::CopyString(outCppDiscoveredNodeData.commissionData.instanceName,
+        chip::Platform::CopyString(outCppDiscoveredNodeData.nodeData.instanceName,
                                    chip::Dnssd::Commission::kInstanceNameMaxLength + 1, env->GetStringUTFChars(jInstanceName, 0));
     }
 
     jfieldID jLongDiscriminatorField = env->GetFieldID(jDiscoveredNodeDataClass, "longDiscriminator", "J");
-    outCppDiscoveredNodeData.commissionData.vendorId =
+    outCppDiscoveredNodeData.nodeData.vendorId =
         static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jLongDiscriminatorField));
 
-    jfieldID jVendorIdField = env->GetFieldID(jDiscoveredNodeDataClass, "vendorId", "J");
-    outCppDiscoveredNodeData.commissionData.vendorId =
-        static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jVendorIdField));
+    jfieldID jVendorIdField                    = env->GetFieldID(jDiscoveredNodeDataClass, "vendorId", "J");
+    outCppDiscoveredNodeData.nodeData.vendorId = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jVendorIdField));
 
-    jfieldID jProductIdField = env->GetFieldID(jDiscoveredNodeDataClass, "productId", "J");
-    outCppDiscoveredNodeData.commissionData.productId =
-        static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jProductIdField));
+    jfieldID jProductIdField                    = env->GetFieldID(jDiscoveredNodeDataClass, "productId", "J");
+    outCppDiscoveredNodeData.nodeData.productId = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jProductIdField));
 
     jfieldID jCommissioningModeField = env->GetFieldID(jDiscoveredNodeDataClass, "commissioningMode", "B");
-    outCppDiscoveredNodeData.commissionData.commissioningMode =
+    outCppDiscoveredNodeData.nodeData.commissioningMode =
         static_cast<uint8_t>(env->GetByteField(jDiscoveredNodeData, jCommissioningModeField));
 
-    jfieldID jDeviceTypeField = env->GetFieldID(jDiscoveredNodeDataClass, "deviceType", "J");
-    outCppDiscoveredNodeData.commissionData.deviceType =
-        static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jDeviceTypeField));
+    jfieldID jDeviceTypeField                    = env->GetFieldID(jDiscoveredNodeDataClass, "deviceType", "J");
+    outCppDiscoveredNodeData.nodeData.deviceType = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jDeviceTypeField));
 
     jfieldID getDeviceNameField = env->GetFieldID(jDiscoveredNodeDataClass, "deviceName", "Ljava/lang/String;");
     jstring jDeviceName         = static_cast<jstring>(env->GetObjectField(jDiscoveredNodeData, getDeviceNameField));
     if (jDeviceName != nullptr)
     {
-        chip::Platform::CopyString(outCppDiscoveredNodeData.commissionData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
+        chip::Platform::CopyString(outCppDiscoveredNodeData.nodeData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
                                    env->GetStringUTFChars(jDeviceName, 0));
     }
 
     // TODO: map rotating ID
     jfieldID jRotatingIdLenField = env->GetFieldID(jDiscoveredNodeDataClass, "rotatingIdLen", "I");
-    outCppDiscoveredNodeData.commissionData.rotatingIdLen =
+    outCppDiscoveredNodeData.nodeData.rotatingIdLen =
         static_cast<size_t>(env->GetIntField(jDiscoveredNodeData, jRotatingIdLenField));
 
     jfieldID jPairingHintField = env->GetFieldID(jDiscoveredNodeDataClass, "pairingHint", "S");
-    outCppDiscoveredNodeData.commissionData.pairingHint =
+    outCppDiscoveredNodeData.nodeData.pairingHint =
         static_cast<uint16_t>(env->GetShortField(jDiscoveredNodeData, jPairingHintField));
 
     jfieldID getPairingInstructionField = env->GetFieldID(jDiscoveredNodeDataClass, "pairingInstruction", "Ljava/lang/String;");
     jstring jPairingInstruction = static_cast<jstring>(env->GetObjectField(jDiscoveredNodeData, getPairingInstructionField));
     if (jPairingInstruction != nullptr)
     {
-        chip::Platform::CopyString(outCppDiscoveredNodeData.commissionData.pairingInstruction,
-                                   chip::Dnssd::kMaxPairingInstructionLen + 1, env->GetStringUTFChars(jPairingInstruction, 0));
+        chip::Platform::CopyString(outCppDiscoveredNodeData.nodeData.pairingInstruction, chip::Dnssd::kMaxPairingInstructionLen + 1,
+                                   env->GetStringUTFChars(jPairingInstruction, 0));
     }
 
     jfieldID jPortField                          = env->GetFieldID(jDiscoveredNodeDataClass, "port", "I");

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.mm
@@ -48,20 +48,20 @@
                            outDiscoveredNodeData:(chip::Dnssd::DiscoveredNodeData &)outDiscoveredNodeData
 {
     // setting CommissionNodeData
-    outDiscoveredNodeData.commissionData.deviceType = objCDiscoveredNodeData.deviceType;
-    outDiscoveredNodeData.commissionData.vendorId = objCDiscoveredNodeData.vendorId;
-    outDiscoveredNodeData.commissionData.productId = objCDiscoveredNodeData.productId;
-    outDiscoveredNodeData.commissionData.longDiscriminator = objCDiscoveredNodeData.longDiscriminator;
-    outDiscoveredNodeData.commissionData.commissioningMode = objCDiscoveredNodeData.commissioningMode;
-    outDiscoveredNodeData.commissionData.pairingHint = objCDiscoveredNodeData.pairingHint;
-    memset(outDiscoveredNodeData.commissionData.deviceName, '\0', sizeof(outDiscoveredNodeData.commissionData.deviceName));
+    outDiscoveredNodeData.nodeData.deviceType = objCDiscoveredNodeData.deviceType;
+    outDiscoveredNodeData.nodeData.vendorId = objCDiscoveredNodeData.vendorId;
+    outDiscoveredNodeData.nodeData.productId = objCDiscoveredNodeData.productId;
+    outDiscoveredNodeData.nodeData.longDiscriminator = objCDiscoveredNodeData.longDiscriminator;
+    outDiscoveredNodeData.nodeData.commissioningMode = objCDiscoveredNodeData.commissioningMode;
+    outDiscoveredNodeData.nodeData.pairingHint = objCDiscoveredNodeData.pairingHint;
+    memset(outDiscoveredNodeData.nodeData.deviceName, '\0', sizeof(outDiscoveredNodeData.nodeData.deviceName));
     if (objCDiscoveredNodeData.deviceName != nullptr) {
-        chip::Platform::CopyString(outDiscoveredNodeData.commissionData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
+        chip::Platform::CopyString(outDiscoveredNodeData.nodeData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
             [objCDiscoveredNodeData.deviceName UTF8String]);
     }
-    outDiscoveredNodeData.commissionData.rotatingIdLen = objCDiscoveredNodeData.rotatingIdLen;
+    outDiscoveredNodeData.nodeData.rotatingIdLen = objCDiscoveredNodeData.rotatingIdLen;
     memcpy(
-        outDiscoveredNodeData.commissionData.rotatingId, objCDiscoveredNodeData.rotatingId, objCDiscoveredNodeData.rotatingIdLen);
+        outDiscoveredNodeData.nodeData.rotatingId, objCDiscoveredNodeData.rotatingId, objCDiscoveredNodeData.rotatingIdLen);
 
     // setting CommonResolutionData
     outDiscoveredNodeData.resolutionData.port = objCDiscoveredNodeData.port;
@@ -121,17 +121,17 @@
     DiscoveredNodeData * objCDiscoveredNodeData = [DiscoveredNodeData new];
 
     // from CommissionNodeData
-    objCDiscoveredNodeData.deviceType = cppDiscoveredNodedata->commissionData.deviceType;
-    objCDiscoveredNodeData.vendorId = cppDiscoveredNodedata->commissionData.vendorId;
-    objCDiscoveredNodeData.productId = cppDiscoveredNodedata->commissionData.productId;
-    objCDiscoveredNodeData.longDiscriminator = cppDiscoveredNodedata->commissionData.longDiscriminator;
-    objCDiscoveredNodeData.commissioningMode = cppDiscoveredNodedata->commissionData.commissioningMode;
-    objCDiscoveredNodeData.pairingHint = cppDiscoveredNodedata->commissionData.pairingHint;
-    objCDiscoveredNodeData.deviceName = [NSString stringWithCString:cppDiscoveredNodedata->commissionData.deviceName
+    objCDiscoveredNodeData.deviceType = cppDiscoveredNodedata->nodeData.deviceType;
+    objCDiscoveredNodeData.vendorId = cppDiscoveredNodedata->nodeData.vendorId;
+    objCDiscoveredNodeData.productId = cppDiscoveredNodedata->nodeData.productId;
+    objCDiscoveredNodeData.longDiscriminator = cppDiscoveredNodedata->nodeData.longDiscriminator;
+    objCDiscoveredNodeData.commissioningMode = cppDiscoveredNodedata->nodeData.commissioningMode;
+    objCDiscoveredNodeData.pairingHint = cppDiscoveredNodedata->nodeData.pairingHint;
+    objCDiscoveredNodeData.deviceName = [NSString stringWithCString:cppDiscoveredNodedata->nodeData.deviceName
                                                            encoding:NSUTF8StringEncoding];
-    objCDiscoveredNodeData.rotatingIdLen = cppDiscoveredNodedata->commissionData.rotatingIdLen;
-    objCDiscoveredNodeData.rotatingId = cppDiscoveredNodedata->commissionData.rotatingId;
-    objCDiscoveredNodeData.instanceName = [NSString stringWithCString:cppDiscoveredNodedata->commissionData.instanceName
+    objCDiscoveredNodeData.rotatingIdLen = cppDiscoveredNodedata->nodeData.rotatingIdLen;
+    objCDiscoveredNodeData.rotatingId = cppDiscoveredNodedata->nodeData.rotatingId;
+    objCDiscoveredNodeData.instanceName = [NSString stringWithCString:cppDiscoveredNodedata->nodeData.instanceName
                                                              encoding:NSUTF8StringEncoding];
 
     // from CommonResolutionData

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -83,10 +83,10 @@ void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::Discover
     CastingPlayerAttributes attributes;
     snprintf(attributes.id, kIdMaxLength + 1, "%s%u", nodeData.resolutionData.hostName, nodeData.resolutionData.port);
 
-    chip::Platform::CopyString(attributes.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1, nodeData.commissionData.deviceName);
+    chip::Platform::CopyString(attributes.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1, nodeData.nodeData.deviceName);
     chip::Platform::CopyString(attributes.hostName, chip::Dnssd::kHostNameMaxLength + 1, nodeData.resolutionData.hostName);
     chip::Platform::CopyString(attributes.instanceName, chip::Dnssd::Commission::kInstanceNameMaxLength + 1,
-                               nodeData.commissionData.instanceName);
+                               nodeData.nodeData.instanceName);
 
     attributes.numIPs = (unsigned int) nodeData.resolutionData.numIPs;
     for (unsigned j = 0; j < attributes.numIPs; j++)
@@ -95,9 +95,9 @@ void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::Discover
     }
     attributes.interfaceId = nodeData.resolutionData.interfaceId;
     attributes.port        = nodeData.resolutionData.port;
-    attributes.productId   = nodeData.commissionData.productId;
-    attributes.vendorId    = nodeData.commissionData.vendorId;
-    attributes.deviceType  = nodeData.commissionData.deviceType;
+    attributes.productId   = nodeData.nodeData.productId;
+    attributes.vendorId    = nodeData.nodeData.vendorId;
+    attributes.deviceType  = nodeData.nodeData.deviceType;
 
     memory::Strong<CastingPlayer> player = std::make_shared<CastingPlayer>(attributes);
 

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -226,20 +226,20 @@ CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(Dnssd::Discovered
         getIpAddressForUDCRequest(selectedCommissioner->resolutionData.ipAddress, selectedCommissioner->resolutionData.numIPs);
     ReturnErrorOnFailure(SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress::UDP(
         *ipAddressToUse, selectedCommissioner->resolutionData.port, selectedCommissioner->resolutionData.interfaceId)));
-    mTargetVideoPlayerVendorId   = selectedCommissioner->commissionData.vendorId;
-    mTargetVideoPlayerProductId  = selectedCommissioner->commissionData.productId;
-    mTargetVideoPlayerDeviceType = selectedCommissioner->commissionData.deviceType;
+    mTargetVideoPlayerVendorId   = selectedCommissioner->nodeData.vendorId;
+    mTargetVideoPlayerProductId  = selectedCommissioner->nodeData.productId;
+    mTargetVideoPlayerDeviceType = selectedCommissioner->nodeData.deviceType;
     mTargetVideoPlayerNumIPs     = selectedCommissioner->resolutionData.numIPs;
     for (size_t i = 0; i < mTargetVideoPlayerNumIPs && i < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; i++)
     {
         mTargetVideoPlayerIpAddress[i] = selectedCommissioner->resolutionData.ipAddress[i];
     }
     chip::Platform::CopyString(mTargetVideoPlayerDeviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
-                               selectedCommissioner->commissionData.deviceName);
+                               selectedCommissioner->nodeData.deviceName);
     chip::Platform::CopyString(mTargetVideoPlayerHostName, chip::Dnssd::kHostNameMaxLength + 1,
                                selectedCommissioner->resolutionData.hostName);
     chip::Platform::CopyString(mTargetVideoPlayerInstanceName, chip::Dnssd::Commission::kInstanceNameMaxLength + 1,
-                               selectedCommissioner->commissionData.instanceName);
+                               selectedCommissioner->nodeData.instanceName);
     mTargetVideoPlayerPort = selectedCommissioner->resolutionData.port;
     return CHIP_NO_ERROR;
 }

--- a/examples/tv-casting-app/tv-casting-common/src/ConversionUtils.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/ConversionUtils.cpp
@@ -23,10 +23,10 @@ CHIP_ERROR ConvertToDiscoveredNodeData(TargetVideoPlayerInfo * inPlayer, chip::D
     if (inPlayer == nullptr)
         return CHIP_ERROR_INVALID_ARGUMENT;
 
-    outNodeData.commissionData.vendorId   = inPlayer->GetVendorId();
-    outNodeData.commissionData.productId  = static_cast<uint16_t>(inPlayer->GetProductId());
-    outNodeData.commissionData.deviceType = inPlayer->GetDeviceType();
-    outNodeData.resolutionData.numIPs     = inPlayer->GetNumIPs();
+    outNodeData.nodeData.vendorId     = inPlayer->GetVendorId();
+    outNodeData.nodeData.productId    = static_cast<uint16_t>(inPlayer->GetProductId());
+    outNodeData.nodeData.deviceType   = inPlayer->GetDeviceType();
+    outNodeData.resolutionData.numIPs = inPlayer->GetNumIPs();
 
     const chip::Inet::IPAddress * ipAddresses = inPlayer->GetIpAddresses();
     if (ipAddresses != nullptr)
@@ -37,8 +37,7 @@ CHIP_ERROR ConvertToDiscoveredNodeData(TargetVideoPlayerInfo * inPlayer, chip::D
         }
     }
 
-    chip::Platform::CopyString(outNodeData.commissionData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
-                               inPlayer->GetDeviceName());
+    chip::Platform::CopyString(outNodeData.nodeData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1, inPlayer->GetDeviceName());
     chip::Platform::CopyString(outNodeData.resolutionData.hostName, chip::Dnssd::kHostNameMaxLength + 1, inPlayer->GetHostName());
 
     return CHIP_NO_ERROR;

--- a/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
@@ -232,6 +232,6 @@ bool TargetVideoPlayerInfo::IsSameAs(const chip::Dnssd::DiscoveredNodeData * dis
         return false;
     }
 
-    return IsSameAs(discoveredNodeData->resolutionData.hostName, discoveredNodeData->commissionData.deviceName,
+    return IsSameAs(discoveredNodeData->resolutionData.hostName, discoveredNodeData->nodeData.deviceName,
                     discoveredNodeData->resolutionData.numIPs, discoveredNodeData->resolutionData.ipAddress);
 }

--- a/src/controller/AbstractDnssdDiscoveryController.h
+++ b/src/controller/AbstractDnssdDiscoveryController.h
@@ -36,7 +36,7 @@ namespace Controller {
  *   to maintain a list of DiscoveredNodes and providing the implementation
  *   of the template GetDiscoveredNodes() function.
  */
-class DLL_EXPORT AbstractDnssdDiscoveryController : public Dnssd::CommissioningResolveDelegate
+class DLL_EXPORT AbstractDnssdDiscoveryController : public Dnssd::DiscoverNodeDelegate
 {
 public:
     explicit AbstractDnssdDiscoveryController(Dnssd::Resolver * resolver = nullptr) : mDNSResolver(resolver) {}

--- a/src/controller/CHIPCommissionableNodeController.cpp
+++ b/src/controller/CHIPCommissionableNodeController.cpp
@@ -36,13 +36,13 @@ CHIP_ERROR CommissionableNodeController::DiscoverCommissioners(Dnssd::DiscoveryF
     mDNSResolver.Shutdown(); // reset if already inited
     ReturnErrorOnFailure(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()));
 #endif
-    mDNSResolver.SetCommissioningDelegate(this);
+    mDNSResolver.SetDiscoveryDelegate(this);
     return mDNSResolver.DiscoverCommissioners(discoveryFilter);
 }
 
 CommissionableNodeController::~CommissionableNodeController()
 {
-    mDNSResolver.SetCommissioningDelegate(nullptr);
+    mDNSResolver.SetDiscoveryDelegate(nullptr);
 }
 
 const Dnssd::DiscoveredNodeData * CommissionableNodeController::GetDiscoveredCommissioner(int idx)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -110,7 +110,7 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
     VerifyOrReturnError(params.systemState->TransportMgr() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     ReturnErrorOnFailure(mDNSResolver.Init(params.systemState->UDPEndPointManager()));
-    mDNSResolver.SetCommissioningDelegate(this);
+    mDNSResolver.SetDiscoveryDelegate(this);
     RegisterDeviceDiscoveryDelegate(params.deviceDiscoveryDelegate);
 
     mVendorId = params.controllerVendorId;

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -332,23 +332,22 @@ bool SetUpCodePairer::IdIsPresent(uint16_t vendorOrProductID)
 
 bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData & nodeData) const
 {
-    if (nodeData.commissionData.commissioningMode == 0)
+    if (nodeData.nodeData.commissioningMode == 0)
     {
         ChipLogProgress(Controller, "Discovered device does not have an open commissioning window.");
         return false;
     }
 
     // The advertisement may not include a vendor id.
-    if (IdIsPresent(mPayloadVendorID) && IdIsPresent(nodeData.commissionData.vendorId) &&
-        mPayloadVendorID != nodeData.commissionData.vendorId)
+    if (IdIsPresent(mPayloadVendorID) && IdIsPresent(nodeData.nodeData.vendorId) && mPayloadVendorID != nodeData.nodeData.vendorId)
     {
         ChipLogProgress(Controller, "Discovered device does not match our vendor id.");
         return false;
     }
 
     // The advertisement may not include a product id.
-    if (IdIsPresent(mPayloadProductID) && IdIsPresent(nodeData.commissionData.productId) &&
-        mPayloadProductID != nodeData.commissionData.productId)
+    if (IdIsPresent(mPayloadProductID) && IdIsPresent(nodeData.nodeData.productId) &&
+        mPayloadProductID != nodeData.nodeData.productId)
     {
         ChipLogProgress(Controller, "Discovered device does not match our product id.");
         return false;
@@ -358,10 +357,10 @@ bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData &
     switch (mCurrentFilter.type)
     {
     case Dnssd::DiscoveryFilterType::kShortDiscriminator:
-        discriminatorMatches = (((nodeData.commissionData.longDiscriminator >> 8) & 0x0F) == mCurrentFilter.code);
+        discriminatorMatches = (((nodeData.nodeData.longDiscriminator >> 8) & 0x0F) == mCurrentFilter.code);
         break;
     case Dnssd::DiscoveryFilterType::kLongDiscriminator:
-        discriminatorMatches = (nodeData.commissionData.longDiscriminator == mCurrentFilter.code);
+        discriminatorMatches = (nodeData.nodeData.longDiscriminator == mCurrentFilter.code);
         break;
     default:
         ChipLogError(Controller, "Unknown filter type; all matches will fail");

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1905,7 +1905,7 @@ JNI_METHOD(jobject, getDiscoveredDevice)(JNIEnv * env, jobject self, jlong handl
 
     jobject discoveredObj = env->NewObject(discoveredDeviceCls, constructor);
 
-    env->SetLongField(discoveredObj, discrminatorID, data->commissionData.longDiscriminator);
+    env->SetLongField(discoveredObj, discrminatorID, data->nodeData.longDiscriminator);
 
     char ipAddress[100];
     data->resolutionData.ipAddress[0].ToString(ipAddress, 100);
@@ -1913,13 +1913,13 @@ JNI_METHOD(jobject, getDiscoveredDevice)(JNIEnv * env, jobject self, jlong handl
 
     env->SetObjectField(discoveredObj, ipAddressID, jniipAdress);
     env->SetIntField(discoveredObj, portID, static_cast<jint>(data->resolutionData.port));
-    env->SetLongField(discoveredObj, deviceTypeID, static_cast<jlong>(data->commissionData.deviceType));
-    env->SetIntField(discoveredObj, vendorIdID, static_cast<jint>(data->commissionData.vendorId));
-    env->SetIntField(discoveredObj, productIdID, static_cast<jint>(data->commissionData.productId));
+    env->SetLongField(discoveredObj, deviceTypeID, static_cast<jlong>(data->nodeData.deviceType));
+    env->SetIntField(discoveredObj, vendorIdID, static_cast<jint>(data->nodeData.vendorId));
+    env->SetIntField(discoveredObj, productIdID, static_cast<jint>(data->nodeData.productId));
 
     jbyteArray jRotatingId;
-    CHIP_ERROR err = JniReferences::GetInstance().N2J_ByteArray(
-        env, data->commissionData.rotatingId, static_cast<jsize>(data->commissionData.rotatingIdLen), jRotatingId);
+    CHIP_ERROR err = JniReferences::GetInstance().N2J_ByteArray(env, data->nodeData.rotatingId,
+                                                                static_cast<jsize>(data->nodeData.rotatingIdLen), jRotatingId);
 
     if (err != CHIP_NO_ERROR)
     {
@@ -1927,12 +1927,12 @@ JNI_METHOD(jobject, getDiscoveredDevice)(JNIEnv * env, jobject self, jlong handl
         return nullptr;
     }
     env->SetObjectField(discoveredObj, rotatingIdID, static_cast<jobject>(jRotatingId));
-    env->SetObjectField(discoveredObj, instanceNameID, env->NewStringUTF(data->commissionData.instanceName));
-    env->SetObjectField(discoveredObj, deviceNameID, env->NewStringUTF(data->commissionData.deviceName));
-    env->SetObjectField(discoveredObj, pairingInstructionID, env->NewStringUTF(data->commissionData.pairingInstruction));
+    env->SetObjectField(discoveredObj, instanceNameID, env->NewStringUTF(data->nodeData.instanceName));
+    env->SetObjectField(discoveredObj, deviceNameID, env->NewStringUTF(data->nodeData.deviceName));
+    env->SetObjectField(discoveredObj, pairingInstructionID, env->NewStringUTF(data->nodeData.pairingInstruction));
 
-    env->CallVoidMethod(discoveredObj, setCommissioningModeID, static_cast<jint>(data->commissionData.commissioningMode));
-    env->CallVoidMethod(discoveredObj, setPairingHintID, static_cast<jint>(data->commissionData.pairingHint));
+    env->CallVoidMethod(discoveredObj, setCommissioningModeID, static_cast<jint>(data->nodeData.commissioningMode));
+    env->CallVoidMethod(discoveredObj, setPairingHintID, static_cast<jint>(data->nodeData.pairingHint));
 
     return discoveredObj;
 }

--- a/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
+++ b/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
@@ -82,22 +82,22 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
             continue;
         }
         char rotatingId[chip::Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-        Encoding::BytesToUppercaseHexString(dnsSdInfo->commissionData.rotatingId, dnsSdInfo->commissionData.rotatingIdLen,
-                                            rotatingId, sizeof(rotatingId));
+        Encoding::BytesToUppercaseHexString(dnsSdInfo->nodeData.rotatingId, dnsSdInfo->nodeData.rotatingIdLen, rotatingId,
+                                            sizeof(rotatingId));
 
         ChipLogProgress(Discovery, "Commissioner %d", i);
-        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->commissionData.instanceName);
+        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->nodeData.instanceName);
         ChipLogProgress(Discovery, "\tHost name:\t\t%s", dnsSdInfo->resolutionData.hostName);
         ChipLogProgress(Discovery, "\tPort:\t\t\t%u", dnsSdInfo->resolutionData.port);
-        ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->commissionData.longDiscriminator);
-        ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", dnsSdInfo->commissionData.vendorId);
-        ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", dnsSdInfo->commissionData.productId);
-        ChipLogProgress(Discovery, "\tCommissioning Mode\t%u", dnsSdInfo->commissionData.commissioningMode);
-        ChipLogProgress(Discovery, "\tDevice Type\t\t%u", dnsSdInfo->commissionData.deviceType);
-        ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->commissionData.deviceName);
+        ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->nodeData.longDiscriminator);
+        ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", dnsSdInfo->nodeData.vendorId);
+        ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", dnsSdInfo->nodeData.productId);
+        ChipLogProgress(Discovery, "\tCommissioning Mode\t%u", dnsSdInfo->nodeData.commissioningMode);
+        ChipLogProgress(Discovery, "\tDevice Type\t\t%u", dnsSdInfo->nodeData.deviceType);
+        ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->nodeData.deviceName);
         ChipLogProgress(Discovery, "\tRotating Id\t\t%s", rotatingId);
-        ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->commissionData.pairingInstruction);
-        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->commissionData.pairingHint);
+        ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->nodeData.pairingInstruction);
+        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->nodeData.pairingHint);
         if (dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().HasValue())
         {
             ChipLogProgress(Discovery, "\tMrp Interval idle\t%u",

--- a/src/controller/python/ChipDeviceController-Discovery.cpp
+++ b/src/controller/python/ChipDeviceController-Discovery.cpp
@@ -110,21 +110,21 @@ void pychip_DeviceController_IterateDiscoveredCommissionableNodes(Controller::De
         Json::Value jsonVal;
 
         char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-        Encoding::BytesToUppercaseHexString(dnsSdInfo->commissionData.rotatingId, dnsSdInfo->commissionData.rotatingIdLen,
-                                            rotatingId, sizeof(rotatingId));
+        Encoding::BytesToUppercaseHexString(dnsSdInfo->nodeData.rotatingId, dnsSdInfo->nodeData.rotatingIdLen, rotatingId,
+                                            sizeof(rotatingId));
 
         ChipLogProgress(Discovery, "Commissionable Node %d", i);
-        jsonVal["instanceName"]       = dnsSdInfo->commissionData.instanceName;
+        jsonVal["instanceName"]       = dnsSdInfo->nodeData.instanceName;
         jsonVal["hostName"]           = dnsSdInfo->resolutionData.hostName;
         jsonVal["port"]               = dnsSdInfo->resolutionData.port;
-        jsonVal["longDiscriminator"]  = dnsSdInfo->commissionData.longDiscriminator;
-        jsonVal["vendorId"]           = dnsSdInfo->commissionData.vendorId;
-        jsonVal["productId"]          = dnsSdInfo->commissionData.productId;
-        jsonVal["commissioningMode"]  = dnsSdInfo->commissionData.commissioningMode;
-        jsonVal["deviceType"]         = dnsSdInfo->commissionData.deviceType;
-        jsonVal["deviceName"]         = dnsSdInfo->commissionData.deviceName;
-        jsonVal["pairingInstruction"] = dnsSdInfo->commissionData.pairingInstruction;
-        jsonVal["pairingHint"]        = dnsSdInfo->commissionData.pairingHint;
+        jsonVal["longDiscriminator"]  = dnsSdInfo->nodeData.longDiscriminator;
+        jsonVal["vendorId"]           = dnsSdInfo->nodeData.vendorId;
+        jsonVal["productId"]          = dnsSdInfo->nodeData.productId;
+        jsonVal["commissioningMode"]  = dnsSdInfo->nodeData.commissioningMode;
+        jsonVal["deviceType"]         = dnsSdInfo->nodeData.deviceType;
+        jsonVal["deviceName"]         = dnsSdInfo->nodeData.deviceName;
+        jsonVal["pairingInstruction"] = dnsSdInfo->nodeData.pairingInstruction;
+        jsonVal["pairingHint"]        = dnsSdInfo->nodeData.pairingHint;
         if (dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().HasValue())
         {
             jsonVal["mrpRetryIntervalIdle"] = dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().Value().count();
@@ -152,7 +152,7 @@ void pychip_DeviceController_IterateDiscoveredCommissionableNodes(Controller::De
         {
             jsonVal["isICDOperatingAsLIT"] = dnsSdInfo->resolutionData.isICDOperatingAsLIT.Value();
         }
-        if (dnsSdInfo->commissionData.rotatingIdLen > 0)
+        if (dnsSdInfo->nodeData.rotatingIdLen > 0)
         {
             jsonVal["rotatingId"] = rotatingId;
         }
@@ -174,22 +174,22 @@ void pychip_DeviceController_PrintDiscoveredDevices(Controller::DeviceCommission
             continue;
         }
         char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-        Encoding::BytesToUppercaseHexString(dnsSdInfo->commissionData.rotatingId, dnsSdInfo->commissionData.rotatingIdLen,
-                                            rotatingId, sizeof(rotatingId));
+        Encoding::BytesToUppercaseHexString(dnsSdInfo->nodeData.rotatingId, dnsSdInfo->nodeData.rotatingIdLen, rotatingId,
+                                            sizeof(rotatingId));
 
         ChipLogProgress(Discovery, "Commissionable Node %d", i);
-        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->commissionData.instanceName);
+        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->nodeData.instanceName);
         ChipLogProgress(Discovery, "\tHost name:\t\t%s", dnsSdInfo->resolutionData.hostName);
         ChipLogProgress(Discovery, "\tPort:\t\t\t%u", dnsSdInfo->resolutionData.port);
-        ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->commissionData.longDiscriminator);
-        ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", dnsSdInfo->commissionData.vendorId);
-        ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", dnsSdInfo->commissionData.productId);
-        ChipLogProgress(Discovery, "\tCommissioning Mode\t%u", dnsSdInfo->commissionData.commissioningMode);
-        ChipLogProgress(Discovery, "\tDevice Type\t\t%u", dnsSdInfo->commissionData.deviceType);
-        ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->commissionData.deviceName);
+        ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->nodeData.longDiscriminator);
+        ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", dnsSdInfo->nodeData.vendorId);
+        ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", dnsSdInfo->nodeData.productId);
+        ChipLogProgress(Discovery, "\tCommissioning Mode\t%u", dnsSdInfo->nodeData.commissioningMode);
+        ChipLogProgress(Discovery, "\tDevice Type\t\t%u", dnsSdInfo->nodeData.deviceType);
+        ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->nodeData.deviceName);
         ChipLogProgress(Discovery, "\tRotating Id\t\t%s", rotatingId);
-        ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->commissionData.pairingInstruction);
-        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->commissionData.pairingHint);
+        ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->nodeData.pairingInstruction);
+        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->nodeData.pairingHint);
         if (dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().HasValue())
         {
             ChipLogProgress(Discovery, "\tMrp Interval idle\t%u",

--- a/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
@@ -24,7 +24,7 @@ namespace Controller {
 void ScriptPairingDeviceDiscoveryDelegate::OnDiscoveredDevice(const Dnssd::DiscoveredNodeData & nodeData)
 {
     // Ignore nodes with closed comissioning window
-    VerifyOrReturn(nodeData.commissionData.commissioningMode != 0);
+    VerifyOrReturn(nodeData.nodeData.commissioningMode != 0);
     VerifyOrReturn(mActiveDeviceCommissioner != nullptr);
 
     const uint16_t port = nodeData.resolutionData.port;

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -38,9 +38,10 @@ public:
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override { return ResolveNodeIdStatus; }
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override {}
-    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext &) override { return DiscoverCommissionersStatus; }
-    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryContext &) override
+    CHIP_ERROR StartDiscovery(DiscoveryType type, DiscoveryFilter filter, DiscoveryContext &) override
     {
+        if (DiscoveryType::kCommissionerNode == type)
+            return DiscoverCommissionersStatus;
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
     CHIP_ERROR StopDiscovery(DiscoveryContext &) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
@@ -53,7 +53,7 @@ using namespace chip::Tracing::DarwinFramework;
 @implementation MTRCommissionableBrowserResult
 @end
 
-class CommissionableBrowserInternal : public CommissioningResolveDelegate,
+class CommissionableBrowserInternal : public DiscoverNodeDelegate,
                                       public DnssdBrowseDelegate
 #if CONFIG_NETWORK_LAYER_BLE
     ,
@@ -156,12 +156,12 @@ public:
         mDiscoveredResults = discoveredResultsCopy;
     }
 
-    /////////// CommissioningResolveDelegate Interface /////////
+    /////////// DiscoverNodeDelegate Interface /////////
     void OnNodeDiscovered(const DiscoveredNodeData & nodeData) override
     {
         assertChipStackLockedByCurrentThread();
 
-        auto & commissionData = nodeData.commissionData;
+        auto & commissionData = nodeData.nodeData;
         auto key = [NSString stringWithUTF8String:commissionData.instanceName];
         if ([mDiscoveredResults objectForKey:key] == nil) {
             // It should not happens.

--- a/src/lib/dnssd/ActiveResolveAttempts.h
+++ b/src/lib/dnssd/ActiveResolveAttempts.h
@@ -159,17 +159,17 @@ public:
             case chip::Dnssd::DiscoveryFilterType::kNone:
                 return true;
             case chip::Dnssd::DiscoveryFilterType::kShortDiscriminator:
-                return browse.filter.code == static_cast<uint64_t>((data.commissionData.longDiscriminator >> 8) & 0x0F);
+                return browse.filter.code == static_cast<uint64_t>((data.nodeData.longDiscriminator >> 8) & 0x0F);
             case chip::Dnssd::DiscoveryFilterType::kLongDiscriminator:
-                return browse.filter.code == data.commissionData.longDiscriminator;
+                return browse.filter.code == data.nodeData.longDiscriminator;
             case chip::Dnssd::DiscoveryFilterType::kVendorId:
-                return browse.filter.code == data.commissionData.vendorId;
+                return browse.filter.code == data.nodeData.vendorId;
             case chip::Dnssd::DiscoveryFilterType::kDeviceType:
-                return browse.filter.code == data.commissionData.deviceType;
+                return browse.filter.code == data.nodeData.deviceType;
             case chip::Dnssd::DiscoveryFilterType::kCommissioningMode:
-                return browse.filter.code == data.commissionData.commissioningMode;
+                return browse.filter.code == data.nodeData.commissioningMode;
             case chip::Dnssd::DiscoveryFilterType::kInstanceName:
-                return strncmp(browse.filter.instanceName, data.commissionData.instanceName,
+                return strncmp(browse.filter.instanceName, data.nodeData.instanceName,
                                chip::Dnssd::Commission::kInstanceNameMaxLength + 1) == 0;
             case chip::Dnssd::DiscoveryFilterType::kCommissioner:
             case chip::Dnssd::DiscoveryFilterType::kCompressedFabricId:

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -340,7 +340,7 @@ void DiscoveryImplPlatform::HandleNodeIdResolve(void * context, DnssdService * r
 void DnssdService::ToDiscoveredNodeData(const Span<Inet::IPAddress> & addresses, DiscoveredNodeData & nodeData)
 {
     auto & resolutionData = nodeData.resolutionData;
-    auto & commissionData = nodeData.commissionData;
+    auto & commissionData = nodeData.nodeData;
 
     Platform::CopyString(resolutionData.hostName, mHostName);
     Platform::CopyString(commissionData.instanceName, mName);
@@ -741,6 +741,21 @@ CHIP_ERROR DiscoveryImplPlatform::DiscoverCommissioners(DiscoveryFilter filter, 
     }
 
     return error;
+}
+
+CHIP_ERROR DiscoveryImplPlatform::StartDiscovery(DiscoveryType type, DiscoveryFilter filter, DiscoveryContext & context)
+{
+    switch (type)
+    {
+    case DiscoveryType::kCommissionableNode:
+        return DiscoverCommissionableNodes(filter, context);
+    case DiscoveryType::kCommissionerNode:
+        return DiscoverCommissioners(filter, context);
+    case DiscoveryType::kOperational:
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    default:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 }
 
 CHIP_ERROR DiscoveryImplPlatform::StopDiscovery(DiscoveryContext & context)

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -53,8 +53,9 @@ public:
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override { mOperationalDelegate = delegate; }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId) override;
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override;
-    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryContext & context) override;
-    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext & context) override;
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryContext & context);
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext & context);
+    CHIP_ERROR StartDiscovery(DiscoveryType type, DiscoveryFilter filter, DiscoveryContext & context) override;
     CHIP_ERROR StopDiscovery(DiscoveryContext & context) override;
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override;
 

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -189,7 +189,7 @@ CHIP_ERROR IncrementalResolver::InitializeParsing(mdns::Minimal::SerializedQName
         break;
     case ServiceNameType::kCommissioner:
     case ServiceNameType::kCommissionable:
-        mSpecificResolutionData.Set<CommissionNodeData>();
+        mSpecificResolutionData.Set<DnssdNodeData>();
 
         {
             // Commission addresses start with instance name
@@ -199,10 +199,10 @@ CHIP_ERROR IncrementalResolver::InitializeParsing(mdns::Minimal::SerializedQName
                 return CHIP_ERROR_INVALID_ARGUMENT;
             }
 
-            Platform::CopyString(mSpecificResolutionData.Get<CommissionNodeData>().instanceName, nameCopy.Value());
+            Platform::CopyString(mSpecificResolutionData.Get<DnssdNodeData>().instanceName, nameCopy.Value());
         }
 
-        LogFoundCommissionSrvRecord(mSpecificResolutionData.Get<CommissionNodeData>().instanceName, mTargetHostName.Get());
+        LogFoundCommissionSrvRecord(mSpecificResolutionData.Get<DnssdNodeData>().instanceName, mTargetHostName.Get());
         break;
     default:
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -304,9 +304,9 @@ CHIP_ERROR IncrementalResolver::OnTxtRecord(const ResourceData & data, BytesRang
         }
     }
 
-    if (IsActiveCommissionParse())
+    if (IsActiveBrowseParse())
     {
-        TxtParser<CommissionNodeData> delegate(mSpecificResolutionData.Get<CommissionNodeData>());
+        TxtParser<DnssdNodeData> delegate(mSpecificResolutionData.Get<DnssdNodeData>());
         if (!ParseTxtRecord(data.GetData(), &delegate))
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
@@ -343,12 +343,12 @@ CHIP_ERROR IncrementalResolver::OnIpAddress(Inet::InterfaceId interface, const I
 
 CHIP_ERROR IncrementalResolver::Take(DiscoveredNodeData & outputData)
 {
-    VerifyOrReturnError(IsActiveCommissionParse(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(IsActiveBrowseParse(), CHIP_ERROR_INCORRECT_STATE);
 
     IPAddressSorter::Sort(mCommonResolutionData.ipAddress, mCommonResolutionData.numIPs, mCommonResolutionData.interfaceId);
 
     outputData.resolutionData = mCommonResolutionData;
-    outputData.commissionData = mSpecificResolutionData.Get<CommissionNodeData>();
+    outputData.nodeData = mSpecificResolutionData.Get<DnssdNodeData>();
 
     ResetToInactive();
 

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -348,7 +348,7 @@ CHIP_ERROR IncrementalResolver::Take(DiscoveredNodeData & outputData)
     IPAddressSorter::Sort(mCommonResolutionData.ipAddress, mCommonResolutionData.numIPs, mCommonResolutionData.interfaceId);
 
     outputData.resolutionData = mCommonResolutionData;
-    outputData.nodeData = mSpecificResolutionData.Get<DnssdNodeData>();
+    outputData.nodeData       = mSpecificResolutionData.Get<DnssdNodeData>();
 
     ResetToInactive();
 

--- a/src/lib/dnssd/IncrementalResolve.h
+++ b/src/lib/dnssd/IncrementalResolve.h
@@ -99,7 +99,7 @@ public:
     /// method.
     bool IsActive() const { return mSpecificResolutionData.Valid(); }
 
-    bool IsActiveCommissionParse() const { return mSpecificResolutionData.Is<CommissionNodeData>(); }
+    bool IsActiveBrowseParse() const { return mSpecificResolutionData.Is<DnssdNodeData>(); }
     bool IsActiveOperationalParse() const { return mSpecificResolutionData.Is<OperationalNodeData>(); }
 
     ServiceNameType GetCurrentType() const { return mServiceNameType; }
@@ -143,7 +143,7 @@ public:
 
     /// Take the current value of the object and clear it once returned.
     ///
-    /// Object must be in `IsActiveCommissionParse()` for this to succeed.
+    /// Object must be in `IsActiveBrowseParse()` for this to succeed.
     /// Data will be returned (and cleared) even if not yet complete based
     /// on `GetMissingRequiredInformation()`. This method takes as much data as
     /// it was parsed so far.
@@ -170,7 +170,7 @@ private:
     /// Input data MUST have GetType() == QType::TXT
     CHIP_ERROR OnTxtRecord(const mdns::Minimal::ResourceData & data, mdns::Minimal::BytesRange packetRange);
 
-    /// Notify that a new IP addres has been found.
+    /// Notify that a new IP address has been found.
     ///
     /// This is to be called on both A (if IPv4 support is enabled) and AAAA
     /// addresses.
@@ -178,7 +178,7 @@ private:
     /// Prerequisite: IP address belongs to the right nost name
     CHIP_ERROR OnIpAddress(Inet::InterfaceId interface, const Inet::IPAddress & addr);
 
-    using ParsedRecordSpecificData = Variant<OperationalNodeData, CommissionNodeData>;
+    using ParsedRecordSpecificData = Variant<OperationalNodeData, DnssdNodeData>;
 
     StoredServerName mRecordName;     // Record name for what is parsed (SRV/PTR/TXT)
     StoredServerName mTargetHostName; // `Target` for the SRV record

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -78,12 +78,12 @@ public:
     void ClearBrowseIdentifier() { mBrowseIdentifier.ClearValue(); }
     const Optional<intptr_t> & GetBrowseIdentifier() const { return mBrowseIdentifier; }
 
-    void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) { mCommissioningDelegate = delegate; }
+    void SetDiscoveryDelegate(DiscoverNodeDelegate * delegate) { mDelegate = delegate; }
     void OnNodeDiscovered(const DiscoveredNodeData & nodeData)
     {
-        if (mCommissioningDelegate != nullptr)
+        if (mDelegate != nullptr)
         {
-            mCommissioningDelegate->OnNodeDiscovered(nodeData);
+            mDelegate->OnNodeDiscovered(nodeData);
         }
         else
         {
@@ -92,7 +92,7 @@ public:
     }
 
 private:
-    CommissioningResolveDelegate * mCommissioningDelegate = nullptr;
+    DiscoverNodeDelegate * mDelegate = nullptr;
     Optional<intptr_t> mBrowseIdentifier;
 };
 
@@ -168,31 +168,19 @@ public:
     virtual void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) = 0;
 
     /**
-     * Finds all commissionable nodes matching the given filter.
+     * Finds all nodes of given type matching the given filter.
      *
      * Whenever a new matching node is found, the node information is passed to
-     * the `OnNodeDiscovered` method of the commissioning delegate configured
+     * the `OnNodeDiscovered` method of the discovery delegate configured
      * in the context object.
      *
      * This method is expected to increase the reference count of the context
      * object for as long as it takes to complete the discovery request.
      */
-    virtual CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryContext & context) = 0;
+    virtual CHIP_ERROR StartDiscovery(DiscoveryType type, DiscoveryFilter filter, DiscoveryContext & context) = 0;
 
     /**
-     * Finds all commissioner nodes matching the given filter.
-     *
-     * Whenever a new matching node is found, the node information is passed to
-     * the `OnNodeDiscovered` method of the commissioning delegate configured
-     * in the context object.
-     *
-     * This method is expected to increase the reference count of the context
-     * object for as long as it takes to complete the discovery request.
-     */
-    virtual CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext & context) = 0;
-
-    /**
-     * Stop discovery (of commissionable or commissioner nodes).
+     * Stop discovery (of all node types).
      *
      * Some back ends may not support stopping discovery, so consumers should
      * not assume they will stop getting callbacks after calling this.

--- a/src/lib/dnssd/ResolverProxy.cpp
+++ b/src/lib/dnssd/ResolverProxy.cpp
@@ -36,7 +36,7 @@ CHIP_ERROR ResolverProxy::Init(Inet::EndPointManager<Inet::UDPEndPoint> * udpEnd
 void ResolverProxy::Shutdown()
 {
     VerifyOrReturn(mContext != nullptr);
-    mContext->SetCommissioningDelegate(nullptr);
+    mContext->SetDiscoveryDelegate(nullptr);
     mContext->Release();
     mContext = nullptr;
 }
@@ -45,14 +45,14 @@ CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)
 {
     VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    return mResolver.DiscoverCommissionableNodes(filter, *mContext);
+    return mResolver.StartDiscovery(DiscoveryType::kCommissionableNode, filter, *mContext);
 }
 
 CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
 {
     VerifyOrReturnError(mContext != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    return mResolver.DiscoverCommissioners(filter, *mContext);
+    return mResolver.StartDiscovery(DiscoveryType::kCommissionerNode, filter, *mContext);
 }
 
 CHIP_ERROR ResolverProxy::StopDiscovery()

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -44,11 +44,11 @@ public:
     CHIP_ERROR Init(Inet::EndPointManager<Inet::UDPEndPoint> * udpEndPoint = nullptr);
     void Shutdown();
 
-    void SetCommissioningDelegate(CommissioningResolveDelegate * delegate)
+    void SetDiscoveryDelegate(DiscoverNodeDelegate * delegate)
     {
         if (mContext != nullptr)
         {
-            mContext->SetCommissioningDelegate(delegate);
+            mContext->SetDiscoveryDelegate(delegate);
         }
     }
 

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -40,11 +40,7 @@ public:
     {
         ChipLogError(Discovery, "Failed to stop resolving node ID: dnssd resolving not available");
     }
-    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryContext & context) override
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
-    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext & context) override
+    CHIP_ERROR StartDiscovery(DiscoveryType type, DiscoveryFilter filter, DiscoveryContext & context) override
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -225,7 +225,7 @@ TxtFieldKey GetTxtFieldKey(const ByteSpan & key)
 
 } // namespace Internal
 
-void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, CommissionNodeData & nodeData)
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, DnssdNodeData & nodeData)
 {
     TxtFieldKey keyType = Internal::GetTxtFieldKey(key);
     switch (keyType)

--- a/src/lib/dnssd/TxtFields.h
+++ b/src/lib/dnssd/TxtFields.h
@@ -192,7 +192,7 @@ constexpr size_t ValSize(TxtFieldKey key)
 }
 
 void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, CommonResolutionData & nodeData);
-void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, CommissionNodeData & nodeData);
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, DnssdNodeData & nodeData);
 
 } // namespace Dnssd
 } // namespace chip

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -205,7 +205,7 @@ inline constexpr size_t kMaxRotatingIdLen         = 50;
 inline constexpr size_t kMaxPairingInstructionLen = 128;
 
 /// Data that is specific to commisionable/commissioning node discovery
-struct CommissionNodeData
+struct DnssdNodeData
 {
     size_t rotatingIdLen                                      = 0;
     uint32_t deviceType                                       = 0;
@@ -220,13 +220,13 @@ struct CommissionNodeData
     char deviceName[kMaxDeviceNameLen + 1]                    = {};
     char pairingInstruction[kMaxPairingInstructionLen + 1]    = {};
 
-    CommissionNodeData() {}
+    DnssdNodeData() {}
 
     void Reset()
     {
         // Let constructor clear things as default
-        this->~CommissionNodeData();
-        new (this) CommissionNodeData();
+        this->~DnssdNodeData();
+        new (this) DnssdNodeData();
     }
 
     bool IsInstanceName(const char * instance) const { return strcmp(instance, instanceName) == 0; }
@@ -300,12 +300,14 @@ struct ResolvedNodeData
 struct DiscoveredNodeData
 {
     CommonResolutionData resolutionData;
-    CommissionNodeData commissionData;
+    DnssdNodeData nodeData;
+    DiscoveryType nodeType;
 
     void Reset()
     {
         resolutionData.Reset();
-        commissionData.Reset();
+        nodeData.Reset();
+        nodeType = DiscoveryType::kUnknown;
     }
     DiscoveredNodeData() { Reset(); }
 
@@ -313,7 +315,7 @@ struct DiscoveredNodeData
     {
         ChipLogDetail(Discovery, "Discovered node:");
         resolutionData.LogDetail();
-        commissionData.LogDetail();
+        nodeData.LogDetail();
     }
 };
 
@@ -321,10 +323,10 @@ struct DiscoveredNodeData
 ///   - Commissioners
 ///   - Nodes in commissioning modes over IP (e.g. ethernet devices, devices already
 ///     connected to thread/wifi or devices with a commissioning window open)
-class CommissioningResolveDelegate
+class DiscoverNodeDelegate
 {
 public:
-    virtual ~CommissioningResolveDelegate() = default;
+    virtual ~DiscoverNodeDelegate() = default;
 
     /// Called within the CHIP event loop once a node is discovered.
     ///

--- a/src/lib/dnssd/platform/Dnssd.h
+++ b/src/lib/dnssd/platform/Dnssd.h
@@ -288,8 +288,7 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
  * @retval Error code                   The resolve fails.
  *
  */
-CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId interface,
-                            CommissioningResolveDelegate * delegate);
+CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId interface, DiscoverNodeDelegate * delegate);
 #endif // CHIP_DEVICE_LAYER_TARGET_DARWIN
 
 /**

--- a/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
@@ -126,7 +126,7 @@ void TestSingleBrowseAddRemove(nlTestSuite * inSuite, void * inContext)
 
     // once complete, nothing to schedule
     Dnssd::DiscoveredNodeData data;
-    data.commissionData.longDiscriminator = 1234;
+    data.nodeData.longDiscriminator = 1234;
     attempts.CompleteCommissionable(data);
     NL_TEST_ASSERT(inSuite, !attempts.GetTimeUntilNextExpectedResponse().HasValue());
     NL_TEST_ASSERT(inSuite, !attempts.NextScheduled().HasValue());
@@ -375,7 +375,7 @@ void TestCombination(nlTestSuite * inSuite, void * inContext)
     attempts.Complete(MakePeerId(2));
     attempts.Complete(MakePeerId(1));
     Dnssd::DiscoveredNodeData data;
-    data.commissionData.longDiscriminator = 1234;
+    data.nodeData.longDiscriminator = 1234;
     attempts.CompleteCommissionable(data);
 
     NL_TEST_ASSERT(inSuite, !attempts.GetTimeUntilNextExpectedResponse().HasValue());

--- a/src/lib/dnssd/tests/TestIncrementalResolve.cpp
+++ b/src/lib/dnssd/tests/TestIncrementalResolve.cpp
@@ -163,7 +163,7 @@ void TestCreation(nlTestSuite * inSuite, void * inContext)
     IncrementalResolver resolver;
 
     NL_TEST_ASSERT(inSuite, !resolver.IsActive());
-    NL_TEST_ASSERT(inSuite, !resolver.IsActiveCommissionParse());
+    NL_TEST_ASSERT(inSuite, !resolver.IsActiveBrowseParse());
     NL_TEST_ASSERT(inSuite, !resolver.IsActiveOperationalParse());
     NL_TEST_ASSERT(
         inSuite,
@@ -183,7 +183,7 @@ void TestInactiveResetOnInitError(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, resolver.InitializeParsing(kTestHostName.Serialized(), srvRecord) != CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, !resolver.IsActive());
-    NL_TEST_ASSERT(inSuite, !resolver.IsActiveCommissionParse());
+    NL_TEST_ASSERT(inSuite, !resolver.IsActiveBrowseParse());
     NL_TEST_ASSERT(inSuite, !resolver.IsActiveOperationalParse());
 }
 
@@ -199,7 +199,7 @@ void TestStartOperational(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, resolver.InitializeParsing(kTestOperationalName.Serialized(), srvRecord) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, resolver.IsActive());
-    NL_TEST_ASSERT(inSuite, !resolver.IsActiveCommissionParse());
+    NL_TEST_ASSERT(inSuite, !resolver.IsActiveBrowseParse());
     NL_TEST_ASSERT(inSuite, resolver.IsActiveOperationalParse());
     NL_TEST_ASSERT(inSuite,
                    resolver.GetMissingRequiredInformation().HasOnly(IncrementalResolver::RequiredInformationBitFlags::kIpAddress));
@@ -218,7 +218,7 @@ void TestStartCommissionable(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, resolver.InitializeParsing(kTestCommissionableNode.Serialized(), srvRecord) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, resolver.IsActive());
-    NL_TEST_ASSERT(inSuite, resolver.IsActiveCommissionParse());
+    NL_TEST_ASSERT(inSuite, resolver.IsActiveBrowseParse());
     NL_TEST_ASSERT(inSuite, !resolver.IsActiveOperationalParse());
     NL_TEST_ASSERT(inSuite,
                    resolver.GetMissingRequiredInformation().HasOnly(IncrementalResolver::RequiredInformationBitFlags::kIpAddress));
@@ -237,7 +237,7 @@ void TestStartCommissioner(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, resolver.InitializeParsing(kTestCommissionerNode.Serialized(), srvRecord) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, resolver.IsActive());
-    NL_TEST_ASSERT(inSuite, resolver.IsActiveCommissionParse());
+    NL_TEST_ASSERT(inSuite, resolver.IsActiveBrowseParse());
     NL_TEST_ASSERT(inSuite, !resolver.IsActiveOperationalParse());
     NL_TEST_ASSERT(inSuite,
                    resolver.GetMissingRequiredInformation().HasOnly(IncrementalResolver::RequiredInformationBitFlags::kIpAddress));
@@ -336,7 +336,7 @@ void TestParseCommissionable(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, resolver.InitializeParsing(kTestCommissionableNode.Serialized(), srvRecord) == CHIP_NO_ERROR);
 
     // once initialized, parsing should be ready however no IP address is available
-    NL_TEST_ASSERT(inSuite, resolver.IsActiveCommissionParse());
+    NL_TEST_ASSERT(inSuite, resolver.IsActiveBrowseParse());
     NL_TEST_ASSERT(inSuite,
                    resolver.GetMissingRequiredInformation().HasOnly(IncrementalResolver::RequiredInformationBitFlags::kIpAddress));
     NL_TEST_ASSERT(inSuite, resolver.GetTargetHostName() == kTestHostName.Serialized());
@@ -414,10 +414,10 @@ void TestParseCommissionable(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.ipAddress[1] == addr);
 
     // parsed txt data for discovered nodes
-    NL_TEST_ASSERT(inSuite, nodeData.commissionData.longDiscriminator == 22345);
-    NL_TEST_ASSERT(inSuite, nodeData.commissionData.vendorId == 321);
-    NL_TEST_ASSERT(inSuite, nodeData.commissionData.productId == 654);
-    NL_TEST_ASSERT(inSuite, strcmp(nodeData.commissionData.deviceName, "mytest") == 0);
+    NL_TEST_ASSERT(inSuite, nodeData.nodeData.longDiscriminator == 22345);
+    NL_TEST_ASSERT(inSuite, nodeData.nodeData.vendorId == 321);
+    NL_TEST_ASSERT(inSuite, nodeData.nodeData.productId == 654);
+    NL_TEST_ASSERT(inSuite, strcmp(nodeData.nodeData.deviceName, "mytest") == 0);
 }
 
 const nlTest sTests[] = {

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -304,20 +304,20 @@ void TestGetCommissionerPasscode(nlTestSuite * inSuite, void * inContext)
 bool NodeDataIsEmpty(const DiscoveredNodeData & node)
 {
 
-    if (node.commissionData.longDiscriminator != 0 || node.commissionData.vendorId != 0 || node.commissionData.productId != 0 ||
-        node.commissionData.commissioningMode != 0 || node.commissionData.deviceType != 0 ||
-        node.commissionData.rotatingIdLen != 0 || node.commissionData.pairingHint != 0 ||
-        node.resolutionData.mrpRetryIntervalIdle.HasValue() || node.resolutionData.mrpRetryIntervalActive.HasValue() ||
-        node.resolutionData.mrpRetryActiveThreshold.HasValue() || node.resolutionData.isICDOperatingAsLIT.HasValue() ||
-        node.resolutionData.supportsTcp || node.commissionData.commissionerPasscode != 0)
+    if (node.nodeData.longDiscriminator != 0 || node.nodeData.vendorId != 0 || node.nodeData.productId != 0 ||
+        node.nodeData.commissioningMode != 0 || node.nodeData.deviceType != 0 || node.nodeData.rotatingIdLen != 0 ||
+        node.nodeData.pairingHint != 0 || node.resolutionData.mrpRetryIntervalIdle.HasValue() ||
+        node.resolutionData.mrpRetryIntervalActive.HasValue() || node.resolutionData.mrpRetryActiveThreshold.HasValue() ||
+        node.resolutionData.isICDOperatingAsLIT.HasValue() || node.resolutionData.supportsTcp ||
+        node.nodeData.commissionerPasscode != 0)
     {
         return false;
     }
-    if (strcmp(node.commissionData.deviceName, "") != 0 || strcmp(node.commissionData.pairingInstruction, "") != 0)
+    if (strcmp(node.nodeData.deviceName, "") != 0 || strcmp(node.nodeData.pairingInstruction, "") != 0)
     {
         return false;
     }
-    for (uint8_t id : node.commissionData.rotatingId)
+    for (uint8_t id : node.nodeData.rotatingId)
     {
         if (id != 0)
         {
@@ -337,78 +337,78 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Long discriminator
     strcpy(key, "D");
     strcpy(val, "840");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
-    NL_TEST_ASSERT(inSuite, filled.commissionData.longDiscriminator == 840);
-    filled.commissionData.longDiscriminator = 0;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
+    NL_TEST_ASSERT(inSuite, filled.nodeData.longDiscriminator == 840);
+    filled.nodeData.longDiscriminator = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // vendor and product
     strcpy(key, "VP");
     strcpy(val, "123+456");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
-    NL_TEST_ASSERT(inSuite, filled.commissionData.vendorId == 123);
-    NL_TEST_ASSERT(inSuite, filled.commissionData.productId == 456);
-    filled.commissionData.vendorId  = 0;
-    filled.commissionData.productId = 0;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
+    NL_TEST_ASSERT(inSuite, filled.nodeData.vendorId == 123);
+    NL_TEST_ASSERT(inSuite, filled.nodeData.productId == 456);
+    filled.nodeData.vendorId  = 0;
+    filled.nodeData.productId = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Commissioning mode
     strcpy(key, "CM");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
-    NL_TEST_ASSERT(inSuite, filled.commissionData.commissioningMode == 1);
-    filled.commissionData.commissioningMode = 0;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
+    NL_TEST_ASSERT(inSuite, filled.nodeData.commissioningMode == 1);
+    filled.nodeData.commissioningMode = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Commissioning mode
     strcpy(key, "CP");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
-    NL_TEST_ASSERT(inSuite, filled.commissionData.commissionerPasscode == 1);
-    filled.commissionData.commissionerPasscode = 0;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
+    NL_TEST_ASSERT(inSuite, filled.nodeData.commissionerPasscode == 1);
+    filled.nodeData.commissionerPasscode = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Device type
     strcpy(key, "DT");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
-    NL_TEST_ASSERT(inSuite, filled.commissionData.deviceType == 1);
-    filled.commissionData.deviceType = 0;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
+    NL_TEST_ASSERT(inSuite, filled.nodeData.deviceType == 1);
+    filled.nodeData.deviceType = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Device name
     strcpy(key, "DN");
     strcpy(val, "abc");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
-    NL_TEST_ASSERT(inSuite, strcmp(filled.commissionData.deviceName, "abc") == 0);
-    memset(filled.commissionData.deviceName, 0, sizeof(filled.commissionData.deviceName));
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
+    NL_TEST_ASSERT(inSuite, strcmp(filled.nodeData.deviceName, "abc") == 0);
+    memset(filled.nodeData.deviceName, 0, sizeof(filled.nodeData.deviceName));
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Rotating device id
     strcpy(key, "RI");
     strcpy(val, "1A2B");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
-    NL_TEST_ASSERT(inSuite, filled.commissionData.rotatingId[0] == 0x1A);
-    NL_TEST_ASSERT(inSuite, filled.commissionData.rotatingId[1] == 0x2B);
-    NL_TEST_ASSERT(inSuite, filled.commissionData.rotatingIdLen == 2);
-    filled.commissionData.rotatingIdLen = 0;
-    memset(filled.commissionData.rotatingId, 0, sizeof(filled.commissionData.rotatingId));
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
+    NL_TEST_ASSERT(inSuite, filled.nodeData.rotatingId[0] == 0x1A);
+    NL_TEST_ASSERT(inSuite, filled.nodeData.rotatingId[1] == 0x2B);
+    NL_TEST_ASSERT(inSuite, filled.nodeData.rotatingIdLen == 2);
+    filled.nodeData.rotatingIdLen = 0;
+    memset(filled.nodeData.rotatingId, 0, sizeof(filled.nodeData.rotatingId));
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Pairing instruction
     strcpy(key, "PI");
     strcpy(val, "hint");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
-    NL_TEST_ASSERT(inSuite, strcmp(filled.commissionData.pairingInstruction, "hint") == 0);
-    memset(filled.commissionData.pairingInstruction, 0, sizeof(filled.commissionData.pairingInstruction));
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
+    NL_TEST_ASSERT(inSuite, strcmp(filled.nodeData.pairingInstruction, "hint") == 0);
+    memset(filled.nodeData.pairingInstruction, 0, sizeof(filled.nodeData.pairingInstruction));
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Pairing hint
     strcpy(key, "PH");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
-    NL_TEST_ASSERT(inSuite, filled.commissionData.pairingHint == 1);
-    filled.commissionData.pairingHint = 0;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
+    NL_TEST_ASSERT(inSuite, filled.nodeData.pairingHint == 1);
+    filled.nodeData.pairingHint = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 }
 

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -40,7 +40,7 @@ Shell::Engine sShellDnsBrowseSubcommands;
 Shell::Engine sShellDnsSubcommands;
 Dnssd::ResolverProxy sResolverProxy;
 
-class DnsShellResolverDelegate : public Dnssd::CommissioningResolveDelegate, public AddressResolve::NodeListener
+class DnsShellResolverDelegate : public Dnssd::DiscoverNodeDelegate, public AddressResolve::NodeListener
 {
 public:
     DnsShellResolverDelegate() { mSelfHandle.SetListener(this); }
@@ -92,20 +92,21 @@ public:
         }
 
         char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1];
-        Encoding::BytesToUppercaseHexString(nodeData.commissionData.rotatingId, nodeData.commissionData.rotatingIdLen, rotatingId,
+        Encoding::BytesToUppercaseHexString(nodeData.nodeData.rotatingId, nodeData.nodeData.rotatingIdLen, rotatingId,
                                             sizeof(rotatingId));
 
         streamer_printf(streamer_get(), "DNS browse succeeded: \r\n");
+        streamer_printf(streamer_get(), "   Node Type: %u\r\n", nodeData.nodeType);
         streamer_printf(streamer_get(), "   Hostname: %s\r\n", nodeData.resolutionData.hostName);
-        streamer_printf(streamer_get(), "   Vendor ID: %u\r\n", nodeData.commissionData.vendorId);
-        streamer_printf(streamer_get(), "   Product ID: %u\r\n", nodeData.commissionData.productId);
-        streamer_printf(streamer_get(), "   Long discriminator: %u\r\n", nodeData.commissionData.longDiscriminator);
-        streamer_printf(streamer_get(), "   Device type: %u\r\n", nodeData.commissionData.deviceType);
-        streamer_printf(streamer_get(), "   Device name: %s\n", nodeData.commissionData.deviceName);
+        streamer_printf(streamer_get(), "   Vendor ID: %u\r\n", nodeData.nodeData.vendorId);
+        streamer_printf(streamer_get(), "   Product ID: %u\r\n", nodeData.nodeData.productId);
+        streamer_printf(streamer_get(), "   Long discriminator: %u\r\n", nodeData.nodeData.longDiscriminator);
+        streamer_printf(streamer_get(), "   Device type: %u\r\n", nodeData.nodeData.deviceType);
+        streamer_printf(streamer_get(), "   Device name: %s\n", nodeData.nodeData.deviceName);
         streamer_printf(streamer_get(), "   Commissioning mode: %d\r\n",
-                        static_cast<int>(nodeData.commissionData.commissioningMode));
-        streamer_printf(streamer_get(), "   Pairing hint: %u\r\n", nodeData.commissionData.pairingHint);
-        streamer_printf(streamer_get(), "   Pairing instruction: %s\r\n", nodeData.commissionData.pairingInstruction);
+                        static_cast<int>(nodeData.nodeData.commissioningMode));
+        streamer_printf(streamer_get(), "   Pairing hint: %u\r\n", nodeData.nodeData.pairingHint);
+        streamer_printf(streamer_get(), "   Pairing instruction: %s\r\n", nodeData.nodeData.pairingInstruction);
         streamer_printf(streamer_get(), "   Rotating ID %s\r\n", rotatingId);
 
         auto retryInterval = nodeData.resolutionData.GetMrpRetryIntervalIdle();
@@ -237,7 +238,7 @@ CHIP_ERROR BrowseHandler(int argc, char ** argv)
     }
 
     sResolverProxy.Init(DeviceLayer::UDPEndPointManager());
-    sResolverProxy.SetCommissioningDelegate(&sDnsShellResolverDelegate);
+    sResolverProxy.SetDiscoveryDelegate(&sDnsShellResolverDelegate);
 
     return sShellDnsBrowseSubcommands.ExecCommand(argc, argv);
 }

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -103,8 +103,7 @@ public:
         streamer_printf(streamer_get(), "   Long discriminator: %u\r\n", nodeData.nodeData.longDiscriminator);
         streamer_printf(streamer_get(), "   Device type: %u\r\n", nodeData.nodeData.deviceType);
         streamer_printf(streamer_get(), "   Device name: %s\n", nodeData.nodeData.deviceName);
-        streamer_printf(streamer_get(), "   Commissioning mode: %d\r\n",
-                        static_cast<int>(nodeData.nodeData.commissioningMode));
+        streamer_printf(streamer_get(), "   Commissioning mode: %d\r\n", static_cast<int>(nodeData.nodeData.commissioningMode));
         streamer_printf(streamer_get(), "   Pairing hint: %u\r\n", nodeData.nodeData.pairingHint);
         streamer_printf(streamer_get(), "   Pairing instruction: %s\r\n", nodeData.nodeData.pairingInstruction);
         streamer_printf(streamer_get(), "   Rotating ID %s\r\n", rotatingId);

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -478,7 +478,7 @@ ResolveContext::ResolveContext(void * cbContext, DnssdResolveCallback cb, chip::
     consumerCounter = std::move(consumerCounterToUse);
 }
 
-ResolveContext::ResolveContext(CommissioningResolveDelegate * delegate, chip::Inet::IPAddressType cbAddressType,
+ResolveContext::ResolveContext(DiscoverNodeDelegate * delegate, chip::Inet::IPAddressType cbAddressType,
                                const char * instanceNameToResolve, std::shared_ptr<uint32_t> && consumerCounterToUse) :
     browseThatCausedResolve(nullptr)
 {
@@ -593,7 +593,7 @@ bool ResolveContext::TryReportingResultsForInterfaceIndex(uint32_t interfaceInde
     auto addresses = Span<Inet::IPAddress>(ips.data(), ips.size());
     if (nullptr == callback)
     {
-        auto delegate = static_cast<CommissioningResolveDelegate *>(context);
+        auto delegate = static_cast<DiscoverNodeDelegate *>(context);
         DiscoveredNodeData nodeData;
         service.ToDiscoveredNodeData(addresses, nodeData);
         delegate->OnNodeDiscovered(nodeData);

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -406,7 +406,7 @@ static CHIP_ERROR Resolve(void * context, DnssdResolveCallback callback, uint32_
     return Resolve(sdCtx, interfaceId, addressType, type, name, domain);
 }
 
-static CHIP_ERROR Resolve(CommissioningResolveDelegate * delegate, uint32_t interfaceId, chip::Inet::IPAddressType addressType,
+static CHIP_ERROR Resolve(DiscoverNodeDelegate * delegate, uint32_t interfaceId, chip::Inet::IPAddressType addressType,
                           const char * type, const char * name)
 {
     auto counterHolder = GetCounterHolder(name);
@@ -568,7 +568,7 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId inte
     return Resolve(context, callback, interfaceId, service->mAddressType, regtype.c_str(), service->mName, domain);
 }
 
-CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId interface, CommissioningResolveDelegate * delegate)
+CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId interface, DiscoverNodeDelegate * delegate)
 {
     VerifyOrReturnError(service != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(IsSupportedProtocol(service->mProtocol), CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -274,8 +274,8 @@ struct ResolveContext : public GenericContext
     ResolveContext(void * cbContext, DnssdResolveCallback cb, chip::Inet::IPAddressType cbAddressType,
                    const char * instanceNameToResolve, BrowseContext * browseCausingResolve,
                    std::shared_ptr<uint32_t> && consumerCounterToUse);
-    ResolveContext(CommissioningResolveDelegate * delegate, chip::Inet::IPAddressType cbAddressType,
-                   const char * instanceNameToResolve, std::shared_ptr<uint32_t> && consumerCounterToUse);
+    ResolveContext(DiscoverNodeDelegate * delegate, chip::Inet::IPAddressType cbAddressType, const char * instanceNameToResolve,
+                   std::shared_ptr<uint32_t> && consumerCounterToUse);
     virtual ~ResolveContext();
 
     void DispatchFailure(const char * errorStr, CHIP_ERROR err) override;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -405,17 +405,16 @@ void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::Dis
     if (nodeData.resolutionData.numIPs == 0)
     {
         ChipLogError(AppServer, "OnCommissionableNodeFound no IP addresses returned for instance name=%s",
-                     nodeData.commissionData.instanceName);
+                     nodeData.nodeData.instanceName);
         return;
     }
     if (nodeData.resolutionData.port == 0)
     {
-        ChipLogError(AppServer, "OnCommissionableNodeFound no port returned for instance name=%s",
-                     nodeData.commissionData.instanceName);
+        ChipLogError(AppServer, "OnCommissionableNodeFound no port returned for instance name=%s", nodeData.nodeData.instanceName);
         return;
     }
 
-    UDCClientState * client = mUdcClients.FindUDCClientState(nodeData.commissionData.instanceName);
+    UDCClientState * client = mUdcClients.FindUDCClientState(nodeData.nodeData.instanceName);
     if (client != nullptr && client->GetUDCClientProcessingState() == UDCClientProcessingState::kDiscoveringNode)
     {
         ChipLogDetail(AppServer, "OnCommissionableNodeFound instance: name=%s old_state=%d new_state=%d", client->GetInstanceName(),
@@ -458,17 +457,17 @@ void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::Dis
         if (!foundV6)
         {
             ChipLogError(AppServer, "OnCommissionableNodeFound no v6 returned for instance name=%s",
-                         nodeData.commissionData.instanceName);
+                         nodeData.nodeData.instanceName);
             client->SetPeerAddress(
                 chip::Transport::PeerAddress::UDP(nodeData.resolutionData.ipAddress[0], nodeData.resolutionData.port));
         }
 #endif // INET_CONFIG_ENABLE_IPV4
 
-        client->SetDeviceName(nodeData.commissionData.deviceName);
-        client->SetLongDiscriminator(nodeData.commissionData.longDiscriminator);
-        client->SetVendorId(nodeData.commissionData.vendorId);
-        client->SetProductId(nodeData.commissionData.productId);
-        client->SetRotatingId(nodeData.commissionData.rotatingId, nodeData.commissionData.rotatingIdLen);
+        client->SetDeviceName(nodeData.nodeData.deviceName);
+        client->SetLongDiscriminator(nodeData.nodeData.longDiscriminator);
+        client->SetVendorId(nodeData.nodeData.vendorId);
+        client->SetProductId(nodeData.nodeData.productId);
+        client->SetRotatingId(nodeData.nodeData.rotatingId, nodeData.nodeData.rotatingIdLen);
 
         // Call the registered mUserConfirmationProvider, if any.
         if (mUserConfirmationProvider != nullptr)

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -86,15 +86,15 @@ void TestUDCServerUserConfirmationProvider(nlTestSuite * inSuite, void * inConte
     nodeData1.resolutionData.port         = 5540;
     nodeData1.resolutionData.ipAddress[0] = address;
     nodeData1.resolutionData.numIPs       = 1;
-    Platform::CopyString(nodeData1.commissionData.instanceName, instanceName1);
+    Platform::CopyString(nodeData1.nodeData.instanceName, instanceName1);
 
     Dnssd::DiscoveredNodeData nodeData2;
-    nodeData2.resolutionData.port              = 5540;
-    nodeData2.resolutionData.ipAddress[0]      = address;
-    nodeData2.resolutionData.numIPs            = 1;
-    nodeData2.commissionData.longDiscriminator = disc2;
-    Platform::CopyString(nodeData2.commissionData.instanceName, instanceName2);
-    Platform::CopyString(nodeData2.commissionData.deviceName, deviceName2);
+    nodeData2.resolutionData.port         = 5540;
+    nodeData2.resolutionData.ipAddress[0] = address;
+    nodeData2.resolutionData.numIPs       = 1;
+    nodeData2.nodeData.longDiscriminator  = disc2;
+    Platform::CopyString(nodeData2.nodeData.instanceName, instanceName2);
+    Platform::CopyString(nodeData2.nodeData.deviceName, deviceName2);
 
     // test empty UserConfirmationProvider
     udcServer.OnCommissionableNodeFound(nodeData2);


### PR DESCRIPTION
Refactored the existing browse/discover interface in Resolver class to a common interface for all types of node browse and made the delegates common for all browse. 
This also contains renaming changes across all files where resolver interfaces are used.

