### PR TITLE
Replace nl-unit-test with pigweed for platform

### DIFF
--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -14,7 +14,6 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/src/platform/device.gni")
 
@@ -27,7 +26,7 @@ declare_args() {
 if (chip_device_platform != "none" && chip_device_platform != "fake") {
   import("${chip_root}/build/chip/chip_test_suite.gni")
 
-  chip_test_suite_using_nltest("tests") {
+  chip_test_suite("tests") {
     output_name = "libPlatformTests"
 
     test_sources = []
@@ -41,10 +40,8 @@ if (chip_device_platform != "none" && chip_device_platform != "fake") {
     public_deps = [
       "${chip_root}/src/lib/support",
       "${chip_root}/src/lib/support:test_utils",
-      "${chip_root}/src/lib/support:testing_nlunit",
       "${chip_root}/src/platform",
       "${chip_root}/src/system",
-      "${nlunit_test_root}:nlunit-test",
     ]
 
     if (chip_mdns != "none" && chip_enable_dnssd_tests &&
@@ -67,6 +64,7 @@ if (chip_device_platform != "none" && chip_device_platform != "fake") {
     if (chip_enable_openthread) {
       # FIXME: TestThreadStackMgr requires ot-br-posix daemon to be running
       # test_sources += [ "TestThreadStackMgr.cpp" ]
+      # configs = [ "//${chip_root}/third_party/ot-br-posix:dbus_config" ]
     }
 
     if (chip_enable_ble &&

--- a/src/platform/tests/TestCHIPoBLEStackMgr.cpp
+++ b/src/platform/tests/TestCHIPoBLEStackMgr.cpp
@@ -17,25 +17,23 @@
 
 #include "platform/internal/CHIPDeviceLayerInternal.h"
 #include <assert.h>
+#include <gtest/gtest.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/UnitTestRegistration.h>
 #include <memory>
 
 #include "platform/PlatformManager.h"
 #include "platform/internal/BLEManager.h"
 
-void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
+void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t)
 {
-    (void) arg;
     if (event->Type == chip::DeviceLayer::DeviceEventType::kCHIPoBLEConnectionEstablished)
     {
         ChipLogProgress(DeviceLayer, "Receive kCHIPoBLEConnectionEstablished");
-        // exit(0);
     }
 }
 
-int TestCHIPoBLEStackManager()
+TEST(TestCHIPoBLEStackManager, TestCHIPoBLEStackManager)
 {
     chip::Platform::MemoryInit();
 
@@ -54,7 +52,4 @@ int TestCHIPoBLEStackManager()
     chip::DeviceLayer::PlatformMgrImpl().RunEventLoop();
     ChipLogProgress(DeviceLayer, "RunEventLoop completed");
     chip::Platform::MemoryShutdown();
-    return 0;
 }
-
-CHIP_REGISTER_TEST_SUITE(TestCHIPoBLEStackManager);

--- a/src/platform/tests/TestCHIPoBLEStackMgrDriver.cpp
+++ b/src/platform/tests/TestCHIPoBLEStackMgrDriver.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "TestCHIPoBLEStackMgr.h"
+#include <gtest/gtest.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <stdlib.h>
 
@@ -24,7 +25,8 @@ int main(int argc, char * argv[])
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     if (argc == 2 && atoi(argv[1]) == 1)
     {
-        return TestCHIPoBLEStackManager();
+        testing::InitGoogleTest(nullptr, nullptr);
+        return RUN_ALL_TESTS();
     }
     return 0;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -31,6 +31,7 @@
 #include <gtest/gtest.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
+
 #include <platform/BuildTime.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DeviceInstanceInfoProvider.h>
@@ -50,6 +51,7 @@ struct TestConfigurationMgr : ::testing::Test
 {
     static void SetUpTestSuite()
     {
+        // ConfigurationManager is initialized from PlatformManager indirectly
         CHIP_ERROR err = chip::Platform::MemoryInit();
         EXPECT_EQ(err, CHIP_NO_ERROR);
         err = PlatformMgr().InitChipStack();
@@ -89,7 +91,7 @@ TEST_F(TestConfigurationMgr, SerialNumber)
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     EXPECT_EQ(strlen(buf), 12u);
-    ASSERT_STREQ(buf, serialNumber);
+    EXPECT_STREQ(buf, serialNumber);
 
     err = ConfigurationMgr().StoreSerialNumber(serialNumber, 5);
     EXPECT_EQ(err, CHIP_NO_ERROR);
@@ -98,7 +100,7 @@ TEST_F(TestConfigurationMgr, SerialNumber)
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     EXPECT_EQ(strlen(buf), 5u);
-    ASSERT_STREQ(buf, "89051");
+    EXPECT_STREQ(buf, "89051");
 }
 
 TEST_F(TestConfigurationMgr, UniqueId)
@@ -115,7 +117,7 @@ TEST_F(TestConfigurationMgr, UniqueId)
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     EXPECT_EQ(strlen(buf), 14u);
-    ASSERT_STREQ(buf, uniqueId);
+    EXPECT_STREQ(buf, uniqueId);
 
     err = ConfigurationMgr().StoreUniqueId(uniqueId, 7);
     EXPECT_EQ(err, CHIP_NO_ERROR);
@@ -124,7 +126,7 @@ TEST_F(TestConfigurationMgr, UniqueId)
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     EXPECT_EQ(strlen(buf), 7u);
-    ASSERT_STREQ(buf, "67MXAZ0");
+    EXPECT_STREQ(buf, "67MXAZ0");
 }
 
 TEST_F(TestConfigurationMgr, ManufacturingDate)
@@ -265,8 +267,8 @@ TEST_F(TestConfigurationMgr, FirmwareBuildTime)
         const char * timeOfDay = CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME;
 
         // Check that strings look good.
-        EXPECT_TRUE(!BUILD_DATE_IS_BAD(date));
-        EXPECT_TRUE(!BUILD_TIME_IS_BAD(timeOfDay));
+        EXPECT_FALSE(BUILD_DATE_IS_BAD(date));
+        EXPECT_FALSE(BUILD_TIME_IS_BAD(timeOfDay));
         if (BUILD_DATE_IS_BAD(date) || BUILD_TIME_IS_BAD(timeOfDay))
         {
             break;
@@ -299,8 +301,8 @@ TEST_F(TestConfigurationMgr, FirmwareBuildTime)
         }
 
         // Verify match.
-        ASSERT_STREQ(date, parsedDate);
-        ASSERT_STREQ(timeOfDay, parsedTimeOfDay);
+        EXPECT_STREQ(date, parsedDate);
+        EXPECT_STREQ(timeOfDay, parsedTimeOfDay);
     } while (false);
 
     // Generate random chip epoch times and verify that our BuildTime.h parser
@@ -333,8 +335,8 @@ TEST_F(TestConfigurationMgr, FirmwareBuildTime)
         }
 
         // Check that strings look good.
-        EXPECT_TRUE(!BUILD_DATE_IS_BAD(date));
-        EXPECT_TRUE(!BUILD_TIME_IS_BAD(timeOfDay));
+        EXPECT_FALSE(BUILD_DATE_IS_BAD(date));
+        EXPECT_FALSE(BUILD_TIME_IS_BAD(timeOfDay));
         if (BUILD_DATE_IS_BAD(date) || BUILD_TIME_IS_BAD(timeOfDay))
         {
             continue;
@@ -374,7 +376,7 @@ TEST_F(TestConfigurationMgr, CountryCode)
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     EXPECT_EQ(countryCodeLen, strlen(countryCode));
-    ASSERT_STREQ(buf, countryCode);
+    EXPECT_STREQ(buf, countryCode);
 }
 
 TEST_F(TestConfigurationMgr, GetPrimaryMACAddress)
@@ -464,7 +466,3 @@ TEST_F(TestConfigurationMgr, GetProductId)
 }
 
 } // namespace
-
-/**
- *  Main
- */

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -28,11 +28,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <gtest/gtest.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/UnitTestRegistration.h>
-#include <nlunit-test.h>
-
 #include <platform/BuildTime.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DeviceInstanceInfoProvider.h>
@@ -48,14 +46,24 @@ namespace {
 //      Unit tests
 // =================================
 
-static void TestPlatformMgr_Init(nlTestSuite * inSuite, void * inContext)
+struct TestConfigurationMgr : ::testing::Test
 {
-    // ConfigurationManager is initialized from PlatformManager indirectly
-    CHIP_ERROR err = PlatformMgr().InitChipStack();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-}
+    static void SetUpTestSuite()
+    {
+        CHIP_ERROR err = chip::Platform::MemoryInit();
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        err = PlatformMgr().InitChipStack();
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+    }
 
-static void TestPlatformMgr_RunUnitTest(nlTestSuite * inSuite, void * inContext)
+    static void TearDownTestSuite()
+    {
+        PlatformMgr().Shutdown();
+        chip::Platform::MemoryShutdown();
+    }
+};
+
+TEST_F(TestConfigurationMgr, RunUnitTest)
 {
 #if CHIP_DEVICE_LAYER_TARGET_OPEN_IOT_SDK
     // TODO: Fix RunUnitTests() for Open IOT SDK.
@@ -67,7 +75,7 @@ static void TestPlatformMgr_RunUnitTest(nlTestSuite * inSuite, void * inContext)
     ConfigurationMgr().RunUnitTests();
 }
 
-static void TestConfigurationMgr_SerialNumber(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, SerialNumber)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -75,25 +83,25 @@ static void TestConfigurationMgr_SerialNumber(nlTestSuite * inSuite, void * inCo
     const char * serialNumber = "89051AAZZ236";
 
     err = ConfigurationMgr().StoreSerialNumber(serialNumber, strlen(serialNumber));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = GetDeviceInstanceInfoProvider()->GetSerialNumber(buf, 64);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, strlen(buf) == 12);
-    NL_TEST_ASSERT(inSuite, strcmp(buf, serialNumber) == 0);
+    EXPECT_EQ(strlen(buf), 12u);
+    ASSERT_STREQ(buf, serialNumber);
 
     err = ConfigurationMgr().StoreSerialNumber(serialNumber, 5);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = GetDeviceInstanceInfoProvider()->GetSerialNumber(buf, 64);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, strlen(buf) == 5);
-    NL_TEST_ASSERT(inSuite, strcmp(buf, "89051") == 0);
+    EXPECT_EQ(strlen(buf), 5u);
+    ASSERT_STREQ(buf, "89051");
 }
 
-static void TestConfigurationMgr_UniqueId(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, UniqueId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -101,25 +109,25 @@ static void TestConfigurationMgr_UniqueId(nlTestSuite * inSuite, void * inContex
     const char * uniqueId = "67MXAZ012RT8UE";
 
     err = ConfigurationMgr().StoreUniqueId(uniqueId, strlen(uniqueId));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = ConfigurationMgr().GetUniqueId(buf, 64);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, strlen(buf) == 14);
-    NL_TEST_ASSERT(inSuite, strcmp(buf, uniqueId) == 0);
+    EXPECT_EQ(strlen(buf), 14u);
+    ASSERT_STREQ(buf, uniqueId);
 
     err = ConfigurationMgr().StoreUniqueId(uniqueId, 7);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = ConfigurationMgr().GetUniqueId(buf, 64);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, strlen(buf) == 7);
-    NL_TEST_ASSERT(inSuite, strcmp(buf, "67MXAZ0") == 0);
+    EXPECT_EQ(strlen(buf), 7u);
+    ASSERT_STREQ(buf, "67MXAZ0");
 }
 
