### PR TITLE
Temp fix for #32875 (network commissioning cluster check for SSID on Thread feature)

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -492,11 +492,11 @@ void Instance::HandleScanNetworks(HandlerContext & ctx, const Commands::ScanNetw
     else if (mFeatureFlags.Has(Feature::kThreadNetworkInterface))
     {
         // SSID present on Thread violates the `[WI]` conformance.
-        if (req.ssid.HasValue())
-        {
-            ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand);
-            return;
-        }
+        // if (req.ssid.HasValue())
+        // {
+        //     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidCommand);
+        //     return;
+        // }
 
         mCurrentOperationBreadcrumb = req.breadcrumb;
         mAsyncCommandHandle         = CommandHandler::Handle(&ctx.mCommandHandler);

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -491,6 +491,11 @@ void Instance::HandleScanNetworks(HandlerContext & ctx, const Commands::ScanNetw
     }
     else if (mFeatureFlags.Has(Feature::kThreadNetworkInterface))
     {
+        // NOTE: the following lines were commented out due to issue #32875. In short, a popular
+        // commissioner is passing a null SSID argument and this logic breaks interoperability as a result.
+        // The spec has some inconsistency on this which also needs to be fixed. The commissioner maker is
+        // fixing its code and will return to un-comment this code, with that work tracked by Issue #32887.
+        //
         // SSID present on Thread violates the `[WI]` conformance.
         // if (req.ssid.HasValue())
         // {


### PR DESCRIPTION
Fixes  #32875

As part of network commissioning cluster cleanup in 1.3, a check was added to the scan networks handler which checks for the SSID argument on a Thread device and returns an error when found.

There is confusing text in the spec which states that non-WiFi implementations should ignore this argument when null, and so the new check appears to not be conformant to that. But regardless, a popular commissioner was found to be passing a null SSID argument and this change breaks Thread device commissioning for users with that commissioner.

The spec needs to be clarified on this point, and the commissioner needs to be fixed. The commissioner fix is in the works but could take months to fully roll out to customers. In the meantime, this PR comments out the SSID check and a separate issue #32887 has been created to track that work.

Also, I have confirmed that this fix addresses the problem in #32875 (eg. no other fixes are needed).
