### PR TITLE
Do not use CONFIG_NETWORK_LAYER_BLE for runtime checks

### DIFF
--- a/examples/air-purifier-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/air-purifier-app/ameba/main/CHIPDeviceManager.cpp
@@ -84,10 +84,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
     SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
-    if (CONFIG_NETWORK_LAYER_BLE)
-    {
-        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-    }
+#if CONFIG_NETWORK_LAYER_BLE
+    ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+#endif
 
     PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
 

--- a/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp
@@ -77,10 +77,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
     SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
-    if (CONFIG_NETWORK_LAYER_BLE)
-    {
-        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-    }
+#if CONFIG_NETWORK_LAYER_BLE
+    ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+#endif
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/examples/all-clusters-minimal-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-minimal-app/ameba/main/CHIPDeviceManager.cpp
@@ -61,10 +61,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
 
-    if (CONFIG_NETWORK_LAYER_BLE)
-    {
-        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-    }
+#if CONFIG_NETWORK_LAYER_BLE
+    ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+#endif
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/examples/chef/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/chef/ameba/main/CHIPDeviceManager.cpp
@@ -61,10 +61,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
 
-    if (CONFIG_NETWORK_LAYER_BLE)
-    {
-        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-    }
+#if CONFIG_NETWORK_LAYER_BLE
+    ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+#endif
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/examples/light-switch-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/light-switch-app/ameba/main/CHIPDeviceManager.cpp
@@ -77,10 +77,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
     SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
-    if (CONFIG_NETWORK_LAYER_BLE)
-    {
-        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-    }
+#if CONFIG_NETWORK_LAYER_BLE
+    ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+#endif
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/examples/lighting-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/lighting-app/ameba/main/CHIPDeviceManager.cpp
@@ -84,10 +84,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
     SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
-    if (CONFIG_NETWORK_LAYER_BLE)
-    {
-        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-    }
+#if CONFIG_NETWORK_LAYER_BLE
+    ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+#endif
 
     PlatformMgr().AddEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
 

--- a/examples/ota-requestor-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/ota-requestor-app/ameba/main/CHIPDeviceManager.cpp
@@ -77,10 +77,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     SetDeviceAttestationCredentialsProvider(&mFactoryDataProvider);
     SetDeviceInstanceInfoProvider(&mFactoryDataProvider);
 
-    if (CONFIG_NETWORK_LAYER_BLE)
-    {
-        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-    }
+#if CONFIG_NETWORK_LAYER_BLE
+    ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+#endif
 
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.

--- a/examples/platform/asr/init_Matter.cpp
+++ b/examples/platform/asr/init_Matter.cpp
@@ -85,10 +85,10 @@ CHIP_ERROR MatterInitializer::Init_Matter_Stack(const char * appName)
 
     chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(appName);
 
-    if (CONFIG_NETWORK_LAYER_BLE)
-    {
-        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-    }
+#if CONFIG_NETWORK_LAYER_BLE
+    ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+#endif
+
     return CHIP_NO_ERROR;
 }
 

--- a/examples/platform/beken/common/CHIPDeviceManager.cpp
+++ b/examples/platform/beken/common/CHIPDeviceManager.cpp
@@ -60,10 +60,9 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     err = PlatformMgr().InitChipStack();
     SuccessOrExit(err);
 
-    if (CONFIG_NETWORK_LAYER_BLE)
-    {
-        ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-    }
+#if CONFIG_NETWORK_LAYER_BLE
+    ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+#endif
 
     err = Platform::MemoryInit();
     SuccessOrExit(err);


### PR DESCRIPTION
### Problem

The `CONFIG_NETWORK_LAYER_BLE` is a define which can be used with preprocessor to include/exclude optional BLE functionality.

### Testing

CI will check potential build breaks.