### PR TITLE
DGWIFI_2_1 Beacon Rx count for linux platform

### DIFF
--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -761,9 +761,11 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiOverrunCount(uint64_t & overrunCou
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconRxCount(uint32_t & beaconRxCount)
 {
-    beaconRxCount = mBeaconRxCount;
-
-    return CHIP_NO_ERROR;
+    if(DeviceLayer::ConnectivityMgrImpl().IsWiFiManagementStarted()){
+        beaconRxCount = mBeaconRxCount;
+        return CHIP_NO_ERROR;
+    }
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -761,7 +761,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiOverrunCount(uint64_t & overrunCou
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconRxCount(uint32_t & beaconRxCount)
 {
-    if(DeviceLayer::ConnectivityMgrImpl().IsWiFiManagementStarted()){
+    if (DeviceLayer::ConnectivityMgrImpl().IsWiFiManagementStarted())
+    {
         beaconRxCount = mBeaconRxCount;
         return CHIP_NO_ERROR;
     }


### PR DESCRIPTION
Issue: https://github.com/project-chip/connectedhomeip/issues/25747
Old PR: https://github.com/project-chip/connectedhomeip/pull/32805

Description of Problem:
     When the WiFi interface is not enabled, Beacon Rx count should be null.
     When enabled, need to get Beacon Rx count, but allowed to always return 0 if not tracking that count.

Description of Fix:
    added condition for beacon Rx count as per the problem.

Testing:
    Tested locally, working as expected.