### PR TITLE
Make test setup functions terminate on error

### DIFF
--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -163,7 +163,7 @@ public:
             ASSERT_NE(pMessagingContext, nullptr);
         }
 
-        ASSERT_EQ(pMessagingContext->SetUpTestSuite(), CHIP_NO_ERROR);
+        pMessagingContext->SetUpTestSuite();
         ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
 
         DeviceLayer::SetSystemLayerForTesting(&(pMessagingContext->GetSystemLayer()));
@@ -198,7 +198,7 @@ public:
     // Performs setup for each individual test in the test suite
     void SetUp() override
     {
-        EXPECT_EQ(pMessagingContext->SetUp(), CHIP_NO_ERROR);
+        pMessagingContext->SetUp();
 
         mICDStateObserver.ResetAll();
         mICDManager.RegisterObserver(&mICDStateObserver);

--- a/src/app/tests/AppTestContext.cpp
+++ b/src/app/tests/AppTestContext.cpp
@@ -38,15 +38,13 @@ chip::Access::AccessControl gPermissiveAccessControl;
 namespace chip {
 namespace Test {
 
-CHIP_ERROR AppContext::SetUpTestSuite()
+void AppContext::SetUpTestSuite()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit((err = LoopbackMessagingContext::SetUpTestSuite()) == CHIP_NO_ERROR,
-                 ChipLogError(AppServer, "SetUpTestSuite lo messaging context failed: %" CHIP_ERROR_FORMAT, err.Format()));
-    VerifyOrExit((err = chip::DeviceLayer::PlatformMgr().InitChipStack()) == CHIP_NO_ERROR,
-                 ChipLogError(AppServer, "Init CHIP stack failed: %" CHIP_ERROR_FORMAT, err.Format()));
-exit:
-    return err;
+    LoopbackMessagingContext::SetUpTestSuite();
+    // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+    VerifyOrDieWithMsg((err = chip::DeviceLayer::PlatformMgr().InitChipStack()) == CHIP_NO_ERROR, AppServer,
+                       "Init CHIP stack failed: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 void AppContext::TearDownTestSuite()
@@ -55,20 +53,19 @@ void AppContext::TearDownTestSuite()
     LoopbackMessagingContext::TearDownTestSuite();
 }
 
-CHIP_ERROR AppContext::SetUp()
+void AppContext::SetUp()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit((err = LoopbackMessagingContext::SetUp()) == CHIP_NO_ERROR,
-                 ChipLogError(AppServer, "SetUp lo messaging context failed: %" CHIP_ERROR_FORMAT, err.Format()));
-    VerifyOrExit((err = app::InteractionModelEngine::GetInstance()->Init(
-                      &GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler())) == CHIP_NO_ERROR,
-                 ChipLogError(AppServer, "Init InteractionModelEngine failed: %" CHIP_ERROR_FORMAT, err.Format()));
+    LoopbackMessagingContext::SetUp();
+    // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+    VerifyOrDieWithMsg((err = app::InteractionModelEngine::GetInstance()->Init(&GetExchangeManager(), &GetFabricTable(),
+                                                                               app::reporting::GetDefaultReportScheduler())) ==
+                           CHIP_NO_ERROR,
+                       AppServer, "Init InteractionModelEngine failed: %" CHIP_ERROR_FORMAT, err.Format());
     Access::SetAccessControl(gPermissiveAccessControl);
-    VerifyOrExit((err = Access::GetAccessControl().Init(chip::Access::Examples::GetPermissiveAccessControlDelegate(),
-                                                        gDeviceTypeResolver)) == CHIP_NO_ERROR,
-                 ChipLogError(AppServer, "Init AccessControl failed: %" CHIP_ERROR_FORMAT, err.Format()));
-exit:
-    return err;
+    VerifyOrDieWithMsg((err = Access::GetAccessControl().Init(chip::Access::Examples::GetPermissiveAccessControlDelegate(),
+                                                              gDeviceTypeResolver)) == CHIP_NO_ERROR,
+                       AppServer, "Init AccessControl failed: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 void AppContext::TearDown()

--- a/src/app/tests/AppTestContext.h
+++ b/src/app/tests/AppTestContext.h
@@ -28,11 +28,11 @@ class AppContext : public LoopbackMessagingContext
 {
 public:
     // Performs shared setup for all tests in the test suite
-    CHIP_ERROR SetUpTestSuite() override;
+    void SetUpTestSuite() override;
     // Performs shared teardown for all tests in the test suite
     void TearDownTestSuite() override;
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override;
+    void SetUp() override;
     // Performs teardown for each individual test in the test suite
     void TearDown() override;
 };

--- a/src/app/tests/TestAclAttribute.cpp
+++ b/src/app/tests/TestAclAttribute.cpp
@@ -81,12 +81,11 @@ class TestAccessContext : public chip::Test::AppContext
 {
 public:
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
+        chip::Test::AppContext::SetUp();
         Access::GetAccessControl().Finish();
         Access::GetAccessControl().Init(GetTestAccessControlDelegate(), gDeviceTypeResolver);
-        return CHIP_NO_ERROR;
     }
 };
 

