### PR TITLE
[chip-tool] Create ChipToolCheckInDelegate

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -58,6 +58,8 @@ static_library("chip-tool-utils") {
     "commands/common/BDXDiagnosticLogsServerDelegate.cpp",
     "commands/common/CHIPCommand.cpp",
     "commands/common/CHIPCommand.h",
+    "commands/common/ChipToolCheckInDelegate.cpp",
+    "commands/common/ChipToolCheckInDelegate.h",
     "commands/common/Command.cpp",
     "commands/common/Command.h",
     "commands/common/Commands.cpp",

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -655,12 +655,12 @@ void CHIPCommand::ExecuteDeferredCleanups(intptr_t ignored)
     sDeferredCleanups.clear();
 }
 
-void CHIPCommand::RegisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
+void CHIPCommand::SetOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
 {
-    sCheckInDelegate.RegisterOnCheckInCompleteCallback(handler);
+    sCheckInDelegate.SetOnCheckInCompleteCallback(handler);
 }
 
-void CHIPCommand::UnregisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
+void CHIPCommand::UnsetOnCheckInCompleteCallback()
 {
-    sCheckInDelegate.UnregisterOnCheckInCompleteCallback(handler);
+    sCheckInDelegate.UnsetOnCheckInCompleteCallback();
 }

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -654,4 +654,3 @@ void CHIPCommand::ExecuteDeferredCleanups(intptr_t ignored)
     }
     sDeferredCleanups.clear();
 }
-

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -655,12 +655,3 @@ void CHIPCommand::ExecuteDeferredCleanups(intptr_t ignored)
     sDeferredCleanups.clear();
 }
 
-void CHIPCommand::SetOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
-{
-    sCheckInDelegate.SetOnCheckInCompleteCallback(handler);
-}
-
-void CHIPCommand::UnsetOnCheckInCompleteCallback()
-{
-    sCheckInDelegate.UnsetOnCheckInCompleteCallback();
-}

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -18,6 +18,7 @@
 
 #include "CHIPCommand.h"
 
+#include <commands/common/ChipToolCheckInDelegate.h>
 #include <controller/CHIPDeviceControllerFactory.h>
 #include <credentials/attestation_verifier/FileAttestationTrustStore.h>
 #include <lib/core/CHIPConfig.h>
@@ -52,7 +53,7 @@ chip::Credentials::GroupDataProviderImpl CHIPCommand::sGroupDataProvider{ kMaxGr
 // All fabrics share the same ICD client storage.
 chip::app::DefaultICDClientStorage CHIPCommand::sICDClientStorage;
 chip::Crypto::RawKeySessionKeystore CHIPCommand::sSessionKeystore;
-chip::app::DefaultCheckInDelegate CHIPCommand::sCheckInDelegate;
+ChipToolCheckInDelegate CHIPCommand::sCheckInDelegate;
 chip::app::CheckInHandler CHIPCommand::sCheckInHandler;
 
 namespace {
@@ -652,4 +653,14 @@ void CHIPCommand::ExecuteDeferredCleanups(intptr_t ignored)
         cmd->Cleanup();
     }
     sDeferredCleanups.clear();
+}
+
+void CHIPCommand::RegisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
+{
+    sCheckInDelegate.RegisterOnCheckInCompleteCallback(handler);
+}
+
+void CHIPCommand::UnregisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
+{
+    sCheckInDelegate.UnregisterOnCheckInCompleteCallback(handler);
 }

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -28,8 +28,8 @@
 
 #include <TracingCommandLineArgument.h>
 #include <app/icd/client/CheckInHandler.h>
-#include <app/icd/client/DefaultCheckInDelegate.h>
 #include <app/icd/client/DefaultICDClientStorage.h>
+#include <commands/common/ChipToolCheckInDelegate.h>
 #include <commands/common/CredentialIssuerCommands.h>
 #include <commands/example/ExampleCredentialIssuerCommands.h>
 #include <credentials/GroupDataProviderImpl.h>
@@ -164,7 +164,7 @@ protected:
 
     static chip::Credentials::GroupDataProviderImpl sGroupDataProvider;
     static chip::app::DefaultICDClientStorage sICDClientStorage;
-    static chip::app::DefaultCheckInDelegate sCheckInDelegate;
+    static ChipToolCheckInDelegate sCheckInDelegate;
     static chip::app::CheckInHandler sCheckInHandler;
     CredentialIssuerCommands * mCredIssuerCmds;
 
