### PR TITLE
Fix OTA Requestor implementation of write to DefaultOTAProviders.

### DIFF
--- a/src/app/clusters/ota-requestor/ota-requestor-server.cpp
+++ b/src/app/clusters/ota-requestor/ota-requestor-server.cpp
@@ -115,20 +115,24 @@ CHIP_ERROR OtaSoftwareUpdateRequestorAttrAccess::WriteDefaultOtaProviders(const 
         return CHIP_ERROR_NOT_FOUND;
     }
 
-    switch (aPath.mListOp)
+    if (!aPath.IsListOperation() || aPath.mListOp == ConcreteDataAttributePath::ListOperation::ReplaceAll)
     {
-    case ConcreteDataAttributePath::ListOperation::ReplaceAll: {
         DataModel::DecodableList<OtaSoftwareUpdateRequestor::Structs::ProviderLocation::DecodableType> list;
         ReturnErrorOnFailure(aDecoder.Decode(list));
 
-        // With chunking, a single large list is converted to a list of AttributeDataIBs. The first AttributeDataIB contains an
-        // empty list (to signal this is a replace so clear out contents) followed by a succession of single AttributeDataIBs for
-        // each entry to be added.
-        size_t count = 0;
-        ReturnErrorOnFailure(list.ComputeSize(&count));
-        VerifyOrReturnError(count == 0, CHIP_ERROR_INVALID_ARGUMENT);
-        return requestor->ClearDefaultOtaProviderList(aDecoder.AccessingFabricIndex());
+        ReturnErrorOnFailure(requestor->ClearDefaultOtaProviderList(aDecoder.AccessingFabricIndex()));
+
+        auto iter = list.begin();
+        while (iter.Next())
+        {
+            ReturnErrorOnFailure(requestor->AddDefaultOtaProvider(iter.GetValue()));
+        }
+
+        return iter.GetStatus();
     }
+
+    switch (aPath.mListOp)
+    {
     case ConcreteDataAttributePath::ListOperation::ReplaceItem:
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     case ConcreteDataAttributePath::ListOperation::DeleteItem:


### PR DESCRIPTION
Our implementation only handled chunked lists and failed if a non-chunked list was sent.  This is bad, because typically this list is short, and chunking it wastes bytes on the wire.

