### PR TITLE
Added error checking in Android DnssdImpl.cpp and fixed examples/tv-casting-app bug

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
@@ -216,7 +216,6 @@ public class DiscoveryExampleFragment extends Fragment {
   public void onPause() {
     super.onPause();
     Log.i(TAG, "onPause() called");
-    stopDiscovery();
   }
 
   /** Interface for notifying the host. */

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingPlayerDiscovery-JNI.cpp
@@ -246,7 +246,7 @@ JNI_METHOD(jobject, removeCastingPlayerChangeListener)(JNIEnv * env, jobject, jo
 
         return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
     }
-    else if (DiscoveryDelegateImpl::GetInstance()->castingPlayerChangeListenerJavaObject.ObjectRef() == nullptr)
+    else if (!DiscoveryDelegateImpl::GetInstance()->castingPlayerChangeListenerJavaObject.HasValidObjectRef())
     {
         ChipLogError(
             AppServer,

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -191,6 +191,8 @@ CHIP_ERROR ChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, Ine
 
     std::string serviceType = GetFullTypeWithSubTypes(type, protocol);
     JNIEnv * env            = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturnError(env != nullptr, CHIP_JNI_ERROR_NO_ENV,
+                        ChipLogError(Discovery, "Failed to GetEnvForCurrentThread for ChipDnssdBrowse"));
     UtfString jniServiceType(env, serviceType.c_str());
 
     env->CallVoidMethod(sBrowserObject.ObjectRef(), sBrowseMethod, jniServiceType.jniValue(), reinterpret_cast<jlong>(callback),
@@ -204,7 +206,9 @@ CHIP_ERROR ChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, Ine
         return CHIP_JNI_ERROR_EXCEPTION_THROWN;
     }
 
-    auto sdCtx        = chip::Platform::New<BrowseContext>(callback);
+    auto sdCtx = chip::Platform::New<BrowseContext>(callback);
+    VerifyOrReturnError(nullptr != sdCtx, CHIP_ERROR_NO_MEMORY,
+                        ChipLogError(Discovery, "Failed allocate memory for BrowseContext in ChipDnssdBrowse"));
     *browseIdentifier = reinterpret_cast<intptr_t>(sdCtx);
 
     return CHIP_NO_ERROR;
@@ -212,14 +216,19 @@ CHIP_ERROR ChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, Ine
 
 CHIP_ERROR ChipDnssdStopBrowse(intptr_t browseIdentifier)
 {
+    VerifyOrReturnError(browseIdentifier != 0, CHIP_ERROR_INVALID_ARGUMENT,
+                        ChipLogError(Discovery, "ChipDnssdStopBrowse Invalid argument browseIdentifier = 0"));
     VerifyOrReturnError(sBrowserObject.HasValidObjectRef() && sStopBrowseMethod != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    auto ctx     = reinterpret_cast<BrowseContext *>(browseIdentifier);
+    VerifyOrReturnError(env != nullptr, CHIP_JNI_ERROR_NO_ENV,
+                        ChipLogError(Discovery, "Failed to GetEnvForCurrentThread for ChipDnssdStopBrowse"));
+    auto ctx = reinterpret_cast<BrowseContext *>(browseIdentifier);
 
     env->CallVoidMethod(sBrowserObject.ObjectRef(), sStopBrowseMethod, reinterpret_cast<jlong>(ctx->callback));
 
     chip::Platform::Delete(ctx);
+    ctx = nullptr;
     if (env->ExceptionCheck())
     {
         ChipLogError(Discovery, "Java exception in ChipDnssdStopBrowse");
@@ -336,6 +345,12 @@ void InitializeWithObjects(jobject resolverObject, jobject browserObject, jobjec
     if (sBrowseMethod == nullptr)
     {
         ChipLogError(Discovery, "Failed to access Discover 'browse' method");
+        env->ExceptionClear();
+    }
+
+    if (sStopBrowseMethod == nullptr)
+    {
+        ChipLogError(Discovery, "Failed to access Discover 'stopDiscover' method");
         env->ExceptionClear();
     }
 


### PR DESCRIPTION
This change addresses some comments by yunhanw-google, which were made after a previous PR was merged in. Also fixing an examples/tv-casting-app bug causing the app to crash during connection.

**Change summary**

1.	Added error checking and logging in connectedhomeip/src/platform/android/DnssdImpl.cpp ChipDnssdBrowse and ChipDnssdStopBrowse JNI functions.  yunhanw-google left comments on https://github.com/project-chip/connectedhomeip/pull/32801 after it merged in.
2.	The example app was crashing after successfully connecting to a CastingPlayer but before transitioning to the next screen. In /tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java. onPause(), removed the call to stopDiscovery(). onPause() is called when transitioning to the next page and stopDiscovery() calls tv-casting-common/core/CastingPlayerDiscovery.cpp StopDiscovery() to clear the list of discovered Casting Players, including the one being connected to. 

**Testing**
Verified and tested locally with the Android tv-casting-app example app. By calling the stop discovery API form the tv-casting-app app GUI, we are able to stop NsdManagerDiscovery discovery, prior to timeout triggered stop discovery. Also able to connect to a d discovered Casting Player.

