### PR TITLE
Darwin: Leave the work queue running

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -1049,18 +1049,10 @@ static void ShutdownOnExit()
             self->_groupDataProvider->RemoveGroupKeys(fabricIndex);
         }
 
-        if (_otaProviderDelegateBridge) {
-            _otaProviderDelegateBridge->ControllerShuttingDown(controller);
-        }
-
-        [controller shutDownCppController];
-
-        self->_controllerBeingShutDown = nil;
-        if (self->_controllerBeingStarted == controller) {
-            self->_controllerBeingStarted = nil;
-        }
-
         // If there are no other controllers left, we can shut down some things.
+        // Do this before we shut down the controller itself, because the
+        // OtaProviderDelegateBridge uses some services provided by the system
+        // state without retaining it.
         if (_controllers.count == 0) {
             delete self->_operationalBrowser;
             self->_operationalBrowser = nullptr;
@@ -1076,6 +1068,15 @@ static void ShutdownOnExit()
                 [self removeServerEndpoint:_otaProviderEndpoint];
                 _otaProviderEndpoint = nil;
             }
+        } else if (_otaProviderDelegateBridge) {
+            _otaProviderDelegateBridge->ControllerShuttingDown(controller);
+        }
+
+        [controller shutDownCppController];
+
+        self->_controllerBeingShutDown = nil;
+        if (self->_controllerBeingStarted == controller) {
+            self->_controllerBeingStarted = nil;
         }
     });
 


### PR DESCRIPTION
Start the work queue when the MTRDeviceControllerFactory is initialized, and leave it running. This avoids having to conditionally dispatch to the work queue in various scenarios and lets us simplify controller startup and shutdown.
