### PR TITLE
[Dnssd] Refactored DiscoveredNodeData definition and usage

### DIFF
--- a/examples/chip-tool/commands/common/DeviceScanner.cpp
+++ b/examples/chip-tool/commands/common/DeviceScanner.cpp
@@ -55,6 +55,7 @@ CHIP_ERROR DeviceScanner::Stop()
 
 void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
 {
+    VerifyOrReturn(nodeData.Is<CommissionNodeData>())
     auto & commissionData = nodeData.Get<CommissionNodeData>();
 
     auto discriminator = commissionData.longDiscriminator;
@@ -64,7 +65,7 @@ void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
     ChipLogProgress(chipTool, "OnNodeDiscovered (MDNS): discriminator: %u, vendorId: %u, productId: %u", discriminator, vendorId,
                     productId);
 
-    auto & resolutionData = (CommonResolutionData &) commissionData;
+    CommonResolutionData & resolutionData = commissionData;
 
     auto & instanceData  = mDiscoveredResults[commissionData.instanceName];
     auto & interfaceData = instanceData[resolutionData.interfaceId.GetPlatformInterface()];

--- a/examples/chip-tool/commands/common/DeviceScanner.cpp
+++ b/examples/chip-tool/commands/common/DeviceScanner.cpp
@@ -64,7 +64,7 @@ void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
     ChipLogProgress(chipTool, "OnNodeDiscovered (MDNS): discriminator: %u, vendorId: %u, productId: %u", discriminator, vendorId,
                     productId);
 
-    auto & resolutionData = (CommonResolutionData &)commissionData;
+    auto & resolutionData = (CommonResolutionData &) commissionData;
 
     auto & instanceData  = mDiscoveredResults[commissionData.instanceName];
     auto & interfaceData = instanceData[resolutionData.interfaceId.GetPlatformInterface()];

--- a/examples/chip-tool/commands/common/DeviceScanner.cpp
+++ b/examples/chip-tool/commands/common/DeviceScanner.cpp
@@ -55,8 +55,7 @@ CHIP_ERROR DeviceScanner::Stop()
 
 void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
 {
-    VerifyOrReturn(nodeData.Is<CommissionNodeData>())
-    auto & commissionData = nodeData.Get<CommissionNodeData>();
+    VerifyOrReturn(nodeData.Is<CommissionNodeData>()) auto & commissionData = nodeData.Get<CommissionNodeData>();
 
     auto discriminator = commissionData.longDiscriminator;
     auto vendorId      = static_cast<VendorId>(commissionData.vendorId);

--- a/examples/chip-tool/commands/common/DeviceScanner.cpp
+++ b/examples/chip-tool/commands/common/DeviceScanner.cpp
@@ -55,7 +55,8 @@ CHIP_ERROR DeviceScanner::Stop()
 
 void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
 {
-    VerifyOrReturn(nodeData.Is<CommissionNodeData>()) auto & commissionData = nodeData.Get<CommissionNodeData>();
+    VerifyOrReturn(nodeData.Is<CommissionNodeData>());
+    auto & commissionData = nodeData.Get<CommissionNodeData>();
 
     auto discriminator = commissionData.longDiscriminator;
     auto vendorId      = static_cast<VendorId>(commissionData.vendorId);
@@ -64,7 +65,7 @@ void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
     ChipLogProgress(chipTool, "OnNodeDiscovered (MDNS): discriminator: %u, vendorId: %u, productId: %u", discriminator, vendorId,
                     productId);
 
-    CommonResolutionData & resolutionData = commissionData;
+    const CommonResolutionData & resolutionData = commissionData;
 
     auto & instanceData  = mDiscoveredResults[commissionData.instanceName];
     auto & interfaceData = instanceData[resolutionData.interfaceId.GetPlatformInterface()];

--- a/examples/chip-tool/commands/common/DeviceScanner.cpp
+++ b/examples/chip-tool/commands/common/DeviceScanner.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR DeviceScanner::Stop()
 
 void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
 {
-    auto & commissionData = nodeData.nodeData;
+    auto & commissionData = nodeData.Get<CommissionNodeData>();
 
     auto discriminator = commissionData.longDiscriminator;
     auto vendorId      = static_cast<VendorId>(commissionData.vendorId);
@@ -64,7 +64,7 @@ void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
     ChipLogProgress(chipTool, "OnNodeDiscovered (MDNS): discriminator: %u, vendorId: %u, productId: %u", discriminator, vendorId,
                     productId);
 
-    auto & resolutionData = nodeData.resolutionData;
+    auto & resolutionData = (CommonResolutionData &)commissionData;
 
     auto & instanceData  = mDiscoveredResults[commissionData.instanceName];
     auto & interfaceData = instanceData[resolutionData.interfaceId.GetPlatformInterface()];
@@ -76,7 +76,7 @@ void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
         interfaceData.push_back(result);
     }
 
-    nodeData.LogDetail();
+    commissionData.LogDetail();
 }
 
 void DeviceScanner::OnBrowseAdd(chip::Dnssd::DnssdService service)

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -204,12 +204,12 @@ CHIP_ERROR LogIssueNOCChain(const char * noc, const char * icac, const char * rc
     return gDelegate->LogJSON(valueStr.c_str());
 }
 
-CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::DiscoveredNodeData & nodeData)
+CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::CommissionNodeData & nodeData)
 {
     VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
 
-    auto & resolutionData = nodeData.resolutionData;
-    auto & commissionData = nodeData.nodeData;
+    auto & commissionData = nodeData;
+    auto & resolutionData = (chip::Dnssd::CommonResolutionData &)commissionData;
 
     if (!chip::CanCastTo<uint8_t>(resolutionData.numIPs))
     {

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -209,7 +209,7 @@ CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::CommissionNodeData & nodeDat
     VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
 
     auto & commissionData = nodeData;
-    auto & resolutionData = (chip::Dnssd::CommonResolutionData &) commissionData;
+    auto & resolutionData = commissionData;
 
     if (!chip::CanCastTo<uint8_t>(resolutionData.numIPs))
     {

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -209,7 +209,7 @@ CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::CommissionNodeData & nodeDat
     VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
 
     auto & commissionData = nodeData;
-    auto & resolutionData = (chip::Dnssd::CommonResolutionData &)commissionData;
+    auto & resolutionData = (chip::Dnssd::CommonResolutionData &) commissionData;
 
     if (!chip::CanCastTo<uint8_t>(resolutionData.numIPs))
     {

--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.h
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.h
@@ -43,6 +43,6 @@ CHIP_ERROR LogErrorAsJSON(const CHIP_ERROR & error);
 CHIP_ERROR LogGetCommissionerNodeId(chip::NodeId value);
 CHIP_ERROR LogGetCommissionerRootCertificate(const char * value);
 CHIP_ERROR LogIssueNOCChain(const char * noc, const char * icac, const char * rcac, const char * ipk);
-CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::DiscoveredNodeData & nodeData);
+CHIP_ERROR LogDiscoveredNodeData(const chip::Dnssd::CommissionNodeData & nodeData);
 void SetDelegate(RemoteDataModelLoggerDelegate * delegate);
 }; // namespace RemoteDataModelLogger

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -23,7 +23,7 @@
 
 using namespace ::chip;
 
-void DiscoverCommissionablesCommandBase::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
+void DiscoverCommissionablesCommandBase::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData)
 {
     nodeData.LogDetail();
     LogErrorOnFailure(RemoteDataModelLogger::LogDiscoveredNodeData(nodeData));

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
@@ -31,7 +31,7 @@ public:
     }
 
     /////////// DeviceDiscoveryDelegate Interface /////////
-    void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
+    void OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData) override;
 
     /////////// CHIPCommand Interface /////////
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(30); }

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
@@ -32,7 +32,7 @@ void DiscoverCommissionersCommand::Shutdown()
     [[maybe_unused]] int commissionerCount = 0;
     for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; i++)
     {
-        const Dnssd::DiscoveredNodeData * commissioner = mCommissionableNodeController.GetDiscoveredCommissioner(i);
+        const Dnssd::CommissionNodeData * commissioner = mCommissionableNodeController.GetDiscoveredCommissioner(i);
         if (commissioner != nullptr)
         {
             ChipLogProgress(chipTool, "Discovered Commissioner #%d", commissionerCount);

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -484,7 +484,7 @@ void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & 
     // Ignore nodes with closed commissioning window
     VerifyOrReturn(nodeData.commissioningMode != 0);
 
-    auto & resolutionData = (chip::Dnssd::CommonResolutionData &)nodeData;
+    auto & resolutionData = (chip::Dnssd::CommonResolutionData &) nodeData;
 
     const uint16_t port = resolutionData.port;
     char buf[chip::Inet::IPAddress::kMaxStringLength];

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -484,7 +484,7 @@ void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & 
     // Ignore nodes with closed commissioning window
     VerifyOrReturn(nodeData.commissioningMode != 0);
 
-    auto & resolutionData = (chip::Dnssd::CommonResolutionData &) nodeData;
+    auto & resolutionData = nodeData;
 
     const uint16_t port = resolutionData.port;
     char buf[chip::Inet::IPAddress::kMaxStringLength];

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -479,12 +479,12 @@ void PairingCommand::OnICDStayActiveComplete(NodeId deviceId, uint32_t promisedA
                     ChipLogValueX64(deviceId), promisedActiveDuration);
 }
 
-void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
+void PairingCommand::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData)
 {
     // Ignore nodes with closed commissioning window
-    VerifyOrReturn(nodeData.nodeData.commissioningMode != 0);
+    VerifyOrReturn(nodeData.commissioningMode != 0);
 
-    auto & resolutionData = nodeData.resolutionData;
+    auto & resolutionData = (chip::Dnssd::CommonResolutionData &)nodeData;
 
     const uint16_t port = resolutionData.port;
     char buf[chip::Inet::IPAddress::kMaxStringLength];

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -201,7 +201,7 @@ public:
     void OnICDStayActiveComplete(NodeId deviceId, uint32_t promisedActiveDuration) override;
 
     /////////// DeviceDiscoveryDelegate Interface /////////
-    void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
+    void OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData) override;
 
     /////////// DeviceAttestationDelegate /////////
     chip::Optional<uint16_t> FailSafeExpiryTimeoutSecs() const override;

--- a/examples/platform/linux/ControllerShellCommands.cpp
+++ b/examples/platform/linux/ControllerShellCommands.cpp
@@ -116,7 +116,7 @@ static CHIP_ERROR display(bool printHeader)
 
     for (int i = 0; i < 10; i++)
     {
-        const Dnssd::DiscoveredNodeData * next = GetDeviceCommissioner()->GetDiscoveredDevice(i);
+        const Dnssd::CommissionNodeData * next = GetDeviceCommissioner()->GetDiscoveredDevice(i);
         if (next == nullptr)
         {
             streamer_printf(sout, "  Entry %d null\r\n", i);
@@ -124,8 +124,8 @@ static CHIP_ERROR display(bool printHeader)
         else
         {
             streamer_printf(sout, "  Entry %d instanceName=%s host=%s longDiscriminator=%d vendorId=%d productId=%d\r\n", i,
-                            next->nodeData.instanceName, next->resolutionData.hostName, next->nodeData.longDiscriminator,
-                            next->nodeData.vendorId, next->nodeData.productId);
+                            next->instanceName, next->hostName, next->longDiscriminator,
+                            next->vendorId, next->productId);
         }
     }
 

--- a/examples/platform/linux/ControllerShellCommands.cpp
+++ b/examples/platform/linux/ControllerShellCommands.cpp
@@ -124,8 +124,7 @@ static CHIP_ERROR display(bool printHeader)
         else
         {
             streamer_printf(sout, "  Entry %d instanceName=%s host=%s longDiscriminator=%d vendorId=%d productId=%d\r\n", i,
-                            next->instanceName, next->hostName, next->longDiscriminator,
-                            next->vendorId, next->productId);
+                            next->instanceName, next->hostName, next->longDiscriminator, next->vendorId, next->productId);
         }
     }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
@@ -324,25 +324,24 @@ CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscovered
     jstring jInstanceName         = static_cast<jstring>(env->GetObjectField(jDiscoveredNodeData, getInstanceNameField));
     if (jInstanceName != nullptr)
     {
-        chip::Platform::CopyString(outCppDiscoveredNodeData.instanceName,
-                                   chip::Dnssd::Commission::kInstanceNameMaxLength + 1, env->GetStringUTFChars(jInstanceName, 0));
+        chip::Platform::CopyString(outCppDiscoveredNodeData.instanceName, chip::Dnssd::Commission::kInstanceNameMaxLength + 1,
+                                   env->GetStringUTFChars(jInstanceName, 0));
     }
 
-    jfieldID jLongDiscriminatorField = env->GetFieldID(jDiscoveredNodeDataClass, "longDiscriminator", "J");
-    outCppDiscoveredNodeData.vendorId =
-        static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jLongDiscriminatorField));
+    jfieldID jLongDiscriminatorField  = env->GetFieldID(jDiscoveredNodeDataClass, "longDiscriminator", "J");
+    outCppDiscoveredNodeData.vendorId = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jLongDiscriminatorField));
 
-    jfieldID jVendorIdField                    = env->GetFieldID(jDiscoveredNodeDataClass, "vendorId", "J");
+    jfieldID jVendorIdField           = env->GetFieldID(jDiscoveredNodeDataClass, "vendorId", "J");
     outCppDiscoveredNodeData.vendorId = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jVendorIdField));
 
-    jfieldID jProductIdField                    = env->GetFieldID(jDiscoveredNodeDataClass, "productId", "J");
+    jfieldID jProductIdField           = env->GetFieldID(jDiscoveredNodeDataClass, "productId", "J");
     outCppDiscoveredNodeData.productId = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jProductIdField));
 
     jfieldID jCommissioningModeField = env->GetFieldID(jDiscoveredNodeDataClass, "commissioningMode", "B");
     outCppDiscoveredNodeData.commissioningMode =
         static_cast<uint8_t>(env->GetByteField(jDiscoveredNodeData, jCommissioningModeField));
 
-    jfieldID jDeviceTypeField                    = env->GetFieldID(jDiscoveredNodeDataClass, "deviceType", "J");
+    jfieldID jDeviceTypeField           = env->GetFieldID(jDiscoveredNodeDataClass, "deviceType", "J");
     outCppDiscoveredNodeData.deviceType = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jDeviceTypeField));
 
     jfieldID getDeviceNameField = env->GetFieldID(jDiscoveredNodeDataClass, "deviceName", "Ljava/lang/String;");
@@ -354,13 +353,11 @@ CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscovered
     }
 
     // TODO: map rotating ID
-    jfieldID jRotatingIdLenField = env->GetFieldID(jDiscoveredNodeDataClass, "rotatingIdLen", "I");
-    outCppDiscoveredNodeData.rotatingIdLen =
-        static_cast<size_t>(env->GetIntField(jDiscoveredNodeData, jRotatingIdLenField));
+    jfieldID jRotatingIdLenField           = env->GetFieldID(jDiscoveredNodeDataClass, "rotatingIdLen", "I");
+    outCppDiscoveredNodeData.rotatingIdLen = static_cast<size_t>(env->GetIntField(jDiscoveredNodeData, jRotatingIdLenField));
 
-    jfieldID jPairingHintField = env->GetFieldID(jDiscoveredNodeDataClass, "pairingHint", "S");
-    outCppDiscoveredNodeData.pairingHint =
-        static_cast<uint16_t>(env->GetShortField(jDiscoveredNodeData, jPairingHintField));
+    jfieldID jPairingHintField           = env->GetFieldID(jDiscoveredNodeDataClass, "pairingHint", "S");
+    outCppDiscoveredNodeData.pairingHint = static_cast<uint16_t>(env->GetShortField(jDiscoveredNodeData, jPairingHintField));
 
     jfieldID getPairingInstructionField = env->GetFieldID(jDiscoveredNodeDataClass, "pairingInstruction", "Ljava/lang/String;");
     jstring jPairingInstruction = static_cast<jstring>(env->GetObjectField(jDiscoveredNodeData, getPairingInstructionField));
@@ -370,10 +367,10 @@ CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscovered
                                    env->GetStringUTFChars(jPairingInstruction, 0));
     }
 
-    jfieldID jPortField                          = env->GetFieldID(jDiscoveredNodeDataClass, "port", "I");
+    jfieldID jPortField           = env->GetFieldID(jDiscoveredNodeDataClass, "port", "I");
     outCppDiscoveredNodeData.port = static_cast<uint16_t>(env->GetIntField(jDiscoveredNodeData, jPortField));
 
-    jfieldID jNumIpsField                          = env->GetFieldID(jDiscoveredNodeDataClass, "numIPs", "I");
+    jfieldID jNumIpsField           = env->GetFieldID(jDiscoveredNodeDataClass, "numIPs", "I");
     outCppDiscoveredNodeData.numIPs = static_cast<size_t>(env->GetIntField(jDiscoveredNodeData, jNumIpsField));
 
     jfieldID jIPAddressesField = env->GetFieldID(jDiscoveredNodeDataClass, "ipAddresses", "Ljava/util/List;");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.cpp
@@ -301,7 +301,7 @@ CHIP_ERROR convertTargetVideoPlayerInfoToJVideoPlayer(TargetVideoPlayerInfo * ta
 }
 
 CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscoveredNodeData,
-                                                             chip::Dnssd::DiscoveredNodeData & outCppDiscoveredNodeData)
+                                                             chip::Dnssd::CommissionNodeData & outCppDiscoveredNodeData)
 {
     ChipLogProgress(AppServer, "convertJDiscoveredNodeDataToCppDiscoveredNodeData called");
     VerifyOrReturnError(jDiscoveredNodeData != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -316,7 +316,7 @@ CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscovered
     jstring jHostName         = static_cast<jstring>(env->GetObjectField(jDiscoveredNodeData, getHostNameField));
     if (jHostName != nullptr)
     {
-        chip::Platform::CopyString(outCppDiscoveredNodeData.resolutionData.hostName, chip::Dnssd::kHostNameMaxLength + 1,
+        chip::Platform::CopyString(outCppDiscoveredNodeData.hostName, chip::Dnssd::kHostNameMaxLength + 1,
                                    env->GetStringUTFChars(jHostName, 0));
     }
 
@@ -324,61 +324,61 @@ CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscovered
     jstring jInstanceName         = static_cast<jstring>(env->GetObjectField(jDiscoveredNodeData, getInstanceNameField));
     if (jInstanceName != nullptr)
     {
-        chip::Platform::CopyString(outCppDiscoveredNodeData.nodeData.instanceName,
+        chip::Platform::CopyString(outCppDiscoveredNodeData.instanceName,
                                    chip::Dnssd::Commission::kInstanceNameMaxLength + 1, env->GetStringUTFChars(jInstanceName, 0));
     }
 
     jfieldID jLongDiscriminatorField = env->GetFieldID(jDiscoveredNodeDataClass, "longDiscriminator", "J");
-    outCppDiscoveredNodeData.nodeData.vendorId =
+    outCppDiscoveredNodeData.vendorId =
         static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jLongDiscriminatorField));
 
     jfieldID jVendorIdField                    = env->GetFieldID(jDiscoveredNodeDataClass, "vendorId", "J");
-    outCppDiscoveredNodeData.nodeData.vendorId = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jVendorIdField));
+    outCppDiscoveredNodeData.vendorId = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jVendorIdField));
 
     jfieldID jProductIdField                    = env->GetFieldID(jDiscoveredNodeDataClass, "productId", "J");
-    outCppDiscoveredNodeData.nodeData.productId = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jProductIdField));
+    outCppDiscoveredNodeData.productId = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jProductIdField));
 
     jfieldID jCommissioningModeField = env->GetFieldID(jDiscoveredNodeDataClass, "commissioningMode", "B");
-    outCppDiscoveredNodeData.nodeData.commissioningMode =
+    outCppDiscoveredNodeData.commissioningMode =
         static_cast<uint8_t>(env->GetByteField(jDiscoveredNodeData, jCommissioningModeField));
 
     jfieldID jDeviceTypeField                    = env->GetFieldID(jDiscoveredNodeDataClass, "deviceType", "J");
