### PR TITLE
[clusters] Implemented ThreadDiagnosticDelegate

### DIFF
--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
@@ -22,6 +22,7 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/EventLogging.h>
 #include <app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.h>
 #include <app/util/attribute-storage.h>
 #include <lib/core/CHIPEncoding.h>
@@ -29,6 +30,9 @@
 #include <lib/core/TLVTypes.h>
 #include <lib/support/CHIPPlatformMemory.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/DiagnosticDataProvider.h>
+#include <tracing/macros.h>
+#include <tracing/metric_event.h>
 
 using namespace chip;
 using namespace chip::app;
@@ -132,6 +136,60 @@ CHIP_ERROR ThreadDiagosticsAttrAccess::Read(const ConcreteReadAttributePath & aP
     return CHIP_NO_ERROR;
 }
 
+class ThreadDiagnosticsDelegate : public DeviceLayer::ThreadDiagnosticsDelegate
+{
+    // Notified when the Node’s connection status to a Thread network has changed.
+    void OnConnectionStatusChanged(ConnectionStatusEnum newConnectionStatus) override
+    {
+        ChipLogProgress(Zcl, "ThreadDiagnosticsDelegate: OnConnectionStatusChanged");
+
+        Events::ConnectionStatus::Type event{ newConnectionStatus };
+
+        // ThreadNetworkDiagnostics cluster should exist only for endpoint 0.
+        if (emberAfContainsServer(kRootEndpointId, ThreadNetworkDiagnostics::Id))
+        {
+            // If Thread Network Diagnostics cluster is implemented on this endpoint
+            EventNumber eventNumber;
+
+            if (CHIP_NO_ERROR != LogEvent(event, kRootEndpointId, eventNumber))
+            {
+                ChipLogError(Zcl, "ThreadDiagnosticsDelegate: Failed to record ConnectionStatus event");
+            }
+        }
+    }
+
+    // Notified when the Node’s faults related to a Thread network have changed.
+    void OnNetworkFaultChanged(const GeneralFaults<kMaxNetworkFaults> & previous,
+                               const GeneralFaults<kMaxNetworkFaults> & current) override
+    {
+        ChipLogProgress(Zcl, "ThreadDiagnosticsDelegate: OnNetworkFaultChanged");
+
+        /* Verify that the data size matches the expected one. */
+        static_assert(sizeof(*current.data()) == sizeof(NetworkFaultEnum));
+
+        DataModel::List<const NetworkFaultEnum> currentList(reinterpret_cast<const NetworkFaultEnum *>(current.data()),
+                                                            current.size());
+        DataModel::List<const NetworkFaultEnum> previousList(reinterpret_cast<const NetworkFaultEnum *>(previous.data()),
+                                                             previous.size());
+
+        Events::NetworkFaultChange::Type event{ currentList, previousList };
+
+        // ThreadNetworkDiagnostics cluster should exist only for endpoint 0.
+        if (emberAfContainsServer(kRootEndpointId, ThreadNetworkDiagnostics::Id))
+        {
+            // If Thread Network Diagnostics cluster is implemented on this endpoint
+            EventNumber eventNumber;
+
+            if (CHIP_NO_ERROR != LogEvent(event, kRootEndpointId, eventNumber))
+            {
+                ChipLogError(Zcl, "ThreadDiagnosticsDelegate: Failed to record NetworkFaultChange event");
+            }
+        }
+    }
+};
+
+ThreadDiagnosticsDelegate gDiagnosticDelegate;
+
 } // anonymous namespace
 
 bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(app::CommandHandler * commandObj,
@@ -146,4 +204,5 @@ bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(app::CommandHandl
 void MatterThreadNetworkDiagnosticsPluginServerInitCallback()
 {
     registerAttributeAccessOverride(&gAttrAccess);
+    GetDiagnosticDataProvider().SetThreadDiagnosticsDelegate(&gDiagnosticDelegate);
 }

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -92,6 +92,29 @@ public:
 };
 
 /**
+ * Defines the Thread Diagnostics Delegate class to notify Thread network events.
+ */
+class ThreadDiagnosticsDelegate
+{
+public:
+    virtual ~ThreadDiagnosticsDelegate() {}
+
+    /**
+     * @brief
+     *   Called when the Node’s connection status to a Thread network has changed.
+     */
+    virtual void OnConnectionStatusChanged(app::Clusters::ThreadNetworkDiagnostics::ConnectionStatusEnum newConnectionStatus) {}
+
+    /**
+     * @brief
+     *   Called when the Node detects change in the set of current Thread network faults.
+     */
+    virtual void OnNetworkFaultChanged(const GeneralFaults<kMaxNetworkFaults> & previous,
+                                       const GeneralFaults<kMaxNetworkFaults> & current)
+    {}
+};
+
+/**
  * Provides access to runtime and build-time configuration information for a chip device.
  */
 class DiagnosticDataProvider
@@ -99,6 +122,8 @@ class DiagnosticDataProvider
 public:
     void SetWiFiDiagnosticsDelegate(WiFiDiagnosticsDelegate * delegate) { mWiFiDiagnosticsDelegate = delegate; }
     WiFiDiagnosticsDelegate * GetWiFiDiagnosticsDelegate() const { return mWiFiDiagnosticsDelegate; }
+    void SetThreadDiagnosticsDelegate(ThreadDiagnosticsDelegate * delegate) { mThreadDiagnosticsDelegate = delegate; }
+    ThreadDiagnosticsDelegate * GetThreadDiagnosticsDelegate() const { return mThreadDiagnosticsDelegate; }
 
     /**
      * General Diagnostics methods.
@@ -238,7 +263,8 @@ protected:
     virtual ~DiagnosticDataProvider() = default;
 
 private:
-    WiFiDiagnosticsDelegate * mWiFiDiagnosticsDelegate = nullptr;
+    WiFiDiagnosticsDelegate * mWiFiDiagnosticsDelegate     = nullptr;
+    ThreadDiagnosticsDelegate * mThreadDiagnosticsDelegate = nullptr;
 
     // No copy, move or assignment.
     DiagnosticDataProvider(const DiagnosticDataProvider &)             = delete;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -40,6 +40,7 @@
 #include <app/icd/server/ICDServerConfig.h>
 #include <lib/dnssd/Advertiser.h>
 #include <lib/dnssd/platform/Dnssd.h>
+#include <platform/GeneralFaults.h>
 #include <platform/NetworkCommissioning.h>
 
 namespace chip {
@@ -229,6 +230,7 @@ private:
 
     DnsBrowseCallback mDnsBrowseCallback;
     DnsResolveCallback mDnsResolveCallback;
+    GeneralFaults<kMaxNetworkFaults> mNetworkFaults;
 
     struct DnsServiceTxtEntries
     {


### PR DESCRIPTION
Added ThreadDiagnosticDelegate to enable generation of optional events from ThreadNetworkDiagnostics cluster.

Additionally implemented generation of ConnectionStatus and NetworkFaultChanged events when Thread link state is changed.


