### PR TITLE
[Silabs] Remove global function from the SilabsTestEventTriggerDelegate

### DIFF
--- a/examples/lit-icd-app/silabs/build_for_wifi_args.gni
+++ b/examples/lit-icd-app/silabs/build_for_wifi_args.gni
@@ -23,6 +23,8 @@ import("${chip_root}/src/platform/silabs/wifi_args.gni")
 chip_enable_ota_requestor = true
 app_data_model = "${chip_root}/examples/lit-icd-app/lit-icd-common"
 
+sl_enable_test_event_trigger = true
+
 # ICD Default configurations
 chip_enable_icd_server = true
 chip_subscription_timeout_resumption = false

--- a/examples/lit-icd-app/silabs/openthread.gni
+++ b/examples/lit-icd-app/silabs/openthread.gni
@@ -26,6 +26,8 @@ chip_enable_openthread = true
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"
 
+sl_enable_test_event_trigger = true
+
 # ICD Default configurations
 chip_enable_icd_server = true
 chip_subscription_timeout_resumption = false

--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -145,6 +145,7 @@ source_set("silabs-factory-data-provider") {
 
   public_deps = [
     "${chip_root}/src/credentials",
+    "${chip_root}/src/lib/support",
     "${chip_root}/src/platform:platform_base",
     "${chip_root}/src/setup_payload",
   ]

--- a/examples/platform/silabs/SilabsDeviceDataProvider.cpp
+++ b/examples/platform/silabs/SilabsDeviceDataProvider.cpp
@@ -18,6 +18,7 @@
 #include "SilabsDeviceDataProvider.h"
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/support/Base64.h>
+#include <lib/support/BytesToHex.h>
 #include <lib/support/CHIPMemString.h>
 #include <platform/silabs/SilabsConfig.h>
 #include <setup_payload/Base38Encode.h>

--- a/examples/platform/silabs/SilabsTestEventTriggerDelegate.h
+++ b/examples/platform/silabs/SilabsTestEventTriggerDelegate.h
@@ -25,28 +25,12 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
 
-/**
- * @brief User handler for handling the test event trigger
- *
- * @note If TestEventTrigger is enabled, it needs to be implemented in the app
- *
- * @param eventTrigger Event trigger to handle
- *
- * @warning *** DO NOT USE FOR STANDARD CLUSTER EVENT TRIGGERS ***
- *
- * TODO(#31723): Rename `emberAfHandleEventTrigger` to `SilabsHandleGlobalTestEventTrigger`
- *
- * @retval true on success
- * @retval false if error happened
- */
-bool emberAfHandleEventTrigger(uint64_t eventTrigger);
-
 namespace chip {
 
-class SilabsTestEventTriggerDelegate : public TestEventTriggerDelegate, TestEventTriggerHandler
+class SilabsTestEventTriggerDelegate : public TestEventTriggerDelegate
 {
 public:
-    explicit SilabsTestEventTriggerDelegate() { VerifyOrDie(AddHandler(this) == CHIP_NO_ERROR); }
+    explicit SilabsTestEventTriggerDelegate() = default;
 
     /**
      * @brief Checks to see if `enableKey` provided matches value chosen by the manufacturer.
@@ -54,18 +38,6 @@ public:
      * @return True or False.
      */
     bool DoesEnableKeyMatch(const ByteSpan & enableKey) const override;
-
-    /**
-     * @brief Delegates handling to global `emberAfHandleEventTrigger` function. DO NOT EXTEND.
-     *
-     * @param eventTrigger - trigger to process.
-     * @return CHIP_NO_ERROR if properly handled, else another CHIP_ERROR.
-     */
-    CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
-    {
-        // WARNING: LEGACY SUPPORT ONLY, DO NOT EXTEND FOR STANDARD CLUSTERS
-        return (emberAfHandleEventTrigger(eventTrigger)) ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_ARGUMENT;
-    }
 };
 
 } // namespace chip

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -178,6 +178,7 @@ source_set("silabs-factory-data-provider") {
 
   public_deps = [
     "${chip_root}/src/credentials",
+    "${chip_root}/src/lib/support",
     "${chip_root}/src/platform:platform_base",
     "${chip_root}/src/setup_payload",
   ]

--- a/examples/smoke-co-alarm-app/silabs/include/SmokeCoAlarmManager.h
+++ b/examples/smoke-co-alarm-app/silabs/include/SmokeCoAlarmManager.h
@@ -21,14 +21,17 @@
 #include <stdint.h>
 
 #include "AppEvent.h"
-
+#include <app/TestEventTriggerDelegate.h>
 #include <app/clusters/smoke-co-alarm-server/smoke-co-alarm-server.h>
 #include <cmsis_os2.h>
 #include <lib/core/CHIPError.h>
 
-class SmokeCoAlarmManager
+class SmokeCoAlarmManager : public chip::TestEventTriggerHandler
 {
 public:
+    SmokeCoAlarmManager()  = default;
+    ~SmokeCoAlarmManager() = default;
+
     CHIP_ERROR Init();
 
     /**
@@ -36,6 +39,14 @@ public:
      *
      */
     void SelfTestingEventHandler();
+
+    /**
+     * @brief Delegates handling to global `emberAfHandleEventTrigger` function. DO NOT EXTEND.
+     *
+     * @param eventTrigger - trigger to process.
+     * @return CHIP_NO_ERROR if properly handled, else another CHIP_ERROR.
+     */
+    CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override;
 
 private:
     friend SmokeCoAlarmManager & AlarmMgr(void);

--- a/examples/smoke-co-alarm-app/silabs/src/AppTask.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/AppTask.cpp
@@ -18,24 +18,18 @@
 #include "AppTask.h"
 #include "AppConfig.h"
 #include "AppEvent.h"
-
 #include "LEDWidget.h"
 
 #include <app/clusters/smoke-co-alarm-server/smoke-co-alarm-server.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
-
 #include <assert.h>
-
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <platform/silabs/platformAbstraction/SilabsPlatform.h>
-
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
-
-#include <lib/support/CodeUtils.h>
-
-#include <platform/CHIPDeviceLayer.h>
 
 #if (defined(SL_CATALOG_SIMPLE_LED_LED1_PRESENT) || defined(BRD4325B))
 #define LIGHT_LED 1
@@ -82,6 +76,9 @@ CHIP_ERROR AppTask::Init()
         SILABS_LOG("AlarmMgr::Init() failed");
         appError(err);
     }
+
+    // Register Smoke & Co Test Event Trigger
+    Server::GetInstance().GetTestEventTriggerDelegate()->AddHandler(&AlarmMgr());
 
     sAlarmLED.Init(LIGHT_LED);
     sAlarmLED.Set(false);

--- a/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
@@ -117,7 +117,7 @@ void SmokeCoAlarmManager::EndSelfTestingEventHandler(AppEvent * aEvent)
     SILABS_LOG("End self-testing!");
 }
 
-bool emberAfHandleEventTrigger(uint64_t eventTrigger)
+CHIP_ERROR SmokeCoAlarmManager::HandleEventTrigger(uint64_t eventTrigger)
 {
     SmokeCOTrigger trigger = static_cast<SmokeCOTrigger>(eventTrigger);
 
@@ -125,32 +125,32 @@ bool emberAfHandleEventTrigger(uint64_t eventTrigger)
     {
     case SmokeCOTrigger::kForceSmokeCritical:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force smoke (critical)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(1, AlarmStateEnum::kCritical), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(1, AlarmStateEnum::kCritical), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceSmokeWarning:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force smoke (warning)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(1, AlarmStateEnum::kWarning), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(1, AlarmStateEnum::kWarning), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceSmokeInterconnect:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force smoke interconnect (warning)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectSmokeAlarm(1, AlarmStateEnum::kWarning), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectSmokeAlarm(1, AlarmStateEnum::kWarning), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceCOCritical:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force CO (critical)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(1, AlarmStateEnum::kCritical), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(1, AlarmStateEnum::kCritical), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceCOWarning:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force CO (warning)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(1, AlarmStateEnum::kWarning), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(1, AlarmStateEnum::kWarning), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceCOInterconnect:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force CO (warning)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectCOAlarm(1, AlarmStateEnum::kWarning), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectCOAlarm(1, AlarmStateEnum::kWarning), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceSmokeContaminationHigh:
@@ -171,22 +171,22 @@ bool emberAfHandleEventTrigger(uint64_t eventTrigger)
         break;
     case SmokeCOTrigger::kForceMalfunction:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force malfunction");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetHardwareFaultAlert(1, true), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetHardwareFaultAlert(1, true), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceLowBatteryWarning:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force low battery (warning)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(1, AlarmStateEnum::kWarning), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(1, AlarmStateEnum::kWarning), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceLowBatteryCritical:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force low battery (critical)");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(1, AlarmStateEnum::kCritical), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(1, AlarmStateEnum::kCritical), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceEndOfLife:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Force end-of-life");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetEndOfServiceAlert(1, EndOfServiceEnum::kExpired), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetEndOfServiceAlert(1, EndOfServiceEnum::kExpired), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kForceSilence:
@@ -195,32 +195,32 @@ bool emberAfHandleEventTrigger(uint64_t eventTrigger)
         break;
     case SmokeCOTrigger::kClearSmoke:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear smoke");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(1, AlarmStateEnum::kNormal), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetSmokeState(1, AlarmStateEnum::kNormal), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearCO:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear CO");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(1, AlarmStateEnum::kNormal), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetCOState(1, AlarmStateEnum::kNormal), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearSmokeInterconnect:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear smoke interconnect");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectSmokeAlarm(1, AlarmStateEnum::kNormal), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectSmokeAlarm(1, AlarmStateEnum::kNormal), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearCOInterconnect:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear CO interconnect");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectCOAlarm(1, AlarmStateEnum::kNormal), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetInterconnectCOAlarm(1, AlarmStateEnum::kNormal), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearMalfunction:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear malfunction");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetHardwareFaultAlert(1, false), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetHardwareFaultAlert(1, false), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearEndOfLife:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear end-of-life");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetEndOfServiceAlert(1, EndOfServiceEnum::kNormal), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetEndOfServiceAlert(1, EndOfServiceEnum::kNormal), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearSilence:
