### PR TITLE
Updating the existing xml with features per cluster and features per device type

### DIFF
--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,13 +8,13 @@
                 "mac-amd64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2024.03.14-nightly.1"]
+            "tags": ["version:2@v2024.04.15-nightly.1"]
         },
         {
             "_comment": "Always get the amd64 version on mac until usable arm64 zap build is available",
             "path": "fuchsia/third_party/zap/mac-amd64",
             "platforms": ["mac-arm64"],
-            "tags": ["version:2@v2024.03.14-nightly.1"]
+            "tags": ["version:2@v2024.04.15-nightly.1"]
         }
     ]
 }

--- a/scripts/setup/zap.version
+++ b/scripts/setup/zap.version
@@ -1,1 +1,1 @@
-v2024.03.14-nightly
+v2024.04.15-nightly

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2024.3.14'
+MIN_ZAP_VERSION = '2024.4.15'
 
 
 class ZapTool:

--- a/src/app/zap-templates/app-templates.json
+++ b/src/app/zap-templates/app-templates.json
@@ -2,6 +2,7 @@
     "name": "CHIP Application templates",
     "version": "chip-v1",
     "requiredFeatureLevel": 102,
+    "category": "matter",
     "helpers": [
         "partials/helper.js",
         "common/ListHelper.js",

--- a/src/app/zap-templates/app-templates.json
+++ b/src/app/zap-templates/app-templates.json
@@ -1,6 +1,7 @@
 {
     "name": "CHIP Application templates",
     "version": "chip-v1",
+    "requiredFeatureLevel": 102,
     "helpers": [
         "partials/helper.js",
         "common/ListHelper.js",

--- a/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
@@ -69,9 +69,4 @@ limitations under the License.
     </command>
 
   </cluster>
-
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x003c" />
-    <field name="Basic" mask="0x01" />
-  </bitmap>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
@@ -38,6 +38,11 @@ limitations under the License.
     <define>ADMINISTRATOR_COMMISSIONING_CLUSTER</define>
     <description>Commands to trigger a Node to allow a new Administrator to commission it.</description>
 
+    <features>
+      <feature bit="0" code="BC" name="Basic" summary="Node supports Basic Commissioning Method.">
+        <optionalConform/>
+      </feature>
+    </features>
     <attribute side="server" code="0x0000" define="WINDOW_STATUS" type="CommissioningWindowStatusEnum" writable="false" optional="false">WindowStatus</attribute>
     <attribute side="server" code="0x0001" define="ADMIN_FABRIC_INDEX" type="fabric_idx" writable="false" isNullable="true" optional="false">AdminFabricIndex</attribute>
     <attribute side="server" code="0x0002" define="ADMIN_VENDOR_ID" type="vendor_id" writable="false" isNullable="true" optional="false">AdminVendorId</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/air-quality-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/air-quality-cluster.xml
@@ -44,15 +44,6 @@ limitations under the License.
     <attribute side="server" code="0x0000" define="AIR_QUALITY" type="AirQualityEnum" min="0" max="6" writable="false" isNullable="false" default="0" optional="false">AirQuality</attribute>
   </cluster>
 
-  <!-- Feature Map -->
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x005B" />
-    <field name="Fair" mask="0x01" />
-    <field name="Moderate" mask="0x02" />
-    <field name="VeryPoor" mask="0x04" />
-    <field name="ExtremelyPoor" mask="0x08" />
-  </bitmap>
-
   <!-- Cluster Data Types -->
   <enum name="AirQualityEnum" type="enum8">
     <cluster code="0x005B" />

--- a/src/app/zap-templates/zcl/data-model/chip/air-quality-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/air-quality-cluster.xml
@@ -25,6 +25,21 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
 
+    <features>
+      <feature bit="0" code="FAIR" name="Fair" summary="Cluster supports the Fair air quality level">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="MOD" name="Moderate" summary="Cluster supports the Moderate air quality level">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="VPOOR" name="VeryPoor" summary="Cluster supports the Very poor air quality level">
+        <optionalConform/>
+      </feature>
+      <feature bit="3" code="XPOOR" name="ExtremelyPoor" summary="Cluster supports the Extremely poor air quality level">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <!-- Attributes -->
     <attribute side="server" code="0x0000" define="AIR_QUALITY" type="AirQualityEnum" min="0" max="6" writable="false" isNullable="false" default="0" optional="false">AirQuality</attribute>
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
@@ -25,6 +25,12 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>This cluster provides an interface for launching content on a media player device such as a TV or Speaker.</description>
 
+    <features>
+      <feature bit="0" code="AP" name="ApplicationPlatform" summary="Support for attributes and commands required for endpoint to support launching any application within the supported application catalogs">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="APPLICATION_LAUNCHER_LIST"        type="array" entryType="int16u" reportable="true"  writable="false" optional="true">CatalogList</attribute>
     <attribute side="server" code="0x0001" define="APPLICATION_LAUNCHER_CURRENT_APP" type="ApplicationEPStruct"      isNullable="true" writable="false"  optional="true">CurrentApp</attribute>
 

--- a/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
@@ -81,9 +81,4 @@ limitations under the License.
     <item name="AppNotAvailable" value="0x01"/>
     <item name="SystemBusy" value="0x02"/>
   </enum>
-
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x050c"/>
-    <field name="ApplicationPlatform" mask="0x1"/>
-  </bitmap>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
@@ -65,9 +65,4 @@ limitations under the License.
     <item name="Other" value="0x05"/>
   </enum>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x050b"/>
-    <field name="NameUpdates" mask="0x1"/>
-  </bitmap>
-
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
@@ -24,6 +24,13 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster provides an interface for controlling the Output on a media device such as a TV.</description>
+
+    <features>
+      <feature bit="0" code="NU" name="NameUpdates" summary="Supports updates to output names">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="AUDIO_OUTPUT_LIST"           type="array" entryType="OutputInfoStruct" length="254"          writable="false"  optional="false">OutputList</attribute>
     <attribute side="server" code="0x0001" define="AUDIO_OUTPUT_CURRENT_OUTPUT" type="int8u" default="0x00"               min="0x00" max="0xFF" writable="false"  optional="false">CurrentOutput</attribute>
 

--- a/src/app/zap-templates/zcl/data-model/chip/boolean-state-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/boolean-state-configuration-cluster.xml
@@ -46,6 +46,26 @@ limitations under the License.
     <description>This cluster is used to configure a boolean sensor.</description>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
 
+    <features>
+      <feature bit="0" code="VIS" name="Visual" summary="Supports visual alarms">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="AUD" name="Audible" summary="Supports audible alarms">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="SPRS" name="AlarmSuppress" summary="Supports ability to suppress or acknowledge alarms">
+        <optionalConform>
+          <orTerm>
+            <feature name="VIS"/>
+            <feature name="AUD"/>
+          </orTerm>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="SENSLVL" name="SensitivityLevel" summary="Supports ability to set sensor sensitivity">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="CURRENT_SENSITIVITY_LEVEL" type="int8u" isNullable="false" writable="true" optional="true">CurrentSensitivityLevel</attribute>
     <attribute side="server" code="0x0001" define="SUPPORTED_SENSITIVITY_LEVELS" type="int8u" isNullable="false" min="2" max="10" writable="false" optional="true">SupportedSensitivityLevels</attribute>
     <attribute side="server" code="0x0002" define="DEFAULT_SENSITIVITY_LEVEL" type="int8u" isNullable="false" writable="false" optional="true">DefaultSensitivityLevel</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/boolean-state-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/boolean-state-configuration-cluster.xml
@@ -17,14 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0080"/>
-    <field name="Visual" mask="0x1"/>
-    <field name="Audible" mask="0x2"/>
-    <field name="AlarmSuppress" mask="0x4"/>
-    <field name="SensitivityLevel" mask="0x8"/>
-  </bitmap>
-
   <bitmap name="AlarmModeBitmap" type="bitmap8">
     <cluster code="0x0080"/>
     <field name="Visual" mask="0x1"/>

--- a/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
@@ -25,6 +25,22 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="2"/> <!-- Revision   -->
     <description>This cluster provides an interface for controlling the current Channel on a device.</description>
+
+    <features>
+      <feature bit="0" code="CL" name="ChannelList" summary="Provides list of available channels.">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="LI" name="LineupInfo" summary="Provides lineup info, which is a reference to an external source of lineup information.">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="EG" name="ElectronicGuide" summary="Provides electronic program guide information.">
+        <optionalConform/>
+      </feature>
+      <feature bit="3" code="RP" name="RecordProgram" summary="Provides ability to record program.">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="CHANNEL_LIST"            type="array" entryType="ChannelInfoStruct" length="254"                    writable="false" optional="true">ChannelList</attribute>
     <attribute side="server" code="0x0001" define="CHANNEL_LINEUP"          type="LineupInfoStruct"                    default="0x0" isNullable="true" writable="false" optional="true">Lineup</attribute>
     <attribute side="server" code="0x0002" define="CHANNEL_CURRENT_CHANNEL" type="ChannelInfoStruct"                   default="0x0" isNullable="true" writable="false" optional="true">CurrentChannel</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
@@ -208,12 +208,4 @@ limitations under the License.
     <field name="Recorded" mask="0x4"/>
   </bitmap>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0504"/>
-    <field name="ChannelList" mask="0x1"/>
-    <field name="LineupInfo"  mask="0x2"/>
-    <field name="ElectronicGuide" mask="0x4"/>
-    <field name="RecordProgram"  mask="0x8"/>
-  </bitmap>
-
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
@@ -107,6 +107,24 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="6"/>
 
+    <features>
+      <feature bit="0" code="HS" name="Hue/Saturation" summary="Supports color specification via hue/saturation.">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="EHUE" name="Enhanced Hue" summary="Enhanced hue is supported.">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="CL" name="Color loop" summary="Color loop is supported.">
+        <optionalConform/>
+      </feature>
+      <feature bit="3" code="XY" name="XY" summary="Supports color specification via XY.">
+        <optionalConform/>
+      </feature>
+      <feature bit="4" code="CT" name="Color temperature" summary="Supports specification of color temperature.">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="COLOR_CONTROL_CURRENT_HUE" type="int8u" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">CurrentHue</attribute>
     <!-- CURRENT_HUE -->
     <attribute side="server" code="0x0001" define="COLOR_CONTROL_CURRENT_SATURATION" type="int8u" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">CurrentSaturation</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
@@ -15,14 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <configurator>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0300" />
-    <field name="HueAndSaturation" mask="0x01" />
-    <field name="EnhancedHue" mask="0x02" />
-    <field name="ColorLoop" mask="0x04" />
-    <field name="XY" mask="0x08" />
-    <field name="ColorTemperature" mask="0x10" />
-  </bitmap>
+
 
   <enum name="HueDirection" type="enum8">
     <cluster code="0x0300"/>

--- a/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
@@ -101,7 +101,7 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="6"/>
 
     <features>
-      <feature bit="0" code="HS" name="Hue/Saturation" summary="Supports color specification via hue/saturation.">
+      <feature bit="0" code="HS" name="Hue And Saturation" summary="Supports color specification via hue/saturation.">
         <optionalConform/>
       </feature>
       <feature bit="1" code="EHUE" name="Enhanced Hue" summary="Enhanced hue is supported.">

--- a/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
@@ -29,6 +29,35 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
+    <features>
+      <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+        <optionalConform>
+          <feature name="LEV"/>
+        </optionalConform>
+      </feature>
+      <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+      <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+        <optionalConform>
+          <feature name="MEA"/>
+        </optionalConform>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
     <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
@@ -83,6 +83,35 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
+    <features>
+       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+     </features>
+
     <!-- Attributes -->
     <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
@@ -109,6 +138,35 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
+    <features>
+       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+     </features>
+
     <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
     <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
@@ -133,6 +191,35 @@ limitations under the License.
     <server tick="false" init="false">true</server>
 
     <globalAttribute side="either" code="0xFFFD" value="3"/>
+
+    <features>
+       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+     </features>
 
     <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
@@ -159,6 +246,35 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
+    <features>
+       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+     </features>
+
     <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
     <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
@@ -183,6 +299,35 @@ limitations under the License.
     <server tick="false" init="false">true</server>
 
     <globalAttribute side="either" code="0xFFFD" value="3"/>
+
+    <features>
+       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+     </features>
 
     <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
@@ -209,6 +354,35 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
+    <features>
+       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+     </features>
+
     <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
     <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
@@ -233,6 +407,35 @@ limitations under the License.
     <server tick="false" init="false">true</server>
 
     <globalAttribute side="either" code="0xFFFD" value="3"/>
+
+    <features>
+       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+     </features>
 
     <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
@@ -259,6 +462,35 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
+    <features>
+       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+     </features>
+
     <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
     <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
@@ -283,6 +515,35 @@ limitations under the License.
     <server tick="false" init="false">true</server>
 
     <globalAttribute side="either" code="0xFFFD" value="3"/>
+
+    <features>
+       <feature bit="0" code="MEA" name="NumericMeasurement" summary="Cluster supports numeric measurement of substance">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="1" code="LEV" name="LevelIndication" summary="Cluster supports basic level indication for substance using the ConcentrationLevel enum">
+         <optionalConform choice="a" more="true"/>
+       </feature>
+       <feature bit="2" code="MED" name="MediumLevel" summary="Cluster supports the Medium Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="3" code="CRI" name="CriticalLevel" summary="Cluster supports the Critical Concentration Level">
+         <optionalConform>
+           <feature name="LEV"/>
+         </optionalConform>
+       </feature>
+       <feature bit="4" code="PEA" name="PeakMeasurement" summary="Cluster supports peak numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+       <feature bit="5" code="AVG" name="AverageMeasurement" summary="Cluster supports average numeric measurement of substance">
+         <optionalConform>
+           <feature name="MEA"/>
+         </optionalConform>
+       </feature>
+     </features>
 
     <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
@@ -297,26 +297,6 @@ limitations under the License.
     <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
   </cluster>
 
-  <!-- Feature Map -->
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x040c"/>
-    <cluster code="0x040d" />
-    <cluster code="0x0413" />
-    <cluster code="0x0415" />
-    <cluster code="0x042a" />
-    <cluster code="0x042b" />
-    <cluster code="0x042c" />
-    <cluster code="0x042d" />
-    <cluster code="0x042e" />
-    <cluster code="0x042f" />
-    <field name="Numeric Measurement" mask="0x01" />
-    <field name="Level Indication" mask="0x02" />
-    <field name="Medium Level" mask="0x04" />
-    <field name="Critical Level" mask="0x08" />
-    <field name="Peak Measurement" mask="0x10" />
-    <field name="Average Measurement" mask="0x20" />
-  </bitmap>
-
   <!-- Cluster Data Types -->
   <enum name="LevelValueEnum" type="enum8">
     <cluster code="0x040c"/>

--- a/src/app/zap-templates/zcl/data-model/chip/content-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-control-cluster.xml
@@ -124,13 +124,4 @@ limitations under the License.
     <item name="RatingNameDesc" type="char_string" optional="true"/>
   </struct>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x050F"/>
-    <field name="ScreenTime" mask="0x1"/>
-    <field name="PINManagement"  mask="0x2"/>
-    <field name="BlockUnrated" mask="0x4"/>
-    <field name="OnDemandContentRating"  mask="0x8"/>
-    <field name="ScheduledContentRating"  mask="0x10"/>
-  </bitmap>
-
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/content-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-control-cluster.xml
@@ -24,6 +24,34 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster is used for managing the content control (including "parental control") settings on a media device such as a TV, or Set-top Box.</description>
+
+    <features>
+      <feature bit="0" code="ST" name="ScreenTime" summary="Supports managing screen time limits.">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="PM" name="PINManagement" summary="Supports managing a PIN code which is used for restricting access to configuration of this feature.">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="BU" name="BlockUnrated" summary="Supports managing content controls for unrated content.">
+        <optionalConform/>
+      </feature>
+      <feature bit="3" code="OCR" name="OnDemandContentRating" summary="Supports managing content controls based upon rating threshold for on demand content.">
+        <optionalConform/>
+      </feature>
+      <feature bit="4" code="SCR" name="ScheduledContentRating" summary="Supports managing content controls based upon rating threshold for scheduled content.">
+        <optionalConform/>
+      </feature>
+      <feature bit="5" code="BC" name="BlockChannels" summary="Supports managing a set of channels that are prohibited.">
+        <optionalConform/>
+      </feature>
+      <feature bit="6" code="BA" name="BlockApplications" summary="Supports managing a set of applications that are prohibited.">
+        <optionalConform/>
+      </feature>
+      <feature bit="7" code="BTW" name="BlockContentTimeWindow" summary="Supports managing content controls based upon setting time window in which all contents and applications SHALL be blocked.">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="ENABLED" type="boolean" writable="false" optional="false">Enabled</attribute>
     <attribute side="server" code="0x0001" define="ON_DEMAND_RATINGS" type="ARRAY" entryType="RatingNameStruct" writable="false" optional="true">OnDemandRatings</attribute>
     <attribute side="server" code="0x0002" define="ON_DEMAND_THRESHOLD" type="char_string" length="8" writable="false" optional="true">OnDemandRatingThreshold</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/content-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-control-cluster.xml
@@ -41,15 +41,6 @@ limitations under the License.
       <feature bit="4" code="SCR" name="ScheduledContentRating" summary="Supports managing content controls based upon rating threshold for scheduled content.">
         <optionalConform/>
       </feature>
-      <feature bit="5" code="BC" name="BlockChannels" summary="Supports managing a set of channels that are prohibited.">
-        <optionalConform/>
-      </feature>
-      <feature bit="6" code="BA" name="BlockApplications" summary="Supports managing a set of applications that are prohibited.">
-        <optionalConform/>
-      </feature>
-      <feature bit="7" code="BTW" name="BlockContentTimeWindow" summary="Supports managing content controls based upon setting time window in which all contents and applications SHALL be blocked.">
-        <optionalConform/>
-      </feature>
     </features>
 
     <attribute side="server" code="0x0000" define="ENABLED" type="boolean" writable="false" optional="false">Enabled</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -194,12 +194,4 @@ limitations under the License.
     <field name="HLS" mask="0x2"/>
   </bitmap>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x050a"/>
-    <field name="ContentSearch" mask="0x1"/>
-    <field name="URLPlayback" mask="0x2"/>
-    <field name="AdvancedSeek" mask="0x3"/>
-    <field name="TextTracks" mask="0x4"/>
-    <field name="AudioTracks" mask="0x5"/>
-  </bitmap>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -26,6 +26,24 @@ limitations under the License.
     <description>This cluster provides an interface for launching content on a media player device such as a TV or Speaker.</description>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
 
+    <features>
+      <feature bit="0" code="CS" name="ContentSearch" summary="Device supports content search (non-app specific)">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="UP" name="URLPlayback" summary="Device supports basic URL-based file playback">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="AS" name="AdvancedSeek" summary="Enables clients to implement more advanced media seeking behavior in their user interface, such as for example a &quot;seek bar&quot;.">
+        <optionalConform/>
+      </feature>
+      <feature bit="3" code="TT" name="TextTracks" summary="Device or app supports Text Tracks.">
+        <optionalConform/>
+      </feature>
+      <feature bit="4" code="AT" name="AudioTracks" summary="Device or app supports Audio Tracks.">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="CONTENT_LAUNCHER_ACCEPT_HEADER"                 type="array" entryType="char_string" length="254" writable="false" optional="true">AcceptHeader</attribute>
     <attribute side="server" code="0x0001" define="CONTENT_LAUNCHER_SUPPORTED_STREAMING_PROTOCOLS" type="SupportedProtocolsBitmap" default="0"                       writable="false"  optional="true">SupportedStreamingProtocols</attribute>
 

--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -26,24 +26,6 @@ limitations under the License.
     <description>This cluster provides an interface for launching content on a media player device such as a TV or Speaker.</description>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
 
-    <features>
-      <feature bit="0" code="CS" name="ContentSearch" summary="Device supports content search (non-app specific)">
-        <optionalConform/>
-      </feature>
-      <feature bit="1" code="UP" name="URLPlayback" summary="Device supports basic URL-based file playback">
-        <optionalConform/>
-      </feature>
-      <feature bit="2" code="AS" name="AdvancedSeek" summary="Enables clients to implement more advanced media seeking behavior in their user interface, such as for example a &quot;seek bar&quot;.">
-        <optionalConform/>
-      </feature>
-      <feature bit="3" code="TT" name="TextTracks" summary="Device or app supports Text Tracks.">
-        <optionalConform/>
-      </feature>
-      <feature bit="4" code="AT" name="AudioTracks" summary="Device or app supports Audio Tracks.">
-        <optionalConform/>
-      </feature>
-    </features>
-
     <attribute side="server" code="0x0000" define="CONTENT_LAUNCHER_ACCEPT_HEADER"                 type="array" entryType="char_string" length="254" writable="false" optional="true">AcceptHeader</attribute>
     <attribute side="server" code="0x0001" define="CONTENT_LAUNCHER_SUPPORTED_STREAMING_PROTOCOLS" type="SupportedProtocolsBitmap" default="0"                       writable="false"  optional="true">SupportedStreamingProtocols</attribute>
 
@@ -193,5 +175,14 @@ limitations under the License.
     <field name="DASH" mask="0x1"/>
     <field name="HLS" mask="0x2"/>
   </bitmap>
+
+  <bitmap name="Feature" type="bitmap32">
+     <cluster code="0x050a"/>
+     <field name="ContentSearch" mask="0x1"/>
+     <field name="URLPlayback" mask="0x2"/>
+     <field name="AdvancedSeek" mask="0x3"/>
+     <field name="TextTracks" mask="0x4"/>
+     <field name="AudioTracks" mask="0x5"/>
+   </bitmap>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/descriptor-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/descriptor-cluster.xml
@@ -31,11 +31,6 @@ limitations under the License.
     <item name="Label" type="char_string" isNullable="true" optional="true"/>
   </struct>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x001d" />
-    <field name="TagList" mask="0x01" />
-  </bitmap>
-
   <cluster>
     <domain>General</domain>
     <name>Descriptor</name>

--- a/src/app/zap-templates/zcl/data-model/chip/descriptor-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/descriptor-cluster.xml
@@ -45,6 +45,10 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="2"/>
 
+    <features>
+      <feature bit="0" code="TAGLIST" name="TagList" summary="The TagList attribute is present"/>
+    </features>
+
     <attribute side="server" code="0x0000" define="DEVICE_LIST" type="array" entryType="DeviceTypeStruct" writable="false" optional="false">DeviceTypeList</attribute>
     <attribute side="server" code="0x0001" define="SERVER_LIST" type="array" entryType="cluster_id" writable="false" optional="false">ServerList</attribute>
     <attribute side="server" code="0x0002" define="CLIENT_LIST" type="array" entryType="cluster_id" writable="false" optional="false">ClientList</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/device-energy-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/device-energy-management-cluster.xml
@@ -37,6 +37,73 @@ limitations under the License.
     <description>This cluster allows a client to manage the power draw of a device. An example of such a client could be an Energy Management System (EMS) which controls an Energy Smart Appliance (ESA).</description>
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
+    <features>
+      <feature bit="0" code="PA" name="PowerAdjustment" summary="Allows an EMS to make a temporary power
+                                                                              adjustment (within the limits offered by the ESA).">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="PFR" name="PowerForecastReporting" summary="Allows an ESA to advertise its indicative
+                                                                              future power consumption vs time.">
+        <otherwiseConform>
+          <mandatoryConform>
+            <andTerm>
+              <orTerm>
+                <feature name="STA"/>
+                <feature name="PAU"/>
+                <feature name="FA"/>
+                <feature name="CON"/>
+              </orTerm>
+              <notTerm>
+                <feature name="SFR"/>
+              </notTerm>
+            </andTerm>
+          </mandatoryConform>
+          <optionalConform choice="a" more="true"/>
+        </otherwiseConform>
+      </feature>
+      <feature bit="2" code="SFR" name="StateForecastReporting" summary="Allows an ESA to advertise its indicative
+                                                                              future state vs time.">
+        <otherwiseConform>
+          <mandatoryConform>
+            <andTerm>
+              <orTerm>
+                <feature name="STA"/>
+                <feature name="PAU"/>
+                <feature name="FA"/>
+                <feature name="CON"/>
+              </orTerm>
+              <notTerm>
+                <feature name="PFR"/>
+              </notTerm>
+            </andTerm>
+          </mandatoryConform>
+          <optionalConform choice="a" more="true"/>
+        </otherwiseConform>
+      </feature>
+      <feature bit="3" code="STA" name="StartTimeAdjustment" summary="Allows an EMS to delay an ESA's
+                                                                              planned operation.">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="4" code="PAU" name="Pausable" summary="Allows an EMS to pause an ESA's
+                                                                              planned operation.">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="5" code="FA" name="ForecastAdjustment" summary="Allows an EMS to adjust an ESA's
+                                                                              planned operation.">
+        <otherwiseConform>
+          <provisionalConform/>
+          <optionalConform choice="a" more="true"/>
+        </otherwiseConform>
+      </feature>
+      <feature bit="6" code="CON" name="ConstraintBasedAdjustment" summary="Allows an EMS to request constraints to an ESA's
+                                                                              planned operation.">
+        <otherwiseConform>
+          <provisionalConform/>
+          <optionalConform choice="a" more="true"/>
+        </otherwiseConform>
+      </feature>
+    </features>
+
     <!--Attributes-->
     <attribute code="0x0000" side="server" type="ESATypeEnum" define="ESA_TYPE" writable="false" optional="false" min="0x00" max="0xFF" default="0xFF">ESAType</attribute>
     <attribute code="0x0001" side="server" type="boolean" define="ESA_CAN_GENERATE" writable="false" optional="false" default="0">ESACanGenerate</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/device-energy-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/device-energy-management-cluster.xml
@@ -16,16 +16,7 @@ limitations under the License.
 -->
 <configurator>
   <domain name="Energy Management"/>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0098"/>
-    <field name="PowerAdjustment" mask="0x01"/>
-    <field name="PowerForecastReporting" mask="0x02"/>
-    <field name="StateForecastReporting" mask="0x04"/>
-    <field name="StartTimeAdjustment" mask="0x08"/>
-    <field name="Pausable" mask="0x10"/>
-    <field name="ForecastAdjustment" mask="0x20"/>
-    <field name="ConstraintBasedAdjustment" mask="0x40"/>
-  </bitmap>
+
 
   <cluster apiMaturity="provisional">
     <name>Device Energy Management</name>

--- a/src/app/zap-templates/zcl/data-model/chip/device-energy-management-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/device-energy-management-mode-cluster.xml
@@ -34,6 +34,13 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
+
+    <features>
+      <feature bit="0" code="DEPONOFF" name="OnOff" summary="Dependency with the OnOff cluster">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/dishwasher-alarm-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/dishwasher-alarm-cluster.xml
@@ -37,6 +37,12 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
 
+    <features>
+      <feature bit="0" code="RESET" name="Reset" summary="Supports the ability to reset alarms">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="MASK"      type="AlarmBitmap" default="0" writable="false" optional="false">Mask</attribute>
     <attribute side="server" code="0x0001" define="LATCH"     type="AlarmBitmap" default="0" writable="false" optional="true">Latch</attribute>
     <attribute side="server" code="0x0002" define="STATE"     type="AlarmBitmap" default="0" writable="false" optional="false">State</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/dishwasher-alarm-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/dishwasher-alarm-cluster.xml
@@ -60,9 +60,4 @@ limitations under the License.
         <field id="3" name="Mask" type="AlarmBitmap" />
     </event>
   </cluster>
-
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x005D" />
-    <field name="Reset" mask="0x01" />
-  </bitmap>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/dishwasher-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/dishwasher-mode-cluster.xml
@@ -33,6 +33,13 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <globalAttribute side="either" code="0xFFFD" value="2"/>
+
+    <features>
+      <feature bit="0" code="DEPONOFF" name="OnOff" summary="Dependency with the OnOff cluster">
+        <optionalConform/>
+      </feature>
+    </features>
+    
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
@@ -65,10 +65,10 @@ limitations under the License.
         </globalAttribute>
 
         <features>
-            <feature bit="0" code="PIN" name="PINCredential" summary="Lock supports PIN credentials (via keypad, or over-the-air)">
+            <feature bit="0" code="PIN" name="PIN Credential" summary="Lock supports PIN credentials (via keypad, or over-the-air)">
             <optionalConform/>
             </feature>
-            <feature bit="1" code="RID" name="RFIDCredential" summary="Lock supports RFID credentials">
+            <feature bit="1" code="RID" name="RFID Credential" summary="Lock supports RFID credentials">
             <optionalConform/>
             </feature>
             <feature bit="2" code="FGP" name="FingerCredentials" summary="Lock supports finger related credentials (fingerprint, finger vein)">

--- a/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
@@ -64,6 +64,61 @@ limitations under the License.
             <featureBit tag="ALBU" bit="14">true</featureBit> <!-- TODO: Depends on ALIRO -->
         </globalAttribute>
 
+        <features>
+            <feature bit="0" code="PIN" name="PINCredential" summary="Lock supports PIN credentials (via keypad, or over-the-air)">
+            <optionalConform/>
+            </feature>
+            <feature bit="1" code="RID" name="RFIDCredential" summary="Lock supports RFID credentials">
+            <optionalConform/>
+            </feature>
+            <feature bit="2" code="FGP" name="FingerCredentials" summary="Lock supports finger related credentials (fingerprint, finger vein)">
+            <otherwiseConform>
+                <provisionalConform/>
+                <optionalConform/>
+            </otherwiseConform>
+            </feature>
+            <feature bit="3" code="LOG" name="Logging" summary="Lock supports local/on-lock logging when Events are not supported">
+            <optionalConform/>
+            </feature>
+            <feature bit="4" code="WDSCH" name="WeekDayAccessSchedules" summary="Lock supports week day user access schedules">
+            <optionalConform/>
+            </feature>
+            <feature bit="5" code="DPS" name="DoorPositionSensor" summary="Lock supports a door position sensor that indicates door's state">
+            <optionalConform/>
+            </feature>
+            <feature bit="6" code="FACE" name="FaceCredentials" summary="Lock supports face related credentials (face, iris, retina)">
+            <otherwiseConform>
+                <provisionalConform/>
+                <optionalConform/>
+            </otherwiseConform>
+            </feature>
+            <feature bit="7" code="COTA" name="CredentialOverTheAirAccess" summary="PIN codes over-the-air supported for lock/unlock operations">
+            <optionalConform/>
+            </feature>
+            <feature bit="8" code="USR" name="User" summary="Lock supports the user commands and database">
+            <optionalConform>
+                <orTerm>
+                <feature name="PIN"/>
+                <feature name="RID"/>
+                <feature name="FGP"/>
+                <feature name="FACE"/>
+                </orTerm>
+            </optionalConform>
+            </feature>
+            <feature bit="9" code="NOT" name="Notification" summary="Operation and Programming Notifications">
+            <optionalConform/>
+            </feature>
+            <feature bit="10" code="YDSCH" name="YearDayAccessSchedules" summary="Lock supports year day user access schedules">
+            <optionalConform/>
+            </feature>
+            <feature bit="11" code="HDSCH" name="HolidaySchedules" summary="Lock supports holiday schedules">
+            <optionalConform/>
+            </feature>
+            <feature bit="12" code="UBOLT" name="Unbolting" summary="Lock supports unbolting">
+            <optionalConform/>
+            </feature>
+        </features>
+
         <!-- The principle behind  mandatory/optional is the following:
          1. If attribute/command is marked as mandatory it should be mandatory here.
          2. If attribute/command is marked as optional it should be optional here.

--- a/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
@@ -65,10 +65,10 @@ limitations under the License.
         </globalAttribute>
 
         <features>
-            <feature bit="0" code="PIN" name="PINCredential" summary="Lock supports PIN credentials (via keypad, or over-the-air)">
+            <feature bit="0" code="PIN" name="PinCredential" summary="Lock supports PIN credentials (via keypad, or over-the-air)">
             <optionalConform/>
             </feature>
-            <feature bit="1" code="RID" name="RFIDCredential" summary="Lock supports RFID credentials">
+            <feature bit="1" code="RID" name="RfidCredential" summary="Lock supports RFID credentials">
             <optionalConform/>
             </feature>
             <feature bit="2" code="FGP" name="FingerCredentials" summary="Lock supports finger related credentials (fingerprint, finger vein)">
@@ -92,7 +92,7 @@ limitations under the License.
                 <optionalConform/>
             </otherwiseConform>
             </feature>
-            <feature bit="7" code="COTA" name="CredentialOverTheAirAccess" summary="PIN codes over-the-air supported for lock/unlock operations">
+            <feature bit="7" code="COTA" name="CredentialsOverTheAirAccess" summary="PIN codes over-the-air supported for lock/unlock operations">
             <optionalConform/>
             </feature>
             <feature bit="8" code="USR" name="User" summary="Lock supports the user commands and database">
@@ -114,7 +114,13 @@ limitations under the License.
             <feature bit="11" code="HDSCH" name="HolidaySchedules" summary="Lock supports holiday schedules">
             <optionalConform/>
             </feature>
-            <feature bit="12" code="UBOLT" name="Unbolting" summary="Lock supports unbolting">
+            <feature bit="12" code="UBOLT" name="Unbolt" summary="Lock supports unbolting">
+            <optionalConform/>
+            </feature>
+            <feature bit="13" code="ALIRO" name="AliroProvisioning" summary="AliroProvisioning">
+            <optionalConform/>
+            </feature>
+            <feature bit="14" code="ALBU" name="AliroBLEUWB" summary="AliroBLEUWB">
             <optionalConform/>
             </feature>
         </features>

--- a/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
@@ -839,6 +839,18 @@ limitations under the License.
         <field mask="0x10" name="PINChanged" />
     </bitmap>
 
+    <!-- RemoteProgrammingEventMask attribute bit meaning set -->
+     <bitmap name="DlRemoteProgrammingEventMask" type="bitmap16">
+         <cluster code="0x0101" />
+         <field mask="0x01" name="Unknown" />
+         <field mask="0x02" name="ProgrammingPINChanged" />
+         <field mask="0x04" name="PINAdded" />
+         <field mask="0x08" name="PINCleared" />
+         <field mask="0x10" name="PINChanged" />
+         <field mask="0x20" name="RFIDCodeAdded" />
+         <field mask="0x40" name="RFIDCodeCleared" />
+     </bitmap>
+
     <!-- RFIDProgrammingEventMask attribute bit meaning set -->
     <bitmap name="DlRFIDProgrammingEventMask" type="bitmap16">
         <cluster code="0x0101" />

--- a/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
@@ -839,18 +839,6 @@ limitations under the License.
         <field mask="0x10" name="PINChanged" />
     </bitmap>
 
-    <!-- RemoteProgrammingEventMask attribute bit meaning set -->
-    <bitmap name="DlRemoteProgrammingEventMask" type="bitmap16">
-        <cluster code="0x0101" />
-        <field mask="0x01" name="Unknown" />
-        <field mask="0x02" name="ProgrammingPINChanged" />
-        <field mask="0x04" name="PINAdded" />
-        <field mask="0x08" name="PINCleared" />
-        <field mask="0x10" name="PINChanged" />
-        <field mask="0x20" name="RFIDCodeAdded" />
-        <field mask="0x40" name="RFIDCodeCleared" />
-    </bitmap>
-
     <!-- RFIDProgrammingEventMask attribute bit meaning set -->
     <bitmap name="DlRFIDProgrammingEventMask" type="bitmap16">
         <cluster code="0x0101" />
@@ -869,25 +857,6 @@ limitations under the License.
         <item value="0x89" name="ResourceExhausted" />
         <item value="0x8B" name="NotFound" />
     </enum>
-
-    <bitmap name="Feature" type="bitmap32">
-        <cluster code="0x0101" />
-        <field name="PIN Credential" mask="0x01" />
-        <field name="RFID Credential" mask="0x02" />
-        <field name="Finger Credentials" mask="0x04" />
-        <field name="Logging" mask="0x08" />
-        <field name="Week Day Access Schedules" mask="0x10" />
-        <field name="Door Position Sensor" mask="0x20" />
-        <field name="Face Credentials" mask="0x40" />
-        <field name="Credentials Over-the-Air Access" mask="0x80" />
-        <field name="User" mask="0x100" />
-        <field name="Notification" mask="0x200" />
-        <field name="Year Day Access Schedules" mask="0x400" />
-        <field name="Holiday Schedules" mask="0x800" />
-        <field name="Unbolt" mask="0x1000" />
-        <field name="AliroProvisioning" mask="0x2000" />
-        <field name="AliroBLEUWB" mask="0x4000" />
-    </bitmap>
 
     <enum name="DoorLockSetPinOrIdStatus" type="enum8">
         <cluster code="0x0101"/>

--- a/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/door-lock-cluster.xml
@@ -65,10 +65,10 @@ limitations under the License.
         </globalAttribute>
 
         <features>
-            <feature bit="0" code="PIN" name="PinCredential" summary="Lock supports PIN credentials (via keypad, or over-the-air)">
+            <feature bit="0" code="PIN" name="PINCredential" summary="Lock supports PIN credentials (via keypad, or over-the-air)">
             <optionalConform/>
             </feature>
-            <feature bit="1" code="RID" name="RfidCredential" summary="Lock supports RFID credentials">
+            <feature bit="1" code="RID" name="RFIDCredential" summary="Lock supports RFID credentials">
             <optionalConform/>
             </feature>
             <feature bit="2" code="FGP" name="FingerCredentials" summary="Lock supports finger related credentials (fingerprint, finger vein)">

--- a/src/app/zap-templates/zcl/data-model/chip/drlc-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/drlc-cluster.xml
@@ -17,16 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="Energy Management"/>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0096"/>
-    <field name="EnrollmentGroups" mask="0x1"/>
-    <field name="TemperatureOffset" mask="0x2"/>
-    <field name="TemperatureSetpoint" mask="0x4"/>
-    <field name="LoadAdjustment" mask="0x8"/>
-    <field name="DutyCycle" mask="0x10"/>
-    <field name="PowerSavings" mask="0x20"/>
-    <field name="HeatingSource" mask="0x40"/>
-  </bitmap>
 
   <bitmap name="DeviceClassBitmap" type="bitmap32">
     <cluster code="0x0096"/>

--- a/src/app/zap-templates/zcl/data-model/chip/drlc-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/drlc-cluster.xml
@@ -185,6 +185,30 @@ limitations under the License.
     <server tick="false" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="4"/>
 
+    <features>
+      <feature bit="0" code="ENRLG" name="Enrollment Groups" summary="Supports enrollment groups">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="TEMPO" name="TemperatureOffset" summary="Supports temperature offsets">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="TEMPS" name="TemperatureSetpoint" summary="Supports temperature setpoints">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="3" code="LOADA" name="LoadAdjustment" summary="Supports average load adjustment percentage">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="4" code="DUTYC" name="DutyCycle" summary="Supports duty cycle adjustment">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="5" code="PWRSV" name="PowerSavings" summary="Supports power savings">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="6" code="HEATS" name="HeatingSource" summary="Supports selecting heating source">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="LOAD_CONTROL_PROGRAMS" type="array" entryType="LoadControlProgramStruct" writable="false">LoadControlPrograms</attribute>
     <attribute side="server" code="0x0001" define="NUMBER_OF_LOAD_CONTROL_PROGRAMS" type="int8u" min="5" writable="false" default="5">NumberOfLoadControlPrograms</attribute>
     <attribute side="server" code="0x0002" define="LOAD_CONTROL_EVENTS" type="array" entryType="LoadControlEventStruct" writable="false">Events</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/electrical-energy-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/electrical-energy-measurement-cluster.xml
@@ -16,13 +16,6 @@ limitations under the License.
 -->
 <configurator>
   <domain name="CHIP"/>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0091"/>
-    <field name="ImportedEnergy" mask="0x01"/>
-    <field name="ExportedEnergy" mask="0x02"/>
-    <field name="CumulativeEnergy" mask="0x04"/>
-    <field name="PeriodicEnergy" mask="0x08"/>
-  </bitmap>
   <cluster apiMaturity="provisional">
     <name>Electrical Energy Measurement</name>
     <domain>Measurement &amp; Sensing</domain>

--- a/src/app/zap-templates/zcl/data-model/chip/electrical-energy-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/electrical-energy-measurement-cluster.xml
@@ -32,6 +32,22 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
     <description>This cluster provides a mechanism for querying data about the electrical energy imported or provided by the server.</description>
+
+    <features>
+      <feature bit="0" code="IMPE" name="ImportedEnergy" summary="Measurement of energy imported by the server">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="EXPE" name="ExportedEnergy" summary="Measurement of energy provided by the server">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="CUME" name="CumulativeEnergy" summary="Measurements are cumulative">
+        <optionalConform choice="b" more="true"/>
+      </feature>
+      <feature bit="3" code="PERE" name="PeriodicEnergy" summary="Measurements are periodic">
+        <optionalConform choice="b" more="true"/>
+      </feature>
+    </features>
+
     <!--Attributes-->
     <attribute code="0x0000" side="server" define="ACCURACY" type="MeasurementAccuracyStruct">Accuracy</attribute>
     <attribute code="0x0001" side="server" define="CUMULATIVE_ENERGY_IMPORTED" type="EnergyMeasurementStruct" optional="true" isNullable="true">CumulativeEnergyImported</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/electrical-power-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/electrical-power-measurement-cluster.xml
@@ -33,6 +33,31 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
     <description>This cluster provides a mechanism for querying data about electrical power as measured by the server.</description>
+
+    <features>
+      <feature bit="0" code="DIRC" name="DirectCurrent" summary="Supports measurement of direct current">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="ALTC" name="AlternatingCurrent" summary="Supports measurement of alternating current">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="POLY" name="PolyphasePower" summary="Supports polyphase measurements">
+        <optionalConform>
+          <feature name="ALTC"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="HARM" name="Harmonics" summary="Supports measurement of AC harmonics">
+        <optionalConform>
+          <feature name="ALTC"/>
+        </optionalConform>
+      </feature>
+      <feature bit="4" code="PWRQ" name="PowerQuality" summary="Supports measurement of AC harmonic phases">
+        <optionalConform>
+          <feature name="ALTC"/>
+        </optionalConform>
+      </feature>
+    </features>
+
     <!--Attributes-->
     <attribute code="0x0000" side="server" define="POWER_MODE" type="PowerModeEnum" min="0x00" max="0x02">PowerMode</attribute>
     <attribute code="0x0001" side="server" define="NUMBER_OF_MEASUREMENT_TYPES" type="int8u" min="1">NumberOfMeasurementTypes</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/electrical-power-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/electrical-power-measurement-cluster.xml
@@ -16,14 +16,6 @@ limitations under the License.
 -->
 <configurator>
   <domain name="CHIP"/>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0090"/>
-    <field name="DirectCurrent" mask="0x01"/>
-    <field name="AlternatingCurrent" mask="0x02"/>
-    <field name="PolyphasePower" mask="0x04"/>
-    <field name="Harmonics" mask="0x08"/>
-    <field name="PowerQuality" mask="0x10"/>
-  </bitmap>
   <cluster apiMaturity="provisional">
     <name>Electrical Power Measurement</name>
     <domain>Measurement &amp; Sensing</domain>

--- a/src/app/zap-templates/zcl/data-model/chip/energy-evse-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-evse-cluster.xml
@@ -96,6 +96,24 @@ limitations under the License.
     <description>Electric Vehicle Supply Equipment (EVSE) is equipment used to charge an Electric Vehicle (EV) or Plug-In Hybrid Electric Vehicle. This cluster provides an interface to the functionality of Electric Vehicle Supply Equipment (EVSE) management.</description>
     <globalAttribute side="either" code="0xFFFD" value="2"/>
 
+    <features>
+      <feature bit="0" code="PREF" name="ChargingPreferences" summary="EVSE supports storing user charging preferences">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="SOC" name="SoCReporting" summary="EVSE supports reporting of vehicle State of Charge (SoC)">
+        <provisionalConform/>
+      </feature>
+      <feature bit="2" code="PNC" name="PlugAndCharge" summary="EVSE supports PLC to support Plug and Charge">
+        <provisionalConform/>
+      </feature>
+      <feature bit="3" code="RFID" name="RFID" summary="EVSE is fitted with an RFID reader">
+        <optionalConform/>
+      </feature>
+      <feature bit="4" code="V2X" name="V2X" summary="EVSE supports bi-directional charging / discharging">
+        <provisionalConform/>
+      </feature>
+    </features>
+
     <!--Attributes-->
     
     <attribute code="0x0000" side="server" type="StateEnum" define="STATE" isNullable="true" writable="false" optional="false" min="0x00" max="0x06">State</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/energy-evse-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-evse-cluster.xml
@@ -242,13 +242,5 @@ limitations under the License.
       <field id="0" name="UID" type="octet_string" length="10" apiMaturity="provisional"/>
     </event>
   </cluster>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0099"/>
-    <field name="ChargingPreferences" mask="0x01"/>
-    <field name="SoCReporting" mask="0x02"/>
-    <field name="PlugAndCharge" mask="0x04"/>
-    <field name="RFID" mask="0x08"/>
-    <field name="V2X" mask="0x10"/>
-  </bitmap>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/energy-evse-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-evse-mode-cluster.xml
@@ -33,6 +33,13 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
+
+    <features>
+      <feature bit="0" code="DEPONOFF" name="OnOff" summary="Dependency with the OnOff cluster">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/energy-preference-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-preference-cluster.xml
@@ -24,6 +24,15 @@ limitations under the License.
     <!--Attributes-->
     <globalAttribute side="either" code="0xFFFD" value="1"/>
 
+    <features>
+      <feature bit="0" code="BALA" name="EnergyBalance" summary="Device can balance energy consumption vs. another priority">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="LPMS" name="LowPowerModeSensitivity" summary="Device can adjust the conditions for entering a low power mode">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+    </features>
+
     <!--Conformance feature BALA - for now optional-->
     <attribute code="0x0000" side="server" type="array" entryType="BalanceStruct" define="ENERGY_PREFERENCE_ENERGY_BALANCES" isNullable="false" min="2" max="10" writable="false" optional="true">EnergyBalances</attribute>
 

--- a/src/app/zap-templates/zcl/data-model/chip/energy-preference-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-preference-cluster.xml
@@ -58,12 +58,6 @@ limitations under the License.
 
   </cluster>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x009B"/>
-    <field name="EnergyBalance" mask="0x1"/>
-    <field name="LowPowerModeSensitivity" mask="0x2"/>
-  </bitmap>
-
   <enum name="EnergyPriorityEnum" type="enum8">
     <cluster code="0x009B"/>
     <item name="Comfort" value="0x00"/>

--- a/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
@@ -35,6 +35,16 @@ limitations under the License.
     <code>0x0037</code>
     <define>ETHERNET_NETWORK_DIAGNOSTICS_CLUSTER</define>
     <description>The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.</description>
+
+    <features>
+    <feature bit="0" code="PKTCNT" name="PacketCounts" summary="Node makes available the counts for the number of received and transmitted packets on the ethernet interface.">
+      <optionalConform/>
+    </feature>
+    <feature bit="1" code="ERRCNT" name="ErrorCounts" summary="Node makes available the counts for the number of errors that have occurred during the reception and transmission of packets on the ethernet interface.">
+      <optionalConform/>
+    </feature>
+  </features>
+  
     <attribute side="server" code="0x00" define="PHY_RATE" type="PHYRateEnum" writable="false" isNullable="true" optional="true">PHYRate</attribute>
     <attribute side="server" code="0x01" define="FULL_DUPLEX" type="boolean" min="0x00" max="0x01" writable="false" isNullable="true" optional="true">FullDuplex</attribute>
     <attribute side="server" code="0x02" define="PACKET_RX_COUNT" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">PacketRxCount</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/ethernet-network-diagnostics-cluster.xml
@@ -29,11 +29,6 @@ limitations under the License.
     <item name="Rate200G" value="0x08"/>
     <item name="Rate400G" value="0x09"/>
   </enum>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0037"/>
-    <field name="PacketCounts" mask="0x1"/>
-    <field name="ErrorCounts" mask="0x2"/>
-  </bitmap>
   <cluster>
     <domain>General</domain>
     <name>Ethernet Network Diagnostics</name>

--- a/src/app/zap-templates/zcl/data-model/chip/fan-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/fan-control-cluster.xml
@@ -17,16 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="HVAC"/>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0202" />
-    <field name="MultiSpeed" mask="0x01" />
-    <field name="Auto" mask="0x02" />
-    <field name="Rocking" mask="0x04" />
-    <field name="Wind" mask="0x08" />
-    <field name="Step" mask="0x10" />
-    <field name="Airflow Direction" mask="0x20" />
-  </bitmap>
-
   <enum name="FanModeEnum" type="enum8">
     <cluster code="0x0202"/>
     <item name="Off" value="0x00"/>

--- a/src/app/zap-templates/zcl/data-model/chip/fan-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/fan-control-cluster.xml
@@ -85,6 +85,27 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="4"/>
 
+    <features>
+      <feature bit="0" code="SPD" name="MultiSpeed" summary="0-SpeedMax Fan Speeds">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="AUT" name="Auto" summary="Automatic mode supported for fan speed">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="RCK" name="Rocking" summary="Rocking movement supported">
+        <optionalConform/>
+      </feature>
+      <feature bit="3" code="WND" name="Wind" summary="Wind emulation supported">
+        <optionalConform/>
+      </feature>
+      <feature bit="4" code="STEP" name="Step" summary="Step command supported">
+        <optionalConform/>
+      </feature>
+      <feature bit="5" code="DIR" name="AirflowDirection" summary="Airflow Direction attribute is supported">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="FAN_MODE" type="FanModeEnum" min="0" max="6" writable="true" default="0" optional="false">FanMode</attribute>
     <attribute side="server" code="0x0001" define="FAN_MODE_SEQUENCE" type="FanModeSequenceEnum" min="0" max="5" writable="false" default="2" optional="false">FanModeSequence</attribute>
     <attribute side="server" code="0x0002" define="PERCENT_SETTING" type="percent" min="0" max="100" writable="true" default="0" isNullable="true" optional="false">PercentSetting</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
@@ -85,6 +85,13 @@ limitations under the License.
     <define>GENERAL_DIAGNOSTICS_CLUSTER</define>
     <description>The General Diagnostics Cluster, along with other diagnostics clusters, provide a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.</description>
     <globalAttribute side="either" code="0xFFFD" value="2"/>
+
+    <features>
+      <feature bit="0" code="DMTEST" name="DataModelTest" summary="Support specific testing needs for extended Data Model features">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x00" define="NETWORK_INTERFACES" type="array" entryType="NetworkInterface" length="8" writable="false" optional="false">NetworkInterfaces</attribute>
     <attribute side="server" code="0x01" define="REBOOT_COUNT" type="int16u" writable="false" default="0x0000" optional="false">RebootCount</attribute>
     <!-- ***NOTE***: UpTime attribute is mandatory starting at Rev >= 2, but because of backwards compatibility, has to be optional here.

--- a/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-diagnostics-cluster.xml
@@ -17,11 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0033"/>
-    <field name="DataModelTest" mask="0x1"/>
-  </bitmap>
-
   <enum name="HardwareFaultEnum" type="enum8">
     <cluster code="0x0033"/>
     <item name="Unspecified" value="0x00"/>

--- a/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
@@ -36,11 +36,6 @@ limitations under the License.
     <item name="CacheAndSync" value="0x01"/>
   </enum>
 
-  <bitmap name="Feature" type="bitmap32">
-      <cluster code="0x003F"/>
-      <field name="CacheAndSync" mask="0x1"/>
-  </bitmap>
-
   <struct name="GroupKeySetStruct">
     <cluster code="0x003F"/>
     <item fieldId="0" name="GroupKeySetID" type="int16u"/>

--- a/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
@@ -59,6 +59,13 @@ limitations under the License.
     <code>0x003F</code>
     <define>GROUP_KEY_MANAGEMENT_CLUSTER</define>
     <description>The Group Key Management Cluster is the mechanism by which group keys are managed.</description>
+
+    <features>
+      <feature bit="0" code="CS" name="CacheAndSync" summary="The ability to support CacheAndSync security policy and MCSP.">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="GROUP_KEY_MAP" type="array" length="254" entryType="GroupKeyMapStruct" writable="true" optional="false">
       <description>GroupKeyMap</description>
       <access op="read" privilege="view"/>

--- a/src/app/zap-templates/zcl/data-model/chip/groups-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/groups-cluster.xml
@@ -39,6 +39,12 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="4"/>
 
+    <features>
+      <feature bit="0" code="GN" name="GroupNames" summary="The ability to store a name for a group.">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="GROUP_NAME_SUPPORT" type="NameSupportBitmap" min="0x00" max="0x80" writable="false" optional="false">NameSupport</attribute>
 
     <command source="client" code="0x00" name="AddGroup" response="AddGroupResponse" isFabricScoped="true" optional="false" cli="zcl groups add">

--- a/src/app/zap-templates/zcl/data-model/chip/groups-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/groups-cluster.xml
@@ -17,11 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="General"/>
 
-  <bitmap name="Feature" type="bitmap32">
-      <cluster code="0x0004"/>
-      <field name="GroupNames" mask="0x1"/>
-  </bitmap>
-
   <bitmap name="NameSupportBitmap" type="bitmap8">
       <cluster code="0x0004"/>
       <field name="GroupNames" mask="0x80"/>

--- a/src/app/zap-templates/zcl/data-model/chip/icd-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/icd-management-cluster.xml
@@ -71,6 +71,33 @@ limitations under the License.
         <!-- Current cluster version -->
         <globalAttribute side="either" code="0xFFFD" value="2"/>
 
+        <features>
+            <feature bit="0" code="CIP" name="CheckInProtocolSupport" summary="Device supports attributes and commands for the Check-In Protocol support.">
+            <otherwiseConform>
+                <provisionalConform/>
+                <mandatoryConform>
+                <feature name="LITS"/>
+                </mandatoryConform>
+                <optionalConform/>
+            </otherwiseConform>
+            </feature>
+            <feature bit="1" code="UAT" name="UserActiveModeTrigger" summary="Device supports the user active mode trigger feature.">
+            <otherwiseConform>
+                <provisionalConform/>
+                <mandatoryConform>
+                <feature name="LITS"/>
+                </mandatoryConform>
+                <optionalConform/>
+            </otherwiseConform>
+            </feature>
+            <feature bit="2" code="LITS" name="LongIdleTimeSupport" summary="Device supports operating as a Long Idle Time ICD.">
+            <otherwiseConform>
+                <provisionalConform/>
+                <optionalConform/>
+            </otherwiseConform>
+            </feature>
+        </features>
+
         <attribute side="server" code="0x00" define="IDLE_MODE_DURATION" type="int32u" min="1" max="64800" default="1" writable="false" optional="false" isNullable="false">IdleModeDuration</attribute>
         <attribute side="server" code="0x01" define="ACTIVE_MODE_DURATION" type="int32u" default="300" writable="false" optional="false" isNullable="false">ActiveModeDuration</attribute>
         <attribute side="server" code="0x02" define="ACTIVE_MODE_THRESHOLD" type="int16u" default="300" writable="false" optional="false" isNullable="false">ActiveModeThreshold</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/icd-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/icd-management-cluster.xml
@@ -18,13 +18,6 @@ limitations under the License.
 <configurator>
     <domain name="CHIP" />
 
-    <bitmap name="Feature" type="bitmap32">
-        <cluster code="0x0046"/>
-        <field name="CheckInProtocolSupport" mask="0x1"/>
-        <field name="UserActiveModeTrigger" mask="0x2"/>
-        <field name="LongIdleTimeSupport" mask="0x4"/>
-    </bitmap>
-
     <bitmap name="UserActiveModeTriggerBitmap" type="bitmap32">
         <cluster code="0x0046"/>
         <field name="PowerCycle" mask="0x1"/>

--- a/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
@@ -152,11 +152,5 @@ limitations under the License.
     <item name="Data" value="0x76"/>
   </enum>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0509"/>
-    <field name="NavigationKeyCodes" mask="0x1"/>
-    <field name="LocationKeys" mask="0x2"/>
-    <field name="NumberKeys" mask="0x4"/>
-  </bitmap>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/keypad-input-cluster.xml
@@ -25,6 +25,18 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>This cluster provides an interface for controlling a device like a TV using action commands such as UP, DOWN, and SELECT.</description>
 
+    <features>
+      <feature bit="0" code="NV" name="NavigationKeyCodes" summary="Supports UP, DOWN, LEFT, RIGHT, SELECT, BACK, EXIT, MENU">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="LK" name="LocationKeys" summary="Supports CEC keys 0x0A (Settings) and 0x09 (Home)">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="NK" name="NumberKeys" summary="Supports numeric input 0..9">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <command source="client" code="0x00" name="SendKey" response="SendKeyResponse" optional="false">
       <description>Upon receipt, this SHALL process a keycode as input to the media device.</description>
       <arg name="KeyCode" type="CECKeyCodeEnum"/>

--- a/src/app/zap-templates/zcl/data-model/chip/laundry-washer-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/laundry-washer-mode-cluster.xml
@@ -40,15 +40,6 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-
-    <features>
-      <feature bit="0" code="SPIN" name="Spin" summary="Multiple spin speeds supported">
-        <optionalConform/>
-      </feature>
-      <feature bit="1" code="RINSE" name="Rinse" summary="Multiple rinse cycles supported">
-        <optionalConform/>
-      </feature>
-    </features>
     
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/laundry-washer-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/laundry-washer-mode-cluster.xml
@@ -36,6 +36,12 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="2"/>
 
     <features>
+      <feature bit="0" code="DEPONOFF" name="OnOff" summary="Dependency with the OnOff cluster">
+        <optionalConform/>
+      </feature>
+    </features>
+
+    <features>
       <feature bit="0" code="SPIN" name="Spin" summary="Multiple spin speeds supported">
         <optionalConform/>
       </feature>

--- a/src/app/zap-templates/zcl/data-model/chip/laundry-washer-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/laundry-washer-mode-cluster.xml
@@ -34,6 +34,16 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <globalAttribute side="either" code="0xFFFD" value="2"/>
+
+    <features>
+      <feature bit="0" code="SPIN" name="Spin" summary="Multiple spin speeds supported">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="RINSE" name="Rinse" summary="Multiple rinse cycles supported">
+        <optionalConform/>
+      </feature>
+    </features>
+    
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/level-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/level-control-cluster.xml
@@ -54,6 +54,20 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="5"/>
 
+    <features>
+      <feature bit="0" code="OO" name="OnOff" default="1" summary="Dependency with the On/Off cluster">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="LT" name="Lighting" default="0" summary="Behavior that supports lighting applications">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="FQ" name="Frequency" default="0" summary="Supports frequency attributes and behavior.
+                                        The Pulse Width Modulation cluster was created
+                                        for frequency control.">
+        <provisionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="CURRENT_LEVEL"                 type="int8u"                isNullable="true"           writable="false" default="0x00"   optional="false">CurrentLevel</attribute>
     <attribute side="server" code="0x0001" define="LEVEL_CONTROL_REMAINING_TIME"  type="int16u"               min="0x0000"  max="0xFFFF"  writable="false" default="0x0000" optional="true">RemainingTime</attribute>
     <attribute side="server" code="0x0002" define="MINIMUM_LEVEL"                 type="int8u"                min="0x00"    max="0xFF"    writable="false" default="0x00"   optional="true">MinLevel</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/level-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/level-control-cluster.xml
@@ -17,12 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="General"/>
 
-  <bitmap name="Feature" type="bitmap32">
-      <cluster code="0x0008"/>
-      <field name="OnOff" mask="0x1"/>
-      <field name="Lighting" mask="0x2"/>
-      <field name="Frequency" mask="0x4"/>
-  </bitmap>
 
   <enum name="MoveModeEnum" type="enum8">
     <cluster code="0x0008"/>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -86,7 +86,18 @@ limitations under the License.
             <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="WiFi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="ICD Management" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="ICD Management" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="LITS">
+                    <otherwiseConform>
+                        <provisionalConform/>
+                        <mandatoryConform>
+                        <feature name="LIT"/>
+                        </mandatoryConform>
+                    </otherwiseConform>
+                    </feature>
+                </features>
+            </include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -253,6 +264,11 @@ limitations under the License.
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
                 <requireAttribute>ON_TIME</requireAttribute>
@@ -266,6 +282,14 @@ limitations under the License.
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
             <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="OO">
+                    <mandatoryConform/>
+                    </feature>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
@@ -341,6 +365,11 @@ limitations under the License.
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
                 <requireAttribute>ON_TIME</requireAttribute>
@@ -354,6 +383,14 @@ limitations under the License.
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
             <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                    <feature code="" name="OO">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
@@ -426,6 +463,11 @@ limitations under the License.
                 <requireCommand>CopySceneResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
                 <requireAttribute>ON_TIME</requireAttribute>
@@ -439,6 +481,14 @@ limitations under the License.
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
             <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="OO">
+                    <mandatoryConform/>
+                    </feature>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
@@ -455,6 +505,11 @@ limitations under the License.
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
             <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="CT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_COLOR_TEMPERATURE</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_COLOR_MODE</requireAttribute>
@@ -525,6 +580,11 @@ limitations under the License.
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
                 <requireAttribute>ON_TIME</requireAttribute>
@@ -538,6 +598,14 @@ limitations under the License.
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
             <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="OO">
+                    <mandatoryConform/>
+                    </feature>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
@@ -554,6 +622,23 @@ limitations under the License.
                 <requireCommand>StopWithOnOff</requireCommand>
             </include>
             <include cluster="Color Control" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="HS">
+                    <optionalConform/>
+                    </feature>
+                    <feature code="" name="EHUE">
+                    <optionalConform/>
+                    </feature>
+                    <feature code="" name="CL">
+                    <optionalConform/>
+                    </feature>
+                    <feature code="" name="XY">
+                    <mandatoryConform/>
+                    </feature>
+                    <feature code="" name="CT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>COLOR_CONTROL_REMAINING_TIME</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_CURRENT_X</requireAttribute>
                 <requireAttribute>COLOR_CONTROL_CURRENT_Y</requireAttribute>
@@ -628,6 +713,11 @@ limitations under the License.
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
                 <requireAttribute>ON_TIME</requireAttribute>
@@ -641,6 +731,14 @@ limitations under the License.
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
             <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="OO">
+                    <mandatoryConform/>
+                    </feature>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
@@ -709,6 +807,11 @@ limitations under the License.
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireAttribute>GLOBAL_SCENE_CONTROL</requireAttribute>
                 <requireAttribute>ON_TIME</requireAttribute>
@@ -722,6 +825,14 @@ limitations under the License.
                 <requireCommand>OnWithTimedOff</requireCommand>
             </include>
             <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="OO">
+                    <mandatoryConform/>
+                    </feature>
+                    <feature code="" name="LT">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireAttribute>OPTIONS</requireAttribute>
                 <requireAttribute>LEVEL_CONTROL_REMAINING_TIME</requireAttribute>
@@ -1377,7 +1488,29 @@ limitations under the License.
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Door Lock" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Door Lock" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="USR">
+                    <mandatoryConform>
+                        <andTerm>
+                        <condition name="Matter"/>
+                        <orTerm>
+                            <feature name="PIN"/>
+                            <feature name="RID"/>
+                            <feature name="FPG"/>
+                            <feature name="FACE"/>
+                        </orTerm>
+                        </andTerm>
+                    </mandatoryConform>
+                    </feature>
+                    <feature code="" name="RID">
+                    <otherwiseConform>
+                        <provisionalConform/>
+                        <optionalConform/>
+                    </otherwiseConform>
+                    </feature>
+                </features>
+            </include>
             <include cluster="Time Synchronization" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
@@ -1457,7 +1590,15 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Window Covering" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Window Covering" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="Absolute">
+                    <mandatoryConform>
+                        <condition name="Zigbee"/>
+                    </mandatoryConform>
+                    </feature>
+                </features>
+            </include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1486,7 +1627,15 @@ limitations under the License.
             </include>
             <include cluster="Scenes Management" client="false" server="false" clientLocked="false" serverLocked="true"></include>
             <include cluster="Groups" client="false" server="false" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Window Covering" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Window Covering" client="true" server="false" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="Absolute">
+                    <mandatoryConform>
+                        <condition name="Zigbee"/>
+                    </mandatoryConform>
+                    </feature>
+                </features>
+            </include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1674,7 +1823,13 @@ limitations under the License.
             </include>
             <include cluster="Media Playback" client="false" server="true" clientLocked="false" serverLocked="true"></include>
             <include cluster="Keypad Input" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Application Launcher" client="false" server="true" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Application Launcher" client="false" server="true" clientLocked="false" serverLocked="false">
+                <features>
+                    <feature code="" name="Application">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
+            </include>
             <include cluster="Media Input" client="false" server="true" clientLocked="false" serverLocked="false"></include>
             <include cluster="On/Off" client="false" server="true" clientLocked="false" serverLocked="true"></include>
             <include cluster="Channel" client="false" server="true" clientLocked="false" serverLocked="false"></include>
@@ -1829,7 +1984,13 @@ limitations under the License.
             </include>
             <include cluster="Application Basic" client="false" server="true" clientLocked="false" serverLocked="true"></include>
             <include cluster="Keypad Input" client="false" server="true" clientLocked="false" serverLocked="true"></include>
-            <include cluster="Application Launcher" client="false" server="true" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Application Launcher" client="false" server="true" clientLocked="false" serverLocked="true">
+                <features>
+                    <feature code="" name="Application">
+                    <disallowConform/>
+                    </feature>
+                </features>
+            </include>
             <include cluster="Account Login" client="false" server="true" clientLocked="false" serverLocked="false"></include>
             <include cluster="Content Launcher" client="false" server="true" clientLocked="false" serverLocked="false"></include>
             <include cluster="Media Playback" client="false" server="true" clientLocked="false" serverLocked="false"></include>
@@ -1877,6 +2038,11 @@ limitations under the License.
                 <requireCommand>Identify</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="DF">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
                 <requireAttribute>ON_OFF</requireAttribute>
                 <requireCommand>Off</requireCommand>
                 <requireCommand>On</requireCommand>
@@ -1976,10 +2142,22 @@ limitations under the License.
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="DF">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
+            </include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Temperature Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Dishwasher Mode" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Dishwasher Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="OnOff">
+                    <disallowConform/>
+                    </feature>
+                </features>
+            </include>
             <include cluster="Dishwasher Alarm" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
@@ -2008,7 +2186,16 @@ limitations under the License.
         <clusters lockOthers="true">
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="Wind">
+                    <disallowConform/>
+                    </feature>
+                    <feature code="" name="AirflowDirection">
+                    <disallowConform/>
+                    </feature>
+                </features>
+            </include>
             <include cluster="Microwave Oven Mode"  client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Microwave Oven Control"  client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
@@ -2025,7 +2212,13 @@ limitations under the License.
         <clusters lockOthers="true">
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="OnOff">
+                    <disallowConform/>
+                    </feature>
+                </features>
+            </include>
             <include cluster="Refrigerator Alarm" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
@@ -2040,8 +2233,20 @@ limitations under the License.
         <clusters lockOthers="true">
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="DF">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
+            </include>
+            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="OnOff">
+                    <disallowConform/>
+                    </feature>
+                </features>
+            </include>
             <include cluster="Laundry Washer Controls" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Temperature Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
@@ -2058,8 +2263,20 @@ limitations under the License.
         <clusters lockOthers="true">
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="On/Off" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="DF">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
+            </include>
+            <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="OnOff">
+                    <disallowConform/>
+                    </feature>
+                </features>
+            </include>
             <include cluster="Laundry Dryer Controls" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Temperature Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Operational State" client="false" server="true" clientLocked="true" serverLocked="true"></include>
@@ -2078,7 +2295,19 @@ limitations under the License.
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="HEPA Filter Monitoring" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Activated Carbon Filter Monitoring" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Fan Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Fan Control" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="Rocking">
+                    <disallowConform/>
+                    </feature>
+                    <feature code="" name="Wind">
+                    <disallowConform/>
+                    </feature>
+                    <feature code="" name="AirflowDirection">
+                    <disallowConform/>
+                    </feature>
+                </features>
+            </include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -2110,8 +2339,20 @@ limitations under the License.
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Temperature Control" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Oven Mode" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="OnOff">
+                    <disallowConform/>
+                    </feature>
+                </features>
+            </include>
+            <include cluster="Oven Mode" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="" name="OnOff">
+                    <disallowConform/>
+                    </feature>
+                </features>
+            </include>
             <include cluster="Oven Cavity Operational State" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>
@@ -2375,6 +2616,11 @@ limitations under the License.
             </include>
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="" name="OFFONLY">
+                    <mandatoryConform/>
+                    </feature>
+                </features>
             </include>
         </clusters>
     </deviceType>

--- a/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
@@ -26,6 +26,12 @@ limitations under the License.
 
     <description>This cluster provides an interface for controlling the Input Selector on a media device such as a TV.</description>
 
+    <features>
+      <feature bit="0" code="NU" name="NameUpdates" summary="Supports updates to the input names">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="MEDIA_INPUT_LIST"          type="array" entryType="InputInfoStruct" length="254"           writable="false" optional="false">InputList</attribute>
     <attribute side="server" code="0x0001" define="MEDIA_INPUT_CURRENT_INPUT" type="int8u" default="0x00"              min="0x00" max="0xFF"  writable="false" optional="false">CurrentInput</attribute>
 

--- a/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-input-cluster.xml
@@ -81,9 +81,5 @@ limitations under the License.
     <item name="Other" value="0x0B"/>
   </enum>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0507"/>
-    <field name="NameUpdates" mask="0x1"/>
-  </bitmap>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
@@ -180,14 +180,6 @@ limitations under the License.
     <item name="SeekOutOfRange"         value="0x05"/>
   </enum>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0506"/>
-    <field name="AdvancedSeek" mask="0x1"/>
-    <field name="VariableSpeed" mask="0x2"/>
-    <field name="TextTracks" mask="0x4"/>
-    <field name="AudioTracks" mask="0x8"/>
-    <field name="AudioAdvance" mask="0x10"/>
-  </bitmap>
 
   <enum name="CharacteristicEnum" type="enum8">
     <cluster code="0x0506"/>

--- a/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/media-playback-cluster.xml
@@ -27,6 +27,25 @@ limitations under the License.
     <description>This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media device such as a TV or Speaker.</description>
 
     <globalAttribute side="server" code="0xFFFC" value="0" />
+
+    <features>
+      <feature bit="0" code="AS" name="AdvancedSeek" summary="Advanced media seeking">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="VS" name="VariableSpeed" summary="Variable speed playback">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="TT" name="TextTracks" summary="Text Tracks">
+        <optionalConform/>
+      </feature>
+      <feature bit="3" code="AT" name="AudioTracks" summary="Audio Tracks">
+        <optionalConform/>
+      </feature>
+      <feature bit="4" code="AA" name="AudioAdvance" summary="Can play audio during fast and slow playback speeds">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="MEDIA_PLAYBACK_STATE"                     type="PlaybackStateEnum" min="0x00" max="0x03" default="0x00" writable="false"                    optional="false">CurrentState</attribute>
     <attribute side="server" code="0x0001" define="MEDIA_PLAYBACK_START_TIME"                type="epoch_us"          min="0x00"            default="0x00" writable="false" isNullable="true"  optional="true">StartTime</attribute>
     <attribute side="server" code="0x0002" define="MEDIA_PLAYBACK_DURATION"                  type="int64u"            min="0x00"            default="0"    writable="false" isNullable="true"  optional="true">Duration</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/messages-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/messages-cluster.xml
@@ -78,6 +78,26 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="3"/><!-- Revision   -->
+
+    <features>
+      <feature bit="0" code="CONF" name="ReceivedConfirmation">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="RESP" name="ConfirmationResponse">
+        <optionalConform>
+          <feature name="CONF"/>
+        </optionalConform>
+      </feature>
+      <feature bit="2" code="RPLY" name="ConfirmationReply">
+        <optionalConform>
+          <feature name="CONF"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="PROT" name="ProtectedMessages">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="LIST_MESSAGES" type="array" entryType="MessageStruct" length="8" writable="false" optional="false">Messages</attribute>
     <attribute side="server" code="0x0001" define="MESSAGES_CLUSTER_ACTIVE_MESSAGES_IDS" type="ARRAY" entryType="octet_string" max="8" writable="false" optional="false">ActiveMessageIDs</attribute>
     <command source="client" code="0x00" name="PresentMessagesRequest" isFabricScoped="true" optional="false">

--- a/src/app/zap-templates/zcl/data-model/chip/messages-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/messages-cluster.xml
@@ -17,13 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="General"/>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0097"/>
-    <field name="ReceivedConfirmation" mask="0x1"/>
-    <field name="ConfirmationResponse" mask="0x2"/>
-    <field name="ConfirmationReply" mask="0x4"/>
-    <field name="ProtectedMessages" mask="0x8"/>
-  </bitmap>
 
   <bitmap name="MessageControlBitmap" type="bitmap8">
     <cluster code="0x0097"/>

--- a/src/app/zap-templates/zcl/data-model/chip/microwave-oven-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/microwave-oven-control-cluster.xml
@@ -32,6 +32,21 @@ limitations under the License.
     <define>MICROWAVE_OVEN_CONTROL_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
+
+    <features>
+      <feature bit="0" code="PWRNUM" name="PowerAsNumber" summary="Power is specified as a unitless number or a percentage">
+        <optionalConform choice="a"/>
+      </feature>
+      <feature bit="1" code="WATTS" name="PowerInWatts" summary="Power is specified in Watts">
+        <optionalConform choice="a"/>
+      </feature>
+      <feature bit="2" code="PWRLMTS" name="PowerNumberLimits" summary="Supports the limit attributes used with the PWRNUM feature">
+        <optionalConform>
+          <feature name="PWRNUM"/>
+        </optionalConform>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="COOK_TIME"           type="elapsed_s" default="30"  writable="false" optional="false">CookTime</attribute>
     <attribute side="server" code="0x0001" define="MAX_COOK_TIME"       type="elapsed_s"               writable="false" optional="false" min="1" max="86400">MaxCookTime</attribute>
     <attribute side="server" code="0x0002" define="POWER_SETTING"       type="int8u"     default="100" writable="false" optional="true">PowerSetting</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/microwave-oven-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/microwave-oven-control-cluster.xml
@@ -17,12 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x005F" />
-    <field name="PowerAsNumber"       mask="0x01" />
-    <field name="PowerInWatts"        mask="0x02" />
-    <field name="PowerNumberLimits"   mask="0x04" />
-  </bitmap>
 
   <cluster apiMaturity="provisional">
     <name>Microwave Oven Control</name>

--- a/src/app/zap-templates/zcl/data-model/chip/microwave-oven-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/microwave-oven-mode-cluster.xml
@@ -32,6 +32,13 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
+
+    <features>
+      <feature bit="0" code="DEPONOFF" name="OnOff" summary="Dependency with the OnOff cluster">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/mode-base-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/mode-base-cluster.xml
@@ -86,17 +86,5 @@ This is because zap does not currently support generating code for clusters that
 <!--    </command>-->
 <!--  </cluster>-->
 
-  <bitmap name="Feature" type="bitmap32">
-<!--    <cluster code="0x..."/>-->
-    <cluster code="0x0051"/> <!-- Laundry Washer Mode -->
-    <cluster code="0x0052"/> <!-- Refrigerator and temperature controlled cabinet Mode -->
-    <!-- <cluster code="0x0054"/> RVC Run Mode. This feature map is implemented in rvc-run-mode-cluster.xml -->
-    <!-- <cluster code="0x0055"/> RVC Clean Mode. This feature map is implemented in rvc-clean-mode-cluster.xml -->
-    <cluster code="0x0059"/> <!-- Dishwasher Mode -->
-    <cluster code="0x005E"/> <!-- Microwave Oven Mode -->
-    <cluster code="0x0049"/> <!-- Oven Mode -->
-    <cluster code="0x009D"/> <!-- Energy EVSE Mode -->
-    <cluster code="0x009F"/> <!-- Device Energy Management Mode -->
-    <field name="OnOff" mask="0x1"/>
-  </bitmap>
+
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/mode-select-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/mode-select-cluster.xml
@@ -65,8 +65,5 @@ limitations under the License.
 
   </cluster>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0050"/>
-    <field name="OnOff" mask="0x1"/>
-  </bitmap>
+
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/mode-select-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/mode-select-cluster.xml
@@ -40,6 +40,12 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="2"/>
 
+    <features>
+      <feature bit="0" code="DEPONOFF" name="OnOff" summary="Dependency with the OnOff cluster">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="MODE_DESCRIPTION"   type="char_string"                        length="64"  writable="false" optional="false" isNullable="false">Description</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/network-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/network-commissioning-cluster.xml
@@ -107,6 +107,9 @@ limitations under the License.
             <feature bit="2" code="ET" name="EthernetNetworkInterface" summary="Ethernet related features">
             <optionalConform choice="a"/>
             </feature>
+            <feature bit="3" code="PC" name="PerDeviceCredentials" summary="Device related features">
+            <optionalConform choice="a"/>
+            </feature>
         </features>
 
         <attribute side="server" code="0x0000" define="MAX_NETWORKS" type="int8u" writable="false" optional="false">

--- a/src/app/zap-templates/zcl/data-model/chip/network-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/network-commissioning-cluster.xml
@@ -105,6 +105,18 @@ limitations under the License.
         <client tick="false" init="false">true</client>
         <server tick="false" init="false">true</server>
 
+        <features>
+            <feature bit="0" code="WI" name="WiFiNetworkInterface" summary="Wi-Fi related features">
+            <optionalConform choice="a"/>
+            </feature>
+            <feature bit="1" code="TH" name="ThreadNetworkInterface" summary="Thread related features">
+            <optionalConform choice="a"/>
+            </feature>
+            <feature bit="2" code="ET" name="EthernetNetworkInterface" summary="Ethernet related features">
+            <optionalConform choice="a"/>
+            </feature>
+        </features>
+
         <attribute side="server" code="0x0000" define="MAX_NETWORKS" type="int8u" writable="false" optional="false">
             <description>MaxNetworks</description>
             <access op="read" privilege="administer"/>

--- a/src/app/zap-templates/zcl/data-model/chip/network-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/network-commissioning-cluster.xml
@@ -88,14 +88,6 @@ limitations under the License.
         <item name="ClientIdentifier" type="octet_string" length="20" optional="true" isNullable="true"/>
     </struct>
 
-    <bitmap name="Feature" type="bitmap32">
-      <cluster code="0x0031"/>
-      <field name="WiFiNetworkInterface" mask="0x1"/>
-      <field name="ThreadNetworkInterface" mask="0x2"/>
-      <field name="EthernetNetworkInterface" mask="0x4"/>
-      <field name="PerDeviceCredentials" mask="0x8"/>
-    </bitmap>
-
     <cluster>
         <name>Network Commissioning</name>
         <domain>CHIP</domain>

--- a/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
@@ -55,6 +55,33 @@ limitations under the License.
     <description>Attributes and commands for switching devices between 'On' and 'Off' states.</description>
     <globalAttribute side="either" code="0xFFFD" value="6"/>
 
+    <features>
+      <feature bit="0" code="LT" name="Lighting" summary="Behavior that supports lighting applications.">
+        <optionalConform>
+          <notTerm>
+            <feature name="OFFONLY"/>
+          </notTerm>
+        </optionalConform>
+      </feature>
+      <feature bit="1" code="DF" name="DeadFrontBehavior" summary="Device has DeadFrontBehavior Feature">
+        <optionalConform>
+          <notTerm>
+            <feature name="OFFONLY"/>
+          </notTerm>
+        </optionalConform>
+      </feature>
+      <feature bit="2" code="OFFONLY" name="OffOnly" summary="Device supports the OffOnly Feature feature">
+        <optionalConform>
+          <notTerm>
+            <orTerm>
+              <feature name="LT"/>
+              <feature name="DF"/>
+            </orTerm>
+          </notTerm>
+        </optionalConform>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="ON_OFF"               type="boolean" default="0" reportable="true"              >OnOff</attribute>
     <attribute side="server" code="0x4000" define="GLOBAL_SCENE_CONTROL" type="boolean" default="1"                 optional="true">GlobalSceneControl</attribute>
     <attribute side="server" code="0x4001" define="ON_TIME"              type="int16u"  default="0" writable="true" optional="true">OnTime</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/onoff-cluster.xml
@@ -122,10 +122,4 @@ limitations under the License.
     </command>
   </cluster>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0006" />
-    <field name="Lighting" mask="0x01" />
-    <field name="DeadFrontBehavior" mask="0x02" />
-    <field name="OffOnly" mask="0x04" />
-  </bitmap>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/oven-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/oven-mode-cluster.xml
@@ -39,6 +39,13 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
+
+    <features>
+      <feature bit="0" code="DEPONOFF" name="OnOff" summary="Dependency with the OnOff cluster">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/power-source-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/power-source-cluster.xml
@@ -24,6 +24,25 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster is used to describe the configuration and capabilities of a physical power source that provides power to the Node.</description>
+
+    <features>
+      <feature bit="0" code="WIRED" name="Wired" summary="A wired power source">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="BAT" name="Battery" summary="A battery power source">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="RECHG" name="Rechargeable" summary="A rechargeable battery power source">
+        <optionalConform>
+          <feature name="BAT"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="REPLC" name="Replaceable" summary="A replaceable battery power source">
+        <optionalConform>
+          <feature name="BAT"/>
+        </optionalConform>
+      </feature>
+    </features>
     
     <attribute side="server" code="0x0000" define="POWER_SOURCE_STATUS" type="PowerSourceStatusEnum" writable="false">Status</attribute>
     <attribute side="server" code="0x0001" define="POWER_SOURCE_ORDER" type="int8u" min="0x00" max="0xFF" writable="false">Order</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/power-source-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/power-source-cluster.xml
@@ -99,13 +99,6 @@ limitations under the License.
 
   </cluster>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x002F"/>
-    <field name="Wired" mask="0x1"/>
-    <field name="Battery" mask="0x2"/>
-    <field name="Rechargeable" mask="0x4"/>
-    <field name="Replaceable" mask="0x8"/>
-  </bitmap>
 
   <enum name="WiredFaultEnum" type="enum8">
     <cluster code="0x002F"/>

--- a/src/app/zap-templates/zcl/data-model/chip/power-topology-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/power-topology-cluster.xml
@@ -32,6 +32,24 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <globalAttribute code="0xFFFD" side="either" value="1"/>
+
+    <features>
+      <feature bit="0" code="NODE" name="NodeTopology" summary="This endpoint provides or consumes power to/from the entire node">
+        <optionalConform choice="a"/>
+      </feature>
+      <feature bit="1" code="TREE" name="TreeTopology" summary="This endpoint provides or consumes power to/from itself and its child endpoints">
+        <optionalConform choice="a"/>
+      </feature>
+      <feature bit="2" code="SET" name="SetTopology" summary="This endpoint provides or consumes power to/from a specified set of endpoints">
+        <optionalConform choice="a"/>
+      </feature>
+      <feature bit="3" code="DYPF" name="DynamicPowerFlow" summary="The specified set of endpoints may change">
+        <optionalConform>
+          <feature name="SET"/>
+        </optionalConform>
+      </feature>
+    </features>
+    
     <attribute code="0x0000" side="server" define="AVAILABLE_ENDPOINTS" type="array" entryType="endpoint_no" length="20" optional="true">AvailableEndpoints</attribute>
     <attribute code="0x0001" side="server" define="ACTIVE_ENDPOINTS" type="array" entryType="endpoint_no" length="20" optional="true">ActiveEndpoints</attribute>
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/power-topology-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/power-topology-cluster.xml
@@ -16,13 +16,7 @@ limitations under the License.
 -->
 <configurator>
   <domain name="Measurement &amp; Sensing"/>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x009C"/>
-    <field name="NodeTopology" mask="0x01"/>
-    <field name="TreeTopology" mask="0x02"/>
-    <field name="SetTopology" mask="0x04"/>
-    <field name="DynamicPowerFlow" mask="0x08"/>
-  </bitmap>
+
   <cluster code="0x009C" apiMaturity="provisional">
     <domain>Measurement &amp; Sensing</domain>
     <name>Power Topology</name>

--- a/src/app/zap-templates/zcl/data-model/chip/pressure-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pressure-measurement-cluster.xml
@@ -43,8 +43,4 @@ limitations under the License.
     <attribute side="server" code="0x0014" define="PRESSURE_SCALE" type="int8s" writable="false" optional="true" default="0">Scale</attribute>
   </cluster>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0403"/>
-    <field name="Extended" mask="0x1"/>
-  </bitmap>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/pressure-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pressure-measurement-cluster.xml
@@ -25,6 +25,13 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" tickFrequency="half" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="3"/>
+
+    <features>
+      <feature bit="0" code="EXT" name="Extended" summary="Extended range and resolution">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="PRESSURE_MEASURED_VALUE" type="int16s" writable="false" reportable="true" optional="false" isNullable="true">MeasuredValue</attribute>
     <attribute side="server" code="0x0001" define="PRESSURE_MIN_MEASURED_VALUE" type="int16s" writable="false" optional="false" isNullable="true">MinMeasuredValue</attribute>
     <attribute side="server" code="0x0002" define="PRESSURE_MAX_MEASURED_VALUE" type="int16s" writable="false" optional="false" isNullable="true">MaxMeasuredValue</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
@@ -25,6 +25,31 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" tickFrequency="half" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="3"/>
+
+    <features>
+      <feature bit="0" code="PRSCONST" name="ConstantPressure" summary="Supports operating in constant pressure mode">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="PRSCOMP" name="CompensatedPressure" summary="Supports operating in compensated pressure mode">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="FLW" name="ConstantFlow" summary="Supports operating in constant flow mode">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="3" code="SPD" name="ConstantSpeed" summary="Supports operating in constant speed mode">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="4" code="TEMP" name="ConstantTemperature" summary="Supports operating in constant temperature mode">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="5" code="AUTO" name="Automatic" summary="Supports operating in automatic mode">
+        <optionalConform/>
+      </feature>
+      <feature bit="6" code="LOCAL" name="LocalOperation" summary="Supports operating using local settings">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="MAX_PRESSURE" type="int16s" isNullable="true" min="0x8001" max="0x7FFF" writable="false" optional="false">MaxPressure</attribute>
     <attribute side="server" code="0x0001" define="MAX_SPEED" type="int16u" isNullable="true" min="0x0000" max="0xFFFE" writable="false" optional="false">MaxSpeed</attribute>
     <attribute side="server" code="0x0002" define="MAX_FLOW" type="int16u" isNullable="true" min="0x0000" max="0xFFFE" writable="false" optional="false">MaxFlow</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/pump-configuration-and-control-cluster.xml
@@ -174,15 +174,5 @@ limitations under the License.
     <item name="Automatic" value="0x7"/>
   </enum>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0200"/>
-    <field mask="0x01" name="ConstantPressure" />
-    <field mask="0x02" name="CompensatedPressure" />
-    <field mask="0x04" name="ConstantFlow"/>
-    <field mask="0x08" name="ConstantSpeed"/>
-    <field mask="0x10" name="ConstantTemperature"/>
-    <field mask="0x20" name="Automatic"/>
-    <field mask="0x40" name="LocalOperation"/>
-  </bitmap>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/refrigerator-alarm.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/refrigerator-alarm.xml
@@ -29,12 +29,6 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
 
-    <features>
-      <feature bit="0" code="RESET" name="Reset" summary="Supports the ability to reset alarms">
-        <disallowConform/>
-      </feature>
-    </features>
-
     <attribute side="server" code="0x0000" define="MASK" type="AlarmBitmap" default="0" writable="false" optional="false">Mask</attribute>
     <attribute side="server" code="0x0002" define="STATE" type="AlarmBitmap" default="0" writable="false" optional="false">State</attribute>
     <attribute side="server" code="0x0003" define="SUPPORTED" type="AlarmBitmap" default="0" writable="false" optional="false">Supported</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/refrigerator-alarm.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/refrigerator-alarm.xml
@@ -28,6 +28,13 @@ limitations under the License.
     <define>REFRIGERATOR_ALARM_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
+
+    <features>
+      <feature bit="0" code="RESET" name="Reset" summary="Supports the ability to reset alarms">
+        <disallowConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="MASK" type="AlarmBitmap" default="0" writable="false" optional="false">Mask</attribute>
     <attribute side="server" code="0x0002" define="STATE" type="AlarmBitmap" default="0" writable="false" optional="false">State</attribute>
     <attribute side="server" code="0x0003" define="SUPPORTED" type="AlarmBitmap" default="0" writable="false" optional="false">Supported</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/refrigerator-and-temperature-controlled-cabinet-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/refrigerator-and-temperature-controlled-cabinet-mode-cluster.xml
@@ -32,6 +32,13 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <globalAttribute side="either" code="0xFFFD" value="2"/>
+
+    <features>
+      <feature bit="0" code="DEPONOFF" name="OnOff" summary="Dependency with the OnOff cluster">
+        <optionalConform/>
+      </feature>
+    </features>
+    
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/resource-monitoring-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/resource-monitoring-cluster.xml
@@ -60,6 +60,18 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
 
+    <features>
+      <feature bit="0" code="CON" name="Condition" summary="Supports monitoring the condition of the resource in percentage">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="WRN" name="Warning" summary="Supports warning indication">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="REP" name="Replacement Product List" summary="Supports specifying the list of replacement products">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <!-- Attributes -->
     <attribute side="server" code="0x0000" define="CONDITION" type="percent" min="0" max="100" writable="false" isNullable="false" optional="true">Condition</attribute>
     <attribute side="server" code="0x0001" define="DEGRADATION_DIRECTION" type="DegradationDirectionEnum" min="0" max="1" writable="false" isNullable="false" optional="true">DegradationDirection</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/resource-monitoring-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/resource-monitoring-cluster.xml
@@ -25,6 +25,18 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
 
+    <features>
+      <feature bit="0" code="CON" name="Condition" summary="Supports monitoring the condition of the resource in percentage">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="WRN" name="Warning" summary="Supports warning indication">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="REP" name="Replacement Product List" summary="Supports specifying the list of replacement products">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <!-- Attributes -->
     <attribute side="server" code="0x0000" define="CONDITION" type="percent" min="0" max="100" writable="false" isNullable="false" optional="true">Condition</attribute>
     <attribute side="server" code="0x0001" define="DEGRADATION_DIRECTION" type="DegradationDirectionEnum" min="0" max="1" writable="false" isNullable="false" optional="true">DegradationDirection</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/resource-monitoring-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/resource-monitoring-cluster.xml
@@ -74,14 +74,6 @@ limitations under the License.
     </command>
   </cluster>
 
-  <!-- Feature Map -->
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0071" />
-    <cluster code="0x0072" />
-    <field name="Condition" mask="0x01" />
-    <field name="Warning" mask="0x02" />
-    <field name="ReplacementProductList" mask="0x04" />
-  </bitmap>
 
   <!-- Cluster Data Types -->
   <enum name="DegradationDirectionEnum" type="enum8">

--- a/src/app/zap-templates/zcl/data-model/chip/rvc-clean-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/rvc-clean-mode-cluster.xml
@@ -38,6 +38,7 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <globalAttribute side="either" code="0xFFFD" value="2"/>
+  
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>
@@ -61,5 +62,10 @@ limitations under the License.
     </command>
   </cluster>
 
+  <bitmap name="Feature" type="bitmap32">
+     <cluster code="0x0055"/>
+     <field name="NoFeatures" mask="0x0"/>
+     <!-- Feature OnOff with code 0x01 is deprecated -->
+   </bitmap>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/rvc-clean-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/rvc-clean-mode-cluster.xml
@@ -61,10 +61,5 @@ limitations under the License.
     </command>
   </cluster>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0055"/>
-    <field name="NoFeatures" mask="0x0"/>
-    <!-- Feature OnOff with code 0x01 is deprecated -->
-  </bitmap>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
@@ -68,5 +68,9 @@ limitations under the License.
     </command>
   </cluster>
 
-
+  <bitmap name="Feature" type="bitmap32">
+     <cluster code="0x0054"/>
+     <field name="NoFeatures" mask="0x0"/>
+     <!-- Feature OnOff with code 0x01 is deprecated -->
+   </bitmap>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
@@ -68,10 +68,5 @@ limitations under the License.
     </command>
   </cluster>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0054"/>
-    <field name="NoFeatures" mask="0x0"/>
-    <!-- Feature OnOff with code 0x01 is deprecated -->
-  </bitmap>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/scene.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/scene.xml
@@ -201,8 +201,4 @@ limitations under the License.
     </command>
   </cluster>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0062" />
-    <field name="SceneNames" mask="0x01" />
-  </bitmap>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/scene.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/scene.xml
@@ -51,6 +51,12 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
+
+    <features>
+      <feature bit="0" code="SN" name="SceneNames" summary="The ability to store a name for a scene.">
+        <optionalConform/>
+      </feature>
+    </features>
    
     <attribute side="server" code="0x0000" define="LAST_CONFIGURED_BY" type="node_id" writable="false" isNullable="true" optional="true">LastConfiguredBy</attribute>
     <attribute side="server" code="0x0001" define="SCENE_TABLE_SIZE" type="int16u" min="16" default="16" writable="false" optional="false">SceneTableSize</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
@@ -157,9 +157,4 @@ limitations under the License.
     <item value="3" name="Critical" />
   </enum>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x005C" />
-    <field name="Smoke Alarm" mask="0x01" />
-    <field name="CO alarm" mask="0x02" />
-  </bitmap>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
@@ -40,7 +40,7 @@ limitations under the License.
       <feature bit="0" code="SMOKE" name="SmokeAlarm" summary="Supports Smoke alarm">
         <optionalConform choice="a" more="true"/>
       </feature>
-      <feature bit="1" code="CO" name="COAlarm" summary="Supports CO alarm">
+      <feature bit="1" code="CO" name="CO Alarm" summary="Supports CO alarm">
         <optionalConform choice="a" more="true"/>
       </feature>
     </features>

--- a/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
@@ -40,7 +40,7 @@ limitations under the License.
       <feature bit="0" code="SMOKE" name="SmokeAlarm" summary="Supports Smoke alarm">
         <optionalConform choice="a" more="true"/>
       </feature>
-      <feature bit="1" code="CO" name="COAlarm" summary="Supports CO alarm">
+      <feature bit="1" code="CO" name="CoAlarm" summary="Supports CO alarm">
         <optionalConform choice="a" more="true"/>
       </feature>
     </features>

--- a/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
@@ -36,6 +36,15 @@ limitations under the License.
     <!-- Cluster feature map -->
     <globalAttribute side="server" code="0xFFFC" type="Feature" value="3" />
 
+    <features>
+      <feature bit="0" code="SMOKE" name="SmokeAlarm" summary="Supports Smoke alarm">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="CO" name="COAlarm" summary="Supports CO alarm">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+    </features>
+
     <!-- Attributes -->
     <attribute side="server" code="0x0000" define="EXPRESSED_STATE" type="ExpressedStateEnum" writable="false" optional="false">ExpressedState</attribute>
     <attribute side="server" code="0x0001" define="SMOKE_STATE" type="AlarmStateEnum" writable="false" optional="true">SmokeState</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/smoke-co-alarm-cluster.xml
@@ -40,7 +40,7 @@ limitations under the License.
       <feature bit="0" code="SMOKE" name="SmokeAlarm" summary="Supports Smoke alarm">
         <optionalConform choice="a" more="true"/>
       </feature>
-      <feature bit="1" code="CO" name="CoAlarm" summary="Supports CO alarm">
+      <feature bit="1" code="CO" name="COAlarm" summary="Supports CO alarm">
         <optionalConform choice="a" more="true"/>
       </feature>
     </features>

--- a/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
@@ -30,6 +30,13 @@ limitations under the License.
     <code>0x0034</code>
     <define>SOFTWARE_DIAGNOSTICS_CLUSTER</define>
     <description>The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.</description>
+
+    <features>
+      <feature bit="0" code="WTRMRK" name="Watermarks" summary="Node makes available the metrics for high watermark related to memory consumption.">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x00" define="THREAD_METRICS" type="array" entryType="ThreadMetricsStruct" length="254" writable="false" optional="true">ThreadMetrics</attribute>
     <attribute side="server" code="0x01" define="CURRENT_HEAP_FREE" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">CurrentHeapFree</attribute>
     <attribute side="server" code="0x02" define="CURRENT_HEAP_USED" type="int64u" min="0x0000000000000000" max="0xFFFFFFFFFFFFFFFF" writable="false" default="0x0000000000000000" optional="true">CurrentHeapUsed</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
@@ -45,8 +45,5 @@ limitations under the License.
       <field id="2" name="FaultRecording" type="octet_string" length="1024" optional="true"/>
     </event>    
   </cluster>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0034"/>
-    <field name="Watermarks" mask="0x1"/>
-  </bitmap>   
+
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/switch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/switch-cluster.xml
@@ -30,6 +30,36 @@ Interactions with the switch device are exposed as attributes (for the latching 
     <globalAttribute side="server" code="0xFFFC" value="0" />
     <globalAttribute side="either" code="0xFFFD" value="1" />
 
+    <features>
+      <feature bit="0" code="LS" name="LatchingSwitch" summary="Switch is latching">
+        <optionalConform choice="a"/>
+      </feature>
+      <feature bit="1" code="MS" name="MomentarySwitch" summary="Switch is momentary">
+        <optionalConform choice="a"/>
+      </feature>
+      <feature bit="2" code="MSR" name="MomentarySwitchRelease" summary="Switch supports release">
+        <optionalConform>
+          <feature name="MS"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="MSL" name="MomentarySwitchLongPress" summary="Switch supports long press">
+        <optionalConform>
+          <andTerm>
+            <feature name="MS"/>
+            <feature name="MSR"/>
+          </andTerm>
+        </optionalConform>
+      </feature>
+      <feature bit="4" code="MSM" name="MomentarySwitchMultiPress" summary="Switch supports multi-press">
+        <optionalConform>
+          <andTerm>
+            <feature name="MS"/>
+            <feature name="MSR"/>
+          </andTerm>
+        </optionalConform>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="NUMBER_OF_POSITIONS" type="int8u" writable="false" optional="false" default="2" min="2">NumberOfPositions</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_POSITION" type="int8u" writable="false" reportable="true" optional="false">CurrentPosition</attribute>
     <attribute side="server" code="0x0002" define="MULTI_PRESS_MAX" type="int8u" writable="false" optional="true" default="2" min="2">MultiPressMax</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/switch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/switch-cluster.xml
@@ -96,13 +96,5 @@ Interactions with the switch device are exposed as attributes (for the latching 
 
   </cluster>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x003B" />
-    <field name="Latching Switch" mask="0x1" />
-    <field name="Momentary Switch" mask="0x2" />
-    <field name="Momentary Switch Release" mask="0x4" />
-    <field name="Momentary Switch LongPress" mask="0x8" />
-    <field name="Momentary Switch MultiPress" mask="0x10" />
-  </bitmap>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/temperature-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/temperature-control-cluster.xml
@@ -25,6 +25,21 @@ limitations under the License.
     <define>TEMPERATURE_CONTROL_CLUSTER</define>
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
+
+    <features>
+      <feature bit="0" code="TN" name="TemperatureNumber" summary="Use actual temperature numbers">
+        <optionalConform choice="a"/>
+      </feature>
+      <feature bit="1" code="TL" name="TemperatureLevel" summary="Use temperature levels">
+        <optionalConform choice="a"/>
+      </feature>
+      <feature bit="2" code="STEP" name="TemperatureStep" summary="Use step control with temperature numbers">
+        <optionalConform>
+          <feature name="TN"/>
+        </optionalConform>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="TEMP_SETPOINT" type="temperature" writable="false" optional="true">TemperatureSetpoint</attribute>
     <attribute side="server" code="0x0001" define="MIN_TEMP" type="temperature" writable="false" optional="true">MinTemperature</attribute>
     <attribute side="server" code="0x0002" define="MAX_TEMP" type="temperature" writable="false" optional="true">MaxTemperature</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/temperature-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/temperature-control-cluster.xml
@@ -53,10 +53,5 @@ limitations under the License.
         <arg name="TargetTemperatureLevel" type="int8u" optional="true"/>
     </command>
   </cluster>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0056"/>
-    <field mask="0x01" name="TemperatureNumber" />
-    <field mask="0x02" name="TemperatureLevel" />
-    <field mask="0x04" name="TemperatureStep" />
-  </bitmap>
+
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
@@ -16,20 +16,7 @@ limitations under the License.
 -->
 <configurator>
   <domain name="HVAC"/>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0201"/>
-    <field name="Heating" mask="0x1"/>
-    <field name="Cooling" mask="0x2"/>
-    <field name="Occupancy" mask="0x4"/>
-    <field name="ScheduleConfiguration" mask="0x8"/>
-    <field name="Setback" mask="0x10"/>
-    <field name="AutoMode" mask="0x20"/>
-    <field name="LocalTemperatureNotExposed" mask="0x40"/>
-    <field name="MatterScheduleConfiguration" mask="0x80"/>
-    <field name="Presets" mask="0x100"/>
-    <field name="Setpoints" mask="0x200"/>
-    <field name="QueuedPresetsSupported" mask="0x400"/>
-  </bitmap>
+
 
   <bitmap name="ACErrorCodeBitmap" type="bitmap32">
     <cluster code="0x0201"/>

--- a/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
@@ -314,6 +314,18 @@ limitations under the License.
       <feature bit="6" code="LTNE" name="LocalTemperatureNotExposed" summary="Thermostat does not expose the LocalTemperature Value in the LocalTemperature attribute">
         <optionalConform/>
       </feature>
+      <feature bit="7" code="MSC" name="MatterScheduleConfiguration" summary="MatterScheduleConfiguration">
+        <optionalConform/>
+      </feature>
+      <feature bit="8" code="P" name="Presets" summary="Presets">
+        <optionalConform/>
+      </feature>
+      <feature bit="9" code="S" name="Setpoints" summary="Setpoints">
+        <optionalConform/>
+      </feature>
+      <feature bit="10" code="QPS" name="QueuedPresetsSupported" summary="QueuedPresetsSupported">
+        <optionalConform/>
+      </feature>
     </features>
 
     <!-- Attributes -->

--- a/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
@@ -290,6 +290,45 @@ limitations under the License.
     <server tick="false" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="6"/>
 
+    <features>
+      <feature bit="0" code="HEAT" name="Heating" summary="Thermostat is capable of managing a heating device">
+        <otherwiseConform>
+          <mandatoryConform>
+            <feature name="AUTO"/>
+          </mandatoryConform>
+          <optionalConform choice="a" more="true"/>
+        </otherwiseConform>
+      </feature>
+      <feature bit="1" code="COOL" name="Cooling" summary="Thermostat is capable of managing a cooling device">
+        <otherwiseConform>
+          <mandatoryConform>
+            <feature name="AUTO"/>
+          </mandatoryConform>
+          <optionalConform choice="a" more="true"/>
+        </otherwiseConform>
+      </feature>
+      <feature bit="2" code="OCC" name="Occupancy" summary="Supports Occupied and Unoccupied setpoints">
+        <optionalConform/>
+      </feature>
+      <feature bit="3" code="SCH" name="ScheduleConfiguration" summary="Supports remote configuration of a weekly schedule of setpoint transitions">
+        <otherwiseConform>
+          <optionalConform>
+            <condition name="Zigbee"/>
+          </optionalConform>
+          <deprecateConform/>
+        </otherwiseConform>
+      </feature>
+      <feature bit="4" code="SB" name="Setback" summary="Supports configurable setback (or span)">
+        <optionalConform/>
+      </feature>
+      <feature bit="5" code="AUTO" name="AutoMode" summary="Supports a System Mode of Auto">
+        <optionalConform/>
+      </feature>
+      <feature bit="6" code="LTNE" name="LocalTemperatureNotExposed" summary="Thermostat does not expose the LocalTemperature Value in the LocalTemperature attribute">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <!-- Attributes -->
 
     <attribute side="server" code="0x0000" define="LOCAL_TEMPERATURE" type="temperature" writable="false" reportable="true" optional="false" isNullable="true">LocalTemperature</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/thread-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-network-diagnostics-cluster.xml
@@ -169,11 +169,5 @@ limitations under the License.
       <field id="1" name="Previous" type="NetworkFaultEnum" array="true"/>
     </event>    
   </cluster>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0035"/>
-    <field name="PacketCounts" mask="0x1"/>
-    <field name="ErrorCounts" mask="0x2"/>
-    <field name="MLECounts" mask="0x4"/>
-    <field name="MACCounts" mask="0x8"/>
-  </bitmap>  
+
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/thread-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-network-diagnostics-cluster.xml
@@ -92,6 +92,22 @@ limitations under the License.
     <define>THREAD_NETWORK_DIAGNOSTICS_CLUSTER</define>
     <description>The Thread Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems</description>
     <globalAttribute side="either" code="0xFFFD" value="2"/>
+
+    <features>
+      <feature bit="0" code="PKTCNT" name="PacketCounts" summary="Server supports the counts for the number of received and transmitted packets on the Thread interface.">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="ERRCNT" name="ErrorCounts" summary="Server supports the counts for the number of errors that have occurred during the reception and transmission of packets on the Thread interface.">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="MLECNT" name="MLECounts" summary="Server supports the counts for various MLE layer happenings.">
+        <optionalConform/>
+      </feature>
+      <feature bit="3" code="MACCNT" name="MACCounts" summary="Server supports the counts for various MAC layer happenings.">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x00" define="CHANNEL" type="int16u" min="0x00" max="0xFFFF" writable="false" isNullable="true" optional="false">Channel</attribute>
     <attribute side="server" code="0x01" define="ROUTING_ROLE" type="RoutingRoleEnum" writable="false" isNullable="true" optional="false">RoutingRole</attribute>
     <attribute side="server" code="0x02" define="NETWORK_NAME" type="char_string" length="16" writable="false" default="" isNullable="true" optional="false">NetworkName</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/time-format-localization-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/time-format-localization-cluster.xml
@@ -23,11 +23,6 @@ limitations under the License.
     <item name="UseActiveLocale" value="0xFF"/>                   
   </enum>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x002c"/>
-    <field name="CalendarFormat" mask="0x1"/>
-  </bitmap>
-
   <enum name="CalendarTypeEnum" type="enum8">
     <cluster code="0x002c"/>
     <item name="Buddhist" value="0x00"/>

--- a/src/app/zap-templates/zcl/data-model/chip/time-format-localization-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/time-format-localization-cluster.xml
@@ -50,6 +50,13 @@ limitations under the License.
       may have differing preferences for how dates and times are conveyed. As such, Nodes that visually
       or audibly convey time information need a mechanism by which they can be configured to use a
       user’s preferred format.</description>
+
+      <features>
+        <feature bit="0" code="CALFMT" name="CalendarFormat" summary="The Node can be configured to use different calendar formats when conveying values to a user.">
+          <optionalConform/>
+        </feature>
+      </features>
+
     <!-- Base data types -->
     <attribute side="server" code="0x00" define="HOUR_FORMAT" type="HourFormatEnum" writable="true" optional="false">
         <description>HourFormat</description>

--- a/src/app/zap-templates/zcl/data-model/chip/time-synchronization-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/time-synchronization-cluster.xml
@@ -106,6 +106,21 @@ limitations under the License.
     <description>Accurate time is required for a number of reasons, including scheduling, display and validating security materials.</description>
     <globalAttribute side="either" code="0xFFFD" value="2"/>
 
+    <features>
+      <feature bit="0" code="TZ" name="TimeZone" summary="Server supports time zone.">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="NTPC" name="NTPClient" summary="Server supports an NTP or SNTP client.">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="NTPS" name="NTPServer" summary="Server supports an NTP server role.">
+        <optionalConform/>
+      </feature>
+      <feature bit="3" code="TSC" name="TimeSyncClient" summary="Time synchronization client cluster is present.">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="UTC_TIME" type="epoch_us" isNullable="true" optional="false">UTCTime</attribute>
     <attribute side="server" code="0x0001" define="GRANULARITY" type="GranularityEnum" default="0x00" optional="false">Granularity</attribute>
     <attribute side="server" code="0x0002" define="TIME_SOURCE" type="TimeSourceEnum" default="0x00" optional="true">TimeSource</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/time-synchronization-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/time-synchronization-cluster.xml
@@ -17,13 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0038"/>
-    <field name="TimeZone" mask="0x1"/>
-    <field name="NTPClient" mask="0x2"/>
-    <field name="NTPServer" mask="0x4"/>
-    <field name="TimeSyncClient" mask="0x8"/>
-  </bitmap>
 
   <!-- NOTE: This type is not defined as an enum in the spec, but the Status Codes section
   of this cluster defines these status codes, and we're choosing to represent them as an enum. -->

--- a/src/app/zap-templates/zcl/data-model/chip/timer-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/timer-cluster.xml
@@ -38,6 +38,13 @@ limitations under the License.
 
         <globalAttribute side="either" code="0xFFFD" value="1" />
 
+        <features>
+            <feature bit="0" code="RESET" name="Reset" summary="Supports the ability to reset timer">
+                <optionalConform/>
+            </feature>
+        </features>
+
+
         <attribute side="server" code="0x0000" define="SET_TIME" type="elapsed_s"  writable="false" isNullable="false" optional="false">SetTime</attribute>
         <attribute side="server" code="0x0001" define="TIME_REMAINING" type="elapsed_s"  writable="false"  isNullable="false"   optional="false">TimeRemaining</attribute>
         <attribute side="server" code="0x0002" define="TIMER_STATE" type="TimerStatusEnum"  writable="false"  isNullable="false"   optional="false">TimerState</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/timer-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/timer-cluster.xml
@@ -18,10 +18,6 @@ limitations under the License.
 <configurator>
     <domain name="CHIP" />
 
-    <bitmap name="Feature" type="bitmap32">
-        <cluster code="0x0047"/>
-        <field mask="0x01" name="Reset"/>
-    </bitmap>
 
     <enum name="TimerStatusEnum" type="enum8">
         <cluster code="0x0047" />

--- a/src/app/zap-templates/zcl/data-model/chip/unit-localization-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/unit-localization-cluster.xml
@@ -34,6 +34,13 @@ limitations under the License.
       user. As such, Nodes that visually or audibly convey measurable values to the user need a
       mechanism by which they can be configured to use a user’s preferred unit.</description>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
+
+    <features>
+      <feature bit="0" code="TEMP" name="TemperatureUnit" summary="The Node can be configured to use different units of temperature when conveying values to a user.">
+        <optionalConform/>
+      </feature>
+    </features>
+    
     <!-- Base data types -->
     <attribute side="server" code="0x00" define="TEMPERATURE_UNIT" type="TempUnitEnum" min="0" max="2" writable="true" optional="true">
         <description>TemperatureUnit</description>

--- a/src/app/zap-templates/zcl/data-model/chip/unit-localization-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/unit-localization-cluster.xml
@@ -40,8 +40,5 @@ limitations under the License.
         <access op="write" role="manage"/>
     </attribute>
   </cluster>
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x002d"/>
-    <field name="TemperatureUnit" mask="0x1"/>
-  </bitmap>
+
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/valve-configuration-and-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/valve-configuration-and-control-cluster.xml
@@ -55,6 +55,13 @@ limitations under the License.
     <description>This cluster is used to configure a valve.</description>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
 
+    <features>
+      <feature bit="0" code="TS" name="TimeSync" summary="UTC time is used for time indications"/>
+      <feature bit="1" code="LVL" name="Level" summary="Device supports setting the specific position of the valve">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <!-- min max definition for attribute size larger than 2 bytes is not allowed by zap codegen https://github.com/project-chip/zap/issues/1187 -->
     <!-- Therefore, this check needs to be done in code. -->
     <attribute side="server" code="0x0000" define="OPEN_DURATION" type="elapsed_s" isNullable="true" writable="false" optional="false">OpenDuration</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/valve-configuration-and-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/valve-configuration-and-control-cluster.xml
@@ -17,11 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0081"/>
-    <field name="TimeSync" mask="0x01"/>
-    <field name="Level" mask="0x02"/>
-  </bitmap>
 
   <bitmap name="ValveFaultBitmap" type="bitmap16">
     <cluster code="0x0081"/>

--- a/src/app/zap-templates/zcl/data-model/chip/washer-controls-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/washer-controls-cluster.xml
@@ -37,6 +37,15 @@ limitations under the License.
 
     <globalAttribute side="either" code="0xFFFD" value="1" />
 
+    <features>
+      <feature bit="0" code="SPIN" name="Spin" summary="Multiple spin speeds supported">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="RINSE" name="Rinse" summary="Multiple rinse cycles supported">
+        <optionalConform/>
+      </feature>
+    </features>
+
     <attribute side="server" code="0x0000" define="SPIN_SPEEDS"               type="array" entryType="char_string"                                writable="false" isNullable="false" optional="true">SpinSpeeds</attribute>
     <attribute side="server" code="0x0001" define="SPIN_SPEED_CURRENT"        type="int8u"                                min="0x00" max="0x1F"   writable="true"  isNullable="true"  optional="true">SpinSpeedCurrent</attribute>
     <attribute side="server" code="0x0002" define="NUMBER_OF_RINSES"          type="NumberOfRinsesEnum"                                           writable="true"  isNullable="false"  optional="true">NumberOfRinses</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/washer-controls-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/washer-controls-cluster.xml
@@ -17,11 +17,6 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0053"/>
-    <field mask="0x01" name="Spin"/>
-    <field mask="0x02" name="Rinse"/>
-  </bitmap>
 
   <enum name="NumberOfRinsesEnum" type="enum8">
     <cluster code="0x0053"/>

--- a/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
@@ -47,11 +47,7 @@ limitations under the License.
     <item name="Connected" value="0x00"/>
     <item name="NotConnected" value="0x01"/>
   </enum>  
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0036"/>
-    <field name="PacketCounts" mask="0x1"/>
-    <field name="ErrorCounts" mask="0x2"/>
-  </bitmap>  
+
   <cluster>
     <domain>General</domain>
     <name>WiFi Network Diagnostics</name>

--- a/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
@@ -54,6 +54,16 @@ limitations under the License.
     <code>0x0036</code>
     <define>WIFI_NETWORK_DIAGNOSTICS_CLUSTER</define>
     <description>The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.</description>
+
+    <features>
+      <feature bit="0" code="PKTCNT" name="PacketCounts" summary="Node makes available the counts for the number of received and transmitted packets on the ethernet interface.">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="ERRCNT" name="ErrorCounts" summary="Node makes available the counts for the number of errors that have occurred during the reception and transmission of packets on the ethernet interface.">
+        <optionalConform/>
+      </feature>
+    </features>
+  
     <attribute side="server" code="0x00" define="BSSID" type="octet_string" length="6" writable="false" isNullable="true" optional="false">BSSID</attribute>
     <attribute side="server" code="0x01" define="SECURITY_TYPE" type="SecurityTypeEnum" writable="false" isNullable="true" optional="false">SecurityType</attribute>
     <attribute side="server" code="0x02" define="WIFI_VERSION" type="WiFiVersionEnum" writable="false" isNullable="true" optional="false">WiFiVersion</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
@@ -233,12 +233,4 @@ limitations under the License.
     <field mask="0x0800" name="Protection"/>
   </bitmap>
 
-  <bitmap name="Feature" type="bitmap32">
-    <cluster code="0x0102"/>
-    <field mask="0x01" name="Lift" />
-    <field mask="0x02" name="Tilt" />
-    <field mask="0x04" name="PositionAwareLift"/>
-    <field mask="0x08" name="AbsolutePosition"/>
-    <field mask="0x10" name="PositionAwareTilt"/>
-  </bitmap>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/window-covering.xml
@@ -33,6 +33,28 @@ limitations under the License.
     <!-- Current cluster version -->
     <globalAttribute side="either" code="0xFFFD" value="5"/>
 
+    <features>
+      <feature bit="0" code="LF" name="Lift" summary="Lift control and behavior for lifting/sliding window coverings">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="1" code="TL" name="Tilt" summary="Tilt control and behavior for tilting window coverings">
+        <optionalConform choice="a" more="true"/>
+      </feature>
+      <feature bit="2" code="PA_LF" name="PositionAwareLift" summary="Position aware lift control is supported.">
+        <optionalConform>
+          <feature name="LF"/>
+        </optionalConform>
+      </feature>
+      <feature bit="3" code="ABS" name="AbsolutePosition" summary="Absolute positioning is supported.">
+        <optionalConform/>
+      </feature>
+      <feature bit="4" code="PA_TL" name="PositionAwareTilt" summary="Position aware tilt control is supported.">
+        <optionalConform>
+          <feature name="TL"/>
+        </optionalConform>
+      </feature>
+    </features>
+
     <!-- Window Covering Information Attribute Set -->
     <!-- Conformance feature M -->
     <attribute side="server" writable="false" code="0x0000" define="WC_TYPE"                                      type="Type"     min="0x00"   max="0x09"   default="0x00"   optional="false">Type</attribute>

--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -2,6 +2,7 @@
     "description": "Matter SDK ZCL data with some extensions",
     "category": "matter",
     "version": 1,
+    "requiredFeatureLevel": 102,
     "xmlRoot": [
         ".",
         "./data-model/chip/",

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -2,6 +2,7 @@
     "description": "Matter SDK ZCL data",
     "category": "matter",
     "version": 1,
+    "requiredFeatureLevel": 102,
     "xmlRoot": [
         ".",
         "./data-model/chip/",


### PR DESCRIPTION

JIRA: ZAPP-1346

No direct chip repo ticket associated to the changes here. However, these changes are associated to populating the feature map attribute based on the device type selected in ZAP. See ZAP PR: https://github.com/project-chip/zap/pull/1300 .

Note: The ZAP changes here only populate the feature map attribute for mandatory features for now during the creation of an endpoint. Existing apps will also get a warning during the .zap file open if the feature map attribute is not correctly set as per the device type specification for features.

