### PR TITLE
Separate out attribute access interface registry/cache, remove free functions from InteractionModelEngine.h

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,7 +96,6 @@ jobs:
                      --known-failure app/app-platform/ContentAppPlatform.h \
                      --known-failure controller/ExamplePersistentStorage.cpp \
                      --known-failure controller/ExamplePersistentStorage.h \
-                     --known-failure app/AttributeAccessInterface.h \
                      --known-failure app/AttributeAccessToken.h \
                      --known-failure app/CommandHandler.h \
                      --known-failure app/CommandHandlerInterface.h \
@@ -107,11 +106,11 @@ jobs:
                      --known-failure app/reporting/tests/MockReportScheduler.cpp \
                      --known-failure app/reporting/tests/MockReportScheduler.h \
                      --known-failure app/util/attribute-storage.cpp \
-                     --known-failure app/util/attribute-storage.h \
                      --known-failure app/util/attribute-storage-detail.h \
+                     --known-failure app/util/attribute-storage.h \
                      --known-failure app/util/attribute-table.cpp \
-                     --known-failure app/util/attribute-table.h \
                      --known-failure app/util/attribute-table-detail.h \
+                     --known-failure app/util/attribute-table.h \
                      --known-failure app/util/binding-table.cpp \
                      --known-failure app/util/binding-table.h \
                      --known-failure app/util/config.h \
@@ -123,6 +122,7 @@ jobs:
                      --known-failure app/util/generic-callbacks.h \
                      --known-failure app/util/generic-callback-stubs.cpp \
                      --known-failure app/util/im-client-callbacks.h \
+                     --known-failure app/util/IMClusterCommandHandler.h \
                      --known-failure app/util/util.cpp \
                      --known-failure app/util/util.h \
                      --known-failure app/WriteHandler.h \

--- a/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
@@ -19,6 +19,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/examples/all-clusters-app/all-clusters-common/src/fan-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/fan-stub.cpp
@@ -20,8 +20,8 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
-#include <app/clusters/fan-control-server/fan-control-server.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
+#include <app/clusters/fan-control-server/fan-control-server.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/examples/all-clusters-app/all-clusters-common/src/fan-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/fan-stub.cpp
@@ -21,6 +21,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/clusters/fan-control-server/fan-control-server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/examples/bridge-app/asr/src/bridged-actions-stub.cpp
+++ b/examples/bridge-app/asr/src/bridged-actions-stub.cpp
@@ -18,6 +18,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/examples/bridge-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/bridge-app/esp32/main/DeviceCallbacks.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/examples/bridge-app/linux/bridged-actions-stub.cpp
+++ b/examples/bridge-app/linux/bridged-actions-stub.cpp
@@ -19,6 +19,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -22,11 +22,11 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
 #include <app/util/af-types.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <app/util/util.h>

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -26,6 +26,7 @@
 #include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
 #include <app/util/af-types.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <app/util/util.h>

--- a/examples/bridge-app/telink/src/DeviceCallbacks.cpp
+++ b/examples/bridge-app/telink/src/DeviceCallbacks.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/examples/chef/common/chef-fan-control-manager.cpp
+++ b/examples/chef/common/chef-fan-control-manager.cpp
@@ -20,8 +20,8 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
-#include <app/clusters/fan-control-server/fan-control-server.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
+#include <app/clusters/fan-control-server/fan-control-server.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/examples/chef/common/chef-fan-control-manager.cpp
+++ b/examples/chef/common/chef-fan-control-manager.cpp
@@ -21,6 +21,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/clusters/fan-control-server/fan-control-server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/examples/placeholder/linux/InteractiveServer.cpp
+++ b/examples/placeholder/linux/InteractiveServer.cpp
@@ -25,6 +25,7 @@
 #include <platform/logging/LogV.h>
 
 #include <string>
+#include <vector>
 
 using namespace chip::DeviceLayer;
 

--- a/examples/placeholder/linux/InteractiveServer.cpp
+++ b/examples/placeholder/linux/InteractiveServer.cpp
@@ -19,6 +19,7 @@
 #include "InteractiveServer.h"
 
 #include <json/json.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/Base64.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/logging/LogV.h>

--- a/examples/placeholder/linux/src/bridged-actions-stub.cpp
+++ b/examples/placeholder/linux/src/bridged-actions-stub.cpp
@@ -19,6 +19,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/AttributeAccessInterfaceRegistry.cpp
+++ b/src/app/AttributeAccessInterfaceRegistry.cpp
@@ -66,7 +66,7 @@ void unregisterAttributeAccessOverride(AttributeAccessInterface * attrOverride)
     UnregisterMatchingAttributeAccessInterfaces([attrOverride](AttributeAccessInterface * entry) { return entry == attrOverride; });
 }
 
-void unregisterAttributeAccessOverrideForEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
+void unregisterAllAttributeAccessOverridesForEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
 {
     UnregisterMatchingAttributeAccessInterfaces(
         [endpoint = definedEndpoint->endpoint](AttributeAccessInterface * entry) { return entry->MatchesEndpoint(endpoint); });

--- a/src/app/AttributeAccessInterfaceRegistry.cpp
+++ b/src/app/AttributeAccessInterfaceRegistry.cpp
@@ -1,0 +1,126 @@
+/**
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <app/AttributeAccessInterfaceRegistry.h>
+
+#include <app/AttributeAccessInterfaceCache.h>
+
+using namespace chip::app;
+
+namespace {
+
+AttributeAccessInterface * gAttributeAccessOverrides = nullptr;
+AttributeAccessInterfaceCache gAttributeAccessInterfaceCache;
+
+// shouldUnregister returns true if the given AttributeAccessInterface should be
+// unregistered.
+template <typename F>
+void UnregisterMatchingAttributeAccessInterfaces(F shouldUnregister)
+{
+    AttributeAccessInterface * prev = nullptr;
+    AttributeAccessInterface * cur  = gAttributeAccessOverrides;
+    while (cur)
+    {
+        AttributeAccessInterface * next = cur->GetNext();
+        if (shouldUnregister(cur))
+        {
+            // Remove it from the list
+            if (prev)
+            {
+                prev->SetNext(next);
+            }
+            else
+            {
+                gAttributeAccessOverrides = next;
+            }
+
+            cur->SetNext(nullptr);
+
+            // Do not change prev in this case.
+        }
+        else
+        {
+            prev = cur;
+        }
+        cur = next;
+    }
+}
+
+} // namespace
+
+void unregisterAttributeAccessOverride(AttributeAccessInterface * attrOverride)
+{
+    gAttributeAccessInterfaceCache.Invalidate();
+    UnregisterMatchingAttributeAccessInterfaces([attrOverride](AttributeAccessInterface * entry) { return entry == attrOverride; });
+}
+
+void unregisterAttributeAccessOverrideForEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
+{
+    UnregisterMatchingAttributeAccessInterfaces(
+        [endpoint = definedEndpoint->endpoint](AttributeAccessInterface * entry) { return entry->MatchesEndpoint(endpoint); });
+}
+
+bool registerAttributeAccessOverride(AttributeAccessInterface * attrOverride)
+{
+    gAttributeAccessInterfaceCache.Invalidate();
+    for (auto * cur = gAttributeAccessOverrides; cur; cur = cur->GetNext())
+    {
+        if (cur->Matches(*attrOverride))
+        {
+            ChipLogError(Zcl, "Duplicate attribute override registration failed");
+            return false;
+        }
+    }
+    attrOverride->SetNext(gAttributeAccessOverrides);
+    gAttributeAccessOverrides = attrOverride;
+    return true;
+}
+
+namespace chip {
+namespace app {
+
+app::AttributeAccessInterface * GetAttributeAccessOverride(EndpointId endpointId, ClusterId clusterId)
+{
+    using CacheResult = AttributeAccessInterfaceCache::CacheResult;
+
+    AttributeAccessInterface * cached = nullptr;
+    CacheResult result                = gAttributeAccessInterfaceCache.Get(endpointId, clusterId, &cached);
+    switch (result)
+    {
+    case CacheResult::kDefinitelyUnused:
+        return nullptr;
+    case CacheResult::kDefinitelyUsed:
+        return cached;
+    case CacheResult::kCacheMiss:
+    default:
+        // Did not cache yet, search set of AAI registered, and cache if found.
+        for (app::AttributeAccessInterface * cur = gAttributeAccessOverrides; cur; cur = cur->GetNext())
+        {
+            if (cur->Matches(endpointId, clusterId))
+            {
+                gAttributeAccessInterfaceCache.MarkUsed(endpointId, clusterId, cur);
+                return cur;
+            }
+        }
+
+        // Did not find AAI registered: mark as definitely not using.
+        gAttributeAccessInterfaceCache.MarkUnused(endpointId, clusterId);
+    }
+
+    return nullptr;
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/AttributeAccessInterfaceRegistry.cpp
+++ b/src/app/AttributeAccessInterfaceRegistry.cpp
@@ -79,7 +79,7 @@ bool registerAttributeAccessOverride(AttributeAccessInterface * attrOverride)
     {
         if (cur->Matches(*attrOverride))
         {
-            ChipLogError(Zcl, "Duplicate attribute override registration failed");
+            ChipLogError(InteractionModel, "Duplicate attribute override registration failed");
             return false;
         }
     }

--- a/src/app/AttributeAccessInterfaceRegistry.h
+++ b/src/app/AttributeAccessInterfaceRegistry.h
@@ -1,0 +1,54 @@
+/**
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/util/af-types.h>
+#include <app/AttributeAccessInterface.h>
+
+/**
+ * Register an attribute access override.  It will remain registered until the
+ * endpoint it's registered for is disabled (or until shutdown if it's
+ * registered for all endpoints) or until it is explicitly unregistered.
+ * Registration will fail if there is an already-registered override for the
+ * same set of attributes.
+ *
+ * @return false if there is an existing override that the new one would
+ *               conflict with.  In this case the override is not registered.
+ * @return true if registration was successful.
+ */
+bool registerAttributeAccessOverride(chip::app::AttributeAccessInterface * attrOverride);
+
+/**
+ * Unregister an attribute access override (for example if the object
+ * implementing AttributeAccessInterface is being destroyed).
+ */
+void unregisterAttributeAccessOverride(chip::app::AttributeAccessInterface * attrOverride);
+
+/**
+ * Unregister all attribute access interfaces that match this given endpoint.
+ */
+void unregisterAttributeAccessOverrideForEndpoint(EmberAfDefinedEndpoint *definedEndpoint);
+
+namespace chip {
+namespace app {
+
+/**
+ *  Get the registered attribute access override. nullptr when attribute access override is not found.
+ */
+AttributeAccessInterface * GetAttributeAccessOverride(EndpointId aEndpointId, ClusterId aClusterId);
+
+} // namespace app
+} // namespace chip

--- a/src/app/AttributeAccessInterfaceRegistry.h
+++ b/src/app/AttributeAccessInterfaceRegistry.h
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <app/util/af-types.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/util/af-types.h>
 
 /**
  * Register an attribute access override.  It will remain registered until the
@@ -40,7 +40,7 @@ void unregisterAttributeAccessOverride(chip::app::AttributeAccessInterface * att
 /**
  * Unregister all attribute access interfaces that match this given endpoint.
  */
-void unregisterAttributeAccessOverrideForEndpoint(EmberAfDefinedEndpoint *definedEndpoint);
+void unregisterAttributeAccessOverrideForEndpoint(EmberAfDefinedEndpoint * definedEndpoint);
 
 namespace chip {
 namespace app {

--- a/src/app/AttributeAccessInterfaceRegistry.h
+++ b/src/app/AttributeAccessInterfaceRegistry.h
@@ -40,7 +40,7 @@ void unregisterAttributeAccessOverride(chip::app::AttributeAccessInterface * att
 /**
  * Unregister all attribute access interfaces that match this given endpoint.
  */
-void unregisterAttributeAccessOverrideForEndpoint(EmberAfDefinedEndpoint * definedEndpoint);
+void unregisterAllAttributeAccessOverridesForEndpoint(EmberAfDefinedEndpoint * definedEndpoint);
 
 namespace chip {
 namespace app {

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -276,13 +276,13 @@ source_set("events") {
 }
 
 static_library("attribute-access") {
-   sources = [
-      "AttributeAccessInterfaceCache.h",
-      "AttributeAccessInterface.cpp",
-      "AttributeAccessInterface.h",
-      "AttributeAccessInterfaceRegistry.cpp",
-      "AttributeAccessInterfaceRegistry.h",
-   ]
+  sources = [
+    "AttributeAccessInterface.cpp",
+    "AttributeAccessInterface.h",
+    "AttributeAccessInterfaceCache.h",
+    "AttributeAccessInterfaceRegistry.cpp",
+    "AttributeAccessInterfaceRegistry.h",
+  ]
 
   # TODO: double-check if this is still a thing:
   # TODO: the following items cannot be included due to platform includes not being
@@ -290,15 +290,15 @@ static_library("attribute-access") {
   #       Name with _ so that linter does not recognize it
   # "_AttributeAccessInterface._h",
 
-    deps = [
-      ":paths",
-      "${chip_root}/src/access:types",
-      "${chip_root}/src/app/data-model",
-      "${chip_root}/src/app/MessageDef",
-      "${chip_root}/src/app/util:af-types",
-      "${chip_root}/src/lib/core",
-      "${chip_root}/src/lib/support",
-    ]
+  deps = [
+    ":paths",
+    "${chip_root}/src/access:types",
+    "${chip_root}/src/app/MessageDef",
+    "${chip_root}/src/app/data-model",
+    "${chip_root}/src/app/util:af-types",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+  ]
 }
 
 # Note to developpers, instead of continuously adding files in the app librabry, it is recommand to create smaller source_sets that app can depend on.
@@ -343,10 +343,10 @@ static_library("app") {
 
   public_deps = [
     ":app_config",
+    ":attribute-access",
     ":constants",
     ":global-attributes",
     ":interaction-model",
-    ":attribute-access",
     "${chip_root}/src/app/data-model",
     "${chip_root}/src/app/icd/server:icd-server-config",
     "${chip_root}/src/app/util:callbacks",

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -275,14 +275,38 @@ source_set("events") {
   ]
 }
 
+static_library("attribute-access") {
+   sources = [
+      "AttributeAccessInterfaceCache.h",
+      "AttributeAccessInterface.cpp",
+      "AttributeAccessInterface.h",
+      "AttributeAccessInterfaceRegistry.cpp",
+      "AttributeAccessInterfaceRegistry.h",
+   ]
+
+  # TODO: double-check if this is still a thing:
+  # TODO: the following items cannot be included due to platform includes not being
+  #       able to depend on src/app
+  #       Name with _ so that linter does not recognize it
+  # "_AttributeAccessInterface._h",
+
+    deps = [
+      ":paths",
+      "${chip_root}/src/access:types",
+      "${chip_root}/src/app/data-model",
+      "${chip_root}/src/app/MessageDef",
+      "${chip_root}/src/app/util:af-types",
+      "${chip_root}/src/lib/core",
+      "${chip_root}/src/lib/support",
+    ]
+}
+
 # Note to developpers, instead of continuously adding files in the app librabry, it is recommand to create smaller source_sets that app can depend on.
 # This way, we can have a better understanding of dependencies and other componenets can depend on the different source_sets without needing to depend on the entire app library.
 static_library("app") {
   output_name = "libCHIPDataModel"
 
   sources = [
-    "AttributeAccessInterface.cpp",
-    "AttributeAccessInterfaceCache.h",
     "AttributePathExpandIterator.cpp",
     "AttributePathExpandIterator.h",
     "AttributePersistenceProvider.h",
@@ -315,11 +339,6 @@ static_library("app") {
     # "CommandHandler._h"
     # "ReadHandler._h",
     # "WriteHandler._h"
-
-    # TODO: the following items cannot be included due to platform includes not being
-    #       able to depend on src/app
-    #       Name with _ so that linter does not recognize it
-    # "_AttributeAccessInterface._h",
   ]
 
   public_deps = [
@@ -327,6 +346,7 @@ static_library("app") {
     ":constants",
     ":global-attributes",
     ":interaction-model",
+    ":attribute-access",
     "${chip_root}/src/app/data-model",
     "${chip_root}/src/app/icd/server:icd-server-config",
     "${chip_root}/src/app/util:callbacks",

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -284,12 +284,6 @@ static_library("attribute-access") {
     "AttributeAccessInterfaceRegistry.h",
   ]
 
-  # TODO: double-check if this is still a thing:
-  # TODO: the following items cannot be included due to platform includes not being
-  #       able to depend on src/app
-  #       Name with _ so that linter does not recognize it
-  # "_AttributeAccessInterface._h",
-
   deps = [
     ":paths",
     "${chip_root}/src/access:types",

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -31,6 +31,7 @@
 #include "access/SubjectDescriptor.h"
 #include <app/AppConfig.h>
 #include <app/RequiredPrivilege.h>
+#include <app/util/IMClusterCommandHandler.h>
 #include <app/util/af-types.h>
 #include <app/util/ember-compatibility-functions.h>
 #include <app/util/endpoint-config-api.h>

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -715,12 +715,6 @@ private:
 void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,
                                   CommandHandler * apCommandObj);
 
-/**
- *  Get the registered attribute access override. nullptr when attribute access override is not found.
- *
- * TODO(#16806): This function and registerAttributeAccessOverride can be member functions of InteractionModelEngine.
- */
-AttributeAccessInterface * GetAttributeAccessOverride(EndpointId aEndpointId, ClusterId aClusterId);
 
 } // namespace app
 } // namespace chip

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -712,9 +712,5 @@ private:
     uint32_t mMagic = 0;
 };
 
-void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,
-                                  CommandHandler * apCommandObj);
-
-
 } // namespace app
 } // namespace chip

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -18,6 +18,7 @@
 
 #include "messaging/ExchangeContext.h"
 #include <app/AppConfig.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/EventPathIB.h>
 #include <app/StatusResponse.h>

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -26,6 +26,7 @@
 #include <app/data-model/Encode.h>
 #include <app/server/AclStorage.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -20,13 +20,13 @@
 #include <app-common/zap-generated/cluster-objects.h>
 
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
 #include <app/server/AclStorage.h>
 #include <app/server/Server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -26,11 +26,11 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -30,6 +30,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -26,6 +26,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/server/CommissioningWindowManager.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -22,11 +22,11 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/server/CommissioningWindowManager.h>
 #include <app/server/Server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/air-quality-server/air-quality-server.cpp
+++ b/src/app/clusters/air-quality-server/air-quality-server.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/clusters/air-quality-server/air-quality-server.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/air-quality-server/air-quality-server.cpp
+++ b/src/app/clusters/air-quality-server/air-quality-server.cpp
@@ -18,9 +18,9 @@
 
 #include "app-common/zap-generated/ids/Clusters.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/clusters/air-quality-server/air-quality-server.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -26,8 +26,8 @@
 #include <app/clusters/application-basic-server/application-basic-server.h>
 
 #include <app/AttributeAccessInterface.h>
-#include <app/data-model/Encode.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
+#include <app/data-model/Encode.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -27,6 +27,7 @@
 
 #include <app/AttributeAccessInterface.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -29,10 +29,10 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -32,6 +32,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -30,6 +30,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -27,10 +27,10 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/basic-information/basic-information.cpp
+++ b/src/app/clusters/basic-information/basic-information.cpp
@@ -20,10 +20,10 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/EventLogging.h>
 #include <app/InteractionModelEngine.h>
 #include <app/SpecificationDefinedRevisions.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPConfig.h>
 #include <platform/CHIPDeviceLayer.h>

--- a/src/app/clusters/basic-information/basic-information.cpp
+++ b/src/app/clusters/basic-information/basic-information.cpp
@@ -23,6 +23,7 @@
 #include <app/EventLogging.h>
 #include <app/InteractionModelEngine.h>
 #include <app/SpecificationDefinedRevisions.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPConfig.h>
 #include <platform/CHIPDeviceLayer.h>

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -26,6 +26,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/clusters/bindings/bindings.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -23,10 +23,10 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/clusters/bindings/bindings.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-server.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-server.cpp
@@ -23,12 +23,12 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/SafeAttributePersistenceProvider.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <lib/core/CHIPError.h>

--- a/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-server.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-server.cpp
@@ -28,6 +28,7 @@
 #include <app/EventLogging.h>
 #include <app/SafeAttributePersistenceProvider.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <lib/core/CHIPError.h>

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -17,12 +17,12 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/clusters/channel-server/channel-delegate.h>
 #include <app/clusters/channel-server/channel-server.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -22,6 +22,7 @@
 #include <app/clusters/channel-server/channel-delegate.h>
 #include <app/clusters/channel-server/channel-server.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/concentration-measurement-server/concentration-measurement-server.h
+++ b/src/app/clusters/concentration-measurement-server/concentration-measurement-server.h
@@ -20,9 +20,9 @@
 
 #include "concentration-measurement-cluster-objects.h"
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/data-model/Nullable.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/IntrusiveList.h>
 #include <type_traits>

--- a/src/app/clusters/concentration-measurement-server/concentration-measurement-server.h
+++ b/src/app/clusters/concentration-measurement-server/concentration-measurement-server.h
@@ -22,6 +22,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/data-model/Nullable.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/IntrusiveList.h>
 #include <type_traits>

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -20,10 +20,10 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -23,6 +23,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -24,6 +24,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <lib/support/CodeUtils.h>

--- a/src/app/clusters/device-energy-management-server/device-energy-management-server.cpp
+++ b/src/app/clusters/device-energy-management-server/device-energy-management-server.cpp
@@ -17,9 +17,9 @@
 #include "device-energy-management-server.h"
 
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelEngine.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/device-energy-management-server/device-energy-management-server.cpp
+++ b/src/app/clusters/device-energy-management-server/device-energy-management-server.cpp
@@ -19,6 +19,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelEngine.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -27,6 +27,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/EventLogging.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <cinttypes>

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -25,9 +25,9 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/callback.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/EventLogging.h>
 #include <app/server/Server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <cinttypes>

--- a/src/app/clusters/electrical-energy-measurement-server/electrical-energy-measurement-server.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/electrical-energy-measurement-server.cpp
@@ -20,9 +20,9 @@
 #include <protocols/interaction_model/StatusCode.h>
 
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 

--- a/src/app/clusters/electrical-energy-measurement-server/electrical-energy-measurement-server.cpp
+++ b/src/app/clusters/electrical-energy-measurement-server/electrical-energy-measurement-server.cpp
@@ -22,6 +22,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 

--- a/src/app/clusters/electrical-power-measurement-server/electrical-power-measurement-server.cpp
+++ b/src/app/clusters/electrical-power-measurement-server/electrical-power-measurement-server.cpp
@@ -20,9 +20,9 @@
 #include <protocols/interaction_model/StatusCode.h>
 
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/electrical-power-measurement-server/electrical-power-measurement-server.cpp
+++ b/src/app/clusters/electrical-power-measurement-server/electrical-power-measurement-server.cpp
@@ -22,6 +22,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/energy-evse-server/energy-evse-server.cpp
+++ b/src/app/clusters/energy-evse-server/energy-evse-server.cpp
@@ -17,9 +17,9 @@
 #include "energy-evse-server.h"
 
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelEngine.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/energy-evse-server/energy-evse-server.cpp
+++ b/src/app/clusters/energy-evse-server/energy-evse-server.cpp
@@ -19,6 +19,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelEngine.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/energy-preference-server/energy-preference-server.cpp
+++ b/src/app/clusters/energy-preference-server/energy-preference-server.cpp
@@ -17,6 +17,7 @@
 
 #include "energy-preference-server.h"
 
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h> // Needed for registerAttributeAccessOverride
 
 #include <app-common/zap-generated/attributes/Accessors.h>

--- a/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
+++ b/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
@@ -20,9 +20,9 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/Optional.h>
 #include <platform/DiagnosticDataProvider.h>

--- a/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
+++ b/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
@@ -22,6 +22,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/Optional.h>
 #include <platform/DiagnosticDataProvider.h>

--- a/src/app/clusters/fixed-label-server/fixed-label-server.cpp
+++ b/src/app/clusters/fixed-label-server/fixed-label-server.cpp
@@ -24,6 +24,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -23,11 +23,11 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/server/CommissioningWindowManager.h>
 #include <app/server/Server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -27,6 +27,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/server/CommissioningWindowManager.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
+++ b/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
@@ -30,6 +30,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/ScopedBuffer.h>
 #include <platform/ConnectivityManager.h>

--- a/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
+++ b/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
@@ -28,9 +28,9 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/ScopedBuffer.h>
 #include <platform/ConnectivityManager.h>

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -18,10 +18,10 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/MessageDef/StatusIB.h>
 #include <app/server/Server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/att-storage.h>
 #include <app/util/attribute-storage.h>
 #include <credentials/GroupDataProvider.h>

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -21,6 +21,7 @@
 #include <app/CommandHandler.h>
 #include <app/MessageDef/StatusIB.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/att-storage.h>
 #include <app/util/attribute-storage.h>
 #include <credentials/GroupDataProvider.h>

--- a/src/app/clusters/icd-management-server/icd-management-server.cpp
+++ b/src/app/clusters/icd-management-server/icd-management-server.cpp
@@ -23,9 +23,9 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/icd/server/ICDNotifier.h>
 #include <app/server/Server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/icd-management-server/icd-management-server.cpp
+++ b/src/app/clusters/icd-management-server/icd-management-server.cpp
@@ -25,6 +25,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/icd/server/ICDNotifier.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -29,6 +29,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -26,10 +26,10 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-server.cpp
+++ b/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-server.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 

--- a/src/app/clusters/laundry-washer-controls-server/laundry-washer-controls-server.cpp
+++ b/src/app/clusters/laundry-washer-controls-server/laundry-washer-controls-server.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 

--- a/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
+++ b/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
@@ -25,6 +25,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -29,6 +29,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -26,10 +26,10 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -31,6 +31,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -27,11 +27,11 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/messages-server/messages-server.cpp
+++ b/src/app/clusters/messages-server/messages-server.cpp
@@ -24,6 +24,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/messages-server/messages-server.cpp
+++ b/src/app/clusters/messages-server/messages-server.cpp
@@ -20,11 +20,11 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/microwave-oven-control-server/microwave-oven-control-server.cpp
+++ b/src/app/clusters/microwave-oven-control-server/microwave-oven-control-server.cpp
@@ -21,6 +21,7 @@
 #include <app/clusters/microwave-oven-control-server/microwave-oven-control-server.h>
 #include <app/clusters/mode-base-server/mode-base-server.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/ember-compatibility-functions.h>
 

--- a/src/app/clusters/microwave-oven-control-server/microwave-oven-control-server.cpp
+++ b/src/app/clusters/microwave-oven-control-server/microwave-oven-control-server.cpp
@@ -17,11 +17,11 @@
  */
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/microwave-oven-control-server/microwave-oven-control-server.h>
 #include <app/clusters/mode-base-server/mode-base-server.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/ember-compatibility-functions.h>
 

--- a/src/app/clusters/mode-base-server/mode-base-server.cpp
+++ b/src/app/clusters/mode-base-server/mode-base-server.cpp
@@ -22,6 +22,7 @@
 #include <app/clusters/mode-base-server/mode-base-server.h>
 #include <app/clusters/on-off-server/on-off-server.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <platform/DiagnosticDataProvider.h>
 #include <tracing/macros.h>

--- a/src/app/clusters/mode-base-server/mode-base-server.cpp
+++ b/src/app/clusters/mode-base-server/mode-base-server.cpp
@@ -17,12 +17,12 @@
  */
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/InteractionModelEngine.h>
 #include <app/SafeAttributePersistenceProvider.h>
 #include <app/clusters/mode-base-server/mode-base-server.h>
 #include <app/clusters/on-off-server/on-off-server.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <platform/DiagnosticDataProvider.h>
 #include <tracing/macros.h>

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -20,11 +20,11 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/clusters/mode-select-server/supported-modes-manager.h>
 #include <app/util/att-storage.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <app/util/odd-sized-integers.h>

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -24,6 +24,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/clusters/mode-select-server/supported-modes-manager.h>
 #include <app/util/att-storage.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <app/util/odd-sized-integers.h>

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -28,6 +28,7 @@
 #include <app/data-model/Nullable.h>
 #include <app/reporting/reporting.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <credentials/CHIPCert.h>
 #include <lib/core/CHIPConfig.h>

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -22,13 +22,13 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/general-commissioning-server/general-commissioning-server.h>
 #include <app/data-model/Nullable.h>
 #include <app/reporting/reporting.h>
 #include <app/server/Server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <credentials/CHIPCert.h>
 #include <lib/core/CHIPConfig.h>

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -25,6 +25,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
@@ -32,7 +33,6 @@
 #include <app/reporting/reporting.h>
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <credentials/CHIPCert.h>
 #include <credentials/CertificationDeclaration.h>

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -32,6 +32,7 @@
 #include <app/reporting/reporting.h>
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <credentials/CHIPCert.h>
 #include <credentials/CertificationDeclaration.h>

--- a/src/app/clusters/operational-state-server/operational-state-server.cpp
+++ b/src/app/clusters/operational-state-server/operational-state-server.cpp
@@ -22,10 +22,10 @@
 #include "operational-state-server.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/callback.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/EventLogging.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/operational-state-server/operational-state-server.cpp
+++ b/src/app/clusters/operational-state-server/operational-state-server.cpp
@@ -25,6 +25,7 @@
 #include <app/EventLogging.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/ota-requestor/ota-requestor-server.cpp
+++ b/src/app/clusters/ota-requestor/ota-requestor-server.cpp
@@ -21,11 +21,11 @@
  */
 
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/EventLogging.h>
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 #include <app/clusters/ota-requestor/ota-requestor-server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <protocols/interaction_model/StatusCode.h>
 

--- a/src/app/clusters/ota-requestor/ota-requestor-server.cpp
+++ b/src/app/clusters/ota-requestor/ota-requestor-server.cpp
@@ -25,6 +25,7 @@
 #include <app/EventLogging.h>
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 #include <app/clusters/ota-requestor/ota-requestor-server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <protocols/interaction_model/StatusCode.h>
 

--- a/src/app/clusters/power-source-configuration-server/power-source-configuration-server.cpp
+++ b/src/app/clusters/power-source-configuration-server/power-source-configuration-server.cpp
@@ -25,6 +25,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/power-source-server/power-source-server.cpp
+++ b/src/app/clusters/power-source-server/power-source-server.cpp
@@ -23,6 +23,7 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <lib/support/CodeUtils.h>

--- a/src/app/clusters/power-topology-server/power-topology-server.cpp
+++ b/src/app/clusters/power-topology-server/power-topology-server.cpp
@@ -20,9 +20,9 @@
 #include <protocols/interaction_model/StatusCode.h>
 
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/power-topology-server/power-topology-server.cpp
+++ b/src/app/clusters/power-topology-server/power-topology-server.cpp
@@ -22,6 +22,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/EventLogging.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/resource-monitoring-server/resource-monitoring-server.cpp
+++ b/src/app/clusters/resource-monitoring-server/resource-monitoring-server.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/ConcreteClusterPath.h>
@@ -26,7 +27,6 @@
 #include <app/clusters/resource-monitoring-server/resource-monitoring-server.h>
 #include <app/data-model/Nullable.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>

--- a/src/app/clusters/resource-monitoring-server/resource-monitoring-server.cpp
+++ b/src/app/clusters/resource-monitoring-server/resource-monitoring-server.cpp
@@ -26,6 +26,7 @@
 #include <app/clusters/resource-monitoring-server/resource-monitoring-server.h>
 #include <app/data-model/Nullable.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>

--- a/src/app/clusters/sample-mei-server/sample-mei-server.cpp
+++ b/src/app/clusters/sample-mei-server/sample-mei-server.cpp
@@ -9,6 +9,7 @@
 #include <app/EventLogging.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <app/util/util.h>

--- a/src/app/clusters/sample-mei-server/sample-mei-server.cpp
+++ b/src/app/clusters/sample-mei-server/sample-mei-server.cpp
@@ -4,12 +4,12 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Commands.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <app/util/util.h>

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -24,6 +24,7 @@
 #include <app/clusters/scenes-server/SceneTableImpl.h>
 #include <app/reporting/reporting.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <credentials/GroupDataProvider.h>

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -19,12 +19,12 @@
 #include "scenes-server.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/scenes-server/SceneTableImpl.h>
 #include <app/reporting/reporting.h>
 #include <app/server/Server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <credentials/GroupDataProvider.h>

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
@@ -21,12 +21,12 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/InteractionModelEngine.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/Optional.h>
 #include <platform/DiagnosticDataProvider.h>

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
@@ -26,6 +26,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/InteractionModelEngine.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/Optional.h>
 #include <platform/DiagnosticDataProvider.h>

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -26,11 +26,11 @@
 #include <app/clusters/target-navigator-server/target-navigator-server.h>
 
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -30,6 +30,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/temperature-control-server/temperature-control-server.cpp
+++ b/src/app/clusters/temperature-control-server/temperature-control-server.cpp
@@ -18,9 +18,9 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/temperature-control-server/supported-temperature-levels-manager.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/temperature-control-server/temperature-control-server.cpp
+++ b/src/app/clusters/temperature-control-server/temperature-control-server.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/temperature-control-server/supported-temperature-levels-manager.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -28,6 +28,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/core/TLV.h>

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -24,11 +24,11 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Commands.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/server/Server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/core/TLV.h>

--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 #include <app-common/zap-generated/attributes/Accessors.h>

--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
@@ -20,10 +20,10 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/core/Optional.h>

--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
@@ -23,6 +23,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/core/Optional.h>

--- a/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
+++ b/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
@@ -26,6 +26,7 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -27,6 +27,7 @@
 #include <app/CommandHandler.h>
 #include <app/EventLogging.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -24,10 +24,10 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/EventLogging.h>
 #include <app/server/Server.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -24,8 +24,8 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
-#include <app/server/Server.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
+#include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 #include <credentials/FabricTable.h>
 #include <lib/support/CodeUtils.h>

--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -25,6 +25,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/server/Server.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <credentials/FabricTable.h>
 #include <lib/support/CodeUtils.h>

--- a/src/app/clusters/valve-configuration-and-control-server/valve-configuration-and-control-server.cpp
+++ b/src/app/clusters/valve-configuration-and-control-server/valve-configuration-and-control-server.cpp
@@ -31,12 +31,12 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
 #include <app/reporting/reporting.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/valve-configuration-and-control-server/valve-configuration-and-control-server.cpp
+++ b/src/app/clusters/valve-configuration-and-control-server/valve-configuration-and-control-server.cpp
@@ -36,6 +36,7 @@
 #include <app/EventLogging.h>
 #include <app/data-model/Encode.h>
 #include <app/reporting/reporting.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
+++ b/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
@@ -26,10 +26,10 @@
 #include <app/clusters/wake-on-lan-server/wake-on-lan-server.h>
 
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
+++ b/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
@@ -29,6 +29,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
@@ -20,10 +20,10 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/Optional.h>
 #include <platform/DiagnosticDataProvider.h>

--- a/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
@@ -23,6 +23,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/Optional.h>
 #include <platform/DiagnosticDataProvider.h>

--- a/src/app/dynamic_server/DynamicDispatcher.cpp
+++ b/src/app/dynamic_server/DynamicDispatcher.cpp
@@ -23,7 +23,6 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app-common/zap-generated/ids/Commands.h>
-#include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/ConcreteCommandPath.h>

--- a/src/app/dynamic_server/DynamicDispatcher.cpp
+++ b/src/app/dynamic_server/DynamicDispatcher.cpp
@@ -189,13 +189,6 @@ CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, 
     return aWriteHandler->AddStatus(aPath, status);
 }
 
-// No attribute access overrides on iOS and Android for now.
-// TODO (#16806): This function can be moved to InteractionModelEngine.
-AttributeAccessInterface * GetAttributeAccessOverride(EndpointId endpointId, ClusterId clusterId)
-{
-    return nullptr;
-}
-
 void DispatchSingleClusterCommand(const ConcreteCommandPath & aPath, TLV::TLVReader & aReader, CommandHandler * aCommandObj)
 {
     // This command passed ServerClusterCommandExists so we know it's one of our

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -26,7 +26,6 @@
 #include <platform/ConnectivityManager.h>
 #include <platform/LockTracker.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <stdlib.h>
 
 namespace {
 enum class ICDTestEventTriggerEvent : uint64_t

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -19,6 +19,7 @@
 #include <app/icd/server/ICDServerConfig.h>
 
 #include <app-common/zap-generated/cluster-enums.h>
+#include <app/AppConfig.h>
 #include <app/SubscriptionsInfoProvider.h>
 #include <app/TestEventTriggerDelegate.h>
 #include <app/icd/server/ICDConfigurationData.h>
@@ -26,7 +27,6 @@
 #include <app/icd/server/ICDStateObserver.h>
 #include <credentials/FabricTable.h>
 #include <crypto/SessionKeystore.h>
-#include <functional>
 #include <lib/support/BitFlags.h>
 #include <messaging/ExchangeMgr.h>
 #include <platform/CHIPDeviceConfig.h>

--- a/src/app/util/IMClusterCommandHandler.h
+++ b/src/app/util/IMClusterCommandHandler.h
@@ -1,0 +1,38 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/CommandHandler.h>
+#include <app/ConcreteCommandPath.h>
+#include <lib/core/TLVReader.h>
+
+namespace chip {
+namespace app {
+
+/**
+ * Dispatch is generally implemented in code-generated code in ember within
+ * IMClusterCommandHandler.cpp
+ *
+ * aCommandPath - the path that is invoked
+ * aReader      - the input TLV data for this command
+ * apCommandObj - how to send back the reply
+ */
+void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,
+                                  CommandHandler * apCommandObj);
+
+} // namespace app
+} // namespace chip

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -24,7 +24,6 @@
  */
 
 #include <stdbool.h> // For bool
-#include <stddef.h>  // For NULL.
 #include <stdint.h>  // For various uint*_t types
 
 #include <app/util/basic-types.h>

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -19,8 +19,8 @@
 
 #include <app/util/attribute-storage-detail.h>
 
-#include <app/AttributeAccessInterfaceCache.h>
 #include <app/AttributePersistenceProvider.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/reporting.h>
 #include <app/util/config.h>
@@ -139,43 +139,6 @@ constexpr const EmberAfDeviceType fixedDeviceTypeList[]             = FIXED_DEVI
 // Not const, because these need to mutate.
 DataVersion fixedEndpointDataVersions[ZAP_FIXED_ENDPOINT_DATA_VERSION_COUNT];
 #endif // FIXED_ENDPOINT_COUNT > 0
-
-AttributeAccessInterface * gAttributeAccessOverrides = nullptr;
-AttributeAccessInterfaceCache gAttributeAccessInterfaceCache;
-
-// shouldUnregister returns true if the given AttributeAccessInterface should be
-// unregistered.
-template <typename F>
-void UnregisterMatchingAttributeAccessInterfaces(F shouldUnregister)
-{
-    AttributeAccessInterface * prev = nullptr;
-    AttributeAccessInterface * cur  = gAttributeAccessOverrides;
-    while (cur)
-    {
-        AttributeAccessInterface * next = cur->GetNext();
-        if (shouldUnregister(cur))
-        {
-            // Remove it from the list
-            if (prev)
-            {
-                prev->SetNext(next);
-            }
-            else
-            {
-                gAttributeAccessOverrides = next;
-            }
-
-            cur->SetNext(nullptr);
-
-            // Do not change prev in this case.
-        }
-        else
-        {
-            prev = cur;
-        }
-        cur = next;
-    }
-}
 
 bool emberAfIsThisDataTypeAListType(EmberAfAttributeType dataType)
 {
@@ -462,10 +425,8 @@ static void shutdownEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
     // endpoint.
     chip::app::InteractionModelEngine::GetInstance()->UnregisterCommandHandlers(definedEndpoint->endpoint);
 
-    // Clear out any attribute access overrides registered for this
-    // endpoint.
-    UnregisterMatchingAttributeAccessInterfaces(
-        [endpoint = definedEndpoint->endpoint](AttributeAccessInterface * entry) { return entry->MatchesEndpoint(endpoint); });
+
+    unregisterAttributeAccessOverrideForEndpoint(definedEndpoint);
 }
 
 // Calls the init functions.
@@ -1382,61 +1343,8 @@ EmberAfGenericClusterFunction emberAfFindClusterFunction(const EmberAfCluster * 
     return cluster->functions[functionIndex];
 }
 
-bool registerAttributeAccessOverride(AttributeAccessInterface * attrOverride)
-{
-    gAttributeAccessInterfaceCache.Invalidate();
-    for (auto * cur = gAttributeAccessOverrides; cur; cur = cur->GetNext())
-    {
-        if (cur->Matches(*attrOverride))
-        {
-            ChipLogError(Zcl, "Duplicate attribute override registration failed");
-            return false;
-        }
-    }
-    attrOverride->SetNext(gAttributeAccessOverrides);
-    gAttributeAccessOverrides = attrOverride;
-    return true;
-}
-
-void unregisterAttributeAccessOverride(AttributeAccessInterface * attrOverride)
-{
-    gAttributeAccessInterfaceCache.Invalidate();
-    UnregisterMatchingAttributeAccessInterfaces([attrOverride](AttributeAccessInterface * entry) { return entry == attrOverride; });
-}
-
 namespace chip {
 namespace app {
-
-app::AttributeAccessInterface * GetAttributeAccessOverride(EndpointId endpointId, ClusterId clusterId)
-{
-    using CacheResult = AttributeAccessInterfaceCache::CacheResult;
-
-    AttributeAccessInterface * cached = nullptr;
-    CacheResult result                = gAttributeAccessInterfaceCache.Get(endpointId, clusterId, &cached);
-    switch (result)
-    {
-    case CacheResult::kDefinitelyUnused:
-        return nullptr;
-    case CacheResult::kDefinitelyUsed:
-        return cached;
-    case CacheResult::kCacheMiss:
-    default:
-        // Did not cache yet, search set of AAI registered, and cache if found.
-        for (app::AttributeAccessInterface * cur = gAttributeAccessOverrides; cur; cur = cur->GetNext())
-        {
-            if (cur->Matches(endpointId, clusterId))
-            {
-                gAttributeAccessInterfaceCache.MarkUsed(endpointId, clusterId, cur);
-                return cur;
-            }
-        }
-
-        // Did not find AAI registered: mark as definitely not using.
-        gAttributeAccessInterfaceCache.MarkUnused(endpointId, clusterId);
-    }
-
-    return nullptr;
-}
 
 CHIP_ERROR SetParentEndpointForEndpoint(EndpointId childEndpoint, EndpointId parentEndpoint)
 {

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -19,8 +19,8 @@
 
 #include <app/util/attribute-storage-detail.h>
 
-#include <app/AttributePersistenceProvider.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
+#include <app/AttributePersistenceProvider.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/reporting.h>
 #include <app/util/config.h>
@@ -424,7 +424,6 @@ static void shutdownEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
     // Clear out any command handler overrides registered for this
     // endpoint.
     chip::app::InteractionModelEngine::GetInstance()->UnregisterCommandHandlers(definedEndpoint->endpoint);
-
 
     unregisterAttributeAccessOverrideForEndpoint(definedEndpoint);
 }

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -425,7 +425,7 @@ static void shutdownEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
     // endpoint.
     chip::app::InteractionModelEngine::GetInstance()->UnregisterCommandHandlers(definedEndpoint->endpoint);
 
-    unregisterAttributeAccessOverrideForEndpoint(definedEndpoint);
+    unregisterAllAttributeAccessOverridesForEndpoint(definedEndpoint);
 }
 
 // Calls the init functions.

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -343,12 +343,5 @@ bool IsFlatCompositionForEndpoint(EndpointId endpoint);
  */
 bool IsTreeCompositionForEndpoint(EndpointId endpoint);
 
-/**
- *  Get the registered attribute access override. nullptr when attribute access override is not found.
- *
- * TODO(#16806): This function and registerAttributeAccessOverride can be member functions of InteractionModelEngine.
- */
-AttributeAccessInterface * GetAttributeAccessOverride(EndpointId aEndpointId, ClusterId aClusterId);
-
 } // namespace app
 } // namespace chip

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -362,5 +362,12 @@ bool IsFlatCompositionForEndpoint(EndpointId endpoint);
  */
 bool IsTreeCompositionForEndpoint(EndpointId endpoint);
 
+/**
+ *  Get the registered attribute access override. nullptr when attribute access override is not found.
+ *
+ * TODO(#16806): This function and registerAttributeAccessOverride can be member functions of InteractionModelEngine.
+ */
+AttributeAccessInterface * GetAttributeAccessOverride(EndpointId aEndpointId, ClusterId aClusterId);
+
 } // namespace app
 } // namespace chip

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -184,25 +184,6 @@ chip::DataVersion * emberAfDataVersionStorage(const chip::app::ConcreteClusterPa
 uint16_t emberAfFixedEndpointCount();
 
 /**
- * Register an attribute access override.  It will remain registered until the
- * endpoint it's registered for is disabled (or until shutdown if it's
- * registered for all endpoints) or until it is explicitly unregistered.
- * Registration will fail if there is an already-registered override for the
- * same set of attributes.
- *
- * @return false if there is an existing override that the new one would
- *               conflict with.  In this case the override is not registered.
- * @return true if registration was successful.
- */
-bool registerAttributeAccessOverride(chip::app::AttributeAccessInterface * attrOverride);
-
-/**
- * Unregister an attribute access override (for example if the object
- * implementing AttributeAccessInterface is being destroyed).
- */
-void unregisterAttributeAccessOverride(chip::app::AttributeAccessInterface * attrOverride);
-
-/**
  * Get the semantic tags of the endpoint.
  * Fills in the provided SemanticTagStruct with tag at index `index` if there is one,
  * or returns CHIP_ERROR_NOT_FOUND if the index is out of range for the list of tag,

--- a/src/app/util/ember-compatibility-functions.h
+++ b/src/app/util/ember-compatibility-functions.h
@@ -17,6 +17,7 @@
 
 #include <access/SubjectDescriptor.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/ConcreteEventPath.h>

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -267,11 +267,6 @@ DataVersion * emberAfDataVersionStorage(const chip::app::ConcreteClusterPath & a
 namespace chip {
 namespace app {
 
-AttributeAccessInterface * GetAttributeAccessOverride(EndpointId aEndpointId, ClusterId aClusterId)
-{
-    return nullptr;
-}
-
 EndpointId EnabledEndpointsWithServerCluster::operator*() const
 {
     return emberAfEndpointFromIndex(mEndpointIndex);

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -31,6 +31,7 @@
 #include <app/data-model/Decode.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/DataModelHandler.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <controller/InvokeInteraction.h>
 #include <lib/core/CHIPCore.h>

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -23,6 +23,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AppConfig.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/EventLogging.h>
@@ -31,7 +32,6 @@
 #include <app/data-model/Decode.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/DataModelHandler.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <controller/InvokeInteraction.h>
 #include <lib/core/CHIPCore.h>

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -23,6 +23,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AppConfig.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/GlobalAttributes.h>
@@ -30,7 +31,6 @@
 #include <app/data-model/Decode.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/DataModelHandler.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <controller/InvokeInteraction.h>

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -30,6 +30,7 @@
 #include <app/data-model/Decode.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/DataModelHandler.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
 #include <controller/InvokeInteraction.h>

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -23,13 +23,13 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AppConfig.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/InteractionModelEngine.h>
 #include <app/WriteClient.h>
 #include <app/data-model/Decode.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/DataModelHandler.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <controller/InvokeInteraction.h>
 #include <lib/core/ErrorStr.h>

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -29,6 +29,7 @@
 #include <app/data-model/Decode.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/DataModelHandler.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <controller/InvokeInteraction.h>
 #include <lib/core/ErrorStr.h>

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.mm
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.mm
@@ -37,6 +37,7 @@
 
 // TODO: These attribute-*.h bits are a hack that should eventually go away.
 #include <app/util/attribute-metadata.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.mm
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.mm
@@ -35,7 +35,7 @@
 #include <lib/support/SafeInt.h>
 #include <protocols/interaction_model/StatusCode.h>
 
-// TODO: These attribute-*.h bits are a hack that should eventually go away.
+// TODO: These attribute-*.h and AttributeAccessInterfaceRegistry.h bits are a hack that should eventually go away.
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-metadata.h>
 #include <app/util/attribute-storage.h>

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.mm
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerCluster.mm
@@ -36,8 +36,8 @@
 #include <protocols/interaction_model/StatusCode.h>
 
 // TODO: These attribute-*.h bits are a hack that should eventually go away.
-#include <app/util/attribute-metadata.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
+#include <app/util/attribute-metadata.h>
 #include <app/util/attribute-storage.h>
 
 using namespace chip;

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -24,7 +24,6 @@
 #pragma once
 #include <memory>
 
-#include <app/AttributeAccessInterface.h>
 #include <app/icd/server/ICDServerConfig.h>
 #include <inet/UDPEndPoint.h>
 #include <lib/support/CodeUtils.h>

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -25,7 +25,6 @@
 
 #include <app/icd/server/ICDServerConfig.h>
 
-#include <app/AttributeAccessInterface.h>
 #include <app/util/basic-types.h>
 #include <inet/IPAddress.h>
 #include <lib/support/Span.h>

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
@@ -24,7 +24,6 @@
 
 #pragma once
 #include <app-common/zap-generated/ids/Attributes.h>
-#include <app/AttributeAccessInterface.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_Thread.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include <app/AttributeAccessInterface.h>
 #include <app/icd/server/ICDServerConfig.h>
 #include <lib/support/BitFlags.h>
 #include <platform/ThreadStackManager.h>

--- a/src/platform/ASR/ConnectivityManagerImpl.cpp
+++ b/src/platform/ASR/ConnectivityManagerImpl.cpp
@@ -52,7 +52,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -55,7 +55,6 @@
 
 using namespace ::chip;
 using namespace ::chip::Inet;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/Beken/ConnectivityManagerImpl.cpp
+++ b/src/platform/Beken/ConnectivityManagerImpl.cpp
@@ -55,7 +55,6 @@
 
 using namespace ::chip;
 using namespace ::chip::Inet;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/Darwin/ConnectivityManagerImpl.cpp
+++ b/src/platform/Darwin/ConnectivityManagerImpl.cpp
@@ -21,8 +21,6 @@
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/BLEManager.h>
 
-#include <new>
-
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -51,7 +49,6 @@
 #endif // TARGET_OS_OSX
 
 using namespace ::chip;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -30,6 +30,8 @@
 
 #include "sdkconfig.h"
 
+#include <lib/core/Optional.h>
+
 #if CONFIG_BT_BLUEDROID_ENABLED
 
 #include "esp_bt.h"

--- a/src/platform/ESP32/ConnectivityManagerImpl.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl.cpp
@@ -47,7 +47,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using namespace ::chip::app::Clusters::GeneralDiagnostics;
 
 namespace chip {

--- a/src/platform/ESP32/ConnectivityManagerImpl_Ethernet.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_Ethernet.cpp
@@ -43,7 +43,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using chip::DeviceLayer::Internal::ESP32Utils;
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -46,7 +46,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using chip::DeviceLayer::Internal::ESP32Utils;
 
 namespace chip {

--- a/src/platform/ESP32/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/ESP32/KeyValueStoreManagerImpl.cpp
@@ -24,12 +24,12 @@
 #include <platform/ESP32/ScopedNvsHandle.h>
 #include <platform/KeyValueStoreManager.h>
 
-#include <algorithm>
 #include <string.h>
 
 #include "nvs.h"
 #include "nvs_flash.h"
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/CodeUtils.h>
 

--- a/src/platform/Infineon/PSOC6/ConnectivityManagerImpl.cpp
+++ b/src/platform/Infineon/PSOC6/ConnectivityManagerImpl.cpp
@@ -55,7 +55,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -67,7 +67,6 @@
 #endif
 
 using namespace ::chip;
-using namespace ::chip::TLV;
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Internal;

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -18,7 +18,6 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 
-#include <app/AttributeAccessInterface.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/GLibTypeDeleter.h>

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -20,7 +20,6 @@
 #include <memory>
 #include <vector>
 
-#include <app/AttributeAccessInterface.h>
 #include <app/icd/server/ICDServerConfig.h>
 #include <lib/support/ThreadOperationalDataset.h>
 #include <platform/GLibTypeDeleter.h>

--- a/src/platform/Tizen/ConnectivityManagerImpl.h
+++ b/src/platform/Tizen/ConnectivityManagerImpl.h
@@ -28,6 +28,8 @@
 #include <system/SystemClock.h>
 #include <system/SystemLayer.h>
 
+#include <app-common/zap-generated/cluster-enums.h>
+
 #include "platform/internal/GenericConnectivityManagerImpl.h"
 #include "platform/internal/GenericConnectivityManagerImpl_UDP.h"
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT

--- a/src/platform/Tizen/DiagnosticDataProviderImpl.h
+++ b/src/platform/Tizen/DiagnosticDataProviderImpl.h
@@ -24,6 +24,8 @@
 
 #include <platform/DiagnosticDataProvider.h>
 
+#include <app-common/zap-generated/cluster-enums.h>
+
 namespace chip {
 namespace DeviceLayer {
 

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -39,7 +39,6 @@
 #include <thread.h>
 #include <tizen_error.h>
 
-#include <app/AttributeAccessInterface.h>
 #include <inet/IPAddress.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>

--- a/src/platform/Tizen/ThreadStackManagerImpl.h
+++ b/src/platform/Tizen/ThreadStackManagerImpl.h
@@ -28,7 +28,6 @@
 
 #include <thread.h>
 
-#include <app/AttributeAccessInterface.h>
 #include <inet/IPAddress.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>

--- a/src/platform/Zephyr/ConnectivityManagerImpl.cpp
+++ b/src/platform/Zephyr/ConnectivityManagerImpl.cpp
@@ -38,7 +38,6 @@
 #endif
 
 using namespace ::chip;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/Zephyr/wifi/ConnectivityManagerImplWiFi.cpp
+++ b/src/platform/Zephyr/wifi/ConnectivityManagerImplWiFi.cpp
@@ -29,7 +29,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/android/ConnectivityManagerImpl.cpp
+++ b/src/platform/android/ConnectivityManagerImpl.cpp
@@ -46,7 +46,6 @@
 #endif
 
 using namespace ::chip;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/bouffalolab/common/BLEManagerImpl.h
+++ b/src/platform/bouffalolab/common/BLEManagerImpl.h
@@ -14,10 +14,13 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 #pragma once
 
+#include <platform/CHIPDeviceConfig.h>
+
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+
+#include <ble/BleLayer.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>

--- a/src/platform/bouffalolab/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/bouffalolab/common/ConnectivityManagerImpl.cpp
@@ -53,7 +53,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/cc13xx_26xx/ConnectivityManagerImpl.cpp
+++ b/src/platform/cc13xx_26xx/ConnectivityManagerImpl.cpp
@@ -49,7 +49,6 @@
 #include <lwip/netif.h>
 
 using namespace ::chip;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/cc32xx/ConnectivityManagerImpl.cpp
+++ b/src/platform/cc32xx/ConnectivityManagerImpl.cpp
@@ -62,7 +62,6 @@ extern void SlNetConnEventHandler(uint32_t ifID, SlNetConnStatus_e netStatus, vo
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 
 extern "C" void cc32xxLog(const char * aFormat, ...);
 static struct netif * m_pNetIf = NULL;

--- a/src/platform/mbed/BLEManagerImpl.h
+++ b/src/platform/mbed/BLEManagerImpl.h
@@ -23,7 +23,11 @@
 
 #pragma once
 
+#include <platform/CHIPDeviceConfig.h>
+
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+
+#include <ble/BleLayer.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/mt793x/ConnectivityManagerImpl.cpp
+++ b/src/platform/mt793x/ConnectivityManagerImpl.cpp
@@ -49,7 +49,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/mt793x/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/mt793x/ConnectivityManagerImpl_WIFI.cpp
@@ -41,7 +41,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
+++ b/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
@@ -29,7 +29,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -67,7 +67,6 @@ extern "C" {
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 using namespace ::chip::DeviceLayer::DeviceEventType;
 

--- a/src/platform/nxp/k32w/k32w0/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConnectivityManagerImpl.cpp
@@ -48,7 +48,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/nxp/k32w/k32w1/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w1/ConnectivityManagerImpl.cpp
@@ -48,7 +48,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/nxp/mw320/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/mw320/ConnectivityManagerImpl.cpp
@@ -57,7 +57,6 @@ static struct wlan_network sta_network;
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 using namespace ::chip::app::Clusters::GeneralDiagnostics;
 using namespace ::chip::app::Clusters::WiFiNetworkDiagnostics;

--- a/src/platform/nxp/zephyr/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/zephyr/ConnectivityManagerImpl.cpp
@@ -38,7 +38,6 @@
 #endif
 
 using namespace ::chip;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/qpg/ConnectivityManagerImpl.cpp
+++ b/src/platform/qpg/ConnectivityManagerImpl.cpp
@@ -37,7 +37,6 @@
 #include <platform/internal/BLEManager.h>
 
 using namespace ::chip;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -45,7 +45,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/silabs/efr32/ConnectivityManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ConnectivityManagerImpl.cpp
@@ -40,7 +40,6 @@
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/stm32/ConnectivityManagerImpl.cpp
+++ b/src/platform/stm32/ConnectivityManagerImpl.cpp
@@ -37,7 +37,6 @@
 #include <platform/internal/BLEManager.h>
 
 using namespace ::chip;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/telink/ConnectivityManagerImpl.cpp
+++ b/src/platform/telink/ConnectivityManagerImpl.cpp
@@ -38,7 +38,6 @@
 #endif
 
 using namespace ::chip;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -65,7 +65,6 @@
 #endif
 
 using namespace ::chip;
-using namespace ::chip::TLV;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Internal;
 using namespace ::chip::app::Clusters::GeneralDiagnostics;

--- a/src/platform/webos/ThreadStackManagerImpl.cpp
+++ b/src/platform/webos/ThreadStackManagerImpl.cpp
@@ -18,7 +18,6 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 
-#include <app/AttributeAccessInterface.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/PlatformManager.h>

--- a/src/platform/webos/ThreadStackManagerImpl.h
+++ b/src/platform/webos/ThreadStackManagerImpl.h
@@ -20,7 +20,6 @@
 #include <memory>
 #include <vector>
 
-#include <app/AttributeAccessInterface.h>
 #include <lib/support/ThreadOperationalDataset.h>
 #include <platform/GLibTypeDeleter.h>
 #include <platform/NetworkCommissioning.h>


### PR DESCRIPTION
AttributeAccessInterface is very stand-alone and has no reason to be tied to ember directly (as its use is mostly inside the compatibility functions as a hook and the only callbacks ember needs is a cleanup).

### Changes

- create `AttributeAccessInterfaceRegistry.h/cpp`  to contain the old functions that existed in `attribute-storage.cpp`.
  - as a sideffect, mocks do not need to return nullptr for all attribute access interfaces
  - as a sideffect, dynamic server would in theory also support attributeaccessinterface
- moved the declaration of the `DispatchSingleClusterCommand` method into its own `src/app/util/IMClusterCommandHandler.h` to represent that we generate this code into `IMClusterCommandHandler.cpp`
- removed invalid/unused platform includes: it turns out platform code was including `attributeaccessinterface` but not using it ... and as a sideffect this made a `using chip::TLV` needing removal (that was also there due to copy and paste, but no TLV is used in platform)
- Fixed a few other platform includes that we transitively assumed due to AttributeAccessInterface (added some safecasts and cluster-enums includes).