### PR TITLE
Remove CHIPoBLE testing dead code

### DIFF
--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -42,13 +42,11 @@
 #include <ble/BleLayer.h>
 #include <ble/BtpEngine.h>
 
-// clang-format off
-
 // Define below to enable extremely verbose, BLE end point-specific debug logging.
 #undef CHIP_BLE_END_POINT_DEBUG_LOGGING_ENABLED
 
 #ifdef CHIP_BLE_END_POINT_DEBUG_LOGGING_ENABLED
-#define ChipLogDebugBleEndPoint(MOD, MSG, ...) ChipLogDetail(MOD, MSG, ## __VA_ARGS__)
+#define ChipLogDebugBleEndPoint(MOD, MSG, ...) ChipLogDetail(MOD, MSG, ##__VA_ARGS__)
 #else
 #define ChipLogDebugBleEndPoint(MOD, MSG, ...)
 #endif
@@ -61,7 +59,7 @@
  *    packet to re-open its window instead of waiting for the send-ack timer to expire.
  *
  */
-#define BLE_CONFIG_IMMEDIATE_ACK_WINDOW_THRESHOLD                   1
+#define BLE_CONFIG_IMMEDIATE_ACK_WINDOW_THRESHOLD 1
 
 /**
  *  @def BLE_UNSUBSCRIBE_TIMEOUT_MS
@@ -71,14 +69,18 @@
  *    before it automatically releases its BLE connection and frees itself. The default value of 5 seconds is arbitrary.
  *
  */
-#define BLE_UNSUBSCRIBE_TIMEOUT_MS                            5000 // 5 seconds
+#define BLE_UNSUBSCRIBE_TIMEOUT_MS 5000
 
-#define BTP_ACK_SEND_TIMEOUT_MS                               2500 // 2.5 seconds
+#define BTP_ACK_SEND_TIMEOUT_MS 2500
 