@@ -179,6 +179,10 @@ protected:
     ChipDeviceCommissioner & CurrentCommissioner();
 
     ChipDeviceCommissioner & GetCommissioner(std::string identity);
+
+    static void RegisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
+
+    static void UnregisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
 
 private:
     CHIP_ERROR MaybeSetUpStack();

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -180,10 +180,6 @@ protected:
 
     ChipDeviceCommissioner & GetCommissioner(std::string identity);
 
-    static void SetOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
-
-    static void UnsetOnCheckInCompleteCallback();
-
 private:
     CHIP_ERROR MaybeSetUpStack();
     void MaybeTearDownStack();

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -180,9 +180,9 @@ protected:
 
     ChipDeviceCommissioner & GetCommissioner(std::string identity);
 
-    static void RegisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
+    static void SetOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
 
-    static void UnregisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
+    static void UnsetOnCheckInCompleteCallback();
 
 private:
     CHIP_ERROR MaybeSetUpStack();

--- a/examples/chip-tool/commands/common/ChipToolCheckInDelegate.cpp
+++ b/examples/chip-tool/commands/common/ChipToolCheckInDelegate.cpp
@@ -40,10 +40,6 @@ void ChipToolCheckInDelegate::OnCheckInComplete(const ICDClientInfo & clientInfo
     ChipLogProgress(
         ICD, "Check In Message processing complete: start_counter=%" PRIu32 " offset=%" PRIu32 " nodeid=" ChipLogFormatScopedNodeId,
         clientInfo.start_icd_counter, clientInfo.offset, ChipLogValueScopedNodeId(clientInfo.peer_node));
-    if (mpCheckInCompleteCallbacks != nullptr)
-    {
-        mpCheckInCompleteCallbacks->OnCheckInComplete(clientInfo);
-    }
 }
 
 RefreshKeySender * ChipToolCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & clientInfo, ICDClientStorage * clientStorage)
@@ -77,14 +73,4 @@ void ChipToolCheckInDelegate::OnKeyRefreshDone(RefreshKeySender * refreshKeySend
         Platform::Delete(refreshKeySender);
         refreshKeySender = nullptr;
     }
-}
-
-void ChipToolCheckInDelegate::SetOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
-{
-    mpCheckInCompleteCallbacks = handler;
-}
-
-void ChipToolCheckInDelegate::UnsetOnCheckInCompleteCallback()
-{
-    mpCheckInCompleteCallbacks = nullptr;
 }

--- a/examples/chip-tool/commands/common/ChipToolCheckInDelegate.cpp
+++ b/examples/chip-tool/commands/common/ChipToolCheckInDelegate.cpp
@@ -58,12 +58,7 @@ RefreshKeySender * ChipToolCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & c
         return nullptr;
     }
 
-    auto refreshKeySender = Platform::New<RefreshKeySender>(this, clientInfo, clientStorage, mpImEngine, newKey);
-    if (refreshKeySender == nullptr)
-    {
-        return nullptr;
-    }
-    return refreshKeySender;
+    return Platform::New<RefreshKeySender>(this, clientInfo, clientStorage, mpImEngine, newKey);
 }
 
 void ChipToolCheckInDelegate::OnKeyRefreshDone(RefreshKeySender * refreshKeySender, CHIP_ERROR error)

