### PR TITLE
Report an attribute if a read will get a changed value and no expected value exists

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2343,24 +2343,25 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 #endif
             }
 
-            // if expected values exists, purge and update read cache
-            NSArray * expectedValue = _expectedValueCache[attributePath];
-            if (expectedValue) {
-                previousValue = expectedValue[MTRDeviceExpectedValueFieldValueIndex];
-                _readCache[attributePath] = attributeDataValue;
-                shouldReportAttribute = NO;
-            } else if (readCacheValueChanged) {
-                // otherwise compare and update read cache
+            // Report the attribute if the attribute value is different from the read cache value.
+            if (readCacheValueChanged) {
                 previousValue = _readCache[attributePath];
-                _readCache[attributePath] = attributeDataValue;
                 shouldReportAttribute = YES;
             }
 
+            // Update the readCache with the attribute value.
+            _readCache[attributePath] = attributeDataValue;
+
             if (!shouldReportAttribute) {
+                NSArray * expectedValue = _expectedValueCache[attributePath];
+
+                // If an expected value exists, do not report the attribute during this time.
+                // When the expected value interval expires, the correct value will be reported.
                 if (expectedValue) {
-                    MTR_LOG_INFO("%@ report %@ value filtered - same as expected values", self, attributePath);
-                } else {
-                    MTR_LOG_INFO("%@ report %@ value filtered - same values as cache", self, attributePath);
+                    MTR_LOG_INFO("%@ report %@ value filtered - new expected value present. Do not report old value", self, attributePath);
+                } else
+                {
+                    MTR_LOG_INFO("%@ report %@ value filtered - same as read cache", self, attributePath);
                 }
             }
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2360,8 +2360,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                 // if needed.
                 if (expectedValue) {
                     MTR_LOG_INFO("%@ report %@ value filtered - expected value still present", self, attributePath);
-                } else
-                {
+                } else {
                     MTR_LOG_INFO("%@ report %@ value filtered - same as read cache", self, attributePath);
                 }
             }

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2355,7 +2355,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             if (!shouldReportAttribute) {
                 NSArray * expectedValue = _expectedValueCache[attributePath];
 
-                // If an expected value exists, do not report the attribute during this time.
+                // If an expected value exists, the attribute will not be reported at this time.
                 // When the expected value interval expires, the correct value will be reported.
                 if (expectedValue) {
                     MTR_LOG_INFO("%@ report %@ value filtered - new expected value present. Do not report old value", self, attributePath);

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2342,9 +2342,10 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                 [attributesToPersist addObject:attributeResponseValueToPersist];
 #endif
             }
+            NSArray * expectedValue = _expectedValueCache[attributePath];
 
-            // Report the attribute if the attribute value is different from the read cache value.
-            if (readCacheValueChanged) {
+            // Report the attribute if read attribute would get a value that is changing and no expected value exists.
+            if (readCacheValueChanged && !expectedValue) {
                 previousValue = _readCache[attributePath];
                 shouldReportAttribute = YES;
             }
@@ -2353,12 +2354,11 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             _readCache[attributePath] = attributeDataValue;
 
             if (!shouldReportAttribute) {
-                NSArray * expectedValue = _expectedValueCache[attributePath];
 
                 // If an expected value exists, the attribute will not be reported at this time.
                 // When the expected value interval expires, the correct value will be reported.
                 if (expectedValue) {
-                    MTR_LOG_INFO("%@ report %@ value filtered - new expected value present. Do not report old value", self, attributePath);
+                    MTR_LOG_INFO("%@ report %@ value filtered - expected value still present", self, attributePath);
                 } else
                 {
                     MTR_LOG_INFO("%@ report %@ value filtered - same as read cache", self, attributePath);

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -2344,19 +2344,20 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             }
             NSArray * expectedValue = _expectedValueCache[attributePath];
 
-            // Report the attribute if read attribute would get a value that is changing and no expected value exists.
+            // Report the attribute if a read would get a changed value.  This happens
+            // when our cached value changes and no expected value exists.
             if (readCacheValueChanged && !expectedValue) {
                 previousValue = _readCache[attributePath];
                 shouldReportAttribute = YES;
             }
 
-            // Update the readCache with the attribute value.
+            // Now that we have grabbed previousValue, update the readCache with the attribute value.
             _readCache[attributePath] = attributeDataValue;
 
             if (!shouldReportAttribute) {
-
                 // If an expected value exists, the attribute will not be reported at this time.
-                // When the expected value interval expires, the correct value will be reported.
+                // When the expected value interval expires, the correct value will be reported,
+                // if needed.
                 if (expectedValue) {
                     MTR_LOG_INFO("%@ report %@ value filtered - expected value still present", self, attributePath);
                 } else


### PR DESCRIPTION
- Report the attribute only when we expect the read to have a changed value and no expected value exists

- Fix logging for use cases where we didn't report since there was an expected value or the attribute value didn't change from the read cache value.

Fixes: #33013 

