### PR TITLE
DeviceControllerFactory: Add InitAndRetainSystemState

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -388,7 +388,7 @@ bool DeviceControllerFactory::ReleaseSystemState()
     return mSystemState->Release();
 }
 
-CHIP_ERROR DeviceControllerFactory::InitAndRetainSystemState()
+CHIP_ERROR DeviceControllerFactory::EnsureAndRetainSystemState()
 {
     ReturnErrorOnFailure(ReinitSystemStateIfNecessary());
     RetainSystemState();

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -210,7 +210,7 @@ public:
     bool ReleaseSystemState();
 
     // Like RetainSystemState(), but will re-initialize the system state first if necessary.
-    CHIP_ERROR InitAndRetainSystemState();
+    CHIP_ERROR EnsureAndRetainSystemState();
 
     //
     // Retrieve a read-only pointer to the system state object that contains pointers to key stack

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -209,6 +209,9 @@ public:
     //
     bool ReleaseSystemState();
 
+    // Like RetainSystemState(), but will re-initialize the system state first if necessary.
+    CHIP_ERROR InitAndRetainSystemState();
+
     //
     // Retrieve a read-only pointer to the system state object that contains pointers to key stack
     // singletons. If the pointer is null, it indicates that the DeviceControllerFactory has yet to
@@ -272,7 +275,7 @@ private:
     DeviceControllerFactory() {}
     void PopulateInitParams(ControllerInitParams & controllerParams, const SetupParams & params);
     CHIP_ERROR InitSystemState(FactoryInitParams params);
-    CHIP_ERROR InitSystemState();
+    CHIP_ERROR ReinitSystemStateIfNecessary();
     void ControllerInitialized(const DeviceController & controller);
 
     uint16_t mListenPort;


### PR DESCRIPTION
This does a RetainSystemState, but re-initializes if necessary.

Also rename no-arg InitSystemState() to ReinitSystemStateIfNecessary() and check for the case where no work is necessary before creating the FactoryInitParams and calling InitSystemState(params).

This means InitSystemState(params) doesn't have to handle that case anymore since it's only called from Init() or after ReinitSystemStateIfNecessary() has already done the check.
