### PR TITLE
Improve DNS-SD resolution logging.

### DIFF
--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -97,7 +97,8 @@ NodeLookupAction NodeLookupHandle::NextAction(System::Clock::Timestamp now)
 {
     const System::Clock::Timestamp elapsed = now - mRequestStartTime;
 
-    ChipLogProgress(Discovery, "Checking node lookup status after %lu ms", static_cast<unsigned long>(elapsed.count()));
+    ChipLogProgress(Discovery, "Checking node lookup status for " ChipLogFormatPeerId " after %lu ms",
+                    ChipLogValuePeerId(mRequest.GetPeerId()), static_cast<unsigned long>(elapsed.count()));
 
     // We are still within the minimal search time. Wait for more results.
     if (elapsed < mRequest.GetMinLookupTime())
@@ -186,9 +187,11 @@ CHIP_ERROR Resolver::LookupNode(const NodeLookupRequest & request, Impl::NodeLoo
     VerifyOrReturnError(mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     handle.ResetForLookup(mTimeSource.GetMonotonicTimestamp(), request);
-    ReturnErrorOnFailure(Dnssd::Resolver::Instance().ResolveNodeId(request.GetPeerId()));
+    auto & peerId = request.GetPeerId();
+    ReturnErrorOnFailure(Dnssd::Resolver::Instance().ResolveNodeId(peerId));
     mActiveLookups.PushBack(&handle);
     ReArmTimer();
+    ChipLogProgress(Discovery, "Lookup started for " ChipLogFormatPeerId, ChipLogValuePeerId(peerId));
     return CHIP_NO_ERROR;
 }
 

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -289,9 +289,7 @@ struct ResolvedNodeData
 #if CHIP_PROGRESS_LOGGING
         // Would be nice to log the interface id, but sorting out how to do so
         // across our different InterfaceId implementations is a pain.
-        ChipLogProgress(Discovery, "Node ID resolved for " ChipLogFormatX64 ":" ChipLogFormatX64,
-                        ChipLogValueX64(operationalData.peerId.GetCompressedFabricId()),
-                        ChipLogValueX64(operationalData.peerId.GetNodeId()));
+        ChipLogProgress(Discovery, "Node ID resolved for " ChipLogFormatPeerId, ChipLogValuePeerId(operationalData.peerId));
         resolutionData.LogDetail();
 #endif // CHIP_PROGRESS_LOGGING
     }

--- a/src/lib/support/logging/TextOnlyLogging.h
+++ b/src/lib/support/logging/TextOnlyLogging.h
@@ -313,6 +313,14 @@ using LogRedirectCallback_t = void (*)(const char * module, uint8_t category, co
 #define ChipLogFormatScopedNodeId "<" ChipLogFormatX64 ", %d>"
 #define ChipLogValueScopedNodeId(id) ChipLogValueX64((id).GetNodeId()), (id).GetFabricIndex()
 
+/** Logging helpers for PeerId, which is a tuple of <Compressed Fabric Id, NodeId>
+ *
+ * This gets logged in the form that's used for the DNS-SD instance name for the
+ * peer.
+ */
+#define ChipLogFormatPeerId ChipLogFormatX64 "-" ChipLogFormatX64
+#define ChipLogValuePeerId(id) ChipLogValueX64((id).GetCompressedFabricId()), ChipLogValueX64((id).GetNodeId())
+
 /**
  * CHIP Logging Implementation internals.
  */


### PR DESCRIPTION
When logging that we are checking for results, include the instance name we are checking for.  Otherwise the logs are completely inscrutable when multiple resolves are in progress at the same time.
