### PR TITLE
Third party submodule unintentional update check

### DIFF
--- a/.github/workflows/third-party-check.yaml
+++ b/.github/workflows/third-party-check.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check for Unintentional Submodule Updates
+
+on:
+    pull_request:
+        branches-ignore:
+            - 'dependabot/**'
+        paths:
+            - "third_party/**"
+            - ".gitmodules"
+
+jobs:
+    check-submodule-update-label:
+        name: Check For Submodule Update Label
+        runs-on: ubuntu-latest
+        if: "!contains(github.event.pull_request.labels.*.name, 'changing-submodules-on-purpose')"
+        steps:
+            - name: Error Message
+              run: echo This pull request attempts to update submodules without the changing-submodules-on-purpose label. Please apply that label if the changes are intentional, or remove those changes.
+            - name: Fail Job
+              run: exit 1


### PR DESCRIPTION
Workflow that runs on pull request - if changes are detected in third_party/ or .gitmodules, ensure the correct label is applied. Otherwise fail the check.

#30746