### PR TITLE
[Silabs] Fix forgotten type change pdTrue(FreeRTOS) to osOk (CMSISOS)

### DIFF
--- a/examples/platform/silabs/efr32/uart.cpp
+++ b/examples/platform/silabs/efr32/uart.cpp
@@ -442,7 +442,7 @@ void uartMainLoop(void * args)
     {
 
         osStatus_t eventReceived = osMessageQueueGet(sUartTxQueue, &workBuffer, nullptr, osWaitForever);
-        while (eventReceived == pdTRUE)
+        while (eventReceived == osOK)
         {
             uartSendBytes(workBuffer.data, workBuffer.length);
             eventReceived = osMessageQueueGet(sUartTxQueue, &workBuffer, nullptr, 0);


### PR DESCRIPTION
Now that CMSIS API is used instead of freeRTOS for the uart queue the check must be `osOk`
pdTrue =1 while osOK =0