### PR TITLE
Remove unused variable from scenes-server

### DIFF
--- a/src/app/clusters/scenes-server/SceneTableImpl.h
+++ b/src/app/clusters/scenes-server/SceneTableImpl.h
@@ -40,7 +40,6 @@ static_assert(kMaxScenesPerEndpoint <= CHIP_CONFIG_MAX_SCENES_TABLE_SIZE,
               "CHIP_CONFIG_MAX_SCENES_TABLE_SIZE in CHIPConfig.h if you really need more scenes");
 static_assert(kMaxScenesPerEndpoint >= 16, "Per spec, kMaxScenesPerEndpoint must be at least 16");
 static constexpr uint16_t kMaxScenesPerFabric = (kMaxScenesPerEndpoint - 1) / 2;
-static constexpr uint8_t kMaxFabrics          = CHIP_CONFIG_MAX_FABRICS;
 
 /**
  * @brief Implementation of a storage in nonvolatile storage of the scene table.


### PR DESCRIPTION
```
$ git grep "kMaxFabrics" | cat
src/app/clusters/scenes-server/SceneTableImpl.h:static constexpr uint8_t kMaxFabrics          = CHIP_CONFIG_MAX_FABRICS;
```