### PR TITLE
More fixes to src/app/util/mock.

### DIFF
--- a/src/app/util/mock/Functions.h
+++ b/src/app/util/mock/Functions.h
@@ -36,7 +36,15 @@ namespace Test {
 CHIP_ERROR ReadSingleMockClusterData(FabricIndex aAccessingFabricIndex, const app::ConcreteAttributePath & aPath,
                                      app::AttributeReportIBs::Builder & aAttributeReports,
                                      app::AttributeValueEncoder::AttributeEncodeState * apEncoderState);
+
+/// Increase the current value for `GetVersion`
 void BumpVersion();
+
+/// Sets GetVersion to return 0
+void ResetVersion();
+
+/// Gets the current value for the version that will
+/// be returned by emberAfDataVersionStorage
 DataVersion GetVersion();
 
 /// Configures the singular global mock attribute storage to use the specified configuration.

--- a/src/app/util/mock/MockNodeConfig.cpp
+++ b/src/app/util/mock/MockNodeConfig.cpp
@@ -70,6 +70,22 @@ MockClusterConfig::MockClusterConfig(ClusterId aId, std::initializer_list<MockAt
     mEmberCluster.mask           = CLUSTER_MASK_SERVER;
     mEmberCluster.eventCount     = static_cast<uint16_t>(mEmberEventList.size());
     mEmberCluster.eventList      = mEmberEventList.data();
+
+    for (auto & attr : attributes)
+    {
+        mAttributeMetaData.push_back(attr.attributeMetaData);
+    }
+
+    // Make sure ember side has access to attribute metadata
+    mEmberCluster.attributes = mAttributeMetaData.data();
+}
+
+MockClusterConfig::MockClusterConfig(const MockClusterConfig & other) :
+    id(other.id), attributes(other.attributes), events(other.events), mEmberCluster(other.mEmberCluster),
+    mEmberEventList(other.mEmberEventList), mAttributeMetaData(other.mAttributeMetaData)
+{
+    // Fix self-referencial dependencies after data copy
+    mEmberCluster.attributes = mAttributeMetaData.data();
 }
 
 const MockAttributeConfig * MockClusterConfig::attributeById(AttributeId attributeId, ptrdiff_t * outIndex) const

--- a/src/app/util/mock/MockNodeConfig.h
+++ b/src/app/util/mock/MockNodeConfig.h
@@ -71,7 +71,7 @@ struct MockClusterConfig
     MockClusterConfig(ClusterId aId, std::initializer_list<MockAttributeConfig> aAttributes = {},
                       std::initializer_list<MockEventConfig> aEvents = {});
 
-    // Cluster-config is self-referntial: mEmberCluster.attributes references  mAttributeMetaData.data()
+    // Cluster-config is self-referential: mEmberCluster.attributes references  mAttributeMetaData.data()
     MockClusterConfig(const MockClusterConfig & other);
     MockClusterConfig & operator=(const MockClusterConfig &) = delete;
 
@@ -92,7 +92,7 @@ struct MockEndpointConfig
 {
     MockEndpointConfig(EndpointId aId, std::initializer_list<MockClusterConfig> aClusters = {});
 
-    // Endpoint-config is self-referntial: mEmberEndpoint.clusters references  mEmberClusters.data()
+    // Endpoint-config is self-referential: mEmberEndpoint.clusters references  mEmberClusters.data()
     MockEndpointConfig(const MockEndpointConfig & other);
     MockEndpointConfig & operator=(const MockEndpointConfig &) = delete;
 

--- a/src/app/util/mock/MockNodeConfig.h
+++ b/src/app/util/mock/MockNodeConfig.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <app-common/zap-generated/attribute-type.h>
 #include <app/util/af-types.h>
 #include <lib/core/DataModelTypes.h>
 
@@ -28,10 +29,35 @@
 namespace chip {
 namespace Test {
 
+namespace internal {
+
+constexpr EmberAfAttributeMetadata DefaultAttributeMetadata(chip::AttributeId id)
+{
+    return EmberAfAttributeMetadata{
+        .defaultValue  = EmberAfDefaultOrMinMaxAttributeValue(0u),
+        .attributeId   = id,
+        .size          = 4,
+        .attributeType = ZCL_INT32U_ATTRIBUTE_TYPE,
+        .mask          = ATTRIBUTE_MASK_WRITABLE | ATTRIBUTE_MASK_NULLABLE,
+    };
+}
+
+} // namespace internal
+
 struct MockAttributeConfig
 {
-    MockAttributeConfig(AttributeId aId) : id(aId) {}
+    MockAttributeConfig(AttributeId aId) : id(aId), attributeMetaData(internal::DefaultAttributeMetadata(aId)) {}
+    MockAttributeConfig(AttributeId aId, EmberAfAttributeType type,
+                        EmberAfAttributeMask mask = ATTRIBUTE_MASK_WRITABLE | ATTRIBUTE_MASK_NULLABLE) :
+        id(aId),
+        attributeMetaData(internal::DefaultAttributeMetadata(aId))
+    {
+        attributeMetaData.attributeType = type;
+        attributeMetaData.mask          = mask;
+    }
+
     const AttributeId id;
+    EmberAfAttributeMetadata attributeMetaData;
 };
 
 struct MockEventConfig
@@ -45,6 +71,10 @@ struct MockClusterConfig
     MockClusterConfig(ClusterId aId, std::initializer_list<MockAttributeConfig> aAttributes = {},
                       std::initializer_list<MockEventConfig> aEvents = {});
 
+    // Cluster-config is self-referntial: mEmberCluster.attributes references  mAttributeMetaData.data()
+    MockClusterConfig(const MockClusterConfig & other);
+    MockClusterConfig & operator=(const MockClusterConfig &) = delete;
+
     const MockAttributeConfig * attributeById(AttributeId attributeId, ptrdiff_t * outIndex = nullptr) const;
     const EmberAfCluster * emberCluster() const { return &mEmberCluster; }
 
@@ -55,13 +85,14 @@ struct MockClusterConfig
 private:
     EmberAfCluster mEmberCluster;
     std::vector<EventId> mEmberEventList;
+    std::vector<EmberAfAttributeMetadata> mAttributeMetaData;
 };
 
 struct MockEndpointConfig
 {
     MockEndpointConfig(EndpointId aId, std::initializer_list<MockClusterConfig> aClusters = {});
 
-    // Cluster-config is self-referntial: mEmberCluster.clusters references  mEmberClusters
+    // Endpoint-config is self-referntial: mEmberEndpoint.clusters references  mEmberClusters.data()
     MockEndpointConfig(const MockEndpointConfig & other);
     MockEndpointConfig & operator=(const MockEndpointConfig &) = delete;
 

--- a/src/app/util/mock/MockNodeConfig.h
+++ b/src/app/util/mock/MockNodeConfig.h
@@ -34,7 +34,7 @@ namespace internal {
 constexpr EmberAfAttributeMetadata DefaultAttributeMetadata(chip::AttributeId id)
 {
     return EmberAfAttributeMetadata{
-        .defaultValue  = EmberAfDefaultOrMinMaxAttributeValue(0u),
+        .defaultValue  = EmberAfDefaultOrMinMaxAttributeValue(static_cast<uint32_t>(0)),
         .attributeId   = id,
         .size          = 4,
         .attributeType = ZCL_INT32U_ATTRIBUTE_TYPE,

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -418,7 +418,6 @@ void SetMockNodeConfig(const MockNodeConfig & config)
     mockConfig = &config;
 }
 
-/// Resets the mock attribute storage to the default configuration.
 void ResetMockNodeConfig()
 {
     mockConfig = nullptr;

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -307,7 +307,13 @@ void EnabledEndpointsWithServerCluster::EnsureMatchingEndpoint()
 }
 
 } // namespace app
+//
 namespace Test {
+
+void ResetVersion()
+{
+    dataVersion = 0;
+}
 
 void BumpVersion()
 {
@@ -405,6 +411,17 @@ CHIP_ERROR ReadSingleMockClusterData(FabricIndex aAccessingFabricIndex, const Co
 
     ReturnErrorOnFailure(attributeData.EndOfAttributeDataIB());
     return attributeReport.EndOfAttributeReportIB();
+}
+
+void SetMockNodeConfig(const MockNodeConfig & config)
+{
+    mockConfig = &config;
+}
+
+/// Resets the mock attribute storage to the default configuration.
+void ResetMockNodeConfig()
+{
+    mockConfig = nullptr;
 }
 
 } // namespace Test

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -307,7 +307,7 @@ void EnabledEndpointsWithServerCluster::EnsureMatchingEndpoint()
 }
 
 } // namespace app
-//
+
 namespace Test {
 
 void ResetVersion()


### PR DESCRIPTION
More fixes for mock ember: attribute metadata support, implement non-implemented methods, add data version reset functionality for unit tests (so unit tests can start from a know state)

### Changes

- add `ResetVersion` to reset the data version to 0, so unit tests can start from a known state
- implement `SetMockNodeConfig` and `ResetMockNodeConfig` as these were declared in Functions.h but never implemented
- add attribute metadata support for mock endpoint config, otherwise the configurations were setting `cluster->attributes` to nullptr, which seems unexpected when using ember. I did NOT followup for setting the correct sizing/typing for the default mock config though, as that does not seem used anyway. I expect as I add unit tests I will need some followups here due to fixed data buffers.