--- a/examples/chip-tool/commands/common/ChipToolCheckInDelegate.cpp
+++ b/examples/chip-tool/commands/common/ChipToolCheckInDelegate.cpp
@@ -1,0 +1,94 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "ChipToolCheckInDelegate.h"
+
+#include <app/icd/client/RefreshKeySender.h>
+#include <crypto/CHIPCryptoPAL.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+using namespace chip;
+using namespace chip::app;
+
+CHIP_ERROR ChipToolCheckInDelegate::Init(ICDClientStorage * storage, InteractionModelEngine * engine)
+{
+    VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mpStorage == nullptr, CHIP_ERROR_INCORRECT_STATE);
+    mpStorage  = storage;
+    mpImEngine = engine;
+    return CHIP_NO_ERROR;
+}
+
+void ChipToolCheckInDelegate::OnCheckInComplete(const ICDClientInfo & clientInfo)
+{
+    ChipLogProgress(
+        ICD, "Check In Message processing complete: start_counter=%" PRIu32 " offset=%" PRIu32 " nodeid=" ChipLogFormatScopedNodeId,
+        clientInfo.start_icd_counter, clientInfo.offset, ChipLogValueScopedNodeId(clientInfo.peer_node));
+    for (auto handler : mCheckInCompleteCallbacks)
+    {
+        handler->OnCheckInComplete(clientInfo);
+    }
+}
+
+RefreshKeySender * ChipToolCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & clientInfo, ICDClientStorage * clientStorage)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    RefreshKeySender::RefreshKeyBuffer newKey;
+
+    err = Crypto::DRBG_get_bytes(newKey.Bytes(), newKey.Capacity());
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(ICD, "Generation of new key failed: %" CHIP_ERROR_FORMAT, err.Format());
+        return nullptr;
+    }
+
+    auto refreshKeySender = Platform::New<RefreshKeySender>(this, clientInfo, clientStorage, mpImEngine, newKey);
+    if (refreshKeySender == nullptr)
+    {
+        return nullptr;
+    }
+    return refreshKeySender;
+}
+
+void ChipToolCheckInDelegate::OnKeyRefreshDone(RefreshKeySender * refreshKeySender, CHIP_ERROR error)
+{
+    if (error == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(ICD, "Re-registration with new key completed successfully");
+    }
+    else
+    {
+        ChipLogError(ICD, "Re-registration with new key failed with error : %" CHIP_ERROR_FORMAT, error.Format());
+        // The callee can take corrective action  based on the error received.
+    }
+    if (refreshKeySender != nullptr)
+    {
+        Platform::Delete(refreshKeySender);
+        refreshKeySender = nullptr;
+    }
+}
+
+void ChipToolCheckInDelegate::RegisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
+{
+    chip::DeviceLayer::SystemLayer().ScheduleLambda([this, handler]() { mCheckInCompleteCallbacks.insert(handler); });
+}
+
+void ChipToolCheckInDelegate::UnregisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
+{
+    chip::DeviceLayer::SystemLayer().ScheduleLambda([this, handler]() { mCheckInCompleteCallbacks.insert(handler); });
+}