--- a/src/app/tests/TestAclEvent.cpp
+++ b/src/app/tests/TestAclEvent.cpp
@@ -86,7 +86,7 @@ class TestContext : public chip::Test::AppContext
 {
 public:
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
         const chip::app::LogStorageResources logStorageResources[] = {
             { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
@@ -94,19 +94,17 @@ public:
             { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
         };
 
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
+        chip::Test::AppContext::SetUp();
 
         CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit((err = mEventCounter.Init(0)) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format()));
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDieWithMsg((err = mEventCounter.Init(0)) == CHIP_NO_ERROR, AppServer,
+                           "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format());
         chip::app::EventManagement::CreateEventManagement(&GetExchangeManager(), ArraySize(logStorageResources),
                                                           gCircularEventBuffer, logStorageResources, &mEventCounter);
 
         Access::GetAccessControl().Finish();
         Access::GetAccessControl().Init(GetTestAccessControlDelegate(), gDeviceTypeResolver);
-
-    exit:
-        return err;
     }
 
     // Performs teardown for each individual test in the test suite

--- a/src/app/tests/TestEventLogging.cpp
+++ b/src/app/tests/TestEventLogging.cpp
@@ -64,7 +64,7 @@ class TestContext : public chip::Test::AppContext
 {
 public:
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
         const chip::app::LogStorageResources logStorageResources[] = {
             { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
@@ -72,16 +72,14 @@ public:
             { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
         };
 
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
+        chip::Test::AppContext::SetUp();
 
         CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit((err = mEventCounter.Init(0)) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format()));
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDieWithMsg((err = mEventCounter.Init(0)) == CHIP_NO_ERROR, AppServer,
+                           "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format());
         chip::app::EventManagement::CreateEventManagement(&GetExchangeManager(), ArraySize(logStorageResources),
                                                           gCircularEventBuffer, logStorageResources, &mEventCounter);
-
-    exit:
-        return err;
     }
 
     // Performs teardown for each individual test in the test suite

--- a/src/app/tests/TestEventLoggingNoUTCTime.cpp
+++ b/src/app/tests/TestEventLoggingNoUTCTime.cpp
@@ -84,11 +84,10 @@ class TestContext : public chip::Test::AppContext
 {
 public:
     // Performs shared setup for all tests in the test suite
-    CHIP_ERROR SetUpTestSuite() override
+    void SetUpTestSuite() override
     {
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUpTestSuite());
+        chip::Test::AppContext::SetUpTestSuite();
         mClock.Emplace(chip::System::SystemClock());
-        return CHIP_NO_ERROR;
     }
 
     // Performs shared teardown for all tests in the test suite
@@ -99,7 +98,7 @@ public:
     }
 
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
         const chip::app::LogStorageResources logStorageResources[] = {
             { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
@@ -107,16 +106,14 @@ public:
             { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
         };
 
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
+        chip::Test::AppContext::SetUp();
 
         CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit((err = mEventCounter.Init(0)) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format()));
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDieWithMsg((err = mEventCounter.Init(0)) == CHIP_NO_ERROR, AppServer,
+                           "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format());
         chip::app::EventManagement::CreateEventManagement(&GetExchangeManager(), ArraySize(logStorageResources),
                                                           gCircularEventBuffer, logStorageResources, &mEventCounter);
-
-    exit:
-        return err;
     }
 
     // Performs teardown for each individual test in the test suite

--- a/src/app/tests/TestEventOverflow.cpp
+++ b/src/app/tests/TestEventOverflow.cpp
@@ -56,7 +56,7 @@ class TestContext : public chip::Test::AppContext
 {
 public:
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
         const chip::app::LogStorageResources logStorageResources[] = {
             { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
@@ -64,16 +64,14 @@ public:
             { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
         };
 
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
+        chip::Test::AppContext::SetUp();
 
         CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit((err = mEventCounter.Init(0)) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format()));
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDieWithMsg((err = mEventCounter.Init(0)) == CHIP_NO_ERROR, AppServer,
+                           "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format());
         chip::app::EventManagement::CreateEventManagement(&GetExchangeManager(), ArraySize(logStorageResources),
                                                           gCircularEventBuffer, logStorageResources, &mEventCounter);
-
-    exit:
-        return err;
     }
 
     // Performs teardown for each individual test in the test suite

--- a/src/app/tests/TestFabricScopedEventLogging.cpp
+++ b/src/app/tests/TestFabricScopedEventLogging.cpp
@@ -64,7 +64,7 @@ class TestContext : public chip::Test::AppContext
 {
 public:
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
         const chip::app::LogStorageResources logStorageResources[] = {
             { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
@@ -72,16 +72,14 @@ public:
             { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
         };
 
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
+        chip::Test::AppContext::SetUp();
 
         CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit((err = mEventCounter.Init(0)) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format()));
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDieWithMsg((err = mEventCounter.Init(0)) == CHIP_NO_ERROR, AppServer,
+                           "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format());
         chip::app::EventManagement::CreateEventManagement(&GetExchangeManager(), ArraySize(logStorageResources),
                                                           gCircularEventBuffer, logStorageResources, &mEventCounter);
-
-    exit:
-        return err;
     }
 
     // Performs teardown for each individual test in the test suite

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -79,9 +79,9 @@ class TestContext : public chip::Test::AppContext
 {
 public:
     // Performs shared setup for all tests in the test suite
-    CHIP_ERROR SetUpTestSuite() override
+    void SetUpTestSuite() override
     {
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUpTestSuite());
+        chip::Test::AppContext::SetUpTestSuite();
         gRealClock = &chip::System::SystemClock();
         chip::System::Clock::Internal::SetSystemClockForTesting(&gMockClock);
 
@@ -94,8 +94,6 @@ public:
         {
             gReportScheduler = chip::app::reporting::GetDefaultReportScheduler();
         }
-
-        return CHIP_NO_ERROR;
     }
 
     static int nlTestSetUpTestSuite_Sync(void * context)
@@ -112,7 +110,7 @@ public:
     }
 
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
         const chip::app::LogStorageResources logStorageResources[] = {
             { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
@@ -120,16 +118,12 @@ public:
             { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
         };
 
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
+        chip::Test::AppContext::SetUp();
 
-        CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit((err = mEventCounter.Init(0)) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format()));
+        // TODO: change to ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDie(mEventCounter.Init(0) == CHIP_NO_ERROR);
         chip::app::EventManagement::CreateEventManagement(&GetExchangeManager(), ArraySize(logStorageResources),
                                                           gCircularEventBuffer, logStorageResources, &mEventCounter);
-
-    exit:
-        return err;
     }
 
     // Performs teardown for each individual test in the test suite
@@ -4244,7 +4238,7 @@ void TestReadInteraction::TestSubscribeClientReceiveUnsolicitedInvalidReportMess
 
         ctx.GetLoopback().mSentMessageCount = 0;
         auto exchange                       = InteractionModelEngine::GetInstance()->GetExchangeManager()->NewContext(
-            delegate.mpReadHandler->mSessionHandle.Get().Value(), delegate.mpReadHandler);
+                                  delegate.mpReadHandler->mSessionHandle.Get().Value(), delegate.mpReadHandler);
         delegate.mpReadHandler->mExchangeCtx.Grab(exchange);
         err = delegate.mpReadHandler->mExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReportData, std::move(msgBuf),
                                                                 Messaging::SendMessageFlags::kExpectResponse);
@@ -4413,7 +4407,7 @@ void TestReadInteraction::TestSubscribeClientReceiveUnsolicitedReportMessageWith
 
         ctx.GetLoopback().mSentMessageCount = 0;
         auto exchange                       = InteractionModelEngine::GetInstance()->GetExchangeManager()->NewContext(
-            delegate.mpReadHandler->mSessionHandle.Get().Value(), delegate.mpReadHandler);
+                                  delegate.mpReadHandler->mSessionHandle.Get().Value(), delegate.mpReadHandler);
         delegate.mpReadHandler->mExchangeCtx.Grab(exchange);
         err = delegate.mpReadHandler->mExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReportData, std::move(msgBuf),
                                                                 Messaging::SendMessageFlags::kExpectResponse);

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -4238,7 +4238,7 @@ void TestReadInteraction::TestSubscribeClientReceiveUnsolicitedInvalidReportMess
 
         ctx.GetLoopback().mSentMessageCount = 0;
         auto exchange                       = InteractionModelEngine::GetInstance()->GetExchangeManager()->NewContext(
-                                  delegate.mpReadHandler->mSessionHandle.Get().Value(), delegate.mpReadHandler);
+            delegate.mpReadHandler->mSessionHandle.Get().Value(), delegate.mpReadHandler);
         delegate.mpReadHandler->mExchangeCtx.Grab(exchange);
         err = delegate.mpReadHandler->mExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReportData, std::move(msgBuf),
                                                                 Messaging::SendMessageFlags::kExpectResponse);
@@ -4407,7 +4407,7 @@ void TestReadInteraction::TestSubscribeClientReceiveUnsolicitedReportMessageWith
 
         ctx.GetLoopback().mSentMessageCount = 0;
         auto exchange                       = InteractionModelEngine::GetInstance()->GetExchangeManager()->NewContext(
-                                  delegate.mpReadHandler->mSessionHandle.Get().Value(), delegate.mpReadHandler);
+            delegate.mpReadHandler->mSessionHandle.Get().Value(), delegate.mpReadHandler);
         delegate.mpReadHandler->mExchangeCtx.Grab(exchange);
         err = delegate.mpReadHandler->mExchangeCtx->SendMessage(Protocols::InteractionModel::MsgType::ReportData, std::move(msgBuf),
                                                                 Messaging::SendMessageFlags::kExpectResponse);

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -55,22 +55,21 @@ class TestContext : public chip::Test::AppContext
 {
 public:
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
+        chip::Test::AppContext::SetUp();
 
         gTestStorage.ClearStorage();
         gGroupsProvider.SetStorageDelegate(&gTestStorage);
         gGroupsProvider.SetSessionKeystore(&gSessionKeystore);
-        ReturnErrorOnFailure(gGroupsProvider.Init());
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDie(gGroupsProvider.Init() == CHIP_NO_ERROR);
         chip::Credentials::SetGroupDataProvider(&gGroupsProvider);
 
         uint8_t buf[sizeof(chip::CompressedFabricId)];
         chip::MutableByteSpan span(buf);
-        ReturnErrorOnFailure(GetBobFabric()->GetCompressedFabricIdBytes(span));
-        ReturnErrorOnFailure(chip::GroupTesting::InitData(&gGroupsProvider, GetBobFabricIndex(), span));
-
-        return CHIP_NO_ERROR;
+        VerifyOrDie(GetBobFabric()->GetCompressedFabricIdBytes(span) == CHIP_NO_ERROR);
+        VerifyOrDie(chip::GroupTesting::InitData(&gGroupsProvider, GetBobFabricIndex(), span) == CHIP_NO_ERROR);
     }
 
     // Performs teardown for each individual test in the test suite

