### PR TITLE
Darwin: MTRDeviceControllerFactory improvements

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -1795,11 +1795,7 @@ OpenCommissioningWindowHelper::OpenCommissioningWindowHelper(Controller::DeviceC
 CHIP_ERROR OpenCommissioningWindowHelper::OpenCommissioningWindow(Controller::DeviceController * controller, NodeId nodeID,
     System::Clock::Seconds16 timeout, uint16_t discriminator, const Optional<uint32_t> & setupPIN, ResultCallback callback)
 {
-    auto * self = new (std::nothrow) OpenCommissioningWindowHelper(controller, callback);
-    if (self == nullptr) {
-        return CHIP_ERROR_NO_MEMORY;
-    }
-
+    auto * self = new OpenCommissioningWindowHelper(controller, callback);
     SetupPayload unused;
     CHIP_ERROR err = self->mOpener.OpenCommissioningWindow(nodeID, timeout, Crypto::kSpake2p_Min_PBKDF_Iterations, discriminator,
         setupPIN, NullOptional, &self->mOnOpenCommissioningWindowCallback, unused);

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -413,10 +413,6 @@ using namespace chip::Tracing::DarwinFramework;
         }
 
         _cppCommissioner = new chip::Controller::DeviceCommissioner();
-        if (_cppCommissioner == nullptr) {
-            [self checkForStartError:CHIP_ERROR_NO_MEMORY logMsg:kErrorCommissionerInit];
-            return;
-        }
 
         // nocBuffer might not be used, but if it is it needs to live
         // long enough (until after we are done using

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -330,15 +330,12 @@ MTR_DIRECT_MEMBERS
         InitializeServerAccessControl();
 
         if (startupParams.hasStorage) {
-            _persistentStorageDelegate = new (std::nothrow) MTRPersistentStorageDelegateBridge(startupParams.storage);
-            VerifyOrExit(_persistentStorageDelegate != nullptr, err = CHIP_ERROR_NO_MEMORY);
+            _persistentStorageDelegate = new MTRPersistentStorageDelegateBridge(startupParams.storage);
             _sessionResumptionStorage = nullptr;
             _usingPerControllerStorage = NO;
         } else {
-            _persistentStorageDelegate = new (std::nothrow) MTRDemuxingStorage(self);
-            VerifyOrExit(_persistentStorageDelegate != nullptr, err = CHIP_ERROR_NO_MEMORY);
-            _sessionResumptionStorage = new (std::nothrow) MTRSessionResumptionStorageBridge(self);
-            VerifyOrExit(_sessionResumptionStorage != nullptr, err = CHIP_ERROR_NO_MEMORY);
+            _persistentStorageDelegate = new MTRDemuxingStorage(self);
+            _sessionResumptionStorage = new MTRSessionResumptionStorageBridge(self);
             _usingPerControllerStorage = YES;
         }
 
@@ -350,12 +347,10 @@ MTR_DIRECT_MEMBERS
 
         // TODO: Allow passing a different keystore implementation via startupParams.
         _keystore = new PersistentStorageOperationalKeystore();
-        VerifyOrExit(_keystore != nullptr, err = CHIP_ERROR_NO_MEMORY);
         SuccessOrExit((err = _keystore->Init(_persistentStorageDelegate)));
 
         // TODO Allow passing a different opcert store implementation via startupParams.
         _opCertStore = new Credentials::PersistentStorageOpCertStore();
-        VerifyOrExit(_opCertStore != nullptr, err = CHIP_ERROR_NO_MEMORY);
         SuccessOrExit((err = _opCertStore->Init(_persistentStorageDelegate)));
 
         _productAttestationAuthorityCertificates = [startupParams.productAttestationAuthorityCertificates copy];
@@ -689,13 +684,8 @@ MTR_DIRECT_MEMBERS
                                                                                                  keystore:self->_keystore
                                                                                      advertiseOperational:self->_advertiseOperational
                                                                                                    params:startupParams];
-                              if (params == nil) {
-                                  fabricError = CHIP_ERROR_NO_MEMORY;
-                              } else {
-                                  params.productAttestationAuthorityCertificates = self->_productAttestationAuthorityCertificates;
-                                  params.certificationDeclarationCertificates = self->_certificationDeclarationCertificates;
-                              }
-
+                              params.productAttestationAuthorityCertificates = self->_productAttestationAuthorityCertificates;
+                              params.certificationDeclarationCertificates = self->_certificationDeclarationCertificates;
                               return params;
                           }
                                   error:error];
@@ -745,12 +735,8 @@ MTR_DIRECT_MEMBERS
                                                                                             keystore:self->_keystore
                                                                                 advertiseOperational:self->_advertiseOperational
                                                                                               params:startupParams];
-                              if (params == nil) {
-                                  fabricError = CHIP_ERROR_NO_MEMORY;
-                              } else {
-                                  params.productAttestationAuthorityCertificates = self->_productAttestationAuthorityCertificates;
-                                  params.certificationDeclarationCertificates = self->_certificationDeclarationCertificates;
-                              }
+                              params.productAttestationAuthorityCertificates = self->_productAttestationAuthorityCertificates;
+                              params.certificationDeclarationCertificates = self->_certificationDeclarationCertificates;
                               return params;
                           }
                                   error:error];

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -347,11 +347,11 @@ MTR_DIRECT_MEMBERS
 
         // TODO: Allow passing a different keystore implementation via startupParams.
         _keystore = new PersistentStorageOperationalKeystore();
