### PR TITLE
Decouple android CHIP IM APIs from CHIPController to separate CHIPInteractionModel lib

### DIFF
--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -55,6 +55,7 @@ shared_library("jni") {
     "${chip_root}/examples/tv-casting-app/tv-casting-common",
     "${chip_root}/src/app/data-model:heap",
     "${chip_root}/src/app/server/java:jni",
+    "${chip_root}/src/controller/java:android_chip_im_jni",
     "${chip_root}/src/lib",
     "${chip_root}/third_party/inipp",
   ]
@@ -72,6 +73,7 @@ android_library("java") {
   deps = [
     ":android",
     "${chip_root}/src/app/server/java",
+    "${chip_root}/src/controller/java:android_chip_im",
     "${chip_root}/src/platform/android:java",
     "${chip_root}/third_party/android_deps:annotation",
   ]
@@ -136,6 +138,7 @@ group("default") {
     ":java",
     ":jni",
     "${chip_root}/src/app/server/java",
+    "${chip_root}/src/controller/java:android_chip_im",
     "${chip_root}/src/platform/android:java",
   ]
 }

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -243,6 +243,7 @@ class AndroidBuilder(Builder):
 
         jars = {
             "CHIPController.jar": "src/controller/java/CHIPController.jar",
+            "CHIPInteractionModel.jar": "src/controller/java/CHIPInteractionModel.jar",
             "OnboardingPayload.jar": "src/controller/java/OnboardingPayload.jar",
             "AndroidPlatform.jar": "src/platform/android/AndroidPlatform.jar",
             "libMatterJson.jar": "src/controller/java/libMatterJson.jar",
@@ -489,6 +490,7 @@ class AndroidBuilder(Builder):
                 jars = {
                     "AndroidPlatform.jar": "third_party/connectedhomeip/src/platform/android/AndroidPlatform.jar",
                     "CHIPAppServer.jar": "third_party/connectedhomeip/src/app/server/java/CHIPAppServer.jar",
+                    "CHIPInteractionModel.jar": "third_party/connectedhomeip/src/controller/java/CHIPInteractionModel.jar",
                     "TvCastingApp.jar": "TvCastingApp.jar",
                 }
 
@@ -605,6 +607,9 @@ class AndroidBuilder(Builder):
                 ),
                 "CHIPController.jar": os.path.join(
                     self.output_dir, "lib", "src/controller/java/CHIPController.jar"
+                ),
+                "CHIPInteractionModel.jar": os.path.join(
+                    self.output_dir, "lib", "src/controller/java/CHIPInteractionModel.jar"
                 ),
                 "libMatterTlv.jar": os.path.join(
                     self.output_dir, "lib", "src/controller/java/libMatterTlv.jar"

--- a/scripts/build/testdata/dry_run_android-arm64-chip-tool.txt
+++ b/scripts/build/testdata/dry_run_android-arm64-chip-tool.txt
@@ -25,6 +25,8 @@ cp {out}/android-arm64-chip-tool/lib/jni/arm64-v8a/libc++_shared.so {root}/examp
 
 cp {out}/android-arm64-chip-tool/lib/src/controller/java/CHIPController.jar {root}/examples/android/CHIPTool/app/libs/CHIPController.jar
 
+cp {out}/android-arm64-chip-tool/lib/src/controller/java/CHIPInteractionModel.jar {root}/examples/android/CHIPTool/app/libs/CHIPInteractionModel.jar
+
 cp {out}/android-arm64-chip-tool/lib/src/controller/java/OnboardingPayload.jar {root}/examples/android/CHIPTool/app/libs/OnboardingPayload.jar
 
 cp {out}/android-arm64-chip-tool/lib/src/platform/android/AndroidPlatform.jar {root}/examples/android/CHIPTool/app/libs/AndroidPlatform.jar

--- a/scripts/py_matter_idl/matter_idl/generators/java/ChipClusters_java.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/java/ChipClusters_java.jinja
@@ -198,7 +198,7 @@ public class ChipClusters {
         boolean isFabricFiltered) {
       ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
       ChipAttributePath path = ChipAttributePath.newInstance(endpointId, clusterId, attributeId);
-      ChipDeviceController.read(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, isFabricFiltered, timeoutMillis.orElse(0L).intValue(), null);
+      ChipInteractionClient.read(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, isFabricFiltered, timeoutMillis.orElse(0L).intValue(), null);
     }
 
     protected void writeAttribute(
@@ -209,7 +209,7 @@ public class ChipClusters {
       WriteAttributesCallbackJni jniCallback = new WriteAttributesCallbackJni(callback);
       byte[] tlv = encodeToTlv(value);
       AttributeWriteRequest writeRequest = AttributeWriteRequest.newInstance(endpointId, clusterId, attributeId, tlv);
-      ChipDeviceController.write(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(writeRequest), timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
+      ChipInteractionClient.write(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(writeRequest), timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
     }
 
     protected void subscribeAttribute(
@@ -219,7 +219,7 @@ public class ChipClusters {
         int maxInterval) {
       ReportCallbackJni jniCallback = new ReportCallbackJni(callback, callback, null);
       ChipAttributePath path = ChipAttributePath.newInstance(endpointId, clusterId, attributeId);
-      ChipDeviceController.subscribe(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, minInterval, maxInterval, false, true, timeoutMillis.orElse(0L).intValue(), null);
+      ChipInteractionClient.subscribe(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, minInterval, maxInterval, false, true, timeoutMillis.orElse(0L).intValue(), null);
     }
 
     protected void invoke(
@@ -230,7 +230,7 @@ public class ChipClusters {
       InvokeCallbackJni jniCallback = new InvokeCallbackJni(callback);
       byte[] tlv = encodeToTlv(value);
       InvokeElement element = InvokeElement.newInstance(endpointId, clusterId, commandId, tlv, null);
-      ChipDeviceController.invoke(0, jniCallback.getCallbackHandle(), devicePtr, element, timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
+      ChipInteractionClient.invoke(0, jniCallback.getCallbackHandle(), devicePtr, element, timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
     }
 
     private static native byte[] encodeToTlv(BaseTLVType value);

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ChipClusters.java
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ChipClusters.java
@@ -121,7 +121,7 @@ public class ChipClusters {
         boolean isFabricFiltered) {
       ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
       ChipAttributePath path = ChipAttributePath.newInstance(endpointId, clusterId, attributeId);
-      ChipDeviceController.read(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, isFabricFiltered, timeoutMillis.orElse(0L).intValue(), null);
+      ChipInteractionClient.read(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, isFabricFiltered, timeoutMillis.orElse(0L).intValue(), null);
     }
 
     protected void writeAttribute(
@@ -132,7 +132,7 @@ public class ChipClusters {
       WriteAttributesCallbackJni jniCallback = new WriteAttributesCallbackJni(callback);
       byte[] tlv = encodeToTlv(value);
       AttributeWriteRequest writeRequest = AttributeWriteRequest.newInstance(endpointId, clusterId, attributeId, tlv);
-      ChipDeviceController.write(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(writeRequest), timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
+      ChipInteractionClient.write(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(writeRequest), timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
     }
 
     protected void subscribeAttribute(
@@ -142,7 +142,7 @@ public class ChipClusters {
         int maxInterval) {
       ReportCallbackJni jniCallback = new ReportCallbackJni(callback, callback, null);
       ChipAttributePath path = ChipAttributePath.newInstance(endpointId, clusterId, attributeId);
-      ChipDeviceController.subscribe(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, minInterval, maxInterval, false, true, timeoutMillis.orElse(0L).intValue(), null);
+      ChipInteractionClient.subscribe(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, minInterval, maxInterval, false, true, timeoutMillis.orElse(0L).intValue(), null);
     }
 
     protected void invoke(
@@ -153,7 +153,7 @@ public class ChipClusters {
       InvokeCallbackJni jniCallback = new InvokeCallbackJni(callback);
       byte[] tlv = encodeToTlv(value);
       InvokeElement element = InvokeElement.newInstance(endpointId, clusterId, commandId, tlv, null);
-      ChipDeviceController.invoke(0, jniCallback.getCallbackHandle(), devicePtr, element, timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
+      ChipInteractionClient.invoke(0, jniCallback.getCallbackHandle(), devicePtr, element, timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
     }
 
     private static native byte[] encodeToTlv(BaseTLVType value);

--- a/src/controller/java/AndroidInteractionClient.cpp
+++ b/src/controller/java/AndroidInteractionClient.cpp
@@ -626,6 +626,45 @@ exit:
     return err;
 }
 
+CHIP_ERROR shutdownSubscriptions(JNIEnv * env, jlong handle, jobject fabricIndex, jobject peerNodeId, jobject subscriptionId)
+{
+    chip::DeviceLayer::StackLock lock;
+    if (fabricIndex == nullptr && peerNodeId == nullptr && subscriptionId == nullptr)
+    {
+        app::InteractionModelEngine::GetInstance()->ShutdownAllSubscriptions();
+        return CHIP_NO_ERROR;
+    }
+
+    if (fabricIndex != nullptr && peerNodeId != nullptr && subscriptionId == nullptr)
+    {
+        jint jFabricIndex = chip::JniReferences::GetInstance().IntegerToPrimitive(fabricIndex);
+        jlong jPeerNodeId = chip::JniReferences::GetInstance().LongToPrimitive(peerNodeId);
+        app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(static_cast<chip::FabricIndex>(jFabricIndex),
+                                                                          static_cast<chip::NodeId>(jPeerNodeId));
+        return CHIP_NO_ERROR;
+    }
+
+    if (fabricIndex != nullptr && peerNodeId == nullptr && subscriptionId == nullptr)
+    {
+        jint jFabricIndex = chip::JniReferences::GetInstance().IntegerToPrimitive(fabricIndex);
+        app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(static_cast<chip::FabricIndex>(jFabricIndex));
+        return CHIP_NO_ERROR;
+    }
+
+    if (fabricIndex != nullptr && peerNodeId != nullptr && subscriptionId != nullptr)
+    {
+        jint jFabricIndex     = chip::JniReferences::GetInstance().IntegerToPrimitive(fabricIndex);
+        jlong jPeerNodeId     = chip::JniReferences::GetInstance().LongToPrimitive(peerNodeId);
+        jlong jSubscriptionId = chip::JniReferences::GetInstance().LongToPrimitive(subscriptionId);
+        app::InteractionModelEngine::GetInstance()->ShutdownSubscription(
+            chip::ScopedNodeId(static_cast<chip::NodeId>(jPeerNodeId), static_cast<chip::FabricIndex>(jFabricIndex)),
+            static_cast<chip::SubscriptionId>(jSubscriptionId));
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_ERROR_INVALID_ARGUMENT;
+}
+
 CHIP_ERROR invoke(JNIEnv * env, jlong handle, jlong callbackHandle, jlong devicePtr, jobject invokeElement,
                   jint timedRequestTimeoutMs, jint imTimeoutMs)
 {

--- a/src/controller/java/AndroidInteractionClient.cpp
+++ b/src/controller/java/AndroidInteractionClient.cpp
@@ -24,7 +24,6 @@
 #include "AndroidInteractionClient.h"
 
 #include "AndroidCallbacks.h"
-#include "AndroidDeviceControllerWrapper.h"
 
 #include <lib/support/jsontlv/JsonToTlv.h>
 

--- a/src/controller/java/AndroidInteractionClient.h
+++ b/src/controller/java/AndroidInteractionClient.h
@@ -31,3 +31,5 @@ CHIP_ERROR invoke(JNIEnv * env, jlong handle, jlong callbackHandle, jlong device
                   jint timedRequestTimeoutMs, jint imTimeoutMs);
 CHIP_ERROR extendableInvoke(JNIEnv * env, jlong handle, jlong callbackHandle, jlong devicePtr, jobject invokeElementList,
                             jint timedRequestTimeoutMs, jint imTimeoutMs);
+CHIP_ERROR shutdownSubscriptions(JNIEnv * env, jlong handle, jobject fabricIndex, jobject peerNodeId, jobject subscriptionId);
+

--- a/src/controller/java/AndroidInteractionClient.h
+++ b/src/controller/java/AndroidInteractionClient.h
@@ -32,4 +32,3 @@ CHIP_ERROR invoke(JNIEnv * env, jlong handle, jlong callbackHandle, jlong device
 CHIP_ERROR extendableInvoke(JNIEnv * env, jlong handle, jlong callbackHandle, jlong devicePtr, jobject invokeElementList,
                             jint timedRequestTimeoutMs, jint imTimeoutMs);
 CHIP_ERROR shutdownSubscriptions(JNIEnv * env, jlong handle, jobject fabricIndex, jobject peerNodeId, jobject subscriptionId);
-

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -81,6 +81,24 @@ source_set("android_chip_im_jni") {
     ldflags = [ "-Wl,--gc-sections" ]
   }
 
+  if (matter_enable_java_compilation) {
+    include_dirs = java_matter_controller_dependent_paths
+    if (current_os == "mac") {
+      deps += [ "${chip_root}/src/platform/Darwin" ]
+    } else {
+      deps += [ "${chip_root}/src/platform/Linux" ]
+    }
+
+    cflags = [
+      "-Wno-unknown-pragmas",
+      "-Wconversion",
+    ]
+
+    output_dir = "${root_out_dir}/lib/jni"
+  } else {
+    deps += [ "${chip_root}/src/platform/android" ]
+    output_dir = "${root_out_dir}/lib/jni/${android_abi}"
+  }
   public_configs = [ "${chip_root}/src:includes" ]
 }
 

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -42,6 +42,48 @@ if (!matter_enable_java_compilation) {
   import("${build_root}/config/android_abi.gni")
 }
 
+source_set("android_chip_im_jni") {
+  sources = [
+    "AndroidCallbacks-JNI.cpp",
+    "AndroidCallbacks.cpp",
+    "AndroidCallbacks.h",
+    "AndroidConnectionFailureExceptions.cpp",
+    "AndroidConnectionFailureExceptions.h",
+    "AndroidControllerExceptions.cpp",
+    "AndroidControllerExceptions.h",
+    "AndroidInteractionClient.cpp",
+    "AndroidInteractionClient.h",
+    "BaseCHIPCluster-JNI.cpp",
+    "CHIPAttributeTLVValueDecoder.h",
+    "CHIPEventTLVValueDecoder.h",
+    "CHIPInteractionClient-JNI.cpp",
+    "CHIPInteractionClient-JNI.h",
+  ]
+
+  if (matter_enable_tlv_decoder_api) {
+    defines = [ "USE_JAVA_TLV_ENCODE_DECODE" ]
+    sources += [
+      "CHIPTLVValueDecoder-JNI.cpp",
+      "zap-generated/CHIPAttributeTLVValueDecoder.cpp",
+      "zap-generated/CHIPEventTLVValueDecoder.cpp",
+    ]
+  }
+
+  deps = [
+    "${chip_root}/src/lib",
+    "${chip_root}/src/lib/support/jsontlv",
+    "${chip_root}/src/platform",
+  ]
+
+  if (current_os == "mac") {
+    ldflags = [ "-Wl,-dead_strip" ]
+  } else {
+    ldflags = [ "-Wl,--gc-sections" ]
+  }
+
+  public_configs = [ "${chip_root}/src:includes" ]
+}
+
 shared_library("jni") {
   output_name = "libCHIPController"
 
@@ -56,33 +98,21 @@ shared_library("jni") {
   check_includes = false
 
   sources = [
-    "AndroidCallbacks-JNI.cpp",
-    "AndroidCallbacks.cpp",
-    "AndroidCallbacks.h",
     "AndroidCheckInDelegate.cpp",
     "AndroidCheckInDelegate.h",
     "AndroidClusterExceptions.cpp",
     "AndroidClusterExceptions.h",
     "AndroidCommissioningWindowOpener.cpp",
     "AndroidCommissioningWindowOpener.h",
-    "AndroidConnectionFailureExceptions.cpp",
-    "AndroidConnectionFailureExceptions.h",
-    "AndroidControllerExceptions.cpp",
-    "AndroidControllerExceptions.h",
     "AndroidCurrentFabricRemover.cpp",
     "AndroidCurrentFabricRemover.h",
     "AndroidDeviceControllerWrapper.cpp",
     "AndroidDeviceControllerWrapper.h",
-    "AndroidInteractionClient.cpp",
-    "AndroidInteractionClient.h",
     "AndroidOperationalCredentialsIssuer.cpp",
     "AndroidOperationalCredentialsIssuer.h",
     "AttestationTrustStoreBridge.cpp",
     "AttestationTrustStoreBridge.h",
-    "BaseCHIPCluster-JNI.cpp",
-    "CHIPAttributeTLVValueDecoder.h",
     "CHIPDeviceController-JNI.cpp",
-    "CHIPEventTLVValueDecoder.h",
     "DeviceAttestation-JNI.cpp",
     "DeviceAttestationDelegateBridge.cpp",
     "DeviceAttestationDelegateBridge.h",
@@ -92,6 +122,7 @@ shared_library("jni") {
   ]
 
   deps = [
+    ":android_chip_im_jni",
     ":controller_config",
     "${chip_root}/src/app/icd/client:handler",
     "${chip_root}/src/app/icd/client:manager",
@@ -101,16 +132,6 @@ shared_library("jni") {
     "${chip_root}/src/lib/support/jsontlv",
     "${chip_root}/src/platform",
   ]
-
-  if (matter_enable_tlv_decoder_api) {
-    defines += [ "USE_JAVA_TLV_ENCODE_DECODE" ]
-
-    sources += [
-      "CHIPTLVValueDecoder-JNI.cpp",
-      "zap-generated/CHIPAttributeTLVValueDecoder.cpp",
-      "zap-generated/CHIPEventTLVValueDecoder.cpp",
-    ]
-  }
 
   if (chip_build_controller_dynamic_server) {
     sources += [
@@ -175,6 +196,7 @@ if (chip_link_tests) {
     public_configs = [ "${chip_root}/src:includes" ]
 
     deps = [
+      ":android_chip_im_jni",
       ":jni",
       "${chip_root}/src/messaging/tests:helpers",
     ]
@@ -452,58 +474,24 @@ android_library("chipclusterID") {
   ]
 }
 
-android_library("java") {
-  output_name = "CHIPController.jar"
-
-  deps = [
-    ":chipcluster",
-    ":chipclusterID",
-    "${chip_root}/third_party/java_deps:annotation",
-  ]
-
-  data_deps = [ ":jni" ]
+# Android CHIP IM .java files
+android_library("android_chip_im") {
+  output_name = "CHIPInteractionModel.jar"
 
   sources = [
-    "src/chip/devicecontroller/AttestationInfo.java",
-    "src/chip/devicecontroller/AttestationTrustStoreDelegate.java",
-    "src/chip/devicecontroller/CSRInfo.java",
     "src/chip/devicecontroller/ChipClusterException.java",
-    "src/chip/devicecontroller/ChipCommandType.java",
-    "src/chip/devicecontroller/ChipDeviceController.java",
     "src/chip/devicecontroller/ChipDeviceControllerException.java",
-    "src/chip/devicecontroller/CommissioningWindowStatus.java",
-    "src/chip/devicecontroller/ConnectionFailureException.java",
-    "src/chip/devicecontroller/ControllerParams.java",
-    "src/chip/devicecontroller/DeviceAttestation.java",
-    "src/chip/devicecontroller/DeviceAttestationDelegate.java",
-    "src/chip/devicecontroller/DiscoveredDevice.java",
+    "src/chip/devicecontroller/ChipInteractionClient.java",
     "src/chip/devicecontroller/ExtendableInvokeCallback.java",
     "src/chip/devicecontroller/ExtendableInvokeCallbackJni.java",
     "src/chip/devicecontroller/GetConnectedDeviceCallbackJni.java",
-    "src/chip/devicecontroller/GroupKeySecurityPolicy.java",
-    "src/chip/devicecontroller/ICDCheckInDelegate.java",
-    "src/chip/devicecontroller/ICDCheckInDelegateWrapper.java",
-    "src/chip/devicecontroller/ICDClientInfo.java",
-    "src/chip/devicecontroller/ICDDeviceInfo.java",
-    "src/chip/devicecontroller/ICDRegistrationInfo.java",
     "src/chip/devicecontroller/InvokeCallback.java",
     "src/chip/devicecontroller/InvokeCallbackJni.java",
-    "src/chip/devicecontroller/KeypairDelegate.java",
-    "src/chip/devicecontroller/NetworkCredentials.java",
-    "src/chip/devicecontroller/NetworkLocation.java",
-    "src/chip/devicecontroller/OTAProviderDelegate.java",
-    "src/chip/devicecontroller/OpenCommissioningCallback.java",
-    "src/chip/devicecontroller/OperationalKeyConfig.java",
-    "src/chip/devicecontroller/PairingHintBitmap.java",
-    "src/chip/devicecontroller/PaseVerifierParams.java",
     "src/chip/devicecontroller/ReportCallback.java",
     "src/chip/devicecontroller/ReportCallbackJni.java",
     "src/chip/devicecontroller/ResubscriptionAttemptCallback.java",
     "src/chip/devicecontroller/StatusException.java",
     "src/chip/devicecontroller/SubscriptionEstablishedCallback.java",
-    "src/chip/devicecontroller/ThreadScanResult.java",
-    "src/chip/devicecontroller/UnpairDeviceCallback.java",
-    "src/chip/devicecontroller/WiFiScanResult.java",
     "src/chip/devicecontroller/WriteAttributesCallback.java",
     "src/chip/devicecontroller/WriteAttributesCallbackJni.java",
     "src/chip/devicecontroller/model/AttributeState.java",
@@ -543,6 +531,72 @@ android_library("java") {
       "src/chip/devicecontroller/ChipTLVType.java",
     ]
   }
+
+  deps = [
+    ":chipcluster",
+    ":chipclusterID",
+    "${chip_root}/third_party/java_deps:annotation",
+  ]
+
+  if (matter_enable_java_compilation) {
+    deps += [
+      "${chip_root}/third_party/java_deps:json",
+      "${chip_root}/third_party/java_deps/stub_src",
+    ]
+  } else {
+    deps += [ ":android" ]
+
+    data_deps = [ "${chip_root}/build/chip/java:shared_cpplib" ]
+  }
+
+  javac_flags = [
+    "-Xlint:deprecation",
+    "-parameters",  # Store infomation about method parameters
+  ]
+}
+
+android_library("java") {
+  output_name = "CHIPController.jar"
+
+  deps = [
+    ":android_chip_im",
+    ":chipcluster",
+    ":chipclusterID",
+    "${chip_root}/third_party/java_deps:annotation",
+  ]
+
+  data_deps = [ ":jni" ]
+
+  sources = [
+    "src/chip/devicecontroller/AttestationInfo.java",
+    "src/chip/devicecontroller/AttestationTrustStoreDelegate.java",
+    "src/chip/devicecontroller/CSRInfo.java",
+    "src/chip/devicecontroller/ChipCommandType.java",
+    "src/chip/devicecontroller/ChipDeviceController.java",
+    "src/chip/devicecontroller/CommissioningWindowStatus.java",
+    "src/chip/devicecontroller/ConnectionFailureException.java",
+    "src/chip/devicecontroller/ControllerParams.java",
+    "src/chip/devicecontroller/DeviceAttestation.java",
+    "src/chip/devicecontroller/DeviceAttestationDelegate.java",
+    "src/chip/devicecontroller/DiscoveredDevice.java",
+    "src/chip/devicecontroller/GroupKeySecurityPolicy.java",
+    "src/chip/devicecontroller/ICDCheckInDelegate.java",
+    "src/chip/devicecontroller/ICDCheckInDelegateWrapper.java",
+    "src/chip/devicecontroller/ICDClientInfo.java",
+    "src/chip/devicecontroller/ICDDeviceInfo.java",
+    "src/chip/devicecontroller/ICDRegistrationInfo.java",
+    "src/chip/devicecontroller/KeypairDelegate.java",
+    "src/chip/devicecontroller/NetworkCredentials.java",
+    "src/chip/devicecontroller/NetworkLocation.java",
+    "src/chip/devicecontroller/OTAProviderDelegate.java",
+    "src/chip/devicecontroller/OpenCommissioningCallback.java",
+    "src/chip/devicecontroller/OperationalKeyConfig.java",
+    "src/chip/devicecontroller/PairingHintBitmap.java",
+    "src/chip/devicecontroller/PaseVerifierParams.java",
+    "src/chip/devicecontroller/ThreadScanResult.java",
+    "src/chip/devicecontroller/UnpairDeviceCallback.java",
+    "src/chip/devicecontroller/WiFiScanResult.java",
+  ]
 
   if (matter_enable_java_compilation) {
     deps += [

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -2260,65 +2260,6 @@ JNI_METHOD(jobject, getICDClientInfo)(JNIEnv * env, jobject self, jlong handle, 
     return jInfo;
 }
 
-JNI_METHOD(void, subscribe)
-(JNIEnv * env, jclass clz, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributePathList, jobject eventPathList,
- jobject dataVersionFilterList, jint minInterval, jint maxInterval, jboolean keepSubscriptions, jboolean isFabricFiltered,
- jint imTimeoutMs, jobject eventMin)
-{
-    CHIP_ERROR err = subscribe(env, handle, callbackHandle, devicePtr, attributePathList, eventPathList, dataVersionFilterList,
-                               minInterval, maxInterval, keepSubscriptions, isFabricFiltered, imTimeoutMs, eventMin);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller, "JNI IM Subscribe Error: %" CHIP_ERROR_FORMAT, err.Format());
-    }
-}
-
-JNI_METHOD(void, read)
-(JNIEnv * env, jclass clz, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributePathList, jobject eventPathList,
- jobject dataVersionFilterList, jboolean isFabricFiltered, jint imTimeoutMs, jobject eventMin)
-{
-    CHIP_ERROR err = read(env, handle, callbackHandle, devicePtr, attributePathList, eventPathList, dataVersionFilterList,
-                          isFabricFiltered, imTimeoutMs, eventMin);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller, "JNI IM Read Error: %" CHIP_ERROR_FORMAT, err.Format());
-    }
-}
-
-JNI_METHOD(void, write)
-(JNIEnv * env, jclass clz, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributeList, jint timedRequestTimeoutMs,
- jint imTimeoutMs)
-{
-    CHIP_ERROR err = write(env, handle, callbackHandle, devicePtr, attributeList, timedRequestTimeoutMs, imTimeoutMs);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller, "JNI IM Write Error: %" CHIP_ERROR_FORMAT, err.Format());
-    }
-}
-
-JNI_METHOD(void, invoke)
-(JNIEnv * env, jclass clz, jlong handle, jlong callbackHandle, jlong devicePtr, jobject invokeElement, jint timedRequestTimeoutMs,
- jint imTimeoutMs)
-{
-    CHIP_ERROR err = invoke(env, handle, callbackHandle, devicePtr, invokeElement, timedRequestTimeoutMs, imTimeoutMs);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller, "JNI IM Invoke Error: %" CHIP_ERROR_FORMAT, err.Format());
-    }
-}
-
-JNI_METHOD(void, extendableInvoke)
-(JNIEnv * env, jclass clz, jlong handle, jlong callbackHandle, jlong devicePtr, jobject invokeElementList,
- jint timedRequestTimeoutMs, jint imTimeoutMs)
-{
-    CHIP_ERROR err =
-        extendableInvoke(env, handle, callbackHandle, devicePtr, invokeElementList, timedRequestTimeoutMs, imTimeoutMs);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller, "JNI IM Batch Invoke Error: %" CHIP_ERROR_FORMAT, err.Format());
-    }
-}
-
 void * IOThreadMain(void * arg)
 {
     JNIEnv * env;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1726,45 +1726,6 @@ JNI_METHOD(jint, getFabricIndex)(JNIEnv * env, jobject self, jlong handle)
     return wrapper->Controller()->GetFabricIndex();
 }
 
-JNI_METHOD(void, shutdownSubscriptions)
-(JNIEnv * env, jobject self, jobject handle, jobject fabricIndex, jobject peerNodeId, jobject subscriptionId)
-{
-    chip::DeviceLayer::StackLock lock;
-    if (fabricIndex == nullptr && peerNodeId == nullptr && subscriptionId == nullptr)
-    {
-        app::InteractionModelEngine::GetInstance()->ShutdownAllSubscriptions();
-        return;
-    }
-
-    if (fabricIndex != nullptr && peerNodeId != nullptr && subscriptionId == nullptr)
-    {
-        jint jFabricIndex = chip::JniReferences::GetInstance().IntegerToPrimitive(fabricIndex);
-        jlong jPeerNodeId = chip::JniReferences::GetInstance().LongToPrimitive(peerNodeId);
-        app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(static_cast<chip::FabricIndex>(jFabricIndex),
-                                                                          static_cast<chip::NodeId>(jPeerNodeId));
-        return;
-    }
-
-    if (fabricIndex != nullptr && peerNodeId == nullptr && subscriptionId == nullptr)
-    {
-        jint jFabricIndex = chip::JniReferences::GetInstance().IntegerToPrimitive(fabricIndex);
-        app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(static_cast<chip::FabricIndex>(jFabricIndex));
-        return;
-    }
-
-    if (fabricIndex != nullptr && peerNodeId != nullptr && subscriptionId != nullptr)
-    {
-        jint jFabricIndex     = chip::JniReferences::GetInstance().IntegerToPrimitive(fabricIndex);
-        jlong jPeerNodeId     = chip::JniReferences::GetInstance().LongToPrimitive(peerNodeId);
-        jlong jSubscriptionId = chip::JniReferences::GetInstance().LongToPrimitive(subscriptionId);
-        app::InteractionModelEngine::GetInstance()->ShutdownSubscription(
-            chip::ScopedNodeId(static_cast<chip::NodeId>(jPeerNodeId), static_cast<chip::FabricIndex>(jFabricIndex)),
-            static_cast<chip::SubscriptionId>(jSubscriptionId));
-        return;
-    }
-    ChipLogError(Controller, "Failed to shutdown subscriptions with correct input paramemeter");
-}
-
 JNI_METHOD(jstring, getIpAddress)(JNIEnv * env, jobject self, jlong handle, jlong deviceId)
 {
     chip::DeviceLayer::StackLock lock;

--- a/src/controller/java/CHIPInteractionClient-JNI.cpp
+++ b/src/controller/java/CHIPInteractionClient-JNI.cpp
@@ -128,3 +128,14 @@ JNI_METHOD(void, extendableInvoke)
         ChipLogError(Controller, "JNI IM Batch Invoke Error: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
+
+JNI_METHOD(void, shutdownSubscriptions)
+(JNIEnv * env, jobject self, jlong handle, jobject fabricIndex, jobject peerNodeId, jobject subscriptionId)
+{
+    CHIP_ERROR err =
+        shutdownSubscriptions(env, handle, fabricIndex, peerNodeId, subscriptionId);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to shutdown subscriptions with Error: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}

--- a/src/controller/java/CHIPInteractionClient-JNI.cpp
+++ b/src/controller/java/CHIPInteractionClient-JNI.cpp
@@ -72,10 +72,11 @@ void AndroidChipInteractionJNI_OnUnload(JavaVM * jvm, void * reserved)
 
 JNI_METHOD(void, subscribe)
 (JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributePathList, jobject eventPathList,
- jint minInterval, jint maxInterval, jboolean keepSubscriptions, jboolean isFabricFiltered, jint imTimeoutMs)
+ jobject dataVersionFilterList, jint minInterval, jint maxInterval, jboolean keepSubscriptions, jboolean isFabricFiltered,
+ jint imTimeoutMs, jobject eventMin)
 {
-    CHIP_ERROR err = subscribe(env, handle, callbackHandle, devicePtr, attributePathList, eventPathList, nullptr, minInterval,
-                               maxInterval, keepSubscriptions, isFabricFiltered, imTimeoutMs, nullptr);
+    CHIP_ERROR err = subscribe(env, handle, callbackHandle, devicePtr, attributePathList, eventPathList, dataVersionFilterList,
+                               minInterval, maxInterval, keepSubscriptions, isFabricFiltered, imTimeoutMs, eventMin);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "JNI IM Subscribe Error: %" CHIP_ERROR_FORMAT, err.Format());
@@ -84,10 +85,10 @@ JNI_METHOD(void, subscribe)
 
 JNI_METHOD(void, read)
 (JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributePathList, jobject eventPathList,
- jboolean isFabricFiltered, jint imTimeoutMs)
+ jobject dataVersionFilterList, jboolean isFabricFiltered, jint imTimeoutMs, jobject eventMin)
 {
-    CHIP_ERROR err = read(env, handle, callbackHandle, devicePtr, attributePathList, eventPathList, nullptr, isFabricFiltered,
-                          imTimeoutMs, nullptr);
+    CHIP_ERROR err = read(env, handle, callbackHandle, devicePtr, attributePathList, eventPathList, dataVersionFilterList,
+                          isFabricFiltered, imTimeoutMs, eventMin);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "JNI IM Read Error: %" CHIP_ERROR_FORMAT, err.Format());

--- a/src/controller/java/CHIPInteractionClient-JNI.cpp
+++ b/src/controller/java/CHIPInteractionClient-JNI.cpp
@@ -132,8 +132,7 @@ JNI_METHOD(void, extendableInvoke)
 JNI_METHOD(void, shutdownSubscriptions)
 (JNIEnv * env, jobject self, jlong handle, jobject fabricIndex, jobject peerNodeId, jobject subscriptionId)
 {
-    CHIP_ERROR err =
-        shutdownSubscriptions(env, handle, fabricIndex, peerNodeId, subscriptionId);
+    CHIP_ERROR err = shutdownSubscriptions(env, handle, fabricIndex, peerNodeId, subscriptionId);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed to shutdown subscriptions with Error: %" CHIP_ERROR_FORMAT, err.Format());

--- a/src/controller/java/CHIPInteractionClient-JNI.cpp
+++ b/src/controller/java/CHIPInteractionClient-JNI.cpp
@@ -1,0 +1,129 @@
+/*
+ *   Copyright (c) 2024 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+#include "CHIPInteractionClient-JNI.h"
+#include "AndroidInteractionClient.h"
+
+#include <lib/support/CHIPJNIError.h>
+#include <lib/support/CHIPMem.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#define JNI_METHOD(RETURN, METHOD_NAME)                                                                                            \
+    extern "C" JNIEXPORT RETURN JNICALL Java_chip_devicecontroller_ChipInteractionClient_##METHOD_NAME
+
+jint AndroidChipInteractionJNI_OnLoad(JavaVM * jvm, void * reserved)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    JNIEnv * env;
+
+    ChipLogProgress(Controller, "AndroidChipInteractionJNI_OnLoad called");
+
+    chip::Platform::MemoryInit();
+
+    // Save a reference to the JVM.  Will need this to call back into Java.
+    chip::JniReferences::GetInstance().SetJavaVm(jvm, "chip/devicecontroller/ChipInteractionClient");
+
+    // Get a JNI environment object.
+    env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
+    VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
+
+    ChipLogProgress(Controller, "Loading Java class references.");
+
+    // Get various class references need by the API.
+    jclass controllerExceptionCls;
+    err = chip::JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/ChipDeviceControllerException",
+                                                              controllerExceptionCls);
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, JNI_ERR);
+
+    ChipLogProgress(Controller, "Java class references loaded.");
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        chip::JniReferences::GetInstance().ThrowError(env, controllerExceptionCls, err);
+        chip::DeviceLayer::StackUnlock unlock;
+        JNI_OnUnload(jvm, reserved);
+    }
+
+    return (err == CHIP_NO_ERROR) ? JNI_VERSION_1_6 : JNI_ERR;
+}
+
+void AndroidChipInteractionJNI_OnUnload(JavaVM * jvm, void * reserved)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "AndroidChipInteractionJNI_OnUnload() called");
+    chip::Platform::MemoryShutdown();
+}
+
+JNI_METHOD(void, subscribe)
+(JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributePathList, jobject eventPathList,
+ jint minInterval, jint maxInterval, jboolean keepSubscriptions, jboolean isFabricFiltered, jint imTimeoutMs)
+{
+    CHIP_ERROR err = subscribe(env, handle, callbackHandle, devicePtr, attributePathList, eventPathList, nullptr, minInterval,
+                               maxInterval, keepSubscriptions, isFabricFiltered, imTimeoutMs, nullptr);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "JNI IM Subscribe Error: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}
+
+JNI_METHOD(void, read)
+(JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributePathList, jobject eventPathList,
+ jboolean isFabricFiltered, jint imTimeoutMs)
+{
+    CHIP_ERROR err = read(env, handle, callbackHandle, devicePtr, attributePathList, eventPathList, nullptr, isFabricFiltered,
+                          imTimeoutMs, nullptr);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "JNI IM Read Error: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}
+
+JNI_METHOD(void, write)
+(JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributeList, jint timedRequestTimeoutMs,
+ jint imTimeoutMs)
+{
+    CHIP_ERROR err = write(env, handle, callbackHandle, devicePtr, attributeList, timedRequestTimeoutMs, imTimeoutMs);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "JNI IM Write Error: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}
+
+JNI_METHOD(void, invoke)
+(JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject invokeElement, jint timedRequestTimeoutMs,
+ jint imTimeoutMs)
+{
+    CHIP_ERROR err = invoke(env, handle, callbackHandle, devicePtr, invokeElement, timedRequestTimeoutMs, imTimeoutMs);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "JNI IM Invoke Error: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}
+
+JNI_METHOD(void, extendableInvoke)
+(JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject invokeElementList,
+ jint timedRequestTimeoutMs, jint imTimeoutMs)
+{
+    CHIP_ERROR err =
+        extendableInvoke(env, handle, callbackHandle, devicePtr, invokeElementList, timedRequestTimeoutMs, imTimeoutMs);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "JNI IM Batch Invoke Error: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+}

--- a/src/controller/java/CHIPInteractionClient-JNI.h
+++ b/src/controller/java/CHIPInteractionClient-JNI.h
@@ -1,0 +1,24 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+#include <jni.h>
+
+jint AndroidChipInteractionJNI_OnLoad(JavaVM * jvm, void * reserved);
+
+void AndroidChipInteractionJNI_OnUnload(JavaVM * jvm, void * reserved);

--- a/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
@@ -121,7 +121,7 @@ public class ChipClusters {
         boolean isFabricFiltered) {
       ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
       ChipAttributePath path = ChipAttributePath.newInstance(endpointId, clusterId, attributeId);
-      ChipDeviceController.read(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, isFabricFiltered, timeoutMillis.orElse(0L).intValue(), null);
+      ChipInteractionClient.read(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, isFabricFiltered, timeoutMillis.orElse(0L).intValue(), null);
     }
 
     protected void writeAttribute(
@@ -132,7 +132,7 @@ public class ChipClusters {
       WriteAttributesCallbackJni jniCallback = new WriteAttributesCallbackJni(callback);
       byte[] tlv = encodeToTlv(value);
       AttributeWriteRequest writeRequest = AttributeWriteRequest.newInstance(endpointId, clusterId, attributeId, tlv);
-      ChipDeviceController.write(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(writeRequest), timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
+      ChipInteractionClient.write(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(writeRequest), timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
     }
 
     protected void subscribeAttribute(
@@ -142,7 +142,7 @@ public class ChipClusters {
         int maxInterval) {
       ReportCallbackJni jniCallback = new ReportCallbackJni(callback, callback, null);
       ChipAttributePath path = ChipAttributePath.newInstance(endpointId, clusterId, attributeId);
-      ChipDeviceController.subscribe(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, minInterval, maxInterval, false, true, timeoutMillis.orElse(0L).intValue(), null);
+      ChipInteractionClient.subscribe(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, minInterval, maxInterval, false, true, timeoutMillis.orElse(0L).intValue(), null);
     }
 
     protected void invoke(
@@ -153,7 +153,7 @@ public class ChipClusters {
       InvokeCallbackJni jniCallback = new InvokeCallbackJni(callback);
       byte[] tlv = encodeToTlv(value);
       InvokeElement element = InvokeElement.newInstance(endpointId, clusterId, commandId, tlv, null);
-      ChipDeviceController.invoke(0, jniCallback.getCallbackHandle(), devicePtr, element, timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
+      ChipInteractionClient.invoke(0, jniCallback.getCallbackHandle(), devicePtr, element, timedRequestTimeoutMs, timeoutMillis.orElse(0L).intValue());
     }
 
     private static native byte[] encodeToTlv(BaseTLVType value);

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -757,12 +757,12 @@ public class ChipDeviceController {
 
   /* Shuts down all active subscriptions. */
   public void shutdownSubscriptions() {
-    shutdownSubscriptions(deviceControllerPtr, null, null, null);
+    ChipInteractionClient.shutdownSubscriptions(deviceControllerPtr, null, null, null);
   }
 
   /* Shuts down all active subscriptions for the fabric at the given fabricIndex */
   public void shutdownSubscriptions(int fabricIndex) {
-    shutdownSubscriptions(deviceControllerPtr, Integer.valueOf(fabricIndex), null, null);
+    ChipInteractionClient.shutdownSubscriptions(deviceControllerPtr, Integer.valueOf(fabricIndex), null, null);
   }
 
   /**
@@ -772,7 +772,7 @@ public class ChipDeviceController {
    * @param peerNodeId the node ID of the device for which subscriptions should be canceled
    */
   public void shutdownSubscriptions(int fabricIndex, long peerNodeId) {
-    shutdownSubscriptions(
+    ChipInteractionClient.shutdownSubscriptions(
         deviceControllerPtr, Integer.valueOf(fabricIndex), Long.valueOf(peerNodeId), null);
   }
 
@@ -784,7 +784,7 @@ public class ChipDeviceController {
    * @param subscriptionId the ID of the subscription on the node which should be canceled
    */
   public void shutdownSubscriptions(int fabricIndex, long peerNodeId, long subscriptionId) {
-    shutdownSubscriptions(
+    ChipInteractionClient.shutdownSubscriptions(
         deviceControllerPtr,
         Integer.valueOf(fabricIndex),
         Long.valueOf(peerNodeId),
@@ -1530,12 +1530,6 @@ public class ChipDeviceController {
   private native long onNOCChainGeneration(long deviceControllerPtr, ControllerParams params);
 
   private native int getFabricIndex(long deviceControllerPtr);
-
-  private native void shutdownSubscriptions(
-      long deviceControllerPtr,
-      @Nullable Integer fabricIndex,
-      @Nullable Long peerNodeId,
-      @Nullable Long subscriptionId);
 
   private native void shutdownCommissioning(long deviceControllerPtr);
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -762,7 +762,8 @@ public class ChipDeviceController {
 
   /* Shuts down all active subscriptions for the fabric at the given fabricIndex */
   public void shutdownSubscriptions(int fabricIndex) {
-    ChipInteractionClient.shutdownSubscriptions(deviceControllerPtr, Integer.valueOf(fabricIndex), null, null);
+    ChipInteractionClient.shutdownSubscriptions(
+        deviceControllerPtr, Integer.valueOf(fabricIndex), null, null);
   }
 
   /**

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -825,7 +825,7 @@ public class ChipDeviceController {
       int imTimeoutMs) {
     ReportCallbackJni jniCallback =
         new ReportCallbackJni(subscriptionEstablishedCallback, reportCallback, null);
-    subscribe(
+    ChipInteractionClient.subscribe(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -863,7 +863,7 @@ public class ChipDeviceController {
       int imTimeoutMs) {
     ReportCallbackJni jniCallback =
         new ReportCallbackJni(subscriptionEstablishedCallback, reportCallback, null);
-    subscribe(
+    ChipInteractionClient.subscribe(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -889,7 +889,7 @@ public class ChipDeviceController {
       @Nullable Long eventMin) {
     ReportCallbackJni jniCallback =
         new ReportCallbackJni(subscriptionEstablishedCallback, reportCallback, null);
-    subscribe(
+    ChipInteractionClient.subscribe(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -923,7 +923,7 @@ public class ChipDeviceController {
     ReportCallbackJni jniCallback =
         new ReportCallbackJni(
             subscriptionEstablishedCallback, reportCallback, resubscriptionAttemptCallback);
-    subscribe(
+    ChipInteractionClient.subscribe(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -975,7 +975,7 @@ public class ChipDeviceController {
     ReportCallbackJni jniCallback =
         new ReportCallbackJni(
             subscriptionEstablishedCallback, reportCallback, resubscriptionAttemptCallback);
-    subscribe(
+    ChipInteractionClient.subscribe(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -1006,7 +1006,7 @@ public class ChipDeviceController {
     ReportCallbackJni jniCallback =
         new ReportCallbackJni(
             subscriptionEstablishedCallback, reportCallback, resubscriptionAttemptCallback);
-    subscribe(
+    ChipInteractionClient.subscribe(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -1036,7 +1036,7 @@ public class ChipDeviceController {
       List<ChipAttributePath> attributePaths,
       int imTimeoutMs) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
-    read(
+    ChipInteractionClient.read(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -1060,7 +1060,7 @@ public class ChipDeviceController {
   public void readEventPath(
       ReportCallback callback, long devicePtr, List<ChipEventPath> eventPaths, int imTimeoutMs) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
-    read(
+    ChipInteractionClient.read(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -1080,7 +1080,7 @@ public class ChipDeviceController {
       int imTimeoutMs,
       @Nullable Long eventMin) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
-    read(
+    ChipInteractionClient.read(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -1101,7 +1101,7 @@ public class ChipDeviceController {
       boolean isFabricFiltered,
       int imTimeoutMs) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
-    read(
+    ChipInteractionClient.read(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -1133,7 +1133,7 @@ public class ChipDeviceController {
       boolean isFabricFiltered,
       int imTimeoutMs) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
-    read(
+    ChipInteractionClient.read(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -1155,7 +1155,7 @@ public class ChipDeviceController {
       int imTimeoutMs,
       @Nullable Long eventMin) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
-    read(
+    ChipInteractionClient.read(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -1184,7 +1184,7 @@ public class ChipDeviceController {
       int timedRequestTimeoutMs,
       int imTimeoutMs) {
     WriteAttributesCallbackJni jniCallback = new WriteAttributesCallbackJni(callback);
-    write(
+    ChipInteractionClient.write(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -1210,7 +1210,7 @@ public class ChipDeviceController {
       int timedRequestTimeoutMs,
       int imTimeoutMs) {
     InvokeCallbackJni jniCallback = new InvokeCallbackJni(callback);
-    invoke(
+    ChipInteractionClient.invoke(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -1236,7 +1236,7 @@ public class ChipDeviceController {
       int timedRequestTimeoutMs,
       int imTimeoutMs) {
     ExtendableInvokeCallbackJni jniCallback = new ExtendableInvokeCallbackJni(callback);
-    extendableInvoke(
+    ChipInteractionClient.extendableInvoke(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
@@ -1377,55 +1377,6 @@ public class ChipDeviceController {
 
   private native PaseVerifierParams computePaseVerifier(
       long deviceControllerPtr, long devicePtr, long setupPincode, long iterations, byte[] salt);
-
-  static native void subscribe(
-      long deviceControllerPtr,
-      long callbackHandle,
-      long devicePtr,
-      List<ChipAttributePath> attributePaths,
-      List<ChipEventPath> eventPaths,
-      List<DataVersionFilter> dataVersionFilters,
-      int minInterval,
-      int maxInterval,
-      boolean keepSubscriptions,
-      boolean isFabricFiltered,
-      int imTimeoutMs,
-      @Nullable Long eventMin);
-
-  static native void read(
-      long deviceControllerPtr,
-      long callbackHandle,
-      long devicePtr,
-      List<ChipAttributePath> attributePaths,
-      List<ChipEventPath> eventPaths,
-      List<DataVersionFilter> dataVersionFilters,
-      boolean isFabricFiltered,
-      int imTimeoutMs,
-      @Nullable Long eventMin);
-
-  static native void write(
-      long deviceControllerPtr,
-      long callbackHandle,
-      long devicePtr,
-      List<AttributeWriteRequest> attributeList,
-      int timedRequestTimeoutMs,
-      int imTimeoutMs);
-
-  static native void invoke(
-      long deviceControllerPtr,
-      long callbackHandle,
-      long devicePtr,
-      InvokeElement invokeElement,
-      int timedRequestTimeoutMs,
-      int imTimeoutMs);
-
-  static native void extendableInvoke(
-      long deviceControllerPtr,
-      long callbackHandle,
-      long devicePtr,
-      List<InvokeElement> invokeElementList,
-      int timedRequestTimeoutMs,
-      int imTimeoutMs);
 
   private native long newDeviceController(ControllerParams params);
 

--- a/src/controller/java/src/chip/devicecontroller/ChipInteractionClient.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipInteractionClient.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package chip.devicecontroller;
+
+import chip.devicecontroller.model.AttributeWriteRequest;
+import chip.devicecontroller.model.ChipAttributePath;
+import chip.devicecontroller.model.ChipEventPath;
+import chip.devicecontroller.model.DataVersionFilter;
+import chip.devicecontroller.model.InvokeElement;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public class ChipInteractionClient {
+  static native void subscribe(
+      long deviceControllerPtr,
+      long callbackHandle,
+      long devicePtr,
+      List<ChipAttributePath> attributePaths,
+      List<ChipEventPath> eventPaths,
+      List<DataVersionFilter> dataVersionFilters,
+      int minInterval,
+      int maxInterval,
+      boolean keepSubscriptions,
+      boolean isFabricFiltered,
+      int imTimeoutMs,
+      @Nullable Long eventMin);
+
+  static native void read(
+      long deviceControllerPtr,
+      long callbackHandle,
+      long devicePtr,
+      List<ChipAttributePath> attributePaths,
+      List<ChipEventPath> eventPaths,
+      List<DataVersionFilter> dataVersionFilters,
+      boolean isFabricFiltered,
+      int imTimeoutMs,
+      @Nullable Long eventMin);
+
+  static native void write(
+      long deviceControllerPtr,
+      long callbackHandle,
+      long devicePtr,
+      List<AttributeWriteRequest> attributeList,
+      int timedRequestTimeoutMs,
+      int imTimeoutMs);
+
+  static native void invoke(
+      long deviceControllerPtr,
+      long callbackHandle,
+      long devicePtr,
+      InvokeElement invokeElement,
+      int timedRequestTimeoutMs,
+      int imTimeoutMs);
+
+  static native void extendableInvoke(
+      long deviceControllerPtr,
+      long callbackHandle,
+      long devicePtr,
+      List<InvokeElement> invokeElementList,
+      int timedRequestTimeoutMs,
+      int imTimeoutMs);
+}

--- a/src/controller/java/src/chip/devicecontroller/ChipInteractionClient.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipInteractionClient.java
@@ -73,4 +73,10 @@ public class ChipInteractionClient {
       List<InvokeElement> invokeElementList,
       int timedRequestTimeoutMs,
       int imTimeoutMs);
+
+  static native void shutdownSubscriptions(
+      long deviceControllerPtr,
+      @Nullable Integer fabricIndex,
+      @Nullable Long peerNodeId,
+      @Nullable Long subscriptionId);
 }


### PR DESCRIPTION
Addresses #32977 

Change summary

1.  Moved IM APIs out of the ChipDeviceController.java to a ChipInteractionClient.java and added the corresponding ChipInteractionClient-JNI.h/.cpp code.
2.  Created new targets for the IM related CPP and Java code
3.  Consumed the new CHIPInteractionModel targets in the CHIPController target to maintain backwards compatibility and also consumed it in the examples/tv-casting-app/android/BUILD.gn

Testing

Tested by building the examples/tv-casting-app and seeing that the CHIPInteractionModel gets built in.