### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-46 : [ESP32] Updated the QEMU Dockerfile.
+47 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -12,7 +12,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=65dc1812431bf946dfc110682298acf83d63e27a
+ARG ZEPHYR_REVISION=047fe473eb7e407d9905c7f1f24533e12f534280
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- soc: drivers: boards: telink_b95: Update drivers
- soc: riscv: telink_w91: Use SRAM for IPC
- west.yml: added crypto driver for B95

**Testing**
Tested manually.

**Steps:**

- Build image
- Run docker
- Check if Telink examples able to be built successfully