-        SuccessOrExit((err = _keystore->Init(_persistentStorageDelegate)));
+        SuccessOrExit(err = _keystore->Init(_persistentStorageDelegate));
 
         // TODO Allow passing a different opcert store implementation via startupParams.
         _opCertStore = new Credentials::PersistentStorageOpCertStore();
-        SuccessOrExit((err = _opCertStore->Init(_persistentStorageDelegate)));
+        SuccessOrExit(err = _opCertStore->Init(_persistentStorageDelegate));
 
         _productAttestationAuthorityCertificates = [startupParams.productAttestationAuthorityCertificates copy];
         _certificationDeclarationCertificates = [startupParams.certificationDeclarationCertificates copy];
@@ -370,7 +370,7 @@ MTR_DIRECT_MEMBERS
             params.opCertStore = _opCertStore;
             params.certificateValidityPolicy = &_certificateValidityPolicy;
             params.sessionResumptionStorage = _sessionResumptionStorage;
-            SuccessOrExit((err = _controllerFactory->Init(params)));
+            SuccessOrExit(err = _controllerFactory->Init(params));
         }
 
         // This needs to happen after DeviceControllerFactory::Init,

--- a/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.mm
@@ -50,19 +50,11 @@
     chip::SetupPayload cPlusPluspayload;
     MTRSetupPayload * payload;
 
-    if (_chipManualSetupPayloadParser) {
-        CHIP_ERROR chipError = _chipManualSetupPayloadParser->populatePayload(cPlusPluspayload);
-
-        if (chipError == CHIP_NO_ERROR) {
-            payload = [[MTRSetupPayload alloc] initWithSetupPayload:cPlusPluspayload];
-        } else if (error) {
-            *error = [MTRError errorForCHIPErrorCode:chipError];
-        }
-    } else {
-        // Memory init has failed
-        if (error) {
-            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_NO_MEMORY];
-        }
+    CHIP_ERROR chipError = _chipManualSetupPayloadParser->populatePayload(cPlusPluspayload);
+    if (chipError == CHIP_NO_ERROR) {
+        payload = [[MTRSetupPayload alloc] initWithSetupPayload:cPlusPluspayload];
+    } else if (error) {
+        *error = [MTRError errorForCHIPErrorCode:chipError];
     }
 
     return payload;

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
@@ -64,10 +64,8 @@ CHIP_ERROR MTROperationalCredentialsDelegate::Init(
 
     // Make copies of the certificates, just in case the API consumer
     // has them as MutableData.
-    mRootCert = [NSData dataWithData:rootCert];
-    if (icaCert != nil) {
-        mIntermediateCert = [NSData dataWithData:icaCert];
-    }
+    mRootCert = [rootCert copy];
+    mIntermediateCert = [icaCert copy];
 
     return CHIP_NO_ERROR;
 }

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
@@ -65,15 +65,8 @@ CHIP_ERROR MTROperationalCredentialsDelegate::Init(
     // Make copies of the certificates, just in case the API consumer
     // has them as MutableData.
     mRootCert = [NSData dataWithData:rootCert];
-    if (mRootCert == nil) {
-        return CHIP_ERROR_NO_MEMORY;
-    }
-
     if (icaCert != nil) {
         mIntermediateCert = [NSData dataWithData:icaCert];
-        if (mIntermediateCert == nil) {
-            return CHIP_ERROR_NO_MEMORY;
-        }
     }
 
     return CHIP_NO_ERROR;

--- a/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.mm
@@ -50,19 +50,11 @@
     chip::SetupPayload cPlusPluspayload;
     MTRSetupPayload * payload;
 
-    if (_chipQRCodeSetupPayloadParser) {
-        CHIP_ERROR chipError = _chipQRCodeSetupPayloadParser->populatePayload(cPlusPluspayload);
-
-        if (chipError == CHIP_NO_ERROR) {
-            payload = [[MTRSetupPayload alloc] initWithSetupPayload:cPlusPluspayload];
-        } else if (error) {
-            *error = [MTRError errorForCHIPErrorCode:chipError];
-        }
-    } else {
-        // Memory init has failed
-        if (error) {
-            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_NO_MEMORY];
-        }
+    CHIP_ERROR chipError = _chipQRCodeSetupPayloadParser->populatePayload(cPlusPluspayload);
+    if (chipError == CHIP_NO_ERROR) {
+        payload = [[MTRSetupPayload alloc] initWithSetupPayload:cPlusPluspayload];
+    } else if (error) {
+        *error = [MTRError errorForCHIPErrorCode:chipError];
     }
 
     return payload;

--- a/src/darwin/Framework/CHIPTests/MTRControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerTests.m
@@ -62,6 +62,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
     XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
+    // Starting again with identical params is a no-op
+    __auto_type * factoryParams2 = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams2 error:nil]);
+
     [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 


### PR DESCRIPTION
Handle cleanup after failed factory start in the same dispatch_sync
Also remove some unnecessary OOM handling at the framework level, treat allocation failure as fatal.