### PR TITLE
Darwin: MTRDeviceControllerFactory cleanup

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -551,7 +551,7 @@ using namespace chip::Tracing::DarwinFramework;
         }
 
         errorCode = chip::Credentials::SetSingleIpkEpochKey(
-            _factory.groupData, fabricIdx, _operationalCredentialsDelegate->GetIPK(), compressedId);
+            _factory.groupDataProvider, fabricIdx, _operationalCredentialsDelegate->GetIPK(), compressedId);
         if ([self checkForStartError:errorCode logMsg:kErrorIPKInit]) {
             return;
         }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -118,35 +118,35 @@ MTR_DIRECT_MEMBERS
 
     BOOL _advertiseOperational;
 
-// Lock used to serialize access to the "controllers" array and the
-// "_controllerBeingStarted" and "_controllerBeingShutDown" ivars, since those
-// need to be touched from both whatever queue is starting controllers and from
-// the Matter queue.  The way this lock is used assumes that:
-//
-// 1) The only mutating accesses to the controllers array and the ivars happen
-//    when the current queue is not the Matter queue or in a block that was
-//    sync-dispatched to the Matter queue.  This is a good assumption, because
-//    the implementations of the functions that mutate these do sync dispatch to
-//    the Matter queue, which would deadlock if they were called when that queue
-//    was the current queue.
-//
-// 2) It's our API consumer's responsibility to serialize access to us from
-//    outside.
-//
-// These assumptions mean that if we are in a block that was sync-dispatched to
-// the Matter queue, that block cannot race with either the Matter queue nor the
-// non-Matter queue.  Similarly, if we are in a situation where the Matter queue
-// has been shut down, any accesses to the variables cannot race anything else.
-//
-// This means that:
-//
-// A. In a sync-dispatched block, or if the Matter queue has been shut down, we
-//    do not need to lock and can do read or write access.
-// B. Apart from item A, mutations of the array and ivars must happen outside the
-//    Matter queue and must lock.
-// C. Apart from item A, accesses on the Matter queue must be reads only and
-//    must lock.
-// D. Locking around reads not from the Matter queue is OK but not required.
+    // Lock used to serialize access to the "controllers" array and the
+    // "_controllerBeingStarted" and "_controllerBeingShutDown" ivars, since those
+    // need to be touched from both whatever queue is starting controllers and from
+    // the Matter queue.  The way this lock is used assumes that:
+    //
+    // 1) The only mutating accesses to the controllers array and the ivars happen
+    //    when the current queue is not the Matter queue or in a block that was
+    //    sync-dispatched to the Matter queue.  This is a good assumption, because
+    //    the implementations of the functions that mutate these do sync dispatch to
+    //    the Matter queue, which would deadlock if they were called when that queue
+    //    was the current queue.
+    //
+    // 2) It's our API consumer's responsibility to serialize access to us from
+    //    outside.
+    //
+    // These assumptions mean that if we are in a block that was sync-dispatched to
+    // the Matter queue, that block cannot race with either the Matter queue nor the
+    // non-Matter queue.  Similarly, if we are in a situation where the Matter queue
+    // has been shut down, any accesses to the variables cannot race anything else.
+    //
+    // This means that:
+    //
+    // A. In a sync-dispatched block, or if the Matter queue has been shut down, we
+    //    do not need to lock and can do read or write access.
+    // B. Apart from item A, mutations of the array and ivars must happen outside the
+    //    Matter queue and must lock.
+    // C. Apart from item A, accesses on the Matter queue must be reads only and
+    //    must lock.
+    // D. Locking around reads not from the Matter queue is OK but not required.
     os_unfair_lock _controllersLock;
     NSMutableArray<MTRDeviceController *> * _controllers;
     MTRDeviceController * _controllerBeingStarted;
