### PR TITLE
[Darwin] MTRDevice should trigger resubscription on connectivity changes

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.h
@@ -1,0 +1,29 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^MTRDeviceConnectivityMonitorHandler)(void);
+
+@interface MTRDeviceConnectivityMonitor : NSObject
+- (instancetype)initWithInstanceName:(NSString *)instanceName;
+- (void)startMonitoringWithHandler:(MTRDeviceConnectivityMonitorHandler)handler queue:(dispatch_queue_t)queue;
+- (void)stopMonitoring;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.h
@@ -16,13 +16,27 @@
 
 #import <Foundation/Foundation.h>
 
+#import "MTRDefines_Internal.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^MTRDeviceConnectivityMonitorHandler)(void);
 
+/**
+ * Class that a matter dns-sd instance name, and monitors connectivity to the device.
+ */
+MTR_TESTABLE
 @interface MTRDeviceConnectivityMonitor : NSObject
-- (instancetype)initWithInstanceName:(NSString *)instanceName;
+- (instancetype)initWithCompressedFabricID:(NSNumber *)compressedFabricID nodeID:(NSNumber *)nodeID;
+
+/**
+ * Any time a path becomes satisfied or route becomes viable, the registered handler will be called.
+ */
 - (void)startMonitoringWithHandler:(MTRDeviceConnectivityMonitorHandler)handler queue:(dispatch_queue_t)queue;
