### PR TITLE
Replace enum with enum class

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -209,7 +209,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationConnected()
 
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
+    if (mWpaSupplicant.state != GDBusWpaSupplicant::WpaState::INTERFACE_CONNECTED)
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: _IsWiFiStationConnected: interface not connected");
         return false;
@@ -238,7 +238,7 @@ bool ConnectivityManagerImpl::_IsWiFiStationProvisioned()
 
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
+    if (mWpaSupplicant.state != GDBusWpaSupplicant::WpaState::INTERFACE_CONNECTED)
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: _IsWiFiStationProvisioned: interface not connected");
         return false;
@@ -257,7 +257,7 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision()
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
+    if (mWpaSupplicant.state != GDBusWpaSupplicant::WpaState::INTERFACE_CONNECTED)
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: _ClearWiFiStationProvision: interface not connected");
         return;
@@ -280,8 +280,8 @@ bool ConnectivityManagerImpl::_CanStartWiFiScan()
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    bool ret = mWpaSupplicant.state == GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED &&
-        mWpaSupplicant.scanState == GDBusWpaSupplicant::WIFI_SCANNING_IDLE;
+    bool ret = mWpaSupplicant.state == GDBusWpaSupplicant::WpaState::INTERFACE_CONNECTED &&
+        mWpaSupplicant.scanState == GDBusWpaSupplicant::WpaScanningState::IDLE;
 
     return ret;
 }
@@ -507,7 +507,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * sourceObject, 
     if (iface != nullptr && err == nullptr)
     {
         mWpaSupplicant.iface = iface;
-        mWpaSupplicant.state = GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED;
+        mWpaSupplicant.state = GDBusWpaSupplicant::WpaState::INTERFACE_CONNECTED;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to wpa_supplicant interface proxy");
 
         g_signal_connect(
@@ -527,7 +527,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * sourceObject, 
         ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to create wpa_supplicant interface proxy %s: %s",
                         mWpaSupplicant.interfacePath, err ? err->message : "unknown error");
 
-        mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NOT_CONNECTED;
+        mWpaSupplicant.state = GDBusWpaSupplicant::WpaState::NOT_CONNECTED;
     }
 
     // We need to stop auto scan or it will block our network scan.