@@ -229,7 +229,7 @@ bool emberAfHandleEventTrigger(uint64_t eventTrigger)
         break;
     case SmokeCOTrigger::kClearBatteryLevelLow:
         ChipLogProgress(Support, "[Smoke-CO-Alarm-Test-Event] => Clear low battery");
-        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(1, AlarmStateEnum::kNormal), true);
+        VerifyOrReturnValue(SmokeCoAlarmServer::Instance().SetBatteryAlert(1, AlarmStateEnum::kNormal), CHIP_NO_ERROR);
         SmokeCoAlarmServer::Instance().SetExpressedStateByPriority(1, sPriorityOrder);
         break;
     case SmokeCOTrigger::kClearContamination:
@@ -242,8 +242,8 @@ bool emberAfHandleEventTrigger(uint64_t eventTrigger)
         break;
     default:
 
-        return false;
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    return true;
+    return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Description
`SilabsTestEventTriggerDelegate` was implemented in such a way that it required the implementation of a global function that would implement the buisness logic of the handler.

This prevented the sample apps from using the `SilabsTestEventTriggerDelegate` for a common test event trigger handler without providing its own implementation.

PR removes the global function and makes consummers of the `SilabsTestEventTriggerDelegate` to use the AddHandler if they need to add a handler.

- Refactor SilabsTestEventTrigger to remove `emberAfHandleEventTrigger`
- Enable test event trigger on the lit icd app since `emberAfHandleEventTrigger` is no longuer a requirement

#### Tests
Manual tests to validate the Smoke & Co and LIT test event triggers work

