### PR TITLE
Fix typos in boostrap.sh comments, stop using path as a variable name

### DIFF
--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -67,9 +67,9 @@ _submodules_need_updating() {
     "third_party/editline/repo"
   )
 
-  for path in "${_SUBMODULE_PATHS[@]}"; do
-    if git submodule status "$path" | grep -E '^-' >/dev/null 2>&1; then 
-      echo "git shows that $path has changes"
+  for submodule_path in "${_SUBMODULE_PATHS[@]}"; do
+    if git submodule status "$submodule_path" | grep -E '^-' >/dev/null 2>&1; then 
+      echo "git shows that $submodule_path has changes"
       unset _SUBMODULE_PATHS
       return 0 # Success
     fi

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -57,10 +57,10 @@ _install_additional_pip_requirements() {
 }
 
 _submodules_need_updating() {
-  # Validates if a set o submodules that should always be checked out are up to date
+  # Validates if a set of submodules that should always be checked out are up to date.
 
-  # Pigweed will be up to date on an initial setup, however it may change over time
-  # the rest are a small subset of things that are always checked out (have no platform attachment)
+  # Pigweed will be up to date on an initial setup, however it may change over time.
+  # The rest are a small subset of things that are always checked out (have no platform attachment).
   _SUBMODULE_PATHS=(
     "third_party/pigweed/repo"
     "third_party/openthread/repo"


### PR DESCRIPTION
Post-submit review of #32878 

Also fixes that the name `path` in a loop variable does not seem to be working everywhere (could be a reserved command sometimes - https://unix.stackexchange.com/questions/532148/what-is-the-difference-between-path-and-path-lowercase-versus-uppercase-with/532155#532155 says path and PATH are tied together in zsh/tcsh and such ). Used `submodule_path` instead.