+
+/**
+ * Stops the monitoring. After this method returns no more calls to the handler will be made.
+ */
 - (void)stopMonitoring;
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.mm
@@ -1,0 +1,247 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRDeviceConnectivityMonitor.h"
+#import "MTRLogging_Internal.h"
+#import "MTRUnfairLock.h"
+
+#import <Network/Network.h>
+#import <dns_sd.h>
+#import <os/lock.h>
+
+@interface MTRDeviceConnectivityMonitor ()
+- (void)handleResolvedHostname:(const char *)hostName port:(uint16_t)port error:(DNSServiceErrorType)error;
+@end
+
+@implementation MTRDeviceConnectivityMonitor {
+    NSString * _instanceName;
+    DNSServiceRef _resolver;
+    NSMutableDictionary<NSString *, nw_connection_t> * _connections;
+
+    MTRDeviceConnectivityMonitorHandler _monitorHandler;
+    dispatch_queue_t _handlerQueue;
+}
+
+namespace {
+constexpr char kLocalDot[] = "local.";
+constexpr char kOperationalType[] = "_matter._tcp";
+}
+
+static dispatch_once_t sConnecitivityMonitorOnceToken;
+static os_unfair_lock sConnectivityMonitorLock;
+static NSUInteger sConnectivityMonitorCount;
+static DNSServiceRef sSharedResolverConnection;
+static dispatch_queue_t sSharedResolverQueue;
+
+- (instancetype)initWithInstanceName:(NSString *)instanceName
+{
+    if (self = [super init]) {
+        dispatch_once(&sConnecitivityMonitorOnceToken, ^{
+            sConnectivityMonitorLock = OS_UNFAIR_LOCK_INIT;
+        });
+        _instanceName = [instanceName copy];
+        _connections = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    if (_resolver) {
+        DNSServiceRefDeallocate(_resolver);
+    }
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MTRDeviceConnectivityMonitor: %@>", _instanceName];
+}
+
++ (DNSServiceRef)_sharedResolverConnection
+{
+    os_unfair_lock_assert_owner(&sConnectivityMonitorLock);
+
+    if (!sSharedResolverConnection) {
+        DNSServiceErrorType dnsError = DNSServiceCreateConnection(&sSharedResolverConnection);
+        if (dnsError) {
+            MTR_LOG_ERROR("MTRDeviceConnectivityMonitor: DNSServiceCreateConnection failed %d", dnsError);
+            return NULL;
+        }
+        sSharedResolverQueue = dispatch_queue_create("MTRDeviceConnectivityMonitor", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+        dnsError = DNSServiceSetDispatchQueue(sSharedResolverConnection, sSharedResolverQueue);
+        if (dnsError != kDNSServiceErr_NoError) {
+            MTR_LOG_ERROR("%@ cannot set dispatch queue on resolve", self);
+            DNSServiceRefDeallocate(sSharedResolverConnection);
+            sSharedResolverConnection = NULL;
+            sSharedResolverQueue = nil;
+            return NULL;
+        }
+    }
+
+    return sSharedResolverConnection;
+}
+
+- (void)_callHandler
+{
+    os_unfair_lock_assert_owner(&sConnectivityMonitorLock);
+    MTRDeviceConnectivityMonitorHandler handlerToCall = self->_monitorHandler;
+    if (handlerToCall) {
+        dispatch_async(self->_handlerQueue, ^{ handlerToCall(); });
+    }
+}
+
+- (void)handleResolvedHostname:(const char *)hostName port:(uint16_t)port error:(DNSServiceErrorType)error
+{
+    std::lock_guard lock(sConnectivityMonitorLock);
+
+    // dns_sd.h: must check and call deallocate if error is kDNSServiceErr_ServiceNotRunning
+    if (error == kDNSServiceErr_ServiceNotRunning) {
+        MTR_LOG_ERROR("%@ disconnected from dns-sd subsystem", self);
+        [self _stopMonitoring];
+        return;
+    }
+
+    // Create a nw_connection to monitor connectivity if the host name is not being monitored yet
+    NSString * hostNameString = [NSString stringWithUTF8String:hostName];
+    if (!_connections[hostNameString]) {
+        char portString[6];
+        snprintf(portString, sizeof(portString), "%d", ntohs(port));
+        nw_endpoint_t endpoint = nw_endpoint_create_host(hostName, portString);
+        if (!endpoint) {
+            MTR_LOG_ERROR("%@ failed to create endpoint for %s:%s", self, hostName, portString);
+            return;
+        }
+        nw_parameters_t params = nw_parameters_create_secure_udp(NW_PARAMETERS_DISABLE_PROTOCOL, NW_PARAMETERS_DEFAULT_CONFIGURATION);
+        if (!params) {
+            MTR_LOG_ERROR("%@ failed to create udp parameters", self);
+            return;
+        }
+        nw_connection_t connection = nw_connection_create(endpoint, params);
+        if (!connection) {
+            MTR_LOG_ERROR("%@ failed to create connection for %s:%s", self, hostName, portString);
+            return;
+        }
+        nw_connection_set_queue(connection, sSharedResolverQueue);
+        nw_connection_set_path_changed_handler(connection, ^(nw_path_t _Nonnull path) {
+            nw_path_status_t status = nw_path_get_status(path);
+            if (status == nw_path_status_satisfied) {
+                MTR_LOG_INFO("%@ path is satisfied", self);
+                std::lock_guard lock(sConnectivityMonitorLock);
+                [self _callHandler];
+            }
+        });
+        nw_connection_set_viability_changed_handler(connection, ^(bool viable) {
+            if (viable) {
+                std::lock_guard lock(sConnectivityMonitorLock);
+                MTR_LOG_INFO("%@ connectivity now viable", self);
+                [self _callHandler];
+            }
+        });
+        nw_connection_start(connection);
+    }
+}
+
+static void _resolveReplyCallback(
+    DNSServiceRef sdRef,
+    DNSServiceFlags flags,
+    uint32_t interfaceIndex,
+    DNSServiceErrorType errorCode,
+    const char * fullname,
+    const char * hosttarget,
+    uint16_t port, /* In network byte order */
+    uint16_t txtLen,
+    const unsigned char * txtRecord,
+    void * context)
+{
+    auto * connectivityMonitor = (__bridge MTRDeviceConnectivityMonitor *) context;
+    [connectivityMonitor handleResolvedHostname:hosttarget port:port error:errorCode];
+}
+
+- (void)startMonitoringWithHandler:(MTRDeviceConnectivityMonitorHandler)handler queue:(dispatch_queue_t)queue
+{
+    std::lock_guard lock(sConnectivityMonitorLock);
+
+    MTRDeviceConnectivityMonitorHandler handlerCopy = [handler copy];
+    _monitorHandler = handlerCopy;
+    _handlerQueue = queue;
+
+    // If there's already a resolver running, just return
+    if (_resolver) {
+        MTR_LOG_INFO("%@ connectivity monitor updated handler", self);
+        return;
+    }
+
+    MTR_LOG_INFO("%@ start connectivity monitoring for %@ (%lu monitoring objects)", self, _instanceName, static_cast<unsigned long>(sConnectivityMonitorCount));
+
+    _resolver = [MTRDeviceConnectivityMonitor _sharedResolverConnection];
+    if (!_resolver) {
+        MTR_LOG_ERROR("%@ failed to get shared resolver connection", self);
+        return;
+    }
+    DNSServiceErrorType dnsError = DNSServiceResolve(&_resolver,
+        kDNSServiceFlagsShareConnection,
+        kDNSServiceInterfaceIndexAny,
+        _instanceName.UTF8String,
+        kOperationalType,
+        kLocalDot,
+        _resolveReplyCallback,
+        (__bridge void *) self);
+    if (dnsError != kDNSServiceErr_NoError) {
+        MTR_LOG_ERROR("%@ failed to create resolver", self);
+        return;
+    }
+
+    sConnectivityMonitorCount++;
+}
+
+#define MTRDEVICECONNECTIVITYMONITOR_SHARED_CONNECTION_LINGER_INTERVAL (10)
+
+- (void)_stopMonitoring
+{
+    os_unfair_lock_assert_owner(&sConnectivityMonitorLock);
+    for (NSString * hostName in _connections) {
+        nw_connection_cancel(_connections[hostName]);
+    }
+    [_connections removeAllObjects];
+
+    if (_resolver) {
+        DNSServiceRefDeallocate(_resolver);
+        _resolver = NULL;
+
+        // If no monitor objects exist, schedule to deallocate shared connection and queue
+        sConnectivityMonitorCount--;
+        if (!sConnectivityMonitorCount) {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (MTRDEVICECONNECTIVITYMONITOR_SHARED_CONNECTION_LINGER_INTERVAL * NSEC_PER_SEC)), sSharedResolverQueue, ^{
+                std::lock_guard lock(sConnectivityMonitorLock);
+
+                if (!sConnectivityMonitorCount) {
+                    MTR_LOG_INFO("%@ Closing shared resolver connection", self);
+                    DNSServiceRefDeallocate(sSharedResolverConnection);
+                    sSharedResolverConnection = NULL;
+                    sSharedResolverQueue = nil;
+                }
+            });
+        }
+    }
+}
+
+- (void)stopMonitoring
+{
+    MTR_LOG_INFO("%@ stop connectivity monitoring for %@", self, _instanceName);
+    std::lock_guard lock(sConnectivityMonitorLock);
+    [self _stopMonitoring];
+}
+@end

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -1368,6 +1368,13 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     return @(_cppCommissioner->GetCompressedFabricId());
 }
 
