### PR TITLE
Fix up mock ember implementation (use after free and missing function)

### DIFF
--- a/src/app/util/mock/MockNodeConfig.cpp
+++ b/src/app/util/mock/MockNodeConfig.cpp
@@ -91,6 +91,13 @@ MockEndpointConfig::MockEndpointConfig(EndpointId aId, std::initializer_list<Moc
     mEmberEndpoint.cluster      = mEmberClusters.data();
 }
 
+MockEndpointConfig::MockEndpointConfig(const MockEndpointConfig & other) :
+    id(other.id), clusters(other.clusters), mEmberClusters(other.mEmberClusters), mEmberEndpoint(other.mEmberEndpoint)
+{
+    // fix self-referencing pointers
+    mEmberEndpoint.cluster = mEmberClusters.data();
+}
+
 const MockClusterConfig * MockEndpointConfig::clusterById(ClusterId clusterId, ptrdiff_t * outIndex) const
 {
     return findById(clusters, clusterId, outIndex);

--- a/src/app/util/mock/MockNodeConfig.h
+++ b/src/app/util/mock/MockNodeConfig.h
@@ -61,6 +61,10 @@ struct MockEndpointConfig
 {
     MockEndpointConfig(EndpointId aId, std::initializer_list<MockClusterConfig> aClusters = {});
 
+    // Cluster-config is self-referntial: mEmberCluster.clusters references  mEmberClusters
+    MockEndpointConfig(const MockEndpointConfig & other);
+    MockEndpointConfig & operator=(const MockEndpointConfig &) = delete;
+
     const MockClusterConfig * clusterById(ClusterId clusterId, ptrdiff_t * outIndex = nullptr) const;
     const EmberAfEndpointType * emberEndpoint() const { return &mEmberEndpoint; }
 

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -258,6 +258,12 @@ const EmberAfCluster * emberAfFindServerCluster(EndpointId endpointId, ClusterId
     return cluster->emberCluster();
 }
 
+DataVersion * emberAfDataVersionStorage(const chip::app::ConcreteClusterPath & aConcreteClusterPath)
+{
+    // shared data version storage
+    return &dataVersion;
+}
+
 namespace chip {
 namespace app {
 


### PR DESCRIPTION
MockEndpointConfig is self-referential because the ember structure contains a pointer to an internal vector of data. This means the default copy constructor cannot be used.

Also provide the `emberAfDataVersionStorage` which is a public API that is supposed to be available to the IM.

### Changes

- provide data version function as described by attribute-storage.h
- fix self-referencing structure copying for mock node configurations