@@ -206,7 +206,7 @@ MTR_DIRECT_MEMBERS
     _groupDataProvider.SetSessionKeystore(&_sessionKeystore);
     CHIP_ERROR err = _groupDataProvider.Init();
     VerifyOrDieWithMsg(err == CHIP_NO_ERROR, NotSpecified,
-                       "GroupDataProviderImpl::Init() failed: %" CHIP_ERROR_FORMAT, err.Format());
+        "GroupDataProviderImpl::Init() failed: %" CHIP_ERROR_FORMAT, err.Format());
 
     _controllersLock = OS_UNFAIR_LOCK_INIT;
     _controllers = [[NSMutableArray alloc] init];

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
@@ -28,8 +28,8 @@
 #import <Matter/MTRDiagnosticLogsType.h>
 #import <Matter/MTRServerEndpoint.h>
 
-#import "MTRDeviceControllerFactory.h"
 #import "MTRDefines_Internal.h"
+#import "MTRDeviceControllerFactory.h"
 
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/DataModelTypes.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
@@ -106,6 +106,25 @@ MTR_DIRECT_MEMBERS
  */
 - (void)removeServerEndpoint:(MTRServerEndpoint *)endpoint;
 
+@property (readonly) chip::PersistentStorageDelegate * storageDelegate;
+@property (readonly) chip::Credentials::GroupDataProvider * groupDataProvider;
+
+@end
+
+MTR_DIRECT_MEMBERS
+@interface MTRDeviceControllerFactoryParams ()
+/*
+ * Initialize the device controller factory without storage.  In this mode,
+ * device controllers will need to have per-controller storage provided to allow
+ * storing controller-specific information.
+ */
+- (instancetype)initWithoutStorage;
+@end
+
+// Methods accessed from MTRServerAccessControl linked into darwin-framework-tool
+// TODO: https://github.com/project-chip/connectedhomeip/issues/32991
+@interface MTRDeviceControllerFactory ()
+
 /**
  * Get the access grants that apply for the given fabric index and cluster path.
  *
@@ -125,18 +144,6 @@ MTR_DIRECT_MEMBERS
  */
 - (nullable NSNumber *)neededReadPrivilegeForClusterID:(NSNumber *)clusterID attributeID:(NSNumber *)attributeID;
 
-@property (readonly) chip::PersistentStorageDelegate * storageDelegate;
-@property (readonly) chip::Credentials::GroupDataProvider * groupDataProvider;
-
-@end
-
-@interface MTRDeviceControllerFactoryParams ()
-/*
- * Initialize the device controller factory without storage.  In this mode,
- * device controllers will need to have per-controller storage provided to allow
- * storing controller-specific information.
- */
-- (instancetype)initWithoutStorage;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
@@ -126,7 +126,7 @@ MTR_DIRECT_MEMBERS
 - (nullable NSNumber *)neededReadPrivilegeForClusterID:(NSNumber *)clusterID attributeID:(NSNumber *)attributeID;
 
 @property (readonly) chip::PersistentStorageDelegate * storageDelegate;
-@property (readonly) chip::Credentials::GroupDataProvider * groupData;
+@property (readonly) chip::Credentials::GroupDataProvider * groupDataProvider;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
@@ -29,6 +29,7 @@
 #import <Matter/MTRServerEndpoint.h>
 
 #import "MTRDeviceControllerFactory.h"
+#import "MTRDefines_Internal.h"
 
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/DataModelTypes.h>
@@ -44,7 +45,8 @@ namespace Credentials {
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MTRDeviceControllerFactory (InternalMethods)
+MTR_DIRECT_MEMBERS
+@interface MTRDeviceControllerFactory ()
 
 - (void)controllerShuttingDown:(MTRDeviceController *)controller;
 


### PR DESCRIPTION
Internal methods don't need a named category
Use ivars directly (most internal properties were never used as properties)
Use MTR_DIRECT_MEMBERS for internals / implementation
No need to pre-declare internal methods used only with the same file

Reorder ivars a little to group related things

Allocate C++ objects that are created at init time directly as ivars instead of
as pointers. This avoids the need for manual cleanup code