### PR TITLE
Fix bootstrap if repository path contains symlinks.

### DIFF
--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -167,7 +167,19 @@ EOF
 # bootstrap or run_in_build_env.sh can be executed in a build env
 _ORIGINAL_PW_ENVIRONMENT_ROOT="$PW_ENVIRONMENT_ROOT"
 
+# pigweed does not seem to handle pwd involving symlinks very well.
+original_pwd=$PWD
+if hash realpath 2>/dev/null; then
+    realpwd="$(realpath "$PWD")"
+    if [ "$realpwd" != "$PWD" ]; then
+        echo "Warning: $PWD contains symlinks, using $realpwd instead"
+        cd "$realpwd"
+    fi
+fi
+
 _bootstrap_or_activate "$0"
+
+cd $original_pwd
 
 if [ "$_ACTION_TAKEN" = "bootstrap" ]; then
     # By default, install all extra pip dependencies even if slow. -p/--platform


### PR DESCRIPTION
Pigweed seems to fail with:

    ERROR at /home/angus/projects/connectedhomeip/third_party/pigweed/repo/pw_build/facade.gni:187:7: Assertion failed.
    assert(_dep_is_in_link_dependencies,

when the repo path has symlinks in it and bootstrap is run.

The workaround is to change to the symlink-resolved path temporarily while doing the pigweed parts of bootstrap.sh.

Fixes https://github.com/project-chip/connectedhomeip/issues/31851