+- (NSNumber * _Nullable)syncGetCompressedFabricID
+{
+    return [self syncRunOnWorkQueueWithReturnValue:^NSNumber * {
+        return [self compressedFabricID];
+    } error:nil];
+}
+
 - (CHIP_ERROR)isRunningOnFabric:(chip::FabricTable *)fabricTable
                     fabricIndex:(chip::FabricIndex)fabricIndex
                       isRunning:(BOOL *)isRunning

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -256,6 +256,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (MTRDevice *)deviceForNodeID:(NSNumber *)nodeID;
 - (void)removeDevice:(MTRDevice *)device;
 
+- (NSNumber * _Nullable)syncGetCompressedFabricID;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/MTRDeviceConnectivityMonitorTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceConnectivityMonitorTests.m
@@ -1,0 +1,88 @@
+/**
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <Network/Network.h>
+#import <dns_sd.h>
+
+#import "MTRDeviceConnectivityMonitor.h"
+
+@interface MTRDeviceConnectivityMonitor (Test)
+- (instancetype)initWithInstanceName:(NSString *)instanceName;
+@end
+
+@interface MTRDeviceConnectivityMonitorTests : XCTestCase
+@end
+
+@implementation MTRDeviceConnectivityMonitorTests
+
+static DNSServiceRef sSharedConnection;
+
++ (void)setUp
+{
+    DNSServiceErrorType dnsError = DNSServiceCreateConnection(&sSharedConnection);
+    XCTAssertEqual(dnsError, kDNSServiceErr_NoError);
+}
+
++ (void)tearDown
+{
+    DNSServiceRefDeallocate(sSharedConnection);
+}
+
+static char kLocalDot[] = "local.";
+static char kOperationalType[] = "_matter._tcp";
+
+static void test001_MonitorTest_RegisterCallback(
+    DNSServiceRef sdRef,
+    DNSServiceFlags flags,
+    DNSServiceErrorType errorCode,
+    const char * name,
+    const char * regtype,
+    const char * domain,
+    void * context)
+{
+}
+
+- (void)test001_BasicMonitorTest
+{
+    dispatch_queue_t testQueue = dispatch_queue_create("connectivity-monitor-test-queue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+    DNSServiceRef testAdvertiser;
+    DNSServiceFlags flags = kDNSServiceFlagsNoAutoRename;
+    char testInstanceName[] = "testinstance-name";
+    char testHostName[] = "localhost";
+    uint16_t testPort = htons(15000);
+    DNSServiceErrorType dnsError = DNSServiceRegister(&testAdvertiser, flags, 0, testInstanceName, kOperationalType, kLocalDot, testHostName, testPort, 0, NULL, test001_MonitorTest_RegisterCallback, NULL);
+    XCTAssertEqual(dnsError, kDNSServiceErr_NoError);
+
+    XCTestExpectation * connectivityMonitorCallbackExpectation = [self expectationWithDescription:@"Got connectivity monitor callback"];
+    __block BOOL gotConnectivityMonitorCallback = NO;
+
+    MTRDeviceConnectivityMonitor * monitor = [[MTRDeviceConnectivityMonitor alloc] initWithInstanceName:@(testInstanceName)];
+    [monitor startMonitoringWithHandler:^{
+        if (!gotConnectivityMonitorCallback) {
+            gotConnectivityMonitorCallback = YES;
+            [connectivityMonitorCallbackExpectation fulfill];
+        }
+    } queue:testQueue];
+
+    [self waitForExpectations:@[ connectivityMonitorCallbackExpectation ] timeout:5];
+
+    [monitor stopMonitoring];
+    DNSServiceRefDeallocate(testAdvertiser);
+}
+
+@end

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -264,6 +264,8 @@
 		75A202E52BA8DBAC00A771DD /* reporting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 75A202E42BA8DBAC00A771DD /* reporting.cpp */; };
 		75A202E62BA8DBAC00A771DD /* reporting.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 75A202E42BA8DBAC00A771DD /* reporting.cpp */; };
 		75B0D01E2B71B47F002074DD /* MTRDeviceTestDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 75B0D01D2B71B47F002074DD /* MTRDeviceTestDelegate.m */; };
