### PR TITLE
Move `EventLoggingDelegate.h` into `app:events` gn target

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -261,11 +261,13 @@ source_set("events") {
   sources = [
     "EventHeader.h",
     "EventLoggingTypes.h",
+    "EventLoggingDelegate.h",
   ]
 
   deps = [
     ":paths",
     "${chip_root}/src/access:types",
+    "${chip_root}/src/lib/core",
   ]
 }
 
@@ -291,7 +293,6 @@ static_library("app") {
     "DeferredAttributePersistenceProvider.cpp",
     "DeferredAttributePersistenceProvider.h",
     "EventLogging.h",
-    "EventLoggingDelegate.h",
     "EventManagement.cpp",
     "EventManagement.h",
     "FailSafeContext.cpp",

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -260,8 +260,8 @@ static_library("interaction-model") {
 source_set("events") {
   sources = [
     "EventHeader.h",
-    "EventLoggingTypes.h",
     "EventLoggingDelegate.h",
+    "EventLoggingTypes.h",
   ]
 
   deps = [

--- a/src/app/EventLoggingDelegate.h
+++ b/src/app/EventLoggingDelegate.h
@@ -23,10 +23,7 @@
 
 #pragma once
 
-#include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>
-#include <messaging/ExchangeContext.h>
-#include <system/SystemPacketBuffer.h>
 
 namespace chip {
 namespace app {


### PR DESCRIPTION
This delegate is very stand-alone and seems very coupled to eventing in general.

Moving this helps in defining a IM interface that is stand-alone and does not depend on the entire `src/app`.

### Changes

- move `EventLoggingDelegate.h` from `app` to `app:events`
- Remove unnecessary includes (that would pull too many dependencies) from the header
- add dependency on `lib/core` due to TLVWriter usage.