--- a/examples/chip-tool/commands/common/ChipToolCheckInDelegate.cpp
+++ b/examples/chip-tool/commands/common/ChipToolCheckInDelegate.cpp
@@ -29,6 +29,7 @@ CHIP_ERROR ChipToolCheckInDelegate::Init(ICDClientStorage * storage, Interaction
 {
     VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(mpStorage == nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(engine != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mpStorage  = storage;
     mpImEngine = engine;
     return CHIP_NO_ERROR;
@@ -39,9 +40,9 @@ void ChipToolCheckInDelegate::OnCheckInComplete(const ICDClientInfo & clientInfo
     ChipLogProgress(
         ICD, "Check In Message processing complete: start_counter=%" PRIu32 " offset=%" PRIu32 " nodeid=" ChipLogFormatScopedNodeId,
         clientInfo.start_icd_counter, clientInfo.offset, ChipLogValueScopedNodeId(clientInfo.peer_node));
-    for (auto handler : mCheckInCompleteCallbacks)
+    if (mpCheckInCompleteCallbacks != nullptr)
     {
-        handler->OnCheckInComplete(clientInfo);
+        mpCheckInCompleteCallbacks->OnCheckInComplete(clientInfo);
     }
 }
 
@@ -83,12 +84,12 @@ void ChipToolCheckInDelegate::OnKeyRefreshDone(RefreshKeySender * refreshKeySend
     }
 }
 
-void ChipToolCheckInDelegate::RegisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
+void ChipToolCheckInDelegate::SetOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
 {
-    chip::DeviceLayer::SystemLayer().ScheduleLambda([this, handler]() { mCheckInCompleteCallbacks.insert(handler); });
+    mpCheckInCompleteCallbacks = handler;
 }
 
-void ChipToolCheckInDelegate::UnregisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler)
+void ChipToolCheckInDelegate::UnsetOnCheckInCompleteCallback()
 {
-    chip::DeviceLayer::SystemLayer().ScheduleLambda([this, handler]() { mCheckInCompleteCallbacks.insert(handler); });
+    mpCheckInCompleteCallbacks = nullptr;
 }

--- a/examples/chip-tool/commands/common/ChipToolCheckInDelegate.h
+++ b/examples/chip-tool/commands/common/ChipToolCheckInDelegate.h
@@ -32,7 +32,7 @@ public:
     /**
      * @brief Callback used to let the application know that a check-in message was received and validated.
      *
-     * The callback will be executed in CHIP main loop. Implementations avoid blocking in this callback.
+     * The callback will be executed in CHIP main loop. Implementations should avoid blocking operations in this callback.
      *
      * @param[in] clientInfo - ICDClientInfo object representing the state associated with the
      *                         node that sent the check-in message.
@@ -51,26 +51,24 @@ public:
     void OnKeyRefreshDone(chip::app::RefreshKeySender * refreshKeySender, CHIP_ERROR error) override;
 
     /**
-     * @brief Reigsters a callback when the check-in completes.
+     * @brief Sets a callback for when the Check-In processing completes.
      *
-     * The registeration will be processed inside CHIP main loop.
+     * This method does not consider the race condition that the callback is changed during OnCheckInComplete.
      *
-     * @param[in] handler - A pointer to CheckInCompleteCallback to register.
+     * @param[in] handler - A pointer to the CheckInCompleteCallback to register.
      */
-    void RegisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
+    void SetOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
 
     /**
-     * @brief Unreigsters a callback when the check-in completes.
+     * @brief Unsets the callback for when the Check-In processing completes.
      *
-     * The unregisteration will be processed inside CHIP main loop.
-     *
-     * @param[in] handler - A pointer to CheckInCompleteCallback to unregister.
+     * This method does not consider the race condition that the callback is changed during OnCheckInComplete.
      */
-    void UnregisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
+    void UnsetOnCheckInCompleteCallback();
 
 private:
     chip::app::ICDClientStorage * mpStorage        = nullptr;
     chip::app::InteractionModelEngine * mpImEngine = nullptr;
 
-    std::set<CheckInCompleteCallback *> mCheckInCompleteCallbacks;
+    CheckInCompleteCallback * mpCheckInCompleteCallbacks;
 };

--- a/examples/chip-tool/commands/common/ChipToolCheckInDelegate.h
+++ b/examples/chip-tool/commands/common/ChipToolCheckInDelegate.h
@@ -24,22 +24,6 @@
 #include <app/icd/client/CheckInDelegate.h>
 #include <app/icd/client/ICDClientStorage.h>
 
-class CheckInCompleteCallback
-{
-public:
-    virtual ~CheckInCompleteCallback() {}
-
-    /**
-     * @brief Callback used to let the application know that a check-in message was received and validated.
-     *
-     * The callback will be executed in CHIP main loop. Implementations should avoid blocking operations in this callback.
-     *
-     * @param[in] clientInfo - ICDClientInfo object representing the state associated with the
-     *                         node that sent the check-in message.
-     */
-    virtual void OnCheckInComplete(const chip::app::ICDClientInfo & clientInfo) = 0;
-};
-
 class ChipToolCheckInDelegate : public chip::app::CheckInDelegate
 {
 public:
@@ -50,25 +34,7 @@ public:
                                                      chip::app::ICDClientStorage * clientStorage) override;
     void OnKeyRefreshDone(chip::app::RefreshKeySender * refreshKeySender, CHIP_ERROR error) override;
 
-    /**
-     * @brief Sets a callback for when the Check-In processing completes.
-     *
-     * This method does not consider the race condition that the callback is changed during OnCheckInComplete.
-     *
-     * @param[in] handler - A pointer to the CheckInCompleteCallback to register.
-     */
-    void SetOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
-
-    /**
-     * @brief Unsets the callback for when the Check-In processing completes.
-     *
-     * This method does not consider the race condition that the callback is changed during OnCheckInComplete.
-     */
-    void UnsetOnCheckInCompleteCallback();
-
 private:
     chip::app::ICDClientStorage * mpStorage        = nullptr;
     chip::app::InteractionModelEngine * mpImEngine = nullptr;
-
-    CheckInCompleteCallback * mpCheckInCompleteCallbacks;
 };

--- a/examples/chip-tool/commands/common/ChipToolCheckInDelegate.h
+++ b/examples/chip-tool/commands/common/ChipToolCheckInDelegate.h
@@ -37,7 +37,7 @@ public:
      * @param[in] clientInfo - ICDClientInfo object representing the state associated with the
      *                         node that sent the check-in message.
      */