+		75B3269C2BCDB9D600E17C4E /* MTRDeviceConnectivityMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 75B3269B2BCDB9D600E17C4E /* MTRDeviceConnectivityMonitor.h */; };
+		75B3269E2BCDB9EA00E17C4E /* MTRDeviceConnectivityMonitor.mm in Sources */ = {isa = PBXBuildFile; fileRef = 75B3269D2BCDB9EA00E17C4E /* MTRDeviceConnectivityMonitor.mm */; };
 		75B765C12A1D71BC0014719B /* MTRAttributeSpecifiedCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = 75B765C02A1D71BC0014719B /* MTRAttributeSpecifiedCheck.h */; };
 		75B765C32A1D82D30014719B /* MTRAttributeSpecifiedCheck.mm in Sources */ = {isa = PBXBuildFile; fileRef = 75B765C22A1D82D30014719B /* MTRAttributeSpecifiedCheck.mm */; };
 		8874C1322B69C7060084BEFD /* MTRMetricsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8874C1312B69C7060084BEFD /* MTRMetricsTests.m */; };
@@ -673,6 +675,8 @@
 		75A202E42BA8DBAC00A771DD /* reporting.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = reporting.cpp; sourceTree = "<group>"; };
 		75B0D01C2B71B46F002074DD /* MTRDeviceTestDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDeviceTestDelegate.h; sourceTree = "<group>"; };
 		75B0D01D2B71B47F002074DD /* MTRDeviceTestDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRDeviceTestDelegate.m; sourceTree = "<group>"; };
+		75B3269B2BCDB9D600E17C4E /* MTRDeviceConnectivityMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDeviceConnectivityMonitor.h; sourceTree = "<group>"; };
+		75B3269D2BCDB9EA00E17C4E /* MTRDeviceConnectivityMonitor.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceConnectivityMonitor.mm; sourceTree = "<group>"; };
 		75B765BF2A1D70F80014719B /* MTRAttributeSpecifiedCheck-src.zapt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "MTRAttributeSpecifiedCheck-src.zapt"; sourceTree = "<group>"; };
 		75B765C02A1D71BC0014719B /* MTRAttributeSpecifiedCheck.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRAttributeSpecifiedCheck.h; sourceTree = "<group>"; };
 		75B765C22A1D82D30014719B /* MTRAttributeSpecifiedCheck.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRAttributeSpecifiedCheck.mm; sourceTree = "<group>"; };
@@ -1273,6 +1277,8 @@
 				88EBF8CC27FABDD500686BC1 /* MTRDeviceAttestationDelegateBridge.mm */,
 				2C5EEEF4268A85C400CAE3D3 /* MTRDeviceConnectionBridge.h */,
 				2C5EEEF5268A85C400CAE3D3 /* MTRDeviceConnectionBridge.mm */,
