### PR TITLE
Add missing [[maybe_unused]] annotations in unit tests

### DIFF
--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -89,18 +89,18 @@ void OnSoftwareFaultEventHandler(const char * faultRecordString)
 extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
 {
 #if SILABS_LOG_ENABLED
-    uint32_t cfsr  = SCB->CFSR;
-    uint32_t hfsr  = SCB->HFSR;
-    uint32_t mmfar = SCB->MMFAR;
-    uint32_t bfar  = SCB->BFAR;
-    uint32_t r0    = sp[0];
-    uint32_t r1    = sp[1];
-    uint32_t r2    = sp[2];
-    uint32_t r3    = sp[3];
-    uint32_t r12   = sp[4];
-    uint32_t lr    = sp[5];
-    uint32_t pc    = sp[6];
-    uint32_t psr   = sp[7];
+    [[maybe_unused]] uint32_t cfsr  = SCB->CFSR;
+    [[maybe_unused]] uint32_t hfsr  = SCB->HFSR;
+    [[maybe_unused]] uint32_t mmfar = SCB->MMFAR;
+    [[maybe_unused]] uint32_t bfar  = SCB->BFAR;
+    [[maybe_unused]] uint32_t r0    = sp[0];
+    [[maybe_unused]] uint32_t r1    = sp[1];
+    [[maybe_unused]] uint32_t r2    = sp[2];
+    [[maybe_unused]] uint32_t r3    = sp[3];
+    [[maybe_unused]] uint32_t r12   = sp[4];
+    [[maybe_unused]] uint32_t lr    = sp[5];
+    [[maybe_unused]] uint32_t pc    = sp[6];
+    [[maybe_unused]] uint32_t psr   = sp[7];
 
     ChipLogError(NotSpecified, "HardFault:");
     ChipLogError(NotSpecified, "SCB->CFSR   0x%08lx", cfsr);

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -640,7 +640,7 @@ static void TestRawIntegerToDerInvalidCases(nlTestSuite * inSuite, void * inCont
         { .input = bad_buffer_empty, .output = good_out_buffer, .expected_status = CHIP_ERROR_INVALID_ARGUMENT }
     };
 
-    int case_idx = 0;
+    [[maybe_unused]] int case_idx = 0;
     for (const ErrorCase & v : error_cases)
     {
         CHIP_ERROR status = ConvertIntegerRawToDerWithoutTag(v.input, v.output);
@@ -704,7 +704,7 @@ static void TestReadDerLengthValidCases(nlTestSuite * inSuite, void * inContext)
         { .input_buf = max_byte_length_large_buf, .expected_length = SIZE_MAX },
     };
 
-    int case_idx = 0;
+    [[maybe_unused]] int case_idx = 0;
     for (const SuccessCase & v : cases)
     {
         size_t output_length = SIZE_MAX - 1;
@@ -768,7 +768,7 @@ static void TestReadDerLengthInvalidCases(nlTestSuite * inSuite, void * inContex
         { .input_buf = max_byte_length_large_insufficient_bytes_buf, .expected_status = CHIP_ERROR_BUFFER_TOO_SMALL },
     };
 
-    int case_idx = 0;
+    [[maybe_unused]] int case_idx = 0;
     for (const ErrorCase & v : error_cases)
     {
         size_t output_length = SIZE_MAX;
@@ -2135,7 +2135,7 @@ static void TestX509_VerifyAttestationCertificateFormat(nlTestSuite * inSuite, v
     };
     // clang-format on
 
-    int case_idx = 0;
+    [[maybe_unused]] int case_idx = 0;
     for (auto & testCase : sValidationTestCases)
     {
         ByteSpan cert  = testCase.cert;

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -166,7 +166,6 @@ template("siwx917_sdk") {
       "MBEDTLS_CONFIG_FILE=\"siwx917-chip-mbedtls-config.h\"",
       "__STARTUP_CLEAR_BSS",
       "HARD_FAULT_LOG_ENABLE",
-      "SILABS_LOG_ENABLED=${silabs_log_enabled}",
       "SL_HEAP_SIZE=32768",
       "SL_WIFI=1",
       "CCP_SI917_BRINGUP=1",
@@ -223,6 +222,12 @@ template("siwx917_sdk") {
       "RADIO_CONFIG_DMP_SUPPORT=1",
       "configUSE_POSIX_ERRNO=1",
     ]
+
+    if (silabs_log_enabled && chip_logging) {
+      defines += [ "SILABS_LOG_ENABLED=1" ]
+    } else {
+      defines += [ "SILABS_LOG_ENABLED=0" ]
+    }
 
     if (chip_build_libshell) {
       defines += [ "ENABLE_CHIP_SHELL" ]

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -283,7 +283,6 @@ template("efr32_sdk") {
       "__STARTUP_CLEAR_BSS",
       "HARD_FAULT_LOG_ENABLE",
       "CORTEXM3_EFM32_MICRO",
-      "SILABS_LOG_ENABLED=${silabs_log_enabled}",
       "NVM3_DEFAULT_NVM_SIZE=40960",
       "NVM3_DEFAULT_MAX_OBJECT_SIZE=4092",
       "KVS_MAX_ENTRIES=${kvs_max_entries}",
@@ -307,6 +306,12 @@ template("efr32_sdk") {
 
       #"__STACK_SIZE=0",
     ]
+
+    if (silabs_log_enabled && chip_logging) {
+      defines += [ "SILABS_LOG_ENABLED=1" ]
+    } else {
+      defines += [ "SILABS_LOG_ENABLED=0" ]
+    }
 
     # Temporary configuration to enable COAP specific configurations
     if (use_thread_coap_lib) {


### PR DESCRIPTION
Added [[maybe_unused]] to allow building unit test and Silabs apps without logs