-    outCppDiscoveredNodeData.nodeData.deviceType = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jDeviceTypeField));
+    outCppDiscoveredNodeData.deviceType = static_cast<uint16_t>(env->GetLongField(jDiscoveredNodeData, jDeviceTypeField));
 
     jfieldID getDeviceNameField = env->GetFieldID(jDiscoveredNodeDataClass, "deviceName", "Ljava/lang/String;");
     jstring jDeviceName         = static_cast<jstring>(env->GetObjectField(jDiscoveredNodeData, getDeviceNameField));
     if (jDeviceName != nullptr)
     {
-        chip::Platform::CopyString(outCppDiscoveredNodeData.nodeData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
+        chip::Platform::CopyString(outCppDiscoveredNodeData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
                                    env->GetStringUTFChars(jDeviceName, 0));
     }
 
     // TODO: map rotating ID
     jfieldID jRotatingIdLenField = env->GetFieldID(jDiscoveredNodeDataClass, "rotatingIdLen", "I");
-    outCppDiscoveredNodeData.nodeData.rotatingIdLen =
+    outCppDiscoveredNodeData.rotatingIdLen =
         static_cast<size_t>(env->GetIntField(jDiscoveredNodeData, jRotatingIdLenField));
 
     jfieldID jPairingHintField = env->GetFieldID(jDiscoveredNodeDataClass, "pairingHint", "S");
-    outCppDiscoveredNodeData.nodeData.pairingHint =
+    outCppDiscoveredNodeData.pairingHint =
         static_cast<uint16_t>(env->GetShortField(jDiscoveredNodeData, jPairingHintField));
 
     jfieldID getPairingInstructionField = env->GetFieldID(jDiscoveredNodeDataClass, "pairingInstruction", "Ljava/lang/String;");
     jstring jPairingInstruction = static_cast<jstring>(env->GetObjectField(jDiscoveredNodeData, getPairingInstructionField));
     if (jPairingInstruction != nullptr)
     {
-        chip::Platform::CopyString(outCppDiscoveredNodeData.nodeData.pairingInstruction, chip::Dnssd::kMaxPairingInstructionLen + 1,
+        chip::Platform::CopyString(outCppDiscoveredNodeData.pairingInstruction, chip::Dnssd::kMaxPairingInstructionLen + 1,
                                    env->GetStringUTFChars(jPairingInstruction, 0));
     }
 
     jfieldID jPortField                          = env->GetFieldID(jDiscoveredNodeDataClass, "port", "I");
-    outCppDiscoveredNodeData.resolutionData.port = static_cast<uint16_t>(env->GetIntField(jDiscoveredNodeData, jPortField));
+    outCppDiscoveredNodeData.port = static_cast<uint16_t>(env->GetIntField(jDiscoveredNodeData, jPortField));
 
     jfieldID jNumIpsField                          = env->GetFieldID(jDiscoveredNodeDataClass, "numIPs", "I");
-    outCppDiscoveredNodeData.resolutionData.numIPs = static_cast<size_t>(env->GetIntField(jDiscoveredNodeData, jNumIpsField));
+    outCppDiscoveredNodeData.numIPs = static_cast<size_t>(env->GetIntField(jDiscoveredNodeData, jNumIpsField));
 
     jfieldID jIPAddressesField = env->GetFieldID(jDiscoveredNodeDataClass, "ipAddresses", "Ljava/util/List;");
     jobject jIPAddresses       = env->GetObjectField(jDiscoveredNodeData, jIPAddressesField);
-    if (jIPAddresses == nullptr && outCppDiscoveredNodeData.resolutionData.numIPs > 0)
+    if (jIPAddresses == nullptr && outCppDiscoveredNodeData.numIPs > 0)
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
@@ -400,11 +400,11 @@ CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscovered
         chip::Inet::IPAddress addressInet;
         chip::JniUtfString addressJniString(env, jIPAddressStr);
         VerifyOrReturnError(chip::Inet::IPAddress::FromString(addressJniString.c_str(), addressInet), CHIP_ERROR_INVALID_ARGUMENT);
-        outCppDiscoveredNodeData.resolutionData.ipAddress[ipAddressCount] = addressInet;
+        outCppDiscoveredNodeData.ipAddress[ipAddressCount] = addressInet;
 
         if (ipAddressCount == 0)
         {
-            outCppDiscoveredNodeData.resolutionData.interfaceId = chip::Inet::InterfaceId::FromIPAddress(addressInet);
+            outCppDiscoveredNodeData.interfaceId = chip::Inet::InterfaceId::FromIPAddress(addressInet);
         }
         ipAddressCount++;
     }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/ConversionUtils.h
@@ -33,4 +33,4 @@ CHIP_ERROR convertJVideoPlayerToTargetVideoPlayerInfo(jobject videoPlayer, Targe
 CHIP_ERROR convertTargetVideoPlayerInfoToJVideoPlayer(TargetVideoPlayerInfo * targetVideoPlayerInfo, jobject & outVideoPlayer);
 
 CHIP_ERROR convertJDiscoveredNodeDataToCppDiscoveredNodeData(jobject jDiscoveredNodeData,
-                                                             chip::Dnssd::DiscoveredNodeData & cppDiscoveredNodeData);
+                                                             chip::Dnssd::CommissionNodeData & cppDiscoveredNodeData);

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -372,7 +372,7 @@ JNI_METHOD(jboolean, sendCommissioningRequest)(JNIEnv * env, jobject, jobject jD
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "JNI_METHOD sendCommissioningRequest called");
 
-    chip::Dnssd::DiscoveredNodeData commissioner;
+    chip::Dnssd::CommissionNodeData commissioner;
     CHIP_ERROR err = convertJDiscoveredNodeDataToCppDiscoveredNodeData(jDiscoveredNodeData, commissioner);
     VerifyOrExit(err == CHIP_NO_ERROR,
                  ChipLogError(AppServer,

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -456,7 +456,7 @@
                              block:^{
                                  chip::Optional<TargetVideoPlayerInfo *> associatedConnectableVideoPlayer;
                                  DiscoveredNodeData * commissioner = nil;
-                                 const chip::Dnssd::DiscoveredNodeData * cppDiscoveredNodeData
+                                 const chip::Dnssd::CommissionNodeData * cppDiscoveredNodeData
                                      = CastingServer::GetInstance()->GetDiscoveredCommissioner(
                                          index, associatedConnectableVideoPlayer);
                                  if (cppDiscoveredNodeData != nullptr) {
@@ -530,7 +530,7 @@
                              block:^{
                                  bool udcRequestStatus;
 
-                                 chip::Dnssd::DiscoveredNodeData cppCommissioner;
+                                 chip::Dnssd::CommissionNodeData cppCommissioner;
                                  if ([ConversionUtils convertToCppDiscoveredNodeDataFrom:commissioner
                                                                    outDiscoveredNodeData:cppCommissioner]
                                      != CHIP_NO_ERROR) {

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionerDiscoveryDelegateImpl.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CommissionerDiscoveryDelegateImpl.h
@@ -61,10 +61,10 @@ public:
         }
     }
 
-    void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
+    void OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData)
     {
         ChipLogProgress(AppServer, "CommissionerDiscoveryDelegateImpl().OnDiscoveredDevice() called");
-        __block const chip::Dnssd::DiscoveredNodeData cppNodeData = nodeData;
+        __block const chip::Dnssd::CommissionNodeData cppNodeData = nodeData;
         dispatch_async(mClientQueue, ^{
             DiscoveredNodeData * objCDiscoveredNodeData = [ConversionUtils convertToObjCDiscoveredNodeDataFrom:&cppNodeData];
             mDiscoveredCommissioners.push_back(objCDiscoveredNodeData); // add to the list of discovered commissioners

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.hpp
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.hpp
@@ -43,7 +43,7 @@
                            outTargetVideoPlayerInfo:(TargetVideoPlayerInfo &)outTargetVideoPlayerInfo;
 
 + (CHIP_ERROR)convertToCppDiscoveredNodeDataFrom:(DiscoveredNodeData * _Nonnull)objCDiscoveredNodeData
-                           outDiscoveredNodeData:(chip::Dnssd::DiscoveredNodeData &)outDiscoveredNodeData;
+                           outDiscoveredNodeData:(chip::Dnssd::CommissionNodeData &)outDiscoveredNodeData;
 
 /**
  * @brief C++ to Objective C converters
@@ -51,7 +51,7 @@
 + (ContentApp * _Nonnull)convertToObjCContentAppFrom:(TargetEndpointInfo * _Nonnull)cppTargetEndpointInfo;
 
 + (DiscoveredNodeData * _Nonnull)convertToObjCDiscoveredNodeDataFrom:
-    (const chip::Dnssd::DiscoveredNodeData * _Nonnull)cppDiscoveredNodedata;
+    (const chip::Dnssd::CommissionNodeData * _Nonnull)cppDiscoveredNodedata;
 
 + (VideoPlayer * _Nonnull)convertToObjCVideoPlayerFrom:(TargetVideoPlayerInfo * _Nonnull)cppTargetVideoPlayerInfo;
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/ConversionUtils.mm
@@ -45,36 +45,36 @@
 }
 
 + (CHIP_ERROR)convertToCppDiscoveredNodeDataFrom:(DiscoveredNodeData * _Nonnull)objCDiscoveredNodeData
-                           outDiscoveredNodeData:(chip::Dnssd::DiscoveredNodeData &)outDiscoveredNodeData
+                           outDiscoveredNodeData:(chip::Dnssd::CommissionNodeData &)outDiscoveredNodeData
 {
     // setting CommissionNodeData
-    outDiscoveredNodeData.nodeData.deviceType = objCDiscoveredNodeData.deviceType;
-    outDiscoveredNodeData.nodeData.vendorId = objCDiscoveredNodeData.vendorId;
-    outDiscoveredNodeData.nodeData.productId = objCDiscoveredNodeData.productId;
-    outDiscoveredNodeData.nodeData.longDiscriminator = objCDiscoveredNodeData.longDiscriminator;
-    outDiscoveredNodeData.nodeData.commissioningMode = objCDiscoveredNodeData.commissioningMode;
-    outDiscoveredNodeData.nodeData.pairingHint = objCDiscoveredNodeData.pairingHint;
-    memset(outDiscoveredNodeData.nodeData.deviceName, '\0', sizeof(outDiscoveredNodeData.nodeData.deviceName));
+    outDiscoveredNodeData.deviceType = objCDiscoveredNodeData.deviceType;
+    outDiscoveredNodeData.vendorId = objCDiscoveredNodeData.vendorId;
+    outDiscoveredNodeData.productId = objCDiscoveredNodeData.productId;
+    outDiscoveredNodeData.longDiscriminator = objCDiscoveredNodeData.longDiscriminator;
+    outDiscoveredNodeData.commissioningMode = objCDiscoveredNodeData.commissioningMode;
+    outDiscoveredNodeData.pairingHint = objCDiscoveredNodeData.pairingHint;
+    memset(outDiscoveredNodeData.deviceName, '\0', sizeof(outDiscoveredNodeData.deviceName));
     if (objCDiscoveredNodeData.deviceName != nullptr) {
-        chip::Platform::CopyString(outDiscoveredNodeData.nodeData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
+        chip::Platform::CopyString(outDiscoveredNodeData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
             [objCDiscoveredNodeData.deviceName UTF8String]);
     }
-    outDiscoveredNodeData.nodeData.rotatingIdLen = objCDiscoveredNodeData.rotatingIdLen;
+    outDiscoveredNodeData.rotatingIdLen = objCDiscoveredNodeData.rotatingIdLen;
     memcpy(
-        outDiscoveredNodeData.nodeData.rotatingId, objCDiscoveredNodeData.rotatingId, objCDiscoveredNodeData.rotatingIdLen);
+        outDiscoveredNodeData.rotatingId, objCDiscoveredNodeData.rotatingId, objCDiscoveredNodeData.rotatingIdLen);
 
     // setting CommonResolutionData
-    outDiscoveredNodeData.resolutionData.port = objCDiscoveredNodeData.port;
-    memset(outDiscoveredNodeData.resolutionData.hostName, '\0', sizeof(outDiscoveredNodeData.resolutionData.hostName));
+    outDiscoveredNodeData.port = objCDiscoveredNodeData.port;
+    memset(outDiscoveredNodeData.hostName, '\0', sizeof(outDiscoveredNodeData.hostName));
     if (objCDiscoveredNodeData.hostName != nullptr) {
-        chip::Platform::CopyString(outDiscoveredNodeData.resolutionData.hostName, chip::Dnssd::kHostNameMaxLength + 1,
+        chip::Platform::CopyString(outDiscoveredNodeData.hostName, chip::Dnssd::kHostNameMaxLength + 1,
             [objCDiscoveredNodeData.hostName UTF8String]);
     }
-    outDiscoveredNodeData.resolutionData.interfaceId = chip::Inet::InterfaceId(objCDiscoveredNodeData.platformInterface);
-    outDiscoveredNodeData.resolutionData.numIPs = objCDiscoveredNodeData.numIPs;
+    outDiscoveredNodeData.interfaceId = chip::Inet::InterfaceId(objCDiscoveredNodeData.platformInterface);
+    outDiscoveredNodeData.numIPs = objCDiscoveredNodeData.numIPs;
     for (size_t i = 0; i < objCDiscoveredNodeData.numIPs; i++) {
         chip::Inet::IPAddress::FromString(
-            [objCDiscoveredNodeData.ipAddresses[i] UTF8String], outDiscoveredNodeData.resolutionData.ipAddress[i]);
+            [objCDiscoveredNodeData.ipAddresses[i] UTF8String], outDiscoveredNodeData.ipAddress[i]);
     }
     return CHIP_NO_ERROR;
 }
@@ -116,36 +116,36 @@
     return objCContentApp;
 }
 
-+ (DiscoveredNodeData *)convertToObjCDiscoveredNodeDataFrom:(const chip::Dnssd::DiscoveredNodeData * _Nonnull)cppDiscoveredNodedata
++ (DiscoveredNodeData *)convertToObjCDiscoveredNodeDataFrom:(const chip::Dnssd::CommissionNodeData * _Nonnull)cppDiscoveredNodedata
 {
     DiscoveredNodeData * objCDiscoveredNodeData = [DiscoveredNodeData new];
 
     // from CommissionNodeData
-    objCDiscoveredNodeData.deviceType = cppDiscoveredNodedata->nodeData.deviceType;
-    objCDiscoveredNodeData.vendorId = cppDiscoveredNodedata->nodeData.vendorId;
-    objCDiscoveredNodeData.productId = cppDiscoveredNodedata->nodeData.productId;
-    objCDiscoveredNodeData.longDiscriminator = cppDiscoveredNodedata->nodeData.longDiscriminator;
-    objCDiscoveredNodeData.commissioningMode = cppDiscoveredNodedata->nodeData.commissioningMode;
-    objCDiscoveredNodeData.pairingHint = cppDiscoveredNodedata->nodeData.pairingHint;
-    objCDiscoveredNodeData.deviceName = [NSString stringWithCString:cppDiscoveredNodedata->nodeData.deviceName
+    objCDiscoveredNodeData.deviceType = cppDiscoveredNodedata->deviceType;
+    objCDiscoveredNodeData.vendorId = cppDiscoveredNodedata->vendorId;
+    objCDiscoveredNodeData.productId = cppDiscoveredNodedata->productId;
+    objCDiscoveredNodeData.longDiscriminator = cppDiscoveredNodedata->longDiscriminator;
+    objCDiscoveredNodeData.commissioningMode = cppDiscoveredNodedata->commissioningMode;
+    objCDiscoveredNodeData.pairingHint = cppDiscoveredNodedata->pairingHint;
+    objCDiscoveredNodeData.deviceName = [NSString stringWithCString:cppDiscoveredNodedata->deviceName
                                                            encoding:NSUTF8StringEncoding];
-    objCDiscoveredNodeData.rotatingIdLen = cppDiscoveredNodedata->nodeData.rotatingIdLen;
-    objCDiscoveredNodeData.rotatingId = cppDiscoveredNodedata->nodeData.rotatingId;
-    objCDiscoveredNodeData.instanceName = [NSString stringWithCString:cppDiscoveredNodedata->nodeData.instanceName
+    objCDiscoveredNodeData.rotatingIdLen = cppDiscoveredNodedata->rotatingIdLen;
+    objCDiscoveredNodeData.rotatingId = cppDiscoveredNodedata->rotatingId;
+    objCDiscoveredNodeData.instanceName = [NSString stringWithCString:cppDiscoveredNodedata->instanceName
                                                              encoding:NSUTF8StringEncoding];
 
     // from CommonResolutionData
-    objCDiscoveredNodeData.port = cppDiscoveredNodedata->resolutionData.port;
-    objCDiscoveredNodeData.hostName = [NSString stringWithCString:cppDiscoveredNodedata->resolutionData.hostName
+    objCDiscoveredNodeData.port = cppDiscoveredNodedata->port;
+    objCDiscoveredNodeData.hostName = [NSString stringWithCString:cppDiscoveredNodedata->hostName
                                                          encoding:NSUTF8StringEncoding];
-    objCDiscoveredNodeData.platformInterface = cppDiscoveredNodedata->resolutionData.interfaceId.GetPlatformInterface();
-    objCDiscoveredNodeData.numIPs = cppDiscoveredNodedata->resolutionData.numIPs;
-    if (cppDiscoveredNodedata->resolutionData.numIPs > 0) {
+    objCDiscoveredNodeData.platformInterface = cppDiscoveredNodedata->interfaceId.GetPlatformInterface();
+    objCDiscoveredNodeData.numIPs = cppDiscoveredNodedata->numIPs;
+    if (cppDiscoveredNodedata->numIPs > 0) {
         objCDiscoveredNodeData.ipAddresses = [NSMutableArray new];
     }
-    for (size_t i = 0; i < cppDiscoveredNodedata->resolutionData.numIPs; i++) {
+    for (size_t i = 0; i < cppDiscoveredNodedata->numIPs; i++) {
         char addrCString[chip::Inet::IPAddress::kMaxStringLength];
-        cppDiscoveredNodedata->resolutionData.ipAddress[i].ToString(addrCString, chip::Inet::IPAddress::kMaxStringLength);
+        cppDiscoveredNodedata->ipAddress[i].ToString(addrCString, chip::Inet::IPAddress::kMaxStringLength);
         objCDiscoveredNodeData.ipAddresses[i] = [NSString stringWithCString:addrCString encoding:NSASCIIStringEncoding];
     }
     return objCDiscoveredNodeData;

--- a/examples/tv-casting-app/linux/CastingUtils.cpp
+++ b/examples/tv-casting-app/linux/CastingUtils.cpp
@@ -44,7 +44,7 @@ CHIP_ERROR DiscoverCommissioners()
 CHIP_ERROR RequestCommissioning(int index)
 {
     chip::Optional<TargetVideoPlayerInfo *> associatedConnectableVideoPlayer;
-    const Dnssd::DiscoveredNodeData * selectedCommissioner =
+    const Dnssd::CommissionNodeData * selectedCommissioner =
         CastingServer::GetInstance()->GetDiscoveredCommissioner(index, associatedConnectableVideoPlayer);
     if (selectedCommissioner == nullptr)
     {
@@ -60,7 +60,7 @@ CHIP_ERROR RequestCommissioning(int index)
  * If non-null selectedCommissioner is provided, sends user directed commissioning
  * request to the selectedCommissioner and advertises self as commissionable node over DNS-SD
  */
-void PrepareForCommissioning(const Dnssd::DiscoveredNodeData * selectedCommissioner)
+void PrepareForCommissioning(const Dnssd::CommissionNodeData * selectedCommissioner)
 {
     CastingServer::GetInstance()->Init();
 
@@ -96,7 +96,7 @@ void InitCommissioningFlow(intptr_t commandArg)
     for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; i++)
     {
         chip::Optional<TargetVideoPlayerInfo *> associatedConnectableVideoPlayer;
-        const Dnssd::DiscoveredNodeData * commissioner =
+        const Dnssd::CommissionNodeData * commissioner =
             CastingServer::GetInstance()->GetDiscoveredCommissioner(i, associatedConnectableVideoPlayer);
         if (commissioner != nullptr)
         {
@@ -286,7 +286,7 @@ void HandleCommissioningCompleteCallback(CHIP_ERROR err)
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 void HandleUDCSendExpiration(System::Layer * aSystemLayer, void * context)
 {
-    Dnssd::DiscoveredNodeData * selectedCommissioner = (Dnssd::DiscoveredNodeData *) context;
+    Dnssd::CommissionNodeData * selectedCommissioner = (Dnssd::CommissionNodeData *) context;
 
     // Send User Directed commissioning request
     ReturnOnFailure(CastingServer::GetInstance()->SendUserDirectedCommissioningRequest(selectedCommissioner));

--- a/examples/tv-casting-app/linux/CastingUtils.h
+++ b/examples/tv-casting-app/linux/CastingUtils.h
@@ -34,7 +34,7 @@ CHIP_ERROR DiscoverCommissioners();
 
 CHIP_ERROR RequestCommissioning(int index);
 
-void PrepareForCommissioning(const chip::Dnssd::DiscoveredNodeData * selectedCommissioner = nullptr);
+void PrepareForCommissioning(const chip::Dnssd::CommissionNodeData * selectedCommissioner = nullptr);
 
 void InitCommissioningFlow(intptr_t commandArg);
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -86,8 +86,7 @@ void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::Commissi
 
     chip::Platform::CopyString(attributes.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1, nodeData.deviceName);
     chip::Platform::CopyString(attributes.hostName, chip::Dnssd::kHostNameMaxLength + 1, nodeData.hostName);
-    chip::Platform::CopyString(attributes.instanceName, chip::Dnssd::Commission::kInstanceNameMaxLength + 1,
-                               nodeData.instanceName);
+    chip::Platform::CopyString(attributes.instanceName, chip::Dnssd::Commission::kInstanceNameMaxLength + 1, nodeData.instanceName);
 
     attributes.numIPs = (unsigned int) nodeData.numIPs;
     for (unsigned j = 0; j < attributes.numIPs; j++)

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -73,13 +73,12 @@ CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
     return CHIP_NO_ERROR;
 }
 
-void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & discNodeData)
+void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData)
 {
     ChipLogProgress(Discovery, "DeviceDiscoveryDelegateImpl::OnDiscoveredDevice() called");
     VerifyOrReturn(mClientDelegate != nullptr,
                    ChipLogError(Discovery, "DeviceDiscoveryDelegateImpl::OnDiscoveredDevice mClientDelegate is a nullptr"));
 
-    auto & nodeData = discNodeData;
     // convert nodeData to CastingPlayer
     CastingPlayerAttributes attributes;
     snprintf(attributes.id, kIdMaxLength + 1, "%s%u", nodeData.hostName, nodeData.port);

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -73,32 +73,33 @@ CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
     return CHIP_NO_ERROR;
 }
 
-void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData)
+void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & discNodeData)
 {
     ChipLogProgress(Discovery, "DeviceDiscoveryDelegateImpl::OnDiscoveredDevice() called");
     VerifyOrReturn(mClientDelegate != nullptr,
                    ChipLogError(Discovery, "DeviceDiscoveryDelegateImpl::OnDiscoveredDevice mClientDelegate is a nullptr"));
 
+    auto & nodeData = discNodeData;
     // convert nodeData to CastingPlayer
     CastingPlayerAttributes attributes;
-    snprintf(attributes.id, kIdMaxLength + 1, "%s%u", nodeData.resolutionData.hostName, nodeData.resolutionData.port);
+    snprintf(attributes.id, kIdMaxLength + 1, "%s%u", nodeData.hostName, nodeData.port);
 
-    chip::Platform::CopyString(attributes.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1, nodeData.nodeData.deviceName);
-    chip::Platform::CopyString(attributes.hostName, chip::Dnssd::kHostNameMaxLength + 1, nodeData.resolutionData.hostName);
+    chip::Platform::CopyString(attributes.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1, nodeData.deviceName);
+    chip::Platform::CopyString(attributes.hostName, chip::Dnssd::kHostNameMaxLength + 1, nodeData.hostName);
     chip::Platform::CopyString(attributes.instanceName, chip::Dnssd::Commission::kInstanceNameMaxLength + 1,
-                               nodeData.nodeData.instanceName);
+                               nodeData.instanceName);
 
-    attributes.numIPs = (unsigned int) nodeData.resolutionData.numIPs;
+    attributes.numIPs = (unsigned int) nodeData.numIPs;
     for (unsigned j = 0; j < attributes.numIPs; j++)
     {
-        attributes.ipAddresses[j] = nodeData.resolutionData.ipAddress[j];
+        attributes.ipAddresses[j] = nodeData.ipAddress[j];
     }
-    attributes.interfaceId                           = nodeData.resolutionData.interfaceId;
-    attributes.port                                  = nodeData.resolutionData.port;
-    attributes.productId                             = nodeData.nodeData.productId;
-    attributes.vendorId                              = nodeData.nodeData.vendorId;
-    attributes.deviceType                            = nodeData.nodeData.deviceType;
-    attributes.supportsCommissionerGeneratedPasscode = nodeData.nodeData.supportsCommissionerGeneratedPasscode;
+    attributes.interfaceId                           = nodeData.interfaceId;
+    attributes.port                                  = nodeData.port;
+    attributes.productId                             = nodeData.productId;
+    attributes.vendorId                              = nodeData.vendorId;
+    attributes.deviceType                            = nodeData.deviceType;
+    attributes.supportsCommissionerGeneratedPasscode = nodeData.supportsCommissionerGeneratedPasscode;
 
     memory::Strong<CastingPlayer> player = std::make_shared<CastingPlayer>(attributes);
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
@@ -68,7 +68,7 @@ public:
     DeviceDiscoveryDelegateImpl() {}
     DeviceDiscoveryDelegateImpl(DiscoveryDelegate * delegate) { mClientDelegate = delegate; }
 
-    void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
+    void OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData) override;
 };
 
 /**

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -73,7 +73,7 @@ public:
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
     CHIP_ERROR DiscoverCommissioners(chip::Controller::DeviceDiscoveryDelegate * deviceDiscoveryDelegate = nullptr);
-    const chip::Dnssd::DiscoveredNodeData *
+    const chip::Dnssd::CommissionNodeData *
     GetDiscoveredCommissioner(int index, chip::Optional<TargetVideoPlayerInfo *> & outAssociatedConnectableVideoPlayer);
     CHIP_ERROR OpenBasicCommissioningWindow(CommissioningCallbacks commissioningCallbacks,
                                             std::function<void(TargetVideoPlayerInfo *)> onConnectionSuccess,
@@ -82,7 +82,7 @@ public:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     CHIP_ERROR SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress commissioner);
-    CHIP_ERROR SendUserDirectedCommissioningRequest(chip::Dnssd::DiscoveredNodeData * selectedCommissioner);
+    CHIP_ERROR SendUserDirectedCommissioningRequest(chip::Dnssd::CommissionNodeData * selectedCommissioner);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
     TargetVideoPlayerInfo * GetActiveTargetVideoPlayer() { return &mActiveTargetVideoPlayerInfo; }

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -85,7 +85,7 @@ public:
     const char * GetHostName() const { return mHostName; }
     size_t GetNumIPs() const { return mNumIPs; }
     const chip::Inet::IPAddress * GetIpAddresses() const { return mIpAddress; }
-    bool IsSameAs(const chip::Dnssd::DiscoveredNodeData * discoveredNodeData);
+    bool IsSameAs(const chip::Dnssd::CommissionNodeData * discoveredNodeData);
     bool IsSameAs(const char * hostName, const char * deviceName, size_t numIPs, const chip::Inet::IPAddress * ipAddresses);
 
     uint16_t GetPort() const { return mPort; }

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -253,37 +253,37 @@ chip::Inet::IPAddress * CastingServer::getIpAddressForUDCRequest(chip::Inet::IPA
     return &ipAddresses[ipIndexToUse];
 }
 
-CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(Dnssd::DiscoveredNodeData * selectedCommissioner)
+CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(Dnssd::CommissionNodeData * selectedCommissioner)
 {
     mUdcInProgress = true;
     // Send User Directed commissioning request
     chip::Inet::IPAddress * ipAddressToUse =
-        getIpAddressForUDCRequest(selectedCommissioner->resolutionData.ipAddress, selectedCommissioner->resolutionData.numIPs);
+        getIpAddressForUDCRequest(selectedCommissioner->ipAddress, selectedCommissioner->numIPs);
     ReturnErrorOnFailure(SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress::UDP(
-        *ipAddressToUse, selectedCommissioner->resolutionData.port, selectedCommissioner->resolutionData.interfaceId)));
-    mTargetVideoPlayerVendorId   = selectedCommissioner->nodeData.vendorId;
-    mTargetVideoPlayerProductId  = selectedCommissioner->nodeData.productId;
-    mTargetVideoPlayerDeviceType = selectedCommissioner->nodeData.deviceType;
-    mTargetVideoPlayerNumIPs     = selectedCommissioner->resolutionData.numIPs;
+        *ipAddressToUse, selectedCommissioner->port, selectedCommissioner->interfaceId)));
+    mTargetVideoPlayerVendorId   = selectedCommissioner->vendorId;
+    mTargetVideoPlayerProductId  = selectedCommissioner->productId;
+    mTargetVideoPlayerDeviceType = selectedCommissioner->deviceType;
+    mTargetVideoPlayerNumIPs     = selectedCommissioner->numIPs;
     for (size_t i = 0; i < mTargetVideoPlayerNumIPs && i < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; i++)
     {
-        mTargetVideoPlayerIpAddress[i] = selectedCommissioner->resolutionData.ipAddress[i];
+        mTargetVideoPlayerIpAddress[i] = selectedCommissioner->ipAddress[i];
     }
     chip::Platform::CopyString(mTargetVideoPlayerDeviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
-                               selectedCommissioner->nodeData.deviceName);
+                               selectedCommissioner->deviceName);
     chip::Platform::CopyString(mTargetVideoPlayerHostName, chip::Dnssd::kHostNameMaxLength + 1,
-                               selectedCommissioner->resolutionData.hostName);
+                               selectedCommissioner->hostName);
     chip::Platform::CopyString(mTargetVideoPlayerInstanceName, chip::Dnssd::Commission::kInstanceNameMaxLength + 1,
-                               selectedCommissioner->nodeData.instanceName);
-    mTargetVideoPlayerPort = selectedCommissioner->resolutionData.port;
+                               selectedCommissioner->instanceName);
+    mTargetVideoPlayerPort = selectedCommissioner->port;
     return CHIP_NO_ERROR;
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
-const Dnssd::DiscoveredNodeData *
+const Dnssd::CommissionNodeData *
 CastingServer::GetDiscoveredCommissioner(int index, chip::Optional<TargetVideoPlayerInfo *> & outAssociatedConnectableVideoPlayer)
 {
-    const Dnssd::DiscoveredNodeData * discoveredNodeData = mCommissionableNodeController.GetDiscoveredCommissioner(index);
+    const Dnssd::CommissionNodeData * discoveredNodeData = mCommissionableNodeController.GetDiscoveredCommissioner(index);
     if (discoveredNodeData != nullptr)
     {
         for (size_t i = 0; i < kMaxCachedVideoPlayers && mCachedTargetVideoPlayerInfo[i].IsInitialized(); i++)

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -259,8 +259,8 @@ CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(Dnssd::Commission
     // Send User Directed commissioning request
     chip::Inet::IPAddress * ipAddressToUse =
         getIpAddressForUDCRequest(selectedCommissioner->ipAddress, selectedCommissioner->numIPs);
-    ReturnErrorOnFailure(SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress::UDP(
-        *ipAddressToUse, selectedCommissioner->port, selectedCommissioner->interfaceId)));
+    ReturnErrorOnFailure(SendUserDirectedCommissioningRequest(
+        chip::Transport::PeerAddress::UDP(*ipAddressToUse, selectedCommissioner->port, selectedCommissioner->interfaceId)));
     mTargetVideoPlayerVendorId   = selectedCommissioner->vendorId;
     mTargetVideoPlayerProductId  = selectedCommissioner->productId;
     mTargetVideoPlayerDeviceType = selectedCommissioner->deviceType;
@@ -269,10 +269,8 @@ CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(Dnssd::Commission
     {
         mTargetVideoPlayerIpAddress[i] = selectedCommissioner->ipAddress[i];
     }
-    chip::Platform::CopyString(mTargetVideoPlayerDeviceName, chip::Dnssd::kMaxDeviceNameLen + 1,
-                               selectedCommissioner->deviceName);
-    chip::Platform::CopyString(mTargetVideoPlayerHostName, chip::Dnssd::kHostNameMaxLength + 1,
-                               selectedCommissioner->hostName);
+    chip::Platform::CopyString(mTargetVideoPlayerDeviceName, chip::Dnssd::kMaxDeviceNameLen + 1, selectedCommissioner->deviceName);
+    chip::Platform::CopyString(mTargetVideoPlayerHostName, chip::Dnssd::kHostNameMaxLength + 1, selectedCommissioner->hostName);
     chip::Platform::CopyString(mTargetVideoPlayerInstanceName, chip::Dnssd::Commission::kInstanceNameMaxLength + 1,
                                selectedCommissioner->instanceName);
     mTargetVideoPlayerPort = selectedCommissioner->port;

--- a/examples/tv-casting-app/tv-casting-common/src/ConversionUtils.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/ConversionUtils.cpp
@@ -26,10 +26,10 @@ CHIP_ERROR ConvertToDiscoveredNodeData(TargetVideoPlayerInfo * inPlayer, chip::D
     outDiscNodeData.Set<chip::Dnssd::CommissionNodeData>();
     auto & outNodeData = outDiscNodeData.Get<chip::Dnssd::CommissionNodeData>();
 
-    outNodeData.vendorId     = inPlayer->GetVendorId();
-    outNodeData.productId    = static_cast<uint16_t>(inPlayer->GetProductId());
-    outNodeData.deviceType   = inPlayer->GetDeviceType();
-    outNodeData.numIPs = inPlayer->GetNumIPs();
+    outNodeData.vendorId   = inPlayer->GetVendorId();
+    outNodeData.productId  = static_cast<uint16_t>(inPlayer->GetProductId());
+    outNodeData.deviceType = inPlayer->GetDeviceType();
+    outNodeData.numIPs     = inPlayer->GetNumIPs();
 
     const chip::Inet::IPAddress * ipAddresses = inPlayer->GetIpAddresses();
     if (ipAddresses != nullptr)

--- a/examples/tv-casting-app/tv-casting-common/src/ConversionUtils.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/ConversionUtils.cpp
@@ -18,27 +18,30 @@
 
 #include "ConversionUtils.h"
 
-CHIP_ERROR ConvertToDiscoveredNodeData(TargetVideoPlayerInfo * inPlayer, chip::Dnssd::DiscoveredNodeData & outNodeData)
+CHIP_ERROR ConvertToDiscoveredNodeData(TargetVideoPlayerInfo * inPlayer, chip::Dnssd::DiscoveredNodeData & outDiscNodeData)
 {
     if (inPlayer == nullptr)
         return CHIP_ERROR_INVALID_ARGUMENT;
+    
+    outDiscNodeData.Set<chip::Dnssd::CommissionNodeData>();
+    auto & outNodeData = outDiscNodeData.Get<chip::Dnssd::CommissionNodeData>();
 
-    outNodeData.nodeData.vendorId     = inPlayer->GetVendorId();
-    outNodeData.nodeData.productId    = static_cast<uint16_t>(inPlayer->GetProductId());
-    outNodeData.nodeData.deviceType   = inPlayer->GetDeviceType();
-    outNodeData.resolutionData.numIPs = inPlayer->GetNumIPs();
+    outNodeData.vendorId     = inPlayer->GetVendorId();
+    outNodeData.productId    = static_cast<uint16_t>(inPlayer->GetProductId());
+    outNodeData.deviceType   = inPlayer->GetDeviceType();
+    outNodeData.numIPs = inPlayer->GetNumIPs();
 
     const chip::Inet::IPAddress * ipAddresses = inPlayer->GetIpAddresses();
     if (ipAddresses != nullptr)
     {
-        for (size_t i = 0; i < outNodeData.resolutionData.numIPs && i < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; i++)
+        for (size_t i = 0; i < outNodeData.numIPs && i < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; i++)
         {
-            outNodeData.resolutionData.ipAddress[i] = ipAddresses[i];
+            outNodeData.ipAddress[i] = ipAddresses[i];
         }
     }
 
-    chip::Platform::CopyString(outNodeData.nodeData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1, inPlayer->GetDeviceName());
-    chip::Platform::CopyString(outNodeData.resolutionData.hostName, chip::Dnssd::kHostNameMaxLength + 1, inPlayer->GetHostName());
+    chip::Platform::CopyString(outNodeData.deviceName, chip::Dnssd::kMaxDeviceNameLen + 1, inPlayer->GetDeviceName());
+    chip::Platform::CopyString(outNodeData.hostName, chip::Dnssd::kHostNameMaxLength + 1, inPlayer->GetHostName());
 
     return CHIP_NO_ERROR;
 }

--- a/examples/tv-casting-app/tv-casting-common/src/ConversionUtils.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/ConversionUtils.cpp
@@ -22,7 +22,7 @@ CHIP_ERROR ConvertToDiscoveredNodeData(TargetVideoPlayerInfo * inPlayer, chip::D
 {
     if (inPlayer == nullptr)
         return CHIP_ERROR_INVALID_ARGUMENT;
-    
+
     outDiscNodeData.Set<chip::Dnssd::CommissionNodeData>();
     auto & outNodeData = outDiscNodeData.Get<chip::Dnssd::CommissionNodeData>();
 

--- a/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
@@ -232,6 +232,6 @@ bool TargetVideoPlayerInfo::IsSameAs(const chip::Dnssd::CommissionNodeData * dis
         return false;
     }
 
-    return IsSameAs(discoveredNodeData->hostName, discoveredNodeData->deviceName,
-                    discoveredNodeData->numIPs, discoveredNodeData->ipAddress);
+    return IsSameAs(discoveredNodeData->hostName, discoveredNodeData->deviceName, discoveredNodeData->numIPs,
+                    discoveredNodeData->ipAddress);
 }

--- a/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
@@ -224,7 +224,7 @@ bool TargetVideoPlayerInfo::IsSameAs(const char * hostName, const char * deviceN
     return true;
 }
 
-bool TargetVideoPlayerInfo::IsSameAs(const chip::Dnssd::DiscoveredNodeData * discoveredNodeData)
+bool TargetVideoPlayerInfo::IsSameAs(const chip::Dnssd::CommissionNodeData * discoveredNodeData)
 {
     // return false because 'this' VideoPlayer is not null
     if (discoveredNodeData == nullptr)
@@ -232,6 +232,6 @@ bool TargetVideoPlayerInfo::IsSameAs(const chip::Dnssd::DiscoveredNodeData * dis
         return false;
     }
 
-    return IsSameAs(discoveredNodeData->resolutionData.hostName, discoveredNodeData->nodeData.deviceName,
-                    discoveredNodeData->resolutionData.numIPs, discoveredNodeData->resolutionData.ipAddress);
+    return IsSameAs(discoveredNodeData->hostName, discoveredNodeData->deviceName,
+                    discoveredNodeData->numIPs, discoveredNodeData->ipAddress);
 }

--- a/src/controller/AbstractDnssdDiscoveryController.cpp
+++ b/src/controller/AbstractDnssdDiscoveryController.cpp
@@ -30,7 +30,7 @@ void AbstractDnssdDiscoveryController::OnNodeDiscovered(const chip::Dnssd::Disco
     VerifyOrReturn(discNodeData.Is<chip::Dnssd::CommissionNodeData>());
 
     auto discoveredNodes = GetDiscoveredNodes();
-    auto & nodeData = discNodeData.Get<chip::Dnssd::CommissionNodeData>();
+    auto & nodeData      = discNodeData.Get<chip::Dnssd::CommissionNodeData>();
     for (auto & discoveredNode : discoveredNodes)
     {
 
@@ -40,8 +40,7 @@ void AbstractDnssdDiscoveryController::OnNodeDiscovered(const chip::Dnssd::Disco
         }
         // TODO(#32576) Check if IP address are the same. Must account for `numIPs` in the list of `ipAddress`.
         // Additionally, must NOT assume that the ordering is consistent.
-        if (strcmp(discoveredNode.hostName, nodeData.hostName) == 0 &&
-            discoveredNode.port == nodeData.port &&
+        if (strcmp(discoveredNode.hostName, nodeData.hostName) == 0 && discoveredNode.port == nodeData.port &&
             discoveredNode.numIPs == nodeData.numIPs)
         {
             discoveredNode = nodeData;

--- a/src/controller/AbstractDnssdDiscoveryController.h
+++ b/src/controller/AbstractDnssdDiscoveryController.h
@@ -45,9 +45,9 @@ public:
     CHIP_ERROR StopDiscovery() { return mDNSResolver.StopDiscovery(); };
 
 protected:
-    using DiscoveredNodeList = FixedSpan<Dnssd::DiscoveredNodeData, CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES>;
+    using DiscoveredNodeList = FixedSpan<Dnssd::CommissionNodeData, CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES>;
     CHIP_ERROR SetUpNodeDiscovery();
-    const Dnssd::DiscoveredNodeData * GetDiscoveredNode(int idx);
+    const Dnssd::CommissionNodeData * GetDiscoveredNode(int idx);
     virtual DiscoveredNodeList GetDiscoveredNodes()    = 0;
     DeviceDiscoveryDelegate * mDeviceDiscoveryDelegate = nullptr;
     Dnssd::ResolverProxy mDNSResolver;

--- a/src/controller/CHIPCommissionableNodeController.cpp
+++ b/src/controller/CHIPCommissionableNodeController.cpp
@@ -45,7 +45,7 @@ CommissionableNodeController::~CommissionableNodeController()
     mDNSResolver.SetDiscoveryDelegate(nullptr);
 }
 
-const Dnssd::DiscoveredNodeData * CommissionableNodeController::GetDiscoveredCommissioner(int idx)
+const Dnssd::CommissionNodeData * CommissionableNodeController::GetDiscoveredCommissioner(int idx)
 {
     return GetDiscoveredNode(idx);
 }

--- a/src/controller/CHIPCommissionableNodeController.h
+++ b/src/controller/CHIPCommissionableNodeController.h
@@ -49,13 +49,13 @@ public:
      *   Otherwise, returns nullptr
      *   See Resolver.h IsValid()
      */
-    const Dnssd::DiscoveredNodeData * GetDiscoveredCommissioner(int idx);
+    const Dnssd::CommissionNodeData * GetDiscoveredCommissioner(int idx);
 
 protected:
     DiscoveredNodeList GetDiscoveredNodes() override { return DiscoveredNodeList(mDiscoveredCommissioners); }
 
 private:
-    Dnssd::DiscoveredNodeData mDiscoveredCommissioners[CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES];
+    Dnssd::CommissionNodeData mDiscoveredCommissioners[CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES];
 };
 
 } // namespace Controller

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1706,7 +1706,7 @@ CHIP_ERROR DeviceCommissioner::StopCommissionableDiscovery()
     return mDNSResolver.StopDiscovery();
 }
 