+				75B3269B2BCDB9D600E17C4E /* MTRDeviceConnectivityMonitor.h */,
+				75B3269D2BCDB9EA00E17C4E /* MTRDeviceConnectivityMonitor.mm */,
 				991DC0822475F45400C13860 /* MTRDeviceController.h */,
 				5136660F28067D540025EDAE /* MTRDeviceController_Internal.h */,
 				991DC0872475F47D00C13860 /* MTRDeviceController.mm */,
@@ -1559,6 +1565,7 @@
 				3D843717294979230070D20A /* MTRClusters_Internal.h in Headers */,
 				7596A85728788557004DAE0E /* MTRClusters.h in Headers */,
 				99D466E12798936D0089A18F /* MTRCommissioningParameters.h in Headers */,
+				75B3269C2BCDB9D600E17C4E /* MTRDeviceConnectivityMonitor.h in Headers */,
 				5136661528067D550025EDAE /* MTRDeviceControllerFactory_Internal.h in Headers */,
 				515C1C70284F9FFB00A48F0C /* MTRFramework.h in Headers */,
 				7534F12928BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h in Headers */,
@@ -1929,6 +1936,7 @@
 				510470FB2A2F7DF60053EA7E /* MTRBackwardsCompatShims.mm in Sources */,
 				5173A47629C0E2ED00F67F48 /* MTRFabricInfo.mm in Sources */,
 				5ACDDD7D27CD16D200EFD68A /* MTRClusterStateCacheContainer.mm in Sources */,
+				75B3269E2BCDB9EA00E17C4E /* MTRDeviceConnectivityMonitor.mm in Sources */,
 				513DDB8A2761F6F900DAA01A /* MTRAttributeTLVValueDecoder.mm in Sources */,
 				5117DD3829A931AE00FFA1AA /* MTROperationalBrowser.mm in Sources */,
 				514C79F02B62ADDA00DD6D7B /* descriptor.cpp in Sources */,

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -266,6 +266,7 @@
 		75B0D01E2B71B47F002074DD /* MTRDeviceTestDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 75B0D01D2B71B47F002074DD /* MTRDeviceTestDelegate.m */; };
 		75B3269C2BCDB9D600E17C4E /* MTRDeviceConnectivityMonitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 75B3269B2BCDB9D600E17C4E /* MTRDeviceConnectivityMonitor.h */; };
 		75B3269E2BCDB9EA00E17C4E /* MTRDeviceConnectivityMonitor.mm in Sources */ = {isa = PBXBuildFile; fileRef = 75B3269D2BCDB9EA00E17C4E /* MTRDeviceConnectivityMonitor.mm */; };
