### PR TITLE
Make sure binary comparison operators are const to fix C++20

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -72,7 +72,7 @@ class TargetVideoPlayerInfo
 public:
     TargetVideoPlayerInfo() {}
 
-    bool operator==(const TargetVideoPlayerInfo & other) { return this->mNodeId == other.mNodeId; }
+    bool operator==(const TargetVideoPlayerInfo & other) const { return this->mNodeId == other.mNodeId; }
 
     bool IsInitialized() { return mInitialized; }
     void Reset();

--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -142,7 +142,10 @@ struct ConcreteDataAttributePath : public ConcreteAttributePath
                         ChipLogValueMEI(mClusterId), ChipLogValueMEI(mAttributeId));
     }
 
-    bool MatchesConcreteAttributePath(const ConcreteAttributePath & aOther) { return ConcreteAttributePath::operator==(aOther); }
+    bool MatchesConcreteAttributePath(const ConcreteAttributePath & aOther) const
+    {
+        return ConcreteAttributePath::operator==(aOther);
+    }
 
     bool operator==(const ConcreteDataAttributePath & aOther) const
     {

--- a/src/app/clusters/bindings/PendingNotificationMap.h
+++ b/src/app/clusters/bindings/PendingNotificationMap.h
@@ -88,9 +88,9 @@ public:
             return *this;
         }
 
-        bool operator!=(const Iterator & rhs) { return mIndex != rhs.mIndex; }
+        bool operator!=(const Iterator & rhs) const { return mIndex != rhs.mIndex; }
 
-        bool operator==(const Iterator & rhs) { return mIndex == rhs.mIndex; }
+        bool operator==(const Iterator & rhs) const { return mIndex == rhs.mIndex; }
 
     private:
         PendingNotificationMap * mMap;

--- a/src/app/clusters/scenes-server/SceneTable.h
+++ b/src/app/clusters/scenes-server/SceneTable.h
@@ -149,7 +149,7 @@ public:
 
         bool IsValid() { return (mSceneId != kUndefinedSceneId); }
 
-        bool operator==(const SceneStorageId & other) { return (mGroupId == other.mGroupId && mSceneId == other.mSceneId); }
+        bool operator==(const SceneStorageId & other) const { return (mGroupId == other.mGroupId && mSceneId == other.mSceneId); }
     };
 
     /// @brief struct used to store data held in a scene
@@ -235,7 +235,7 @@ public:
         SceneTableEntry(SceneStorageId id) : mStorageId(id) {}
         SceneTableEntry(const SceneStorageId id, const SceneData data) : mStorageId(id), mStorageData(data) {}
 
-        bool operator==(const SceneTableEntry & other)
+        bool operator==(const SceneTableEntry & other) const
         {
             return (mStorageId == other.mStorageId && mStorageData == other.mStorageData);
         }

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -298,7 +298,7 @@ public:
         return GetCurrent();
     }
 
-    bool operator==(const ConstFabricIterator & other)
+    bool operator==(const ConstFabricIterator & other) const
     {
         if (IsAtEnd())
         {
@@ -308,7 +308,7 @@ public:
         // Pending entry does not participate in finding this.
         return (mStart == other.mStart) && (mIndex == other.mIndex) && (mMaxSize == other.mMaxSize);
     }
-    bool operator!=(const ConstFabricIterator & other) { return !(*this == other); }
+    bool operator!=(const ConstFabricIterator & other) const { return !(*this == other); }
 
     bool IsAtEnd() const { return (mIndex == mMaxSize); }
 

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -72,7 +72,7 @@ public:
                 Platform::CopyString(name, groupName);
             }
         }
-        bool operator==(const GroupInfo & other)
+        bool operator==(const GroupInfo & other) const
         {
             return (this->group_id == other.group_id) && !strncmp(this->name, other.name, kGroupNameMax);
         }
@@ -151,7 +151,7 @@ public:
         // Number of keys present
         uint8_t num_keys_used = 0;
 
-        bool operator==(const KeySet & other)
+        bool operator==(const KeySet & other) const
         {
             VerifyOrReturnError(this->policy == other.policy && this->num_keys_used == other.num_keys_used, false);
             return !memcmp(this->epoch_keys, other.epoch_keys, this->num_keys_used * sizeof(EpochKey));

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -146,7 +146,7 @@ bool PayloadContents::CheckPayloadCommonConstraints() const
     return true;
 }
 