-static void TestConfigurationMgr_ManufacturingDate(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, ManufacturingDate)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -129,28 +137,28 @@ static void TestConfigurationMgr_ManufacturingDate(nlTestSuite * inSuite, void *
     uint8_t dayOfMonth;
 
     err = ConfigurationMgr().StoreManufacturingDate(mfgDate, strlen(mfgDate));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = GetDeviceInstanceInfoProvider()->GetManufacturingDate(year, month, dayOfMonth);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, year == 2008);
-    NL_TEST_ASSERT(inSuite, month == 9);
-    NL_TEST_ASSERT(inSuite, dayOfMonth == 20);
+    EXPECT_EQ(year, 2008);
+    EXPECT_EQ(month, 9);
+    EXPECT_EQ(dayOfMonth, 20);
 }
 
-static void TestConfigurationMgr_HardwareVersion(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, HardwareVersion)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint16_t hardwareVer;
 
     err = ConfigurationMgr().StoreHardwareVersion(1234);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = GetDeviceInstanceInfoProvider()->GetHardwareVersion(hardwareVer);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, hardwareVer == 1234);
+    EXPECT_EQ(hardwareVer, 1234);
 }
 
 static int SnprintfBuildDate(char * s, size_t n, uint16_t year, uint8_t month, uint8_t day)
@@ -237,18 +245,18 @@ static int SnprintfBuildTimeOfDay(char * s, size_t n, System::Clock::Seconds32 c
     return SnprintfBuildTimeOfDay(s, n, hour, minute, second);
 }
 
-static void TestConfigurationMgr_FirmwareBuildTime(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, FirmwareBuildTime)
 {
     // Read the firmware build time from the configuration manager.
     // This is referenced to the CHIP epoch.
     System::Clock::Seconds32 chipEpochTime;
-    NL_TEST_ASSERT(inSuite, ConfigurationMgr().GetFirmwareBuildChipEpochTime(chipEpochTime) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConfigurationMgr().GetFirmwareBuildChipEpochTime(chipEpochTime), CHIP_NO_ERROR);
 
     // Override the hard-coded build time with the setter and verify operation.
     System::Clock::Seconds32 overrideValue = System::Clock::Seconds32(rand());
-    NL_TEST_ASSERT(inSuite, ConfigurationMgr().SetFirmwareBuildChipEpochTime(overrideValue) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, ConfigurationMgr().GetFirmwareBuildChipEpochTime(chipEpochTime) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, overrideValue == chipEpochTime);
+    EXPECT_EQ(ConfigurationMgr().SetFirmwareBuildChipEpochTime(overrideValue), CHIP_NO_ERROR);
+    EXPECT_EQ(ConfigurationMgr().GetFirmwareBuildChipEpochTime(chipEpochTime), CHIP_NO_ERROR);
+    EXPECT_EQ(overrideValue, chipEpochTime);
 
     // Verify that the BuildTime.h parser can parse current CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_DATE / TIME.
     do
@@ -257,8 +265,8 @@ static void TestConfigurationMgr_FirmwareBuildTime(nlTestSuite * inSuite, void *
         const char * timeOfDay = CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME;
 
         // Check that strings look good.
-        NL_TEST_ASSERT(inSuite, !BUILD_DATE_IS_BAD(date));
-        NL_TEST_ASSERT(inSuite, !BUILD_TIME_IS_BAD(timeOfDay));
+        EXPECT_TRUE(!BUILD_DATE_IS_BAD(date));
+        EXPECT_TRUE(!BUILD_TIME_IS_BAD(timeOfDay));
         if (BUILD_DATE_IS_BAD(date) || BUILD_TIME_IS_BAD(timeOfDay))
         {
             break;
@@ -277,7 +285,8 @@ static void TestConfigurationMgr_FirmwareBuildTime(nlTestSuite * inSuite, void *
         {
             int printed;
             printed = SnprintfBuildDate(parsedDate, sizeof(parsedDate), year, month, day);
-            NL_TEST_ASSERT(inSuite, printed > 0 && printed < static_cast<int>(sizeof(parsedDate)));
+            EXPECT_GT(printed, 0);
+            EXPECT_LT(printed, static_cast<int>(sizeof(parsedDate)));
         }
 
         // Print the time of day to a straing as would be given by the __TIME__ macro.
@@ -285,12 +294,13 @@ static void TestConfigurationMgr_FirmwareBuildTime(nlTestSuite * inSuite, void *
         {
             int printed;
             printed = SnprintfBuildTimeOfDay(parsedTimeOfDay, sizeof(parsedTimeOfDay), hour, minute, second);
-            NL_TEST_ASSERT(inSuite, printed > 0 && printed < static_cast<int>(sizeof(parsedTimeOfDay)));
+            EXPECT_GT(printed, 0);
+            EXPECT_LT(printed, static_cast<int>(sizeof(parsedTimeOfDay)));
         }
 
         // Verify match.
-        NL_TEST_ASSERT(inSuite, strcmp(date, parsedDate) == 0);
-        NL_TEST_ASSERT(inSuite, strcmp(timeOfDay, parsedTimeOfDay) == 0);
+        ASSERT_STREQ(date, parsedDate);
+        ASSERT_STREQ(timeOfDay, parsedTimeOfDay);
     } while (false);
 
     // Generate random chip epoch times and verify that our BuildTime.h parser
@@ -310,19 +320,21 @@ static void TestConfigurationMgr_FirmwareBuildTime(nlTestSuite * inSuite, void *
         {
             int printed;
             printed = SnprintfBuildDate(date, sizeof(date), chipEpochTime);
-            NL_TEST_ASSERT(inSuite, printed > 0 && printed < static_cast<int>(sizeof(date)));
+            EXPECT_GT(printed, 0);
+            EXPECT_LT(printed, static_cast<int>(sizeof(date)));
         }
 
         // Print the time of day to a straing as would be given by the __TIME__ macro.
         {
             int printed;
             printed = SnprintfBuildTimeOfDay(timeOfDay, sizeof(timeOfDay), chipEpochTime);
-            NL_TEST_ASSERT(inSuite, printed > 0 && printed < static_cast<int>(sizeof(timeOfDay)));
+            EXPECT_GT(printed, 0);
+            EXPECT_LT(printed, static_cast<int>(sizeof(timeOfDay)));
         }
 
         // Check that strings look good.
-        NL_TEST_ASSERT(inSuite, !BUILD_DATE_IS_BAD(date));
-        NL_TEST_ASSERT(inSuite, !BUILD_TIME_IS_BAD(timeOfDay));
+        EXPECT_TRUE(!BUILD_DATE_IS_BAD(date));
+        EXPECT_TRUE(!BUILD_TIME_IS_BAD(timeOfDay));
         if (BUILD_DATE_IS_BAD(date) || BUILD_TIME_IS_BAD(timeOfDay))
         {
             continue;
@@ -338,16 +350,16 @@ static void TestConfigurationMgr_FirmwareBuildTime(nlTestSuite * inSuite, void *
         ChipEpochToCalendarTime(chipEpochTime.count(), year, month, day, hour, minute, second);
 
         // Verify that our BuildTime.h macros can correctly parse the date / time strings.
-        NL_TEST_ASSERT(inSuite, year == COMPUTE_BUILD_YEAR(date));
-        NL_TEST_ASSERT(inSuite, month == COMPUTE_BUILD_MONTH(date));
-        NL_TEST_ASSERT(inSuite, day == COMPUTE_BUILD_DAY(date));
-        NL_TEST_ASSERT(inSuite, hour == COMPUTE_BUILD_HOUR(timeOfDay));
-        NL_TEST_ASSERT(inSuite, minute == COMPUTE_BUILD_MIN(timeOfDay));
-        NL_TEST_ASSERT(inSuite, second == COMPUTE_BUILD_SEC(timeOfDay));
+        EXPECT_EQ(year, COMPUTE_BUILD_YEAR(date));
+        EXPECT_EQ(month, COMPUTE_BUILD_MONTH(date));
+        EXPECT_EQ(day, COMPUTE_BUILD_DAY(date));
+        EXPECT_EQ(hour, COMPUTE_BUILD_HOUR(timeOfDay));
+        EXPECT_EQ(minute, COMPUTE_BUILD_MIN(timeOfDay));
+        EXPECT_EQ(second, COMPUTE_BUILD_SEC(timeOfDay));
     }
 }
 
-static void TestConfigurationMgr_CountryCode(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, CountryCode)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -356,16 +368,16 @@ static void TestConfigurationMgr_CountryCode(nlTestSuite * inSuite, void * inCon
     const char * countryCode = "US";
 
     err = ConfigurationMgr().StoreCountryCode(countryCode, strlen(countryCode));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = ConfigurationMgr().GetCountryCode(buf, 8, countryCodeLen);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, countryCodeLen == strlen(countryCode));
-    NL_TEST_ASSERT(inSuite, strcmp(buf, countryCode) == 0);
+    EXPECT_EQ(countryCodeLen, strlen(countryCode));
+    ASSERT_STREQ(buf, countryCode);
 }
 
-static void TestConfigurationMgr_GetPrimaryMACAddress(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, GetPrimaryMACAddress)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint8_t macBuffer8Bytes[8];
@@ -376,13 +388,13 @@ static void TestConfigurationMgr_GetPrimaryMACAddress(nlTestSuite * inSuite, voi
     err = ConfigurationMgr().GetPrimaryMACAddress(mac8Bytes);
     if (mac8Bytes.size() != ConfigurationManager::kPrimaryMACAddressLength)
     {
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+        EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     err = ConfigurationMgr().GetPrimaryMACAddress(mac6Bytes);
     if (mac6Bytes.size() != ConfigurationManager::kPrimaryMACAddressLength)
     {
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+        EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     // NOTICE for above:
@@ -391,102 +403,64 @@ static void TestConfigurationMgr_GetPrimaryMACAddress(nlTestSuite * inSuite, voi
     //      expecially if running in emulators (zephyr and qemu)
 }
 
-static void TestConfigurationMgr_GetFailSafeArmed(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, GetFailSafeArmed)
 {
     CHIP_ERROR err     = CHIP_NO_ERROR;
     bool failSafeArmed = false;
 
     err = ConfigurationMgr().SetFailSafeArmed(true);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = ConfigurationMgr().GetFailSafeArmed(failSafeArmed);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, failSafeArmed == true);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(failSafeArmed, true);
 
     err = ConfigurationMgr().SetFailSafeArmed(false);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 }
 
-static void TestConfigurationMgr_GetVendorName(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, GetVendorName)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     char buf[64];
 
     err = GetDeviceInstanceInfoProvider()->GetVendorName(buf, 64);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strlen(buf) > 0 && strlen(buf) <= ConfigurationManager::kMaxVendorNameLength);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_GT(strlen(buf), 0u);
+    EXPECT_LE(strlen(buf), ConfigurationManager::kMaxVendorNameLength);
 }
 
-static void TestConfigurationMgr_GetVendorId(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, GetVendorId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint16_t vendorId;
 
     err = GetDeviceInstanceInfoProvider()->GetVendorId(vendorId);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, vendorId >= 0 && vendorId <= 0xfff4);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_GE(vendorId, 0u);
+    EXPECT_LE(vendorId, 0xfff4);
 }
 
-static void TestConfigurationMgr_GetProductName(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, GetProductName)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     char buf[64];
 
     err = GetDeviceInstanceInfoProvider()->GetProductName(buf, 64);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strlen(buf) > 0 && strlen(buf) <= ConfigurationManager::kMaxProductNameLength);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_GT(strlen(buf), 0u);
+    EXPECT_LE(strlen(buf), ConfigurationManager::kMaxProductNameLength);
 }
 
-static void TestConfigurationMgr_GetProductId(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestConfigurationMgr, GetProductId)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     uint16_t productId;
 
     err = GetDeviceInstanceInfoProvider()->GetProductId(productId);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, productId >= 1 && productId <= 0xffff);