+		75B326A22BCF12E900E17C4E /* MTRDeviceConnectivityMonitorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 75B326A12BCF12E900E17C4E /* MTRDeviceConnectivityMonitorTests.m */; };
 		75B765C12A1D71BC0014719B /* MTRAttributeSpecifiedCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = 75B765C02A1D71BC0014719B /* MTRAttributeSpecifiedCheck.h */; };
 		75B765C32A1D82D30014719B /* MTRAttributeSpecifiedCheck.mm in Sources */ = {isa = PBXBuildFile; fileRef = 75B765C22A1D82D30014719B /* MTRAttributeSpecifiedCheck.mm */; };
 		8874C1322B69C7060084BEFD /* MTRMetricsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8874C1312B69C7060084BEFD /* MTRMetricsTests.m */; };
@@ -677,6 +678,7 @@
 		75B0D01D2B71B47F002074DD /* MTRDeviceTestDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRDeviceTestDelegate.m; sourceTree = "<group>"; };
 		75B3269B2BCDB9D600E17C4E /* MTRDeviceConnectivityMonitor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDeviceConnectivityMonitor.h; sourceTree = "<group>"; };
 		75B3269D2BCDB9EA00E17C4E /* MTRDeviceConnectivityMonitor.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceConnectivityMonitor.mm; sourceTree = "<group>"; };
+		75B326A12BCF12E900E17C4E /* MTRDeviceConnectivityMonitorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRDeviceConnectivityMonitorTests.m; sourceTree = "<group>"; };
 		75B765BF2A1D70F80014719B /* MTRAttributeSpecifiedCheck-src.zapt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "MTRAttributeSpecifiedCheck-src.zapt"; sourceTree = "<group>"; };
 		75B765C02A1D71BC0014719B /* MTRAttributeSpecifiedCheck.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRAttributeSpecifiedCheck.h; sourceTree = "<group>"; };
 		75B765C22A1D82D30014719B /* MTRAttributeSpecifiedCheck.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRAttributeSpecifiedCheck.mm; sourceTree = "<group>"; };
@@ -1378,6 +1380,7 @@
 				99C65E0F267282F1003402F6 /* MTRControllerTests.m */,
 				51A2F1312A00402A00F03298 /* MTRDataValueParserTests.m */,
 				5AE6D4E327A99041001F2493 /* MTRDeviceTests.m */,
+				75B326A12BCF12E900E17C4E /* MTRDeviceConnectivityMonitorTests.m */,
 				51D9CB0A2BA37DCE0049D6DB /* MTRDSTOffsetTests.m */,
 				3D0C484A29DA4FA0006D811F /* MTRErrorTests.m */,
 				5173A47829C0E82300F67F48 /* MTRFabricInfoTests.m */,
@@ -1988,6 +1991,7 @@
 				518D3F832AA132DC008E0007 /* MTRTestPerControllerStorage.m in Sources */,
 				51339B1F2A0DA64D00C798C1 /* MTRCertificateValidityTests.m in Sources */,
 				5173A47929C0E82300F67F48 /* MTRFabricInfoTests.m in Sources */,
+				75B326A22BCF12E900E17C4E /* MTRDeviceConnectivityMonitorTests.m in Sources */,
 				5143851E2A65885500EDC8E6 /* MTRSwiftPairingTests.swift in Sources */,
 				75B0D01E2B71B47F002074DD /* MTRDeviceTestDelegate.m in Sources */,
 				3D0C484B29DA4FA0006D811F /* MTRErrorTests.m in Sources */,


### PR DESCRIPTION
This change is to add a method to monitor network path/viability changes during the subscription / resubscription process, so that in the event network routes to the resolved host name become available / viable, the exponential backoff is reset, and a retry is triggered immediately if appropriate.