### PR TITLE
Remove examples/android/CHIPTest from detekt

### DIFF
--- a/.github/workflows/kotlin-style.yaml
+++ b/.github/workflows/kotlin-style.yaml
@@ -22,11 +22,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "detekt"
-        uses: natiginfo/action-detekt-all@1.23.5
+        uses: natiginfo/action-detekt-all@1.23.6
         # Detekt seems not to like circular symlinks, so we set up
         # explicit paths below
+        #
+        # - `examples/android/CHIPTest` is excluded because detekt seems to hang on
+        #    them (unclear why)
         with:
-          args: --parallel --build-upon-default-config --config kotlin-detect-config.yaml --input examples/android/CHIPTest,examples/android/CHIPTool,examples/java-matter-controller/java,src/controller/java
+          args: --parallel --build-upon-default-config --config kotlin-detect-config.yaml --input examples/android/CHIPTool,examples/java-matter-controller/java,src/controller/java
 
   ktlint:
     name: "Format check"

--- a/.github/workflows/kotlin-style.yaml
+++ b/.github/workflows/kotlin-style.yaml
@@ -26,10 +26,13 @@ jobs:
         # Detekt seems not to like circular symlinks, so we set up
         # explicit paths below
         #
-        # - `examples/android/CHIPTest` is excluded because detekt seems to hang on
-        #    them (unclear why)
+        # In particular, if symlinks exist and recurse, detekt tries to
+        # follow, so for example `examples/android/CHIPTest` as a path
+        # will never end (and eventually run out of HEAP) because
+        # `examples/android/CHIPTest/third_party/connectedhomeip` is
+        # circular
         with:
-          args: --parallel --build-upon-default-config --config kotlin-detect-config.yaml --input examples/android/CHIPTool,examples/java-matter-controller/java,src/controller/java
+          args: --parallel --build-upon-default-config --config kotlin-detect-config.yaml --input examples/android/CHIPTest/app,examples/android/CHIPTool,examples/java-matter-controller/java,src/controller/java
 
   ktlint:
     name: "Format check"


### PR DESCRIPTION
detekt seems to hang/never finish after #32704 

The reason is that detekt follows symlinks and third_party/connectedhomeip is circular.