-}
-
-/**
- *   Test Suite. It lists all the test functions.
- */
-static const nlTest sTests[] = {
-    NL_TEST_DEF("Test PlatformMgr::Init", TestPlatformMgr_Init),
-    NL_TEST_DEF("Test PlatformMgr::RunUnitTest", TestPlatformMgr_RunUnitTest),
-    NL_TEST_DEF("Test ConfigurationMgr::SerialNumber", TestConfigurationMgr_SerialNumber),
-    NL_TEST_DEF("Test ConfigurationMgr::UniqueId", TestConfigurationMgr_UniqueId),
-    NL_TEST_DEF("Test ConfigurationMgr::ManufacturingDate", TestConfigurationMgr_ManufacturingDate),
-    NL_TEST_DEF("Test ConfigurationMgr::HardwareVersion", TestConfigurationMgr_HardwareVersion),
-    NL_TEST_DEF("Test ConfigurationMgr::FirmwareBuildTime", TestConfigurationMgr_FirmwareBuildTime),
-    NL_TEST_DEF("Test ConfigurationMgr::CountryCode", TestConfigurationMgr_CountryCode),
-    NL_TEST_DEF("Test ConfigurationMgr::GetPrimaryMACAddress", TestConfigurationMgr_GetPrimaryMACAddress),
-    NL_TEST_DEF("Test ConfigurationMgr::GetFailSafeArmed", TestConfigurationMgr_GetFailSafeArmed),
-    NL_TEST_DEF("Test ConfigurationMgr::GetVendorName", TestConfigurationMgr_GetVendorName),
-    NL_TEST_DEF("Test ConfigurationMgr::GetVendorId", TestConfigurationMgr_GetVendorId),
-    NL_TEST_DEF("Test ConfigurationMgr::GetProductName", TestConfigurationMgr_GetProductName),
-    NL_TEST_DEF("Test ConfigurationMgr::GetProductId", TestConfigurationMgr_GetProductId),
-    NL_TEST_SENTINEL(),
-};
-
-/**
- *  Set up the test suite.
- */
-int TestConfigurationMgr_Setup(void * inContext)
-{
-    CHIP_ERROR error = chip::Platform::MemoryInit();
-    if (error != CHIP_NO_ERROR)
-        return FAILURE;
-    return SUCCESS;
-}
-
-/**
- *  Tear down the test suite.
- */
-int TestConfigurationMgr_Teardown(void * inContext)
-{
-    PlatformMgr().Shutdown();
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_GE(productId, 1u);
+    EXPECT_LE(productId, 0xffff);
 }
 
 } // namespace
@@ -494,13 +468,3 @@ int TestConfigurationMgr_Teardown(void * inContext)
 /**
  *  Main
  */
-int TestConfigurationMgr()
-{
-    nlTestSuite theSuite = { "ConfigurationMgr tests", &sTests[0], TestConfigurationMgr_Setup, TestConfigurationMgr_Teardown };
-
-    // Run test suite against one context.
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestConfigurationMgr)

--- a/src/platform/tests/TestConnectivityMgr.cpp
+++ b/src/platform/tests/TestConnectivityMgr.cpp
@@ -50,11 +50,8 @@ struct TestConnectivityMgr : public ::testing::Test
 
     static void SetUpTestSuite()
     {
-        // ConfigurationManager is initialized from PlatformManager indirectly
-        CHIP_ERROR err = PlatformMgr().InitChipStack();
+        auto err = chip::Platform::MemoryInit();
         EXPECT_EQ(err, CHIP_NO_ERROR);
-        err = chip::Platform::MemoryInit();
-        ASSERT_EQ(err, CHIP_NO_ERROR);
     }
 
     static void TearDownTestSuite()
@@ -63,6 +60,12 @@ struct TestConnectivityMgr : public ::testing::Test
         chip::DeviceLayer::PlatformMgr().Shutdown();
     }
 };
+TEST_F(TestConnectivityMgr, Init)
+{
+    // ConfigurationManager is initialized from PlatformManager indirectly
+    CHIP_ERROR err = PlatformMgr().InitChipStack();
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+}
 
 TEST_F(TestConnectivityMgr, GetNetworkInterfaces)
 {
@@ -72,7 +75,7 @@ TEST_F(TestConnectivityMgr, GetNetworkInterfaces)
 
     err = GetDiagnosticDataProvider().GetNetworkInterfaces(&netifs);
     EXPECT_EQ(err, CHIP_NO_ERROR);
-    ASSERT_NE(netifs, nullptr);
+    EXPECT_NE(netifs, nullptr);
 
     GetDiagnosticDataProvider().ReleaseNetworkInterfaces(netifs);
 }

--- a/src/platform/tests/TestConnectivityMgr.cpp
+++ b/src/platform/tests/TestConnectivityMgr.cpp
@@ -52,6 +52,7 @@ struct TestConnectivityMgr : public ::testing::Test
     {
         auto err = chip::Platform::MemoryInit();
         EXPECT_EQ(err, CHIP_NO_ERROR);
+        // TODO: Move initialization of the platform manager from Init test to here
     }
 
     static void TearDownTestSuite()
@@ -60,6 +61,7 @@ struct TestConnectivityMgr : public ::testing::Test
         chip::DeviceLayer::PlatformMgr().Shutdown();
     }
 };
+
 TEST_F(TestConnectivityMgr, Init)
 {
     // ConfigurationManager is initialized from PlatformManager indirectly

--- a/src/platform/tests/TestConnectivityMgr.cpp
+++ b/src/platform/tests/TestConnectivityMgr.cpp
@@ -30,8 +30,8 @@
 
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/UnitTestRegistration.h>
-#include <nlunit-test.h>
+
+#include <gtest/gtest.h>
 
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DiagnosticDataProvider.h>
@@ -45,63 +45,34 @@ using namespace chip::DeviceLayer;
 //      Unit tests
 // =================================
 
-static void TestPlatformMgr_Init(nlTestSuite * inSuite, void * inContext)
+struct TestConnectivityMgr : public ::testing::Test
 {
-    // ConfigurationManager is initialized from PlatformManager indirectly
-    CHIP_ERROR err = PlatformMgr().InitChipStack();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-}
 
-static void TestConnectivityMgr_GetNetworkInterfaces(nlTestSuite * inSuite, void * inContext)
+    static void SetUpTestSuite()
+    {
+        // ConfigurationManager is initialized from PlatformManager indirectly
+        CHIP_ERROR err = PlatformMgr().InitChipStack();
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        err = chip::Platform::MemoryInit();
+        ASSERT_EQ(err, CHIP_NO_ERROR);
+    }
+
+    static void TearDownTestSuite()
+    {
+        chip::Platform::MemoryShutdown();
+        chip::DeviceLayer::PlatformMgr().Shutdown();
+    }
+};
+
+TEST_F(TestConnectivityMgr, GetNetworkInterfaces)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     NetworkInterface * netifs = nullptr;
 
     err = GetDiagnosticDataProvider().GetNetworkInterfaces(&netifs);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, netifs != nullptr);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    ASSERT_NE(netifs, nullptr);
 
     GetDiagnosticDataProvider().ReleaseNetworkInterfaces(netifs);
 }
