### PR TITLE
Update test_metadata.py to use temporary files for test cases, for easier extensibility

### DIFF
--- a/scripts/tests/py/test_metadata.py
+++ b/scripts/tests/py/test_metadata.py
@@ -35,17 +35,17 @@ class TestMetadataReader(unittest.TestCase):
             actual = self.reader.parse_script(fp.name)
             self.assertEqual(actual, expected)
 
-
     def test_parse_single_run(self):
         self.assertMetadataParse(''' 
             # test-runner-runs: run1 
             # test-runner-run/run1: app/all-clusters discriminator passcode
             ''',
-            [
-                Metadata(app="out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app",
-                         discriminator=1234, run="run1", passcode=20202021)
-            ]
-        )
+                                 [
+                                     Metadata(app="out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app",
+                                              discriminator=1234, run="run1", passcode=20202021)
+                                 ]
+                                 )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/py/test_metadata.py
+++ b/scripts/tests/py/test_metadata.py
@@ -21,7 +21,6 @@ from metadata import Metadata, MetadataReader
 
 
 class TestMetadataReader(unittest.TestCase):
-    path_under_test = path.join(path.dirname(__file__), "simple_run_args.txt")
 
     def setUp(self):
         # build the reader object
@@ -44,7 +43,7 @@ class TestMetadataReader(unittest.TestCase):
             ''',
             [
                 Metadata(app="out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app",
-                         discriminator=1234, py_script_path=self.path_under_test, run="run1", passcode=20202021)
+                         discriminator=1234, run="run1", passcode=20202021)
             ]
         )
 

--- a/scripts/tests/py/test_metadata.py
+++ b/scripts/tests/py/test_metadata.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tempfile
 import unittest
 from os import path
-import tempfile
 from typing import List
 
 from metadata import Metadata, MetadataReader

--- a/scripts/tests/py/test_metadata.py
+++ b/scripts/tests/py/test_metadata.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 from os import path
 import tempfile


### PR DESCRIPTION
Work for Issue #31317   

Follow up to PR #32752 
PR #4 - Modified the test script to make it more cleaner, and creating the temporary file required on the fly.

Files Worked:
- scripts/tests/py/test_metadata.py
