### PR TITLE
Spec parsing: Use new ID table (#32410)

### DIFF
--- a/src/python_testing/TestSpecParsingSupport.py
+++ b/src/python_testing/TestSpecParsingSupport.py
@@ -21,8 +21,8 @@ import chip.clusters as Clusters
 from global_attribute_ids import GlobalAttributeIds
 from matter_testing_support import MatterBaseTest, ProblemNotice, default_matter_test_main
 from mobly import asserts
-from spec_parsing_support import (ClusterParser, XmlCluster, add_cluster_data_from_xml, check_clusters_for_unknown_commands,
-                                  combine_derived_clusters_with_base)
+from spec_parsing_support import (ClusterParser, XmlCluster, add_cluster_data_from_xml, build_xml_clusters,
+                                  check_clusters_for_unknown_commands, combine_derived_clusters_with_base)
 
 # TODO: improve the test coverage here
 # https://github.com/project-chip/connectedhomeip/issues/30958
@@ -40,6 +40,9 @@ def single_attribute_cluster_xml(read_access: str, write_access: str, write_supp
                       '<revision revision="2" summary="Some other revision"/>'
                       '<revision revision="3" summary="another revision"/>'
                       '</revisionHistory>')
+    id_table = ('<clusterIds>'
+                f'<clusterId id="{CLUSTER_ID}" name="{CLUSTER_NAME}"/>'
+                '</clusterIds>')
     classification = '<classification hierarchy="base" role="utility" picsCode="TEST" scope="Node"/>'
     read_access_str = f'read="true" readPrivilege="{read_access}"' if read_access is not None else ""
     write_access_str = f'write="{write_supported}" writePrivilege="{write_access}"' if write_access is not None else ""
@@ -53,6 +56,7 @@ def single_attribute_cluster_xml(read_access: str, write_access: str, write_supp
 
     return (f'{xml_cluster}'
             f'{revision_table}'
+            f'{id_table}'
             f'{classification}'
             f'{attribute}'
             '</cluster>')
@@ -60,7 +64,7 @@ def single_attribute_cluster_xml(read_access: str, write_access: str, write_supp
 
 def parse_cluster(xml: str) -> XmlCluster:
     cluster = ElementTree.fromstring(xml)
-    parser = ClusterParser(cluster, CLUSTER_ID, CLUSTER_NAME, False)
+    parser = ClusterParser(cluster, CLUSTER_ID, CLUSTER_NAME)
     return parser.create_cluster()
 
 
@@ -83,6 +87,9 @@ BASE_CLUSTER_XML_STR = (
     '  <revisionHistory>'
     '    <revision revision="1" summary="Initial version"/>'
     '  </revisionHistory>'
+    '  <clusterIds>'
+    '    <clusterId name="Test Base"/>'
+    '  </clusterIds>'
     '  <classification hierarchy="base" role="application" picsCode="BASE" scope="Endpoint"/>'
     '  <features>'
     '    <feature bit="0" code="DEPONOFF" name="OnOff" summary="Dependency with the OnOff cluster">'
@@ -151,6 +158,9 @@ DERIVED_CLUSTER_XML_STR = (
     '  <revisionHistory>'
     '    <revision revision="1" summary="Initial Release"/>'
     '  </revisionHistory>'
+    '  <clusterIds>'
+    '    <clusterId id="0xFFFF" name="Test Derived"/>'
+    '  </clusterIds>'
     '  <classification hierarchy="derived" baseCluster="Test Base" role="application" picsCode="MWOM" scope="Endpoint"/>'
     '  <attributes>'
     '    <attribute id="0x0000" name="SupportedModes">'
@@ -181,6 +191,9 @@ CLUSTER_WITH_UNKNOWN_COMMAND = (
     '  <revisionHistory>'
     '    <revision revision="1" summary="Initial version"/>'
     '  </revisionHistory>'
+    '  <clusterIds>'
+    '    <clusterId id="0xFFFE" name="Test Unknown Command"/>'
+    '  </clusterIds>'
     '  <classification hierarchy="base" role="application" picsCode="BASE" scope="Endpoint"/>'
     '  <commands>'
     '    <command id="0x00" name="ChangeToMode" direction="commandToClient">'
@@ -191,8 +204,32 @@ CLUSTER_WITH_UNKNOWN_COMMAND = (
     '</cluster>'
 )
 
+ALIASED_CLUSTERS = (
+    '<cluster xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="types types.xsd cluster cluster.xsd" id="" name="Test Aliases" revision="1">'
+    '  <revisionHistory>'
+    '    <revision revision="1" summary="Initial version"/>'
+    '  </revisionHistory>'
+    '  <clusterIds>'
+    '    <clusterId id="0xFFFE" name="Test Alias1"/>'
+    '    <clusterId id="0xFFFD" name="Test Alias2"/>'
+    '  </clusterIds>'
+    '  <classification hierarchy="base" role="application" picsCode="BASE" scope="Endpoint"/>'
+    '  <commands>'
+    '    <command id="0x00" name="ChangeToMode" direction="commandToServer">'
+    '      <access invokePrivilege="operate"/>'
+    '      <mandatoryConform/>'
+    '    </command>'
+    '  </commands>'
+    '</cluster>'
+)
+
 
 class TestSpecParsingSupport(MatterBaseTest):
+    def setup_class(self):
+        super().setup_class()
+        self.spec_xml_clusters, self.spec_problems = build_xml_clusters()
+        self.all_spec_clusters = set([(id, c.name, c.pics) for id, c in self.spec_xml_clusters.items()])
+
     def test_spec_parsing_access(self):
         strs = [None, 'view', 'operate', 'manage', 'admin']
         for read in strs:
@@ -295,6 +332,61 @@ class TestSpecParsingSupport(MatterBaseTest):
         asserts.assert_equal(len(problems), 1, "Unexpected number of problems found")
         asserts.assert_equal(problems[0].location.cluster_id, 0xFFFE, "Unexpected problem location (cluster id)")
         asserts.assert_equal(problems[0].location.command_id, 0, "Unexpected problem location (command id)")
+
+    def test_aliased_clusters(self):
+        clusters: dict[int, XmlCluster] = {}
+        pure_base_clusters: dict[str, XmlCluster] = {}
+        ids_by_name: dict[str, int] = {}
+        problems: list[ProblemNotice] = []
+        cluster_xml = ElementTree.fromstring(ALIASED_CLUSTERS)
+
+        add_cluster_data_from_xml(cluster_xml, clusters, pure_base_clusters, ids_by_name, problems)
+        asserts.assert_equal(len(problems), 0, "Unexpected problem parsing aliased clusters")
+        asserts.assert_equal(len(clusters), 2, "Unexpected number of clusters when parsing aliased cluster set")
+        asserts.assert_equal(len(pure_base_clusters), 0, "Unexpected number of pure base clusters")
+        asserts.assert_equal(len(ids_by_name), 2, "Unexpected number of ids by name")
+
+        ids = [(id, c.name) for id, c in clusters.items()]
+        asserts.assert_true((0xFFFE, 'Test Alias1') in ids, "Unable to find Test Alias1 cluster in parsed clusters")
+        asserts.assert_true((0xFFFD, 'Test Alias2') in ids, "Unable to find Test Alias2 cluster in parsed clusters")
+
+    def test_known_aliased_clusters(self):
+        known_aliased_clusters = set([(0x040C, 'Carbon Monoxide Concentration Measurement', 'CMOCONC'),
+                                      (0x040D, 'Carbon Dioxide Concentration Measurement', 'CDOCONC'),
+                                      (0x0413, 'Nitrogen Dioxide Concentration Measurement', 'NDOCONC'),
+                                      (0x0415, 'Ozone Concentration Measurement', 'OZCONC'),
+                                      # Change to "PM2.5 Concentration Measurement" once https://github.com/csa-data-model/projects/issues/453 is fixed
+                                      (0x042A, 'PM2', 'PMICONC'),
+                                      (0x042B, 'Formaldehyde Concentration Measurement', 'FLDCONC'),
+                                      (0x042C, 'PM1 Concentration Measurement', 'PMHCONC'),
+                                      (0x042D, 'PM10 Concentration Measurement', 'PMKCONC'),
+                                      (0x042E, 'Total Volatile Organic Compounds Concentration Measurement', 'TVOCCONC'),
+                                      (0x042F, 'Radon Concentration Measurement', 'RNCONC'),
+                                      (0x0071, 'HEPA Filter Monitoring', 'HEPAFREMON'),
+                                      (0x0072, 'Activated Carbon Filter Monitoring', 'ACFREMON'),
+                                      (0x0405, 'Relative Humidity Measurement', 'RH')])
+
+        missing_clusters = known_aliased_clusters - self.all_spec_clusters
+        asserts.assert_equal(len(missing_clusters), 0, f"Missing aliased clusters from DM XML - {missing_clusters}")
+
+    def test_known_derived_clusters(self):
+        known_derived_clusters = set([(0x0048, 'Oven Cavity Operational State', 'OVENOPSTATE'),
+                                      (0x0049, 'Oven Mode', 'OTCCM'),
+                                      (0x0051, 'Laundry Washer Mode', 'LWM'),
+                                      (0x0052, 'Refrigerator And Temperature Controlled Cabinet Mode', 'TCCM'),
+                                      (0x0054, 'RVC Run Mode', 'RVCRUNM'),
+                                      (0x0055, 'RVC Clean Mode', 'RVCCLEANM'),
+                                      (0x0057, 'Refrigerator Alarm', 'REFALM'),
+                                      (0x0059, 'Dishwasher Mode', 'DISHM'),
+                                      (0x005c, 'Smoke CO Alarm', 'SMOKECO'),
+                                      (0x005d, 'Dishwasher Alarm', 'DISHALM'),
+                                      (0x005e, 'Microwave Oven Mode', 'MWOM'),
+                                      (0x0061, 'RVC Operational State', 'RVCOPSTATE')])
+
+        missing_clusters = known_derived_clusters - self.all_spec_clusters
+        asserts.assert_equal(len(missing_clusters), 0, f"Missing aliased clusters from DM XML - {missing_clusters}")
+        for d in known_derived_clusters:
+            asserts.assert_true(self.spec_xml_clusters is not None, "Derived cluster with no base cluster marker")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cherry pick from main branch - gets the ID from the correct location for the new DM XML format.

