### PR TITLE
Do not report attribute in _getAttributesToReportWithReportedValues i…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2144,13 +2144,8 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             // if expected values exists, purge and update read cache
             NSArray * expectedValue = _expectedValueCache[attributePath];
             if (expectedValue) {
-                if (![self _attributeDataValue:attributeDataValue
-                            isEqualToDataValue:expectedValue[MTRDeviceExpectedValueFieldValueIndex]]) {
-                    shouldReportAttribute = YES;
-                    previousValue = expectedValue[MTRDeviceExpectedValueFieldValueIndex];
-                }
-                _expectedValueCache[attributePath] = nil;
                 _readCache[attributePath] = attributeDataValue;
+                shouldReportAttribute = NO;
             } else if (readCacheValueChanged) {
                 // otherwise compare and update read cache
                 previousValue = _readCache[attributePath];

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2144,6 +2144,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             // if expected values exists, purge and update read cache
             NSArray * expectedValue = _expectedValueCache[attributePath];
             if (expectedValue) {
+                previousValue = expectedValue[MTRDeviceExpectedValueFieldValueIndex];
                 _readCache[attributePath] = attributeDataValue;
                 shouldReportAttribute = NO;
             } else if (readCacheValueChanged) {


### PR DESCRIPTION
…f an expected value is present

- The expiry timer for the expected value will take care of the reporting and we shouldn't report an attribute in the expected value interval if there is an existing expected value

Fixes: #32882 