-const Dnssd::DiscoveredNodeData * DeviceCommissioner::GetDiscoveredDevice(int idx)
+const Dnssd::CommissionNodeData * DeviceCommissioner::GetDiscoveredDevice(int idx)
 {
     return GetDiscoveredNode(idx);
 }

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -412,7 +412,7 @@ protected:
 
     // TODO(cecille): Make this configuarable.
     static constexpr int kMaxCommissionableNodes = 10;
-    Dnssd::DiscoveredNodeData mCommissionableNodes[kMaxCommissionableNodes];
+    Dnssd::CommissionNodeData mCommissionableNodes[kMaxCommissionableNodes];
     DeviceControllerSystemState * mSystemState = nullptr;
 
     ControllerDeviceInitParams GetControllerDeviceInitParams();
@@ -730,7 +730,7 @@ public:
      *   Should be called on main loop thread.
      * @return const DiscoveredNodeData* info about the selected device. May be nullptr if no information has been returned yet.
      */
-    const Dnssd::DiscoveredNodeData * GetDiscoveredDevice(int idx);
+    const Dnssd::CommissionNodeData * GetDiscoveredDevice(int idx);
 
     /**
      * @brief

--- a/src/controller/DeviceDiscoveryDelegate.h
+++ b/src/controller/DeviceDiscoveryDelegate.h
@@ -29,7 +29,7 @@ class DLL_EXPORT DeviceDiscoveryDelegate
 {
 public:
     virtual ~DeviceDiscoveryDelegate() {}
-    virtual void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) = 0;
+    virtual void OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData) = 0;
 };
 
 } // namespace Controller

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -330,24 +330,30 @@ bool SetUpCodePairer::IdIsPresent(uint16_t vendorOrProductID)
     return vendorOrProductID != kNotAvailable;
 }
 
-bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData & nodeData) const
+bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData & discNodeData) const
 {
-    if (nodeData.nodeData.commissioningMode == 0)
+    if (!discNodeData.Is<Dnssd::CommissionNodeData>())
+    {
+        return false;
+    }
+
+    Dnssd::CommissionNodeData nodeData = discNodeData.Get<Dnssd::CommissionNodeData>();
+    if (nodeData.commissioningMode == 0)
     {
         ChipLogProgress(Controller, "Discovered device does not have an open commissioning window.");
         return false;
     }
 
     // The advertisement may not include a vendor id.
-    if (IdIsPresent(mPayloadVendorID) && IdIsPresent(nodeData.nodeData.vendorId) && mPayloadVendorID != nodeData.nodeData.vendorId)
+    if (IdIsPresent(mPayloadVendorID) && IdIsPresent(nodeData.vendorId) && mPayloadVendorID != nodeData.vendorId)
     {
         ChipLogProgress(Controller, "Discovered device does not match our vendor id.");
         return false;
     }
 
     // The advertisement may not include a product id.
-    if (IdIsPresent(mPayloadProductID) && IdIsPresent(nodeData.nodeData.productId) &&
-        mPayloadProductID != nodeData.nodeData.productId)
+    if (IdIsPresent(mPayloadProductID) && IdIsPresent(nodeData.productId) &&
+        mPayloadProductID != nodeData.productId)
     {
         ChipLogProgress(Controller, "Discovered device does not match our product id.");
         return false;
@@ -357,10 +363,10 @@ bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData &
     switch (mCurrentFilter.type)
     {
     case Dnssd::DiscoveryFilterType::kShortDiscriminator:
-        discriminatorMatches = (((nodeData.nodeData.longDiscriminator >> 8) & 0x0F) == mCurrentFilter.code);
+        discriminatorMatches = (((nodeData.longDiscriminator >> 8) & 0x0F) == mCurrentFilter.code);
         break;
     case Dnssd::DiscoveryFilterType::kLongDiscriminator:
-        discriminatorMatches = (nodeData.nodeData.longDiscriminator == mCurrentFilter.code);
+        discriminatorMatches = (nodeData.longDiscriminator == mCurrentFilter.code);
         break;
     default:
         ChipLogError(Controller, "Unknown filter type; all matches will fail");
@@ -382,7 +388,7 @@ void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::Discover
 
     ChipLogProgress(Controller, "Discovered device to be commissioned over DNS-SD");
 
-    NotifyCommissionableDeviceDiscovered(nodeData.resolutionData);
+    NotifyCommissionableDeviceDiscovered((Dnssd::CommonResolutionData &)nodeData.Get<Dnssd::CommissionNodeData>());
 }
 
 void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::CommonResolutionData & resolutionData)

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -387,7 +387,7 @@ void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::Discover
 
     ChipLogProgress(Controller, "Discovered device to be commissioned over DNS-SD");
 
-    NotifyCommissionableDeviceDiscovered((Dnssd::CommonResolutionData &) nodeData.Get<Dnssd::CommissionNodeData>());
+    NotifyCommissionableDeviceDiscovered(nodeData.Get<Dnssd::CommissionNodeData>());
 }
 
 void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::CommonResolutionData & resolutionData)

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -337,7 +337,7 @@ bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData &
         return false;
     }
 
-    Dnssd::CommissionNodeData nodeData = discNodeData.Get<Dnssd::CommissionNodeData>();
+    const Dnssd::CommissionNodeData & nodeData = discNodeData.Get<Dnssd::CommissionNodeData>();
     if (nodeData.commissioningMode == 0)
     {
         ChipLogProgress(Controller, "Discovered device does not have an open commissioning window.");

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -352,8 +352,7 @@ bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData &
     }
 
     // The advertisement may not include a product id.
-    if (IdIsPresent(mPayloadProductID) && IdIsPresent(nodeData.productId) &&
-        mPayloadProductID != nodeData.productId)
+    if (IdIsPresent(mPayloadProductID) && IdIsPresent(nodeData.productId) && mPayloadProductID != nodeData.productId)
     {
         ChipLogProgress(Controller, "Discovered device does not match our product id.");
         return false;
@@ -388,7 +387,7 @@ void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::Discover
 
     ChipLogProgress(Controller, "Discovered device to be commissioned over DNS-SD");
 
-    NotifyCommissionableDeviceDiscovered((Dnssd::CommonResolutionData &)nodeData.Get<Dnssd::CommissionNodeData>());
+    NotifyCommissionableDeviceDiscovered((Dnssd::CommonResolutionData &) nodeData.Get<Dnssd::CommissionNodeData>());
 }
 
 void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::CommonResolutionData & resolutionData)

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1839,7 +1839,7 @@ JNI_METHOD(jobject, getDiscoveredDevice)(JNIEnv * env, jobject self, jlong handl
     chip::DeviceLayer::StackLock lock;
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    const Dnssd::DiscoveredNodeData * data   = wrapper->Controller()->GetDiscoveredDevice(idx);
+    const Dnssd::CommissionNodeData * data   = wrapper->Controller()->GetDiscoveredDevice(idx);
 
     if (data == nullptr)
     {
@@ -1866,21 +1866,21 @@ JNI_METHOD(jobject, getDiscoveredDevice)(JNIEnv * env, jobject self, jlong handl
 
     jobject discoveredObj = env->NewObject(discoveredDeviceCls, constructor);
 
-    env->SetLongField(discoveredObj, discrminatorID, data->nodeData.longDiscriminator);
+    env->SetLongField(discoveredObj, discrminatorID, data->longDiscriminator);
 
     char ipAddress[100];
-    data->resolutionData.ipAddress[0].ToString(ipAddress, 100);
+    data->ipAddress[0].ToString(ipAddress, 100);
     jstring jniipAdress = env->NewStringUTF(ipAddress);
 
     env->SetObjectField(discoveredObj, ipAddressID, jniipAdress);
-    env->SetIntField(discoveredObj, portID, static_cast<jint>(data->resolutionData.port));
-    env->SetLongField(discoveredObj, deviceTypeID, static_cast<jlong>(data->nodeData.deviceType));
-    env->SetIntField(discoveredObj, vendorIdID, static_cast<jint>(data->nodeData.vendorId));
-    env->SetIntField(discoveredObj, productIdID, static_cast<jint>(data->nodeData.productId));
+    env->SetIntField(discoveredObj, portID, static_cast<jint>(data->port));
+    env->SetLongField(discoveredObj, deviceTypeID, static_cast<jlong>(data->deviceType));
+    env->SetIntField(discoveredObj, vendorIdID, static_cast<jint>(data->vendorId));
+    env->SetIntField(discoveredObj, productIdID, static_cast<jint>(data->productId));
 
     jbyteArray jRotatingId;
-    CHIP_ERROR err = JniReferences::GetInstance().N2J_ByteArray(env, data->nodeData.rotatingId,
-                                                                static_cast<jsize>(data->nodeData.rotatingIdLen), jRotatingId);
+    CHIP_ERROR err = JniReferences::GetInstance().N2J_ByteArray(env, data->rotatingId,
+                                                                static_cast<jsize>(data->rotatingIdLen), jRotatingId);
 
     if (err != CHIP_NO_ERROR)
     {
@@ -1888,12 +1888,12 @@ JNI_METHOD(jobject, getDiscoveredDevice)(JNIEnv * env, jobject self, jlong handl
         return nullptr;
     }
     env->SetObjectField(discoveredObj, rotatingIdID, static_cast<jobject>(jRotatingId));
-    env->SetObjectField(discoveredObj, instanceNameID, env->NewStringUTF(data->nodeData.instanceName));
-    env->SetObjectField(discoveredObj, deviceNameID, env->NewStringUTF(data->nodeData.deviceName));
-    env->SetObjectField(discoveredObj, pairingInstructionID, env->NewStringUTF(data->nodeData.pairingInstruction));
+    env->SetObjectField(discoveredObj, instanceNameID, env->NewStringUTF(data->instanceName));
+    env->SetObjectField(discoveredObj, deviceNameID, env->NewStringUTF(data->deviceName));
+    env->SetObjectField(discoveredObj, pairingInstructionID, env->NewStringUTF(data->pairingInstruction));
 
-    env->CallVoidMethod(discoveredObj, setCommissioningModeID, static_cast<jint>(data->nodeData.commissioningMode));
-    env->CallVoidMethod(discoveredObj, setPairingHintID, static_cast<jint>(data->nodeData.pairingHint));
+    env->CallVoidMethod(discoveredObj, setCommissioningModeID, static_cast<jint>(data->commissioningMode));
+    env->CallVoidMethod(discoveredObj, setPairingHintID, static_cast<jint>(data->pairingHint));
 
     return discoveredObj;
 }

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1879,8 +1879,8 @@ JNI_METHOD(jobject, getDiscoveredDevice)(JNIEnv * env, jobject self, jlong handl
     env->SetIntField(discoveredObj, productIdID, static_cast<jint>(data->productId));
 
     jbyteArray jRotatingId;
-    CHIP_ERROR err = JniReferences::GetInstance().N2J_ByteArray(env, data->rotatingId,
-                                                                static_cast<jsize>(data->rotatingIdLen), jRotatingId);
+    CHIP_ERROR err =
+        JniReferences::GetInstance().N2J_ByteArray(env, data->rotatingId, static_cast<jsize>(data->rotatingIdLen), jRotatingId);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
+++ b/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
@@ -76,58 +76,58 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
 {
     for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; ++i)
     {
-        const chip::Dnssd::DiscoveredNodeData * dnsSdInfo = commissionableNodeCtrl->GetDiscoveredCommissioner(i);
+        const chip::Dnssd::CommissionNodeData * dnsSdInfo = commissionableNodeCtrl->GetDiscoveredCommissioner(i);
         if (dnsSdInfo == nullptr)
         {
             continue;
         }
         char rotatingId[chip::Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-        Encoding::BytesToUppercaseHexString(dnsSdInfo->nodeData.rotatingId, dnsSdInfo->nodeData.rotatingIdLen, rotatingId,
+        Encoding::BytesToUppercaseHexString(dnsSdInfo->rotatingId, dnsSdInfo->rotatingIdLen, rotatingId,
                                             sizeof(rotatingId));
 
         ChipLogProgress(Discovery, "Commissioner %d", i);
-        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->nodeData.instanceName);
-        ChipLogProgress(Discovery, "\tHost name:\t\t%s", dnsSdInfo->resolutionData.hostName);
-        ChipLogProgress(Discovery, "\tPort:\t\t\t%u", dnsSdInfo->resolutionData.port);
-        ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->nodeData.longDiscriminator);
-        ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", dnsSdInfo->nodeData.vendorId);
-        ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", dnsSdInfo->nodeData.productId);
-        ChipLogProgress(Discovery, "\tCommissioning Mode\t%u", dnsSdInfo->nodeData.commissioningMode);
-        ChipLogProgress(Discovery, "\tDevice Type\t\t%u", dnsSdInfo->nodeData.deviceType);
-        ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->nodeData.deviceName);
+        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->instanceName);
+        ChipLogProgress(Discovery, "\tHost name:\t\t%s", dnsSdInfo->hostName);
+        ChipLogProgress(Discovery, "\tPort:\t\t\t%u", dnsSdInfo->port);
+        ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->longDiscriminator);
+        ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", dnsSdInfo->vendorId);
+        ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", dnsSdInfo->productId);
+        ChipLogProgress(Discovery, "\tCommissioning Mode\t%u", dnsSdInfo->commissioningMode);
+        ChipLogProgress(Discovery, "\tDevice Type\t\t%u", dnsSdInfo->deviceType);
+        ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->deviceName);
         ChipLogProgress(Discovery, "\tRotating Id\t\t%s", rotatingId);
-        ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->nodeData.pairingInstruction);
-        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->nodeData.pairingHint);
-        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().HasValue())
+        ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->pairingInstruction);
+        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->pairingHint);
+        if (dnsSdInfo->GetMrpRetryIntervalIdle().HasValue())
         {
             ChipLogProgress(Discovery, "\tMrp Interval idle\t%u",
-                            dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().Value().count());
+                            dnsSdInfo->GetMrpRetryIntervalIdle().Value().count());
         }
         else
         {
             ChipLogProgress(Discovery, "\tMrp Interval idle\tNot present");
         }
-        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().HasValue())
+        if (dnsSdInfo->GetMrpRetryIntervalActive().HasValue())
         {
             ChipLogProgress(Discovery, "\tMrp Interval active\t%u",
-                            dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().Value().count());
+                            dnsSdInfo->GetMrpRetryIntervalActive().Value().count());
         }
         else
         {
             ChipLogProgress(Discovery, "\tMrp Interval active\tNot present");
         }
-        ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->resolutionData.supportsTcp);
+        ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->supportsTcp);
 
-        if (dnsSdInfo->resolutionData.isICDOperatingAsLIT.HasValue())
+        if (dnsSdInfo->isICDOperatingAsLIT.HasValue())
         {
             ChipLogProgress(Discovery, "\tICD is operating as a\t%s",
-                            dnsSdInfo->resolutionData.isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
+                            dnsSdInfo->isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
         }
 
-        for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)
+        for (unsigned j = 0; j < dnsSdInfo->numIPs; ++j)
         {
             char buf[chip::Inet::IPAddress::kMaxStringLength];
-            dnsSdInfo->resolutionData.ipAddress[j].ToString(buf);
+            dnsSdInfo->ipAddress[j].ToString(buf);
             ChipLogProgress(Discovery, "\tAddress %d:\t\t%s", j, buf);
         }
     }

--- a/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
+++ b/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
@@ -82,8 +82,7 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
             continue;
         }
         char rotatingId[chip::Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-        Encoding::BytesToUppercaseHexString(dnsSdInfo->rotatingId, dnsSdInfo->rotatingIdLen, rotatingId,
-                                            sizeof(rotatingId));
+        Encoding::BytesToUppercaseHexString(dnsSdInfo->rotatingId, dnsSdInfo->rotatingIdLen, rotatingId, sizeof(rotatingId));
 
         ChipLogProgress(Discovery, "Commissioner %d", i);
         ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->instanceName);
@@ -100,8 +99,7 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
         ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->pairingHint);
         if (dnsSdInfo->GetMrpRetryIntervalIdle().HasValue())
         {
-            ChipLogProgress(Discovery, "\tMrp Interval idle\t%u",
-                            dnsSdInfo->GetMrpRetryIntervalIdle().Value().count());
+            ChipLogProgress(Discovery, "\tMrp Interval idle\t%u", dnsSdInfo->GetMrpRetryIntervalIdle().Value().count());
         }
         else
         {
@@ -109,8 +107,7 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
         }
         if (dnsSdInfo->GetMrpRetryIntervalActive().HasValue())
         {
-            ChipLogProgress(Discovery, "\tMrp Interval active\t%u",
-                            dnsSdInfo->GetMrpRetryIntervalActive().Value().count());
+            ChipLogProgress(Discovery, "\tMrp Interval active\t%u", dnsSdInfo->GetMrpRetryIntervalActive().Value().count());
         }
         else
         {
@@ -120,8 +117,7 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
 
         if (dnsSdInfo->isICDOperatingAsLIT.HasValue())
         {
-            ChipLogProgress(Discovery, "\tICD is operating as a\t%s",
-                            dnsSdInfo->isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
+            ChipLogProgress(Discovery, "\tICD is operating as a\t%s", dnsSdInfo->isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
         }
 
         for (unsigned j = 0; j < dnsSdInfo->numIPs; ++j)

--- a/src/controller/python/ChipDeviceController-Discovery.cpp
+++ b/src/controller/python/ChipDeviceController-Discovery.cpp
@@ -40,7 +40,7 @@ bool pychip_DeviceController_HasDiscoveredCommissionableNode(Controller::DeviceC
 {
     for (int i = 0; i < devCtrl->GetMaxCommissionableNodesSupported(); ++i)
     {
-        const Dnssd::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
+        const Dnssd::CommissionNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
         if (dnsSdInfo == nullptr)
         {
             continue;
@@ -101,7 +101,7 @@ void pychip_DeviceController_IterateDiscoveredCommissionableNodes(Controller::De
 
     for (int i = 0; i < devCtrl->GetMaxCommissionableNodesSupported(); ++i)
     {
-        const Dnssd::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
+        const Dnssd::CommissionNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
         if (dnsSdInfo == nullptr)
         {
             continue;
@@ -110,49 +110,49 @@ void pychip_DeviceController_IterateDiscoveredCommissionableNodes(Controller::De
         Json::Value jsonVal;
 
         char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-        Encoding::BytesToUppercaseHexString(dnsSdInfo->nodeData.rotatingId, dnsSdInfo->nodeData.rotatingIdLen, rotatingId,
+        Encoding::BytesToUppercaseHexString(dnsSdInfo->rotatingId, dnsSdInfo->rotatingIdLen, rotatingId,
                                             sizeof(rotatingId));
 
         ChipLogProgress(Discovery, "Commissionable Node %d", i);
-        jsonVal["instanceName"]       = dnsSdInfo->nodeData.instanceName;
-        jsonVal["hostName"]           = dnsSdInfo->resolutionData.hostName;
-        jsonVal["port"]               = dnsSdInfo->resolutionData.port;
-        jsonVal["longDiscriminator"]  = dnsSdInfo->nodeData.longDiscriminator;
-        jsonVal["vendorId"]           = dnsSdInfo->nodeData.vendorId;
-        jsonVal["productId"]          = dnsSdInfo->nodeData.productId;
-        jsonVal["commissioningMode"]  = dnsSdInfo->nodeData.commissioningMode;
-        jsonVal["deviceType"]         = dnsSdInfo->nodeData.deviceType;
-        jsonVal["deviceName"]         = dnsSdInfo->nodeData.deviceName;
-        jsonVal["pairingInstruction"] = dnsSdInfo->nodeData.pairingInstruction;
-        jsonVal["pairingHint"]        = dnsSdInfo->nodeData.pairingHint;
-        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().HasValue())
+        jsonVal["instanceName"]       = dnsSdInfo->instanceName;
+        jsonVal["hostName"]           = dnsSdInfo->hostName;
+        jsonVal["port"]               = dnsSdInfo->port;
+        jsonVal["longDiscriminator"]  = dnsSdInfo->longDiscriminator;
+        jsonVal["vendorId"]           = dnsSdInfo->vendorId;
+        jsonVal["productId"]          = dnsSdInfo->productId;
+        jsonVal["commissioningMode"]  = dnsSdInfo->commissioningMode;
+        jsonVal["deviceType"]         = dnsSdInfo->deviceType;
+        jsonVal["deviceName"]         = dnsSdInfo->deviceName;
+        jsonVal["pairingInstruction"] = dnsSdInfo->pairingInstruction;
+        jsonVal["pairingHint"]        = dnsSdInfo->pairingHint;
+        if (dnsSdInfo->GetMrpRetryIntervalIdle().HasValue())
         {
-            jsonVal["mrpRetryIntervalIdle"] = dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().Value().count();
+            jsonVal["mrpRetryIntervalIdle"] = dnsSdInfo->GetMrpRetryIntervalIdle().Value().count();
         }
-        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().HasValue())
+        if (dnsSdInfo->GetMrpRetryIntervalActive().HasValue())
         {
-            jsonVal["mrpRetryIntervalActive"] = dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().Value().count();
+            jsonVal["mrpRetryIntervalActive"] = dnsSdInfo->GetMrpRetryIntervalActive().Value().count();
         }
-        if (dnsSdInfo->resolutionData.GetMrpRetryActiveThreshold().HasValue())
+        if (dnsSdInfo->GetMrpRetryActiveThreshold().HasValue())
         {
-            jsonVal["mrpRetryActiveThreshold"] = dnsSdInfo->resolutionData.GetMrpRetryActiveThreshold().Value().count();
+            jsonVal["mrpRetryActiveThreshold"] = dnsSdInfo->GetMrpRetryActiveThreshold().Value().count();
         }
-        jsonVal["supportsTcp"] = dnsSdInfo->resolutionData.supportsTcp;
+        jsonVal["supportsTcp"] = dnsSdInfo->supportsTcp;
         {
             Json::Value addresses;
-            for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)
+            for (unsigned j = 0; j < dnsSdInfo->numIPs; ++j)
             {
                 char buf[Inet::IPAddress::kMaxStringLength];
-                dnsSdInfo->resolutionData.ipAddress[j].ToString(buf);
+                dnsSdInfo->ipAddress[j].ToString(buf);
                 addresses[j] = buf;
             }
             jsonVal["addresses"] = addresses;
         }
-        if (dnsSdInfo->resolutionData.isICDOperatingAsLIT.HasValue())
+        if (dnsSdInfo->isICDOperatingAsLIT.HasValue())
         {
-            jsonVal["isICDOperatingAsLIT"] = dnsSdInfo->resolutionData.isICDOperatingAsLIT.Value();
+            jsonVal["isICDOperatingAsLIT"] = dnsSdInfo->isICDOperatingAsLIT.Value();
         }
-        if (dnsSdInfo->nodeData.rotatingIdLen > 0)
+        if (dnsSdInfo->rotatingIdLen > 0)
         {
             jsonVal["rotatingId"] = rotatingId;
         }
@@ -168,56 +168,56 @@ void pychip_DeviceController_PrintDiscoveredDevices(Controller::DeviceCommission
 {
     for (int i = 0; i < devCtrl->GetMaxCommissionableNodesSupported(); ++i)
     {
-        const Dnssd::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
+        const Dnssd::CommissionNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
         if (dnsSdInfo == nullptr)
         {
             continue;
         }
         char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-        Encoding::BytesToUppercaseHexString(dnsSdInfo->nodeData.rotatingId, dnsSdInfo->nodeData.rotatingIdLen, rotatingId,
+        Encoding::BytesToUppercaseHexString(dnsSdInfo->rotatingId, dnsSdInfo->rotatingIdLen, rotatingId,
                                             sizeof(rotatingId));
 
         ChipLogProgress(Discovery, "Commissionable Node %d", i);
-        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->nodeData.instanceName);
-        ChipLogProgress(Discovery, "\tHost name:\t\t%s", dnsSdInfo->resolutionData.hostName);
-        ChipLogProgress(Discovery, "\tPort:\t\t\t%u", dnsSdInfo->resolutionData.port);
-        ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->nodeData.longDiscriminator);
-        ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", dnsSdInfo->nodeData.vendorId);
-        ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", dnsSdInfo->nodeData.productId);
-        ChipLogProgress(Discovery, "\tCommissioning Mode\t%u", dnsSdInfo->nodeData.commissioningMode);
-        ChipLogProgress(Discovery, "\tDevice Type\t\t%u", dnsSdInfo->nodeData.deviceType);
-        ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->nodeData.deviceName);
+        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->instanceName);
+        ChipLogProgress(Discovery, "\tHost name:\t\t%s", dnsSdInfo->hostName);
+        ChipLogProgress(Discovery, "\tPort:\t\t\t%u", dnsSdInfo->port);
+        ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->longDiscriminator);
+        ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", dnsSdInfo->vendorId);
+        ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", dnsSdInfo->productId);
+        ChipLogProgress(Discovery, "\tCommissioning Mode\t%u", dnsSdInfo->commissioningMode);
+        ChipLogProgress(Discovery, "\tDevice Type\t\t%u", dnsSdInfo->deviceType);
+        ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->deviceName);
         ChipLogProgress(Discovery, "\tRotating Id\t\t%s", rotatingId);
-        ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->nodeData.pairingInstruction);
-        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->nodeData.pairingHint);
-        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().HasValue())
+        ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->pairingInstruction);
+        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->pairingHint);
+        if (dnsSdInfo->GetMrpRetryIntervalIdle().HasValue())
         {
             ChipLogProgress(Discovery, "\tMrp Interval idle\t%u",
-                            dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().Value().count());
+                            dnsSdInfo->GetMrpRetryIntervalIdle().Value().count());
         }
         else
         {
             ChipLogProgress(Discovery, "\tMrp Interval idle\tNot present");
         }
-        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().HasValue())
+        if (dnsSdInfo->GetMrpRetryIntervalActive().HasValue())
         {
             ChipLogProgress(Discovery, "\tMrp Interval active\t%u",
-                            dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().Value().count());
+                            dnsSdInfo->GetMrpRetryIntervalActive().Value().count());
         }
         else
         {
             ChipLogProgress(Discovery, "\tMrp Interval active\tNot present");
         }
-        ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->resolutionData.supportsTcp);
-        if (dnsSdInfo->resolutionData.isICDOperatingAsLIT.HasValue())
+        ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->supportsTcp);
+        if (dnsSdInfo->isICDOperatingAsLIT.HasValue())
         {
             ChipLogProgress(Discovery, "\tICD is operating as a\t%s",
-                            dnsSdInfo->resolutionData.isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
+                            dnsSdInfo->isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
         }
-        for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)
+        for (unsigned j = 0; j < dnsSdInfo->numIPs; ++j)
         {
             char buf[Inet::IPAddress::kMaxStringLength];
-            dnsSdInfo->resolutionData.ipAddress[j].ToString(buf);
+            dnsSdInfo->ipAddress[j].ToString(buf);
             ChipLogProgress(Discovery, "\tAddress %d:\t\t%s", j, buf);
         }
     }
@@ -226,13 +226,13 @@ void pychip_DeviceController_PrintDiscoveredDevices(Controller::DeviceCommission
 bool pychip_DeviceController_GetIPForDiscoveredDevice(Controller::DeviceCommissioner * devCtrl, int idx, char * addrStr,
                                                       uint32_t len)
 {
-    const Dnssd::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(idx);
+    const Dnssd::CommissionNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(idx);
     if (dnsSdInfo == nullptr)
     {
         return false;
     }
     // TODO(cecille): Select which one we actually want.
-    if (dnsSdInfo->resolutionData.ipAddress[0].ToString(addrStr, len) == addrStr)
+    if (dnsSdInfo->ipAddress[0].ToString(addrStr, len) == addrStr)
     {
         return true;
     }

--- a/src/controller/python/ChipDeviceController-Discovery.cpp
+++ b/src/controller/python/ChipDeviceController-Discovery.cpp
@@ -110,8 +110,7 @@ void pychip_DeviceController_IterateDiscoveredCommissionableNodes(Controller::De
         Json::Value jsonVal;
 
         char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-        Encoding::BytesToUppercaseHexString(dnsSdInfo->rotatingId, dnsSdInfo->rotatingIdLen, rotatingId,
-                                            sizeof(rotatingId));
+        Encoding::BytesToUppercaseHexString(dnsSdInfo->rotatingId, dnsSdInfo->rotatingIdLen, rotatingId, sizeof(rotatingId));
 
         ChipLogProgress(Discovery, "Commissionable Node %d", i);
         jsonVal["instanceName"]       = dnsSdInfo->instanceName;
@@ -174,8 +173,7 @@ void pychip_DeviceController_PrintDiscoveredDevices(Controller::DeviceCommission
             continue;
         }
         char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-        Encoding::BytesToUppercaseHexString(dnsSdInfo->rotatingId, dnsSdInfo->rotatingIdLen, rotatingId,
-                                            sizeof(rotatingId));
+        Encoding::BytesToUppercaseHexString(dnsSdInfo->rotatingId, dnsSdInfo->rotatingIdLen, rotatingId, sizeof(rotatingId));
 
         ChipLogProgress(Discovery, "Commissionable Node %d", i);
         ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->instanceName);
@@ -192,8 +190,7 @@ void pychip_DeviceController_PrintDiscoveredDevices(Controller::DeviceCommission
         ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->pairingHint);
         if (dnsSdInfo->GetMrpRetryIntervalIdle().HasValue())
         {
-            ChipLogProgress(Discovery, "\tMrp Interval idle\t%u",
-                            dnsSdInfo->GetMrpRetryIntervalIdle().Value().count());
+            ChipLogProgress(Discovery, "\tMrp Interval idle\t%u", dnsSdInfo->GetMrpRetryIntervalIdle().Value().count());
         }
         else
         {
@@ -201,8 +198,7 @@ void pychip_DeviceController_PrintDiscoveredDevices(Controller::DeviceCommission
         }
         if (dnsSdInfo->GetMrpRetryIntervalActive().HasValue())
         {
-            ChipLogProgress(Discovery, "\tMrp Interval active\t%u",
-                            dnsSdInfo->GetMrpRetryIntervalActive().Value().count());
+            ChipLogProgress(Discovery, "\tMrp Interval active\t%u", dnsSdInfo->GetMrpRetryIntervalActive().Value().count());
         }
         else
         {
@@ -211,8 +207,7 @@ void pychip_DeviceController_PrintDiscoveredDevices(Controller::DeviceCommission
         ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->supportsTcp);
         if (dnsSdInfo->isICDOperatingAsLIT.HasValue())
         {
-            ChipLogProgress(Discovery, "\tICD is operating as a\t%s",
-                            dnsSdInfo->isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
+            ChipLogProgress(Discovery, "\tICD is operating as a\t%s", dnsSdInfo->isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
         }
         for (unsigned j = 0; j < dnsSdInfo->numIPs; ++j)
         {

--- a/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
@@ -38,9 +38,8 @@ void ScriptPairingDeviceDiscoveryDelegate::OnDiscoveredDevice(const Dnssd::Commi
     // Stop Mdns discovery.
     mActiveDeviceCommissioner->RegisterDeviceDiscoveryDelegate(nullptr);
 
-    Inet::InterfaceId interfaceId =
-        nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId : Inet::InterfaceId::Null();
-    auto peerAddress = Transport::PeerAddress::UDP(nodeData.ipAddress[0], port, interfaceId);
+    Inet::InterfaceId interfaceId = nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId : Inet::InterfaceId::Null();
+    auto peerAddress              = Transport::PeerAddress::UDP(nodeData.ipAddress[0], port, interfaceId);
 
     RendezvousParameters keyExchangeParams = RendezvousParameters().SetSetupPINCode(mSetupPasscode).SetPeerAddress(peerAddress);
 

--- a/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
@@ -21,15 +21,15 @@
 namespace chip {
 namespace Controller {
 
-void ScriptPairingDeviceDiscoveryDelegate::OnDiscoveredDevice(const Dnssd::DiscoveredNodeData & nodeData)
+void ScriptPairingDeviceDiscoveryDelegate::OnDiscoveredDevice(const Dnssd::CommissionNodeData & nodeData)
 {
     // Ignore nodes with closed comissioning window
-    VerifyOrReturn(nodeData.nodeData.commissioningMode != 0);
+    VerifyOrReturn(nodeData.commissioningMode != 0);
     VerifyOrReturn(mActiveDeviceCommissioner != nullptr);
 
-    const uint16_t port = nodeData.resolutionData.port;
+    const uint16_t port = nodeData.port;
     char buf[chip::Inet::IPAddress::kMaxStringLength];
-    nodeData.resolutionData.ipAddress[0].ToString(buf);
+    nodeData.ipAddress[0].ToString(buf);
     ChipLogProgress(chipTool, "Discovered Device: %s:%u", buf, port);
 
     // Cancel discovery timer.
@@ -39,8 +39,8 @@ void ScriptPairingDeviceDiscoveryDelegate::OnDiscoveredDevice(const Dnssd::Disco
     mActiveDeviceCommissioner->RegisterDeviceDiscoveryDelegate(nullptr);
 
     Inet::InterfaceId interfaceId =
-        nodeData.resolutionData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.resolutionData.interfaceId : Inet::InterfaceId::Null();
-    auto peerAddress = Transport::PeerAddress::UDP(nodeData.resolutionData.ipAddress[0], port, interfaceId);
+        nodeData.ipAddress[0].IsIPv6LinkLocal() ? nodeData.interfaceId : Inet::InterfaceId::Null();
+    auto peerAddress = Transport::PeerAddress::UDP(nodeData.ipAddress[0], port, interfaceId);
 
     RendezvousParameters keyExchangeParams = RendezvousParameters().SetSetupPINCode(mSetupPasscode).SetPeerAddress(peerAddress);
 

--- a/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.h
+++ b/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.h
@@ -44,7 +44,7 @@ public:
         return chip::DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(discoveryTimeoutMsec), OnDiscoveredTimeout,
                                                            this);
     }
-    void OnDiscoveredDevice(const Dnssd::DiscoveredNodeData & nodeData);
+    void OnDiscoveredDevice(const Dnssd::CommissionNodeData & nodeData);
 
 private:
     static void OnDiscoveredTimeout(System::Layer * layer, void * context)

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -66,33 +66,37 @@ void TestGetDiscoveredCommissioner_HappyCase(nlTestSuite * inSuite, void * inCon
 {
     MockResolver resolver;
     CommissionableNodeController controller(&resolver);
-    chip::Dnssd::DiscoveredNodeData inNodeData;
-    Platform::CopyString(inNodeData.resolutionData.hostName, "mockHostName");
-    Inet::IPAddress::FromString("192.168.1.10", inNodeData.resolutionData.ipAddress[0]);
-    inNodeData.resolutionData.numIPs++;
-    inNodeData.resolutionData.port = 5540;
+    chip::Dnssd::DiscoveredNodeData discNodeData;
+    discNodeData.Set<chip::Dnssd::CommissionNodeData>();
+    chip::Dnssd::CommissionNodeData & inNodeData = discNodeData.Get<chip::Dnssd::CommissionNodeData>();
+    Platform::CopyString(inNodeData.hostName, "mockHostName");
+    Inet::IPAddress::FromString("192.168.1.10", inNodeData.ipAddress[0]);
+    inNodeData.numIPs++;
+    inNodeData.port = 5540;
 
-    controller.OnNodeDiscovered(inNodeData);
+    controller.OnNodeDiscovered(discNodeData);
 
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0) != nullptr);
     NL_TEST_ASSERT(
-        inSuite, strcmp(inNodeData.resolutionData.hostName, controller.GetDiscoveredCommissioner(0)->resolutionData.hostName) == 0);
+        inSuite, strcmp(inNodeData.hostName, controller.GetDiscoveredCommissioner(0)->hostName) == 0);
     NL_TEST_ASSERT(inSuite,
-                   inNodeData.resolutionData.ipAddress[0] == controller.GetDiscoveredCommissioner(0)->resolutionData.ipAddress[0]);
-    NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->resolutionData.port == 5540);
-    NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->resolutionData.numIPs == 1);
+                   inNodeData.ipAddress[0] == controller.GetDiscoveredCommissioner(0)->ipAddress[0]);
+    NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->port == 5540);
+    NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->numIPs == 1);
 }
 
 void TestGetDiscoveredCommissioner_InvalidNodeDiscovered_ReturnsNullptr(nlTestSuite * inSuite, void * inContext)
 {
     MockResolver resolver;
     CommissionableNodeController controller(&resolver);
-    chip::Dnssd::DiscoveredNodeData inNodeData;
-    Inet::IPAddress::FromString("192.168.1.10", inNodeData.resolutionData.ipAddress[0]);
-    inNodeData.resolutionData.numIPs++;
-    inNodeData.resolutionData.port = 5540;
+    chip::Dnssd::DiscoveredNodeData discNodeData;
+    discNodeData.Set<chip::Dnssd::CommissionNodeData>();
+    chip::Dnssd::CommissionNodeData & inNodeData = discNodeData.Get<chip::Dnssd::CommissionNodeData>();
+    Inet::IPAddress::FromString("192.168.1.10", inNodeData.ipAddress[0]);
+    inNodeData.numIPs++;
+    inNodeData.port = 5540;
 
-    controller.OnNodeDiscovered(inNodeData);
+    controller.OnNodeDiscovered(discNodeData);
 
     for (int i = 0; i < CHIP_DEVICE_CONFIG_MAX_DISCOVERED_NODES; i++)
     {
@@ -104,27 +108,31 @@ void TestGetDiscoveredCommissioner_HappyCase_OneValidOneInvalidNode(nlTestSuite 
 {
     MockResolver resolver;
     CommissionableNodeController controller(&resolver);
-    chip::Dnssd::DiscoveredNodeData invalidNodeData, validNodeData;
-    Inet::IPAddress::FromString("192.168.1.10", invalidNodeData.resolutionData.ipAddress[0]);
-    invalidNodeData.resolutionData.numIPs++;
-    invalidNodeData.resolutionData.port = 5540;
+    chip::Dnssd::DiscoveredNodeData invalidDiscNodeData, validDiscNodeData;
+    invalidDiscNodeData.Set<chip::Dnssd::CommissionNodeData>();
+    validDiscNodeData.Set<chip::Dnssd::CommissionNodeData>();
+    chip::Dnssd::CommissionNodeData & invalidNodeData = invalidDiscNodeData.Get<chip::Dnssd::CommissionNodeData>();
+    chip::Dnssd::CommissionNodeData & validNodeData = validDiscNodeData.Get<chip::Dnssd::CommissionNodeData>();
+    Inet::IPAddress::FromString("192.168.1.10", invalidNodeData.ipAddress[0]);
+    invalidNodeData.numIPs++;
+    invalidNodeData.port = 5540;
 
-    Platform::CopyString(validNodeData.resolutionData.hostName, "mockHostName2");
-    Inet::IPAddress::FromString("192.168.1.11", validNodeData.resolutionData.ipAddress[0]);
-    validNodeData.resolutionData.numIPs++;
-    validNodeData.resolutionData.port = 5540;
+    Platform::CopyString(validNodeData.hostName, "mockHostName2");
+    Inet::IPAddress::FromString("192.168.1.11", validNodeData.ipAddress[0]);
+    validNodeData.numIPs++;
+    validNodeData.port = 5540;
 
-    controller.OnNodeDiscovered(validNodeData);
-    controller.OnNodeDiscovered(invalidNodeData);
+    controller.OnNodeDiscovered(validDiscNodeData);
+    controller.OnNodeDiscovered(invalidDiscNodeData);
 
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0) != nullptr);
     NL_TEST_ASSERT(
         inSuite,
-        strcmp(validNodeData.resolutionData.hostName, controller.GetDiscoveredCommissioner(0)->resolutionData.hostName) == 0);
+        strcmp(validNodeData.hostName, controller.GetDiscoveredCommissioner(0)->hostName) == 0);
     NL_TEST_ASSERT(
-        inSuite, validNodeData.resolutionData.ipAddress[0] == controller.GetDiscoveredCommissioner(0)->resolutionData.ipAddress[0]);
-    NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->resolutionData.port == 5540);
-    NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->resolutionData.numIPs == 1);
+        inSuite, validNodeData.ipAddress[0] == controller.GetDiscoveredCommissioner(0)->ipAddress[0]);
+    NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->port == 5540);
+    NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->numIPs == 1);
 
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(1) == nullptr);
 }

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -77,10 +77,8 @@ void TestGetDiscoveredCommissioner_HappyCase(nlTestSuite * inSuite, void * inCon
     controller.OnNodeDiscovered(discNodeData);
 
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0) != nullptr);
-    NL_TEST_ASSERT(
-        inSuite, strcmp(inNodeData.hostName, controller.GetDiscoveredCommissioner(0)->hostName) == 0);
-    NL_TEST_ASSERT(inSuite,
-                   inNodeData.ipAddress[0] == controller.GetDiscoveredCommissioner(0)->ipAddress[0]);
+    NL_TEST_ASSERT(inSuite, strcmp(inNodeData.hostName, controller.GetDiscoveredCommissioner(0)->hostName) == 0);
+    NL_TEST_ASSERT(inSuite, inNodeData.ipAddress[0] == controller.GetDiscoveredCommissioner(0)->ipAddress[0]);
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->port == 5540);
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->numIPs == 1);
 }
@@ -112,7 +110,7 @@ void TestGetDiscoveredCommissioner_HappyCase_OneValidOneInvalidNode(nlTestSuite 
     invalidDiscNodeData.Set<chip::Dnssd::CommissionNodeData>();
     validDiscNodeData.Set<chip::Dnssd::CommissionNodeData>();
     chip::Dnssd::CommissionNodeData & invalidNodeData = invalidDiscNodeData.Get<chip::Dnssd::CommissionNodeData>();
-    chip::Dnssd::CommissionNodeData & validNodeData = validDiscNodeData.Get<chip::Dnssd::CommissionNodeData>();
+    chip::Dnssd::CommissionNodeData & validNodeData   = validDiscNodeData.Get<chip::Dnssd::CommissionNodeData>();
     Inet::IPAddress::FromString("192.168.1.10", invalidNodeData.ipAddress[0]);
     invalidNodeData.numIPs++;
     invalidNodeData.port = 5540;
@@ -126,11 +124,8 @@ void TestGetDiscoveredCommissioner_HappyCase_OneValidOneInvalidNode(nlTestSuite 
     controller.OnNodeDiscovered(invalidDiscNodeData);
 
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0) != nullptr);
-    NL_TEST_ASSERT(
-        inSuite,
-        strcmp(validNodeData.hostName, controller.GetDiscoveredCommissioner(0)->hostName) == 0);
-    NL_TEST_ASSERT(
-        inSuite, validNodeData.ipAddress[0] == controller.GetDiscoveredCommissioner(0)->ipAddress[0]);
+    NL_TEST_ASSERT(inSuite, strcmp(validNodeData.hostName, controller.GetDiscoveredCommissioner(0)->hostName) == 0);
+    NL_TEST_ASSERT(inSuite, validNodeData.ipAddress[0] == controller.GetDiscoveredCommissioner(0)->ipAddress[0]);
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->port == 5540);
     NL_TEST_ASSERT(inSuite, controller.GetDiscoveredCommissioner(0)->numIPs == 1);
 

--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
@@ -161,6 +161,11 @@ public:
     {
         assertChipStackLockedByCurrentThread();
 
+        if (!nodeData.Is<CommissionNodeData>()) {
+            // not commissionable/commissioners node 
+            return;
+        }
+
         auto & commissionData = nodeData.Get<CommissionNodeData>();
         auto key = [NSString stringWithUTF8String:commissionData.instanceName];
         if ([mDiscoveredResults objectForKey:key] == nil) {

--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
@@ -161,7 +161,7 @@ public:
     {
         assertChipStackLockedByCurrentThread();
 
-        auto & commissionData = nodeData.nodeData;
+        auto & commissionData = nodeData.Get<CommissionNodeData>();
         auto key = [NSString stringWithUTF8String:commissionData.instanceName];
         if ([mDiscoveredResults objectForKey:key] == nil) {
             // It should not happens.
@@ -175,7 +175,7 @@ public:
         result.discriminator = @(commissionData.longDiscriminator);
         result.commissioningMode = commissionData.commissioningMode != 0;
 
-        auto & resolutionData = nodeData.resolutionData;
+        auto & resolutionData = commissionData;
         auto * interfaces = result.interfaces;
         interfaces[@(resolutionData.interfaceId.GetPlatformInterface())].resolutionData = chip::MakeOptional(resolutionData);
 

--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
@@ -180,7 +180,7 @@ public:
         result.discriminator = @(commissionData.longDiscriminator);
         result.commissioningMode = commissionData.commissioningMode != 0;
 
-        auto & resolutionData = commissionData;
+        const CommonResolutionData & resolutionData = commissionData;
         auto * interfaces = result.interfaces;
         interfaces[@(resolutionData.interfaceId.GetPlatformInterface())].resolutionData = chip::MakeOptional(resolutionData);
 

--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
@@ -162,7 +162,7 @@ public:
         assertChipStackLockedByCurrentThread();
 
         if (!nodeData.Is<CommissionNodeData>()) {
-            // not commissionable/commissioners node 
+            // not commissionable/commissioners node
             return;
         }
 

--- a/src/lib/dnssd/ActiveResolveAttempts.h
+++ b/src/lib/dnssd/ActiveResolveAttempts.h
@@ -160,8 +160,7 @@ public:
             case chip::Dnssd::DiscoveryFilterType::kNone:
                 return true;
             case chip::Dnssd::DiscoveryFilterType::kShortDiscriminator:
-                return browse.filter.code ==
-                    static_cast<uint64_t>((nodeData.longDiscriminator >> 8) & 0x0F);
+                return browse.filter.code == static_cast<uint64_t>((nodeData.longDiscriminator >> 8) & 0x0F);
             case chip::Dnssd::DiscoveryFilterType::kLongDiscriminator:
                 return browse.filter.code == nodeData.longDiscriminator;
             case chip::Dnssd::DiscoveryFilterType::kVendorId:

--- a/src/lib/dnssd/ActiveResolveAttempts.h
+++ b/src/lib/dnssd/ActiveResolveAttempts.h
@@ -159,17 +159,17 @@ public:
             case chip::Dnssd::DiscoveryFilterType::kNone:
                 return true;
             case chip::Dnssd::DiscoveryFilterType::kShortDiscriminator:
-                return browse.filter.code == static_cast<uint64_t>((data.nodeData.longDiscriminator >> 8) & 0x0F);
+                return browse.filter.code == static_cast<uint64_t>((data.Get<chip::Dnssd::CommissionNodeData>().longDiscriminator >> 8) & 0x0F);
             case chip::Dnssd::DiscoveryFilterType::kLongDiscriminator:
-                return browse.filter.code == data.nodeData.longDiscriminator;
+                return browse.filter.code == data.Get<chip::Dnssd::CommissionNodeData>().longDiscriminator;
             case chip::Dnssd::DiscoveryFilterType::kVendorId:
-                return browse.filter.code == data.nodeData.vendorId;
+                return browse.filter.code == data.Get<chip::Dnssd::CommissionNodeData>().vendorId;
             case chip::Dnssd::DiscoveryFilterType::kDeviceType:
-                return browse.filter.code == data.nodeData.deviceType;
+                return browse.filter.code == data.Get<chip::Dnssd::CommissionNodeData>().deviceType;
             case chip::Dnssd::DiscoveryFilterType::kCommissioningMode:
-                return browse.filter.code == data.nodeData.commissioningMode;
+                return browse.filter.code == data.Get<chip::Dnssd::CommissionNodeData>().commissioningMode;
             case chip::Dnssd::DiscoveryFilterType::kInstanceName:
-                return strncmp(browse.filter.instanceName, data.nodeData.instanceName,
+                return strncmp(browse.filter.instanceName, data.Get<chip::Dnssd::CommissionNodeData>().instanceName,
                                chip::Dnssd::Commission::kInstanceNameMaxLength + 1) == 0;
             case chip::Dnssd::DiscoveryFilterType::kCommissioner:
             case chip::Dnssd::DiscoveryFilterType::kCompressedFabricId:

--- a/src/lib/dnssd/ActiveResolveAttempts.h
+++ b/src/lib/dnssd/ActiveResolveAttempts.h
@@ -159,7 +159,8 @@ public:
             case chip::Dnssd::DiscoveryFilterType::kNone:
                 return true;
             case chip::Dnssd::DiscoveryFilterType::kShortDiscriminator:
-                return browse.filter.code == static_cast<uint64_t>((data.Get<chip::Dnssd::CommissionNodeData>().longDiscriminator >> 8) & 0x0F);
+                return browse.filter.code ==
+                    static_cast<uint64_t>((data.Get<chip::Dnssd::CommissionNodeData>().longDiscriminator >> 8) & 0x0F);
             case chip::Dnssd::DiscoveryFilterType::kLongDiscriminator:
                 return browse.filter.code == data.Get<chip::Dnssd::CommissionNodeData>().longDiscriminator;
             case chip::Dnssd::DiscoveryFilterType::kVendorId:

--- a/src/lib/dnssd/ActiveResolveAttempts.h
+++ b/src/lib/dnssd/ActiveResolveAttempts.h
@@ -153,6 +153,7 @@ public:
             {
                 return false;
             }
+            auto & nodeData = data.Get<chip::Dnssd::CommissionNodeData>();
 
             switch (browse.filter.type)
             {
@@ -160,17 +161,17 @@ public:
                 return true;
             case chip::Dnssd::DiscoveryFilterType::kShortDiscriminator:
                 return browse.filter.code ==
-                    static_cast<uint64_t>((data.Get<chip::Dnssd::CommissionNodeData>().longDiscriminator >> 8) & 0x0F);
+                    static_cast<uint64_t>((nodeData.longDiscriminator >> 8) & 0x0F);
             case chip::Dnssd::DiscoveryFilterType::kLongDiscriminator:
-                return browse.filter.code == data.Get<chip::Dnssd::CommissionNodeData>().longDiscriminator;
+                return browse.filter.code == nodeData.longDiscriminator;
             case chip::Dnssd::DiscoveryFilterType::kVendorId:
-                return browse.filter.code == data.Get<chip::Dnssd::CommissionNodeData>().vendorId;
+                return browse.filter.code == nodeData.vendorId;
             case chip::Dnssd::DiscoveryFilterType::kDeviceType:
-                return browse.filter.code == data.Get<chip::Dnssd::CommissionNodeData>().deviceType;
+                return browse.filter.code == nodeData.deviceType;
             case chip::Dnssd::DiscoveryFilterType::kCommissioningMode:
-                return browse.filter.code == data.Get<chip::Dnssd::CommissionNodeData>().commissioningMode;
+                return browse.filter.code == nodeData.commissioningMode;
             case chip::Dnssd::DiscoveryFilterType::kInstanceName:
-                return strncmp(browse.filter.instanceName, data.Get<chip::Dnssd::CommissionNodeData>().instanceName,
+                return strncmp(browse.filter.instanceName, nodeData.instanceName,
                                chip::Dnssd::Commission::kInstanceNameMaxLength + 1) == 0;
             case chip::Dnssd::DiscoveryFilterType::kCommissioner:
             case chip::Dnssd::DiscoveryFilterType::kCompressedFabricId:

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -350,7 +350,8 @@ CHIP_ERROR IncrementalResolver::Take(DiscoveredNodeData & outputData)
     outputData.Set<CommissionNodeData>();
     CommissionNodeData & nodeData     = outputData.Get<CommissionNodeData>();
     nodeData                          = mSpecificResolutionData.Get<CommissionNodeData>();
-    (CommonResolutionData &) nodeData = mCommonResolutionData;
+    CommonResolutionData & resolutionData = nodeData;
+    resolutionData = mCommonResolutionData;
 
     ResetToInactive();
 

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -348,9 +348,9 @@ CHIP_ERROR IncrementalResolver::Take(DiscoveredNodeData & outputData)
     IPAddressSorter::Sort(mCommonResolutionData.ipAddress, mCommonResolutionData.numIPs, mCommonResolutionData.interfaceId);
 
     outputData.Set<CommissionNodeData>();
-    CommissionNodeData & nodeData = outputData.Get<CommissionNodeData>();
-    nodeData = mSpecificResolutionData.Get<CommissionNodeData>();
-    (CommonResolutionData &)nodeData = mCommonResolutionData;
+    CommissionNodeData & nodeData     = outputData.Get<CommissionNodeData>();
+    nodeData                          = mSpecificResolutionData.Get<CommissionNodeData>();
+    (CommonResolutionData &) nodeData = mCommonResolutionData;
 
     ResetToInactive();
 

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -189,7 +189,7 @@ CHIP_ERROR IncrementalResolver::InitializeParsing(mdns::Minimal::SerializedQName
         break;
     case ServiceNameType::kCommissioner:
     case ServiceNameType::kCommissionable:
-        mSpecificResolutionData.Set<DnssdNodeData>();
+        mSpecificResolutionData.Set<CommissionNodeData>();
 
         {
             // Commission addresses start with instance name
@@ -199,10 +199,10 @@ CHIP_ERROR IncrementalResolver::InitializeParsing(mdns::Minimal::SerializedQName
                 return CHIP_ERROR_INVALID_ARGUMENT;
             }
 
-            Platform::CopyString(mSpecificResolutionData.Get<DnssdNodeData>().instanceName, nameCopy.Value());
+            Platform::CopyString(mSpecificResolutionData.Get<CommissionNodeData>().instanceName, nameCopy.Value());
         }
 
-        LogFoundCommissionSrvRecord(mSpecificResolutionData.Get<DnssdNodeData>().instanceName, mTargetHostName.Get());
+        LogFoundCommissionSrvRecord(mSpecificResolutionData.Get<CommissionNodeData>().instanceName, mTargetHostName.Get());
         break;
     default:
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -306,7 +306,7 @@ CHIP_ERROR IncrementalResolver::OnTxtRecord(const ResourceData & data, BytesRang
 
     if (IsActiveBrowseParse())
     {
-        TxtParser<DnssdNodeData> delegate(mSpecificResolutionData.Get<DnssdNodeData>());
+        TxtParser<CommissionNodeData> delegate(mSpecificResolutionData.Get<CommissionNodeData>());
         if (!ParseTxtRecord(data.GetData(), &delegate))
         {
             return CHIP_ERROR_INVALID_ARGUMENT;
@@ -347,8 +347,10 @@ CHIP_ERROR IncrementalResolver::Take(DiscoveredNodeData & outputData)
 
     IPAddressSorter::Sort(mCommonResolutionData.ipAddress, mCommonResolutionData.numIPs, mCommonResolutionData.interfaceId);
 
-    outputData.resolutionData = mCommonResolutionData;
-    outputData.nodeData       = mSpecificResolutionData.Get<DnssdNodeData>();
+    outputData.Set<CommissionNodeData>();
+    CommissionNodeData & nodeData = outputData.Get<CommissionNodeData>();
+    nodeData = mSpecificResolutionData.Get<CommissionNodeData>();
+    (CommonResolutionData &)nodeData = mCommonResolutionData;
 
     ResetToInactive();
 

--- a/src/lib/dnssd/IncrementalResolve.cpp
+++ b/src/lib/dnssd/IncrementalResolve.cpp
@@ -348,10 +348,10 @@ CHIP_ERROR IncrementalResolver::Take(DiscoveredNodeData & outputData)
     IPAddressSorter::Sort(mCommonResolutionData.ipAddress, mCommonResolutionData.numIPs, mCommonResolutionData.interfaceId);
 
     outputData.Set<CommissionNodeData>();
-    CommissionNodeData & nodeData     = outputData.Get<CommissionNodeData>();
-    nodeData                          = mSpecificResolutionData.Get<CommissionNodeData>();
+    CommissionNodeData & nodeData         = outputData.Get<CommissionNodeData>();
+    nodeData                              = mSpecificResolutionData.Get<CommissionNodeData>();
     CommonResolutionData & resolutionData = nodeData;
-    resolutionData = mCommonResolutionData;
+    resolutionData                        = mCommonResolutionData;
 
     ResetToInactive();
 

--- a/src/lib/dnssd/IncrementalResolve.h
+++ b/src/lib/dnssd/IncrementalResolve.h
@@ -100,7 +100,7 @@ public:
     /// method.
     bool IsActive() const { return mSpecificResolutionData.Valid(); }
 
-    bool IsActiveBrowseParse() const { return mSpecificResolutionData.Is<DnssdNodeData>(); }
+    bool IsActiveBrowseParse() const { return mSpecificResolutionData.Is<CommissionNodeData>(); }
     bool IsActiveOperationalParse() const { return mSpecificResolutionData.Is<OperationalNodeData>(); }
 
     ServiceNameType GetCurrentType() const { return mServiceNameType; }
@@ -185,7 +185,7 @@ private:
     /// Prerequisite: IP address belongs to the right nost name
     CHIP_ERROR OnIpAddress(Inet::InterfaceId interface, const Inet::IPAddress & addr);
 
-    using ParsedRecordSpecificData = Variant<OperationalNodeData, DnssdNodeData>;
+    using ParsedRecordSpecificData = Variant<OperationalNodeData, CommissionNodeData>;
 
     StoredServerName mRecordName;     // Record name for what is parsed (SRV/PTR/TXT)
     StoredServerName mTargetHostName; // `Target` for the SRV record

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -425,12 +425,10 @@ void MinMdnsResolver::AdvancePendingResolverStates()
             case IncrementalResolver::ServiceNameType::kCommissioner:
                 discoveredNodeIsRelevant = mActiveResolves.HasBrowseFor(chip::Dnssd::DiscoveryType::kCommissionerNode);
                 mActiveResolves.CompleteCommissioner(nodeData);
-                nodeData.nodeType = DiscoveryType::kCommissionerNode;
                 break;
             case IncrementalResolver::ServiceNameType::kCommissionable:
                 discoveredNodeIsRelevant = mActiveResolves.HasBrowseFor(chip::Dnssd::DiscoveryType::kCommissionableNode);
                 mActiveResolves.CompleteCommissionable(nodeData);
-                nodeData.nodeType = DiscoveryType::kCommissionableNode;
                 break;
             default:
                 ChipLogError(Discovery, "Unexpected type for browse data parsing");

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -225,7 +225,7 @@ TxtFieldKey GetTxtFieldKey(const ByteSpan & key)
 
 } // namespace Internal
 
-void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, DnssdNodeData & nodeData)
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, CommissionNodeData & nodeData)
 {
     TxtFieldKey keyType = Internal::GetTxtFieldKey(key);
     switch (keyType)

--- a/src/lib/dnssd/TxtFields.h
+++ b/src/lib/dnssd/TxtFields.h
@@ -192,7 +192,7 @@ constexpr size_t ValSize(TxtFieldKey key)
 }
 
 void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, CommonResolutionData & nodeData);
-void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, DnssdNodeData & nodeData);
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, CommissionNodeData & nodeData);
 
 } // namespace Dnssd
 } // namespace chip

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -235,6 +235,7 @@ struct CommissionNodeData : public CommonResolutionData
 
     void LogDetail() const
     {
+        ChipLogDetail(Discovery, "Discovered commissionable/commissioners node:");
         CommonResolutionData::LogDetail();
 
         if (rotatingIdLen > 0)
@@ -298,30 +299,6 @@ struct ResolvedNodeData
 };
 
 using DiscoveredNodeData = Variant<CommissionNodeData>;
-
-#if 0
-struct DiscoveredNodeData
-{
-    CommonResolutionData resolutionData;
-    CommissionNodeData nodeData;
-    DiscoveryType nodeType;
-
-    void Reset()
-    {
-        resolutionData.Reset();
-        nodeData.Reset();
-        nodeType = DiscoveryType::kUnknown;
-    }
-    DiscoveredNodeData() { Reset(); }
-
-    void LogDetail() const
-    {
-        ChipLogDetail(Discovery, "Discovered node:");
-        resolutionData.LogDetail();
-        nodeData.LogDetail();
-    }
-};
-#endif
 
 /// Callbacks for discovering nodes advertising non-operational status:
 ///   - Commissioners

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -26,6 +26,7 @@
 #include <lib/core/PeerId.h>
 #include <lib/dnssd/Constants.h>
 #include <lib/support/BytesToHex.h>
+#include <lib/support/Variant.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ReliableMessageProtocolConfig.h>
 
@@ -205,7 +206,7 @@ inline constexpr size_t kMaxRotatingIdLen         = 50;
 inline constexpr size_t kMaxPairingInstructionLen = 128;
 
 /// Data that is specific to commisionable/commissioning node discovery
-struct DnssdNodeData
+struct CommissionNodeData : public CommonResolutionData
 {
     size_t rotatingIdLen                                      = 0;
     uint32_t deviceType                                       = 0;
@@ -220,19 +221,22 @@ struct DnssdNodeData
     char deviceName[kMaxDeviceNameLen + 1]                    = {};
     char pairingInstruction[kMaxPairingInstructionLen + 1]    = {};
 
-    DnssdNodeData() {}
+    CommissionNodeData() {}
 
     void Reset()
     {
+        CommonResolutionData::Reset();
         // Let constructor clear things as default
-        this->~DnssdNodeData();
-        new (this) DnssdNodeData();
+        this->~CommissionNodeData();
+        new (this) CommissionNodeData();
     }
 
     bool IsInstanceName(const char * instance) const { return strcmp(instance, instanceName) == 0; }
 
     void LogDetail() const
     {
+        CommonResolutionData::LogDetail();
+
         if (rotatingIdLen > 0)
         {
             char rotatingIdString[chip::Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
@@ -293,10 +297,13 @@ struct ResolvedNodeData
     }
 };
 
+using DiscoveredNodeData = Variant<CommissionNodeData>;
+
+#if 0
 struct DiscoveredNodeData
 {
     CommonResolutionData resolutionData;
-    DnssdNodeData nodeData;
+    CommissionNodeData nodeData;
     DiscoveryType nodeType;
 
     void Reset()
@@ -314,6 +321,7 @@ struct DiscoveredNodeData
         nodeData.LogDetail();
     }
 };
+#endif
 
 /// Callbacks for discovering nodes advertising non-operational status:
 ///   - Commissioners

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -225,7 +225,6 @@ struct CommissionNodeData : public CommonResolutionData
 
     void Reset()
     {
-        CommonResolutionData::Reset();
         // Let constructor clear things as default
         this->~CommissionNodeData();
         new (this) CommissionNodeData();
@@ -235,7 +234,7 @@ struct CommissionNodeData : public CommonResolutionData
 
     void LogDetail() const
     {
-        ChipLogDetail(Discovery, "Discovered commissionable/commissioners node:");
+        ChipLogDetail(Discovery, "Discovered commissionable/commissioner node:");
         CommonResolutionData::LogDetail();
 
         if (rotatingIdLen > 0)

--- a/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
@@ -124,7 +124,8 @@ TEST(TestActiveResolveAttempts, TestSingleBrowseAddRemove)
 
     // once complete, nothing to schedule
     Dnssd::DiscoveredNodeData data;
-    data.nodeData.longDiscriminator = 1234;
+    data.Set<chip::Dnssd::CommissionNodeData>();
+    data.Get<chip::Dnssd::CommissionNodeData>().longDiscriminator = 1234;
     attempts.CompleteCommissionable(data);
     EXPECT_FALSE(attempts.GetTimeUntilNextExpectedResponse().HasValue());
     EXPECT_FALSE(attempts.NextScheduled().HasValue());
@@ -372,7 +373,8 @@ TEST(TestActiveResolveAttempts, TestCombination)
     attempts.Complete(MakePeerId(2));
     attempts.Complete(MakePeerId(1));
     Dnssd::DiscoveredNodeData data;
-    data.nodeData.longDiscriminator = 1234;
+    data.Set<chip::Dnssd::CommissionNodeData>();
+    data.Get<chip::Dnssd::CommissionNodeData>().longDiscriminator = 1234;
     attempts.CompleteCommissionable(data);
 
     EXPECT_FALSE(attempts.GetTimeUntilNextExpectedResponse().HasValue());

--- a/src/lib/dnssd/tests/TestIncrementalResolve.cpp
+++ b/src/lib/dnssd/tests/TestIncrementalResolve.cpp
@@ -385,28 +385,31 @@ TEST(TestIncrementalResolve, TestParseCommissionable)
     EXPECT_FALSE(resolver.GetMissingRequiredInformation().HasAny());
 
     // At this point taking value should work. Once taken, the resolver is reset.
-    DiscoveredNodeData nodeData;
-    EXPECT_EQ(resolver.Take(nodeData), CHIP_NO_ERROR);
+    DiscoveredNodeData discoveredNodeData;
+    EXPECT_TRUE(resolver.Take(discoveredNodeData) == CHIP_NO_ERROR);
     EXPECT_FALSE(resolver.IsActive());
 
+    EXPECT_TRUE(discoveredNodeData.Is<CommissionNodeData>());
+    CommissionNodeData nodeData = discoveredNodeData.Get<CommissionNodeData>();
+
     // validate data as it was passed in
-    EXPECT_EQ(nodeData.resolutionData.numIPs, 2u);
-    EXPECT_EQ(nodeData.resolutionData.port, 0x1234);
-    EXPECT_FALSE(nodeData.resolutionData.supportsTcp);
-    EXPECT_TRUE(nodeData.resolutionData.GetMrpRetryIntervalActive().HasValue());
-    EXPECT_EQ(nodeData.resolutionData.GetMrpRetryIntervalActive().Value(), chip::System::Clock::Milliseconds32(321));
-    EXPECT_FALSE(nodeData.resolutionData.GetMrpRetryIntervalIdle().HasValue());
+    EXPECT_EQ(nodeData.numIPs, 2u);
+    EXPECT_EQ(nodeData.port, 0x1234);
+    EXPECT_FALSE(nodeData.supportsTcp);
+    EXPECT_TRUE(nodeData.GetMrpRetryIntervalActive().HasValue());
+    EXPECT_EQ(nodeData.GetMrpRetryIntervalActive().Value(), chip::System::Clock::Milliseconds32(321));
+    EXPECT_FALSE(nodeData.GetMrpRetryIntervalIdle().HasValue());
 
     Inet::IPAddress addr;
     EXPECT_TRUE(Inet::IPAddress::FromString("fe80::abcd:ef11:2233:4455", addr));
-    EXPECT_EQ(nodeData.resolutionData.ipAddress[0], addr);
+    EXPECT_EQ(nodeData.ipAddress[0], addr);
     EXPECT_TRUE(Inet::IPAddress::FromString("fe80::f0f1:f2f3:f4f5:1234", addr));
-    EXPECT_EQ(nodeData.resolutionData.ipAddress[1], addr);
+    EXPECT_EQ(nodeData.ipAddress[1], addr);
 
     // parsed txt data for discovered nodes
-    EXPECT_EQ(nodeData.nodeData.longDiscriminator, 22345);
-    EXPECT_EQ(nodeData.nodeData.vendorId, 321);
-    EXPECT_EQ(nodeData.nodeData.productId, 654);
-    EXPECT_STREQ(nodeData.nodeData.deviceName, "mytest");
+    EXPECT_EQ(nodeData.longDiscriminator, 22345);
+    EXPECT_EQ(nodeData.vendorId, 321);
+    EXPECT_EQ(nodeData.productId, 654);
+    EXPECT_STREQ(nodeData.deviceName, "mytest");
 }
 } // namespace

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -303,12 +303,10 @@ TEST(TestTxtFields, TestGetCommissionerPasscode)
 bool NodeDataIsEmpty(const CommissionNodeData & node)
 {
 
-    if (node.longDiscriminator != 0 || node.vendorId != 0 || node.productId != 0 ||
-        node.commissioningMode != 0 || node.deviceType != 0 || node.rotatingIdLen != 0 ||
-        node.pairingHint != 0 || node.mrpRetryIntervalIdle.HasValue() ||
-        node.mrpRetryIntervalActive.HasValue() || node.mrpRetryActiveThreshold.HasValue() ||
-        node.isICDOperatingAsLIT.HasValue() || node.supportsTcp ||
-        node.supportsCommissionerGeneratedPasscode != 0)
+    if (node.longDiscriminator != 0 || node.vendorId != 0 || node.productId != 0 || node.commissioningMode != 0 ||
+        node.deviceType != 0 || node.rotatingIdLen != 0 || node.pairingHint != 0 || node.mrpRetryIntervalIdle.HasValue() ||
+        node.mrpRetryIntervalActive.HasValue() || node.mrpRetryActiveThreshold.HasValue() || node.isICDOperatingAsLIT.HasValue() ||
+        node.supportsTcp || node.supportsCommissionerGeneratedPasscode != 0)
     {
         return false;
     }
@@ -461,55 +459,55 @@ void DiscoveredTxtFieldSessionIdleInterval()
     strcpy(key, "SII");
     strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().Value() == 1_ms32);
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().Value() == 1_ms32);
 
     // Maximum
     strcpy(key, "SII");
     strcpy(val, "3600000");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().Value() == 3600000_ms32);
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().Value() == 3600000_ms32);
 
     // Test no other fields were populated
     ResetRetryIntervalIdle(nodeData);
-    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+    EXPECT_TRUE(NodeDataIsEmpty(nodeData.Get<NodeData>()));
 
     // Invalid SII - negative value
     strcpy(key, "SII");
     strcpy(val, "-1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - greater than maximum
     strcpy(key, "SII");
     strcpy(val, "3600001");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - much greater than maximum
     strcpy(key, "SII");
     strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - hexadecimal value
     strcpy(key, "SII");
     strcpy(val, "0x20");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - leading zeros
     strcpy(key, "SII");
     strcpy(val, "0700");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - text at the end
     strcpy(key, "SII");
     strcpy(val, "123abc");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 }
 
 // Test SAI (formerly CRA)
@@ -526,55 +524,55 @@ void DiscoveredTxtFieldSessionActiveInterval()
     strcpy(key, "SAI");
     strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().Value() == 1_ms32);
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryIntervalActive().Value() == 1_ms32);
 
     // Maximum
     strcpy(key, "SAI");
     strcpy(val, "3600000");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().Value() == 3600000_ms32);
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryIntervalActive().Value() == 3600000_ms32);
 
     // Test no other fields were populated
     ResetRetryIntervalActive(nodeData);
-    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+    EXPECT_TRUE(NodeDataIsEmpty(nodeData.Get<NodeData>()));
 
     // Invalid SAI - negative value
     strcpy(key, "SAI");
     strcpy(val, "-1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - greater than maximum
     strcpy(key, "SAI");
     strcpy(val, "3600001");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - much greater than maximum
     strcpy(key, "SAI");
     strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - hexadecimal value
     strcpy(key, "SAI");
     strcpy(val, "0x20");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - leading zeros
     strcpy(key, "SAI");
     strcpy(val, "0700");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - text at the end
     strcpy(key, "SAI");
     strcpy(val, "123abc");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 }
 
 // Test SAT (Session Active Threshold)
@@ -591,55 +589,55 @@ void DiscoveredTxtFieldSessionActiveThreshold()
     strcpy(key, "SAT");
     strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().Value() == 1_ms16);
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().Value() == 1_ms16);
 
     // Maximum
     strcpy(key, "SAT");
     strcpy(val, "65535");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
-    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().Value() == 65535_ms16);
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+    EXPECT_TRUE(nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().Value() == 65535_ms16);
 
     // Test no other fields were populated
     ResetRetryActiveThreshold(nodeData);
-    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+    EXPECT_TRUE(NodeDataIsEmpty(nodeData.Get<NodeData>()));
 
     // Invalid SAI - negative value
     strcpy(key, "SAT");
     strcpy(val, "-1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 
     // Invalid SAI - greater than maximum
     strcpy(key, "SAT");
     strcpy(val, "65536");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 
     // Invalid SAT - much greater than maximum
     strcpy(key, "SAT");
     strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 
     // Invalid SAT - hexadecimal value
     strcpy(key, "SAT");
     strcpy(val, "0x20");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 
     // Invalid SAT - leading zeros
     strcpy(key, "SAT");
     strcpy(val, "0700");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 
     // Invalid SAT - text at the end
     strcpy(key, "SAT");
     strcpy(val, "123abc");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+    EXPECT_TRUE(!nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 }
 
 // Test T (TCP support)
@@ -656,23 +654,23 @@ void DiscoveredTxtFieldTcpSupport()
     strcpy(key, "T");
     strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().supportsTcp);
+    EXPECT_TRUE(nodeData.Get<NodeData>().supportsTcp);
 
     // Test no other fields were populated
     nodeData.Get<NodeData>().supportsTcp = false;
-    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+    EXPECT_TRUE(NodeDataIsEmpty(nodeData.Get<NodeData>()));
 
     // False
     strcpy(key, "T");
     strcpy(val, "0");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().supportsTcp == false);
+    EXPECT_TRUE(nodeData.Get<NodeData>().supportsTcp == false);
 
     // Invalid value, stil false
     strcpy(key, "T");
     strcpy(val, "asdf");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().supportsTcp == false);
+    EXPECT_TRUE(nodeData.Get<NodeData>().supportsTcp == false);
 }
 
 // Test ICD (ICD operation Mode)
@@ -689,27 +687,27 @@ void DiscoveredTxtFieldICDoperatesAsLIT()
     strcpy(key, "ICD");
     strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue());
-    EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.Value());
+    EXPECT_TRUE(nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue());
+    EXPECT_TRUE(nodeData.Get<NodeData>().isICDOperatingAsLIT.Value());
 
     // Test no other fields were populated
     nodeData.Get<NodeData>().isICDOperatingAsLIT.ClearValue();
-    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+    EXPECT_TRUE(NodeDataIsEmpty(nodeData.Get<NodeData>()));
 
     // ICD is operating as a SIT device
     strcpy(key, "ICD");
     strcpy(val, "0");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue());
-    EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.Value() == false);
+    EXPECT_TRUE(nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue());
+    EXPECT_TRUE(nodeData.Get<NodeData>().isICDOperatingAsLIT.Value() == false);
 
     nodeData.Get<NodeData>().isICDOperatingAsLIT.ClearValue();
-    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+    EXPECT_TRUE(NodeDataIsEmpty(nodeData.Get<NodeData>()));
     // Invalid value, No key set
     strcpy(key, "ICD");
     strcpy(val, "asdf");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue() == false);
+    EXPECT_TRUE(nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue() == false);
 }
 
 // Test IsDeviceTreatedAsSleepy() with CRI
@@ -725,19 +723,19 @@ void DiscoveredTestIsDeviceSessionIdle()
     CommonResolutionData & resolutionData = nodeData.Get<NodeData>();
 
     // No key/val set, so the device can't be sleepy
-    EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
+    EXPECT_TRUE(!nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is the default value, the device is not sleepy
     strcpy(key, "SII");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL.count()));
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
+    EXPECT_TRUE(!nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is greater than the default value, the device is sleepy
     sprintf(key, "SII");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL.count() + 1));
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
+    EXPECT_TRUE(nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 }
 
 // Test IsDeviceTreatedAsSleepy() with CRA
@@ -753,19 +751,19 @@ void DiscoveredTestIsDeviceSessionActive()
     CommonResolutionData & resolutionData = nodeData.Get<NodeData>();
 
     // No key/val set, so the device can't be sleepy
-    EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
+    EXPECT_TRUE(!nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is the default value, the device is not sleepy
     sprintf(key, "SAI");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL.count()));
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
+    EXPECT_TRUE(!nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is greater than the default value, the device is sleepy
     strcpy(key, "SAI");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL.count() + 1));
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
-    EXPECT_TRUE( nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
+    EXPECT_TRUE(nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 }
 
 // Test SAI (formally CRI)

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -455,18 +455,19 @@ void DiscoveredTxtFieldSessionIdleInterval()
     char val[16];
     DiscoveredNodeData nodeData;
     nodeData.Set<NodeData>();
+    CommonResolutionData & resolutionData = nodeData.Get<NodeData>();
 
     // Minimum
     strcpy(key, "SII");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().Value() == 1_ms32);
 
     // Maximum
     strcpy(key, "SII");
     strcpy(val, "3600000");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().Value() == 3600000_ms32);
 
@@ -477,37 +478,37 @@ void DiscoveredTxtFieldSessionIdleInterval()
     // Invalid SII - negative value
     strcpy(key, "SII");
     strcpy(val, "-1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - greater than maximum
     strcpy(key, "SII");
     strcpy(val, "3600001");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - much greater than maximum
     strcpy(key, "SII");
     strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - hexadecimal value
     strcpy(key, "SII");
     strcpy(val, "0x20");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - leading zeros
     strcpy(key, "SII");
     strcpy(val, "0700");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - text at the end
     strcpy(key, "SII");
     strcpy(val, "123abc");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
 }
 
@@ -519,18 +520,19 @@ void DiscoveredTxtFieldSessionActiveInterval()
     char val[16];
     DiscoveredNodeData nodeData;
     nodeData.Set<NodeData>();
+    CommonResolutionData & resolutionData = nodeData.Get<NodeData>();
 
     // Minimum
     strcpy(key, "SAI");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().Value() == 1_ms32);
 
     // Maximum
     strcpy(key, "SAI");
     strcpy(val, "3600000");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().Value() == 3600000_ms32);
 
@@ -541,37 +543,37 @@ void DiscoveredTxtFieldSessionActiveInterval()
     // Invalid SAI - negative value
     strcpy(key, "SAI");
     strcpy(val, "-1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - greater than maximum
     strcpy(key, "SAI");
     strcpy(val, "3600001");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - much greater than maximum
     strcpy(key, "SAI");
     strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - hexadecimal value
     strcpy(key, "SAI");
     strcpy(val, "0x20");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - leading zeros
     strcpy(key, "SAI");
     strcpy(val, "0700");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - text at the end
     strcpy(key, "SAI");
     strcpy(val, "123abc");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
 }
 
@@ -583,18 +585,19 @@ void DiscoveredTxtFieldSessionActiveThreshold()
     char val[16];
     DiscoveredNodeData nodeData;
     nodeData.Set<NodeData>();
+    CommonResolutionData & resolutionData = nodeData.Get<NodeData>();
 
     // Minimum
     strcpy(key, "SAT");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().Value() == 1_ms16);
 
     // Maximum
     strcpy(key, "SAT");
     strcpy(val, "65535");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
     EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().Value() == 65535_ms16);
 
@@ -605,37 +608,37 @@ void DiscoveredTxtFieldSessionActiveThreshold()
     // Invalid SAI - negative value
     strcpy(key, "SAT");
     strcpy(val, "-1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 
     // Invalid SAI - greater than maximum
     strcpy(key, "SAT");
     strcpy(val, "65536");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 
     // Invalid SAT - much greater than maximum
     strcpy(key, "SAT");
     strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 
     // Invalid SAT - hexadecimal value
     strcpy(key, "SAT");
     strcpy(val, "0x20");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 
     // Invalid SAT - leading zeros
     strcpy(key, "SAT");
     strcpy(val, "0700");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 
     // Invalid SAT - text at the end
     strcpy(key, "SAT");
     strcpy(val, "123abc");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
 }
 
@@ -647,11 +650,12 @@ void DiscoveredTxtFieldTcpSupport()
     char val[8];
     DiscoveredNodeData nodeData;
     nodeData.Set<NodeData>();
+    CommonResolutionData & resolutionData = nodeData.Get<NodeData>();
 
     // True
     strcpy(key, "T");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().supportsTcp);
 
     // Test no other fields were populated
@@ -661,13 +665,13 @@ void DiscoveredTxtFieldTcpSupport()
     // False
     strcpy(key, "T");
     strcpy(val, "0");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().supportsTcp == false);
 
     // Invalid value, stil false
     strcpy(key, "T");
     strcpy(val, "asdf");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().supportsTcp == false);
 }
 
@@ -679,11 +683,12 @@ void DiscoveredTxtFieldICDoperatesAsLIT()
     char val[16];
     DiscoveredNodeData nodeData;
     nodeData.Set<NodeData>();
+    CommonResolutionData & resolutionData = nodeData.Get<NodeData>();
 
     // ICD is operating as a LIT device
     strcpy(key, "ICD");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue());
     EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.Value());
 
@@ -694,7 +699,7 @@ void DiscoveredTxtFieldICDoperatesAsLIT()
     // ICD is operating as a SIT device
     strcpy(key, "ICD");
     strcpy(val, "0");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue());
     EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.Value() == false);
 
@@ -703,7 +708,7 @@ void DiscoveredTxtFieldICDoperatesAsLIT()
     // Invalid value, No key set
     strcpy(key, "ICD");
     strcpy(val, "asdf");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue() == false);
 }
 
@@ -717,6 +722,7 @@ void DiscoveredTestIsDeviceSessionIdle()
     nodeData.Set<NodeData>();
     const ReliableMessageProtocolConfig defaultMRPConfig(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL,
                                                          CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL);
+    CommonResolutionData & resolutionData = nodeData.Get<NodeData>();
 
     // No key/val set, so the device can't be sleepy
     EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
@@ -724,13 +730,13 @@ void DiscoveredTestIsDeviceSessionIdle()
     // If the interval is the default value, the device is not sleepy
     strcpy(key, "SII");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL.count()));
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is greater than the default value, the device is sleepy
     sprintf(key, "SII");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL.count() + 1));
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 }
 
@@ -744,6 +750,7 @@ void DiscoveredTestIsDeviceSessionActive()
     nodeData.Set<NodeData>();
     const ReliableMessageProtocolConfig defaultMRPConfig(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL,
                                                          CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL);
+    CommonResolutionData & resolutionData = nodeData.Get<NodeData>();
 
     // No key/val set, so the device can't be sleepy
     EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
@@ -751,13 +758,13 @@ void DiscoveredTestIsDeviceSessionActive()
     // If the interval is the default value, the device is not sleepy
     sprintf(key, "SAI");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL.count()));
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is greater than the default value, the device is sleepy
     strcpy(key, "SAI");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL.count() + 1));
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), resolutionData);
     EXPECT_TRUE( nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 }
 

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -300,23 +300,23 @@ TEST(TestTxtFields, TestGetCommissionerPasscode)
     EXPECT_EQ(GetCommissionerPasscode(GetSpan(cm)), 0);
 }
 
-bool NodeDataIsEmpty(const DiscoveredNodeData & node)
+bool NodeDataIsEmpty(const CommissionNodeData & node)
 {
 
-    if (node.nodeData.longDiscriminator != 0 || node.nodeData.vendorId != 0 || node.nodeData.productId != 0 ||
-        node.nodeData.commissioningMode != 0 || node.nodeData.deviceType != 0 || node.nodeData.rotatingIdLen != 0 ||
-        node.nodeData.pairingHint != 0 || node.resolutionData.mrpRetryIntervalIdle.HasValue() ||
-        node.resolutionData.mrpRetryIntervalActive.HasValue() || node.resolutionData.mrpRetryActiveThreshold.HasValue() ||
-        node.resolutionData.isICDOperatingAsLIT.HasValue() || node.resolutionData.supportsTcp ||
-        node.nodeData.supportsCommissionerGeneratedPasscode != 0)
+    if (node.longDiscriminator != 0 || node.vendorId != 0 || node.productId != 0 ||
+        node.commissioningMode != 0 || node.deviceType != 0 || node.rotatingIdLen != 0 ||
+        node.pairingHint != 0 || node.mrpRetryIntervalIdle.HasValue() ||
+        node.mrpRetryIntervalActive.HasValue() || node.mrpRetryActiveThreshold.HasValue() ||
+        node.isICDOperatingAsLIT.HasValue() || node.supportsTcp ||
+        node.supportsCommissionerGeneratedPasscode != 0)
     {
         return false;
     }
-    if (strcmp(node.nodeData.deviceName, "") != 0 || strcmp(node.nodeData.pairingInstruction, "") != 0)
+    if (strcmp(node.deviceName, "") != 0 || strcmp(node.pairingInstruction, "") != 0)
     {
         return false;
     }
-    for (uint8_t id : node.nodeData.rotatingId)
+    for (uint8_t id : node.rotatingId)
     {
         if (id != 0)
         {
@@ -331,83 +331,82 @@ TEST(TestTxtFields, TestFillDiscoveredNodeDataFromTxt)
 {
     char key[3];
     char val[16];
-    DiscoveredNodeData filled;
+    CommissionNodeData filled;
 
     // Long discriminator
     strcpy(key, "D");
     strcpy(val, "840");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
-    EXPECT_EQ(filled.nodeData.longDiscriminator, 840);
-    filled.nodeData.longDiscriminator = 0;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    EXPECT_EQ(filled.longDiscriminator, 840);
+    filled.longDiscriminator = 0;
     EXPECT_TRUE(NodeDataIsEmpty(filled));
 
     // vendor and product
     strcpy(key, "VP");
     strcpy(val, "123+456");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
-    EXPECT_EQ(filled.nodeData.vendorId, 123);
-    EXPECT_EQ(filled.nodeData.productId, 456);
-    filled.nodeData.vendorId  = 0;
-    filled.nodeData.productId = 0;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    EXPECT_EQ(filled.vendorId, 123);
+    EXPECT_EQ(filled.productId, 456);
+    filled.vendorId  = 0;
+    filled.productId = 0;
     EXPECT_TRUE(NodeDataIsEmpty(filled));
 
     // Commissioning mode
     strcpy(key, "CM");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
-    EXPECT_EQ(filled.nodeData.commissioningMode, 1);
-    filled.nodeData.commissioningMode = 0;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    EXPECT_EQ(filled.commissioningMode, 1);
+    filled.commissioningMode = 0;
     EXPECT_TRUE(NodeDataIsEmpty(filled));
-
     // Supports Commissioner Generated Passcode
     strcpy(key, "CP");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
-    EXPECT_TRUE(filled.nodeData.supportsCommissionerGeneratedPasscode);
-    filled.nodeData.supportsCommissionerGeneratedPasscode = false;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    EXPECT_TRUE(filled.supportsCommissionerGeneratedPasscode);
+    filled.supportsCommissionerGeneratedPasscode = false;
     EXPECT_TRUE(NodeDataIsEmpty(filled));
 
     // Device type
     strcpy(key, "DT");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
-    EXPECT_EQ(filled.nodeData.deviceType, 1u);
-    filled.nodeData.deviceType = 0;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    EXPECT_EQ(filled.deviceType, 1u);
+    filled.deviceType = 0;
     EXPECT_TRUE(NodeDataIsEmpty(filled));
 
     // Device name
     strcpy(key, "DN");
     strcpy(val, "abc");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
-    EXPECT_STREQ(filled.nodeData.deviceName, "abc");
-    memset(filled.nodeData.deviceName, 0, sizeof(filled.nodeData.deviceName));
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    EXPECT_STREQ(filled.deviceName, "abc");
+    memset(filled.deviceName, 0, sizeof(filled.deviceName));
     EXPECT_TRUE(NodeDataIsEmpty(filled));
 
     // Rotating device id
     strcpy(key, "RI");
     strcpy(val, "1A2B");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
-    EXPECT_EQ(filled.nodeData.rotatingId[0], 0x1A);
-    EXPECT_EQ(filled.nodeData.rotatingId[1], 0x2B);
-    EXPECT_EQ(filled.nodeData.rotatingIdLen, 2u);
-    filled.nodeData.rotatingIdLen = 0;
-    memset(filled.nodeData.rotatingId, 0, sizeof(filled.nodeData.rotatingId));
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    EXPECT_EQ(filled.rotatingId[0], 0x1A);
+    EXPECT_EQ(filled.rotatingId[1], 0x2B);
+    EXPECT_EQ(filled.rotatingIdLen, 2u);
+    filled.rotatingIdLen = 0;
+    memset(filled.rotatingId, 0, sizeof(filled.rotatingId));
     EXPECT_TRUE(NodeDataIsEmpty(filled));
 
     // Pairing instruction
     strcpy(key, "PI");
     strcpy(val, "hint");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
-    EXPECT_STREQ(filled.nodeData.pairingInstruction, "hint");
-    memset(filled.nodeData.pairingInstruction, 0, sizeof(filled.nodeData.pairingInstruction));
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    EXPECT_STREQ(filled.pairingInstruction, "hint");
+    memset(filled.pairingInstruction, 0, sizeof(filled.pairingInstruction));
     EXPECT_TRUE(NodeDataIsEmpty(filled));
 
     // Pairing hint
     strcpy(key, "PH");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
-    EXPECT_EQ(filled.nodeData.pairingHint, 1);
-    filled.nodeData.pairingHint = 0;
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    EXPECT_EQ(filled.pairingHint, 1);
+    filled.pairingHint = 0;
     EXPECT_TRUE(NodeDataIsEmpty(filled));
 }
 
@@ -421,7 +420,7 @@ bool NodeDataIsEmpty(const ResolvedNodeData & nodeData)
 
 void ResetRetryIntervalIdle(DiscoveredNodeData & nodeData)
 {
-    nodeData.resolutionData.mrpRetryIntervalIdle.ClearValue();
+    nodeData.Get<CommissionNodeData>().mrpRetryIntervalIdle.ClearValue();
 }
 
 void ResetRetryIntervalIdle(ResolvedNodeData & nodeData)
@@ -431,7 +430,7 @@ void ResetRetryIntervalIdle(ResolvedNodeData & nodeData)
 
 void ResetRetryIntervalActive(DiscoveredNodeData & nodeData)
 {
-    nodeData.resolutionData.mrpRetryIntervalActive.ClearValue();
+    nodeData.Get<CommissionNodeData>().mrpRetryIntervalActive.ClearValue();
 }
 
 void ResetRetryIntervalActive(ResolvedNodeData & nodeData)
@@ -441,12 +440,325 @@ void ResetRetryIntervalActive(ResolvedNodeData & nodeData)
 
 void ResetRetryActiveThreshold(DiscoveredNodeData & nodeData)
 {
-    nodeData.resolutionData.mrpRetryActiveThreshold.ClearValue();
+    nodeData.Get<CommissionNodeData>().mrpRetryActiveThreshold.ClearValue();
 }
 
 void ResetRetryActiveThreshold(ResolvedNodeData & nodeData)
 {
     nodeData.resolutionData.mrpRetryActiveThreshold.ClearValue();
+}
+
+template <class NodeData>
+void DiscoveredTxtFieldSessionIdleInterval()
+{
+    char key[4];
+    char val[16];
+    DiscoveredNodeData nodeData;
+    nodeData.Set<NodeData>();
+
+    // Minimum
+    strcpy(key, "SII");
+    strcpy(val, "1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().Value() == 1_ms32);
+
+    // Maximum
+    strcpy(key, "SII");
+    strcpy(val, "3600000");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().Value() == 3600000_ms32);
+
+    // Test no other fields were populated
+    ResetRetryIntervalIdle(nodeData);
+    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+
+    // Invalid SII - negative value
+    strcpy(key, "SII");
+    strcpy(val, "-1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+
+    // Invalid SII - greater than maximum
+    strcpy(key, "SII");
+    strcpy(val, "3600001");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+
+    // Invalid SII - much greater than maximum
+    strcpy(key, "SII");
+    strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+
+    // Invalid SII - hexadecimal value
+    strcpy(key, "SII");
+    strcpy(val, "0x20");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+
+    // Invalid SII - leading zeros
+    strcpy(key, "SII");
+    strcpy(val, "0700");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+
+    // Invalid SII - text at the end
+    strcpy(key, "SII");
+    strcpy(val, "123abc");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalIdle().HasValue());
+}
+
+// Test SAI (formerly CRA)
+template <class NodeData>
+void DiscoveredTxtFieldSessionActiveInterval()
+{
+    char key[4];
+    char val[16];
+    DiscoveredNodeData nodeData;
+    nodeData.Set<NodeData>();
+
+    // Minimum
+    strcpy(key, "SAI");
+    strcpy(val, "1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().Value() == 1_ms32);
+
+    // Maximum
+    strcpy(key, "SAI");
+    strcpy(val, "3600000");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryIntervalActive().Value() == 3600000_ms32);
+
+    // Test no other fields were populated
+    ResetRetryIntervalActive(nodeData);
+    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+
+    // Invalid SAI - negative value
+    strcpy(key, "SAI");
+    strcpy(val, "-1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+
+    // Invalid SAI - greater than maximum
+    strcpy(key, "SAI");
+    strcpy(val, "3600001");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+
+    // Invalid SAI - much greater than maximum
+    strcpy(key, "SAI");
+    strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+
+    // Invalid SAI - hexadecimal value
+    strcpy(key, "SAI");
+    strcpy(val, "0x20");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+
+    // Invalid SAI - leading zeros
+    strcpy(key, "SAI");
+    strcpy(val, "0700");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+
+    // Invalid SAI - text at the end
+    strcpy(key, "SAI");
+    strcpy(val, "123abc");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryIntervalActive().HasValue());
+}
+
+// Test SAT (Session Active Threshold)
+template <class NodeData>
+void DiscoveredTxtFieldSessionActiveThreshold()
+{
+    char key[4];
+    char val[16];
+    DiscoveredNodeData nodeData;
+    nodeData.Set<NodeData>();
+
+    // Minimum
+    strcpy(key, "SAT");
+    strcpy(val, "1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().Value() == 1_ms16);
+
+    // Maximum
+    strcpy(key, "SAT");
+    strcpy(val, "65535");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+    EXPECT_TRUE( nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().Value() == 65535_ms16);
+
+    // Test no other fields were populated
+    ResetRetryActiveThreshold(nodeData);
+    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+
+    // Invalid SAI - negative value
+    strcpy(key, "SAT");
+    strcpy(val, "-1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+
+    // Invalid SAI - greater than maximum
+    strcpy(key, "SAT");
+    strcpy(val, "65536");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+
+    // Invalid SAT - much greater than maximum
+    strcpy(key, "SAT");
+    strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+
+    // Invalid SAT - hexadecimal value
+    strcpy(key, "SAT");
+    strcpy(val, "0x20");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+
+    // Invalid SAT - leading zeros
+    strcpy(key, "SAT");
+    strcpy(val, "0700");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+
+    // Invalid SAT - text at the end
+    strcpy(key, "SAT");
+    strcpy(val, "123abc");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().GetMrpRetryActiveThreshold().HasValue());
+}
+
+// Test T (TCP support)
+template <class NodeData>
+void DiscoveredTxtFieldTcpSupport()
+{
+    char key[4];
+    char val[8];
+    DiscoveredNodeData nodeData;
+    nodeData.Set<NodeData>();
+
+    // True
+    strcpy(key, "T");
+    strcpy(val, "1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().supportsTcp);
+
+    // Test no other fields were populated
+    nodeData.Get<NodeData>().supportsTcp = false;
+    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+
+    // False
+    strcpy(key, "T");
+    strcpy(val, "0");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().supportsTcp == false);
+
+    // Invalid value, stil false
+    strcpy(key, "T");
+    strcpy(val, "asdf");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().supportsTcp == false);
+}
+
+// Test ICD (ICD operation Mode)
+template <class NodeData>
+void DiscoveredTxtFieldICDoperatesAsLIT()
+{
+    char key[4];
+    char val[16];
+    DiscoveredNodeData nodeData;
+    nodeData.Set<NodeData>();
+
+    // ICD is operating as a LIT device
+    strcpy(key, "ICD");
+    strcpy(val, "1");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue());
+    EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.Value());
+
+    // Test no other fields were populated
+    nodeData.Get<NodeData>().isICDOperatingAsLIT.ClearValue();
+    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+
+    // ICD is operating as a SIT device
+    strcpy(key, "ICD");
+    strcpy(val, "0");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue());
+    EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.Value() == false);
+
+    nodeData.Get<NodeData>().isICDOperatingAsLIT.ClearValue();
+    EXPECT_TRUE( NodeDataIsEmpty(nodeData.Get<NodeData>()));
+    // Invalid value, No key set
+    strcpy(key, "ICD");
+    strcpy(val, "asdf");
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().isICDOperatingAsLIT.HasValue() == false);
+}
+
+// Test IsDeviceTreatedAsSleepy() with CRI
+template <class NodeData>
+void DiscoveredTestIsDeviceSessionIdle()
+{
+    char key[4];
+    char val[32];
+    DiscoveredNodeData nodeData;
+    nodeData.Set<NodeData>();
+    const ReliableMessageProtocolConfig defaultMRPConfig(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL,
+                                                         CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL);
+
+    // No key/val set, so the device can't be sleepy
+    EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
+
+    // If the interval is the default value, the device is not sleepy
+    strcpy(key, "SII");
+    sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL.count()));
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
+
+    // If the interval is greater than the default value, the device is sleepy
+    sprintf(key, "SII");
+    sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL.count() + 1));
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
+}
+
+// Test IsDeviceTreatedAsSleepy() with CRA
+template <class NodeData>
+void DiscoveredTestIsDeviceSessionActive()
+{
+    char key[4];
+    char val[32];
+    DiscoveredNodeData nodeData;
+    nodeData.Set<NodeData>();
+    const ReliableMessageProtocolConfig defaultMRPConfig(CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL,
+                                                         CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL);
+
+    // No key/val set, so the device can't be sleepy
+    EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
+
+    // If the interval is the default value, the device is not sleepy
+    sprintf(key, "SAI");
+    sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL.count()));
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( !nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
+
+    // If the interval is greater than the default value, the device is sleepy
+    strcpy(key, "SAI");
+    sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL.count() + 1));
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), (CommonResolutionData &)nodeData.Get<NodeData>());
+    EXPECT_TRUE( nodeData.Get<NodeData>().IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 }
 
 // Test SAI (formally CRI)
@@ -514,7 +826,7 @@ void TxtFieldSessionIdleInterval()
 
 TEST(TestTxtFields, TxtDiscoveredFieldMrpRetryIntervalIdle)
 {
-    TxtFieldSessionIdleInterval<DiscoveredNodeData>();
+    DiscoveredTxtFieldSessionIdleInterval<CommissionNodeData>();
 }
 
 TEST(TestTxtFields, TxtResolvedFieldMrpRetryIntervalIdle)
@@ -587,7 +899,7 @@ void TxtFieldSessionActiveInterval()
 
 TEST(TestTxtFields, TxtDiscoveredFieldMrpRetryIntervalActive)
 {
-    TxtFieldSessionActiveInterval<DiscoveredNodeData>();
+    DiscoveredTxtFieldSessionActiveInterval<CommissionNodeData>();
 }
 
 TEST(TestTxtFields, TxtResolvedFieldMrpRetryIntervalActive)
@@ -660,7 +972,7 @@ void TxtFieldSessionActiveThreshold()
 
 TEST(TestTxtFields, TxtDiscoveredFieldMrpRetryActiveThreshold)
 {
-    TxtFieldSessionActiveThreshold<DiscoveredNodeData>();
+    DiscoveredTxtFieldSessionActiveThreshold<CommissionNodeData>();
 }
 
 TEST(TestTxtFields, TxtResolvedFieldMrpRetryActiveThreshold)
@@ -701,7 +1013,7 @@ void TxtFieldTcpSupport()
 
 TEST(TestTxtFields, TxtDiscoveredFieldTcpSupport)
 {
-    TxtFieldTcpSupport<DiscoveredNodeData>();
+    DiscoveredTxtFieldTcpSupport<CommissionNodeData>();
 }
 
 TEST(TestTxtFields, TxtResolvedFieldTcpSupport)
@@ -746,7 +1058,7 @@ void TxtFieldICDoperatesAsLIT()
 
 TEST(TestTxtFields, TxtDiscoveredIsICDoperatingAsLIT)
 {
-    TxtFieldICDoperatesAsLIT<DiscoveredNodeData>();
+    DiscoveredTxtFieldICDoperatesAsLIT<CommissionNodeData>();
 }
 
 TEST(TestTxtFields, TxtResolvedFieldICDoperatingAsLIT)
@@ -782,7 +1094,7 @@ void TestIsDeviceSessionIdle()
 
 TEST(TestTxtFields, TxtDiscoveredIsDeviceSessionIdle)
 {
-    TestIsDeviceSessionIdle<DiscoveredNodeData>();
+    DiscoveredTestIsDeviceSessionIdle<CommissionNodeData>();
 }
 
 TEST(TestTxtFields, TxtResolvedIsDeviceSessionIdle)
@@ -818,7 +1130,7 @@ void TestIsDeviceSessionActive()
 
 TEST(TestTxtFields, TxtDiscoveredIsDeviceSessionActive)
 {
-    TestIsDeviceSessionActive<DiscoveredNodeData>();
+    DiscoveredTestIsDeviceSessionActive<CommissionNodeData>();
 }
 
 TEST(TestTxtFields, TxtResolvedIsDeviceSessionActive)

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -83,61 +83,67 @@ public:
 
     AddressResolve::NodeLookupHandle & Handle() { return mSelfHandle; }
 
-    void OnNodeDiscovered(const Dnssd::DiscoveredNodeData & nodeData) override
+    void OnNodeDiscovered(const Dnssd::DiscoveredNodeData & discNodeData) override
     {
-        if (!nodeData.resolutionData.IsValid())
+        if (!discNodeData.Is<Dnssd::CommissionNodeData>())
+        {
+            streamer_printf(streamer_get(), "DNS browse failed - not commission type node \r\n");
+            return;
+        }
+
+        Dnssd::CommissionNodeData nodeData = discNodeData.Get<Dnssd::CommissionNodeData>();
+        if (!nodeData.IsValid())
         {
             streamer_printf(streamer_get(), "DNS browse failed - not found valid services \r\n");
             return;
         }
 
         char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1];
-        Encoding::BytesToUppercaseHexString(nodeData.nodeData.rotatingId, nodeData.nodeData.rotatingIdLen, rotatingId,
+        Encoding::BytesToUppercaseHexString(nodeData.rotatingId, nodeData.rotatingIdLen, rotatingId,
                                             sizeof(rotatingId));
 
         streamer_printf(streamer_get(), "DNS browse succeeded: \r\n");
-        streamer_printf(streamer_get(), "   Node Type: %u\r\n", nodeData.nodeType);
-        streamer_printf(streamer_get(), "   Hostname: %s\r\n", nodeData.resolutionData.hostName);
-        streamer_printf(streamer_get(), "   Vendor ID: %u\r\n", nodeData.nodeData.vendorId);
-        streamer_printf(streamer_get(), "   Product ID: %u\r\n", nodeData.nodeData.productId);
-        streamer_printf(streamer_get(), "   Long discriminator: %u\r\n", nodeData.nodeData.longDiscriminator);
-        streamer_printf(streamer_get(), "   Device type: %u\r\n", nodeData.nodeData.deviceType);
-        streamer_printf(streamer_get(), "   Device name: %s\n", nodeData.nodeData.deviceName);
-        streamer_printf(streamer_get(), "   Commissioning mode: %d\r\n", static_cast<int>(nodeData.nodeData.commissioningMode));
-        streamer_printf(streamer_get(), "   Pairing hint: %u\r\n", nodeData.nodeData.pairingHint);
-        streamer_printf(streamer_get(), "   Pairing instruction: %s\r\n", nodeData.nodeData.pairingInstruction);
+        streamer_printf(streamer_get(), "   Hostname: %s\r\n", nodeData.hostName);
+        streamer_printf(streamer_get(), "   Vendor ID: %u\r\n", nodeData.vendorId);
+        streamer_printf(streamer_get(), "   Product ID: %u\r\n", nodeData.productId);
+        streamer_printf(streamer_get(), "   Long discriminator: %u\r\n", nodeData.longDiscriminator);
+        streamer_printf(streamer_get(), "   Device type: %u\r\n", nodeData.deviceType);
+        streamer_printf(streamer_get(), "   Device name: %s\n", nodeData.deviceName);
+        streamer_printf(streamer_get(), "   Commissioning mode: %d\r\n", static_cast<int>(nodeData.commissioningMode));
+        streamer_printf(streamer_get(), "   Pairing hint: %u\r\n", nodeData.pairingHint);
+        streamer_printf(streamer_get(), "   Pairing instruction: %s\r\n", nodeData.pairingInstruction);
         streamer_printf(streamer_get(), "   Rotating ID %s\r\n", rotatingId);
 
-        auto retryInterval = nodeData.resolutionData.GetMrpRetryIntervalIdle();
+        auto retryInterval = nodeData.GetMrpRetryIntervalIdle();
 
         if (retryInterval.HasValue())
             streamer_printf(streamer_get(), "   MRP retry interval (idle): %" PRIu32 "ms\r\n", retryInterval.Value());
 
-        retryInterval = nodeData.resolutionData.GetMrpRetryIntervalActive();
+        retryInterval = nodeData.GetMrpRetryIntervalActive();
 
         if (retryInterval.HasValue())
             streamer_printf(streamer_get(), "   MRP retry interval (active): %" PRIu32 "ms\r\n", retryInterval.Value());
 
-        if (nodeData.resolutionData.GetMrpRetryActiveThreshold().HasValue())
+        if (nodeData.GetMrpRetryActiveThreshold().HasValue())
         {
             streamer_printf(streamer_get(), "   MRP retry active threshold time: %" PRIu32 "ms\r\n",
-                            nodeData.resolutionData.GetMrpRetryActiveThreshold().Value());
+                            nodeData.GetMrpRetryActiveThreshold().Value());
         }
-        streamer_printf(streamer_get(), "   Supports TCP: %s\r\n", nodeData.resolutionData.supportsTcp ? "yes" : "no");
+        streamer_printf(streamer_get(), "   Supports TCP: %s\r\n", nodeData.supportsTcp ? "yes" : "no");
 
-        if (nodeData.resolutionData.isICDOperatingAsLIT.HasValue())
+        if (nodeData.isICDOperatingAsLIT.HasValue())
         {
             streamer_printf(streamer_get(), "   ICD is operating as a: %s\r\n",
-                            nodeData.resolutionData.isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
+                            nodeData.isICDOperatingAsLIT.Value() ? "LIT" : "SIT");
         }
         streamer_printf(streamer_get(), "   IP addresses:\r\n");
-        for (size_t i = 0; i < nodeData.resolutionData.numIPs; i++)
+        for (size_t i = 0; i < nodeData.numIPs; i++)
         {
-            streamer_printf(streamer_get(), "      %s\r\n", nodeData.resolutionData.ipAddress[i].ToString(ipAddressBuf));
+            streamer_printf(streamer_get(), "      %s\r\n", nodeData.ipAddress[i].ToString(ipAddressBuf));
         }
-        if (nodeData.resolutionData.port > 0)
+        if (nodeData.port > 0)
         {
-            streamer_printf(streamer_get(), "   Port: %u\r\n", nodeData.resolutionData.port);
+            streamer_printf(streamer_get(), "   Port: %u\r\n", nodeData.port);
         }
     }
 

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -99,8 +99,7 @@ public:
         }
 
         char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1];
-        Encoding::BytesToUppercaseHexString(nodeData.rotatingId, nodeData.rotatingIdLen, rotatingId,
-                                            sizeof(rotatingId));
+        Encoding::BytesToUppercaseHexString(nodeData.rotatingId, nodeData.rotatingIdLen, rotatingId, sizeof(rotatingId));
 
         streamer_printf(streamer_get(), "DNS browse succeeded: \r\n");
         streamer_printf(streamer_get(), "   Hostname: %s\r\n", nodeData.hostName);

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -476,8 +476,7 @@ void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::Dis
     Dnssd::CommissionNodeData nodeData = discNodeData.Get<Dnssd::CommissionNodeData>();
     if (nodeData.numIPs == 0)
     {
-        ChipLogError(AppServer, "OnCommissionableNodeFound no IP addresses returned for instance name=%s",
-                     nodeData.instanceName);
+        ChipLogError(AppServer, "OnCommissionableNodeFound no IP addresses returned for instance name=%s", nodeData.instanceName);
         return;
     }
     if (nodeData.port == 0)
@@ -501,16 +500,14 @@ void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::Dis
             if (nodeData.ipAddress[i].IsIPv4())
             {
                 foundV4 = true;
-                client->SetPeerAddress(
-                    chip::Transport::PeerAddress::UDP(nodeData.ipAddress[i], nodeData.port));
+                client->SetPeerAddress(chip::Transport::PeerAddress::UDP(nodeData.ipAddress[i], nodeData.port));
                 break;
             }
         }
         // use IPv6 as last resort
         if (!foundV4)
         {
-            client->SetPeerAddress(
-                chip::Transport::PeerAddress::UDP(nodeData.ipAddress[0], nodeData.port));
+            client->SetPeerAddress(chip::Transport::PeerAddress::UDP(nodeData.ipAddress[0], nodeData.port));
         }
 #else  // INET_CONFIG_ENABLE_IPV4
        // if we only support V6, then try to find a v6 address
@@ -520,18 +517,15 @@ void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::Dis
             if (nodeData.ipAddress[i].IsIPv6())
             {
                 foundV6 = true;
-                client->SetPeerAddress(
-                    chip::Transport::PeerAddress::UDP(nodeData.ipAddress[i], nodeData.port));
+                client->SetPeerAddress(chip::Transport::PeerAddress::UDP(nodeData.ipAddress[i], nodeData.port));
                 break;
             }
         }
         // last resort, try with what we have
         if (!foundV6)
         {
-            ChipLogError(AppServer, "OnCommissionableNodeFound no v6 returned for instance name=%s",
-                         nodeData.instanceName);
-            client->SetPeerAddress(
-                chip::Transport::PeerAddress::UDP(nodeData.ipAddress[0], nodeData.port));
+            ChipLogError(AppServer, "OnCommissionableNodeFound no v6 returned for instance name=%s", nodeData.instanceName);
+            client->SetPeerAddress(chip::Transport::PeerAddress::UDP(nodeData.ipAddress[0], nodeData.port));
         }
 #endif // INET_CONFIG_ENABLE_IPV4
 

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -466,21 +466,27 @@ void UserDirectedCommissioningServer::SetUDCClientProcessingState(char * instanc
     mUdcClients.MarkUDCClientActive(client);
 }
 
-void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::DiscoveredNodeData & nodeData)
+void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::DiscoveredNodeData & discNodeData)
 {
-    if (nodeData.resolutionData.numIPs == 0)
+    if (!discNodeData.Is<Dnssd::CommissionNodeData>())
     {
-        ChipLogError(AppServer, "OnCommissionableNodeFound no IP addresses returned for instance name=%s",
-                     nodeData.nodeData.instanceName);
-        return;
-    }
-    if (nodeData.resolutionData.port == 0)
-    {
-        ChipLogError(AppServer, "OnCommissionableNodeFound no port returned for instance name=%s", nodeData.nodeData.instanceName);
         return;
     }
 
-    UDCClientState * client = mUdcClients.FindUDCClientState(nodeData.nodeData.instanceName);
+    Dnssd::CommissionNodeData nodeData = discNodeData.Get<Dnssd::CommissionNodeData>();
+    if (nodeData.numIPs == 0)
+    {
+        ChipLogError(AppServer, "OnCommissionableNodeFound no IP addresses returned for instance name=%s",
+                     nodeData.instanceName);
+        return;
+    }
+    if (nodeData.port == 0)
+    {
+        ChipLogError(AppServer, "OnCommissionableNodeFound no port returned for instance name=%s", nodeData.instanceName);
+        return;
+    }
+
+    UDCClientState * client = mUdcClients.FindUDCClientState(nodeData.instanceName);
     if (client != nullptr && client->GetUDCClientProcessingState() == UDCClientProcessingState::kDiscoveringNode)
     {
         ChipLogDetail(AppServer, "OnCommissionableNodeFound instance: name=%s old_state=%d new_state=%d", client->GetInstanceName(),
@@ -490,13 +496,13 @@ void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::Dis
 #if INET_CONFIG_ENABLE_IPV4
         // prefer IPv4 if its an option
         bool foundV4 = false;
-        for (unsigned i = 0; i < nodeData.resolutionData.numIPs; ++i)
+        for (unsigned i = 0; i < nodeData.numIPs; ++i)
         {
-            if (nodeData.resolutionData.ipAddress[i].IsIPv4())
+            if (nodeData.ipAddress[i].IsIPv4())
             {
                 foundV4 = true;
                 client->SetPeerAddress(
-                    chip::Transport::PeerAddress::UDP(nodeData.resolutionData.ipAddress[i], nodeData.resolutionData.port));
+                    chip::Transport::PeerAddress::UDP(nodeData.ipAddress[i], nodeData.port));
                 break;
             }
         }
@@ -504,18 +510,18 @@ void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::Dis
         if (!foundV4)
         {
             client->SetPeerAddress(
-                chip::Transport::PeerAddress::UDP(nodeData.resolutionData.ipAddress[0], nodeData.resolutionData.port));
+                chip::Transport::PeerAddress::UDP(nodeData.ipAddress[0], nodeData.port));
         }
 #else  // INET_CONFIG_ENABLE_IPV4
        // if we only support V6, then try to find a v6 address
         bool foundV6 = false;
-        for (unsigned i = 0; i < nodeData.resolutionData.numIPs; ++i)
+        for (unsigned i = 0; i < nodeData.numIPs; ++i)
         {
-            if (nodeData.resolutionData.ipAddress[i].IsIPv6())
+            if (nodeData.ipAddress[i].IsIPv6())
             {
                 foundV6 = true;
                 client->SetPeerAddress(
-                    chip::Transport::PeerAddress::UDP(nodeData.resolutionData.ipAddress[i], nodeData.resolutionData.port));
+                    chip::Transport::PeerAddress::UDP(nodeData.ipAddress[i], nodeData.port));
                 break;
             }
         }
@@ -523,17 +529,17 @@ void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::Dis
         if (!foundV6)
         {
             ChipLogError(AppServer, "OnCommissionableNodeFound no v6 returned for instance name=%s",
-                         nodeData.nodeData.instanceName);
+                         nodeData.instanceName);
             client->SetPeerAddress(
-                chip::Transport::PeerAddress::UDP(nodeData.resolutionData.ipAddress[0], nodeData.resolutionData.port));
+                chip::Transport::PeerAddress::UDP(nodeData.ipAddress[0], nodeData.port));
         }
 #endif // INET_CONFIG_ENABLE_IPV4
 
-        client->SetDeviceName(nodeData.nodeData.deviceName);
-        client->SetLongDiscriminator(nodeData.nodeData.longDiscriminator);
-        client->SetVendorId(nodeData.nodeData.vendorId);
-        client->SetProductId(nodeData.nodeData.productId);
-        client->SetRotatingId(nodeData.nodeData.rotatingId, nodeData.nodeData.rotatingIdLen);
+        client->SetDeviceName(nodeData.deviceName);
+        client->SetLongDiscriminator(nodeData.longDiscriminator);
+        client->SetVendorId(nodeData.vendorId);
+        client->SetProductId(nodeData.productId);
+        client->SetRotatingId(nodeData.rotatingId, nodeData.rotatingIdLen);
 
         // Call the registered mUserConfirmationProvider, if any.
         if (mUserConfirmationProvider != nullptr)

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -473,7 +473,7 @@ void UserDirectedCommissioningServer::OnCommissionableNodeFound(const Dnssd::Dis
         return;
     }
 
-    Dnssd::CommissionNodeData nodeData = discNodeData.Get<Dnssd::CommissionNodeData>();
+    const Dnssd::CommissionNodeData & nodeData = discNodeData.Get<Dnssd::CommissionNodeData>();
     if (nodeData.numIPs == 0)
     {
         ChipLogError(AppServer, "OnCommissionableNodeFound no IP addresses returned for instance name=%s", nodeData.instanceName);

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -89,18 +89,18 @@ void TestUDCServerUserConfirmationProvider(nlTestSuite * inSuite, void * inConte
     Dnssd::DiscoveredNodeData discNodeData1;
     discNodeData1.Set<CommissionNodeData>();
     Dnssd::CommissionNodeData & nodeData1 = discNodeData1.Get<CommissionNodeData>();
-    nodeData1.port         = 5540;
-    nodeData1.ipAddress[0] = address;
-    nodeData1.numIPs       = 1;
+    nodeData1.port                        = 5540;
+    nodeData1.ipAddress[0]                = address;
+    nodeData1.numIPs                      = 1;
     Platform::CopyString(nodeData1.instanceName, instanceName1);
 
     Dnssd::DiscoveredNodeData discNodeData2;
     discNodeData2.Set<CommissionNodeData>();
     Dnssd::CommissionNodeData & nodeData2 = discNodeData2.Get<CommissionNodeData>();
-    nodeData2.port         = 5540;
-    nodeData2.ipAddress[0] = address;
-    nodeData2.numIPs       = 1;
-    nodeData2.longDiscriminator  = disc2;
+    nodeData2.port                        = 5540;
+    nodeData2.ipAddress[0]                = address;
+    nodeData2.numIPs                      = 1;
+    nodeData2.longDiscriminator           = disc2;
     Platform::CopyString(nodeData2.instanceName, instanceName2);
     Platform::CopyString(nodeData2.deviceName, deviceName2);
 

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -86,23 +86,27 @@ void TestUDCServerUserConfirmationProvider(nlTestSuite * inSuite, void * inConte
     // setup for tests
     udcServer.SetUDCClientProcessingState((char *) instanceName1, UDCClientProcessingState::kUserDeclined);
 
-    Dnssd::DiscoveredNodeData nodeData1;
-    nodeData1.resolutionData.port         = 5540;
-    nodeData1.resolutionData.ipAddress[0] = address;
-    nodeData1.resolutionData.numIPs       = 1;
-    Platform::CopyString(nodeData1.nodeData.instanceName, instanceName1);
+    Dnssd::DiscoveredNodeData discNodeData1;
+    discNodeData1.Set<CommissionNodeData>();
+    Dnssd::CommissionNodeData & nodeData1 = discNodeData1.Get<CommissionNodeData>();
+    nodeData1.port         = 5540;
+    nodeData1.ipAddress[0] = address;
+    nodeData1.numIPs       = 1;
+    Platform::CopyString(nodeData1.instanceName, instanceName1);
 
-    Dnssd::DiscoveredNodeData nodeData2;
-    nodeData2.resolutionData.port         = 5540;
-    nodeData2.resolutionData.ipAddress[0] = address;
-    nodeData2.resolutionData.numIPs       = 1;
-    nodeData2.nodeData.longDiscriminator  = disc2;
-    Platform::CopyString(nodeData2.nodeData.instanceName, instanceName2);
-    Platform::CopyString(nodeData2.nodeData.deviceName, deviceName2);
+    Dnssd::DiscoveredNodeData discNodeData2;
+    discNodeData2.Set<CommissionNodeData>();
+    Dnssd::CommissionNodeData & nodeData2 = discNodeData2.Get<CommissionNodeData>();
+    nodeData2.port         = 5540;
+    nodeData2.ipAddress[0] = address;
+    nodeData2.numIPs       = 1;
+    nodeData2.longDiscriminator  = disc2;
+    Platform::CopyString(nodeData2.instanceName, instanceName2);
+    Platform::CopyString(nodeData2.deviceName, deviceName2);
 
     // test empty UserConfirmationProvider
-    udcServer.OnCommissionableNodeFound(nodeData2);
-    udcServer.OnCommissionableNodeFound(nodeData1);
+    udcServer.OnCommissionableNodeFound(discNodeData2);
+    udcServer.OnCommissionableNodeFound(discNodeData1);
     state = udcServer.GetUDCClients().FindUDCClientState(instanceName1);
     NL_TEST_EXIT_ON_FAILED_ASSERT(inSuite, nullptr != state);
     NL_TEST_ASSERT(inSuite, UDCClientProcessingState::kUserDeclined == state->GetUDCClientProcessingState());
@@ -115,8 +119,8 @@ void TestUDCServerUserConfirmationProvider(nlTestSuite * inSuite, void * inConte
     // test current state check
     udcServer.SetUDCClientProcessingState((char *) instanceName1, UDCClientProcessingState::kUserDeclined);
     udcServer.SetUDCClientProcessingState((char *) instanceName2, UDCClientProcessingState::kDiscoveringNode);
-    udcServer.OnCommissionableNodeFound(nodeData2);
-    udcServer.OnCommissionableNodeFound(nodeData1);
+    udcServer.OnCommissionableNodeFound(discNodeData2);
+    udcServer.OnCommissionableNodeFound(discNodeData1);
     state = udcServer.GetUDCClients().FindUDCClientState(instanceName1);
     NL_TEST_EXIT_ON_FAILED_ASSERT(inSuite, nullptr != state);
     NL_TEST_ASSERT(inSuite, UDCClientProcessingState::kUserDeclined == state->GetUDCClientProcessingState());
@@ -132,9 +136,9 @@ void TestUDCServerUserConfirmationProvider(nlTestSuite * inSuite, void * inConte
     udcServer.SetUserConfirmationProvider(&testCallback);
     udcServer.SetUDCClientProcessingState((char *) instanceName1, UDCClientProcessingState::kUserDeclined);
     udcServer.SetUDCClientProcessingState((char *) instanceName2, UDCClientProcessingState::kDiscoveringNode);
-    udcServer.OnCommissionableNodeFound(nodeData1);
+    udcServer.OnCommissionableNodeFound(discNodeData1);
     NL_TEST_ASSERT(inSuite, !testCallback.mOnUserDirectedCommissioningRequestCalled);
-    udcServer.OnCommissionableNodeFound(nodeData2);
+    udcServer.OnCommissionableNodeFound(discNodeData2);
     NL_TEST_ASSERT(inSuite, testCallback.mOnUserDirectedCommissioningRequestCalled);
     NL_TEST_ASSERT(inSuite, 0 == strcmp(testCallback.mState.GetInstanceName(), instanceName2));
 }


### PR DESCRIPTION
As part of mDNS browse interface clean up, updated `DiscoveredNodeData `definition to be a variant of `CommissionNodeData`. Also `CommissionNodeData` inherits `CommonResolutionData` so that the delegate structured are flattened.

Also all references/usage of these structures are updated accordingly.

This work is in continuation to the comments in #32866 