-bool PayloadContents::operator==(PayloadContents & input) const
+bool PayloadContents::operator==(const PayloadContents & input) const
 {
     return (this->version == input.version && this->vendorID == input.vendorID && this->productID == input.productID &&
             this->commissioningFlow == input.commissioningFlow && this->rendezvousInformation == input.rendezvousInformation &&
@@ -257,10 +257,11 @@ CHIP_ERROR SetupPayload::addOptionalExtensionData(const OptionalQRCodeInfoExtens
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SetupPayload::getOptionalVendorData(uint8_t tag, OptionalQRCodeInfo & info)
+CHIP_ERROR SetupPayload::getOptionalVendorData(uint8_t tag, OptionalQRCodeInfo & info) const
 {
-    VerifyOrReturnError(optionalVendorData.find(tag) != optionalVendorData.end(), CHIP_ERROR_KEY_NOT_FOUND);
-    info = optionalVendorData[tag];
+    const auto it = optionalVendorData.find(tag);
+    VerifyOrReturnError(it != optionalVendorData.end(), CHIP_ERROR_KEY_NOT_FOUND);
+    info = it->second;
 
     return CHIP_NO_ERROR;
 }
@@ -273,7 +274,7 @@ CHIP_ERROR SetupPayload::getOptionalExtensionData(uint8_t tag, OptionalQRCodeInf
     return CHIP_NO_ERROR;
 }
 
-optionalQRCodeInfoType SetupPayload::getNumericTypeFor(uint8_t tag)
+optionalQRCodeInfoType SetupPayload::getNumericTypeFor(uint8_t tag) const
 {
     optionalQRCodeInfoType elemType = optionalQRCodeInfoTypeUnknown;
 
@@ -289,7 +290,7 @@ optionalQRCodeInfoType SetupPayload::getNumericTypeFor(uint8_t tag)
     return elemType;
 }
 
-std::vector<OptionalQRCodeInfoExtension> SetupPayload::getAllOptionalExtensionData()
+std::vector<OptionalQRCodeInfoExtension> SetupPayload::getAllOptionalExtensionData() const
 {
     std::vector<OptionalQRCodeInfoExtension> returnedOptionalInfo;
     for (auto & entry : optionalExtensionData)
@@ -299,7 +300,7 @@ std::vector<OptionalQRCodeInfoExtension> SetupPayload::getAllOptionalExtensionDa
     return returnedOptionalInfo;
 }
 
-bool SetupPayload::operator==(SetupPayload & input)
+bool SetupPayload::operator==(const SetupPayload & input) const
 {
     std::vector<OptionalQRCodeInfo> inputOptionalVendorData;
     std::vector<OptionalQRCodeInfoExtension> inputOptionalExtensionData;

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -130,7 +130,7 @@ struct PayloadContents
 
     bool isValidQRCodePayload() const;
     bool isValidManualCode() const;
-    bool operator==(PayloadContents & input) const;
+    bool operator==(const PayloadContents & input) const;
 
     static bool IsValidSetupPIN(uint32_t setupPIN);
 
@@ -233,7 +233,7 @@ public:
      **/
     CHIP_ERROR removeSerialNumber();
 
-    bool operator==(SetupPayload & input);
+    bool operator==(const SetupPayload & input) const;
 
 private:
     std::map<uint8_t, OptionalQRCodeInfo> optionalVendorData;
@@ -267,14 +267,14 @@ private:
      * @brief A function to retrieve the vector of CHIPQRCodeInfo infos
      * @return Returns a vector of CHIPQRCodeInfos
      **/
-    std::vector<OptionalQRCodeInfoExtension> getAllOptionalExtensionData();
+    std::vector<OptionalQRCodeInfoExtension> getAllOptionalExtensionData() const;
 
     /** @brief A function to retrieve an optional QR Code info vendor object
      * @param tag 7 bit [0-127] tag number
      * @param info retrieved OptionalQRCodeInfo object
      * @return Returns a CHIP_ERROR_KEY_NOT_FOUND on error, CHIP_NO_ERROR otherwise
      **/
-    CHIP_ERROR getOptionalVendorData(uint8_t tag, OptionalQRCodeInfo & info);
+    CHIP_ERROR getOptionalVendorData(uint8_t tag, OptionalQRCodeInfo & info) const;
 
     /** @brief A function to retrieve an optional QR Code info extended object
      * @param tag 8 bit [128-255] tag number
@@ -287,7 +287,7 @@ private:
      * @param tag 8 bit [0-255] tag number
      * @return Returns an optionalQRCodeInfoType value
      **/
-    optionalQRCodeInfoType getNumericTypeFor(uint8_t tag);
+    optionalQRCodeInfoType getNumericTypeFor(uint8_t tag) const;
 };
 
 } // namespace chip

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -687,7 +687,7 @@ private:
 
     PacketBuffer * Get() const { return mBuffer; }
 
-    bool operator==(const PacketBufferHandle & aOther) { return mBuffer == aOther.mBuffer; }
+    bool operator==(const PacketBufferHandle & aOther) const { return mBuffer == aOther.mBuffer; }
 
 #if CHIP_SYSTEM_PACKETBUFFER_HAS_RIGHTSIZE
     void InternalRightSize();


### PR DESCRIPTION
Fix errors of the form

```
../../src/system/tests/TestSystemPacketBuffer.cpp:1063:72: error: C++20 says that these are ambiguous, even though the second is reversed: [-Werror]
 1063 |                             NL_TEST_ASSERT(inSuite, config_1.handle == original_handle_1);
      |                                                                        ^~~~~~~~~~~~~~~~~
../../third_party/nlunit-test/repo/src/nlunit-test.h:366:15: note: in definition of macro ‘NL_TEST_ASSERT’
  366 |         if (!(inCondition))                             \
      |               ^~~~~~~~~~~
../../src/system/SystemPacketBuffer.h:690:10: note: candidate 1: ‘bool chip::System::PacketBufferHandle::operator==(const chip::System::PacketBufferHandle&)’
  690 |     bool operator==(const PacketBufferHandle & aOther) { return mBuffer == aOther.mBuffer; }
      |          ^~~~~~~~
../../src/system/SystemPacketBuffer.h:690:10: note: candidate 2: ‘bool chip::System::PacketBufferHandle::operator==(const chip::System::PacketBufferHandle&)’ (reversed)
../../src/system/SystemPacketBuffer.h:690:10: note: try making the operator a ‘const’ member function
```
when compiling with cpp_standard="gnu++20" by making sure comparators are const members.