--- a/src/controller/tests/TestEventCaching.cpp
+++ b/src/controller/tests/TestEventCaching.cpp
@@ -56,7 +56,7 @@ class TestContext : public chip::Test::AppContext
 {
 public:
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
         const chip::app::LogStorageResources logStorageResources[] = {
             { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
@@ -64,16 +64,14 @@ public:
             { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
         };
 
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
+        chip::Test::AppContext::SetUp();
 
         CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit((err = mEventCounter.Init(0)) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format()));
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDieWithMsg((err = mEventCounter.Init(0)) == CHIP_NO_ERROR, AppServer,
+                           "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format());
         chip::app::EventManagement::CreateEventManagement(&GetExchangeManager(), ArraySize(logStorageResources),
                                                           gCircularEventBuffer, logStorageResources, &mEventCounter);
-
-    exit:
-        return err;
     }
 
     // Performs teardown for each individual test in the test suite

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -60,7 +60,7 @@ class TestContext : public chip::Test::AppContext
 {
 public:
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
         const chip::app::LogStorageResources logStorageResources[] = {
             { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
@@ -68,16 +68,14 @@ public:
             { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
         };
 
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
+        chip::Test::AppContext::SetUp();
 
         CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit((err = mEventCounter.Init(0)) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format()));
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDieWithMsg((err = mEventCounter.Init(0)) == CHIP_NO_ERROR, AppServer,
+                           "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format());
         chip::app::EventManagement::CreateEventManagement(&GetExchangeManager(), ArraySize(logStorageResources),
                                                           gCircularEventBuffer, logStorageResources, &mEventCounter);
-
-    exit:
-        return err;
     }
 
     // Performs teardown for each individual test in the test suite

--- a/src/controller/tests/TestEventNumberCaching.cpp
+++ b/src/controller/tests/TestEventNumberCaching.cpp
@@ -53,7 +53,7 @@ class TestContext : public chip::Test::AppContext
 {
 public:
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
         const chip::app::LogStorageResources logStorageResources[] = {
             { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
@@ -61,16 +61,14 @@ public:
             { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
         };
 
-        ReturnErrorOnFailure(chip::Test::AppContext::SetUp());
+        chip::Test::AppContext::SetUp();
 
         CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit((err = mEventCounter.Init(0)) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format()));
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDieWithMsg((err = mEventCounter.Init(0)) == CHIP_NO_ERROR, AppServer,
+                           "Init EventCounter failed: %" CHIP_ERROR_FORMAT, err.Format());
         chip::app::EventManagement::CreateEventManagement(&GetExchangeManager(), ArraySize(logStorageResources),
                                                           gCircularEventBuffer, logStorageResources, &mEventCounter);
-
-    exit:
-        return err;
     }
 
     // Performs teardown for each individual test in the test suite

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -212,15 +212,14 @@ public:
     virtual ~LoopbackMessagingContext() {}
 
     // Performs shared setup for all tests in the test suite
-    virtual CHIP_ERROR SetUpTestSuite()
+    virtual void SetUpTestSuite()
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit((err = chip::Platform::MemoryInit()) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init CHIP memory failed: %" CHIP_ERROR_FORMAT, err.Format()));
-        VerifyOrExit((err = LoopbackTransportManager::Init()) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init LoopbackTransportManager failed: %" CHIP_ERROR_FORMAT, err.Format()));
-    exit:
-        return err;
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDieWithMsg((err = chip::Platform::MemoryInit()) == CHIP_NO_ERROR, AppServer,
+                           "Init CHIP memory failed: %" CHIP_ERROR_FORMAT, err.Format());
+        VerifyOrDieWithMsg((err = LoopbackTransportManager::Init()) == CHIP_NO_ERROR, AppServer,
+                           "Init LoopbackTransportManager failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Performs shared teardown for all tests in the test suite
@@ -231,13 +230,11 @@ public:
     }
 
     // Performs setup for each individual test in the test suite
-    virtual CHIP_ERROR SetUp()
+    virtual void SetUp()
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
-        VerifyOrExit((err = MessagingContext::Init(&GetTransportMgr(), &GetIOContext())) == CHIP_NO_ERROR,
-                     ChipLogError(AppServer, "Init MessagingContext failed: %" CHIP_ERROR_FORMAT, err.Format()));
-    exit:
-        return err;
+        VerifyOrDieWithMsg((err = MessagingContext::Init(&GetTransportMgr(), &GetIOContext())) == CHIP_NO_ERROR, AppServer,
+                           "Init MessagingContext failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Performs teardown for each individual test in the test suite
@@ -247,8 +244,8 @@ public:
 
     static int nlTestSetUpTestSuite(void * context)
     {
-        auto err = static_cast<LoopbackMessagingContext *>(context)->SetUpTestSuite();
-        return err == CHIP_NO_ERROR ? SUCCESS : FAILURE;
+        static_cast<LoopbackMessagingContext *>(context)->SetUpTestSuite();
+        return SUCCESS;
     }
 
     static int nlTestTearDownTestSuite(void * context)
@@ -259,8 +256,8 @@ public:
 
     static int nlTestSetUp(void * context)
     {
-        auto err = static_cast<LoopbackMessagingContext *>(context)->SetUp();
-        return err == CHIP_NO_ERROR ? SUCCESS : FAILURE;
+        static_cast<LoopbackMessagingContext *>(context)->SetUp();
+        return SUCCESS;
     }
 
     static int nlTestTearDown(void * context)

--- a/src/messaging/tests/TestAbortExchangesForFabric.cpp
+++ b/src/messaging/tests/TestAbortExchangesForFabric.cpp
@@ -51,13 +51,13 @@ using namespace chip::Protocols;
 
 struct TestContext : Test::LoopbackMessagingContext
 {
-    virtual CHIP_ERROR SetUp()
+    void SetUp() override
     {
 #if CHIP_CRYPTO_PSA
-        ReturnErrorOnFailure(psa_crypto_init() == PSA_SUCCESS ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL);
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDie(psa_crypto_init() == PSA_SUCCESS);
 #endif
-        ReturnErrorOnFailure(chip::Test::LoopbackMessagingContext::SetUp());
-        return CHIP_NO_ERROR;
+        chip::Test::LoopbackMessagingContext::SetUp();
     }
 };
 

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -55,13 +55,13 @@ struct TestContext : Test::LoopbackMessagingContext
 {
     // TODO Add TearDown function during changing test framework to Pigweed to make it more clear how does it work.
     // Currently, the TearDown function is from LoopbackMessagingContext
-    virtual CHIP_ERROR SetUp()
+    void SetUp() override
     {
 #if CHIP_CRYPTO_PSA
-        ReturnErrorOnFailure(psa_crypto_init() == PSA_SUCCESS ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL);
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDie(psa_crypto_init() == PSA_SUCCESS);
 #endif
-        ReturnErrorOnFailure(chip::Test::LoopbackMessagingContext::SetUp());
-        return CHIP_NO_ERROR;
+        chip::Test::LoopbackMessagingContext::SetUp();
     }
 };
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -77,15 +77,15 @@ class TestContext : public chip::Test::LoopbackMessagingContext
 {
 public:
     // Performs setup for each individual test in the test suite
-    CHIP_ERROR SetUp() override
+    void SetUp() override
     {
 #if CHIP_CRYPTO_PSA
-        ReturnErrorOnFailure(psa_crypto_init() == PSA_SUCCESS ? CHIP_NO_ERROR : CHIP_ERROR_INTERNAL);
+        // TODO: use ASSERT_EQ, once transition to pw_unit_test is complete
+        VerifyOrDie(psa_crypto_init() == PSA_SUCCESS);
 #endif
-        ReturnErrorOnFailure(chip::Test::LoopbackMessagingContext::SetUp());
+        chip::Test::LoopbackMessagingContext::SetUp();
         GetSessionAliceToBob()->AsSecureSession()->SetRemoteSessionParameters(GetLocalMRPConfig().ValueOr(GetDefaultMRPConfig()));
         GetSessionBobToAlice()->AsSecureSession()->SetRemoteSessionParameters(GetLocalMRPConfig().ValueOr(GetDefaultMRPConfig()));
-        return CHIP_NO_ERROR;
     }
 };
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -1040,9 +1040,9 @@ void TestCASESession::SessionResumptionStorage(nlTestSuite * inSuite, void * inC
                                                                     &gDeviceGroupDataProvider) == CHIP_NO_ERROR);
         ExchangeContext * contextCommissioner = ctx.NewUnauthenticatedExchangeToBob(pairingCommissioner);
         auto establishmentReturnVal           = pairingCommissioner->EstablishSession(
-                      ctx.GetSecureSessionManager(), &gCommissionerFabrics, ScopedNodeId{ Node01_01, gCommissionerFabricIndex },
-                      contextCommissioner, &testVectors[i].initiatorStorage, nullptr, &delegateCommissioner,
-                      Optional<ReliableMessageProtocolConfig>::Missing());
+            ctx.GetSecureSessionManager(), &gCommissionerFabrics, ScopedNodeId{ Node01_01, gCommissionerFabricIndex },
+            contextCommissioner, &testVectors[i].initiatorStorage, nullptr, &delegateCommissioner,
+            Optional<ReliableMessageProtocolConfig>::Missing());
         ServiceEvents(ctx);
         NL_TEST_ASSERT(inSuite, establishmentReturnVal == CHIP_NO_ERROR);
         NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == testVectors[i].expectedSentMessageCount);

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -89,10 +89,10 @@ class TestContext : public chip::Test::LoopbackMessagingContext
 {
 public:
     // Performs shared setup for all tests in the test suite
-    CHIP_ERROR SetUpTestSuite() override
+    void SetUpTestSuite() override
     {
         ConfigInitializeNodes(false);
-        return chip::Test::LoopbackMessagingContext::SetUpTestSuite();
+        chip::Test::LoopbackMessagingContext::SetUpTestSuite();
     }
 };
 


### PR DESCRIPTION
I changed test setup and teardown functions to take no arguments and return void, because that's what pw_unit_test expects. If an error occurs in the initialization / deinitialization code, I call `VerifyOrDie` instead of returning an error value.

**Followup**: `VerifyOrDie(...)` should be replaced by `ASSERT_SOMETHING(...)` once transition to pw_unit_test is completed.

EDIT: Following suggestions by @andy31415, the scope was reduced - I will make the necessary methods static and rename some context classes in followup PRs.