### PR TITLE
[Silabs] Enable test event trigger on ICD apps

### DIFF
--- a/examples/light-switch-app/silabs/openthread.gni
+++ b/examples/light-switch-app/silabs/openthread.gni
@@ -25,6 +25,8 @@ chip_enable_openthread = true
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"
 
+sl_enable_test_event_trigger = true
+
 # ICD Default configurations
 chip_enable_icd_server = true
 chip_subscription_timeout_resumption = false

--- a/examples/lock-app/silabs/build_for_wifi_args.gni
+++ b/examples/lock-app/silabs/build_for_wifi_args.gni
@@ -21,6 +21,8 @@ import("${chip_root}/src/platform/silabs/wifi_args.gni")
 chip_enable_ota_requestor = true
 app_data_model = "${chip_root}/examples/lock-app/lock-common"
 
+sl_enable_test_event_trigger = true
+
 # ICD Default configurations
 chip_enable_icd_server = true
 chip_subscription_timeout_resumption = false

--- a/examples/lock-app/silabs/openthread.gni
+++ b/examples/lock-app/silabs/openthread.gni
@@ -25,6 +25,8 @@ chip_enable_openthread = true
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"
 
+sl_enable_test_event_trigger = true
+
 # ICD Default configurations
 chip_enable_icd_server = true
 chip_subscription_timeout_resumption = false

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -193,7 +193,7 @@ else
                 shift
                 ;;
             --icd)
-                optArgs+="chip_enable_icd_server=true chip_openthread_ftd=false "
+                optArgs+="chip_enable_icd_server=true chip_openthread_ftd=false sl_enable_test_event_trigger=true"
                 shift
                 ;;
             --low-power)


### PR DESCRIPTION
#### Description
PR enables the test event trigger on all apps that are ICD by default. Without the trigger, ICD apps crash when trying to add the ICD test event trigger.

- Enable test event trigger on default ICD apps
- Adds test event trigger build flag to the `--icd` macro

#### Testing
Manual tests to make sure device boots