@@ -584,7 +584,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * sourceObject, GAsyn
                                                                           &err.GetReceiver());
     if (result)
     {
-        mWpaSupplicant.state = GDBusWpaSupplicant::WPA_GOT_INTERFACE_PATH;
+        mWpaSupplicant.state = GDBusWpaSupplicant::WpaState::GOT_INTERFACE_PATH;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface: %s", mWpaSupplicant.interfacePath);
 
         wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(
@@ -623,7 +623,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * sourceObject, GAsyn
 
         if (result)
         {
-            mWpaSupplicant.state = GDBusWpaSupplicant::WPA_GOT_INTERFACE_PATH;
+            mWpaSupplicant.state = GDBusWpaSupplicant::WpaState::GOT_INTERFACE_PATH;
             ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface: %s", mWpaSupplicant.interfacePath);
 
             Platform::CopyString(sWiFiIfName, CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME);
@@ -649,7 +649,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceReady(GObject * sourceObject, GAsyn
             ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to create interface %s: %s",
                             CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME, error ? error->message : "unknown error");
 
-            mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NO_INTERFACE_PATH;
+            mWpaSupplicant.state = GDBusWpaSupplicant::WpaState::NO_INTERFACE_PATH;
 
             if (mWpaSupplicant.interfacePath)
             {
@@ -676,7 +676,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * prox
     mWpaSupplicant.interfacePath = const_cast<gchar *>(path);
     if (mWpaSupplicant.interfacePath)
     {
-        mWpaSupplicant.state = GDBusWpaSupplicant::WPA_GOT_INTERFACE_PATH;
+        mWpaSupplicant.state = GDBusWpaSupplicant::WpaState::GOT_INTERFACE_PATH;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface added: %s", mWpaSupplicant.interfacePath);
 
         wpa_fi_w1_wpa_supplicant1_interface_proxy_new_for_bus(
@@ -710,7 +710,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * pr
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface removed: %s", StringOrNullMarker(path));
 
-        mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NO_INTERFACE_PATH;
+        mWpaSupplicant.state = GDBusWpaSupplicant::WpaState::NO_INTERFACE_PATH;
 
         if (mWpaSupplicant.interfacePath)
         {
@@ -730,7 +730,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * pr
             mWpaSupplicant.bss = nullptr;
         }
 
-        mWpaSupplicant.scanState = GDBusWpaSupplicant::WIFI_SCANNING_IDLE;
+        mWpaSupplicant.scanState = GDBusWpaSupplicant::WpaScanningState::IDLE;
     }
 }
 
@@ -747,7 +747,7 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * sourceObject, GAsyncRes
     mWpaSupplicant.proxy = wpa_fi_w1_wpa_supplicant1_proxy_new_for_bus_finish(res, &err.GetReceiver());
     if (mWpaSupplicant.proxy != nullptr && err.get() == nullptr)
     {
-        mWpaSupplicant.state = GDBusWpaSupplicant::WPA_CONNECTED;
+        mWpaSupplicant.state = GDBusWpaSupplicant::WpaState::CONNECTED;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to wpa_supplicant proxy");
 
         g_signal_connect(
@@ -773,7 +773,7 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * sourceObject, GAsyncRes
     {
         ChipLogProgress(DeviceLayer, "wpa_supplicant: failed to create wpa_supplicant proxy %s",
                         err ? err->message : "unknown error");
-        mWpaSupplicant.state = GDBusWpaSupplicant::WPA_NOT_CONNECTED;
+        mWpaSupplicant.state = GDBusWpaSupplicant::WpaState::NOT_CONNECTED;
     }
 }
 
@@ -793,7 +793,7 @@ bool ConnectivityManagerImpl::IsWiFiManagementStarted()
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    bool ret = mWpaSupplicant.state == GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED;
+    bool ret = mWpaSupplicant.state == GDBusWpaSupplicant::WpaState::INTERFACE_CONNECTED;
 
     return ret;
 }
@@ -1322,7 +1322,7 @@ CHIP_ERROR ConnectivityManagerImpl::CommitConfig()
 
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
+    if (mWpaSupplicant.state != GDBusWpaSupplicant::WpaState::INTERFACE_CONNECTED)
     {
         ChipLogError(DeviceLayer, "wpa_supplicant: CommitConfig: interface proxy not connected");
         return CHIP_ERROR_INCORRECT_STATE;
@@ -1391,7 +1391,7 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiSecurityType(SecurityTypeEnum & secur
 
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
+    if (mWpaSupplicant.state != GDBusWpaSupplicant::WpaState::INTERFACE_CONNECTED)
     {
         ChipLogError(DeviceLayer, "wpa_supplicant: GetWiFiSecurityType: interface proxy not connected");
         return CHIP_ERROR_INCORRECT_STATE;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -66,25 +66,25 @@ namespace DeviceLayer {
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 struct GDBusWpaSupplicant
 {
-    enum WpaState
+    enum class WpaState
     {
         INIT,
-        WPA_CONNECTING,
-        WPA_CONNECTED,
-        WPA_NOT_CONNECTED,
-        WPA_NO_INTERFACE_PATH,
-        WPA_GOT_INTERFACE_PATH,
-        WPA_INTERFACE_CONNECTED,
+        CONNECTING,
+        CONNECTED,
+        NOT_CONNECTED,
+        NO_INTERFACE_PATH,
+        GOT_INTERFACE_PATH,
+        INTERFACE_CONNECTED,
     };
 
-    enum WpaScanning
+    enum class WpaScanningState
     {
-        WIFI_SCANNING_IDLE,
-        WIFI_SCANNING,
+        IDLE,
+        SCANNING,
     };
 
-    WpaState state                          = INIT;
-    WpaScanning scanState                   = WIFI_SCANNING_IDLE;
+    WpaState state                          = WpaState::INIT;
+    WpaScanningState scanState              = WpaScanningState::IDLE;
     WpaFiW1Wpa_supplicant1 * proxy          = nullptr;
     WpaFiW1Wpa_supplicant1Interface * iface = nullptr;
     WpaFiW1Wpa_supplicant1BSS * bss         = nullptr;

--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -65,14 +65,14 @@ CHIP_ERROR ChipDeviceScanner::Init(BluezAdapter1 * adapter, ChipDeviceScannerDel
     mAdapter.reset(reinterpret_cast<BluezAdapter1 *>(g_object_ref(adapter)));
     mDelegate = delegate;
 
-    mScannerState = ChipDeviceScannerState::SCANNER_INITIALIZED;
+    mScannerState = ChipDeviceScannerState::INITIALIZED;
 
     return CHIP_NO_ERROR;
 }
 
 void ChipDeviceScanner::Shutdown()
 {
-    VerifyOrReturn(mScannerState != ChipDeviceScannerState::SCANNER_UNINITIALIZED);
+    VerifyOrReturn(mScannerState != ChipDeviceScannerState::UNINITIALIZED);
 
     StopScan();
 
@@ -86,13 +86,13 @@ void ChipDeviceScanner::Shutdown()
         },
         this);
 
-    mScannerState = ChipDeviceScannerState::SCANNER_UNINITIALIZED;
+    mScannerState = ChipDeviceScannerState::UNINITIALIZED;
 }
 
 CHIP_ERROR ChipDeviceScanner::StartScan()
 {
     assertChipStackLockedByCurrentThread();
-    VerifyOrReturnError(mScannerState != ChipDeviceScannerState::SCANNER_SCANNING, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mScannerState != ChipDeviceScannerState::SCANNING, CHIP_ERROR_INCORRECT_STATE);
 
     mCancellable.reset(g_cancellable_new());
     CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
@@ -104,7 +104,7 @@ CHIP_ERROR ChipDeviceScanner::StartScan()
         return err;
     }
 
-    mScannerState = ChipDeviceScannerState::SCANNER_SCANNING;
+    mScannerState = ChipDeviceScannerState::SCANNING;
     ChipLogDetail(Ble, "ChipDeviceScanner has started scanning!");
 
     return CHIP_NO_ERROR;
@@ -113,7 +113,7 @@ CHIP_ERROR ChipDeviceScanner::StartScan()
 CHIP_ERROR ChipDeviceScanner::StopScan()
 {
     assertChipStackLockedByCurrentThread();
-    VerifyOrReturnError(mScannerState == ChipDeviceScannerState::SCANNER_SCANNING, CHIP_NO_ERROR);
+    VerifyOrReturnError(mScannerState == ChipDeviceScannerState::SCANNING, CHIP_NO_ERROR);
 
     CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
         +[](ChipDeviceScanner * self) { return self->StopScanImpl(); }, this);
@@ -124,7 +124,7 @@ CHIP_ERROR ChipDeviceScanner::StopScan()
     }
 
     // Stop scanning and return to initialization state
-    mScannerState = ChipDeviceScannerState::SCANNER_INITIALIZED;
+    mScannerState = ChipDeviceScannerState::INITIALIZED;
 
     ChipLogDetail(Ble, "ChipDeviceScanner has stopped scanning!");
 

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -79,7 +79,7 @@ public:
     CHIP_ERROR StopScan();
 
     /// Check if the scanner is active
-    bool IsScanning() const { return mScannerState == ChipDeviceScannerState::SCANNER_SCANNING; }
+    bool IsScanning() const { return mScannerState == ChipDeviceScannerState::SCANNING; }
 
     /// Members that implement virtual methods on BluezObjectManagerAdapterNotificationsDelegate
     void OnDeviceAdded(BluezDevice1 & device) override;
@@ -87,11 +87,11 @@ public:
     void OnDeviceRemoved(BluezDevice1 & device) override {}
 
 private:
-    enum ChipDeviceScannerState
+    enum class ChipDeviceScannerState
     {
-        SCANNER_UNINITIALIZED,
-        SCANNER_INITIALIZED,
-        SCANNER_SCANNING
+        UNINITIALIZED,
+        INITIALIZED,
+        SCANNING
     };
 
     CHIP_ERROR StartScanImpl();
@@ -108,7 +108,7 @@ private:
     GAutoPtr<BluezAdapter1> mAdapter;
 
     ChipDeviceScannerDelegate * mDelegate = nullptr;
-    ChipDeviceScannerState mScannerState  = ChipDeviceScannerState::SCANNER_UNINITIALIZED;
+    ChipDeviceScannerState mScannerState  = ChipDeviceScannerState::UNINITIALIZED;
     GAutoPtr<GCancellable> mCancellable;
 };
 


### PR DESCRIPTION
## Problem
There are simple enum used in Linux platform code.

## Changes
Converting an enumeration (enum) to an enumeration class (enum class) is advisable to utilise stronger typing. This change enhances the robustness of the code by providing better type safety and scope containment for the enumeration values.