-
-/**
- *   Test Suite. It lists all the test functions.
- */
-static const nlTest sTests[] = {
-
-    NL_TEST_DEF("Test PlatformMgr::Init", TestPlatformMgr_Init),
-    NL_TEST_DEF("Test ConfigurationMgr::GetNetworkInterfaces", TestConnectivityMgr_GetNetworkInterfaces), NL_TEST_SENTINEL()
-};
-
-/**
- *  Set up the test suite.
- */
-int TestConnectivityMgr_Setup(void * inContext)
-{
-    CHIP_ERROR error = chip::Platform::MemoryInit();
-    if (error != CHIP_NO_ERROR)
-        return FAILURE;
-    return SUCCESS;
-}
-
-/**
- *  Tear down the test suite.
- */
-int TestConnectivityMgr_Teardown(void * inContext)
-{
-    PlatformMgr().Shutdown();
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-int TestConnectivityMgr()
-{
-    nlTestSuite theSuite = { "ConfigurationMgr tests", &sTests[0], TestConnectivityMgr_Setup, TestConnectivityMgr_Teardown };
-
-    // Run test suite against one context.
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestConnectivityMgr)

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -17,7 +17,7 @@
 
 #include <atomic>
 
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 #include "lib/dnssd/platform/Dnssd.h"
 #include "platform/CHIPDeviceLayer.h"
@@ -34,8 +34,6 @@
 #include <lib/dnssd/minimal_mdns/responders/Srv.h>
 #include <lib/dnssd/minimal_mdns/responders/Txt.h>
 #include <lib/support/CHIPMem.h>
-#include <lib/support/UnitTestContext.h>
-#include <lib/support/UnitTestRegistration.h>
 
 using chip::Dnssd::DnssdService;
 using chip::Dnssd::DnssdServiceProtocol;
@@ -45,8 +43,6 @@ namespace {
 
 struct DnssdContext
 {
-    nlTestSuite * mTestSuite;
-
     std::atomic<bool> mTimeoutExpired{ false };
 
     intptr_t mBrowseIdentifier = 0;
@@ -87,6 +83,21 @@ private:
 
 } // namespace
 
+class TestDnssd : public ::testing::Test
+{
+public: // protected
+    static void SetUpTestSuite()
+    {
+        EXPECT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
+        EXPECT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
+    }
+    static void TearDownTestSuite()
+    {
+        chip::DeviceLayer::PlatformMgr().Shutdown();
+        chip::Platform::MemoryShutdown();
+    }
+};
+
 static void Timeout(chip::System::Layer * systemLayer, void * context)
 {
     auto * ctx = static_cast<DnssdContext *>(context);
@@ -98,12 +109,11 @@ static void Timeout(chip::System::Layer * systemLayer, void * context)
 static void HandleResolve(void * context, DnssdService * result, const chip::Span<chip::Inet::IPAddress> & addresses,
                           CHIP_ERROR error)
 {
-    auto * ctx   = static_cast<DnssdContext *>(context);
-    auto * suite = ctx->mTestSuite;
+    auto * ctx = static_cast<DnssdContext *>(context);
     char addrBuf[100];
 
-    NL_TEST_EXIT_ON_FAILED_ASSERT(suite, result != nullptr);
-    NL_TEST_ASSERT(suite, error == CHIP_NO_ERROR);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(error, CHIP_NO_ERROR);
 
     // The NL_TEST_ASSERT above will not abort the test, so we need to
     // explicitly abort it here to avoid dereferencing a null pointer.
@@ -115,9 +125,9 @@ static void HandleResolve(void * context, DnssdService * result, const chip::Spa
         printf("Service[%u] at [%s]:%u\n", ctx->mResolvedServicesCount, addrBuf, result->mPort);
     }
 
-    NL_TEST_ASSERT(suite, result->mTextEntrySize == 1);
-    NL_TEST_ASSERT(suite, strcmp(result->mTextEntries[0].mKey, "key") == 0);
-    NL_TEST_ASSERT(suite, strcmp(reinterpret_cast<const char *>(result->mTextEntries[0].mData), "val") == 0);
+    EXPECT_EQ(result->mTextEntrySize, 1u);
+    EXPECT_EQ(strcmp(result->mTextEntries[0].mKey, "key"), 0);
+    EXPECT_EQ(strcmp(reinterpret_cast<const char *>(result->mTextEntries[0].mData), "val"), 0);
 
     if (ctx->mBrowsedServicesCount == ++ctx->mResolvedServicesCount)
     {
@@ -138,13 +148,12 @@ static void HandleResolve(void * context, DnssdService * result, const chip::Spa
 static void HandleBrowse(void * context, DnssdService * services, size_t servicesSize, bool finalBrowse, CHIP_ERROR error)
 {
     auto * ctx   = static_cast<DnssdContext *>(context);
-    auto * suite = ctx->mTestSuite;
 
     // Make sure that we will not be called again after end-of-input is set
-    NL_TEST_ASSERT(suite, ctx->mEndOfInput == false);
+    EXPECT_EQ(ctx->mEndOfInput, false);
     // Cancelled error is expected when the browse is stopped with
     // ChipDnssdStopBrowse(), so we will not assert on it.
-    NL_TEST_ASSERT(suite, error == CHIP_NO_ERROR || error == CHIP_ERROR_CANCELLED);
+    EXPECT_TRUE(error == CHIP_NO_ERROR || error == CHIP_ERROR_CANCELLED);
 
     ctx->mBrowsedServicesCount += servicesSize;
     ctx->mEndOfInput = finalBrowse;
@@ -156,27 +165,24 @@ static void HandleBrowse(void * context, DnssdService * services, size_t service
         {
             printf("Service[%u] name %s\n", i, services[i].mName);
             printf("Service[%u] type %s\n", i, services[i].mType);
-            NL_TEST_ASSERT(suite, ChipDnssdResolve(&services[i], services[i].mInterface, HandleResolve, context) == CHIP_NO_ERROR);
+            EXPECT_EQ(ChipDnssdResolve(&services[i], services[i].mInterface, HandleResolve, context), CHIP_NO_ERROR);
         }
     }
 }
 
 static void DnssdErrorCallback(void * context, CHIP_ERROR error)
 {
-    auto * ctx = static_cast<DnssdContext *>(context);
-    NL_TEST_ASSERT(ctx->mTestSuite, error == CHIP_NO_ERROR);
+    EXPECT_EQ(error, CHIP_NO_ERROR);
 }
 
 void TestDnssdBrowse_DnssdInitCallback(void * context, CHIP_ERROR error)
 {
     auto * ctx = static_cast<DnssdContext *>(context);
-    NL_TEST_ASSERT(ctx->mTestSuite, error == CHIP_NO_ERROR);
-    auto * suite = ctx->mTestSuite;
+    EXPECT_EQ(error, CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(suite,
-                   ChipDnssdBrowse("_mock", DnssdServiceProtocol::kDnssdProtocolUdp, chip::Inet::IPAddressType::kAny,
-                                   chip::Inet::InterfaceId::Null(), HandleBrowse, context,
-                                   &ctx->mBrowseIdentifier) == CHIP_NO_ERROR);
+    EXPECT_EQ(ChipDnssdBrowse("_mock", DnssdServiceProtocol::kDnssdProtocolUdp, chip::Inet::IPAddressType::kAny,
+                              chip::Inet::InterfaceId::Null(), HandleBrowse, context, &ctx->mBrowseIdentifier),
+              CHIP_NO_ERROR);
 }
 
 // Verify that platform DNS-SD implementation can browse and resolve services.
@@ -186,10 +192,9 @@ void TestDnssdBrowse_DnssdInitCallback(void * context, CHIP_ERROR error)
 // A and AAAA queries without additional records. In order to pass this test,
 // the platform DNS-SD client implementation must be able to browse and resolve
 // services by querying for all of these records separately.
-void TestDnssdBrowse(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDnssd, TestDnssdBrowse)
 {
     DnssdContext context;
-    context.mTestSuite = inSuite;
 
     mdns::Minimal::SetDefaultAddressPolicy();
 
@@ -229,20 +234,17 @@ void TestDnssdBrowse(nlTestSuite * inSuite, void * inContext)
     server.SetDelegate(&delegate);
 
     auto endpoints = mdns::Minimal::GetAddressPolicy()->GetListenEndpoints();
-    NL_TEST_ASSERT(inSuite, server.Listen(chip::DeviceLayer::UDPEndPointManager(), endpoints.get(), 5353) == CHIP_NO_ERROR);
+    EXPECT_EQ(server.Listen(chip::DeviceLayer::UDPEndPointManager(), endpoints.get(), 5353), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   chip::Dnssd::ChipDnssdInit(TestDnssdBrowse_DnssdInitCallback, DnssdErrorCallback, &context) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite,
-                   chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(5), Timeout, &context) ==
-                       CHIP_NO_ERROR);
+    EXPECT_EQ(chip::Dnssd::ChipDnssdInit(TestDnssdBrowse_DnssdInitCallback, DnssdErrorCallback, &context), CHIP_NO_ERROR);
+    EXPECT_EQ(chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(5), Timeout, &context), CHIP_NO_ERROR);
 
     ChipLogProgress(DeviceLayer, "Start EventLoop");
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
     ChipLogProgress(DeviceLayer, "End EventLoop");
 
-    NL_TEST_ASSERT(inSuite, context.mResolvedServicesCount > 0);
-    NL_TEST_ASSERT(inSuite, !context.mTimeoutExpired);
+    EXPECT_TRUE(context.mResolvedServicesCount > 0);
+    EXPECT_TRUE(!context.mTimeoutExpired);
 
     // Stop browsing so we can safely shutdown DNS-SD
     chip::Dnssd::ChipDnssdStopBrowse(context.mBrowseIdentifier);
@@ -252,15 +254,13 @@ void TestDnssdBrowse(nlTestSuite * inSuite, void * inContext)
 
 static void HandlePublish(void * context, const char * type, const char * instanceName, CHIP_ERROR error)
 {
-    auto * ctx = static_cast<DnssdContext *>(context);
-    NL_TEST_ASSERT(ctx->mTestSuite, error == CHIP_NO_ERROR);
+    EXPECT_EQ(error, CHIP_NO_ERROR);
 }
 
 static void TestDnssdPublishService_DnssdInitCallback(void * context, CHIP_ERROR error)
 {
     auto * ctx = static_cast<DnssdContext *>(context);
-    NL_TEST_ASSERT(ctx->mTestSuite, error == CHIP_NO_ERROR);
-    auto * suite = ctx->mTestSuite;
+    EXPECT_EQ(error, CHIP_NO_ERROR);
 
     DnssdService service{};
     TextEntry entry{ "key", reinterpret_cast<const uint8_t *>("val"), 3 };
@@ -277,12 +277,11 @@ static void TestDnssdPublishService_DnssdInitCallback(void * context, CHIP_ERROR
     service.mSubTypes      = nullptr;
     service.mSubTypeSize   = 0;
 
-    NL_TEST_ASSERT(suite, ChipDnssdPublishService(&service, HandlePublish, context) == CHIP_NO_ERROR);
+    EXPECT_EQ(ChipDnssdPublishService(&service, HandlePublish, context), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(suite,
-                   ChipDnssdBrowse("_mock", DnssdServiceProtocol::kDnssdProtocolTcp, chip::Inet::IPAddressType::kAny,
-                                   chip::Inet::InterfaceId::Null(), HandleBrowse, context,
-                                   &ctx->mBrowseIdentifier) == CHIP_NO_ERROR);
+    EXPECT_EQ(ChipDnssdBrowse("_mock", DnssdServiceProtocol::kDnssdProtocolTcp, chip::Inet::IPAddressType::kAny,
+                              chip::Inet::InterfaceId::Null(), HandleBrowse, context, &ctx->mBrowseIdentifier),
+              CHIP_NO_ERROR);
 }
 
 // Verify that the platform DNS-SD implementation can publish services.
@@ -290,58 +289,22 @@ static void TestDnssdPublishService_DnssdInitCallback(void * context, CHIP_ERROR
 // This test uses platform implementation of DNS-SD server and client. Since
 // client implementation should be verified by the TestDnssdBrowse test case,
 // here we only verify that the server implementation can publish services.
-void TestDnssdPublishService(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDnssd, TestDnssdPublishService)
 {
     DnssdContext context;
-    context.mTestSuite = inSuite;
 
-    NL_TEST_ASSERT(inSuite,
-                   chip::Dnssd::ChipDnssdInit(TestDnssdPublishService_DnssdInitCallback, DnssdErrorCallback, &context) ==
-                       CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite,
-                   chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(5), Timeout, &context) ==
-                       CHIP_NO_ERROR);
+    EXPECT_EQ(chip::Dnssd::ChipDnssdInit(TestDnssdPublishService_DnssdInitCallback, DnssdErrorCallback, &context), CHIP_NO_ERROR);
+    EXPECT_EQ(chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(5), Timeout, &context), CHIP_NO_ERROR);
 
     ChipLogProgress(DeviceLayer, "Start EventLoop");
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
     ChipLogProgress(DeviceLayer, "End EventLoop");
 
-    NL_TEST_ASSERT(inSuite, context.mResolvedServicesCount > 0);
-    NL_TEST_ASSERT(inSuite, !context.mTimeoutExpired);
+    EXPECT_TRUE(context.mResolvedServicesCount > 0);
+    EXPECT_TRUE(!context.mTimeoutExpired);
 
     // Stop browsing so we can safely shutdown DNS-SD
     chip::Dnssd::ChipDnssdStopBrowse(context.mBrowseIdentifier);
 
     chip::Dnssd::ChipDnssdShutdown();
 }
-
-static const nlTest sTests[] = {
-    NL_TEST_DEF("Test ChipDnssdBrowse", TestDnssdBrowse),
-    NL_TEST_DEF("Test ChipDnssdPublishService", TestDnssdPublishService),
-    NL_TEST_SENTINEL(),
-};
-
-int TestDnssd_Setup(void * inContext)
-{
-    VerifyOrReturnError(chip::Platform::MemoryInit() == CHIP_NO_ERROR, FAILURE);
-    VerifyOrReturnError(chip::DeviceLayer::PlatformMgr().InitChipStack() == CHIP_NO_ERROR, FAILURE);
-    return SUCCESS;
-}
-
-int TestDnssd_Teardown(void * inContext)
-{
-    chip::DeviceLayer::PlatformMgr().Shutdown();
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-int TestDnssd()
-{
-    nlTestSuite theSuite = { "CHIP DeviceLayer mDNS tests", &sTests[0], TestDnssd_Setup, TestDnssd_Teardown };
-
-    // Run test suite against one context.
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestDnssd);

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -119,8 +119,8 @@ static void HandleResolve(void * context, DnssdService * result, const chip::Spa
     }
 
     EXPECT_EQ(result->mTextEntrySize, 1u);
-    EXPECT_EQ(strcmp(result->mTextEntries[0].mKey, "key"), 0);
-    EXPECT_EQ(strcmp(reinterpret_cast<const char *>(result->mTextEntries[0].mData), "val"), 0);
+    EXPECT_STREQ(result->mTextEntries[0].mKey, "key");
+    EXPECT_STREQ(reinterpret_cast<const char *>(result->mTextEntries[0].mData), "val");
 
     if (ctx->mBrowsedServicesCount == ++ctx->mResolvedServicesCount)
     {
@@ -143,7 +143,7 @@ static void HandleBrowse(void * context, DnssdService * services, size_t service
     auto * ctx = static_cast<TestDnssd *>(context);
 
     // Make sure that we will not be called again after end-of-input is set
-    EXPECT_EQ(ctx->mEndOfInput, false);
+    EXPECT_FALSE(ctx->mEndOfInput);
     // Cancelled error is expected when the browse is stopped with
     // ChipDnssdStopBrowse(), so we will not assert on it.
     EXPECT_TRUE(error == CHIP_NO_ERROR || error == CHIP_ERROR_CANCELLED);

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -234,7 +234,7 @@ TEST_F(TestDnssd, TestDnssdBrowse)
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
     ChipLogProgress(DeviceLayer, "End EventLoop");
 
-    EXPECT_GT(mResolvedServicesCount, 0);
+    EXPECT_GT(mResolvedServicesCount, 0u);
     EXPECT_FALSE(mTimeoutExpired);
 
     // Stop browsing so we can safely shutdown DNS-SD
@@ -289,7 +289,7 @@ TEST_F(TestDnssd, TestDnssdPublishService)
     chip::DeviceLayer::PlatformMgr().RunEventLoop();
     ChipLogProgress(DeviceLayer, "End EventLoop");
 
-    EXPECT_GT(mResolvedServicesCount, 0);
+    EXPECT_GT(mResolvedServicesCount, 0u);
     EXPECT_FALSE(mTimeoutExpired);
 
     // Stop browsing so we can safely shutdown DNS-SD

--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -39,7 +39,7 @@ struct TestKeyValueStoreMgr : public ::testing::Test
     static void SetUpTestSuite()
     {
         CHIP_ERROR err = chip::Platform::MemoryInit();
-        ASSERT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
     }
 
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }

--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -22,10 +22,9 @@
  *
  */
 
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 #include <lib/support/CHIPMem.h>
-#include <lib/support/UnitTestRegistration.h>
 
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/KeyValueStoreManager.h>
@@ -34,7 +33,19 @@ using namespace chip;
 using namespace chip::DeviceLayer;
 using namespace chip::DeviceLayer::PersistedStorage;
 
-static void TestKeyValueStoreMgr_EmptyString(nlTestSuite * inSuite, void * inContext)
+struct TestKeyValueStoreMgr : public ::testing::Test
+{
+
+    static void SetUpTestSuite()
+    {
+        CHIP_ERROR err = chip::Platform::MemoryInit();
+        ASSERT_EQ(err, CHIP_NO_ERROR);
+    }
+
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+TEST_F(TestKeyValueStoreMgr, EmptyString)
 {
     static constexpr char kTestKey[]   = "str_key";
     static constexpr char kTestValue[] = "";
@@ -44,32 +55,32 @@ static void TestKeyValueStoreMgr_EmptyString(nlTestSuite * inSuite, void * inCon
     size_t readSize;
 
     CHIP_ERROR err = KeyValueStoreMgr().Put(kTestKey, kTestValue, kTestValueLen);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Verify if read value is the same as wrote one
     err = KeyValueStoreMgr().Get(kTestKey, readValue, sizeof(readValue), &readSize);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, readSize == kTestValueLen);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(readSize, kTestValueLen);
 
     // Verify that read succeeds even if 0-length buffer is provided
     err = KeyValueStoreMgr().Get(kTestKey, readValue, 0, &readSize);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, readSize == kTestValueLen);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(readSize, kTestValueLen);
 
     err = KeyValueStoreMgr().Get(kTestKey, nullptr, 0, &readSize);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, readSize == kTestValueLen);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(readSize, kTestValueLen);
 
     // Verify deletion
     err = KeyValueStoreMgr().Delete(kTestKey);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Try to get deleted key and verify if CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND is returned
     err = KeyValueStoreMgr().Get(kTestKey, readValue, sizeof(readValue), &readSize);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    EXPECT_EQ(err, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 }
 
-static void TestKeyValueStoreMgr_String(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestKeyValueStoreMgr, String)
 {
     static constexpr char kTestKey[]   = "str_key";
     static constexpr char kTestValue[] = "test_value";
@@ -78,24 +89,24 @@ static void TestKeyValueStoreMgr_String(nlTestSuite * inSuite, void * inContext)
     size_t readSize;
 
     CHIP_ERROR err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Verify if read value is the same as wrote one
     err = KeyValueStoreMgr().Get(kTestKey, readValue, sizeof(readValue), &readSize);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, strcmp(kTestValue, readValue) == 0);
-    NL_TEST_ASSERT(inSuite, readSize == sizeof(kTestValue));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_STREQ(kTestValue, readValue);
+    EXPECT_EQ(readSize, sizeof(kTestValue));
 
     // Verify deletion
     err = KeyValueStoreMgr().Delete(kTestKey);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Try to get deleted key and verify if CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND is returned
     err = KeyValueStoreMgr().Get(kTestKey, readValue, sizeof(readValue), &readSize);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    EXPECT_EQ(err, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 }
 
-static void TestKeyValueStoreMgr_Uint32(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestKeyValueStoreMgr, Uint32)
 {
     static constexpr char kTestKey[]    = "uint32_key";
     constexpr const uint32_t kTestValue = 5;
@@ -103,23 +114,23 @@ static void TestKeyValueStoreMgr_Uint32(nlTestSuite * inSuite, void * inContext)
     uint32_t readValue = UINT32_MAX;
 
     CHIP_ERROR err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Verify if read value is the same as wrote one
     err = KeyValueStoreMgr().Get(kTestKey, &readValue);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, kTestValue == readValue);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(kTestValue, readValue);
 
     // Verify deletion
     err = KeyValueStoreMgr().Delete(kTestKey);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Try to get deleted key and verify if CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND is returned
     err = KeyValueStoreMgr().Get(kTestKey, &readValue);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    EXPECT_EQ(err, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 }
 
-static void TestKeyValueStoreMgr_Array(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestKeyValueStoreMgr, Array)
 {
     static constexpr char kTestKey[] = "array_key";
     constexpr uint32_t kTestValue[5] = { 1, 2, 3, 4, 5 };
@@ -128,24 +139,24 @@ static void TestKeyValueStoreMgr_Array(nlTestSuite * inSuite, void * inContext)
     size_t readSize;
 
     CHIP_ERROR err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Verify if read value is the same as wrote one
     err = KeyValueStoreMgr().Get(kTestKey, readValue, sizeof(readValue), &readSize);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, memcmp(kTestValue, readValue, sizeof(kTestValue)) == 0);
-    NL_TEST_ASSERT(inSuite, readSize == sizeof(kTestValue));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(memcmp(kTestValue, readValue, sizeof(kTestValue)), 0);
+    EXPECT_EQ(readSize, sizeof(kTestValue));
 
     // Verify deletion
     err = KeyValueStoreMgr().Delete(kTestKey);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Try to get deleted key and verify if CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND is returned
     err = KeyValueStoreMgr().Get(kTestKey, readValue, sizeof(readValue), &readSize);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    EXPECT_EQ(err, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 }
 
-static void TestKeyValueStoreMgr_Struct(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestKeyValueStoreMgr, Struct)
 {
     struct TestStruct
     {
@@ -160,25 +171,25 @@ static void TestKeyValueStoreMgr_Struct(nlTestSuite * inSuite, void * inContext)
     size_t readSize;
 
     CHIP_ERROR err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Verify if read value is the same as wrote one
     err = KeyValueStoreMgr().Get(kTestKey, &readValue, sizeof(readValue), &readSize);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, kTestValue.value1 == readValue.value1);
-    NL_TEST_ASSERT(inSuite, kTestValue.value2 == readValue.value2);
-    NL_TEST_ASSERT(inSuite, readSize == sizeof(kTestValue));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(kTestValue.value1, readValue.value1);
+    EXPECT_EQ(kTestValue.value2, readValue.value2);
+    EXPECT_EQ(readSize, sizeof(kTestValue));
 
     // Verify deletion
     err = KeyValueStoreMgr().Delete(kTestKey);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Try to get deleted key and verify if CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND is returned
     err = KeyValueStoreMgr().Get(kTestKey, &readValue, sizeof(readValue), &readSize);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    EXPECT_EQ(err, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 }
 
-static void TestKeyValueStoreMgr_UpdateValue(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestKeyValueStoreMgr, UpdateValue)
 {
     static constexpr char kTestKey[] = "update_key";
 
@@ -188,18 +199,18 @@ static void TestKeyValueStoreMgr_UpdateValue(nlTestSuite * inSuite, void * inCon
     for (uint32_t i = 0; i < 10; i++)
     {
         err = KeyValueStoreMgr().Put(kTestKey, i);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = KeyValueStoreMgr().Get(kTestKey, &readValue);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, i == readValue);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(i, readValue);
     }
 
     err = KeyValueStoreMgr().Delete(kTestKey);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 }
 
-static void TestKeyValueStoreMgr_TooSmallBufferRead(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestKeyValueStoreMgr, TooSmallBufferRead)
 {
     static constexpr char kTestKey[] = "too_small_buffer_read_key";
     constexpr uint8_t kTestValue[]   = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
@@ -208,19 +219,19 @@ static void TestKeyValueStoreMgr_TooSmallBufferRead(nlTestSuite * inSuite, void 
     size_t readSize;
 
     CHIP_ERROR err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Returns buffer too small and should read as many bytes as possible
     err = KeyValueStoreMgr().Get(kTestKey, &readValue, sizeof(readValue), &readSize, 0);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
-    NL_TEST_ASSERT(inSuite, readSize == sizeof(readValue));
-    NL_TEST_ASSERT(inSuite, memcmp(kTestValue, readValue, readSize) == 0);
+    EXPECT_EQ(err, CHIP_ERROR_BUFFER_TOO_SMALL);
+    EXPECT_EQ(readSize, sizeof(readValue));
+    EXPECT_EQ(memcmp(kTestValue, readValue, readSize), 0);
 
     err = KeyValueStoreMgr().Delete(kTestKey);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 }
 
-static void TestKeyValueStoreMgr_AllCharactersKey(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestKeyValueStoreMgr, AllCharactersKey)
 {
     // Test that all printable characters [0x20 - 0x7f) can be part of the key
     constexpr size_t kKeyLength   = 32;
@@ -241,33 +252,33 @@ static void TestKeyValueStoreMgr_AllCharactersKey(nlTestSuite * inSuite, void * 
         memcpy(testKey, &allChars[charId], chip::min(sizeof(allChars) - charId, kKeyLength));
 
         CHIP_ERROR err = KeyValueStoreMgr().Put(testKey, kTestValue);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         uint32_t readValue = UINT32_MAX;
         err                = KeyValueStoreMgr().Get(testKey, &readValue);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = KeyValueStoreMgr().Delete(testKey);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
     }
 }
 
-static void TestKeyValueStoreMgr_NonExistentDelete(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestKeyValueStoreMgr, NonExistentDelete)
 {
     static constexpr char kTestKey[] = "non_existent";
 
     CHIP_ERROR err = KeyValueStoreMgr().Delete(kTestKey);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    EXPECT_EQ(err, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 }
 
 #if !defined(__ZEPHYR__) && !defined(__MBED__)
-static void TestKeyValueStoreMgr_MultiRead(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestKeyValueStoreMgr, MultiRead)
 {
     static constexpr char kTestKey[] = "multi_key";
     constexpr uint32_t kTestValue[5] = { 1, 2, 3, 4, 5 };
 
     CHIP_ERROR err = KeyValueStoreMgr().Put(kTestKey, kTestValue);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     for (uint32_t i = 0; i < 5; i++)
     {
@@ -276,86 +287,33 @@ static void TestKeyValueStoreMgr_MultiRead(nlTestSuite * inSuite, void * inConte
 
         // Returns buffer too small for all but the last read.
         err = KeyValueStoreMgr().Get(kTestKey, &readValue, sizeof(readValue), &readSize, i * sizeof(uint32_t));
-        NL_TEST_ASSERT(inSuite, err == (i < 4 ? CHIP_ERROR_BUFFER_TOO_SMALL : CHIP_NO_ERROR));
-        NL_TEST_ASSERT(inSuite, readSize == sizeof(readValue));
-        NL_TEST_ASSERT(inSuite, kTestValue[i] == readValue);
+        EXPECT_EQ(err, (i < 4 ? CHIP_ERROR_BUFFER_TOO_SMALL : CHIP_NO_ERROR));
+        EXPECT_EQ(readSize, sizeof(readValue));
+        EXPECT_EQ(kTestValue[i], readValue);
     }
 
     err = KeyValueStoreMgr().Delete(kTestKey);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 }
 #endif
 
 #ifdef __ZEPHYR__
-static void TestKeyValueStoreMgr_DoFactoryReset(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestKeyValueStoreMgr, DoFactoryReset)
 {
     static constexpr char kStrKey[]  = "string_with_weird_chars\\=_key";
     static constexpr char kUintKey[] = "some_uint_key";
 
-    NL_TEST_ASSERT(inSuite, KeyValueStoreMgr().Put(kStrKey, "some_string") == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, KeyValueStoreMgr().Put(kUintKey, uint32_t(1234)) == CHIP_NO_ERROR);
+    EXPECT_EQ(KeyValueStoreMgr().Put(kStrKey, "some_string"), CHIP_NO_ERROR);
+    EXPECT_EQ(KeyValueStoreMgr().Put(kUintKey, uint32_t(1234)), CHIP_NO_ERROR);
 
     char readString[16];
     uint32_t readValue;
 
-    NL_TEST_ASSERT(inSuite, KeyValueStoreMgr().Get(kStrKey, readString, sizeof(readString)) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, KeyValueStoreMgr().Get(kUintKey, &readValue) == CHIP_NO_ERROR);
+    EXPECT_EQ(KeyValueStoreMgr().Get(kStrKey, readString, sizeof(readString)), CHIP_NO_ERROR);
+    EXPECT_EQ(KeyValueStoreMgr().Get(kUintKey, &readValue), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, KeyValueStoreMgrImpl().DoFactoryReset() == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite,
-                   KeyValueStoreMgr().Get(kStrKey, readString, sizeof(readString)) == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
-    NL_TEST_ASSERT(inSuite, KeyValueStoreMgr().Get(kUintKey, &readValue) == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    EXPECT_EQ(KeyValueStoreMgrImpl().DoFactoryReset(), CHIP_NO_ERROR);
+    EXPECT_EQ(KeyValueStoreMgr().Get(kStrKey, readString, sizeof(readString)), CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    EXPECT_EQ(KeyValueStoreMgr().Get(kUintKey, &readValue), CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 }
 #endif
-/**
- *   Test Suite. It lists all the test functions.
- */
-static const nlTest sTests[] = { NL_TEST_DEF("Test KeyValueStoreMgr_EmptyString", TestKeyValueStoreMgr_EmptyString),
-                                 NL_TEST_DEF("Test KeyValueStoreMgr_String", TestKeyValueStoreMgr_String),
-                                 NL_TEST_DEF("Test KeyValueStoreMgr_Uint32", TestKeyValueStoreMgr_Uint32),
-                                 NL_TEST_DEF("Test KeyValueStoreMgr_Array", TestKeyValueStoreMgr_Array),
-                                 NL_TEST_DEF("Test KeyValueStoreMgr_Struct", TestKeyValueStoreMgr_Struct),
-                                 NL_TEST_DEF("Test KeyValueStoreMgr_UpdateValue", TestKeyValueStoreMgr_UpdateValue),
-                                 NL_TEST_DEF("Test KeyValueStoreMgr_TooSmallBufferRead", TestKeyValueStoreMgr_TooSmallBufferRead),
-                                 NL_TEST_DEF("Test KeyValueStoreMgr_AllCharactersKey", TestKeyValueStoreMgr_AllCharactersKey),
-                                 NL_TEST_DEF("Test KeyValueStoreMgr_NonExistentDelete", TestKeyValueStoreMgr_NonExistentDelete),
-#if !defined(__ZEPHYR__) && !defined(__MBED__)
-                                 // Zephyr and Mbed platforms do not support partial or offset reads yet.
-                                 NL_TEST_DEF("Test KeyValueStoreMgr_MultiRead", TestKeyValueStoreMgr_MultiRead),
-#endif
-#ifdef __ZEPHYR__
-                                 NL_TEST_DEF("Test TestKeyValueStoreMgr_DoFactoryReset", TestKeyValueStoreMgr_DoFactoryReset),
-#endif
-                                 NL_TEST_SENTINEL() };
-
-/**
- *  Set up the test suite.
- */
-int TestKeyValueStoreMgr_Setup(void * inContext)
-{
-    CHIP_ERROR error = chip::Platform::MemoryInit();
-    if (error != CHIP_NO_ERROR)
-        return FAILURE;
-
-    return SUCCESS;
-}
-
-/**
- *  Tear down the test suite.
- */
-int TestKeyValueStoreMgr_Teardown(void * inContext)
-{
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-int TestKeyValueStoreMgr()
-{
-    nlTestSuite theSuite = { "KeyValueStoreMgr tests", &sTests[0], TestKeyValueStoreMgr_Setup, TestKeyValueStoreMgr_Teardown };
-
-    // Run test suite against one context.
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestKeyValueStoreMgr);

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -146,7 +146,7 @@ TEST_F(TestPlatformMgr, BasicRunEventLoop)
 
     PlatformMgr().ScheduleWork(StopTheLoop);
 
-    EXPECT_TRUE(!stopRan);
+    EXPECT_FALSE(stopRan);
     PlatformMgr().RunEventLoop();
     EXPECT_TRUE(stopRan);
     EXPECT_EQ(stopResult, CHIP_NO_ERROR);
@@ -172,8 +172,8 @@ TEST_F(TestPlatformMgr, RunEventLoopTwoTasks)
     PlatformMgr().ScheduleWork(SleepSome);
     PlatformMgr().ScheduleWork(StopTheLoop);
 
-    EXPECT_TRUE(!stopRan);
-    EXPECT_TRUE(!sleepRan);
+    EXPECT_FALSE(stopRan);
+    EXPECT_FALSE(sleepRan);
     PlatformMgr().RunEventLoop();
     EXPECT_TRUE(stopRan);
     EXPECT_TRUE(sleepRan);

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -55,7 +55,7 @@ public:
         CHIP_ERROR error = chip::Platform::MemoryInit();
         EXPECT_EQ(error, CHIP_NO_ERROR);
 
-        // Setup a fake commissionable data provider since required by internals of several
+        // Set up a fake commissionable data provider since required by internals of several
         // Device/SystemLayer components.
         static chip::DeviceLayer::TestOnlyCommissionableDataProvider commissionable_data_provider;
         chip::DeviceLayer::SetCommissionableDataProvider(&commissionable_data_provider);

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -30,12 +30,10 @@
 
 #include <atomic>
 
+#include <gtest/gtest.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/UnitTestExtendedAssertions.h>
-#include <lib/support/UnitTestRegistration.h>
 #include <lib/support/UnitTestUtils.h>
-#include <nlunit-test.h>
 
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/TestOnlyCommissionableDataProvider.h>
@@ -49,24 +47,46 @@ using namespace chip::DeviceLayer;
 //      Unit tests
 // =================================
 
-static void TestPlatformMgr_InitShutdown(nlTestSuite * inSuite, void * inContext)
+class TestPlatformMgr : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite()
+    {
+        CHIP_ERROR error = chip::Platform::MemoryInit();
+        if (error != CHIP_NO_ERROR)
+            FAIL() << "Failed to initialize memory";
+
+        // Setup a fake commissionable data provider since required by internals of several
+        // Device/SystemLayer components.
+        static chip::DeviceLayer::TestOnlyCommissionableDataProvider commissionable_data_provider;
+        chip::DeviceLayer::SetCommissionableDataProvider(&commissionable_data_provider);
+    }
+
+    static void TearDownTestSuite()
+    {
+        chip::Platform::MemoryShutdown();
+        SUCCEED();
+    }
+};
+
+TEST_F(TestPlatformMgr, InitShutdown)
 {
     CHIP_ERROR err = PlatformMgr().InitChipStack();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     PlatformMgr().Shutdown();
 }
 
-static void TestPlatformMgr_BasicEventLoopTask(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestPlatformMgr, BasicEventLoopTask)
 {
     std::atomic<int> counterRun{ 0 };
 
-    NL_TEST_ASSERT_SUCCESS(inSuite, PlatformMgr().InitChipStack());
+    EXPECT_EQ(PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
 
     // Start/stop the event loop task a few times.
     for (size_t i = 0; i < 3; i++)
     {
-        NL_TEST_ASSERT_SUCCESS(inSuite, PlatformMgr().StartEventLoopTask());
+        EXPECT_EQ(PlatformMgr().StartEventLoopTask(), CHIP_NO_ERROR);
 
         std::atomic<int> counterSync{ 2 };
 
@@ -98,7 +118,7 @@ static void TestPlatformMgr_BasicEventLoopTask(nlTestSuite * inSuite, void * inC
         for (size_t t = 0; counterSync != 0 && t < 1000; t++)
             chip::test_utils::SleepMillis(1);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, PlatformMgr().StopEventLoopTask());
+        EXPECT_EQ(PlatformMgr().StopEventLoopTask(), CHIP_NO_ERROR);
 
         // Sleep for a short time to allow the event loop to stop.
         // Note, in some platform implementations the event loop thread
@@ -107,7 +127,7 @@ static void TestPlatformMgr_BasicEventLoopTask(nlTestSuite * inSuite, void * inC
         chip::test_utils::SleepMillis(10);
     }
 
-    NL_TEST_ASSERT(inSuite, counterRun == (3 * 2));
+    EXPECT_EQ(counterRun, (3 * 2));
 
     PlatformMgr().Shutdown();
 }
@@ -123,18 +143,18 @@ static void StopTheLoop(intptr_t)
     stopResult = PlatformMgr().StopEventLoopTask();
 }
 
-static void TestPlatformMgr_BasicRunEventLoop(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestPlatformMgr, BasicRunEventLoop)
 {
     stopRan = false;
 
-    NL_TEST_ASSERT_SUCCESS(inSuite, PlatformMgr().InitChipStack());
+    EXPECT_EQ(PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
 
     PlatformMgr().ScheduleWork(StopTheLoop);
 
-    NL_TEST_ASSERT(inSuite, !stopRan);
+    EXPECT_TRUE(!stopRan);
     PlatformMgr().RunEventLoop();
-    NL_TEST_ASSERT(inSuite, stopRan);
-    NL_TEST_ASSERT_SUCCESS(inSuite, stopResult);
+    EXPECT_TRUE(stopRan);
+    EXPECT_EQ(stopResult, CHIP_NO_ERROR);
 
     PlatformMgr().Shutdown();
 }
@@ -147,51 +167,48 @@ static void SleepSome(intptr_t)
     sleepRan = true;
 }
 
-static void TestPlatformMgr_RunEventLoopTwoTasks(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestPlatformMgr, RunEventLoopTwoTasks)
 {
     stopRan  = false;
     sleepRan = false;
 
-    NL_TEST_ASSERT_SUCCESS(inSuite, PlatformMgr().InitChipStack());
+    EXPECT_EQ(PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
 
     PlatformMgr().ScheduleWork(SleepSome);
     PlatformMgr().ScheduleWork(StopTheLoop);
 
-    NL_TEST_ASSERT(inSuite, !stopRan);
-    NL_TEST_ASSERT(inSuite, !sleepRan);
+    EXPECT_TRUE(!stopRan);
+    EXPECT_TRUE(!sleepRan);
     PlatformMgr().RunEventLoop();
-    NL_TEST_ASSERT(inSuite, stopRan);
-    NL_TEST_ASSERT(inSuite, sleepRan);
+    EXPECT_TRUE(stopRan);
+    EXPECT_TRUE(sleepRan);
 
     PlatformMgr().Shutdown();
 }
 
-void StopAndSleep(intptr_t arg)
-{
-    // Ensure that we don't proceed after stopping until the sleep is done too.
-    StopTheLoop(arg);
-    SleepSome(arg);
-}
-
-static void TestPlatformMgr_RunEventLoopStopBeforeSleep(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestPlatformMgr, RunEventLoopStopBeforeSleep)
 {
     stopRan  = false;
     sleepRan = false;
 
-    NL_TEST_ASSERT_SUCCESS(inSuite, PlatformMgr().InitChipStack());
+    EXPECT_EQ(PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
 
-    PlatformMgr().ScheduleWork(StopAndSleep);
+    PlatformMgr().ScheduleWork([](intptr_t arg) {
+        // Ensure that we don't proceed after stopping until the sleep is done too.
+        StopTheLoop(arg);
+        SleepSome(arg);
+    });
 
-    NL_TEST_ASSERT(inSuite, !stopRan);
-    NL_TEST_ASSERT(inSuite, !sleepRan);
+    EXPECT_TRUE(!stopRan);
+    EXPECT_TRUE(!sleepRan);
     PlatformMgr().RunEventLoop();
-    NL_TEST_ASSERT(inSuite, stopRan);
-    NL_TEST_ASSERT(inSuite, sleepRan);
+    EXPECT_TRUE(stopRan);
+    EXPECT_TRUE(sleepRan);
 
     PlatformMgr().Shutdown();
 }
 
-static void TestPlatformMgr_TryLockChipStack(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestPlatformMgr, TryLockChipStack)
 {
     bool locked = PlatformMgr().TryLockChipStack();
     if (locked)
@@ -202,22 +219,14 @@ static int sEventRecieved = 0;
 
 void DeviceEventHandler(const ChipDeviceEvent * event, intptr_t arg)
 {
-    // NL_TEST_ASSERT(inSuite, arg == 12345);
+    EXPECT_EQ(arg, 12345);
     sEventRecieved++;
 }
 
-static void TestPlatformMgr_AddEventHandler(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestPlatformMgr, AddEventHandler)
 {
     sEventRecieved = 0;
-    NL_TEST_ASSERT_SUCCESS(inSuite, PlatformMgr().AddEventHandler(DeviceEventHandler, 12345));
-
-#if 0
-    while (sEventRecieved == 0)
-    {
-    }
-
-    NL_TEST_ASSERT(inSuite, sEventRecieved > 0);
-#endif
+    EXPECT_EQ(PlatformMgr().AddEventHandler(DeviceEventHandler, 12345), CHIP_NO_ERROR);
 }
 
 class MockSystemLayer : public System::LayerImpl
@@ -233,76 +242,21 @@ public:
     }
 };
 
-static void TestPlatformMgr_MockSystemLayer(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestPlatformMgr, MockSystemLayerTest)
 {
     MockSystemLayer systemLayer;
 
     DeviceLayer::SetSystemLayerForTesting(&systemLayer);
-    NL_TEST_ASSERT(inSuite, &DeviceLayer::SystemLayer() == static_cast<chip::System::Layer *>(&systemLayer));
+    EXPECT_EQ(&DeviceLayer::SystemLayer(), static_cast<chip::System::Layer *>(&systemLayer));
 
     CHIP_ERROR err = PlatformMgr().InitChipStack();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, &DeviceLayer::SystemLayer() == static_cast<chip::System::Layer *>(&systemLayer));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(&DeviceLayer::SystemLayer(), static_cast<chip::System::Layer *>(&systemLayer));
 
-    NL_TEST_ASSERT(
-        inSuite, DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::kZero, nullptr, nullptr) == CHIP_APPLICATION_ERROR(1));
-    NL_TEST_ASSERT(inSuite, DeviceLayer::SystemLayer().ScheduleWork(nullptr, nullptr) == CHIP_APPLICATION_ERROR(2));
+    EXPECT_EQ(DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::kZero, nullptr, nullptr), CHIP_APPLICATION_ERROR(1));
+    EXPECT_EQ(DeviceLayer::SystemLayer().ScheduleWork(nullptr, nullptr), CHIP_APPLICATION_ERROR(2));
 
     PlatformMgr().Shutdown();
 
     DeviceLayer::SetSystemLayerForTesting(nullptr);
 }
-
-/**
- *   Test Suite. It lists all the test functions.
- */
-static const nlTest sTests[] = {
-
-    NL_TEST_DEF("Test PlatformMgr::Init/Shutdown", TestPlatformMgr_InitShutdown),
-    NL_TEST_DEF("Test basic PlatformMgr::StartEventLoopTask", TestPlatformMgr_BasicEventLoopTask),
-    NL_TEST_DEF("Test basic PlatformMgr::RunEventLoop", TestPlatformMgr_BasicRunEventLoop),
-    NL_TEST_DEF("Test PlatformMgr::RunEventLoop with two tasks", TestPlatformMgr_RunEventLoopTwoTasks),
-    NL_TEST_DEF("Test PlatformMgr::RunEventLoop with stop before sleep", TestPlatformMgr_RunEventLoopStopBeforeSleep),
-    NL_TEST_DEF("Test PlatformMgr::TryLockChipStack", TestPlatformMgr_TryLockChipStack),
-    NL_TEST_DEF("Test PlatformMgr::AddEventHandler", TestPlatformMgr_AddEventHandler),
-    NL_TEST_DEF("Test mock System::Layer", TestPlatformMgr_MockSystemLayer),
-
-    NL_TEST_SENTINEL()
-};
-
-/**
- *  Set up the test suite.
- */
-int TestPlatformMgr_Setup(void * inContext)
-{
-    CHIP_ERROR error = chip::Platform::MemoryInit();
-    if (error != CHIP_NO_ERROR)
-        return FAILURE;
-
-    // Setup a fake commissionable data provider since required by internals of several
-    // Device/SystemLayer components.
-    static chip::DeviceLayer::TestOnlyCommissionableDataProvider commissionable_data_provider;
-    chip::DeviceLayer::SetCommissionableDataProvider(&commissionable_data_provider);
-
-    return SUCCESS;
-}
-
-/**
- *  Tear down the test suite.
- */
-int TestPlatformMgr_Teardown(void * inContext)
-{
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-int TestPlatformMgr()
-{
-    nlTestSuite theSuite = { "PlatformMgr tests", &sTests[0], TestPlatformMgr_Setup, TestPlatformMgr_Teardown };
-
-    // Run test suite against one context.
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestPlatformMgr);

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -53,8 +53,7 @@ public:
     static void SetUpTestSuite()
     {
         CHIP_ERROR error = chip::Platform::MemoryInit();
-        if (error != CHIP_NO_ERROR)
-            FAIL() << "Failed to initialize memory";
+        EXPECT_EQ(error, CHIP_NO_ERROR);
 
         // Setup a fake commissionable data provider since required by internals of several
         // Device/SystemLayer components.
@@ -62,11 +61,7 @@ public:
         chip::DeviceLayer::SetCommissionableDataProvider(&commissionable_data_provider);
     }
 
-    static void TearDownTestSuite()
-    {
-        chip::Platform::MemoryShutdown();
-        SUCCEED();
-    }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
 };
 
 TEST_F(TestPlatformMgr, InitShutdown)
@@ -199,8 +194,8 @@ TEST_F(TestPlatformMgr, RunEventLoopStopBeforeSleep)
         SleepSome(arg);
     });
 
-    EXPECT_TRUE(!stopRan);
-    EXPECT_TRUE(!sleepRan);
+    EXPECT_FALSE(stopRan);
+    EXPECT_FALSE(sleepRan);
     PlatformMgr().RunEventLoop();
     EXPECT_TRUE(stopRan);
     EXPECT_TRUE(sleepRan);

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -28,8 +28,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <lib/support/CodeUtils.h>
 #include <gtest/gtest.h>
+#include <lib/support/CodeUtils.h>
 #include <lib/support/UnitTestUtils.h>
 #include <system/SystemClock.h>
 

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -29,9 +29,9 @@
 #include <string.h>
 
 #include <lib/support/CodeUtils.h>
-#include <lib/support/UnitTestRegistration.h>
+
+#include <gtest/gtest.h>
 #include <lib/support/UnitTestUtils.h>
-#include <nlunit-test.h>
 #include <system/SystemClock.h>
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
@@ -48,7 +48,7 @@ constexpr Clock::Microseconds64 kTestTimeMarginUs = 500_us64;
 //      Unit tests
 // =================================
 
-static void TestDevice_GetMonotonicMicroseconds(nlTestSuite * inSuite, void * inContext)
+TEST(TestDevice, GetMonotonicMicroseconds)
 {
     static const Clock::Microseconds64 kTestVectorSystemTimeUs[] = {
         600_us64,
@@ -74,15 +74,15 @@ static void TestDevice_GetMonotonicMicroseconds(nlTestSuite * inSuite, void * in
                         ChipLogValueX64(Tdelay.count()));
 
         // verify that timers don't fire early
-        NL_TEST_ASSERT(inSuite, Tdelta > (Tdelay - margin));
+        EXPECT_GT(Tdelta, (Tdelay - margin));
         // verify they're not too late
         //        NL_TEST_ASSERT(inSuite, Tdelta < (Tdelay + margin));
         numOfTestsRan++;
     }
-    NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
+    EXPECT_GT(numOfTestsRan, 0);
 }
 
-static void TestDevice_GetMonotonicMilliseconds(nlTestSuite * inSuite, void * inContext)
+TEST(TestDevice, GetMonotonicMilliseconds)
 {
     static const System::Clock::Milliseconds64 kTestVectorSystemTimeMs[] = {
         10_ms64,
@@ -108,32 +108,14 @@ static void TestDevice_GetMonotonicMilliseconds(nlTestSuite * inSuite, void * in
                         ChipLogValueX64(Tdelay.count()));
 
         // verify that timers don't fire early
-        NL_TEST_ASSERT(inSuite, Tdelta > (Tdelay - margin));
+        EXPECT_GT(Tdelta, (Tdelay - margin));
         // verify they're not too late
         //        NL_TEST_ASSERT(inSuite, Tdelta < (Tdelay + margin));
         numOfTestsRan++;
     }
-    NL_TEST_ASSERT(inSuite, numOfTestsRan > 0);
+    EXPECT_GT(numOfTestsRan, 0);
 }
 
 /**
  *   Test Suite. It lists all the test functions.
  */
-static const nlTest sTests[] = {
-
-    NL_TEST_DEF("Test DeviceLayer::GetMonotonicMicroseconds", TestDevice_GetMonotonicMicroseconds),
-    NL_TEST_DEF("Test DeviceLayer::GetMonotonicMilliseconds", TestDevice_GetMonotonicMilliseconds),
-
-    NL_TEST_SENTINEL()
-};
-
-int TestPlatformTime()
-{
-    nlTestSuite theSuite = { "PlatformTime tests", &sTests[0], nullptr, nullptr };
-
-    // Run test suite against one context.
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestPlatformTime)

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -29,7 +29,6 @@
 #include <string.h>
 
 #include <lib/support/CodeUtils.h>
-
 #include <gtest/gtest.h>
 #include <lib/support/UnitTestUtils.h>
 #include <system/SystemClock.h>
@@ -76,7 +75,7 @@ TEST(TestDevice, GetMonotonicMicroseconds)
         // verify that timers don't fire early
         EXPECT_GT(Tdelta, (Tdelay - margin));
         // verify they're not too late
-        //        NL_TEST_ASSERT(inSuite, Tdelta < (Tdelay + margin));
+        //        EXPECT_LT(Tdelta, (Tdelay + margin));
         numOfTestsRan++;
     }
     EXPECT_GT(numOfTestsRan, 0);
@@ -110,12 +109,8 @@ TEST(TestDevice, GetMonotonicMilliseconds)
         // verify that timers don't fire early
         EXPECT_GT(Tdelta, (Tdelay - margin));
         // verify they're not too late
-        //        NL_TEST_ASSERT(inSuite, Tdelta < (Tdelay + margin));
+        //        EXPECT_LT(Tdelta, (Tdelay + margin));
         numOfTestsRan++;
     }
     EXPECT_GT(numOfTestsRan, 0);
 }
-
-/**
- *   Test Suite. It lists all the test functions.
- */

--- a/src/platform/tests/TestThreadStackMgr.cpp
+++ b/src/platform/tests/TestThreadStackMgr.cpp
@@ -79,5 +79,5 @@ TEST(TestThreadStackManager, TestThreadStackManager)
     chip::DeviceLayer::PlatformMgrImpl().RunEventLoop();
     chip::Platform::MemoryShutdown();
 
-    ASSERT_TRUE(eventReceived);
+    EXPECT_TRUE(eventReceived);
 }

--- a/src/platform/tests/TestThreadStackMgr.cpp
+++ b/src/platform/tests/TestThreadStackMgr.cpp
@@ -18,16 +18,16 @@
 #include <assert.h>
 #include <memory>
 
+#include <gtest/gtest.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ThreadOperationalDataset.h>
-#include <lib/support/UnitTestRegistration.h>
 
 #include "platform/internal/CHIPDeviceLayerInternal.h"
 
 #include "platform/PlatformManager.h"
 #include "platform/ThreadStackManager.h"
 
-#if CHIP_DEVICE_LAYER_TARGET == LINUX
+#if CHIP_DEVICE_LAYER_TARGET_LINUX
 #include <dbus/dbus.h>
 #include <thread>
 
@@ -39,20 +39,20 @@ struct DBusConnectionDeleter
 using UniqueDBusConnection = std::unique_ptr<DBusConnection, DBusConnectionDeleter>;
 #endif
 
-void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
+static std::atomic_bool eventReceived{ false };
+
+void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t)
 {
-    (void) arg;
     if (event->Type == chip::DeviceLayer::DeviceEventType::kThreadConnectivityChange)
     {
         if (event->ThreadConnectivityChange.Result == chip::DeviceLayer::ConnectivityChange::kConnectivity_Established)
         {
-            chip::Platform::MemoryShutdown();
-            exit(0);
+            eventReceived = true;
         }
     }
 }
 
-int TestThreadStackManager()
+TEST(TestThreadStackManager, TestThreadStackManager)
 {
     chip::DeviceLayer::ThreadStackManagerImpl impl;
     chip::Thread::OperationalDataset dataset{};
@@ -79,7 +79,5 @@ int TestThreadStackManager()
     chip::DeviceLayer::PlatformMgrImpl().RunEventLoop();
     chip::Platform::MemoryShutdown();
 
-    return -1;
+    ASSERT_TRUE(eventReceived);
 }
-
-CHIP_REGISTER_TEST_SUITE(TestThreadStackManager);

--- a/src/test_driver/openiotsdk/unit-tests/test_components.txt
+++ b/src/test_driver/openiotsdk/unit-tests/test_components.txt
@@ -1,1 +1,2 @@
 accesstest
+PlatformTests

--- a/src/test_driver/openiotsdk/unit-tests/test_components_nl.txt
+++ b/src/test_driver/openiotsdk/unit-tests/test_components_nl.txt
@@ -11,7 +11,6 @@ MessagingLayerTests
 MinimalMdnsCoreTests
 MinimalMdnsRecordsTests
 MinimalMdnsRespondersTests
-PlatformTests
 RawTransportTests
 RetransmitTests
 SecureChannelTests


### PR DESCRIPTION
## Problem
The problem was described in #29342. 

## Changes
These changes are another piece of replacing the nl-unit test with the pigweed-unit test. I changed tests for the platform. I didn't introduce any changes to the logic of tests; I only replaced one framework with another. 