-#define BTP_WINDOW_NO_ACK_SEND_THRESHOLD                         1 // Data fragments may only be sent without piggybacked
-                                                                   // acks if receiver's window size is above this threshold.
-
-// clang-format on
+/**
+ *  @def BTP_WINDOW_NO_ACK_SEND_THRESHOLD
+ *
+ *  @brief
+ *    Data fragments may only be sent without piggybacked acks if receiver's window size is above this threshold.
+ *
+ */
+#define BTP_WINDOW_NO_ACK_SEND_THRESHOLD 1
 
 namespace chip {
 namespace Ble {

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -505,7 +505,7 @@ CHIP_ERROR BLEEndPoint::Init(BleLayer * bleLayer, BLE_CONNECTION_OBJECT connObj,
     VerifyOrReturnError((role == kBleRole_Central || role == kBleRole_Peripheral), CHIP_ERROR_INVALID_ARGUMENT);
 
     // If end point plays peripheral role, expect ack for indication sent as last step of BTP handshake.
-    // If central, periperal's handshake indication 'ack's write sent by central to kick off the BTP handshake.
+    // If central, peripheral's handshake indication 'ack's write sent by central to kick off the BTP handshake.
     bool expectInitialAck = (role == kBleRole_Peripheral);
 
     CHIP_ERROR err = mBtpEngine.Init(this, expectInitialAck);
@@ -767,7 +767,7 @@ CHIP_ERROR BLEEndPoint::HandleHandshakeConfirmationReceived()
             }
             else
             {
-                // Drive sending in case application callend Send() after we sent the handshake indication, but
+                // Drive sending in case application called Send() after we sent the handshake indication, but
                 // before the GATT confirmation for this indication was received.
                 err = DriveSending();
                 SuccessOrExit(err);
@@ -1209,7 +1209,7 @@ CHIP_ERROR BLEEndPoint::Receive(PacketBufferHandle && data)
     {
         ChipLogDebugBleEndPoint(Ble, "got btp ack = %u", receivedAck);
 
-        // If ack was rx'd for neweset unacked sent fragment, stop ack received timer.
+        // If ack was rx'd for newest unacked sent fragment, stop ack received timer.
         if (!mBtpEngine.ExpectingAck())
         {
             ChipLogDebugBleEndPoint(Ble, "got ack for last outstanding fragment");

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -32,11 +32,6 @@
 #include <ble/BleRole.h>
 #include <ble/BtpEngine.h>
 
-#if CHIP_ENABLE_CHIPOBLE_TEST
-#include <ble/BtpEngineTest.h>
-#include <system/SystemMutex.h>
-#endif
-
 namespace chip {
 namespace Ble {
 
@@ -53,17 +48,11 @@ class BleLayer;
 class BleEndPointPool;
 // BLEEndPoint holds a pointer to BleLayerDelegate for messages, while BleLayerDelegate functions also accepts BLEEndPoint.
 class BleLayerDelegate;
-#if CHIP_ENABLE_CHIPOBLE_TEST
-class BtpEngineTest;
-#endif
 
 class DLL_EXPORT BLEEndPoint
 {
     friend class BleLayer;
     friend class BleEndPointPool;
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    friend class BtpEngineTest;
-#endif
 
 public:
     typedef uint64_t AlignT;
@@ -89,15 +78,6 @@ public:
 
     typedef void (*OnConnectionClosedFunct)(BLEEndPoint * endPoint, CHIP_ERROR err);
     OnConnectionClosedFunct OnConnectionClosed;
-
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    typedef void (*OnCommandReceivedFunct)(BLEEndPoint * endPoint, PacketBufferHandle && msg);
-    OnCommandReceivedFunct OnCommandReceived;
-    inline void SetOnCommandReceivedCB(OnCommandReceivedFunct cb) { OnCommandReceived = cb; };
-    BtpEngineTest mBtpEngineTest;
-    inline void SetTxWindowSize(uint8_t size) { mRemoteReceiveWindowSize = size; };
-    inline void SetRxWindowSize(uint8_t size) { mReceiveWindowMaxSize = size; };
-#endif
 
     // Public functions:
     CHIP_ERROR Send(PacketBufferHandle && data);
@@ -137,9 +117,6 @@ private:
         kAckReceivedTimerRunning       = 0x04, // Ack received timer running due to unacked sent fragment.
         kSendAckTimerRunning           = 0x08, // Send ack timer running; indicates pending ack to send.
         kUnsubscribeTimerRunning       = 0x10, // Unsubscribe completion timer running.
-#if CHIP_ENABLE_CHIPOBLE_TEST
-        kUnderTestTimerRunnung = 0x80 // running throughput Tx test
-#endif
     };
 
     // BLE connection to which an end point is uniquely bound. Type BLE_CONNECTION_OBJECT is defined by the platform or
@@ -164,9 +141,6 @@ private:
     SequenceNumber_t mLocalReceiveWindowSize;
     SequenceNumber_t mRemoteReceiveWindowSize;
     SequenceNumber_t mReceiveWindowMaxSize;
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    chip::System::Mutex mTxQueueMutex; // For MT-safe Tx queuing
-#endif
 
     // Private functions:
     BLEEndPoint()  = delete;
@@ -229,13 +203,9 @@ private:
     void FreeBtpEngine();
 
     // Mutex lock on Tx queue. Used only in BtpEngine test build for now.
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    inline void QueueTxLock() { mTxQueueMutex.Lock(); }
-    inline void QueueTxUnlock() { mTxQueueMutex.Unlock(); }
-#else
+    // TODO: Remove these lock/unlock?
     inline void QueueTxLock() {}
     inline void QueueTxUnlock() {}
-#endif
     void QueueTx(PacketBufferHandle && data, PacketType_t type);
 };
 

--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -202,10 +202,6 @@ private:
     void Free();
     void FreeBtpEngine();
 
-    // Mutex lock on Tx queue. Used only in BtpEngine test build for now.
-    // TODO: Remove these lock/unlock?
-    inline void QueueTxLock() {}
-    inline void QueueTxUnlock() {}
     void QueueTx(PacketBufferHandle && data, PacketType_t type);
 };
 

--- a/src/ble/BUILD.gn
+++ b/src/ble/BUILD.gn
@@ -29,10 +29,7 @@ buildconfig_header("ble_buildconfig") {
   header = "BleBuildConfig.h"
   header_dir = "ble"
 
-  defines = [
-    "CONFIG_NETWORK_LAYER_BLE=${chip_config_network_layer_ble}",
-    "CHIP_ENABLE_CHIPOBLE_TEST=false",
-  ]
+  defines = [ "CONFIG_NETWORK_LAYER_BLE=${chip_config_network_layer_ble}" ]
 
   if (chip_ble_project_config_include != "") {
     defines +=

--- a/src/ble/BleConfig.h
+++ b/src/ble/BleConfig.h
@@ -65,9 +65,6 @@
 #include BLE_PLATFORM_CONFIG_INCLUDE
 #endif
 
-// clang-format off
-
-
 /**
  *  @def BLE_LAYER_NUM_BLE_ENDPOINTS
  *
@@ -102,7 +99,7 @@
  *
  */
 #ifndef BLE_CONNECTION_OBJECT
-#define BLE_CONNECTION_OBJECT void*
+#define BLE_CONNECTION_OBJECT void *
 #endif // BLE_CONNECTION_OBJECT
 
 /**
@@ -129,7 +126,7 @@
  *
  */
 #ifndef BLE_READ_REQUEST_CONTEXT
-#define BLE_READ_REQUEST_CONTEXT void*
+#define BLE_READ_REQUEST_CONTEXT void *
 #endif // BLE_READ_REQUEST_CONTEXT
 
 /**
@@ -197,7 +194,6 @@
 #define BLE_CONFIG_ERROR(e) (BLE_CONFIG_ERROR_MIN + (e))
 #endif // BLE_CONFIG_ERROR
 
-
 /**
  * @def BTP_CONN_RSP_TIMEOUT_MS
  *
@@ -206,7 +202,7 @@
  *   request to wait for connection establishment.
  */
 #ifndef BTP_CONN_RSP_TIMEOUT_MS
-#define BTP_CONN_RSP_TIMEOUT_MS 15000 // 15 seconds
+#define BTP_CONN_RSP_TIMEOUT_MS 15000
 #endif // BTP_CONN_RSP_TIMEOUT_MS
 
 /**
@@ -217,9 +213,7 @@
  *   an acknowledgement. When the ack is not received within this period the BTP session is closed.
  */
 #ifndef BTP_ACK_TIMEOUT_MS
-#define BTP_ACK_TIMEOUT_MS 15000 // 15 seconds
+#define BTP_ACK_TIMEOUT_MS 15000
 #endif // BTP_ACK_TIMEOUT_MS
-
-// clang-format on
 
 #include <lib/core/CHIPConfig.h>

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -287,10 +287,6 @@ CHIP_ERROR BleLayer::Init(BlePlatformDelegate * platformDelegate, BleConnectionD
 
     mState = kState_Initialized;
 
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    mTestBleEndPoint = NULL;
-#endif
-
     return CHIP_NO_ERROR;
 }
 
@@ -443,10 +439,6 @@ CHIP_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_O
 
     (*retEndPoint)->Init(this, connObj, role, autoClose);
     (*retEndPoint)->mBleTransport = mBleTransport;
-
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    mTestBleEndPoint = *retEndPoint;
-#endif
 
     return CHIP_NO_ERROR;
 }

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -22,7 +22,7 @@
  *      platform's Bluetooth Low Energy (BLE) implementation and the CHIP
  *      stack.
  *
- *      The BleLayer obect accepts BLE data and control input from the
+ *      The BleLayer object accepts BLE data and control input from the
  *      application via a functional interface. It performs the fragmentation
  *      and reassembly required to transmit CHIP message via a BLE GATT
  *      characteristic interface, and drives incoming messages up the CHIP
@@ -197,7 +197,7 @@ public:
  *    and hand the platform-specific BLE_CONNECTION_OBJECT that this receipt
  *    generates to BleLayer via the corresponding platform interface function.
  *    This causes BleLayer to wrap the BLE_CONNECTION_OBJECT in a BLEEndPoint,
- *    and notify chipMessageLayer that a new BLE conneciotn has been received.
+ *    and notify chipMessageLayer that a new BLE connection has been received.
  *    The message layer then wraps the new BLEEndPoint object in a
  *    chipConnection, and hands this object to the application via the message
  *    layer's OnConnectionReceived callback.
@@ -268,7 +268,7 @@ public:
      *     characteristics CHIP cares about.
 
      *     Platform must call this function when a GATT subscription has been established to any CHIP service
-     *     charateristic.
+     *     characteristic.
      *
      *     If this function returns true, CHIP has accepted the BLE connection and wrapped it
      *     in a chipConnection object. If CHIP accepts a BLE connection, the platform MUST
@@ -280,7 +280,7 @@ public:
     bool HandleSubscribeComplete(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId);
 
     /**< Platform must call this function when a GATT unsubscribe is requested on any CHIP
-     *   service charateristic, that is, when an existing GATT subscription on a CHIP service
+     *   service characteristic, that is, when an existing GATT subscription on a CHIP service
      *   characteristic is canceled. */
     bool HandleUnsubscribeReceived(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId);
 

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -214,9 +214,6 @@ public:
 class DLL_EXPORT BleLayer
 {
     friend class BLEEndPoint;
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    friend class BtpEngineTest;
-#endif
 
 public:
     // Public data members:
@@ -318,10 +315,6 @@ public:
      *   the BLE connection close will not generate an upcall to CHIP, HandleConnectionError must be called with
      *   err = BLE_ERROR_APP_CLOSED_CONNECTION to prevent the leak of this chipConnection and its end point object. */
     void HandleConnectionError(BLE_CONNECTION_OBJECT connObj, CHIP_ERROR err);
-
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    BLEEndPoint * mTestBleEndPoint;
-#endif
 
 private:
     // Private data members:

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -30,9 +30,6 @@
 #if CONFIG_NETWORK_LAYER_BLE
 
 #include <ble/BtpEngine.h>
-#if CHIP_ENABLE_CHIPOBLE_TEST
-#include <ble/BtpEngineTest.h>
-#endif
 
 #include <lib/support/BufferReader.h>
 #include <lib/support/CodeUtils.h>
@@ -93,10 +90,6 @@ CHIP_ERROR BtpEngine::Init(void * an_app_state, bool expect_first_ack)
     mTxPacketCount         = 0;
     mTxNewestUnackedSeqNum = 0;
     mTxOldestUnackedSeqNum = 0;
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    mTxPacketType = kType_Data; // Default BtpEngine Data packet
-    mRxPacketType = kType_Data; // Default BtpEngine Data packet
-#endif
 
     if (expect_first_ack)
     {
@@ -143,25 +136,6 @@ SequenceNumber_t BtpEngine::GetAndRecordRxAckSeqNum()
 
     return ret;
 }
-
-#if CHIP_ENABLE_CHIPOBLE_TEST
-bool BtpEngine::IsCommandPacket(const PacketBufferHandle & p)
-{
-    if (p.IsNull())
-    {
-        return false;
-    }
-
-    BitFlags<HeaderFlags> rx_flags;
-    Encoding::LittleEndian::Reader reader(data->Start(), data->DataLength());
-    CHIP_ERROR err = reader.Read8(rx_flags.RawStorage()).StatusCode();
-    if (err != CHIP_NO_ERROR)
-    {
-        return false;
-    }
-    return rx_flags.Has(HeaderFlags::kCommandMessage);
-}
-#endif // CHIP_ENABLE_CHIPOBLE_TEST
 
 bool BtpEngine::HasUnackedData() const
 {
@@ -271,12 +245,6 @@ CHIP_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle &&
         // Get header flags, always in first byte.
         err = reader.Read8(rx_flags.RawStorage()).StatusCode();
         SuccessOrExit(err);
-#if CHIP_ENABLE_CHIPOBLE_TEST
-        if (rx_flags.Has(HeaderFlags::kCommandMessage))
-            SetRxPacketType(kType_Control);
-        else
-            SetRxPacketType(kType_Data);
-#endif
 
         didReceiveAck = rx_flags.Has(HeaderFlags::kFragmentAck);
 
@@ -483,11 +451,6 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         uint8_t cursor = 1; // first position past header flags byte
         BitFlags<HeaderFlags> headerFlags(HeaderFlags::kStartMessage);
 
-#if CHIP_ENABLE_CHIPOBLE_TEST
-        if (TxPacketType() == kType_Control)
-            headerFlags.Set(HeaderFlags::kCommandMessage);
-#endif
-
         if (send_ack)
         {
             headerFlags.Set(HeaderFlags::kFragmentAck);
@@ -535,11 +498,6 @@ bool BtpEngine::HandleCharacteristicSend(System::PacketBufferHandle data, bool s
         uint8_t cursor = 1; // first position past header flags byte
 
         BitFlags<HeaderFlags> headerFlags(HeaderFlags::kContinueMessage);
-
-#if CHIP_ENABLE_CHIPOBLE_TEST
-        if (TxPacketType() == kType_Control)
-            headerFlags.Set(HeaderFlags::kCommandMessage);
-#endif
 
         if (send_ack)
         {

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -275,7 +275,7 @@ CHIP_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle &&
         }
 
         // Truncate the incoming fragment length by the mRxFragmentSize as the negotiated
-        // mRxFragnentSize may be smaller than the characteristic size.  Make sure
+        // mRxFragmentSize may be smaller than the characteristic size.  Make sure
         // we're not truncating to a data length smaller than what we have already consumed.
         VerifyOrExit(reader.OctetsRead() <= mRxFragmentSize, err = BLE_ERROR_REASSEMBLER_INCORRECT_STATE);
         data->SetDataLength(chip::min(data->DataLength(), mRxFragmentSize));

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -56,10 +56,6 @@ using ::chip::System::PacketBufferHandle;
 typedef uint8_t SequenceNumber_t; // If type changed from uint8_t, adjust assumptions in BtpEngine::IsValidAck and
                                   // BLEEndPoint::AdjustReceiveWindow.
 
-#if CHIP_ENABLE_CHIPOBLE_TEST
-class BLEEndPoint;
-#endif
-
 // Public data members:
 typedef enum
 {
@@ -69,10 +65,6 @@ typedef enum
 
 class BtpEngine
 {
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    friend class BLEEndPoint;
-#endif
-
 public:
     // Public data members:
     typedef enum
@@ -90,9 +82,6 @@ public:
         kContinueMessage = 0x02,
         kEndMessage      = 0x04,
         kFragmentAck     = 0x08,
-#if CHIP_ENABLE_CHIPOBLE_TEST
-        kCommandMessage = 0x10,
-#endif
     };
 
     static const uint16_t sDefaultFragmentSize;
@@ -117,29 +106,6 @@ public:
 
     inline State_t RxState() { return mRxState; }
     inline State_t TxState() { return mTxState; }
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    inline PacketType_t SetTxPacketType(PacketType_t type) { return (mTxPacketType = type); }
-    inline PacketType_t SetRxPacketType(PacketType_t type) { return (mRxPacketType = type); }
-    inline PacketType_t TxPacketType() { return mTxPacketType; }
-    inline PacketType_t RxPacketType() { return mRxPacketType; }
-    inline SequenceNumber_t SetTxPacketSeq(SequenceNumber_t seq) { return (mTxPacketSeq = seq); }
-    inline SequenceNumber_t SetRxPacketSeq(SequenceNumber_t seq) { return (mRxPacketSeq = seq); }
-    inline SequenceNumber_t TxPacketSeq() { return mTxPacketSeq; }
-    inline SequenceNumber_t RxPacketSeq() { return mRxPacketSeq; }
-    static bool IsCommandPacket(const PacketBufferHandle & p);
-    inline void PushPacketTag(const PacketBufferHandle & p, PacketType_t type)
-    {
-        p->SetStart(p->Start() - sizeof(type));
-        memcpy(p->Start(), &type, sizeof(type));
-    }
-    inline PacketType_t PopPacketTag(const PacketBufferHandle & p)
-    {
-        PacketType_t type;
-        memcpy(&type, p->Start(), sizeof(type));
-        p->SetStart(p->Start() + sizeof(type));
-        return type;
-    }
-#endif // CHIP_ENABLE_CHIPOBLE_TEST
 
     bool HasUnackedData() const;
 
@@ -160,12 +126,6 @@ public:
 
 private:
     // Private data members:
-#if CHIP_ENABLE_CHIPOBLE_TEST
-    PacketType_t mTxPacketType;
-    PacketType_t mRxPacketType;
-    SequenceNumber_t mTxPacketSeq;
-    SequenceNumber_t mRxPacketSeq;
-#endif
     State_t mRxState;
     uint16_t mRxLength;
     void * mAppState;

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -39,7 +39,7 @@
 namespace chip {
 namespace Ble {
 
-inline constexpr size_t kTransferProtocolHeaderFlagsSize = 1; // Size in bytes of enocded BTP fragment header flag bits
+inline constexpr size_t kTransferProtocolHeaderFlagsSize = 1; // Size in bytes of encoded BTP fragment header flag bits
 inline constexpr size_t kTransferProtocolSequenceNumSize = 1; // Size in bytes of encoded BTP sequence number
 inline constexpr size_t kTransferProtocolAckSize         = 1; // Size in bytes of encoded BTP fragment acknowledgement number
 inline constexpr size_t kTransferProtocolMsgLenSize      = 2; // Size in byte of encoded BTP total fragmented message length

--- a/src/ble/tests/TestBleErrorStr.cpp
+++ b/src/ble/tests/TestBleErrorStr.cpp
@@ -37,9 +37,7 @@ using namespace chip;
 
 // Test input data.
 
-// clang-format off
-static const CHIP_ERROR kTestElements[] =
-{
+static const CHIP_ERROR kTestElements[] = {
     BLE_ERROR_ADAPTER_UNAVAILABLE,
     BLE_ERROR_NO_CONNECTION_RECEIVED_CALLBACK,
     BLE_ERROR_CENTRAL_UNSUBSCRIBED,
@@ -66,7 +64,6 @@ static const CHIP_ERROR kTestElements[] =
     BLE_ERROR_INVALID_BTP_SEQUENCE_NUMBER,
     BLE_ERROR_REASSEMBLER_INCORRECT_STATE,
 };
-// clang-format on
 
 TEST(TestBleErrorStr, CheckBleErrorStr)
 {


### PR DESCRIPTION
### Problem

Code behind `CHIP_ENABLE_CHIPOBLE_TEST` is never enabled. It originates from Weave project which was not open-sourced.

### Testing

CI will verify build.