### PR TITLE
v1.3 Commissioner Passcode field for Linux and Android tv-casting-apps

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
@@ -350,6 +350,10 @@ class CastingPlayerArrayAdapter extends ArrayAdapter<CastingPlayer> {
             ? (aux.isEmpty() ? "" : ", ") + "Device Type: " + player.getDeviceType()
             : "";
     aux += (aux.isEmpty() ? "" : ", ") + "Resolved IP?: " + (player.getIpAddresses().size() > 0);
+    aux +=
+        (aux.isEmpty() ? "" : ", ")
+            + "Commissioner Passcode Supported?: "
+            + (player.isCommissionerPasscodeSupported());
 
     aux = aux.isEmpty() ? aux : "\n" + aux;
     return main + aux;

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
@@ -352,8 +352,8 @@ class CastingPlayerArrayAdapter extends ArrayAdapter<CastingPlayer> {
     aux += (aux.isEmpty() ? "" : ", ") + "Resolved IP?: " + (player.getIpAddresses().size() > 0);
     aux +=
         (aux.isEmpty() ? "" : ", ")
-            + "Commissioner Passcode Supported?: "
-            + (player.isCommissionerPasscodeSupported());
+            + "Commissioner Passcode: "
+            + (player.getCommissionerPasscode());
 
     aux = aux.isEmpty() ? aux : "\n" + aux;
     return main + aux;

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
@@ -352,8 +352,8 @@ class CastingPlayerArrayAdapter extends ArrayAdapter<CastingPlayer> {
     aux += (aux.isEmpty() ? "" : ", ") + "Resolved IP?: " + (player.getIpAddresses().size() > 0);
     aux +=
         (aux.isEmpty() ? "" : ", ")
-            + "CommissionerPasscode: "
-            + (player.isCommissionerPasscodeSupported());
+            + "Supports Commissioner Generated Passcode: "
+            + (player.getSupportsCommissionerGeneratedPasscode());
 
     aux = aux.isEmpty() ? aux : "\n" + aux;
     return main + aux;

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
@@ -352,8 +352,8 @@ class CastingPlayerArrayAdapter extends ArrayAdapter<CastingPlayer> {
     aux += (aux.isEmpty() ? "" : ", ") + "Resolved IP?: " + (player.getIpAddresses().size() > 0);
     aux +=
         (aux.isEmpty() ? "" : ", ")
-            + "Commissioner Passcode: "
-            + (player.getCommissionerPasscode());
+            + "CommissionerPasscode: "
+            + (player.isCommissionerPasscodeSupported());
 
     aux = aux.isEmpty() ? aux : "\n" + aux;
     return main + aux;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -49,7 +49,7 @@ public interface CastingPlayer {
 
   long getDeviceType();
 
-  boolean isCommissionerPasscodeSupported();
+  boolean getSupportsCommissionerGeneratedPasscode();
 
   List<Endpoint> getEndpoints();
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -49,7 +49,7 @@ public interface CastingPlayer {
 
   long getDeviceType();
 
-  short getCommissionerPasscode();
+  boolean isCommissionerPasscodeSupported();
 
   List<Endpoint> getEndpoints();
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -49,6 +49,8 @@ public interface CastingPlayer {
 
   long getDeviceType();
 
+  boolean isCommissionerPasscodeSupported();
+
   List<Endpoint> getEndpoints();
 
   @Override

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -49,7 +49,7 @@ public interface CastingPlayer {
 
   long getDeviceType();
 
-  boolean isCommissionerPasscodeSupported();
+  short getCommissionerPasscode();
 
   List<Endpoint> getEndpoints();
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -47,6 +47,7 @@ public class MatterCastingPlayer implements CastingPlayer {
   private int productId;
   private int vendorId;
   private long deviceType;
+  private boolean commissionerPasscodeSupported;
   protected long _cppCastingPlayer;
 
   public MatterCastingPlayer(
@@ -59,7 +60,8 @@ public class MatterCastingPlayer implements CastingPlayer {
       int port,
       int productId,
       int vendorId,
-      long deviceType) {
+      long deviceType,
+      boolean commissionerPasscodeSupported) {
     this.connected = connected;
     this.deviceId = deviceId;
     this.hostName = hostName;
@@ -70,6 +72,7 @@ public class MatterCastingPlayer implements CastingPlayer {
     this.productId = productId;
     this.vendorId = vendorId;
     this.deviceType = deviceType;
+    this.commissionerPasscodeSupported = commissionerPasscodeSupported;
   }
 
   /**
@@ -129,6 +132,11 @@ public class MatterCastingPlayer implements CastingPlayer {
   @Override
   public long getDeviceType() {
     return this.deviceType;
+  }
+
+  @Override
+  public boolean isCommissionerPasscodeSupported() {
+    return this.commissionerPasscodeSupported;
   }
 
   @Override

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -47,11 +47,7 @@ public class MatterCastingPlayer implements CastingPlayer {
   private int productId;
   private int vendorId;
   private long deviceType;
-  /**
-   * The CommissionerPasscode field indicates whether a CastingPlayer supports the
-   * Commissioner-Generated Passcode feature.
-   */
-  private boolean commissionerPasscode;
+  private boolean supportsCommissionerGeneratedPasscode;
 
   protected long _cppCastingPlayer;
 
@@ -66,7 +62,7 @@ public class MatterCastingPlayer implements CastingPlayer {
       int productId,
       int vendorId,
       long deviceType,
-      boolean commissionerPasscode) {
+      boolean supportsCommissionerGeneratedPasscode) {
     this.connected = connected;
     this.deviceId = deviceId;
     this.hostName = hostName;
@@ -77,7 +73,7 @@ public class MatterCastingPlayer implements CastingPlayer {
     this.productId = productId;
     this.vendorId = vendorId;
     this.deviceType = deviceType;
-    this.commissionerPasscode = commissionerPasscode;
+    this.supportsCommissionerGeneratedPasscode = supportsCommissionerGeneratedPasscode;
   }
 
   /**
@@ -140,8 +136,8 @@ public class MatterCastingPlayer implements CastingPlayer {
   }
 
   @Override
-  public boolean isCommissionerPasscodeSupported() {
-    return this.commissionerPasscode;
+  public boolean getSupportsCommissionerGeneratedPasscode() {
+    return this.supportsCommissionerGeneratedPasscode;
   }
 
   @Override

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -47,7 +47,7 @@ public class MatterCastingPlayer implements CastingPlayer {
   private int productId;
   private int vendorId;
   private long deviceType;
-  private boolean commissionerPasscodeSupported;
+  private short commissionerPasscode;
   protected long _cppCastingPlayer;
 
   public MatterCastingPlayer(
@@ -61,7 +61,7 @@ public class MatterCastingPlayer implements CastingPlayer {
       int productId,
       int vendorId,
       long deviceType,
-      boolean commissionerPasscodeSupported) {
+      short commissionerPasscode) {
     this.connected = connected;
     this.deviceId = deviceId;
     this.hostName = hostName;
@@ -72,7 +72,7 @@ public class MatterCastingPlayer implements CastingPlayer {
     this.productId = productId;
     this.vendorId = vendorId;
     this.deviceType = deviceType;
-    this.commissionerPasscodeSupported = commissionerPasscodeSupported;
+    this.commissionerPasscode = commissionerPasscode;
   }
 
   /**
@@ -135,8 +135,8 @@ public class MatterCastingPlayer implements CastingPlayer {
   }
 
   @Override
-  public boolean isCommissionerPasscodeSupported() {
-    return this.commissionerPasscodeSupported;
+  public short getCommissionerPasscode() {
+    return this.commissionerPasscode;
   }
 
   @Override

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -47,7 +47,12 @@ public class MatterCastingPlayer implements CastingPlayer {
   private int productId;
   private int vendorId;
   private long deviceType;
-  private short commissionerPasscode;
+  /**
+   * The CommissionerPasscode field indicates whether a CastingPlayer supports the
+   * Commissioner-Generated Passcode feature.
+   */
+  private boolean commissionerPasscode;
+
   protected long _cppCastingPlayer;
 
   public MatterCastingPlayer(
@@ -61,7 +66,7 @@ public class MatterCastingPlayer implements CastingPlayer {
       int productId,
       int vendorId,
       long deviceType,
-      short commissionerPasscode) {
+      boolean commissionerPasscode) {
     this.connected = connected;
     this.deviceId = deviceId;
     this.hostName = hostName;
@@ -135,7 +140,7 @@ public class MatterCastingPlayer implements CastingPlayer {
   }
 
   @Override
-  public short getCommissionerPasscode() {
+  public boolean isCommissionerPasscodeSupported() {
     return this.commissionerPasscode;
   }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -151,7 +151,7 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
     // Get the constructor for the com/matter/casting/core/MatterCastingPlayer Java class
     jmethodID constructor =
         env->GetMethodID(matterCastingPlayerJavaClass, "<init>",
-                         "(ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;IIIJS)V");
+                         "(ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;IIIJZ)V");
     if (constructor == nullptr)
     {
         ChipLogError(AppServer, "convertCastingPlayerFromCppToJava() could not locate MatterCastingPlayer Java class constructor");
@@ -182,11 +182,12 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
 
     // Create a new instance of the MatterCastingPlayer Java class
     jobject jMatterCastingPlayer = nullptr;
-    jMatterCastingPlayer         = env->NewObject(
-        matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(player->IsConnected()), env->NewStringUTF(player->GetId()),
-        env->NewStringUTF(player->GetHostName()), env->NewStringUTF(player->GetDeviceName()),
-        env->NewStringUTF(player->GetInstanceName()), jIpAddressList, (jint) (player->GetPort()), (jint) (player->GetProductId()),
-        (jint) (player->GetVendorId()), (jlong) (player->GetDeviceType()), static_cast<jbyte>(player->GetCommissionerPasscode()));
+    jMatterCastingPlayer =
+        env->NewObject(matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(player->IsConnected()),
+                       env->NewStringUTF(player->GetId()), env->NewStringUTF(player->GetHostName()),
+                       env->NewStringUTF(player->GetDeviceName()), env->NewStringUTF(player->GetInstanceName()), jIpAddressList,
+                       (jint) (player->GetPort()), (jint) (player->GetProductId()), (jint) (player->GetVendorId()),
+                       (jlong) (player->GetDeviceType()), static_cast<jboolean>(player->isCommissionerPasscodeSupported()));
     if (jMatterCastingPlayer == nullptr)
     {
         ChipLogError(AppServer, "convertCastingPlayerFromCppToJava(): Could not create MatterCastingPlayer Java object");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -151,7 +151,7 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
     // Get the constructor for the com/matter/casting/core/MatterCastingPlayer Java class
     jmethodID constructor =
         env->GetMethodID(matterCastingPlayerJavaClass, "<init>",
-                         "(ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;IIIJ)V");
+                         "(ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;IIIJZ)V");
     if (constructor == nullptr)
     {
         ChipLogError(AppServer, "convertCastingPlayerFromCppToJava() could not locate MatterCastingPlayer Java class constructor");
@@ -182,11 +182,12 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
 
     // Create a new instance of the MatterCastingPlayer Java class
     jobject jMatterCastingPlayer = nullptr;
-    jMatterCastingPlayer = env->NewObject(matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(player->IsConnected()),
-                                          env->NewStringUTF(player->GetId()), env->NewStringUTF(player->GetHostName()),
-                                          env->NewStringUTF(player->GetDeviceName()), env->NewStringUTF(player->GetInstanceName()),
-                                          jIpAddressList, (jint) (player->GetPort()), (jint) (player->GetProductId()),
-                                          (jint) (player->GetVendorId()), (jlong) (player->GetDeviceType()));
+    jMatterCastingPlayer =
+        env->NewObject(matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(player->IsConnected()),
+                       env->NewStringUTF(player->GetId()), env->NewStringUTF(player->GetHostName()),
+                       env->NewStringUTF(player->GetDeviceName()), env->NewStringUTF(player->GetInstanceName()), jIpAddressList,
+                       (jint) (player->GetPort()), (jint) (player->GetProductId()), (jint) (player->GetVendorId()),
+                       (jlong) (player->GetDeviceType()), static_cast<jboolean>(player->IsCommissionerPasscodeSupported()));
     if (jMatterCastingPlayer == nullptr)
     {
         ChipLogError(AppServer, "convertCastingPlayerFromCppToJava(): Could not create MatterCastingPlayer Java object");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -151,7 +151,7 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
     // Get the constructor for the com/matter/casting/core/MatterCastingPlayer Java class
     jmethodID constructor =
         env->GetMethodID(matterCastingPlayerJavaClass, "<init>",
-                         "(ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;IIIJZ)V");
+                         "(ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;IIIJS)V");
     if (constructor == nullptr)
     {
         ChipLogError(AppServer, "convertCastingPlayerFromCppToJava() could not locate MatterCastingPlayer Java class constructor");
@@ -182,12 +182,11 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
 
     // Create a new instance of the MatterCastingPlayer Java class
     jobject jMatterCastingPlayer = nullptr;
-    jMatterCastingPlayer =
-        env->NewObject(matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(player->IsConnected()),
-                       env->NewStringUTF(player->GetId()), env->NewStringUTF(player->GetHostName()),
-                       env->NewStringUTF(player->GetDeviceName()), env->NewStringUTF(player->GetInstanceName()), jIpAddressList,
-                       (jint) (player->GetPort()), (jint) (player->GetProductId()), (jint) (player->GetVendorId()),
-                       (jlong) (player->GetDeviceType()), static_cast<jboolean>(player->IsCommissionerPasscodeSupported()));
+    jMatterCastingPlayer         = env->NewObject(
+        matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(player->IsConnected()), env->NewStringUTF(player->GetId()),
+        env->NewStringUTF(player->GetHostName()), env->NewStringUTF(player->GetDeviceName()),
+        env->NewStringUTF(player->GetInstanceName()), jIpAddressList, (jint) (player->GetPort()), (jint) (player->GetProductId()),
+        (jint) (player->GetVendorId()), (jlong) (player->GetDeviceType()), static_cast<jbyte>(player->GetCommissionerPasscode()));
     if (jMatterCastingPlayer == nullptr)
     {
         ChipLogError(AppServer, "convertCastingPlayerFromCppToJava(): Could not create MatterCastingPlayer Java object");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -182,12 +182,12 @@ jobject convertCastingPlayerFromCppToJava(matter::casting::memory::Strong<core::
 
     // Create a new instance of the MatterCastingPlayer Java class
     jobject jMatterCastingPlayer = nullptr;
-    jMatterCastingPlayer =
-        env->NewObject(matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(player->IsConnected()),
-                       env->NewStringUTF(player->GetId()), env->NewStringUTF(player->GetHostName()),
-                       env->NewStringUTF(player->GetDeviceName()), env->NewStringUTF(player->GetInstanceName()), jIpAddressList,
-                       (jint) (player->GetPort()), (jint) (player->GetProductId()), (jint) (player->GetVendorId()),
-                       (jlong) (player->GetDeviceType()), static_cast<jboolean>(player->isCommissionerPasscodeSupported()));
+    jMatterCastingPlayer = env->NewObject(matterCastingPlayerJavaClass, constructor, static_cast<jboolean>(player->IsConnected()),
+                                          env->NewStringUTF(player->GetId()), env->NewStringUTF(player->GetHostName()),
+                                          env->NewStringUTF(player->GetDeviceName()), env->NewStringUTF(player->GetInstanceName()),
+                                          jIpAddressList, (jint) (player->GetPort()), (jint) (player->GetProductId()),
+                                          (jint) (player->GetVendorId()), (jlong) (player->GetDeviceType()),
+                                          static_cast<jboolean>(player->GetSupportsCommissionerGeneratedPasscode()));
     if (jMatterCastingPlayer == nullptr)
     {
         ChipLogError(AppServer, "convertCastingPlayerFromCppToJava(): Could not create MatterCastingPlayer Java object");

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -45,6 +45,7 @@ DiscoveryDelegateImpl * DiscoveryDelegateImpl::GetInstance()
 
 void DiscoveryDelegateImpl::HandleOnAdded(matter::casting::memory::Strong<matter::casting::core::CastingPlayer> player)
 {
+    ChipLogProgress(AppServer, "DiscoveryDelegateImpl::HandleOnAdded() called");
     if (commissionersCount == 0)
     {
         ChipLogProgress(AppServer, "Select discovered Casting Player (start index = 0) to request commissioning");
@@ -58,7 +59,7 @@ void DiscoveryDelegateImpl::HandleOnAdded(matter::casting::memory::Strong<matter
 
 void DiscoveryDelegateImpl::HandleOnUpdated(matter::casting::memory::Strong<matter::casting::core::CastingPlayer> player)
 {
-    ChipLogProgress(AppServer, "Updated CastingPlayer with ID: %s", player->GetId());
+    ChipLogProgress(AppServer, "DiscoveryDelegateImpl::HandleOnUpdated() Updated CastingPlayer with ID: %s", player->GetId());
 }
 
 void InvokeContentLauncherLaunchURL(matter::casting::memory::Strong<matter::casting::core::Endpoint> endpoint)

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -282,7 +282,7 @@ void CastingPlayer::LogDetail() const
     {
         ChipLogDetail(AppServer, "\tDevice Type: %" PRIu32, mAttributes.deviceType);
     }
-    ChipLogDetail(AppServer, "\tCommissioner Passcode feature supported: %u", mAttributes.commissionerPasscode);
+    ChipLogDetail(AppServer, "\tCommissioner Passcode: %u", mAttributes.commissionerPasscode);
     if (mAttributes.nodeId > 0)
     {
         ChipLogDetail(AppServer, "\tNode ID: 0x" ChipLogFormatX64, ChipLogValueX64(mAttributes.nodeId));

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -236,6 +236,7 @@ bool CastingPlayer::ContainsDesiredEndpoint(core::CastingPlayer * cachedCastingP
 
 void CastingPlayer::LogDetail() const
 {
+    ChipLogProgress(AppServer, "CastingPlayer::LogDetail() called");
     if (strlen(mAttributes.id) != 0)
     {
         ChipLogDetail(AppServer, "\tID: %s", mAttributes.id);
@@ -281,6 +282,7 @@ void CastingPlayer::LogDetail() const
     {
         ChipLogDetail(AppServer, "\tDevice Type: %" PRIu32, mAttributes.deviceType);
     }
+    ChipLogDetail(AppServer, "\tCommissioner Passcode feature supported: %u", mAttributes.commissionerPasscode);
     if (mAttributes.nodeId > 0)
     {
         ChipLogDetail(AppServer, "\tNode ID: 0x" ChipLogFormatX64, ChipLogValueX64(mAttributes.nodeId));

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -282,7 +282,8 @@ void CastingPlayer::LogDetail() const
     {
         ChipLogDetail(AppServer, "\tDevice Type: %" PRIu32, mAttributes.deviceType);
     }
-    ChipLogDetail(AppServer, "\tCommissionerPasscode: %s", mAttributes.commissionerPasscode ? "true" : "false");
+    ChipLogDetail(AppServer, "\tSupports Commissioner Generated Passcode: %s",
+                  mAttributes.supportsCommissionerGeneratedPasscode ? "true" : "false");
     if (mAttributes.nodeId > 0)
     {
         ChipLogDetail(AppServer, "\tNode ID: 0x" ChipLogFormatX64, ChipLogValueX64(mAttributes.nodeId));

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -282,7 +282,7 @@ void CastingPlayer::LogDetail() const
     {
         ChipLogDetail(AppServer, "\tDevice Type: %" PRIu32, mAttributes.deviceType);
     }
-    ChipLogDetail(AppServer, "\tCommissioner Passcode: %u", mAttributes.commissionerPasscode);
+    ChipLogDetail(AppServer, "\tCommissionerPasscode: %s", mAttributes.commissionerPasscode ? "true" : "false");
     if (mAttributes.nodeId > 0)
     {
         ChipLogDetail(AppServer, "\tNode ID: 0x" ChipLogFormatX64, ChipLogValueX64(mAttributes.nodeId));

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -63,7 +63,10 @@ public:
     uint16_t productId;
     uint16_t vendorId;
     uint32_t deviceType;
-    uint8_t commissionerPasscode = 0; // Indicates whether a CastingPlayer supports the Commissioner-Generated Passcode feature.
+    /**
+     * The CommissionerPasscode field indicates whether a CastingPlayer supports the Commissioner-Generated Passcode feature.
+     */
+    bool commissionerPasscode;
 
     chip::NodeId nodeId           = 0;
     chip::FabricIndex fabricIndex = 0;
@@ -183,7 +186,7 @@ public:
 
     uint32_t GetDeviceType() const { return mAttributes.deviceType; }
 
-    uint8_t GetCommissionerPasscode() const { return mAttributes.commissionerPasscode; }
+    bool isCommissionerPasscodeSupported() const { return mAttributes.commissionerPasscode; }
 
     chip::NodeId GetNodeId() const { return mAttributes.nodeId; }
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -115,11 +115,6 @@ public:
     bool IsConnected() const { return mConnectionState == CASTING_PLAYER_CONNECTED; }
 
     /**
-     * @return true if this CastingPlayer supports the Commissioner-Generated Passcode feature.
-     */
-    bool IsCommissionerPasscodeSupported() const { return mAttributes.commissionerPasscode != 0; }
-
-    /**
      * @brief Verifies that a connection exists with this CastingPlayer, or triggers a new session
      * request. If the CastingApp does not have the nodeId and fabricIndex of this CastingPlayer cached on disk,
      * this will execute the user directed commissioning process.

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -63,10 +63,7 @@ public:
     uint16_t productId;
     uint16_t vendorId;
     uint32_t deviceType;
-    /**
-     * The CommissionerPasscode field indicates whether a CastingPlayer supports the Commissioner-Generated Passcode feature.
-     */
-    bool commissionerPasscode;
+    bool supportsCommissionerGeneratedPasscode;
 
     chip::NodeId nodeId           = 0;
     chip::FabricIndex fabricIndex = 0;
@@ -186,7 +183,7 @@ public:
 
     uint32_t GetDeviceType() const { return mAttributes.deviceType; }
 
-    bool isCommissionerPasscodeSupported() const { return mAttributes.commissionerPasscode; }
+    bool GetSupportsCommissionerGeneratedPasscode() const { return mAttributes.supportsCommissionerGeneratedPasscode; }
 
     chip::NodeId GetNodeId() const { return mAttributes.nodeId; }
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -56,13 +56,14 @@ public:
     char deviceName[chip::Dnssd::kMaxDeviceNameLen + 1]                    = {};
     char hostName[chip::Dnssd::kHostNameMaxLength + 1]                     = {};
     char instanceName[chip::Dnssd::Commission::kInstanceNameMaxLength + 1] = {};
-    unsigned int numIPs; // number of valid IP addresses
+    unsigned int numIPs; // Number of valid IP addresses
     chip::Inet::IPAddress ipAddresses[chip::Dnssd::CommonResolutionData::kMaxIPAddresses];
     chip::Inet::InterfaceId interfaceId;
     uint16_t port;
     uint16_t productId;
     uint16_t vendorId;
     uint32_t deviceType;
+    uint8_t commissionerPasscode = 0; // Indicates whether a CastingPlayer supports the Commissioner-Generated Passcode feature.
 
     chip::NodeId nodeId           = 0;
     chip::FabricIndex fabricIndex = 0;
@@ -112,6 +113,11 @@ public:
      * @return true if this CastingPlayer is connected to the CastingApp
      */
     bool IsConnected() const { return mConnectionState == CASTING_PLAYER_CONNECTED; }
+
+    /**
+     * @return true if this CastingPlayer supports the Commissioner-Generated Passcode feature.
+     */
+    bool IsCommissionerPasscodeSupported() const { return mAttributes.commissionerPasscode != 0; }
 
     /**
      * @brief Verifies that a connection exists with this CastingPlayer, or triggers a new session
@@ -181,6 +187,8 @@ public:
     uint16_t GetVendorId() const { return mAttributes.vendorId; }
 
     uint32_t GetDeviceType() const { return mAttributes.deviceType; }
+
+    uint8_t GetCommissionerPasscode() const { return mAttributes.commissionerPasscode; }
 
     chip::NodeId GetNodeId() const { return mAttributes.nodeId; }
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -93,12 +93,12 @@ void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::Discover
     {
         attributes.ipAddresses[j] = nodeData.resolutionData.ipAddress[j];
     }
-    attributes.interfaceId          = nodeData.resolutionData.interfaceId;
-    attributes.port                 = nodeData.resolutionData.port;
-    attributes.productId            = nodeData.nodeData.productId;
-    attributes.vendorId             = nodeData.nodeData.vendorId;
-    attributes.deviceType           = nodeData.nodeData.deviceType;
-    attributes.commissionerPasscode = nodeData.nodeData.commissionerPasscode;
+    attributes.interfaceId                           = nodeData.resolutionData.interfaceId;
+    attributes.port                                  = nodeData.resolutionData.port;
+    attributes.productId                             = nodeData.nodeData.productId;
+    attributes.vendorId                              = nodeData.nodeData.vendorId;
+    attributes.deviceType                            = nodeData.nodeData.deviceType;
+    attributes.supportsCommissionerGeneratedPasscode = nodeData.nodeData.supportsCommissionerGeneratedPasscode;
 
     memory::Strong<CastingPlayer> player = std::make_shared<CastingPlayer>(attributes);
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -93,11 +93,12 @@ void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::Discover
     {
         attributes.ipAddresses[j] = nodeData.resolutionData.ipAddress[j];
     }
-    attributes.interfaceId = nodeData.resolutionData.interfaceId;
-    attributes.port        = nodeData.resolutionData.port;
-    attributes.productId   = nodeData.nodeData.productId;
-    attributes.vendorId    = nodeData.nodeData.vendorId;
-    attributes.deviceType  = nodeData.nodeData.deviceType;
+    attributes.interfaceId          = nodeData.resolutionData.interfaceId;
+    attributes.port                 = nodeData.resolutionData.port;
+    attributes.productId            = nodeData.nodeData.productId;
+    attributes.vendorId             = nodeData.nodeData.vendorId;
+    attributes.deviceType           = nodeData.nodeData.deviceType;
+    attributes.commissionerPasscode = nodeData.nodeData.commissionerPasscode;
 
     memory::Strong<CastingPlayer> player = std::make_shared<CastingPlayer>(attributes);
 

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -182,9 +182,9 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                 continue;
             }
 
-            if (castingPlayerContainerTagNum == kCastingPlayerCommissionerPasscodeTag)
+            if (castingPlayerContainerTagNum == kCastingPlayerSupportsCommissionerGeneratedPasscodeTag)
             {
-                err = reader.Get(attributes.commissionerPasscode);
+                err = reader.Get(attributes.supportsCommissionerGeneratedPasscode);
                 VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
                                     ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
                 continue;
@@ -480,8 +480,8 @@ CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayer
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerVendorIdTag), castingPlayer.GetVendorId()));
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerProductIdTag), castingPlayer.GetProductId()));
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerDeviceTypeIdTag), castingPlayer.GetDeviceType()));
-        ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerCommissionerPasscodeTag),
-                                           castingPlayer.isCommissionerPasscodeSupported()));
+        ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerSupportsCommissionerGeneratedPasscodeTag),
+                                           castingPlayer.GetSupportsCommissionerGeneratedPasscode()));
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerPortTag), castingPlayer.GetPort()));
         ReturnErrorOnFailure(tlvWriter.PutBytes(chip::TLV::ContextTag(kCastingPlayerInstanceNameTag),
                                                 (const uint8_t *) castingPlayer.GetInstanceName(),

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -182,7 +182,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                 continue;
             }
 
-            if (castingPlayerContainerTagNum == kCastingCommissionerPasscodeTag)
+            if (castingPlayerContainerTagNum == kCastingPlayerCommissionerPasscodeTag)
             {
                 err = reader.Get(attributes.commissionerPasscode);
                 VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
@@ -481,7 +481,7 @@ CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayer
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerProductIdTag), castingPlayer.GetProductId()));
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerDeviceTypeIdTag), castingPlayer.GetDeviceType()));
         ReturnErrorOnFailure(
-            tlvWriter.Put(chip::TLV::ContextTag(kCastingCommissionerPasscodeTag), castingPlayer.GetCommissionerPasscode()));
+            tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerCommissionerPasscodeTag), castingPlayer.GetCommissionerPasscode()));
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerPortTag), castingPlayer.GetPort()));
         ReturnErrorOnFailure(tlvWriter.PutBytes(chip::TLV::ContextTag(kCastingPlayerInstanceNameTag),
                                                 (const uint8_t *) castingPlayer.GetInstanceName(),

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -480,8 +480,8 @@ CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayer
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerVendorIdTag), castingPlayer.GetVendorId()));
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerProductIdTag), castingPlayer.GetProductId()));
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerDeviceTypeIdTag), castingPlayer.GetDeviceType()));
-        ReturnErrorOnFailure(
-            tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerCommissionerPasscodeTag), castingPlayer.GetCommissionerPasscode()));
+        ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerCommissionerPasscodeTag),
+                                           castingPlayer.isCommissionerPasscodeSupported()));
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerPortTag), castingPlayer.GetPort()));
         ReturnErrorOnFailure(tlvWriter.PutBytes(chip::TLV::ContextTag(kCastingPlayerInstanceNameTag),
                                                 (const uint8_t *) castingPlayer.GetInstanceName(),

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -182,6 +182,14 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                 continue;
             }
 
+            if (castingPlayerContainerTagNum == kCastingCommissionerPasscodeTag)
+            {
+                err = reader.Get(attributes.commissionerPasscode);
+                VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
+                                    ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
+                continue;
+            }
+
             if (castingPlayerContainerTagNum == kCastingPlayerPortTag)
             {
                 err = reader.Get(attributes.port);
@@ -472,6 +480,8 @@ CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayer
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerVendorIdTag), castingPlayer.GetVendorId()));
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerProductIdTag), castingPlayer.GetProductId()));
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerDeviceTypeIdTag), castingPlayer.GetDeviceType()));
+        ReturnErrorOnFailure(
+            tlvWriter.Put(chip::TLV::ContextTag(kCastingCommissionerPasscodeTag), castingPlayer.GetCommissionerPasscode()));
         ReturnErrorOnFailure(tlvWriter.Put(chip::TLV::ContextTag(kCastingPlayerPortTag), castingPlayer.GetPort()));
         ReturnErrorOnFailure(tlvWriter.PutBytes(chip::TLV::ContextTag(kCastingPlayerInstanceNameTag),
                                                 (const uint8_t *) castingPlayer.GetInstanceName(),

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
@@ -83,7 +83,7 @@ private:
         kCastingPlayerPortTag,
         kCastingPlayerInstanceNameTag,
         kCastingPlayerDeviceNameTag,
-        kCastingCommissionerPasscodeTag,
+        kCastingPlayerCommissionerPasscodeTag,
         kCastingPlayerHostNameTag,
 
         kCastingPlayerEndpointsContainerTag,

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
@@ -83,6 +83,7 @@ private:
         kCastingPlayerPortTag,
         kCastingPlayerInstanceNameTag,
         kCastingPlayerDeviceNameTag,
+        kCastingCommissionerPasscodeTag,
         kCastingPlayerHostNameTag,
 
         kCastingPlayerEndpointsContainerTag,

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
@@ -97,7 +97,7 @@ private:
         kCastingPlayerEndpointServerListContainerTag,
         kCastingPlayerEndpointServerClusterIdTag,
 
-        kCastingPlayerCommissionerPasscodeTag,
+        kCastingPlayerSupportsCommissionerGeneratedPasscodeTag,
 
         kContextTagMaxNum = UINT8_MAX
     };

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.h
@@ -83,7 +83,6 @@ private:
         kCastingPlayerPortTag,
         kCastingPlayerInstanceNameTag,
         kCastingPlayerDeviceNameTag,
-        kCastingPlayerCommissionerPasscodeTag,
         kCastingPlayerHostNameTag,
 
         kCastingPlayerEndpointsContainerTag,
@@ -97,6 +96,8 @@ private:
 
         kCastingPlayerEndpointServerListContainerTag,
         kCastingPlayerEndpointServerClusterIdTag,
+
+        kCastingPlayerCommissionerPasscodeTag,
 
         kContextTagMaxNum = UINT8_MAX
     };

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -185,7 +185,7 @@ void GetPairingInstruction(const ByteSpan & value, char * pairingInstruction)
 
 uint8_t GetCommissionerPasscode(const ByteSpan & value)
 {
-    return MakeU8FromAsciiDecimal(value);
+    return MakeBoolFromAsciiDecimal(value);
 }
 
 Optional<System::Clock::Milliseconds32> GetRetryInterval(const ByteSpan & value)

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -256,7 +256,7 @@ void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, DnssdNodeDa
         nodeData.pairingHint = Internal::GetPairingHint(val);
         break;
     case TxtFieldKey::kCommissionerPasscode:
-        nodeData.commissionerPasscode = Internal::GetCommissionerPasscode(val);
+        nodeData.supportsCommissionerGeneratedPasscode = Internal::GetCommissionerPasscode(val);
         break;
     default:
         break;

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -214,7 +214,7 @@ struct DnssdNodeData
     uint16_t productId                                        = 0;
     uint16_t pairingHint                                      = 0;
     uint8_t commissioningMode                                 = 0;
-    uint8_t commissionerPasscode                              = 0;
+    bool commissionerPasscode                                 = 0;
     uint8_t rotatingId[kMaxRotatingIdLen]                     = {};
     char instanceName[Commission::kInstanceNameMaxLength + 1] = {};
     char deviceName[kMaxDeviceNameLen + 1]                    = {};
@@ -272,10 +272,7 @@ struct DnssdNodeData
             ChipLogDetail(Discovery, "\tInstance Name: %s", instanceName);
         }
         ChipLogDetail(Discovery, "\tCommissioning Mode: %u", commissioningMode);
-        if (commissionerPasscode > 0)
-        {
-            ChipLogDetail(Discovery, "\tCommissioner Passcode: %u", commissionerPasscode);
-        }
+        ChipLogDetail(Discovery, "\tCommissionerPasscode: %s", commissionerPasscode ? "true" : "false");
     }
 };
 

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -214,7 +214,7 @@ struct DnssdNodeData
     uint16_t productId                                        = 0;
     uint16_t pairingHint                                      = 0;
     uint8_t commissioningMode                                 = 0;
-    bool commissionerPasscode                                 = false;
+    bool supportsCommissionerGeneratedPasscode                = false;
     uint8_t rotatingId[kMaxRotatingIdLen]                     = {};
     char instanceName[Commission::kInstanceNameMaxLength + 1] = {};
     char deviceName[kMaxDeviceNameLen + 1]                    = {};
@@ -272,7 +272,8 @@ struct DnssdNodeData
             ChipLogDetail(Discovery, "\tInstance Name: %s", instanceName);
         }
         ChipLogDetail(Discovery, "\tCommissioning Mode: %u", commissioningMode);
-        ChipLogDetail(Discovery, "\tCommissionerPasscode: %s", commissionerPasscode ? "true" : "false");
+        ChipLogDetail(Discovery, "\tSupports Commissioner Generated Passcode: %s",
+                      supportsCommissionerGeneratedPasscode ? "true" : "false");
     }
 };
 

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -214,7 +214,7 @@ struct DnssdNodeData
     uint16_t productId                                        = 0;
     uint16_t pairingHint                                      = 0;
     uint8_t commissioningMode                                 = 0;
-    bool commissionerPasscode                                 = 0;
+    bool commissionerPasscode                                 = false;
     uint8_t rotatingId[kMaxRotatingIdLen]                     = {};
     char instanceName[Commission::kInstanceNameMaxLength + 1] = {};
     char deviceName[kMaxDeviceNameLen + 1]                    = {};

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -309,7 +309,7 @@ bool NodeDataIsEmpty(const DiscoveredNodeData & node)
         node.nodeData.pairingHint != 0 || node.resolutionData.mrpRetryIntervalIdle.HasValue() ||
         node.resolutionData.mrpRetryIntervalActive.HasValue() || node.resolutionData.mrpRetryActiveThreshold.HasValue() ||
         node.resolutionData.isICDOperatingAsLIT.HasValue() || node.resolutionData.supportsTcp ||
-        node.nodeData.commissionerPasscode != 0)
+        node.nodeData.supportsCommissionerGeneratedPasscode != 0)
     {
         return false;
     }
@@ -360,12 +360,12 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     filled.nodeData.commissioningMode = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
-    // CommissionerPasscode
+    // Supports Commissioner Generated Passcode
     strcpy(key, "CP");
     strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
-    NL_TEST_ASSERT(inSuite, filled.nodeData.commissionerPasscode == true);
-    filled.nodeData.commissionerPasscode = false;
+    NL_TEST_ASSERT(inSuite, filled.nodeData.supportsCommissionerGeneratedPasscode == true);
+    filled.nodeData.supportsCommissionerGeneratedPasscode = false;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Device type

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -360,12 +360,12 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     filled.nodeData.commissioningMode = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
-    // Commissioning mode
+    // CommissionerPasscode
     strcpy(key, "CP");
     strcpy(val, "1");
     FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.nodeData);
-    NL_TEST_ASSERT(inSuite, filled.nodeData.commissionerPasscode == 1);
-    filled.nodeData.commissionerPasscode = 0;
+    NL_TEST_ASSERT(inSuite, filled.nodeData.commissionerPasscode == true);
+    filled.nodeData.commissionerPasscode = false;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
 
     // Device type


### PR DESCRIPTION
Exposed the new Matter v1.3 Commissioner Passcode (CP) field for discovered Casting Players for Linux and Android example tv-casting-apps.

**Change summary**

1.	Updated CastingPlayer.h/cpp with the new Commissioner Passcode field for Linux. Added getter function.
2.	Updated MatterCastingPlayer.java for Android. Updated the DiscoveryExampleFragment.java to display the new field in the UX. 
3. Added Commissioner Passcode field to CastingStore.h/cpp WriteAll() and ReadAll()so that all the details about a connected CastingPLayer can be cached.

**Testing**

Verified and tested locally with the Linux and Android tv-casting-app example apps. The example apps discover CastingPlayers and display the Commissioner Passcode field for each discovered CastingPlayer in the terminal and Android mobile device tv-casting-app UX respectively.