-    virtual void OnCheckInComplete(const chip::app::ICDClientInfo & clientInfo);
+    virtual void OnCheckInComplete(const chip::app::ICDClientInfo & clientInfo) = 0;
 };
 
 class ChipToolCheckInDelegate : public chip::app::CheckInDelegate

--- a/examples/chip-tool/commands/common/ChipToolCheckInDelegate.h
+++ b/examples/chip-tool/commands/common/ChipToolCheckInDelegate.h
@@ -1,0 +1,76 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <set>
+
+#include <app/InteractionModelEngine.h>
+#include <app/icd/client/CheckInDelegate.h>
+#include <app/icd/client/ICDClientStorage.h>
+
+class CheckInCompleteCallback
+{
+public:
+    virtual ~CheckInCompleteCallback() {}
+
+    /**
+     * @brief Callback used to let the application know that a check-in message was received and validated.
+     *
+     * The callback will be executed in CHIP main loop. Implementations avoid blocking in this callback.
+     *
+     * @param[in] clientInfo - ICDClientInfo object representing the state associated with the
+     *                         node that sent the check-in message.
+     */
+    virtual void OnCheckInComplete(const chip::app::ICDClientInfo & clientInfo);
+};
+
+class ChipToolCheckInDelegate : public chip::app::CheckInDelegate
+{
+public:
+    virtual ~ChipToolCheckInDelegate() {}
+    CHIP_ERROR Init(chip::app::ICDClientStorage * storage, chip::app::InteractionModelEngine * engine);
+    void OnCheckInComplete(const chip::app::ICDClientInfo & clientInfo) override;
+    chip::app::RefreshKeySender * OnKeyRefreshNeeded(chip::app::ICDClientInfo & clientInfo,
+                                                     chip::app::ICDClientStorage * clientStorage) override;
+    void OnKeyRefreshDone(chip::app::RefreshKeySender * refreshKeySender, CHIP_ERROR error) override;
+
+    /**
+     * @brief Reigsters a callback when the check-in completes.
+     *
+     * The registeration will be processed inside CHIP main loop.
+     *
+     * @param[in] handler - A pointer to CheckInCompleteCallback to register.
+     */
+    void RegisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
+
+    /**
+     * @brief Unreigsters a callback when the check-in completes.
+     *
+     * The unregisteration will be processed inside CHIP main loop.
+     *
+     * @param[in] handler - A pointer to CheckInCompleteCallback to unregister.
+     */
+    void UnregisterOnCheckInCompleteCallback(CheckInCompleteCallback * handler);
+
+private:
+    chip::app::ICDClientStorage * mpStorage        = nullptr;
+    chip::app::InteractionModelEngine * mpImEngine = nullptr;
+
+    std::set<CheckInCompleteCallback *> mCheckInCompleteCallbacks;
+};

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -170,6 +170,8 @@ config("config") {
 
 executable("darwin-framework-tool") {
   sources = [
+    "${chip_root}/examples/chip-tool/commands/common/ChipToolCheckInDelegate.cpp",
+    "${chip_root}/examples/chip-tool/commands/common/ChipToolCheckInDelegate.h",
     "${chip_root}/examples/chip-tool/commands/common/Command.cpp",
     "${chip_root}/examples/chip-tool/commands/common/Command.h",
     "${chip_root}/examples/chip-tool/commands/common/Commands.cpp",

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -38,6 +38,8 @@ chip_data_model("tv-casting-common") {
     "${chip_root}/examples/chip-tool/commands/clusters/ModelCommand.h",
     "${chip_root}/examples/chip-tool/commands/common/BDXDiagnosticLogsServerDelegate.cpp",
     "${chip_root}/examples/chip-tool/commands/common/CHIPCommand.h",
+    "${chip_root}/examples/chip-tool/commands/common/ChipToolCheckInDelegate.cpp",
+    "${chip_root}/examples/chip-tool/commands/common/ChipToolCheckInDelegate.h",
     "${chip_root}/examples/chip-tool/commands/common/Command.cpp",
     "${chip_root}/examples/chip-tool/commands/common/Command.h",
     "${chip_root}/examples/chip-tool/commands/common/Commands.cpp",


### PR DESCRIPTION
The default check-in delegate does not meet the need of chip-tool usage. (And possibly other applications).

Implement a separate check-in delegate for chip-tool for now, and consider merge it back to the default check-in delegate when it is stabled.

Currently, the extra feature provided by chip-tool version is to support multiple `OnCheckInCompleteCallback`-s