### PR TITLE
Update rpc_config.gni

### DIFF
--- a/examples/common/pigweed/rpc_config.gni
+++ b/examples/common/pigweed/rpc_config.gni
@@ -31,7 +31,8 @@ rpc_sources = [
 ]
 
 rpc_deps = [
-  "$dir_pw_hdlc:pw_rpc",
+  # "$dir_pw_hdlc:pw_rpc", This file is not found on upstream at all.
+  "$dir_pw_hdlc:default_addresses",
   "$dir_pw_hdlc:rpc_channel_output",
   "$dir_pw_log",
   "$dir_pw_rpc:server",

--- a/examples/common/pigweed/rpc_config.gni
+++ b/examples/common/pigweed/rpc_config.gni
@@ -31,7 +31,6 @@ rpc_sources = [
 ]
 
 rpc_deps = [
-  # "$dir_pw_hdlc:pw_rpc", This file is not found on upstream at all.
   "$dir_pw_hdlc:default_addresses",
   "$dir_pw_hdlc:rpc_channel_output",
   "$dir_pw_log",

--- a/examples/common/pigweed/rpc_config.gni
+++ b/examples/common/pigweed/rpc_config.gni
@@ -31,7 +31,7 @@ rpc_sources = [
 ]
 
 rpc_deps = [
-  "$dir_pw_hdlc:default_addresses", 
+  "$dir_pw_hdlc:default_addresses",
   "$dir_pw_hdlc:rpc_channel_output",
   "$dir_pw_log",
   "$dir_pw_rpc:server",

--- a/examples/common/pigweed/rpc_config.gni
+++ b/examples/common/pigweed/rpc_config.gni
@@ -31,7 +31,7 @@ rpc_sources = [
 ]
 
 rpc_deps = [
-  "$dir_pw_hdlc:default_addresses",
+  "$dir_pw_hdlc:default_addresses", 
   "$dir_pw_hdlc:rpc_channel_output",
   "$dir_pw_log",
   "$dir_pw_rpc:server",


### PR DESCRIPTION
Fix for https://github.com/project-chip/connectedhomeip/issues/32979
The "pw_rpc" is not a valid .h file can be found from upstream, neither any file starting with this name so it must be removed.
default_addresses is found on upstream and its required, otherwise the compile process will still fail. 


![image](https://github.com/project-chip/connectedhomeip/assets/25316415/08046fa6-e873-419e-a231-be5cddead494)
