### PR TITLE
Replace nl-unit-test with pigweed for credentials

### DIFF
--- a/src/credentials/tests/BUILD.gn
+++ b/src/credentials/tests/BUILD.gn
@@ -14,7 +14,6 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 import("${chip_root}/build/chip/fuzz_test.gni")
@@ -42,7 +41,7 @@ static_library("cert_test_vectors") {
   ]
 }
 
-chip_test_suite_using_nltest("tests") {
+chip_test_suite("tests") {
   output_name = "libCredentialsTest"
   output_dir = "${root_out_dir}/lib"
 
@@ -71,8 +70,6 @@ chip_test_suite_using_nltest("tests") {
     "${chip_root}/src/credentials:default_attestation_verifier",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support:testing",
-    "${chip_root}/src/lib/support:testing_nlunit",
-    "${nlunit_test_root}:nlunit-test",
   ]
 }
 

--- a/src/credentials/tests/TestCertificationDeclaration.cpp
+++ b/src/credentials/tests/TestCertificationDeclaration.cpp
@@ -30,10 +30,8 @@
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/support/Span.h>
-#include <lib/support/UnitTestExtendedAssertions.h>
-#include <lib/support/UnitTestRegistration.h>
 
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 using namespace chip;
 using namespace chip::ASN1;
@@ -263,59 +261,57 @@ static constexpr TestCase sTestCases[] = {
       ByteSpan(sTestCMS_CDContent02), ByteSpan(sTestCMS_SignedMessage02) },
 };
 
-static void TestCD_EncodeDecode(nlTestSuite * inSuite, void * inContext)
+TEST(TestCertificationDeclaration, TestCD_EncodeDecode)
 {
     for (const auto & testCase : sTestCases)
     {
         uint8_t encodedCertElemBuf[kCertificationElements_TLVEncodedMaxLength];
         MutableByteSpan encodedCDPayload(encodedCertElemBuf);
 
-        NL_TEST_ASSERT(inSuite, EncodeCertificationElements(testCase.cdElements, encodedCDPayload) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, testCase.cdContent.data_equal(encodedCDPayload));
+        EXPECT_EQ(EncodeCertificationElements(testCase.cdElements, encodedCDPayload), CHIP_NO_ERROR);
+        EXPECT_TRUE(testCase.cdContent.data_equal(encodedCDPayload));
 
         CertificationElements decodedElements;
-        NL_TEST_ASSERT(inSuite, DecodeCertificationElements(encodedCDPayload, decodedElements) == CHIP_NO_ERROR);
+        EXPECT_EQ(DecodeCertificationElements(encodedCDPayload, decodedElements), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT(inSuite, decodedElements.FormatVersion == testCase.cdElements.FormatVersion);
-        NL_TEST_ASSERT(inSuite, decodedElements.VendorId == testCase.cdElements.VendorId);
-        NL_TEST_ASSERT(inSuite, decodedElements.ProductIdsCount == testCase.cdElements.ProductIdsCount);
+        EXPECT_EQ(decodedElements.FormatVersion, testCase.cdElements.FormatVersion);
+        EXPECT_EQ(decodedElements.VendorId, testCase.cdElements.VendorId);
+        EXPECT_EQ(decodedElements.ProductIdsCount, testCase.cdElements.ProductIdsCount);
         for (uint8_t j = 0; j < decodedElements.ProductIdsCount; j++)
         {
-            NL_TEST_ASSERT(inSuite, decodedElements.ProductIds[j] == testCase.cdElements.ProductIds[j]);
+            EXPECT_EQ(decodedElements.ProductIds[j], testCase.cdElements.ProductIds[j]);
         }
-        NL_TEST_ASSERT(inSuite, decodedElements.DeviceTypeId == testCase.cdElements.DeviceTypeId);
-        NL_TEST_ASSERT(inSuite,
-                       memcmp(decodedElements.CertificateId, testCase.cdElements.CertificateId, kCertificateIdLength) == 0);
-        NL_TEST_ASSERT(inSuite, decodedElements.SecurityLevel == testCase.cdElements.SecurityLevel);
-        NL_TEST_ASSERT(inSuite, decodedElements.SecurityInformation == testCase.cdElements.SecurityInformation);
-        NL_TEST_ASSERT(inSuite, decodedElements.VersionNumber == testCase.cdElements.VersionNumber);
-        NL_TEST_ASSERT(inSuite, decodedElements.CertificationType == testCase.cdElements.CertificationType);
-        NL_TEST_ASSERT(inSuite, decodedElements.DACOriginVIDandPIDPresent == testCase.cdElements.DACOriginVIDandPIDPresent);
+        EXPECT_EQ(decodedElements.DeviceTypeId, testCase.cdElements.DeviceTypeId);
+        EXPECT_EQ(memcmp(decodedElements.CertificateId, testCase.cdElements.CertificateId, kCertificateIdLength), 0);
+        EXPECT_EQ(decodedElements.SecurityLevel, testCase.cdElements.SecurityLevel);
+        EXPECT_EQ(decodedElements.SecurityInformation, testCase.cdElements.SecurityInformation);
+        EXPECT_EQ(decodedElements.VersionNumber, testCase.cdElements.VersionNumber);
+        EXPECT_EQ(decodedElements.CertificationType, testCase.cdElements.CertificationType);
+        EXPECT_EQ(decodedElements.DACOriginVIDandPIDPresent, testCase.cdElements.DACOriginVIDandPIDPresent);
         if (decodedElements.DACOriginVIDandPIDPresent)
         {
-            NL_TEST_ASSERT(inSuite, decodedElements.DACOriginVendorId == testCase.cdElements.DACOriginVendorId);
-            NL_TEST_ASSERT(inSuite, decodedElements.DACOriginProductId == testCase.cdElements.DACOriginProductId);
+            EXPECT_EQ(decodedElements.DACOriginVendorId, testCase.cdElements.DACOriginVendorId);
+            EXPECT_EQ(decodedElements.DACOriginProductId, testCase.cdElements.DACOriginProductId);
         }
-        NL_TEST_ASSERT(inSuite, decodedElements.AuthorizedPAAListCount == testCase.cdElements.AuthorizedPAAListCount);
+        EXPECT_EQ(decodedElements.AuthorizedPAAListCount, testCase.cdElements.AuthorizedPAAListCount);
         for (uint8_t j = 0; j < decodedElements.AuthorizedPAAListCount; j++)
         {
-            NL_TEST_ASSERT(
-                inSuite,
-                memcmp(decodedElements.AuthorizedPAAList[j], testCase.cdElements.AuthorizedPAAList[j], kKeyIdentifierLength) == 0);
+            EXPECT_EQ(memcmp(decodedElements.AuthorizedPAAList[j], testCase.cdElements.AuthorizedPAAList[j], kKeyIdentifierLength),
+                      0);
         }
     }
 }
 
-static void TestCD_EncodeDecode_Errors(nlTestSuite * inSuite, void * inContext)
+TEST(TestCertificationDeclaration, TestCD_EncodeDecode_Errors)
 {
     uint8_t encodedCertElemBuf[kCertificationElements_TLVEncodedMaxLength];
     MutableByteSpan encodedCDPayload(encodedCertElemBuf);
-    NL_TEST_ASSERT(inSuite, EncodeCertificationElements(sTestCMS_CertElements01, encodedCDPayload) == CHIP_NO_ERROR);
+    EXPECT_EQ(EncodeCertificationElements(sTestCMS_CertElements01, encodedCDPayload), CHIP_NO_ERROR);
 
     // Test Encode Error: CHIP_ERROR_BUFFER_TOO_SMALL
     // Provide a smaller buffer as an input.
     encodedCDPayload.reduce_size(encodedCDPayload.size() - 4);
-    NL_TEST_ASSERT(inSuite, EncodeCertificationElements(sTestCMS_CertElements01, encodedCDPayload) == CHIP_ERROR_BUFFER_TOO_SMALL);
+    EXPECT_EQ(EncodeCertificationElements(sTestCMS_CertElements01, encodedCDPayload), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // Test Decode Error: CHIP_ERROR_INVALID_INTEGER_VALUE
     // Manually modified sTestCMS_CDContent01[]: updated VendorId element to 4-octet
@@ -327,9 +323,7 @@ static void TestCD_EncodeDecode_Errors(nlTestSuite * inSuite, void * inContext)
     };
 
     CertificationElements certElementsOut;
-    NL_TEST_ASSERT(inSuite,
-                   DecodeCertificationElements(ByteSpan(sTestCMS_CDContent01_Err01), certElementsOut) ==
-                       CHIP_ERROR_INVALID_INTEGER_VALUE);
+    EXPECT_EQ(DecodeCertificationElements(ByteSpan(sTestCMS_CDContent01_Err01), certElementsOut), CHIP_ERROR_INVALID_INTEGER_VALUE);
 
     // Test Decode Error: CHIP_ERROR_UNEXPECTED_TLV_ELEMENT
     // Manually modified sTestCMS_CDContent01[]: switched ProductIds and DeviceTypeId elements tag (0x02 <--> 0x03)
@@ -338,12 +332,11 @@ static void TestCD_EncodeDecode_Errors(nlTestSuite * inSuite, void * inContext)
                                                               0x49, 0x47, 0x32, 0x30, 0x31, 0x34, 0x31, 0x5a, 0x42, 0x33, 0x33,
                                                               0x30, 0x30, 0x30, 0x31, 0x2d, 0x32, 0x34, 0x24, 0x05, 0x00, 0x24,
                                                               0x06, 0x00, 0x25, 0x07, 0x94, 0x26, 0x24, 0x08, 0x00, 0x18 };
-    NL_TEST_ASSERT(inSuite,
-                   DecodeCertificationElements(ByteSpan(sTestCMS_CDContent01_Err02), certElementsOut) ==
-                       CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    EXPECT_EQ(DecodeCertificationElements(ByteSpan(sTestCMS_CDContent01_Err02), certElementsOut),
+              CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 }
 
-static void TestCD_CMSSignAndVerify(nlTestSuite * inSuite, void * inContext)
+TEST(TestCertificationDeclaration, TestCD_CMSSignAndVerify)
 {
     ByteSpan cdContentIn(sTestCMS_CDContent01);
     ByteSpan cdContentOut;
@@ -352,14 +345,14 @@ static void TestCD_CMSSignAndVerify(nlTestSuite * inSuite, void * inContext)
     uint8_t signedMessageBuf[kMaxCMSSignedCDMessage];
     MutableByteSpan signedMessage(signedMessageBuf);
 
-    NL_TEST_ASSERT(inSuite, ExtractSKIDFromX509Cert(ByteSpan(sTestCMS_SignerCert), signerKeyId) == CHIP_NO_ERROR);
+    EXPECT_EQ(ExtractSKIDFromX509Cert(ByteSpan(sTestCMS_SignerCert), signerKeyId), CHIP_NO_ERROR);
 
     // Test with random key
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, CMS_Sign(cdContentIn, signerKeyId, keypair, signedMessage) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, CMS_Verify(signedMessage, keypair.Pubkey(), cdContentOut) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, cdContentIn.data_equal(cdContentOut));
+    EXPECT_EQ(keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
+    EXPECT_EQ(CMS_Sign(cdContentIn, signerKeyId, keypair, signedMessage), CHIP_NO_ERROR);
+    EXPECT_EQ(CMS_Verify(signedMessage, keypair.Pubkey(), cdContentOut), CHIP_NO_ERROR);
+    EXPECT_TRUE(cdContentIn.data_equal(cdContentOut));
 
     // Test with known key
     P256Keypair keypair2;
@@ -368,93 +361,89 @@ static void TestCD_CMSSignAndVerify(nlTestSuite * inSuite, void * inContext)
     serializedKeypair.SetLength(sizeof(sTestCMS_SignerSerializedKeypair));
     cdContentIn   = ByteSpan(sTestCMS_CDContent02);
     signedMessage = MutableByteSpan(signedMessageBuf);
-    NL_TEST_ASSERT(inSuite, keypair2.Deserialize(serializedKeypair) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, CMS_Sign(cdContentIn, signerKeyId, keypair2, signedMessage) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, CMS_Verify(signedMessage, keypair2.Pubkey(), cdContentOut) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, cdContentIn.data_equal(cdContentOut));
+    EXPECT_EQ(keypair2.Deserialize(serializedKeypair), CHIP_NO_ERROR);
+    EXPECT_EQ(CMS_Sign(cdContentIn, signerKeyId, keypair2, signedMessage), CHIP_NO_ERROR);
+    EXPECT_EQ(CMS_Verify(signedMessage, keypair2.Pubkey(), cdContentOut), CHIP_NO_ERROR);
+    EXPECT_TRUE(cdContentIn.data_equal(cdContentOut));
 }
 
-static void TestCD_CMSVerifyAndExtract(nlTestSuite * inSuite, void * inContext)
+TEST(TestCertificationDeclaration, TestCD_CMSVerifyAndExtract)
 {
     for (const auto & testCase : sTestCases)
     {
         // Verify using signer P256PublicKey
         ByteSpan cdContentOut;
-        NL_TEST_ASSERT(inSuite,
-                       CMS_Verify(testCase.cdCMSSigned, P256PublicKey(testCase.signerPubkey), cdContentOut) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, testCase.cdContent.data_equal(cdContentOut));
+        EXPECT_EQ(CMS_Verify(testCase.cdCMSSigned, P256PublicKey(testCase.signerPubkey), cdContentOut), CHIP_NO_ERROR);
+        EXPECT_TRUE(testCase.cdContent.data_equal(cdContentOut));
 
         // Verify using signer X509 Certificate
         cdContentOut = ByteSpan();
-        NL_TEST_ASSERT(inSuite, CMS_Verify(testCase.cdCMSSigned, testCase.signerCert, cdContentOut) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, testCase.cdContent.data_equal(cdContentOut));
+        EXPECT_EQ(CMS_Verify(testCase.cdCMSSigned, testCase.signerCert, cdContentOut), CHIP_NO_ERROR);
+        EXPECT_TRUE(testCase.cdContent.data_equal(cdContentOut));
 
         // Test CMS_ExtractCDContent()
         cdContentOut = ByteSpan();
-        NL_TEST_ASSERT(inSuite, CMS_ExtractCDContent(testCase.cdCMSSigned, cdContentOut) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, testCase.cdContent.data_equal(cdContentOut));
+        EXPECT_EQ(CMS_ExtractCDContent(testCase.cdCMSSigned, cdContentOut), CHIP_NO_ERROR);
+        EXPECT_TRUE(testCase.cdContent.data_equal(cdContentOut));
 
         // Test CMS_ExtractKeyId()
         uint8_t signerKeyIdBuf[Crypto::kSubjectKeyIdentifierLength];
         MutableByteSpan signerKeyId(signerKeyIdBuf);
-        NL_TEST_ASSERT(inSuite, ExtractSKIDFromX509Cert(testCase.signerCert, signerKeyId) == CHIP_NO_ERROR);
+        EXPECT_EQ(ExtractSKIDFromX509Cert(testCase.signerCert, signerKeyId), CHIP_NO_ERROR);
 
         ByteSpan signerKeyIdOut;
-        NL_TEST_ASSERT(inSuite, CMS_ExtractKeyId(testCase.cdCMSSigned, signerKeyIdOut) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, signerKeyId.data_equal(signerKeyIdOut));
+        EXPECT_EQ(CMS_ExtractKeyId(testCase.cdCMSSigned, signerKeyIdOut), CHIP_NO_ERROR);
+        EXPECT_TRUE(signerKeyId.data_equal(signerKeyIdOut));
     }
 }
 
-static void TestCD_CertificationElementsDecoder(nlTestSuite * inSuite, void * inContext)
+TEST(TestCertificationDeclaration, TestCD_CertificationElementsDecoder)
 {
     for (const auto & testCase : sTestCases)
     {
         uint8_t encodedCertElemBuf[kCertificationElements_TLVEncodedMaxLength];
         MutableByteSpan encodedCDPayload(encodedCertElemBuf);
 
-        NL_TEST_ASSERT(inSuite, EncodeCertificationElements(testCase.cdElements, encodedCDPayload) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, testCase.cdContent.data_equal(encodedCDPayload));
+        EXPECT_EQ(EncodeCertificationElements(testCase.cdElements, encodedCDPayload), CHIP_NO_ERROR);
+        EXPECT_TRUE(testCase.cdContent.data_equal(encodedCDPayload));
 
         CertificationElementsWithoutPIDs certificationDeclarationContent;
         CertificationElementsDecoder certificationElementsDecoder;
-        NL_TEST_ASSERT(inSuite, DecodeCertificationElements(encodedCDPayload, certificationDeclarationContent) == CHIP_NO_ERROR);
+        EXPECT_EQ(DecodeCertificationElements(encodedCDPayload, certificationDeclarationContent), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT(inSuite, certificationDeclarationContent.formatVersion == testCase.cdElements.FormatVersion);
-        NL_TEST_ASSERT(inSuite, certificationDeclarationContent.vendorId == testCase.cdElements.VendorId);
+        EXPECT_EQ(certificationDeclarationContent.formatVersion, testCase.cdElements.FormatVersion);
+        EXPECT_EQ(certificationDeclarationContent.vendorId, testCase.cdElements.VendorId);
         for (uint8_t j = 0; j < testCase.cdElements.ProductIdsCount; j++)
         {
-            NL_TEST_ASSERT(inSuite,
-                           certificationElementsDecoder.IsProductIdIn(encodedCDPayload, testCase.cdElements.ProductIds[j]));
+            EXPECT_TRUE(certificationElementsDecoder.IsProductIdIn(encodedCDPayload, testCase.cdElements.ProductIds[j]));
             // now test for an unexistent ProductId
-            NL_TEST_ASSERT(inSuite, certificationElementsDecoder.IsProductIdIn(encodedCDPayload, 0x9000) == false);
+            EXPECT_FALSE(certificationElementsDecoder.IsProductIdIn(encodedCDPayload, 0x9000));
         }
-        NL_TEST_ASSERT(inSuite, certificationDeclarationContent.deviceTypeId == testCase.cdElements.DeviceTypeId);
-        NL_TEST_ASSERT(
-            inSuite,
-            memcmp(certificationDeclarationContent.certificateId, testCase.cdElements.CertificateId, kCertificateIdLength) == 0);
-        NL_TEST_ASSERT(inSuite, certificationDeclarationContent.securityLevel == testCase.cdElements.SecurityLevel);
-        NL_TEST_ASSERT(inSuite, certificationDeclarationContent.securityInformation == testCase.cdElements.SecurityInformation);
-        NL_TEST_ASSERT(inSuite, certificationDeclarationContent.versionNumber == testCase.cdElements.VersionNumber);
-        NL_TEST_ASSERT(inSuite, certificationDeclarationContent.certificationType == testCase.cdElements.CertificationType);
-        NL_TEST_ASSERT(inSuite,
-                       certificationDeclarationContent.dacOriginVIDandPIDPresent == testCase.cdElements.DACOriginVIDandPIDPresent);
+        EXPECT_EQ(certificationDeclarationContent.deviceTypeId, testCase.cdElements.DeviceTypeId);
+        EXPECT_EQ(memcmp(certificationDeclarationContent.certificateId, testCase.cdElements.CertificateId, kCertificateIdLength),
+                  0);
+        EXPECT_EQ(certificationDeclarationContent.securityLevel, testCase.cdElements.SecurityLevel);
+        EXPECT_EQ(certificationDeclarationContent.securityInformation, testCase.cdElements.SecurityInformation);
+        EXPECT_EQ(certificationDeclarationContent.versionNumber, testCase.cdElements.VersionNumber);
+        EXPECT_EQ(certificationDeclarationContent.certificationType, testCase.cdElements.CertificationType);
+        EXPECT_EQ(certificationDeclarationContent.dacOriginVIDandPIDPresent, testCase.cdElements.DACOriginVIDandPIDPresent);
         if (certificationDeclarationContent.dacOriginVIDandPIDPresent)
         {
-            NL_TEST_ASSERT(inSuite, certificationDeclarationContent.dacOriginVendorId == testCase.cdElements.DACOriginVendorId);
-            NL_TEST_ASSERT(inSuite, certificationDeclarationContent.dacOriginProductId == testCase.cdElements.DACOriginProductId);
+            EXPECT_EQ(certificationDeclarationContent.dacOriginVendorId, testCase.cdElements.DACOriginVendorId);
+            EXPECT_EQ(certificationDeclarationContent.dacOriginProductId, testCase.cdElements.DACOriginProductId);
         }
         if (testCase.cdElements.AuthorizedPAAListCount > 0)
         {
-            NL_TEST_ASSERT(inSuite, certificationDeclarationContent.authorizedPAAListPresent);
+            EXPECT_TRUE(certificationDeclarationContent.authorizedPAAListPresent);
         }
         else
         {
-            NL_TEST_ASSERT(inSuite, !certificationDeclarationContent.authorizedPAAListPresent);
+            EXPECT_FALSE(certificationDeclarationContent.authorizedPAAListPresent);
         }
     }
 }
 
-static void TestCD_EncodeDecode_Random(nlTestSuite * inSuite, void * inContext)
+TEST(TestCertificationDeclaration, TestCD_EncodeDecode_Random)
 {
     CertificationElements randomElements = { .FormatVersion             = 0x6F,
                                              .VendorId                  = 0x88EA,
@@ -489,97 +478,95 @@ static void TestCD_EncodeDecode_Random(nlTestSuite * inSuite, void * inContext)
     MutableByteSpan encodedCDPayload(encodedCertElemBuf);
     CertificationElements decodedElements;
 
-    NL_TEST_ASSERT(inSuite, EncodeCertificationElements(randomElements, encodedCDPayload) == CHIP_NO_ERROR);
+    EXPECT_EQ(EncodeCertificationElements(randomElements, encodedCDPayload), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, DecodeCertificationElements(encodedCDPayload, decodedElements) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, decodedElements.FormatVersion == randomElements.FormatVersion);
-    NL_TEST_ASSERT(inSuite, decodedElements.VendorId == randomElements.VendorId);
-    NL_TEST_ASSERT(inSuite, decodedElements.ProductIdsCount == randomElements.ProductIdsCount);
+    EXPECT_EQ(DecodeCertificationElements(encodedCDPayload, decodedElements), CHIP_NO_ERROR);
+    EXPECT_EQ(decodedElements.FormatVersion, randomElements.FormatVersion);
+    EXPECT_EQ(decodedElements.VendorId, randomElements.VendorId);
+    EXPECT_EQ(decodedElements.ProductIdsCount, randomElements.ProductIdsCount);
     for (uint8_t j = 0; j < decodedElements.ProductIdsCount; j++)
     {
-        NL_TEST_ASSERT(inSuite, decodedElements.ProductIds[j] == randomElements.ProductIds[j]);
+        EXPECT_EQ(decodedElements.ProductIds[j], randomElements.ProductIds[j]);
     }
-    NL_TEST_ASSERT(inSuite, decodedElements.DeviceTypeId == randomElements.DeviceTypeId);
-    NL_TEST_ASSERT(inSuite, memcmp(decodedElements.CertificateId, randomElements.CertificateId, kCertificateIdLength) == 0);
-    NL_TEST_ASSERT(inSuite, decodedElements.SecurityLevel == randomElements.SecurityLevel);
-    NL_TEST_ASSERT(inSuite, decodedElements.SecurityInformation == randomElements.SecurityInformation);
-    NL_TEST_ASSERT(inSuite, decodedElements.VersionNumber == randomElements.VersionNumber);
-    NL_TEST_ASSERT(inSuite, decodedElements.CertificationType == randomElements.CertificationType);
-    NL_TEST_ASSERT(inSuite, decodedElements.DACOriginVIDandPIDPresent == randomElements.DACOriginVIDandPIDPresent);
+    EXPECT_EQ(decodedElements.DeviceTypeId, randomElements.DeviceTypeId);
+    EXPECT_EQ(memcmp(decodedElements.CertificateId, randomElements.CertificateId, kCertificateIdLength), 0);
+    EXPECT_EQ(decodedElements.SecurityLevel, randomElements.SecurityLevel);
+    EXPECT_EQ(decodedElements.SecurityInformation, randomElements.SecurityInformation);
+    EXPECT_EQ(decodedElements.VersionNumber, randomElements.VersionNumber);
+    EXPECT_EQ(decodedElements.CertificationType, randomElements.CertificationType);
+    EXPECT_EQ(decodedElements.DACOriginVIDandPIDPresent, randomElements.DACOriginVIDandPIDPresent);
     if (decodedElements.DACOriginVIDandPIDPresent)
     {
-        NL_TEST_ASSERT(inSuite, decodedElements.DACOriginVendorId == randomElements.DACOriginVendorId);
-        NL_TEST_ASSERT(inSuite, decodedElements.DACOriginProductId == randomElements.DACOriginProductId);
+        EXPECT_EQ(decodedElements.DACOriginVendorId, randomElements.DACOriginVendorId);
+        EXPECT_EQ(decodedElements.DACOriginProductId, randomElements.DACOriginProductId);
     }
-    NL_TEST_ASSERT(inSuite, decodedElements.AuthorizedPAAListCount == randomElements.AuthorizedPAAListCount);
+    EXPECT_EQ(decodedElements.AuthorizedPAAListCount, randomElements.AuthorizedPAAListCount);
     for (uint8_t j = 0; j < decodedElements.AuthorizedPAAListCount; j++)
     {
-        NL_TEST_ASSERT(
-            inSuite, memcmp(decodedElements.AuthorizedPAAList[j], randomElements.AuthorizedPAAList[j], kKeyIdentifierLength) == 0);
+        EXPECT_EQ(memcmp(decodedElements.AuthorizedPAAList[j], randomElements.AuthorizedPAAList[j], kKeyIdentifierLength), 0);
     }
 
     CertificationElementsWithoutPIDs decodedElements2;
     CertificationElementsDecoder cdElementsDecoder;
-    NL_TEST_ASSERT(inSuite, DecodeCertificationElements(encodedCDPayload, decodedElements2) == CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeCertificationElements(encodedCDPayload, decodedElements2), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, decodedElements2.formatVersion == randomElements.FormatVersion);
-    NL_TEST_ASSERT(inSuite, decodedElements2.vendorId == randomElements.VendorId);
+    EXPECT_EQ(decodedElements2.formatVersion, randomElements.FormatVersion);
+    EXPECT_EQ(decodedElements2.vendorId, randomElements.VendorId);
     for (uint8_t j = 0; j < randomElements.ProductIdsCount; j++)
     {
-        NL_TEST_ASSERT(inSuite, cdElementsDecoder.IsProductIdIn(encodedCDPayload, randomElements.ProductIds[j]));
+        EXPECT_TRUE(cdElementsDecoder.IsProductIdIn(encodedCDPayload, randomElements.ProductIds[j]));
         // now test for an unexistent ProductId
-        NL_TEST_ASSERT(inSuite, cdElementsDecoder.IsProductIdIn(encodedCDPayload, pid++) == false);
+        EXPECT_FALSE(cdElementsDecoder.IsProductIdIn(encodedCDPayload, pid++));
     }
-    NL_TEST_ASSERT(inSuite, decodedElements2.deviceTypeId == randomElements.DeviceTypeId);
-    NL_TEST_ASSERT(inSuite, memcmp(decodedElements2.certificateId, randomElements.CertificateId, kCertificateIdLength) == 0);
-    NL_TEST_ASSERT(inSuite, decodedElements2.securityLevel == randomElements.SecurityLevel);
-    NL_TEST_ASSERT(inSuite, decodedElements2.securityInformation == randomElements.SecurityInformation);
-    NL_TEST_ASSERT(inSuite, decodedElements2.versionNumber == randomElements.VersionNumber);
-    NL_TEST_ASSERT(inSuite, decodedElements2.certificationType == randomElements.CertificationType);
-    NL_TEST_ASSERT(inSuite, decodedElements2.dacOriginVIDandPIDPresent == randomElements.DACOriginVIDandPIDPresent);
+    EXPECT_EQ(decodedElements2.deviceTypeId, randomElements.DeviceTypeId);
+    EXPECT_EQ(memcmp(decodedElements2.certificateId, randomElements.CertificateId, kCertificateIdLength), 0);
+    EXPECT_EQ(decodedElements2.securityLevel, randomElements.SecurityLevel);
+    EXPECT_EQ(decodedElements2.securityInformation, randomElements.SecurityInformation);
+    EXPECT_EQ(decodedElements2.versionNumber, randomElements.VersionNumber);
+    EXPECT_EQ(decodedElements2.certificationType, randomElements.CertificationType);
+    EXPECT_EQ(decodedElements2.dacOriginVIDandPIDPresent, randomElements.DACOriginVIDandPIDPresent);
     if (decodedElements2.dacOriginVIDandPIDPresent)
     {
-        NL_TEST_ASSERT(inSuite, decodedElements2.dacOriginVendorId == randomElements.DACOriginVendorId);
-        NL_TEST_ASSERT(inSuite, decodedElements2.dacOriginProductId == randomElements.DACOriginProductId);
+        EXPECT_EQ(decodedElements2.dacOriginVendorId, randomElements.DACOriginVendorId);
+        EXPECT_EQ(decodedElements2.dacOriginProductId, randomElements.DACOriginProductId);
     }
-    NL_TEST_ASSERT(inSuite, decodedElements2.authorizedPAAListPresent);
+    EXPECT_TRUE(decodedElements2.authorizedPAAListPresent);
     for (uint8_t j = 0; j < randomElements.AuthorizedPAAListCount; j++)
     {
-        NL_TEST_ASSERT(inSuite,
-                       cdElementsDecoder.HasAuthorizedPAA(encodedCDPayload, ByteSpan(randomElements.AuthorizedPAAList[j])));
+        EXPECT_TRUE(cdElementsDecoder.HasAuthorizedPAA(encodedCDPayload, ByteSpan(randomElements.AuthorizedPAAList[j])));
         // now test for an unexistent PAA
         kid[(kKeyIdentifierLength - 1 - j) % kKeyIdentifierLength] ^= 0x5A;
-        NL_TEST_ASSERT(inSuite, cdElementsDecoder.HasAuthorizedPAA(encodedCDPayload, ByteSpan(kid)) == false);
+        EXPECT_FALSE(cdElementsDecoder.HasAuthorizedPAA(encodedCDPayload, ByteSpan(kid)));
     }
 }
 
-static void TestCD_DefaultCdTrustStore(nlTestSuite * inSuite, void * inContext)
+TEST(TestCertificationDeclaration, TestCD_DefaultCdTrustStore)
 {
     chip::Credentials::CsaCdKeysTrustStore trustStore;
 
     // Make sure that for an untrusted CD, whose key is not in truststore, we cannot find the key.
     {
         ByteSpan signerKeyIdOut;
-        NL_TEST_ASSERT_SUCCESS(inSuite, CMS_ExtractKeyId(ByteSpan(gUntrustedCd), signerKeyIdOut));
-        NL_TEST_ASSERT(inSuite, !trustStore.IsCdTestKey(signerKeyIdOut));
+        EXPECT_EQ(CMS_ExtractKeyId(ByteSpan(gUntrustedCd), signerKeyIdOut), CHIP_NO_ERROR);
+        EXPECT_FALSE(trustStore.IsCdTestKey(signerKeyIdOut));
 
         P256PublicKey pubKey;
-        NL_TEST_ASSERT(inSuite, CHIP_ERROR_KEY_NOT_FOUND == trustStore.LookupVerifyingKey(signerKeyIdOut, pubKey));
+        EXPECT_EQ(CHIP_ERROR_KEY_NOT_FOUND, trustStore.LookupVerifyingKey(signerKeyIdOut, pubKey));
     }
 
     // Verify that a payload known to use the test key passes verification w/ default truststore
     {
         const auto & testCase = sTestCases[0];
         ByteSpan signerKeyIdOut;
-        NL_TEST_ASSERT_SUCCESS(inSuite, CMS_ExtractKeyId(testCase.cdCMSSigned, signerKeyIdOut));
-        NL_TEST_ASSERT(inSuite, trustStore.IsCdTestKey(signerKeyIdOut));
+        EXPECT_EQ(CMS_ExtractKeyId(testCase.cdCMSSigned, signerKeyIdOut), CHIP_NO_ERROR);
+        EXPECT_TRUE(trustStore.IsCdTestKey(signerKeyIdOut));
 
         P256PublicKey pubKey;
         ByteSpan cdContentOut;
-        NL_TEST_ASSERT_SUCCESS(inSuite, trustStore.LookupVerifyingKey(signerKeyIdOut, pubKey));
+        EXPECT_EQ(trustStore.LookupVerifyingKey(signerKeyIdOut, pubKey), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT(inSuite, CMS_Verify(testCase.cdCMSSigned, pubKey, cdContentOut) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, testCase.cdContent.data_equal(cdContentOut));
+        EXPECT_EQ(CMS_Verify(testCase.cdCMSSigned, pubKey, cdContentOut), CHIP_NO_ERROR);
+        EXPECT_TRUE(testCase.cdContent.data_equal(cdContentOut));
     }
 
     // Verify that after adding the verifying key to the trust store, it is now possible to
@@ -587,49 +574,25 @@ static void TestCD_DefaultCdTrustStore(nlTestSuite * inSuite, void * inContext)
     {
         P256PublicKey pubKey;
         ByteSpan cdContentOut;
-        NL_TEST_ASSERT_SUCCESS(inSuite, trustStore.AddTrustedKey(ByteSpan(gUntrustedCdKid), gUntrustedCdVerifyingKey));
+        EXPECT_EQ(trustStore.AddTrustedKey(ByteSpan(gUntrustedCdKid), gUntrustedCdVerifyingKey), CHIP_NO_ERROR);
 
         ByteSpan signerKeyIdOut;
-        NL_TEST_ASSERT_SUCCESS(inSuite, CMS_ExtractKeyId(ByteSpan(gUntrustedCd), signerKeyIdOut));
-        NL_TEST_ASSERT(inSuite, signerKeyIdOut.data_equal(ByteSpan(gUntrustedCdKid)));
+        EXPECT_EQ(CMS_ExtractKeyId(ByteSpan(gUntrustedCd), signerKeyIdOut), CHIP_NO_ERROR);
+        EXPECT_TRUE(signerKeyIdOut.data_equal(ByteSpan(gUntrustedCdKid)));
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, trustStore.LookupVerifyingKey(signerKeyIdOut, pubKey));
-        NL_TEST_ASSERT(inSuite, pubKey.Matches(gUntrustedCdVerifyingKey));
+        EXPECT_EQ(trustStore.LookupVerifyingKey(signerKeyIdOut, pubKey), CHIP_NO_ERROR);
+        EXPECT_TRUE(pubKey.Matches(gUntrustedCdVerifyingKey));
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, CMS_Verify(ByteSpan(gUntrustedCd), pubKey, cdContentOut));
+        EXPECT_EQ(CMS_Verify(ByteSpan(gUntrustedCd), pubKey, cdContentOut), CHIP_NO_ERROR);
     }
 
     // Verify that untrusted certificate key cannot be added to the trust store.
     {
-        NL_TEST_ASSERT(inSuite, CHIP_ERROR_INVALID_ARGUMENT == trustStore.AddTrustedKey(ByteSpan(gUntrustedCdCert)));
+        EXPECT_EQ(CHIP_ERROR_INVALID_ARGUMENT, trustStore.AddTrustedKey(ByteSpan(gUntrustedCdCert)));
     }
 
     // Verify that trusted certificate key can be added to the trust store.
     {
-        NL_TEST_ASSERT_SUCCESS(inSuite, trustStore.AddTrustedKey(ByteSpan(gCdSigningCert001)));
+        EXPECT_EQ(trustStore.AddTrustedKey(ByteSpan(gCdSigningCert001)), CHIP_NO_ERROR);
     }
 }
-
-#define NL_TEST_DEF_FN(fn) NL_TEST_DEF("Test " #fn, fn)
-/**
- *   Test Suite. It lists all the test functions.
- */
-static const nlTest sTests[] = { NL_TEST_DEF_FN(TestCD_EncodeDecode),
-                                 NL_TEST_DEF_FN(TestCD_EncodeDecode_Errors),
-                                 NL_TEST_DEF_FN(TestCD_CMSSignAndVerify),
-                                 NL_TEST_DEF_FN(TestCD_CMSVerifyAndExtract),
-                                 NL_TEST_DEF_FN(TestCD_CertificationElementsDecoder),
-                                 NL_TEST_DEF_FN(TestCD_EncodeDecode_Random),
-                                 NL_TEST_DEF_FN(TestCD_DefaultCdTrustStore),
-                                 NL_TEST_SENTINEL() };
-
-int TestCertificationDeclaration()
-{
-    nlTestSuite theSuite = { "CHIP Certification Declaration tests", &sTests[0], nullptr, nullptr };
-
-    // Run test suite against one context.
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestCertificationDeclaration);

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -33,10 +33,8 @@
 #include <lib/core/TLV.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/UnitTestExtendedAssertions.h>
-#include <lib/support/UnitTestRegistration.h>
 
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 #include "CHIPCert_error_test_vectors.h"
 #include "CHIPCert_test_vectors.h"
@@ -163,7 +161,13 @@ static void ClearTimeSource(ValidationContext & validContext)
     validContext.mEffectiveTime = EffectiveTime{};
 }
 
-static void TestChipCert_ChipToX509(nlTestSuite * inSuite, void * inContext)
+struct TestChipCert : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+TEST_F(TestChipCert, TestChipCert_ChipToX509)
 {
     CHIP_ERROR err;
     ByteSpan inCert;
@@ -175,23 +179,23 @@ static void TestChipCert_ChipToX509(nlTestSuite * inSuite, void * inContext)
         TestCert certType = gTestCerts[i];
 
         err = GetTestCert(certType, sNullLoadFlag, inCert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
         err = GetTestCert(certType, sDerFormFlag, expectedOutCert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         MutableByteSpan outCert(outCertBuf);
         err = ConvertChipCertToX509Cert(inCert, outCert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, expectedOutCert.data_equal(outCert));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(expectedOutCert.data_equal(outCert));
     }
 
     // Error Case:
     MutableByteSpan outCert(outCertBuf);
     err = ConvertChipCertToX509Cert(sTestCert_Node01_01_Err01_Chip, outCert);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_TLV_TAG);
+    EXPECT_EQ(err, CHIP_ERROR_INVALID_TLV_TAG);
 }
 
-static void TestChipCert_ChipToX509_ErrorCases(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_ChipToX509_ErrorCases)
 {
     CHIP_ERROR err;
     uint8_t outCertBuf[kMaxDERCertLength];
@@ -201,22 +205,22 @@ static void TestChipCert_ChipToX509_ErrorCases(nlTestSuite * inSuite, void * inC
         MutableByteSpan outCert(outCertBuf);
 
         err = ConvertChipCertToX509Cert(chipCert, outCert);
-        NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+        EXPECT_NE(err, CHIP_NO_ERROR);
     }
 }
 
-static void TestChipCert_ChipCertLoad_ErrorCases(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_ChipCertLoad_ErrorCases)
 {
     CHIP_ERROR err;
     ChipCertificateSet certSet;
 
     err = certSet.Init(1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     for (auto chipCert : gTestCert_ChipCertLoad_ErrorCases)
     {
         err = certSet.LoadCert(chipCert, sNullDecodeFlag);
-        NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+        EXPECT_NE(err, CHIP_NO_ERROR);
 
         certSet.Clear();
     }
@@ -224,34 +228,34 @@ static void TestChipCert_ChipCertLoad_ErrorCases(nlTestSuite * inSuite, void * i
     certSet.Release();
 }
 
-static void TestChipCert_ValidateChipRCAC_ErrorCases(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_ValidateChipRCAC_ErrorCases)
 {
     CHIP_ERROR err;
 
     for (auto chipCert : gTestCert_ValidateChipRCAC_ErrorCases)
     {
         err = ValidateChipRCAC(chipCert);
-        NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+        EXPECT_NE(err, CHIP_NO_ERROR);
     }
 }
 
-static void TestChipCert_GetCertType_ErrorCases(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_GetCertType_ErrorCases)
 {
     CHIP_ERROR err;
     ChipCertificateSet certSet;
 
     err = certSet.Init(1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     for (auto chipCert : gTestCert_GetCertType_ErrorCases)
     {
         CertType certType;
 
         err = certSet.LoadCert(chipCert, sNullDecodeFlag);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = certSet.GetCertSet()->mSubjectDN.GetCertType(certType);
-        NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR || certType == CertType::kNotSpecified);
+        EXPECT_TRUE(err != CHIP_NO_ERROR || certType == CertType::kNotSpecified);
 
         certSet.Clear();
     }
@@ -259,7 +263,7 @@ static void TestChipCert_GetCertType_ErrorCases(nlTestSuite * inSuite, void * in
     certSet.Release();
 }
 
-static void TestChipCert_X509ToChip(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_X509ToChip)
 {
     CHIP_ERROR err;
     ByteSpan inCert;
@@ -271,18 +275,18 @@ static void TestChipCert_X509ToChip(nlTestSuite * inSuite, void * inContext)
         TestCert certType = gTestCerts[i];
 
         err = GetTestCert(certType, sDerFormFlag, inCert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
         err = GetTestCert(certType, sNullLoadFlag, expectedOutCert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         MutableByteSpan outCert(outCertBuf);
         err = ConvertX509CertToChipCert(inCert, outCert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, expectedOutCert.data_equal(outCert));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(expectedOutCert.data_equal(outCert));
     }
 }
 
-static void TestChipCert_X509ToChip_ErrorCases(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_X509ToChip_ErrorCases)
 {
     CHIP_ERROR err;
     uint8_t outCertBuf[kMaxCHIPCertLength];
@@ -292,11 +296,11 @@ static void TestChipCert_X509ToChip_ErrorCases(nlTestSuite * inSuite, void * inC
         MutableByteSpan outCert(outCertBuf);
 
         err = ConvertX509CertToChipCert(derCert, outCert);
-        NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+        EXPECT_NE(err, CHIP_NO_ERROR);
     }
 }
 
-static void TestChipCert_ChipDN(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_ChipDN)
 {
     const static char noc_rdn[]     = "Test NOC";
     const static char noc_rdn2[]    = "John";
@@ -305,51 +309,51 @@ static void TestChipCert_ChipDN(nlTestSuite * inSuite, void * inContext)
     ChipDN chip_dn;
     CertType certType = CertType::kFirmwareSigning; // Start with non-default value
 
-    NL_TEST_ASSERT(inSuite, chip_dn.IsEmpty());
-    NL_TEST_ASSERT(inSuite, chip_dn.RDNCount() == 0);
-    NL_TEST_ASSERT(inSuite, chip_dn.GetCertType(certType) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, chip_dn.IsEmpty() == true);
-    NL_TEST_ASSERT(inSuite, certType == CertType::kNotSpecified);
+    EXPECT_TRUE(chip_dn.IsEmpty());
+    EXPECT_EQ(chip_dn.RDNCount(), 0);
+    EXPECT_EQ(chip_dn.GetCertType(certType), CHIP_NO_ERROR);
+    EXPECT_TRUE(chip_dn.IsEmpty());
+    EXPECT_EQ(certType, CertType::kNotSpecified);
 
-    NL_TEST_ASSERT(inSuite, chip_dn.AddAttribute_CommonName(CharSpan(noc_rdn, strlen(noc_rdn)), false) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, chip_dn.AddAttribute_MatterNodeId(0xAAAABBBBCCCCDDDD) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, chip_dn.AddAttribute_MatterFabricId(0xFAB00000FAB00001) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, chip_dn.AddAttribute_GivenName(CharSpan(noc_rdn2, strlen(noc_rdn2)), true) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, chip_dn.AddCATs(noc_cats) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, chip_dn.RDNCount() == 5);
+    EXPECT_EQ(chip_dn.AddAttribute_CommonName(CharSpan(noc_rdn, strlen(noc_rdn)), false), CHIP_NO_ERROR);
+    EXPECT_EQ(chip_dn.AddAttribute_MatterNodeId(0xAAAABBBBCCCCDDDD), CHIP_NO_ERROR);
+    EXPECT_EQ(chip_dn.AddAttribute_MatterFabricId(0xFAB00000FAB00001), CHIP_NO_ERROR);
+    EXPECT_EQ(chip_dn.AddAttribute_GivenName(CharSpan(noc_rdn2, strlen(noc_rdn2)), true), CHIP_NO_ERROR);
+    EXPECT_EQ(chip_dn.AddCATs(noc_cats), CHIP_NO_ERROR);
+    EXPECT_EQ(chip_dn.RDNCount(), 5);
 
-    NL_TEST_ASSERT(inSuite, chip_dn.AddAttribute_GivenName(CharSpan(noc_rdn2, strlen(noc_rdn2)), true) == CHIP_ERROR_NO_MEMORY);
-    NL_TEST_ASSERT(inSuite, chip_dn.RDNCount() == 5);
+    EXPECT_EQ(chip_dn.AddAttribute_GivenName(CharSpan(noc_rdn2, strlen(noc_rdn2)), true), CHIP_ERROR_NO_MEMORY);
+    EXPECT_EQ(chip_dn.RDNCount(), 5);
 
-    NL_TEST_ASSERT(inSuite, chip_dn.GetCertType(certType) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certType == CertType::kNode);
+    EXPECT_EQ(chip_dn.GetCertType(certType), CHIP_NO_ERROR);
+    EXPECT_EQ(certType, CertType::kNode);
 
     uint64_t certId;
-    NL_TEST_ASSERT(inSuite, chip_dn.GetCertChipId(certId) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certId == 0xAAAABBBBCCCCDDDD);
+    EXPECT_EQ(chip_dn.GetCertChipId(certId), CHIP_NO_ERROR);
+    EXPECT_EQ(certId, 0xAAAABBBBCCCCDDDD);
 
     uint64_t fabricId;
-    NL_TEST_ASSERT(inSuite, chip_dn.GetCertFabricId(fabricId) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, fabricId == 0xFAB00000FAB00001);
+    EXPECT_EQ(chip_dn.GetCertFabricId(fabricId), CHIP_NO_ERROR);
+    EXPECT_EQ(fabricId, 0xFAB00000FAB00001);
 
     chip_dn.Clear();
-    NL_TEST_ASSERT(inSuite, chip_dn.GetCertType(certType) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, chip_dn.IsEmpty() == true);
-    NL_TEST_ASSERT(inSuite, certType == CertType::kNotSpecified);
+    EXPECT_EQ(chip_dn.GetCertType(certType), CHIP_NO_ERROR);
+    EXPECT_TRUE(chip_dn.IsEmpty());
+    EXPECT_EQ(certType, CertType::kNotSpecified);
 
     CATValues noc_cats2;
     chip::CATValues::Serialized serializedCATs;
-    NL_TEST_ASSERT(inSuite, noc_cats.Serialize(serializedCATs) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_cats2.Deserialize(serializedCATs) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, memcmp(&noc_cats, &noc_cats2, chip::CATValues::kSerializedLength) == 0);
+    EXPECT_EQ(noc_cats.Serialize(serializedCATs), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_cats2.Deserialize(serializedCATs), CHIP_NO_ERROR);
+    EXPECT_EQ(memcmp(&noc_cats, &noc_cats2, chip::CATValues::kSerializedLength), 0);
 
     CATValues noc_cats3 = { { 0xABCD0001, 0xFFEEAA00, 0x0001F012 } };
-    NL_TEST_ASSERT(inSuite, noc_cats3.Serialize(serializedCATs) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_cats2.Deserialize(serializedCATs) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, memcmp(&noc_cats3, &noc_cats2, chip::CATValues::kSerializedLength) == 0);
+    EXPECT_EQ(noc_cats3.Serialize(serializedCATs), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_cats2.Deserialize(serializedCATs), CHIP_NO_ERROR);
+    EXPECT_EQ(memcmp(&noc_cats3, &noc_cats2, chip::CATValues::kSerializedLength), 0);
 }
 
-static void TestChipCert_CertValidation(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_CertValidation)
 {
     CHIP_ERROR err;
     ChipCertificateSet certSet;
@@ -512,29 +516,28 @@ static void TestChipCert_CertValidation(nlTestSuite * inSuite, void * inContext)
     {
         const ChipCertificateData * resultCert = nullptr;
         err                                    = certSet.Init(kMaxCertsPerTestCase);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         for (auto inputCert : testCase.InputCerts)
         {
             if (inputCert.Type != TestCert::kNone)
             {
                 err = LoadTestCert(certSet, inputCert.Type, inputCert.LoadFlags, inputCert.DecodeFlags);
-                NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+                EXPECT_EQ(err, CHIP_NO_ERROR);
             }
         }
         // Make sure the test case is valid.
-        NL_TEST_ASSERT(inSuite, testCase.mSubjectCertIndex >= 0 && testCase.mSubjectCertIndex < certSet.GetCertCount());
+        EXPECT_TRUE(testCase.mSubjectCertIndex >= 0 && testCase.mSubjectCertIndex < certSet.GetCertCount());
         if (testCase.mExpectedResult == CHIP_NO_ERROR)
         {
-            NL_TEST_ASSERT(inSuite, testCase.mExpectedCertIndex >= 0 && testCase.mExpectedCertIndex < certSet.GetCertCount());
-            NL_TEST_ASSERT(inSuite,
-                           testCase.mExpectedTrustAnchorIndex >= 0 && testCase.mExpectedTrustAnchorIndex < certSet.GetCertCount());
+            EXPECT_TRUE(testCase.mExpectedCertIndex >= 0 && testCase.mExpectedCertIndex < certSet.GetCertCount());
+            EXPECT_TRUE(testCase.mExpectedTrustAnchorIndex >= 0 && testCase.mExpectedTrustAnchorIndex < certSet.GetCertCount());
         }
 
         // Initialize the validation context.
         validContext.Reset();
         err = SetCurrentTime(validContext, 2021, 1, 1);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
         validContext.mRequiredKeyUsages.Set(KeyUsageFlags::kDigitalSignature);
         validContext.mRequiredKeyPurposes.Set(KeyPurposeFlags::kServerAuth);
         validContext.mRequiredKeyPurposes.Set(KeyPurposeFlags::kClientAuth);
@@ -546,16 +549,16 @@ static void TestChipCert_CertValidation(nlTestSuite * inSuite, void * inContext)
 
         // Invoke the FindValidCert() method (the method being tested).
         err = certSet.FindValidCert(subjectDN, subjectKeyId, validContext, &resultCert);
-        NL_TEST_ASSERT(inSuite, err == testCase.mExpectedResult);
+        EXPECT_EQ(err, testCase.mExpectedResult);
 
         // If the test case is expected to be successful...
         if (err == CHIP_NO_ERROR)
         {
             // Verify that the method found the correct certificate.
-            NL_TEST_ASSERT(inSuite, resultCert == &certSet.GetCertSet()[testCase.mExpectedCertIndex]);
+            EXPECT_EQ(resultCert, &certSet.GetCertSet()[testCase.mExpectedCertIndex]);
 
             // Verify that the method selected the correct trust anchor.
-            NL_TEST_ASSERT(inSuite, validContext.mTrustAnchor == &certSet.GetCertSet()[testCase.mExpectedTrustAnchorIndex]);
+            EXPECT_EQ(validContext.mTrustAnchor, &certSet.GetCertSet()[testCase.mExpectedTrustAnchorIndex]);
         }
 
         // Clear the certificate set.
@@ -563,17 +566,17 @@ static void TestChipCert_CertValidation(nlTestSuite * inSuite, void * inContext)
     }
 }
 
-static void TestChipCert_CertValidTime(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_CertValidTime)
 {
     CHIP_ERROR err;
     ChipCertificateSet certSet;
     ValidationContext validContext;
 
     err = certSet.Init(kStandardCertsCount);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = LoadTestCertSet01(certSet);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     validContext.Reset();
     validContext.mRequiredKeyUsages.Set(KeyUsageFlags::kDigitalSignature);
@@ -588,248 +591,248 @@ static void TestChipCert_CertValidTime(nlTestSuite * inSuite, void * inContext)
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Current time before certificate validity period.
     err = SetCurrentTime(validContext, 2020, 1, 3);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_NOT_VALID_YET);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_NOT_VALID_YET);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_NOT_VALID_YET);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_NOT_VALID_YET);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_NOT_VALID_YET);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_NOT_VALID_YET);
 
     // Current time 1 second before validity period.
     err = SetCurrentTime(validContext, 2020, 10, 15, 14, 23, 42);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_NOT_VALID_YET);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_NOT_VALID_YET);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_NOT_VALID_YET);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_NOT_VALID_YET);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_NOT_VALID_YET);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_NOT_VALID_YET);
 
     // Current time 1st second of validity period.
     err = SetCurrentTime(validContext, 2020, 10, 15, 14, 23, 43);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Current time within validity period.
     err = SetCurrentTime(validContext, 2022, 02, 23, 12, 30, 01);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Current time at last second of validity period.
     err = SetCurrentTime(validContext, 2040, 10, 15, 14, 23, 42);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Current time at 1 second after end of certificate validity period.
     err = SetCurrentTime(validContext, 2040, 10, 15, 14, 23, 43);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
 
     // Current time after end of certificate validity period.
     err = SetCurrentTime(validContext, 2042, 4, 25, 0, 0, 0);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
 
     // Last known good time before certificate validity period.
     // We can't invalidate based on NotBefore with Last Known Good Time.
     // Hence, we expect CHIP_NO_ERROR.
     err = SetLastKnownGoodTime(validContext, 2020, 1, 3);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Last known good time 1 second before certificate validity period.
     // We can't invalidate based on NotBefore with Last Known Good Time.
     // Hence, we expect CHIP_NO_ERROR.
     err = SetLastKnownGoodTime(validContext, 2020, 10, 15, 14, 23, 42);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Last Known Good Time 1st second of validity period.
     err = SetLastKnownGoodTime(validContext, 2020, 10, 15, 14, 23, 43);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Last Known Good Time within validity period.
     err = SetLastKnownGoodTime(validContext, 2022, 02, 23, 12, 30, 01);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Last Known Good Time at last second of validity period.
     err = SetLastKnownGoodTime(validContext, 2040, 10, 15, 14, 23, 42);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Last Known Good Time at 1 second after end of certificate validity period.
     err = SetLastKnownGoodTime(validContext, 2040, 10, 15, 14, 23, 43);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
 
     // Last Known Good Time after end of certificate validity period.
     err = SetLastKnownGoodTime(validContext, 2042, 4, 25, 0, 0, 0);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictCertificateValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimeValidityPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
 
     certSet.Release();
 }
 
-static void TestChipCert_ValidateChipRCAC(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_ValidateChipRCAC)
 {
     struct RCACTestCase
     {
@@ -855,8 +858,8 @@ static void TestChipCert_ValidateChipRCAC(nlTestSuite * inSuite, void * inContex
     for (auto & testCase : sRCACTestCases)
     {
         ByteSpan cert;
-        NL_TEST_ASSERT(inSuite, GetTestCert(testCase.Cert, sNullLoadFlag, cert) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, ValidateChipRCAC(cert) == testCase.mExpectedResult);
+        EXPECT_EQ(GetTestCert(testCase.Cert, sNullLoadFlag, cert), CHIP_NO_ERROR);
+        EXPECT_EQ(ValidateChipRCAC(cert), testCase.mExpectedResult);
     }
 }
 
@@ -884,7 +887,7 @@ public:
     }
 };
 
-static void TestChipCert_CertValidityPolicyInjection(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_CertValidityPolicyInjection)
 {
     CHIP_ERROR err;
     ChipCertificateSet certSet;
@@ -895,10 +898,10 @@ static void TestChipCert_CertValidityPolicyInjection(nlTestSuite * inSuite, void
     AlwaysRejectValidityPolicy alwaysRejectPolicy;
 
     err = certSet.Init(kStandardCertsCount);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = LoadTestCertSet01(certSet);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     validContext.Reset();
     validContext.mRequiredKeyUsages.Set(KeyUsageFlags::kDigitalSignature);
@@ -910,170 +913,170 @@ static void TestChipCert_CertValidityPolicyInjection(nlTestSuite * inSuite, void
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimePolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Always accept policy
     validContext.mValidityPolicy = &alwaysAcceptPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Always reject policy
     validContext.mValidityPolicy = &alwaysRejectPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+    EXPECT_NE(err, CHIP_NO_ERROR);
 
     // Curent time before certificate validity period.
     err = SetCurrentTime(validContext, 2020, 1, 3);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_NOT_VALID_YET);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_NOT_VALID_YET);
     // Strict policy
     validContext.mValidityPolicy = &strictPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_NOT_VALID_YET);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_NOT_VALID_YET);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimePolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_NOT_VALID_YET);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_NOT_VALID_YET);
     // Always accept policy
     validContext.mValidityPolicy = &alwaysAcceptPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Always reject policy
     validContext.mValidityPolicy = &alwaysRejectPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+    EXPECT_NE(err, CHIP_NO_ERROR);
 
     // Last known good time before certificate validity period.
     err = SetLastKnownGoodTime(validContext, 2020, 1, 3);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Always accept policy
     validContext.mValidityPolicy = &alwaysAcceptPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Always reject policy
     validContext.mValidityPolicy = &alwaysRejectPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+    EXPECT_NE(err, CHIP_NO_ERROR);
 
     // Current time during validity period
     err = SetCurrentTime(validContext, 2022, 02, 23, 12, 30, 01);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Always accept policy
     validContext.mValidityPolicy = &alwaysAcceptPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Always reject policy
     validContext.mValidityPolicy = &alwaysRejectPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+    EXPECT_NE(err, CHIP_NO_ERROR);
 
     // Last Known Good Time during validity period
     err = SetLastKnownGoodTime(validContext, 2022, 02, 23, 12, 30, 01);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimePolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Always accept policy
     validContext.mValidityPolicy = &alwaysAcceptPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Always reject policy
     validContext.mValidityPolicy = &alwaysRejectPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+    EXPECT_NE(err, CHIP_NO_ERROR);
 
     // Current time after end of certificate validity period.
     err = SetCurrentTime(validContext, 2042, 4, 25, 0, 0, 0);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Strict policy
     validContext.mValidityPolicy = &strictPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimePolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Always accept policy
     validContext.mValidityPolicy = &alwaysAcceptPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Always reject policy
     validContext.mValidityPolicy = &alwaysRejectPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+    EXPECT_NE(err, CHIP_NO_ERROR);
 
     // Last Known Good Time after end of certificate validity period.
     err = SetLastKnownGoodTime(validContext, 2042, 4, 25, 0, 0, 0);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Default policy
     validContext.mValidityPolicy = nullptr;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Strict policy
     validContext.mValidityPolicy = &strictPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Last Known Good Time policy
     validContext.mValidityPolicy = &lastKnownGoodTimePolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_CERT_EXPIRED);
+    EXPECT_EQ(err, CHIP_ERROR_CERT_EXPIRED);
     // Always accept policy
     validContext.mValidityPolicy = &alwaysAcceptPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
     // Always reject policy
     validContext.mValidityPolicy = &alwaysRejectPolicy;
     err                          = certSet.ValidateCert(certSet.GetLastCert(), validContext);
-    NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
+    EXPECT_NE(err, CHIP_NO_ERROR);
 
     certSet.Release();
 }
 
-static void TestChipCert_CertUsage(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_CertUsage)
 {
     CHIP_ERROR err;
     ChipCertificateSet certSet;
@@ -1164,10 +1167,10 @@ static void TestChipCert_CertUsage(nlTestSuite * inSuite, void * inContext)
     size_t sNumUsageTestCases = ArraySize(sUsageTestCases);
 
     err = certSet.Init(certDataArray, ArraySize(certDataArray));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = LoadTestCertSet01(certSet);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     for (size_t i = 0; i < sNumUsageTestCases; i++)
     {
@@ -1176,16 +1179,16 @@ static void TestChipCert_CertUsage(nlTestSuite * inSuite, void * inContext)
         validContext.mRequiredKeyPurposes = sUsageTestCases[i].mRequiredKeyPurposes;
 
         err = SetCurrentTime(validContext, 2020, 10, 16);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = certSet.ValidateCert(&certSet.GetCertSet()[sUsageTestCases[i].mCertIndex], validContext);
-        NL_TEST_ASSERT(inSuite, err == sUsageTestCases[i].mExpectedResult);
+        EXPECT_EQ(err, sUsageTestCases[i].mExpectedResult);
     }
 
     certSet.Release();
 }
 
-static void TestChipCert_CertType(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_CertType)
 {
     CHIP_ERROR err;
     ChipCertificateData certData;
@@ -1218,16 +1221,16 @@ static void TestChipCert_CertType(nlTestSuite * inSuite, void * inContext)
         CertType certType;
 
         err = DecodeTestCert(certData, testCase.Cert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = certData.mSubjectDN.GetCertType(certType);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT(inSuite, certType == testCase.ExpectedCertType);
+        EXPECT_EQ(certType, testCase.ExpectedCertType);
     }
 }
 
-static void TestChipCert_CertId(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_CertId)
 {
     CHIP_ERROR err;
     ChipCertificateData certData;
@@ -1260,114 +1263,114 @@ static void TestChipCert_CertId(nlTestSuite * inSuite, void * inContext)
         uint64_t chipId;
 
         err = DecodeTestCert(certData, testCase.Cert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = certData.mSubjectDN.GetCertChipId(chipId);
         if (testCase.ExpectedCertId != 0)
         {
-            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, chipId == testCase.ExpectedCertId);
+            EXPECT_EQ(err, CHIP_NO_ERROR);
+            EXPECT_EQ(chipId, testCase.ExpectedCertId);
         }
         else
         {
-            NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_CERT_DN);
+            EXPECT_EQ(err, CHIP_ERROR_WRONG_CERT_DN);
         }
     }
 }
 
-static void TestChipCert_DecodingOptions(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_DecodingOptions)
 {
     CHIP_ERROR err;
     ByteSpan cert;
     ChipCertificateData certData;
 
     err = GetTestCert(TestCert::kRoot01, sNullLoadFlag, cert);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Decode with default (null) options
     err = DecodeChipCert(cert, certData);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, !certData.mCertFlags.Has(CertFlags::kIsTrustAnchor));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_FALSE(certData.mCertFlags.Has(CertFlags::kIsTrustAnchor));
 
     // Decode as trust anchor
     err = DecodeChipCert(cert, certData, CertDecodeFlags::kIsTrustAnchor);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certData.mCertFlags.Has(CertFlags::kIsTrustAnchor));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(certData.mCertFlags.Has(CertFlags::kIsTrustAnchor));
 
     // Decode with TBS Hash calculation
     err = DecodeChipCert(cert, certData, CertDecodeFlags::kGenerateTBSHash);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certData.mCertFlags.Has(CertFlags::kTBSHashPresent));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(certData.mCertFlags.Has(CertFlags::kTBSHashPresent));
     // When the TBS hash is available signature verification should work
     err = VerifyCertSignature(certData, certData); // test cert is a self-signed root
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 }
 
-static void TestChipCert_LoadDuplicateCerts(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_LoadDuplicateCerts)
 {
     CHIP_ERROR err;
     ChipCertificateSet certSet;
     ValidationContext validContext;
 
     err = certSet.Init(kStandardCertsCount);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Let's load two distinct certificates, and make sure cert count is 2
     err = LoadTestCert(certSet, TestCert::kRoot01, sNullLoadFlag, sTrustAnchorFlag);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = LoadTestCert(certSet, TestCert::kICA01, sNullLoadFlag, sGenTBSHashFlag);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certSet.GetCertCount() == 2);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.GetCertCount(), 2);
 
     // Let's load a previously loaded cert and make sure cert count is still 2
     err = LoadTestCert(certSet, TestCert::kRoot01, sNullLoadFlag, sTrustAnchorFlag);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certSet.GetCertCount() == 2);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.GetCertCount(), 2);
 
     // Let's load the other previously loaded cert and make sure cert count is still 2
     err = LoadTestCert(certSet, TestCert::kICA01, sNullLoadFlag, sGenTBSHashFlag);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certSet.GetCertCount() == 2);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.GetCertCount(), 2);
 
     // Let's load a new cert and make sure cert count updates to 3
     err = LoadTestCert(certSet, TestCert::kNode01_01, sNullLoadFlag, sGenTBSHashFlag);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certSet.GetCertCount() == 3);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.GetCertCount(), 3);
 }
 
-static void TestChipCert_GenerateRootCert(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_GenerateRootCert)
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
 
     ChipCertificateData certData;
 
     ChipDN root_dn;
-    NL_TEST_ASSERT(inSuite, root_dn.AddAttribute_MatterRCACId(0xabcdabcd) == CHIP_NO_ERROR);
+    EXPECT_EQ(root_dn.AddAttribute_MatterRCACId(0xabcdabcd), CHIP_NO_ERROR);
 
     X509CertRequestParams root_params = { 1234, 631161876, 729942000, root_dn, root_dn };
     MutableByteSpan signed_cert_span(signed_cert);
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert_span) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewRootX509Cert(root_params, keypair, signed_cert_span), CHIP_NO_ERROR);
 
     uint8_t outCertBuf[kMaxCHIPCertLength];
     MutableByteSpan outCert(outCertBuf);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span, outCert) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(signed_cert_span, outCert), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeChipCert(outCert, certData), CHIP_NO_ERROR);
 
     // Test with FutureExtension
     X509CertRequestParams root_params2 = { 1234, 631161876, 729942000, root_dn, root_dn, kSubjectAltNameAsFutureExt };
     MutableByteSpan signed_cert_span2(signed_cert);
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params2, keypair, signed_cert_span2) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewRootX509Cert(root_params2, keypair, signed_cert_span2), CHIP_NO_ERROR);
     outCert = MutableByteSpan(outCertBuf);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span2, outCert) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(signed_cert_span2, outCert), CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeChipCert(outCert, certData), CHIP_NO_ERROR);
 
     // Test with no defined notAfter time.
     {
@@ -1378,41 +1381,41 @@ static void TestChipCert_GenerateRootCert(nlTestSuite * inSuite, void * inContex
                                                .IssuerDN      = root_dn };
         MutableByteSpan signed_cert_span_no_expiry(signed_cert);
 
-        NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params3, keypair, signed_cert_span_no_expiry) == CHIP_NO_ERROR);
+        EXPECT_EQ(NewRootX509Cert(root_params3, keypair, signed_cert_span_no_expiry), CHIP_NO_ERROR);
         outCert = MutableByteSpan(outCertBuf);
 
-        NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span_no_expiry, outCert) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, certData.mNotAfterTime == kNullCertTime);
+        EXPECT_EQ(ConvertX509CertToChipCert(signed_cert_span_no_expiry, outCert), CHIP_NO_ERROR);
+        EXPECT_EQ(DecodeChipCert(outCert, certData), CHIP_NO_ERROR);
+        EXPECT_EQ(certData.mNotAfterTime, kNullCertTime);
     }
 
     // Test error case: root cert subject provided ICA OID Attribute.
     root_params.SubjectDN.Clear();
-    NL_TEST_ASSERT(inSuite, root_params.SubjectDN.AddAttribute_MatterICACId(0xabcdabcd) == CHIP_NO_ERROR);
+    EXPECT_EQ(root_params.SubjectDN.AddAttribute_MatterICACId(0xabcdabcd), CHIP_NO_ERROR);
     root_params.IssuerDN.Clear();
-    NL_TEST_ASSERT(inSuite, root_params.IssuerDN.AddAttribute_MatterICACId(0xabcdabcd) == CHIP_NO_ERROR);
+    EXPECT_EQ(root_params.IssuerDN.AddAttribute_MatterICACId(0xabcdabcd), CHIP_NO_ERROR);
     MutableByteSpan signed_cert_span1(signed_cert);
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(NewRootX509Cert(root_params, keypair, signed_cert_span1), CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test error case: root cert provided different subject and issuer DNs.
     root_params.SubjectDN.Clear();
-    NL_TEST_ASSERT(inSuite, root_params.SubjectDN.AddAttribute_MatterRCACId(0xabcdabcd) == CHIP_NO_ERROR);
+    EXPECT_EQ(root_params.SubjectDN.AddAttribute_MatterRCACId(0xabcdabcd), CHIP_NO_ERROR);
     root_params.IssuerDN.Clear();
-    NL_TEST_ASSERT(inSuite, root_params.IssuerDN.AddAttribute_MatterRCACId(0xffffeeee) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(root_params.IssuerDN.AddAttribute_MatterRCACId(0xffffeeee), CHIP_NO_ERROR);
+    EXPECT_EQ(NewRootX509Cert(root_params, keypair, signed_cert_span1), CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test that serial number cannot be negative
     root_params.IssuerDN.Clear();
-    NL_TEST_ASSERT(inSuite, root_params.IssuerDN.AddAttribute_MatterRCACId(0xabcdabcd) == CHIP_NO_ERROR);
+    EXPECT_EQ(root_params.IssuerDN.AddAttribute_MatterRCACId(0xabcdabcd), CHIP_NO_ERROR);
     root_params.SerialNumber = -1;
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(NewRootX509Cert(root_params, keypair, signed_cert_span1), CHIP_ERROR_INVALID_ARGUMENT);
 }
 
-static void TestChipCert_GenerateRootFabCert(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_GenerateRootFabCert)
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
 
@@ -1422,24 +1425,24 @@ static void TestChipCert_GenerateRootFabCert(nlTestSuite * inSuite, void * inCon
     MutableByteSpan outCert(outCertBuf);
 
     ChipDN root_dn;
-    NL_TEST_ASSERT(inSuite, root_dn.AddAttribute_MatterRCACId(0xabcdabcd) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, root_dn.AddAttribute_MatterFabricId(0xabcd) == CHIP_NO_ERROR);
+    EXPECT_EQ(root_dn.AddAttribute_MatterRCACId(0xabcdabcd), CHIP_NO_ERROR);
+    EXPECT_EQ(root_dn.AddAttribute_MatterFabricId(0xabcd), CHIP_NO_ERROR);
 
     X509CertRequestParams root_params_fabric = { 1234, 631161876, 729942000, root_dn, root_dn };
 
     MutableByteSpan signed_cert_span(signed_cert);
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params_fabric, keypair, signed_cert_span) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewRootX509Cert(root_params_fabric, keypair, signed_cert_span), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span, outCert) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(signed_cert_span, outCert), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeChipCert(outCert, certData), CHIP_NO_ERROR);
 }
 
-static void TestChipCert_GenerateICACert(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_GenerateICACert)
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
 
@@ -1449,51 +1452,49 @@ static void TestChipCert_GenerateICACert(nlTestSuite * inSuite, void * inContext
     ChipCertificateData certData;
 
     ChipDN ica_dn;
-    NL_TEST_ASSERT(inSuite, ica_dn.AddAttribute_MatterICACId(0xABCDABCDABCDABCD) == CHIP_NO_ERROR);
+    EXPECT_EQ(ica_dn.AddAttribute_MatterICACId(0xABCDABCDABCDABCD), CHIP_NO_ERROR);
     ChipDN issuer_dn;
-    NL_TEST_ASSERT(inSuite, issuer_dn.AddAttribute_MatterRCACId(0x43215678FEDCABCD) == CHIP_NO_ERROR);
+    EXPECT_EQ(issuer_dn.AddAttribute_MatterRCACId(0x43215678FEDCABCD), CHIP_NO_ERROR);
 
     X509CertRequestParams ica_params = { 1234, 631161876, 729942000, ica_dn, issuer_dn };
     P256Keypair ica_keypair;
-    NL_TEST_ASSERT(inSuite, ica_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(ica_keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     MutableByteSpan signed_cert_span(signed_cert);
-    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, signed_cert_span) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, signed_cert_span), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span, outCert) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(signed_cert_span, outCert), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeChipCert(outCert, certData), CHIP_NO_ERROR);
 
     // Test with FutureExtension
     X509CertRequestParams ica_params2 = { 1234, 631161876, 729942000, ica_dn, issuer_dn, kSubjectAltNameAsFutureExt };
     MutableByteSpan signed_cert_span2(signed_cert);
-    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params2, ica_keypair.Pubkey(), keypair, signed_cert_span2) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewICAX509Cert(ica_params2, ica_keypair.Pubkey(), keypair, signed_cert_span2), CHIP_NO_ERROR);
     outCert = MutableByteSpan(outCertBuf);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span2, outCert) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(signed_cert_span2, outCert), CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeChipCert(outCert, certData), CHIP_NO_ERROR);
 
     // Test error case: ICA cert subject provided a node ID attribute
     ica_params.SubjectDN.Clear();
-    NL_TEST_ASSERT(inSuite, ica_params.SubjectDN.AddAttribute_MatterNodeId(0xABCDABCDABCDABCD) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, ica_params.SubjectDN.AddAttribute_MatterFabricId(0xFAB00000FAB00001) == CHIP_NO_ERROR);
+    EXPECT_EQ(ica_params.SubjectDN.AddAttribute_MatterNodeId(0xABCDABCDABCDABCD), CHIP_NO_ERROR);
+    EXPECT_EQ(ica_params.SubjectDN.AddAttribute_MatterFabricId(0xFAB00000FAB00001), CHIP_NO_ERROR);
     MutableByteSpan signed_cert_span1(signed_cert);
-    NL_TEST_ASSERT(inSuite,
-                   NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, signed_cert_span1), CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test that serial number cannot be negative
     ica_params.SubjectDN.Clear();
-    NL_TEST_ASSERT(inSuite, ica_params.SubjectDN.AddAttribute_MatterICACId(0xABCDABCDABCDABCD) == CHIP_NO_ERROR);
+    EXPECT_EQ(ica_params.SubjectDN.AddAttribute_MatterICACId(0xABCDABCDABCDABCD), CHIP_NO_ERROR);
     ica_params.SerialNumber = -1;
-    NL_TEST_ASSERT(inSuite,
-                   NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, signed_cert_span1) == CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, signed_cert_span1), CHIP_ERROR_INVALID_ARGUMENT);
 }
 
-static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_GenerateNOCRoot)
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
 
@@ -1503,68 +1504,62 @@ static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext
     ChipCertificateData certData;
 
     ChipDN noc_dn;
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_MatterNodeId(0xABCDABCDABCDABCD) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_MatterFabricId(0xFAB00000FAB00001) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_MatterNodeId(0xABCDABCDABCDABCD), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_MatterFabricId(0xFAB00000FAB00001), CHIP_NO_ERROR);
     ChipDN issuer_dn;
-    NL_TEST_ASSERT(inSuite, issuer_dn.AddAttribute_MatterRCACId(0x8888999944442222) == CHIP_NO_ERROR);
+    EXPECT_EQ(issuer_dn.AddAttribute_MatterRCACId(0x8888999944442222), CHIP_NO_ERROR);
 
     X509CertRequestParams noc_params = { 123456, 631161876, 729942000, noc_dn, issuer_dn };
     P256Keypair noc_keypair;
-    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     MutableByteSpan signed_cert_span(signed_cert, sizeof(signed_cert));
-    NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span, outCert) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(signed_cert_span, outCert), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeChipCert(outCert, certData), CHIP_NO_ERROR);
 
     // Test with FutureExtension
     X509CertRequestParams noc_params2 = { 123456, 631161876, 729942000, noc_dn, issuer_dn, kSubjectAltNameAsFutureExt };
     MutableByteSpan signed_cert_span2(signed_cert);
-    NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params2, noc_keypair.Pubkey(), keypair, signed_cert_span2) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewNodeOperationalX509Cert(noc_params2, noc_keypair.Pubkey(), keypair, signed_cert_span2), CHIP_NO_ERROR);
     outCert = MutableByteSpan(outCertBuf);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span2, outCert) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(signed_cert_span2, outCert), CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeChipCert(outCert, certData), CHIP_NO_ERROR);
 
     // Test error case: NOC cert subject doesn't have NodeId attribute
     noc_params.SubjectDN.Clear();
-    NL_TEST_ASSERT(inSuite, noc_params.SubjectDN.AddAttribute_MatterFabricId(0xFAB00000FAB00001) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_params.SubjectDN.AddAttribute_MatterFabricId(0xFAB00000FAB00001), CHIP_NO_ERROR);
 
     MutableByteSpan signed_cert_span1(signed_cert, sizeof(signed_cert));
-    NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span1),
+              CHIP_ERROR_INVALID_ARGUMENT);
 
     // Test error case: NOC cert subject doesn't have fabric ID attribute
     noc_params.SubjectDN.Clear();
-    NL_TEST_ASSERT(inSuite, noc_params.SubjectDN.AddAttribute_MatterNodeId(0xABCDABCDABCDABCD) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_params.SubjectDN.AddAttribute_MatterNodeId(0xABCDABCDABCDABCD), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
-                       CHIP_ERROR_WRONG_CERT_DN);
+    EXPECT_EQ(NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span1), CHIP_ERROR_WRONG_CERT_DN);
 
     // Test error case: issuer cert DN type is Node certificate
     noc_params.SubjectDN.Clear();
-    NL_TEST_ASSERT(inSuite, noc_params.SubjectDN.AddAttribute_MatterNodeId(0xABCDABCDABCDABCD) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_params.SubjectDN.AddAttribute_MatterFabricId(0xFAB00000FAB00001) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_params.SubjectDN.AddAttribute_MatterNodeId(0xABCDABCDABCDABCD), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_params.SubjectDN.AddAttribute_MatterFabricId(0xFAB00000FAB00001), CHIP_NO_ERROR);
     noc_params.IssuerDN.Clear();
-    NL_TEST_ASSERT(inSuite, noc_params.IssuerDN.AddAttribute_MatterNodeId(0x8888999944442222) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_params.IssuerDN.AddAttribute_MatterFabricId(0xFAB00000FAB00001) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_params.IssuerDN.AddAttribute_MatterNodeId(0x8888999944442222), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_params.IssuerDN.AddAttribute_MatterFabricId(0xFAB00000FAB00001), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span1) ==
-                       CHIP_ERROR_INVALID_ARGUMENT);
+    EXPECT_EQ(NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span1),
+              CHIP_ERROR_INVALID_ARGUMENT);
 }
 
-static void TestChipCert_GenerateNOCICA(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_GenerateNOCICA)
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     uint8_t signed_cert[kMaxDERCertLength];
 
@@ -1581,78 +1576,75 @@ static void TestChipCert_GenerateNOCICA(nlTestSuite * inSuite, void * inContext)
     const static char noc_name_rdn[]      = "Smith";
 
     ChipDN noc_dn;
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_CommonName(CharSpan(noc_cn_rdn, strlen(noc_cn_rdn)), false) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_MatterNodeId(0xAAAABBBBCCCCDDDD) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_MatterFabricId(0xFAB00000FAB00001) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite,
-                   noc_dn.AddAttribute_GivenName(CharSpan(noc_givenname_rdn, strlen(noc_givenname_rdn)), true) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_Name(CharSpan(noc_name_rdn, strlen(noc_name_rdn)), true) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_CommonName(CharSpan(noc_cn_rdn, strlen(noc_cn_rdn)), false), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_MatterNodeId(0xAAAABBBBCCCCDDDD), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_MatterFabricId(0xFAB00000FAB00001), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_GivenName(CharSpan(noc_givenname_rdn, strlen(noc_givenname_rdn)), true), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_Name(CharSpan(noc_name_rdn, strlen(noc_name_rdn)), true), CHIP_NO_ERROR);
 
     ChipDN ica_dn;
-    NL_TEST_ASSERT(inSuite, ica_dn.AddAttribute_MatterICACId(0x8888999944442222) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, ica_dn.AddAttribute_MatterFabricId(0xFAB00000FAB00001) == CHIP_NO_ERROR);
+    EXPECT_EQ(ica_dn.AddAttribute_MatterICACId(0x8888999944442222), CHIP_NO_ERROR);
+    EXPECT_EQ(ica_dn.AddAttribute_MatterFabricId(0xFAB00000FAB00001), CHIP_NO_ERROR);
 
     X509CertRequestParams noc_params = { 12348765, 631161876, 729942000, noc_dn, ica_dn };
     P256Keypair noc_keypair;
-    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     MutableByteSpan signed_cert_span(signed_cert);
-    NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, signed_cert_span), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span, outCert) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(signed_cert_span, outCert), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, ConvertChipCertToX509Cert(outCert, outCertDER) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, signed_cert_span.data_equal(outCertDER));
+    EXPECT_EQ(ConvertChipCertToX509Cert(outCert, outCertDER), CHIP_NO_ERROR);
+    EXPECT_TRUE(signed_cert_span.data_equal(outCertDER));
 
-    NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeChipCert(outCert, certData), CHIP_NO_ERROR);
 }
 
-static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_VerifyGeneratedCerts)
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     static uint8_t root_cert[kMaxDERCertLength];
 
     ChipDN root_dn;
-    NL_TEST_ASSERT(inSuite, root_dn.AddAttribute_MatterRCACId(0xAAAABBBBCCCCDDDD) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, root_dn.AddAttribute_MatterFabricId(0xFAB0000000008888) == CHIP_NO_ERROR);
+    EXPECT_EQ(root_dn.AddAttribute_MatterRCACId(0xAAAABBBBCCCCDDDD), CHIP_NO_ERROR);
+    EXPECT_EQ(root_dn.AddAttribute_MatterFabricId(0xFAB0000000008888), CHIP_NO_ERROR);
 
     X509CertRequestParams root_params = { 1234, 631161876, 729942000, root_dn, root_dn };
     MutableByteSpan root_cert_span(root_cert);
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert_span) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewRootX509Cert(root_params, keypair, root_cert_span), CHIP_NO_ERROR);
 
     static uint8_t ica_cert[kMaxDERCertLength];
 
     ChipDN ica_dn;
-    NL_TEST_ASSERT(inSuite, ica_dn.AddAttribute_MatterICACId(0xAABBCCDDAABBCCDD) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, ica_dn.AddAttribute_MatterFabricId(0xFAB0000000008888) == CHIP_NO_ERROR);
+    EXPECT_EQ(ica_dn.AddAttribute_MatterICACId(0xAABBCCDDAABBCCDD), CHIP_NO_ERROR);
+    EXPECT_EQ(ica_dn.AddAttribute_MatterFabricId(0xFAB0000000008888), CHIP_NO_ERROR);
 
     X509CertRequestParams ica_params = { 12345, 631161876, 729942000, ica_dn, root_dn };
     P256Keypair ica_keypair;
-    NL_TEST_ASSERT(inSuite, ica_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(ica_keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     MutableByteSpan ica_cert_span(ica_cert);
-    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, ica_cert_span) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewICAX509Cert(ica_params, ica_keypair.Pubkey(), keypair, ica_cert_span), CHIP_NO_ERROR);
 
     static uint8_t noc_cert[kMaxDERCertLength];
 
     ChipDN noc_dn;
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_MatterNodeId(0xAABBCCDDAABBCCDD) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_MatterFabricId(0xFAB0000000008888) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_MatterNodeId(0xAABBCCDDAABBCCDD), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_MatterFabricId(0xFAB0000000008888), CHIP_NO_ERROR);
 
     X509CertRequestParams noc_params = { 123456, 631161876, 729942000, noc_dn, ica_dn };
     P256Keypair noc_keypair;
-    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     MutableByteSpan noc_cert_span(noc_cert, sizeof(noc_cert));
-    NL_TEST_ASSERT(inSuite,
-                   NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), ica_keypair, noc_cert_span) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), ica_keypair, noc_cert_span), CHIP_NO_ERROR);
 
     ChipCertificateSet certSet;
-    NL_TEST_ASSERT(inSuite, certSet.Init(3) == CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.Init(3), CHIP_NO_ERROR);
 
     static uint8_t chipRootCertBuf[kMaxCHIPCertLength];
     static uint8_t chipICACertBuf[kMaxCHIPCertLength];
@@ -1661,19 +1653,19 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
     MutableByteSpan chipICACert(chipICACertBuf);
     MutableByteSpan chipNOCCert(chipNOCCertBuf);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(root_cert_span, chipRootCert) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certSet.LoadCert(chipRootCert, sTrustAnchorFlag) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(root_cert_span, chipRootCert), CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.LoadCert(chipRootCert, sTrustAnchorFlag), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(ica_cert_span, chipICACert) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certSet.LoadCert(chipICACert, sGenTBSHashFlag) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(ica_cert_span, chipICACert), CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.LoadCert(chipICACert, sGenTBSHashFlag), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(noc_cert_span, chipNOCCert) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certSet.LoadCert(chipNOCCert, sGenTBSHashFlag) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(noc_cert_span, chipNOCCert), CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.LoadCert(chipNOCCert, sGenTBSHashFlag), CHIP_NO_ERROR);
 
     ValidationContext validContext;
 
     validContext.Reset();
-    NL_TEST_ASSERT(inSuite, SetCurrentTime(validContext, 2022, 1, 1) == CHIP_NO_ERROR);
+    EXPECT_EQ(SetCurrentTime(validContext, 2022, 1, 1), CHIP_NO_ERROR);
     validContext.mRequiredKeyUsages.Set(KeyUsageFlags::kDigitalSignature);
     validContext.mRequiredKeyPurposes.Set(KeyPurposeFlags::kServerAuth);
     validContext.mRequiredKeyPurposes.Set(KeyPurposeFlags::kClientAuth);
@@ -1683,63 +1675,63 @@ static void TestChipCert_VerifyGeneratedCerts(nlTestSuite * inSuite, void * inCo
     const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[2].mSubjectKeyId;
 
     const ChipCertificateData * resultCert = nullptr;
-    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, &resultCert) == CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.FindValidCert(subjectDN, subjectKeyId, validContext, &resultCert), CHIP_NO_ERROR);
 }
 
-static void TestChipCert_VerifyGeneratedCertsNoICA(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_VerifyGeneratedCertsNoICA)
 {
     // Generate a new keypair for cert signing
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     static uint8_t root_cert[kMaxDERCertLength];
 
     const static char root_cn_rdn[] = "Test Root Operational Cert";
 
     ChipDN root_dn;
-    NL_TEST_ASSERT(inSuite, root_dn.AddAttribute_CommonName(CharSpan(root_cn_rdn, strlen(root_cn_rdn)), false) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, root_dn.AddAttribute_MatterRCACId(0xAAAABBBBCCCCDDDD) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, root_dn.AddAttribute_MatterFabricId(0xFAB0000000008888) == CHIP_NO_ERROR);
+    EXPECT_EQ(root_dn.AddAttribute_CommonName(CharSpan(root_cn_rdn, strlen(root_cn_rdn)), false), CHIP_NO_ERROR);
+    EXPECT_EQ(root_dn.AddAttribute_MatterRCACId(0xAAAABBBBCCCCDDDD), CHIP_NO_ERROR);
+    EXPECT_EQ(root_dn.AddAttribute_MatterFabricId(0xFAB0000000008888), CHIP_NO_ERROR);
 
     X509CertRequestParams root_params = { 1234, 631161876, 729942000, root_dn, root_dn };
     MutableByteSpan root_cert_span(root_cert);
-    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params, keypair, root_cert_span) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewRootX509Cert(root_params, keypair, root_cert_span), CHIP_NO_ERROR);
 
     static uint8_t noc_cert[kMaxDERCertLength];
 
     const static char noc_cn_rdn[] = "Test NOC";
 
     ChipDN noc_dn;
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_CommonName(CharSpan(noc_cn_rdn, strlen(noc_cn_rdn)), true) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_MatterNodeId(0xAABBCCDDAABBCCDD) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_MatterFabricId(0xFAB0000000008888) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, noc_dn.AddAttribute_MatterCASEAuthTag(0xABCD0010) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_CommonName(CharSpan(noc_cn_rdn, strlen(noc_cn_rdn)), true), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_MatterNodeId(0xAABBCCDDAABBCCDD), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_MatterFabricId(0xFAB0000000008888), CHIP_NO_ERROR);
+    EXPECT_EQ(noc_dn.AddAttribute_MatterCASEAuthTag(0xABCD0010), CHIP_NO_ERROR);
 
     X509CertRequestParams noc_params = { 1234, 631161876, 729942000, noc_dn, root_dn };
     P256Keypair noc_keypair;
-    NL_TEST_ASSERT(inSuite, noc_keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(noc_keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     MutableByteSpan noc_cert_span(noc_cert);
-    NL_TEST_ASSERT(inSuite, NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, noc_cert_span) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewNodeOperationalX509Cert(noc_params, noc_keypair.Pubkey(), keypair, noc_cert_span), CHIP_NO_ERROR);
 
     ChipCertificateSet certSet;
-    NL_TEST_ASSERT(inSuite, certSet.Init(2) == CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.Init(2), CHIP_NO_ERROR);
 
     static uint8_t chipRootCertBuf[kMaxCHIPCertLength];
     static uint8_t chipNOCCertBuf[kMaxCHIPCertLength];
     MutableByteSpan chipRootCert(chipRootCertBuf);
     MutableByteSpan chipNOCCert(chipNOCCertBuf);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(root_cert_span, chipRootCert) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certSet.LoadCert(chipRootCert, sTrustAnchorFlag) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(root_cert_span, chipRootCert), CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.LoadCert(chipRootCert, sTrustAnchorFlag), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(noc_cert_span, chipNOCCert) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certSet.LoadCert(chipNOCCert, sGenTBSHashFlag) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(noc_cert_span, chipNOCCert), CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.LoadCert(chipNOCCert, sGenTBSHashFlag), CHIP_NO_ERROR);
 
     ValidationContext validContext;
 
     validContext.Reset();
-    NL_TEST_ASSERT(inSuite, SetCurrentTime(validContext, 2022, 1, 1) == CHIP_NO_ERROR);
+    EXPECT_EQ(SetCurrentTime(validContext, 2022, 1, 1), CHIP_NO_ERROR);
     validContext.mRequiredKeyUsages.Set(KeyUsageFlags::kDigitalSignature);
     validContext.mRequiredKeyPurposes.Set(KeyPurposeFlags::kServerAuth);
     validContext.mRequiredKeyPurposes.Set(KeyPurposeFlags::kClientAuth);
@@ -1749,10 +1741,10 @@ static void TestChipCert_VerifyGeneratedCertsNoICA(nlTestSuite * inSuite, void *
     const CertificateKeyId & subjectKeyId = certSet.GetCertSet()[1].mSubjectKeyId;
 
     const ChipCertificateData * resultCert = nullptr;
-    NL_TEST_ASSERT(inSuite, certSet.FindValidCert(subjectDN, subjectKeyId, validContext, &resultCert) == CHIP_NO_ERROR);
+    EXPECT_EQ(certSet.FindValidCert(subjectDN, subjectKeyId, validContext, &resultCert), CHIP_NO_ERROR);
 }
 
-static void TestChipCert_ExtractNodeIdFabricId(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_ExtractNodeIdFabricId)
 {
     struct TestCase
     {
@@ -1784,14 +1776,14 @@ static void TestChipCert_ExtractNodeIdFabricId(nlTestSuite * inSuite, void * inC
     {
         ByteSpan cert;
         CHIP_ERROR err = GetTestCert(testCase.Cert, sNullLoadFlag, cert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         NodeId nodeId;
         FabricId fabricId;
         err = ExtractNodeIdFabricIdFromOpCert(cert, &nodeId, &fabricId);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, nodeId == testCase.ExpectedNodeId);
-        NL_TEST_ASSERT(inSuite, fabricId == testCase.ExpectedFabricId);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(nodeId, testCase.ExpectedNodeId);
+        EXPECT_EQ(fabricId, testCase.ExpectedFabricId);
     }
 
     // Test node ID and fabric ID extraction from the parsed form.
@@ -1799,17 +1791,17 @@ static void TestChipCert_ExtractNodeIdFabricId(nlTestSuite * inSuite, void * inC
     for (auto & testCase : sTestCases)
     {
         CHIP_ERROR err = certSet.Init(1);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = LoadTestCert(certSet, testCase.Cert, sNullLoadFlag, sNullDecodeFlag);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         NodeId nodeId;
         FabricId fabricId;
         err = ExtractNodeIdFabricIdFromOpCert(certSet.GetCertSet()[0], &nodeId, &fabricId);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, nodeId == testCase.ExpectedNodeId);
-        NL_TEST_ASSERT(inSuite, fabricId == testCase.ExpectedFabricId);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(nodeId, testCase.ExpectedNodeId);
+        EXPECT_EQ(fabricId, testCase.ExpectedFabricId);
         certSet.Release();
     }
 
@@ -1818,27 +1810,27 @@ static void TestChipCert_ExtractNodeIdFabricId(nlTestSuite * inSuite, void * inC
     {
         ByteSpan cert;
         CHIP_ERROR err = GetTestCert(testCase.Cert, sNullLoadFlag, cert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         FabricId fabricId;
         err = ExtractFabricIdFromCert(cert, &fabricId);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, fabricId == testCase.ExpectedFabricId);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(fabricId, testCase.ExpectedFabricId);
     }
 
     // Test fabric ID extraction from the parsed form.
     for (auto & testCase : sTestCases)
     {
         CHIP_ERROR err = certSet.Init(1);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = LoadTestCert(certSet, testCase.Cert, sNullLoadFlag, sNullDecodeFlag);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         FabricId fabricId;
         err = ExtractFabricIdFromCert(certSet.GetCertSet()[0], &fabricId);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, fabricId == testCase.ExpectedFabricId);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(fabricId, testCase.ExpectedFabricId);
         certSet.Release();
     }
 
@@ -1846,29 +1838,29 @@ static void TestChipCert_ExtractNodeIdFabricId(nlTestSuite * inSuite, void * inC
     {
         ByteSpan cert;
         CHIP_ERROR err = GetTestCert(TestCert::kICA01, sNullLoadFlag, cert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         FabricId fabricId;
         err = ExtractFabricIdFromCert(cert, &fabricId);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
+        EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
     }
 
     // Test extraction from the parsed form of ICA Cert that doesn't have FabricId.
     {
         CHIP_ERROR err = certSet.Init(1);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = LoadTestCert(certSet, TestCert::kICA01, sNullLoadFlag, sNullDecodeFlag);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         FabricId fabricId;
         err = ExtractFabricIdFromCert(certSet.GetCertSet()[0], &fabricId);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
+        EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
         certSet.Release();
     }
 }
 
-static void TestChipCert_ExtractOperationalDiscoveryId(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_ExtractOperationalDiscoveryId)
 {
     struct TestCase
     {
@@ -1901,30 +1893,30 @@ static void TestChipCert_ExtractOperationalDiscoveryId(nlTestSuite * inSuite, vo
         ByteSpan noc;
         ByteSpan rcac;
         CHIP_ERROR err = GetTestCert(testCase.Noc, sNullLoadFlag, noc);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
         err = GetTestCert(testCase.Rcac, sNullLoadFlag, rcac);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         // Extract Node ID and Fabric ID from the leaf node certificate.
         NodeId nodeId;
         FabricId fabricId;
         err = ExtractNodeIdFabricIdFromOpCert(noc, &nodeId, &fabricId);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, nodeId == testCase.ExpectedNodeId);
-        NL_TEST_ASSERT(inSuite, fabricId == testCase.ExpectedFabricId);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(nodeId, testCase.ExpectedNodeId);
+        EXPECT_EQ(fabricId, testCase.ExpectedFabricId);
 
         // Extract Node ID, Fabric ID and Compressed Fabric ID from the
         // NOC and root certificate.
         CompressedFabricId compressedFabricId;
         err = ExtractNodeIdFabricIdCompressedFabricIdFromOpCerts(rcac, noc, compressedFabricId, fabricId, nodeId);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, compressedFabricId == testCase.ExpectedCompressedFabricId);
-        NL_TEST_ASSERT(inSuite, fabricId == testCase.ExpectedFabricId);
-        NL_TEST_ASSERT(inSuite, nodeId == testCase.ExpectedNodeId);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(compressedFabricId, testCase.ExpectedCompressedFabricId);
+        EXPECT_EQ(fabricId, testCase.ExpectedFabricId);
+        EXPECT_EQ(nodeId, testCase.ExpectedNodeId);
     }
 }
 
-static void TestChipCert_ExtractAndValidateCATsFromOpCert(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_ExtractAndValidateCATsFromOpCert)
 {
     struct TestCase
     {
@@ -1954,12 +1946,12 @@ static void TestChipCert_ExtractAndValidateCATsFromOpCert(nlTestSuite * inSuite,
     {
         ByteSpan cert;
         CHIP_ERROR err = GetTestCert(testCase.Cert, sNullLoadFlag, cert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         CATValues cats;
         err = ExtractCATsFromOpCert(cert, cats);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, memcmp(&cats, &testCase.ExpectedCATs, sizeof(cats)) == 0);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(memcmp(&cats, &testCase.ExpectedCATs, sizeof(cats)), 0);
     }
 
     // Test extraction from the parsed form.
@@ -1967,15 +1959,15 @@ static void TestChipCert_ExtractAndValidateCATsFromOpCert(nlTestSuite * inSuite,
     for (auto & testCase : sTestCases)
     {
         CHIP_ERROR err = certSet.Init(1);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = LoadTestCert(certSet, testCase.Cert, sNullLoadFlag, sNullDecodeFlag);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         CATValues cats;
         err = ExtractCATsFromOpCert(certSet.GetCertSet()[0], cats);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, memcmp(&cats, &testCase.ExpectedCATs, sizeof(cats)) == 0);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(memcmp(&cats, &testCase.ExpectedCATs, sizeof(cats)), 0);
 
         certSet.Release();
     }
@@ -1983,14 +1975,14 @@ static void TestChipCert_ExtractAndValidateCATsFromOpCert(nlTestSuite * inSuite,
     // Error case: trying to extract CAT from Root Cert.
     {
         CHIP_ERROR err = certSet.Init(1);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = LoadTestCert(certSet, TestCert::kRoot01, sNullLoadFlag, sNullDecodeFlag);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         CATValues cats;
         err = ExtractCATsFromOpCert(certSet.GetCertSet()[0], cats);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+        EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
 
         certSet.Release();
     }
@@ -1999,18 +1991,18 @@ static void TestChipCert_ExtractAndValidateCATsFromOpCert(nlTestSuite * inSuite,
     {
         CATValues cats;
         CHIP_ERROR err = ExtractCATsFromOpCert(ByteSpan(sChipTest_NOC_Subject_CAT_Invalid_Cert_CHIP), cats);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+        EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     // Error case: NOC with multiple versions of the same CAT tag.
     {
         CATValues cats;
         CHIP_ERROR err = ExtractCATsFromOpCert(ByteSpan(sChipTest_NOC_Subject_CAT_Twice_Cert_CHIP), cats);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_WRONG_CERT_DN);
+        EXPECT_EQ(err, CHIP_ERROR_WRONG_CERT_DN);
     }
 }
 
-static void TestChipCert_ExtractSubjectDNFromChipCert(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_ExtractSubjectDNFromChipCert)
 {
     struct TestCase
     {
@@ -2019,29 +2011,28 @@ static void TestChipCert_ExtractSubjectDNFromChipCert(nlTestSuite * inSuite, voi
     };
 
     ChipDN expectedSubjectDN_Root01;
-    NL_TEST_ASSERT(inSuite, expectedSubjectDN_Root01.AddAttribute_MatterRCACId(0xCACACACA00000001) == CHIP_NO_ERROR);
+    EXPECT_EQ(expectedSubjectDN_Root01.AddAttribute_MatterRCACId(0xCACACACA00000001), CHIP_NO_ERROR);
 
     ChipDN expectedSubjectDN_Root02;
-    NL_TEST_ASSERT(inSuite, expectedSubjectDN_Root02.AddAttribute_MatterRCACId(0xCACACACA00000002) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, expectedSubjectDN_Root02.AddAttribute_MatterFabricId(0xFAB000000000001D) == CHIP_NO_ERROR);
+    EXPECT_EQ(expectedSubjectDN_Root02.AddAttribute_MatterRCACId(0xCACACACA00000002), CHIP_NO_ERROR);
+    EXPECT_EQ(expectedSubjectDN_Root02.AddAttribute_MatterFabricId(0xFAB000000000001D), CHIP_NO_ERROR);
 
     ChipDN expectedSubjectDN_ICA02;
-    NL_TEST_ASSERT(inSuite, expectedSubjectDN_ICA02.AddAttribute_MatterICACId(0xCACACACA00000004) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, expectedSubjectDN_ICA02.AddAttribute_MatterFabricId(0xFAB000000000001D) == CHIP_NO_ERROR);
+    EXPECT_EQ(expectedSubjectDN_ICA02.AddAttribute_MatterICACId(0xCACACACA00000004), CHIP_NO_ERROR);
+    EXPECT_EQ(expectedSubjectDN_ICA02.AddAttribute_MatterFabricId(0xFAB000000000001D), CHIP_NO_ERROR);
 
     ChipDN expectedSubjectDN_Node01_01;
-    NL_TEST_ASSERT(inSuite, expectedSubjectDN_Node01_01.AddAttribute_MatterNodeId(0xDEDEDEDE00010001) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, expectedSubjectDN_Node01_01.AddAttribute_MatterFabricId(0xFAB000000000001D) == CHIP_NO_ERROR);
+    EXPECT_EQ(expectedSubjectDN_Node01_01.AddAttribute_MatterNodeId(0xDEDEDEDE00010001), CHIP_NO_ERROR);
+    EXPECT_EQ(expectedSubjectDN_Node01_01.AddAttribute_MatterFabricId(0xFAB000000000001D), CHIP_NO_ERROR);
 
     const static char commonName_RDN[] = "TestCert02_03";
 
     ChipDN expectedSubjectDN_Node02_03;
-    NL_TEST_ASSERT(inSuite, expectedSubjectDN_Node02_03.AddAttribute_MatterNodeId(0xDEDEDEDE00020003) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, expectedSubjectDN_Node02_03.AddAttribute_MatterFabricId(0xFAB000000000001D) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite,
-                   expectedSubjectDN_Node02_03.AddAttribute_CommonName(CharSpan(commonName_RDN, strlen(commonName_RDN)), false) ==
-                       CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, expectedSubjectDN_Node02_03.AddAttribute_MatterCASEAuthTag(0xABCD0001) == CHIP_NO_ERROR);
+    EXPECT_EQ(expectedSubjectDN_Node02_03.AddAttribute_MatterNodeId(0xDEDEDEDE00020003), CHIP_NO_ERROR);
+    EXPECT_EQ(expectedSubjectDN_Node02_03.AddAttribute_MatterFabricId(0xFAB000000000001D), CHIP_NO_ERROR);
+    EXPECT_EQ(expectedSubjectDN_Node02_03.AddAttribute_CommonName(CharSpan(commonName_RDN, strlen(commonName_RDN)), false),
+              CHIP_NO_ERROR);
+    EXPECT_EQ(expectedSubjectDN_Node02_03.AddAttribute_MatterCASEAuthTag(0xABCD0001), CHIP_NO_ERROR);
 
     // clang-format off
     TestCase sTestCases[] = {
@@ -2061,15 +2052,15 @@ static void TestChipCert_ExtractSubjectDNFromChipCert(nlTestSuite * inSuite, voi
     {
         ByteSpan cert;
         CHIP_ERROR err = GetTestCert(testCase.Cert, sNullLoadFlag, cert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         ChipDN subjectDN;
         err = ExtractSubjectDNFromChipCert(cert, subjectDN);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         if (!testCase.ExpectedSubjectDN.IsEmpty())
         {
-            NL_TEST_ASSERT(inSuite, subjectDN.IsEqual(testCase.ExpectedSubjectDN));
+            EXPECT_TRUE(subjectDN.IsEqual(testCase.ExpectedSubjectDN));
         }
     }
 
@@ -2078,20 +2069,20 @@ static void TestChipCert_ExtractSubjectDNFromChipCert(nlTestSuite * inSuite, voi
     {
         ByteSpan cert;
         CHIP_ERROR err = GetTestCert(testCase.Cert, TestCertLoadFlags::kDERForm, cert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         ChipDN subjectDN;
         err = ExtractSubjectDNFromX509Cert(cert, subjectDN);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         if (!testCase.ExpectedSubjectDN.IsEmpty())
         {
-            NL_TEST_ASSERT(inSuite, subjectDN.IsEqual(testCase.ExpectedSubjectDN));
+            EXPECT_TRUE(subjectDN.IsEqual(testCase.ExpectedSubjectDN));
         }
     }
 }
 
-static void TestChipCert_ExtractPublicKeyAndSKID(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_ExtractPublicKeyAndSKID)
 {
     struct TestCase
     {
@@ -2127,28 +2118,28 @@ static void TestChipCert_ExtractPublicKeyAndSKID(nlTestSuite * inSuite, void * i
     {
         ByteSpan cert;
         CHIP_ERROR err = GetTestCert(testCase.Cert, sNullLoadFlag, cert);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
         P256PublicKeySpan publicKey;
         err = ExtractPublicKeyFromChipCert(cert, publicKey);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, publicKey.data_equal(testCase.ExpectedPublicKey));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(publicKey.data_equal(testCase.ExpectedPublicKey));
 
         CertificateKeyId skid;
         err = ExtractSKIDFromChipCert(cert, skid);
         if (!testCase.ExpectedSKID.empty())
         {
-            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, skid.data_equal(testCase.ExpectedSKID));
+            EXPECT_EQ(err, CHIP_NO_ERROR);
+            EXPECT_TRUE(skid.data_equal(testCase.ExpectedSKID));
         }
         else
         {
-            NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
+            EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
         }
     }
 }
 
-static void TestChipCert_PDCIdentityValidation(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_PDCIdentityValidation)
 {
     CertificateKeyIdStorage keyId;
 
@@ -2156,134 +2147,52 @@ static void TestChipCert_PDCIdentityValidation(nlTestSuite * inSuite, void * inC
     for (auto && cert : { sTestCert_PDCID01_Chip, sTestCert_PDCID01_ChipCompact })
     {
         // Validate only
-        NL_TEST_ASSERT(inSuite, ValidateChipNetworkIdentity(cert) == CHIP_NO_ERROR);
+        EXPECT_EQ(ValidateChipNetworkIdentity(cert), CHIP_NO_ERROR);
 
         // Validate and calculate identifier
         keyId.fill(0xaa);
-        NL_TEST_ASSERT(inSuite, ValidateChipNetworkIdentity(cert, keyId) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, CertificateKeyId(keyId).data_equal(sTestCert_PDCID01_KeyId));
+        EXPECT_EQ(ValidateChipNetworkIdentity(cert, keyId), CHIP_NO_ERROR);
+        EXPECT_TRUE(CertificateKeyId(keyId).data_equal(sTestCert_PDCID01_KeyId));
 
         // Extract identifier only
         keyId.fill(0xaa);
-        NL_TEST_ASSERT(inSuite, ExtractIdentifierFromChipNetworkIdentity(cert, keyId) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, CertificateKeyId(keyId).data_equal(sTestCert_PDCID01_KeyId));
+        EXPECT_EQ(ExtractIdentifierFromChipNetworkIdentity(cert, keyId), CHIP_NO_ERROR);
+        EXPECT_TRUE(CertificateKeyId(keyId).data_equal(sTestCert_PDCID01_KeyId));
     }
 }
 
-static void TestChipCert_PDCIdentityGeneration(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_PDCIdentityGeneration)
 {
     // Generate a new keypair
     P256Keypair keypair;
-    NL_TEST_ASSERT(inSuite, keypair.Initialize(ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     // Generate an identity certificate based on the keypair
     uint8_t buffer[kMaxCHIPCompactNetworkIdentityLength];
     MutableByteSpan cert(buffer);
-    NL_TEST_ASSERT(inSuite, NewChipNetworkIdentity(keypair, cert) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, ValidateChipNetworkIdentity(cert) == CHIP_NO_ERROR);
+    EXPECT_EQ(NewChipNetworkIdentity(keypair, cert), CHIP_NO_ERROR);
+    EXPECT_EQ(ValidateChipNetworkIdentity(cert), CHIP_NO_ERROR);
 
     // It should round-trip to X.509 DER and back, and remain valid.
     uint8_t derBuffer[kMaxDERCertLength];
     MutableByteSpan derCert(derBuffer);
-    NL_TEST_ASSERT(inSuite, ConvertChipCertToX509Cert(cert, derCert) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertChipCertToX509Cert(cert, derCert), CHIP_NO_ERROR);
     uint8_t tlvBuffer[kMaxCHIPCertLength];
     MutableByteSpan tlvCert(tlvBuffer); // won't be compact after round-tripping
-    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(derCert, tlvCert) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, ValidateChipNetworkIdentity(tlvCert) == CHIP_NO_ERROR);
+    EXPECT_EQ(ConvertX509CertToChipCert(derCert, tlvCert), CHIP_NO_ERROR);
+    EXPECT_EQ(ValidateChipNetworkIdentity(tlvCert), CHIP_NO_ERROR);
 }
 
-static void TestChipCert_KeypairConversion(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestChipCert, TestChipCert_KeypairConversion)
 {
     P256SerializedKeypair keypair;
-    NL_TEST_ASSERT_SUCCESS(inSuite, GetTestCertKeypair(kPDCID01, keypair));
+    EXPECT_EQ(GetTestCertKeypair(kPDCID01, keypair), CHIP_NO_ERROR);
 
     uint8_t buffer[kP256ECPrivateKeyDERLength];
     MutableByteSpan keypairDer(buffer);
-    NL_TEST_ASSERT_SUCCESS(inSuite, ConvertECDSAKeypairRawToDER(keypair, keypairDer));
+    EXPECT_EQ(ConvertECDSAKeypairRawToDER(keypair, keypairDer), CHIP_NO_ERROR);
 
     // Technically the curve name and public key are optional in the DER format,
     // but both our code and standard tools include them, so we can just compare.
-    NL_TEST_ASSERT(inSuite, keypairDer.data_equal(sTestCert_PDCID01_KeypairDER));
+    EXPECT_TRUE(keypairDer.data_equal(sTestCert_PDCID01_KeypairDER));
 }
-
-/**
- *  Set up the test suite.
- */
-int TestChipCert_Setup(void * inContext)
-{
-    CHIP_ERROR error = chip::Platform::MemoryInit();
-
-    if (error != CHIP_NO_ERROR)
-    {
-        return FAILURE;
-    }
-
-    return SUCCESS;
-}
-
-/**
- *  Tear down the test suite.
- */
-int TestChipCert_Teardown(void * inContext)
-{
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-/**
- *   Test Suite. It lists all the test functions.
- */
-// clang-format off
-static const nlTest sTests[] = {
-    NL_TEST_DEF("Test CHIP Certificate CHIP to X509 Conversion", TestChipCert_ChipToX509),
-    NL_TEST_DEF("Test CHIP Certificate CHIP to X509 Conversion - Error Cases", TestChipCert_ChipToX509_ErrorCases),
-    NL_TEST_DEF("Test CHIP Certificate Loading - Error Cases", TestChipCert_ChipCertLoad_ErrorCases),
-    NL_TEST_DEF("Test CHIP Certificate Validate RCAC - Error Cases", TestChipCert_ValidateChipRCAC_ErrorCases),
-    NL_TEST_DEF("Test CHIP Certificate Get Cert Type from Subject - Error Cases", TestChipCert_GetCertType_ErrorCases),
-    NL_TEST_DEF("Test CHIP Certificate X509 to CHIP Conversion", TestChipCert_X509ToChip),
-    NL_TEST_DEF("Test CHIP Certificate X509 to CHIP Conversion - Error Cases", TestChipCert_X509ToChip_ErrorCases),
-    NL_TEST_DEF("Test CHIP Certificate Distinguish Name", TestChipCert_ChipDN),
-    NL_TEST_DEF("Test CHIP Certificate Validation", TestChipCert_CertValidation),
-    NL_TEST_DEF("Test CHIP Certificate Validation time", TestChipCert_CertValidTime),
-    NL_TEST_DEF("Test CHIP Root Certificate Validation", TestChipCert_ValidateChipRCAC),
-    NL_TEST_DEF("Test CHIP Certificate Validity Policy injection", TestChipCert_CertValidityPolicyInjection),
-    NL_TEST_DEF("Test CHIP Certificate Usage", TestChipCert_CertUsage),
-    NL_TEST_DEF("Test CHIP Certificate Type", TestChipCert_CertType),
-    NL_TEST_DEF("Test CHIP Certificate ID", TestChipCert_CertId),
-    NL_TEST_DEF("Test CHIP Certificate Decoding Options", TestChipCert_DecodingOptions),
-    NL_TEST_DEF("Test Loading Duplicate Certificates", TestChipCert_LoadDuplicateCerts),
-    NL_TEST_DEF("Test CHIP Generate Root Certificate", TestChipCert_GenerateRootCert),
-    NL_TEST_DEF("Test CHIP Generate Root Certificate with Fabric", TestChipCert_GenerateRootFabCert),
-    NL_TEST_DEF("Test CHIP Generate ICA Certificate", TestChipCert_GenerateICACert),
-    NL_TEST_DEF("Test CHIP Generate NOC using Root", TestChipCert_GenerateNOCRoot),
-    NL_TEST_DEF("Test CHIP Generate NOC using ICA", TestChipCert_GenerateNOCICA),
-    NL_TEST_DEF("Test CHIP Verify Generated Cert Chain", TestChipCert_VerifyGeneratedCerts),
-    NL_TEST_DEF("Test CHIP Verify Generated Cert Chain No ICA", TestChipCert_VerifyGeneratedCertsNoICA),
-    NL_TEST_DEF("Test extracting Node ID and Fabric ID from node certificate", TestChipCert_ExtractNodeIdFabricId),
-    NL_TEST_DEF("Test extracting Operational Discovery ID from node and root certificate", TestChipCert_ExtractOperationalDiscoveryId),
-    NL_TEST_DEF("Test extracting and validating CASE Authenticated Tags from NOC", TestChipCert_ExtractAndValidateCATsFromOpCert),
-    NL_TEST_DEF("Test extracting Subject DN from chip certificate", TestChipCert_ExtractSubjectDNFromChipCert),
-    NL_TEST_DEF("Test extracting PublicKey and SKID from chip certificate", TestChipCert_ExtractPublicKeyAndSKID),
-    NL_TEST_DEF("Test PDC Identity Validation", TestChipCert_PDCIdentityValidation),
-    NL_TEST_DEF("Test PDC Identity Generation", TestChipCert_PDCIdentityGeneration),
-    NL_TEST_DEF("Test keypair conversion", TestChipCert_KeypairConversion),
-    NL_TEST_SENTINEL()
-};
-// clang-format on
-
-int TestChipCert()
-{
-    // clang-format off
-    nlTestSuite theSuite =
-    {
-        "Credentials-CHIP-Certs",
-        &sTests[0],
-        TestChipCert_Setup,
-        TestChipCert_Teardown
-    };
-    // clang-format on
-    nlTestRunner(&theSuite, nullptr);
-    return (nlTestRunnerStats(&theSuite));
-}
-
-CHIP_REGISTER_TEST_SUITE(TestChipCert);

--- a/src/credentials/tests/TestCommissionerDUTVectors.cpp
+++ b/src/credentials/tests/TestCommissionerDUTVectors.cpp
@@ -29,10 +29,8 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/Span.h>
-#include <lib/support/UnitTestExtendedAssertions.h>
-#include <lib/support/UnitTestRegistration.h>
 
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 #include <dirent.h>
 #include <stdio.h>
@@ -49,10 +47,17 @@ static void OnAttestationInformationVerificationCallback(void * context, const D
     *pResult                                = result;
 }
 
-static void TestCommissionerDUTVectors(nlTestSuite * inSuite, void * inContext)
+struct TestCommissionerDUTVectors : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+TEST_F(TestCommissionerDUTVectors, TestCommissionerDUTVectors)
 {
     DeviceAttestationVerifier * example_dac_verifier = GetDefaultDACVerifier(GetTestAttestationTrustStore());
-    NL_TEST_ASSERT(inSuite, example_dac_verifier != nullptr);
+    ASSERT_NE(example_dac_verifier, nullptr);
 
     std::string dirPath("../../../../../credentials/development/commissioner_dut/");
     DIR * dir = opendir(dirPath.c_str());
@@ -105,14 +110,14 @@ static void TestCommissionerDUTVectors(nlTestSuite * inSuite, void * inContext)
         VendorId vid = TestVendor1;
         uint16_t pid = strstr(entry->d_name, "_vidpid_fallback_encoding_") ? 0x00B1 : 0x8000;
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, dacProvider.GetCertificationDeclaration(certDeclSpan));
-        NL_TEST_ASSERT_SUCCESS(inSuite, dacProvider.GetDeviceAttestationCert(dacCertSpan));
-        NL_TEST_ASSERT_SUCCESS(inSuite, dacProvider.GetProductAttestationIntermediateCert(paiCertSpan));
+        EXPECT_EQ(dacProvider.GetCertificationDeclaration(certDeclSpan), CHIP_NO_ERROR);
+        EXPECT_EQ(dacProvider.GetDeviceAttestationCert(dacCertSpan), CHIP_NO_ERROR);
+        EXPECT_EQ(dacProvider.GetProductAttestationIntermediateCert(paiCertSpan), CHIP_NO_ERROR);
 
         size_t attestationElementsLen =
             TLV::EstimateStructOverhead(certDeclSpan.size(), attestationNonceSpan.size(), sizeof(uint64_t) * 8);
         Platform::ScopedMemoryBuffer<uint8_t> attestationElements;
-        NL_TEST_ASSERT(inSuite, attestationElements.Alloc(attestationElementsLen + attestationChallengeSpan.size()));
+        EXPECT_TRUE(attestationElements.Alloc(attestationElementsLen + attestationChallengeSpan.size()));
         MutableByteSpan attestationElementsSpan(attestationElements.Get(), attestationElementsLen);
 
         // Construct attestation elements
@@ -121,10 +126,9 @@ static void TestCommissionerDUTVectors(nlTestSuite * inSuite, void * inContext)
             Credentials::DeviceAttestationVendorReservedConstructor emptyVendorReserved(nullptr, 0);
             const ByteSpan kEmptyFirmwareInfo;
 
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   Credentials::ConstructAttestationElements(certDeclSpan, attestationNonceSpan, timestamp,
-                                                                             kEmptyFirmwareInfo, emptyVendorReserved,
-                                                                             attestationElementsSpan));
+            EXPECT_EQ(Credentials::ConstructAttestationElements(certDeclSpan, attestationNonceSpan, timestamp, kEmptyFirmwareInfo,
+                                                                emptyVendorReserved, attestationElementsSpan),
+                      CHIP_NO_ERROR);
         }
 
         // Generate attestation signature
@@ -134,8 +138,8 @@ static void TestCommissionerDUTVectors(nlTestSuite * inSuite, void * inContext)
                    attestationChallengeSpan.size());
             ByteSpan tbsSpan(attestationElementsSpan.data(), attestationElementsSpan.size() + attestationChallengeSpan.size());
 
-            NL_TEST_ASSERT_SUCCESS(inSuite, dacProvider.SignWithDeviceAttestationKey(tbsSpan, attestationSignatureSpan));
-            NL_TEST_ASSERT(inSuite, attestationSignatureSpan.size() == signature.Capacity());
+            EXPECT_EQ(dacProvider.SignWithDeviceAttestationKey(tbsSpan, attestationSignatureSpan), CHIP_NO_ERROR);
+            EXPECT_EQ(attestationSignatureSpan.size(), signature.Capacity());
         }
 
         AttestationVerificationResult attestationResult = AttestationVerificationResult::kNotImplemented;
@@ -167,63 +171,12 @@ static void TestCommissionerDUTVectors(nlTestSuite * inSuite, void * inContext)
 
         if (isSuccessCase)
         {
-            NL_TEST_ASSERT(inSuite, attestationResult == AttestationVerificationResult::kSuccess);
+            EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
         }
         else
         {
-            NL_TEST_ASSERT(inSuite, attestationResult != AttestationVerificationResult::kSuccess);
+            EXPECT_NE(attestationResult, AttestationVerificationResult::kSuccess);
         }
     }
     closedir(dir);
 }
-
-/**
- *  Set up the test suite.
- */
-int TestCommissionerDUT_Setup(void * inContext)
-{
-    CHIP_ERROR error = chip::Platform::MemoryInit();
-
-    if (error != CHIP_NO_ERROR)
-    {
-        return FAILURE;
-    }
-
-    return SUCCESS;
-}
-
-/**
- *  Tear down the test suite.
- */
-int TestCommissionerDUT_Teardown(void * inContext)
-{
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-/**
- *   Test Suite. It lists all the test functions.
- */
-// clang-format off
-static const nlTest sTests[] = {
-    NL_TEST_DEF("Test Device Attestation Credentials Vectors", TestCommissionerDUTVectors),
-    NL_TEST_SENTINEL()
-};
-// clang-format on
-
-int TestCommissionerDUT()
-{
-    // clang-format off
-    nlTestSuite theSuite =
-    {
-        "Device Attestation Credentials Test Vectors",
-        &sTests[0],
-        TestCommissionerDUT_Setup,
-        TestCommissionerDUT_Teardown
-    };
-    // clang-format on
-    nlTestRunner(&theSuite, nullptr);
-    return (nlTestRunnerStats(&theSuite));
-}
-
-CHIP_REGISTER_TEST_SUITE(TestCommissionerDUT);

--- a/src/credentials/tests/TestDeviceAttestationConstruction.cpp
+++ b/src/credentials/tests/TestDeviceAttestationConstruction.cpp
@@ -22,15 +22,20 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/Span.h>
-#include <lib/support/UnitTestRegistration.h>
 
 #include <cstdio>
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 using namespace chip;
 using namespace chip::Credentials;
 
-static void TestAttestationElements_Roundtrip(nlTestSuite * inSuite, void * inContext)
+struct TestDeviceAttestationConstruction : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+TEST_F(TestDeviceAttestationConstruction, TestAttestationElements_Roundtrip)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::Platform::ScopedMemoryBuffer<uint8_t> attestationElements;
@@ -67,7 +72,7 @@ static void TestAttestationElements_Roundtrip(nlTestSuite * inSuite, void * inCo
     attestationElements.Alloc(attestationElementsLen);
     vendorReservedConstructor.addVendorReservedElement(vendorId, profileNum, 1, ByteSpan(vendorReserved1));
     vendorReservedConstructor.addVendorReservedElement(vendorId, profileNum, 3, ByteSpan(vendorReserved3));
-    NL_TEST_ASSERT(inSuite, attestationElements);
+    EXPECT_TRUE(attestationElements);
 
     {
         MutableByteSpan attestationElementsSpan(attestationElements.Get(), attestationElementsLen);
@@ -76,22 +81,22 @@ static void TestAttestationElements_Roundtrip(nlTestSuite * inSuite, void * inCo
         err = ConstructAttestationElements(ByteSpan(certificationDeclaration),
                                            ByteSpan(attestationNonce, sizeof(attestationNonce) - 1), timestamp, ByteSpan(),
                                            vendorReservedConstructor, attestationElementsSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+        EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
 
         // Test with missing mandatory TLV entries
         err = ConstructAttestationElements(ByteSpan(), ByteSpan(attestationNonce), timestamp, ByteSpan(), vendorReservedConstructor,
                                            attestationElementsSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+        EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
 
         // Test with missing mandatory TLV entries
         err = ConstructAttestationElements(ByteSpan(certificationDeclaration), ByteSpan(), timestamp, ByteSpan(),
                                            vendorReservedConstructor, attestationElementsSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+        EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
 
         // Test for success with entirely valid arguments
         err = ConstructAttestationElements(ByteSpan(certificationDeclaration), ByteSpan(attestationNonce), timestamp, ByteSpan(),
                                            vendorReservedConstructor, attestationElementsSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
         attestationElementsLen = attestationElementsSpan.size();
     }
 
@@ -104,13 +109,13 @@ static void TestAttestationElements_Roundtrip(nlTestSuite * inSuite, void * inCo
     err =
         DeconstructAttestationElements(ByteSpan(attestationElements.Get(), attestationElementsLen), certificationDeclarationSpan,
                                        attestationNonceSpan, timestampDeconstructed, firmwareInfoSpan, vendorReservedDeconstructor);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, certificationDeclarationSpan.data_equal(ByteSpan(certificationDeclaration)));
-    NL_TEST_ASSERT(inSuite, attestationNonceSpan.data_equal(ByteSpan(attestationNonce)));
-    NL_TEST_ASSERT(inSuite, timestamp == timestampDeconstructed);
-    NL_TEST_ASSERT(inSuite, firmwareInfoSpan.empty());
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(certificationDeclarationSpan.data_equal(ByteSpan(certificationDeclaration)));
+    EXPECT_TRUE(attestationNonceSpan.data_equal(ByteSpan(attestationNonce)));
+    EXPECT_EQ(timestamp, timestampDeconstructed);
+    EXPECT_TRUE(firmwareInfoSpan.empty());
 
-    NL_TEST_ASSERT(inSuite, vendorReservedConstructor.GetNumberOfElements() == vendorReservedDeconstructor.GetNumberOfElements());
+    EXPECT_EQ(vendorReservedConstructor.GetNumberOfElements(), vendorReservedDeconstructor.GetNumberOfElements());
 
     const VendorReservedElement * constructionElement = vendorReservedConstructor.cbegin();
     VendorReservedElement deconstructionElement;
@@ -118,13 +123,13 @@ static void TestAttestationElements_Roundtrip(nlTestSuite * inSuite, void * inCo
     while ((constructionElement = vendorReservedConstructor.Next()) != nullptr &&
            vendorReservedDeconstructor.GetNextVendorReservedElement(deconstructionElement) == CHIP_NO_ERROR)
     {
-        NL_TEST_ASSERT(inSuite, constructionElement->vendorId == deconstructionElement.vendorId);
-        NL_TEST_ASSERT(inSuite, constructionElement->profileNum == deconstructionElement.profileNum);
-        NL_TEST_ASSERT(inSuite, constructionElement->vendorReservedData.data_equal(deconstructionElement.vendorReservedData));
+        EXPECT_EQ(constructionElement->vendorId, deconstructionElement.vendorId);
+        EXPECT_EQ(constructionElement->profileNum, deconstructionElement.profileNum);
+        EXPECT_TRUE(constructionElement->vendorReservedData.data_equal(deconstructionElement.vendorReservedData));
     }
 }
 
-static void TestAttestationElements_Construction(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationConstruction, TestAttestationElements_Construction)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     Platform::ScopedMemoryBuffer<uint8_t> attestationElements;
@@ -175,21 +180,21 @@ static void TestAttestationElements_Construction(nlTestSuite * inSuite, void * i
     attestationElementsLen = sizeof(certificationDeclaration) + sizeof(attestationNonce) + sizeof(timestamp) +
         sizeof(vendorReserved1) + sizeof(vendorReserved3) + sizeof(uint64_t) * 5;
     attestationElements.Alloc(attestationElementsLen);
-    NL_TEST_ASSERT(inSuite, attestationElements);
+    EXPECT_TRUE(attestationElements);
 
     {
         MutableByteSpan attestationElementsSpan(attestationElements.Get(), attestationElementsLen);
 
         err = ConstructAttestationElements(ByteSpan(certificationDeclaration), ByteSpan(attestationNonce), timestamp, ByteSpan(),
                                            vendorReserved, attestationElementsSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
         attestationElementsLen = attestationElementsSpan.size();
 
-        NL_TEST_ASSERT(inSuite, attestationElementsSpan.data_equal(ByteSpan(attestationElementsTestVector)));
+        EXPECT_TRUE(attestationElementsSpan.data_equal(ByteSpan(attestationElementsTestVector)));
     }
 }
 
-static void TestAttestationElements_Deconstruction(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationConstruction, TestAttestationElements_Deconstruction)
 {
     // This is a test case with only the known TLV tags fields
     constexpr uint8_t attestationElementsTestVectorOnlyKnownTags[] = {
@@ -266,36 +271,36 @@ static void TestAttestationElements_Deconstruction(nlTestSuite * inSuite, void *
         err = DeconstructAttestationElements(attestationElementsTestCase, certificationDeclarationDeconstructed,
                                              attestationNonceDeconstructed, timestampDeconstructed, firmwareInfoDeconstructed,
                                              vendorReserved);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT(inSuite, certificationDeclarationDeconstructed.data_equal(ByteSpan(certificationDeclarationTestVector)));
-        NL_TEST_ASSERT(inSuite, attestationNonceDeconstructed.data_equal(ByteSpan(attestationNonceTestVector)));
-        NL_TEST_ASSERT(inSuite, timestampTestVector == timestampDeconstructed);
-        NL_TEST_ASSERT(inSuite, firmwareInfoDeconstructed.empty());
-        NL_TEST_ASSERT(inSuite, ArraySize(vendorReservedArrayTestVector) == vendorReserved.GetNumberOfElements());
+        EXPECT_TRUE(certificationDeclarationDeconstructed.data_equal(ByteSpan(certificationDeclarationTestVector)));
+        EXPECT_TRUE(attestationNonceDeconstructed.data_equal(ByteSpan(attestationNonceTestVector)));
+        EXPECT_EQ(timestampTestVector, timestampDeconstructed);
+        EXPECT_TRUE(firmwareInfoDeconstructed.empty());
+        EXPECT_EQ(ArraySize(vendorReservedArrayTestVector), vendorReserved.GetNumberOfElements());
         struct VendorReservedElement element;
 
         while (vendorReserved.GetNextVendorReservedElement(element) == CHIP_NO_ERROR)
         {
-            NL_TEST_ASSERT(inSuite, vendorIdTestVector == element.vendorId);
-            NL_TEST_ASSERT(inSuite, profileNumTestVector == element.profileNum);
+            EXPECT_EQ(vendorIdTestVector, element.vendorId);
+            EXPECT_EQ(profileNumTestVector, element.profileNum);
             switch (element.tagNum)
             {
             case 1:
-                NL_TEST_ASSERT(inSuite, element.vendorReservedData.data_equal(vendorReservedArrayTestVector[0]));
+                EXPECT_TRUE(element.vendorReservedData.data_equal(vendorReservedArrayTestVector[0]));
                 break;
             case 3:
-                NL_TEST_ASSERT(inSuite, element.vendorReservedData.data_equal(vendorReservedArrayTestVector[1]));
+                EXPECT_TRUE(element.vendorReservedData.data_equal(vendorReservedArrayTestVector[1]));
                 break;
             default:
-                NL_TEST_ASSERT(inSuite, 0);
+                EXPECT_TRUE(0);
                 break;
             }
         }
     }
 }
 
-static void TestAttestationElements_DeconstructionNoVendorReserved(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationConstruction, TestAttestationElements_DeconstructionNoVendorReserved)
 {
     // This is a test case with only the known TLV tags fields
     constexpr uint8_t attestationElementsTestVectorNoVendor[] = {
@@ -333,19 +338,19 @@ static void TestAttestationElements_DeconstructionNoVendorReserved(nlTestSuite *
     err = DeconstructAttestationElements(ByteSpan{ attestationElementsTestVectorNoVendor }, certificationDeclarationDeconstructed,
                                          attestationNonceDeconstructed, timestampDeconstructed, firmwareInfoDeconstructed,
                                          vendorReserved);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, certificationDeclarationDeconstructed.data_equal(ByteSpan(certificationDeclarationTestVector)));
-    NL_TEST_ASSERT(inSuite, attestationNonceDeconstructed.data_equal(ByteSpan(attestationNonceTestVector)));
-    NL_TEST_ASSERT(inSuite, timestampTestVector == timestampDeconstructed);
-    NL_TEST_ASSERT(inSuite, firmwareInfoDeconstructed.empty());
-    NL_TEST_ASSERT(inSuite, 0 == vendorReserved.GetNumberOfElements());
+    EXPECT_TRUE(certificationDeclarationDeconstructed.data_equal(ByteSpan(certificationDeclarationTestVector)));
+    EXPECT_TRUE(attestationNonceDeconstructed.data_equal(ByteSpan(attestationNonceTestVector)));
+    EXPECT_EQ(timestampTestVector, timestampDeconstructed);
+    EXPECT_TRUE(firmwareInfoDeconstructed.empty());
+    EXPECT_EQ(vendorReserved.GetNumberOfElements(), 0u);
     struct VendorReservedElement element;
 
-    NL_TEST_ASSERT(inSuite, vendorReserved.GetNextVendorReservedElement(element) == CHIP_END_OF_TLV);
+    EXPECT_EQ(vendorReserved.GetNextVendorReservedElement(element), CHIP_END_OF_TLV);
 }
 
-static void TestVendorReservedData(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationConstruction, TestVendorReservedData)
 {
 
     struct VendorReservedElement inputArray[] = { { 3000, 100, 10 }, { 2999, 99, 10 },  { 10, 20, 100 },
@@ -363,7 +368,7 @@ static void TestVendorReservedData(nlTestSuite * inSuite, void * inContext)
             vendorReserved.addVendorReservedElement(inputArray[i].vendorId, inputArray[i].profileNum, inputArray[i].tagNum,
                                                     ByteSpan(strings[i], strlen(reinterpret_cast<char *>(strings[i]))));
 
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
     }
 
     // manually figure out the order these should be read out in when sorted
@@ -372,24 +377,23 @@ static void TestVendorReservedData(nlTestSuite * inSuite, void * inContext)
     };
 
     const struct VendorReservedElement * element = vendorReserved.cbegin();
-    NL_TEST_ASSERT(inSuite, element);
-    NL_TEST_ASSERT(inSuite, element = vendorReserved.Next());
+    EXPECT_TRUE(element);
+    EXPECT_TRUE(element = vendorReserved.Next());
 
     for (i = 0; element && i < ArraySize(desiredOrder); element = vendorReserved.Next(), i++)
     {
-        NL_TEST_ASSERT(inSuite,
-                       element->vendorId == desiredOrder[i]->vendorId && element->profileNum == desiredOrder[i]->profileNum &&
-                           element->tagNum == desiredOrder[i]->tagNum);
+        EXPECT_TRUE(element->vendorId == desiredOrder[i]->vendorId && element->profileNum == desiredOrder[i]->profileNum &&
+                    element->tagNum == desiredOrder[i]->tagNum);
     }
-    NL_TEST_ASSERT(inSuite, i == ArraySize(desiredOrder)); // check if previous loop matched for every array entry.
+    EXPECT_EQ(i, ArraySize(desiredOrder)); // check if previous loop matched for every array entry.
 
     // add another element, it should fail
     uint8_t testByteSpan[] = { 0x1, 0x2, 0x3 };
     CHIP_ERROR err         = vendorReserved.addVendorReservedElement(5, 10, 20, ByteSpan(testByteSpan));
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NO_MEMORY);
+    EXPECT_EQ(err, CHIP_ERROR_NO_MEMORY);
 }
 
-static void TestAttestationElements_DeconstructionWithFirmwareInfo(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationConstruction, TestAttestationElements_DeconstructionWithFirmwareInfo)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -456,39 +460,39 @@ static void TestAttestationElements_DeconstructionWithFirmwareInfo(nlTestSuite *
     err = DeconstructAttestationElements(ByteSpan(attestationElementsTestVectorWithFirmwareInfo),
                                          certificationDeclarationDeconstructed, attestationNonceDeconstructed,
                                          timestampDeconstructed, firmwareInfoDeconstructed, vendorReserved);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, certificationDeclarationDeconstructed.data_equal(ByteSpan(certificationDeclarationTestVector)));
-    NL_TEST_ASSERT(inSuite, attestationNonceDeconstructed.data_equal(ByteSpan(attestationNonceTestVector)));
-    NL_TEST_ASSERT(inSuite, timestampTestVector == timestampDeconstructed);
-    NL_TEST_ASSERT(inSuite, firmwareInfoDeconstructed.data_equal(ByteSpan(firmwareInfoTestVector)));
-    NL_TEST_ASSERT(inSuite, ArraySize(vendorReservedArrayTestVector) == vendorReserved.GetNumberOfElements());
+    EXPECT_TRUE(certificationDeclarationDeconstructed.data_equal(ByteSpan(certificationDeclarationTestVector)));
+    EXPECT_TRUE(attestationNonceDeconstructed.data_equal(ByteSpan(attestationNonceTestVector)));
+    EXPECT_EQ(timestampTestVector, timestampDeconstructed);
+    EXPECT_TRUE(firmwareInfoDeconstructed.data_equal(ByteSpan(firmwareInfoTestVector)));
+    EXPECT_EQ(ArraySize(vendorReservedArrayTestVector), vendorReserved.GetNumberOfElements());
     struct VendorReservedElement element;
     size_t elementsSeen = 0;
 
     while (vendorReserved.GetNextVendorReservedElement(element) == CHIP_NO_ERROR)
     {
-        NL_TEST_ASSERT(inSuite, vendorIdTestVector == element.vendorId);
-        NL_TEST_ASSERT(inSuite, profileNumTestVector == element.profileNum);
+        EXPECT_EQ(vendorIdTestVector, element.vendorId);
+        EXPECT_EQ(profileNumTestVector, element.profileNum);
         switch (element.tagNum)
         {
         case 1:
-            NL_TEST_ASSERT(inSuite, element.vendorReservedData.data_equal(vendorReservedArrayTestVector[0]));
+            EXPECT_TRUE(element.vendorReservedData.data_equal(vendorReservedArrayTestVector[0]));
             elementsSeen++;
             break;
         case 3:
-            NL_TEST_ASSERT(inSuite, element.vendorReservedData.data_equal(vendorReservedArrayTestVector[1]));
+            EXPECT_TRUE(element.vendorReservedData.data_equal(vendorReservedArrayTestVector[1]));
             elementsSeen++;
             break;
         default:
-            NL_TEST_ASSERT(inSuite, 0);
+            EXPECT_TRUE(0);
             break;
         }
     }
-    NL_TEST_ASSERT(inSuite, elementsSeen == ArraySize(vendorReservedArrayTestVector));
+    EXPECT_EQ(elementsSeen, ArraySize(vendorReservedArrayTestVector));
 }
 
-static void TestAttestationElements_DeconstructionUnordered(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationConstruction, TestAttestationElements_DeconstructionUnordered)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -516,10 +520,10 @@ static void TestAttestationElements_DeconstructionUnordered(nlTestSuite * inSuit
     err = DeconstructAttestationElements(ByteSpan(attestationElementsUnorderedTestVector), certificationDeclarationDeconstructed,
                                          attestationNonceDeconstructed, timestampDeconstructed, firmwareInfoDeconstructed,
                                          vendorReserved);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
+    EXPECT_EQ(err, CHIP_ERROR_UNEXPECTED_TLV_ELEMENT);
 }
 
-static void TestAttestationElements_DeconstructionCorruptedTLV(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationConstruction, TestAttestationElements_DeconstructionCorruptedTLV)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     using chip::FormatCHIPError;
@@ -541,10 +545,10 @@ static void TestAttestationElements_DeconstructionCorruptedTLV(nlTestSuite * inS
     DeviceAttestationVendorReservedDeconstructor vendorReserved;
     size_t count = 2;
     err          = vendorReserved.PrepareToReadVendorReservedElements(ByteSpan(attestationElementsCorruptedTLVTestVector), count);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_TLV_UNDERRUN);
+    EXPECT_EQ(err, CHIP_ERROR_TLV_UNDERRUN);
 }
 
-static void TestNocsrElements_Construction(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationConstruction, TestNocsrElements_Construction)
 {
     static constexpr uint8_t kNocsrNonce[] = {
         0x81, 0x4a, 0x4d, 0x4c, 0x1c, 0x4a, 0x8e, 0xbb, 0xea, 0xdb, 0x0a, 0xe2, 0x82, 0xf9, 0x91, 0xeb,
@@ -600,18 +604,18 @@ static void TestNocsrElements_Construction(nlTestSuite * inSuite, void * inConte
         TLV::EstimateStructOverhead(sizeof(kExampleCsr), sizeof(kNocsrNonce), sizeof(kVendorReserved1), sizeof(kVendorReserved3));
 
     nocsrElements.Alloc(nocsrElementsLen);
-    NL_TEST_ASSERT(inSuite, nocsrElements.Get() != nullptr);
+    ASSERT_NE(nocsrElements.Get(), nullptr);
 
     MutableByteSpan nocsrElementsSpan(nocsrElements.Get(), nocsrElementsLen);
 
     CHIP_ERROR err = ConstructNOCSRElements(ByteSpan(kExampleCsr), ByteSpan(kNocsrNonce), ByteSpan{ kVendorReserved1 }, ByteSpan{},
                                             ByteSpan{ kVendorReserved3 }, nocsrElementsSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, nocsrElementsSpan.size() <= nocsrElementsLen);
-    NL_TEST_ASSERT(inSuite, nocsrElementsSpan.data_equal(ByteSpan(kNoCsrElementsVector)));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_LE(nocsrElementsSpan.size(), nocsrElementsLen);
+    EXPECT_TRUE(nocsrElementsSpan.data_equal(ByteSpan(kNoCsrElementsVector)));
 }
 
-static void TestNocsrElements_Deconstruction(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationConstruction, TestNocsrElements_Deconstruction)
 {
     static constexpr uint8_t kNocsrNonce[] = {
         0x81, 0x4a, 0x4d, 0x4c, 0x1c, 0x4a, 0x8e, 0xbb, 0xea, 0xdb, 0x0a, 0xe2, 0x82, 0xf9, 0x91, 0xeb,
@@ -669,66 +673,10 @@ static void TestNocsrElements_Deconstruction(nlTestSuite * inSuite, void * inCon
     ByteSpan vendorReserved3Span;
     CHIP_ERROR err = DeconstructNOCSRElements(ByteSpan(kNoCsrElementsVector), csrSpan, csrNonceSpan, vendorReserved1Span,
                                               vendorReserved2Span, vendorReserved3Span);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, csrSpan.data_equal(ByteSpan(kExampleCsr)));
-    NL_TEST_ASSERT(inSuite, csrNonceSpan.data_equal(ByteSpan(kNocsrNonce)));
-    NL_TEST_ASSERT(inSuite, vendorReserved1Span.data_equal(ByteSpan(kVendorReserved1)));
-    NL_TEST_ASSERT(inSuite, vendorReserved2Span.empty());
-    NL_TEST_ASSERT(inSuite, vendorReserved3Span.data_equal(ByteSpan(kVendorReserved3)));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(csrSpan.data_equal(ByteSpan(kExampleCsr)));
+    EXPECT_TRUE(csrNonceSpan.data_equal(ByteSpan(kNocsrNonce)));
+    EXPECT_TRUE(vendorReserved1Span.data_equal(ByteSpan(kVendorReserved1)));
+    EXPECT_TRUE(vendorReserved2Span.empty());
+    EXPECT_TRUE(vendorReserved3Span.data_equal(ByteSpan(kVendorReserved3)));
 }
-
-/**
- *   Test Suite. It lists all the test functions.
- */
-// clang-format off
-static const nlTest sTests[] = {
-    NL_TEST_DEF("Test Device Attestation Elements Roundtrip", TestAttestationElements_Roundtrip),
-    NL_TEST_DEF("Test Device Attestation Elements Construction", TestAttestationElements_Construction),
-    NL_TEST_DEF("Test Device Attestation Elements Deconstruction", TestAttestationElements_Deconstruction),
-    NL_TEST_DEF("Test Vendor Reserved Data Ordering", TestVendorReservedData),
-    NL_TEST_DEF("Test Device Attestation Elements Deconstruction with Firmware Information", TestAttestationElements_DeconstructionWithFirmwareInfo),
-    NL_TEST_DEF("Test Device Attestation Elements Deconstruction - Corrupted/Out of Order TLV", TestAttestationElements_DeconstructionUnordered),
-    NL_TEST_DEF("Test Device Attestation Elements Deconstruction - Corrupted TLV -- vendor reserved elements", TestAttestationElements_DeconstructionCorruptedTLV),
-    NL_TEST_DEF("Test Device Attestation Elements Deconstruction - No vendor reserved", TestAttestationElements_DeconstructionNoVendorReserved),
-    NL_TEST_DEF("Test Device NOCSR Elements Construction", TestNocsrElements_Construction),
-    NL_TEST_DEF("Test Device NOCSR Elements Deconstruction", TestNocsrElements_Deconstruction),
-    NL_TEST_SENTINEL()
-};
-// clang-format on
-
-/**
- *  Set up the test suite.
- */
-int TestDeviceAttestationElementsConstruction_Setup(void * inContext)
-{
-    CHIP_ERROR error = chip::Platform::MemoryInit();
-    if (error != CHIP_NO_ERROR)
-        return FAILURE;
-    return SUCCESS;
-}
-
-/**
- *  Tear down the test suite.
- */
-int TestDeviceAttestationElementsConstruction_Teardown(void * inContext)
-{
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-int TestDeviceAttestationElementsConstruction()
-{
-    // clang-format off
-    nlTestSuite theSuite =
-    {
-        "Device Attestation Elements Construction",
-        &sTests[0],
-        TestDeviceAttestationElementsConstruction_Setup,
-        TestDeviceAttestationElementsConstruction_Teardown
-    };
-    // clang-format on
-    nlTestRunner(&theSuite, nullptr);
-    return (nlTestRunnerStats(&theSuite));
-}
-
-CHIP_REGISTER_TEST_SUITE(TestDeviceAttestationElementsConstruction);

--- a/src/credentials/tests/TestDeviceAttestationCredentials.cpp
+++ b/src/credentials/tests/TestDeviceAttestationCredentials.cpp
@@ -30,9 +30,8 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/Span.h>
-#include <lib/support/UnitTestRegistration.h>
 
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 #include "CHIPAttCert_test_vectors.h"
 
@@ -48,49 +47,55 @@ static const ByteSpan kExpectedPaiPublicKey = DevelopmentCerts::kPaiPublicKey;
 
 } // namespace
 
-static void TestDACProvidersExample_Providers(nlTestSuite * inSuite, void * inContext)
+struct TestDeviceAttestationCredentials : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+TEST_F(TestDeviceAttestationCredentials, TestDACProvidersExample_Providers)
 {
     uint8_t der_cert_buf[kMaxDERCertLength];
     MutableByteSpan der_cert_span(der_cert_buf);
 
     // Make sure default provider exists and is not implemented on at least one method
     DeviceAttestationCredentialsProvider * default_provider = GetDeviceAttestationCredentialsProvider();
-    NL_TEST_ASSERT(inSuite, default_provider != nullptr);
+    ASSERT_NE(default_provider, nullptr);
 
     CHIP_ERROR err = default_provider->GetDeviceAttestationCert(der_cert_span);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_IMPLEMENTED);
+    EXPECT_EQ(err, CHIP_ERROR_NOT_IMPLEMENTED);
 
     // Replace default provider with example provider
     DeviceAttestationCredentialsProvider * example_dac_provider = Examples::GetExampleDACProvider();
-    NL_TEST_ASSERT(inSuite, example_dac_provider != nullptr);
-    NL_TEST_ASSERT(inSuite, default_provider != example_dac_provider);
+    ASSERT_NE(example_dac_provider, nullptr);
+    EXPECT_NE(default_provider, example_dac_provider);
 
     SetDeviceAttestationCredentialsProvider(example_dac_provider);
     default_provider = GetDeviceAttestationCredentialsProvider();
-    NL_TEST_ASSERT(inSuite, default_provider == example_dac_provider);
+    EXPECT_EQ(default_provider, example_dac_provider);
 
     // Make sure DAC is what we expect, by validating public key
     memset(der_cert_span.data(), 0, der_cert_span.size());
     err = example_dac_provider->GetDeviceAttestationCert(der_cert_span);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     P256PublicKey dac_public_key;
     err = ExtractPubkeyFromX509Cert(der_cert_span, dac_public_key);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, dac_public_key.Length() == kExpectedDacPublicKey.size());
-    NL_TEST_ASSERT(inSuite, 0 == memcmp(dac_public_key.ConstBytes(), kExpectedDacPublicKey.data(), kExpectedDacPublicKey.size()));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(dac_public_key.Length(), kExpectedDacPublicKey.size());
+    EXPECT_EQ(0, memcmp(dac_public_key.ConstBytes(), kExpectedDacPublicKey.data(), kExpectedDacPublicKey.size()));
 
     // Make sure PAI is what we expect, by validating public key
     der_cert_span = MutableByteSpan{ der_cert_span };
     memset(der_cert_span.data(), 0, der_cert_span.size());
     err = example_dac_provider->GetProductAttestationIntermediateCert(der_cert_span);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     P256PublicKey pai_public_key;
     err = ExtractPubkeyFromX509Cert(der_cert_span, pai_public_key);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, pai_public_key.Length() == kExpectedPaiPublicKey.size());
-    NL_TEST_ASSERT(inSuite, 0 == memcmp(pai_public_key.ConstBytes(), kExpectedPaiPublicKey.data(), kExpectedPaiPublicKey.size()));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(pai_public_key.Length(), kExpectedPaiPublicKey.size());
+    EXPECT_EQ(0, memcmp(pai_public_key.ConstBytes(), kExpectedPaiPublicKey.data(), kExpectedPaiPublicKey.size()));
 
     // Check for CD presence
     uint8_t other_data_buf[kMaxCMSSignedCDMessage];
@@ -98,35 +103,35 @@ static void TestDACProvidersExample_Providers(nlTestSuite * inSuite, void * inCo
     memset(other_data_span.data(), 0, other_data_span.size());
 
     err = example_dac_provider->GetCertificationDeclaration(other_data_span);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, other_data_span.size() > 0);
-    NL_TEST_ASSERT(inSuite, other_data_span.data()[0] != 0);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_GT(other_data_span.size(), 0u);
+    EXPECT_NE(other_data_span.data()[0], 0);
 
     // Check for firmware information presence
     other_data_span = MutableByteSpan{ other_data_buf };
     memset(other_data_span.data(), 0, other_data_span.size());
 
     err = example_dac_provider->GetFirmwareInformation(other_data_span);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, other_data_span.size() == 0);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(other_data_span.size(), 0u);
 }
 
-static void TestDACProvidersExample_Signature(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationCredentials, TestDACProvidersExample_Signature)
 {
     constexpr uint8_t kExampleMessage[] = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x10, 0x11, 0x12,
                                             0x13, 0x14, 0x15, 0x16, 0x17, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
                                             0x26, 0x27, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37 };
 
     DeviceAttestationCredentialsProvider * example_dac_provider = Examples::GetExampleDACProvider();
-    NL_TEST_ASSERT(inSuite, example_dac_provider != nullptr);
+    ASSERT_NE(example_dac_provider, nullptr);
 
     // Sign using the example attestation private key
     P256ECDSASignature da_signature;
     MutableByteSpan out_sig_span(da_signature.Bytes(), da_signature.Capacity());
     CHIP_ERROR err = example_dac_provider->SignWithDeviceAttestationKey(ByteSpan{ kExampleMessage }, out_sig_span);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, out_sig_span.size() == kP256_ECDSA_Signature_Length_Raw);
+    EXPECT_EQ(out_sig_span.size(), kP256_ECDSA_Signature_Length_Raw);
     da_signature.SetLength(out_sig_span.size());
 
     // Get DAC from the provider
@@ -135,18 +140,18 @@ static void TestDACProvidersExample_Signature(nlTestSuite * inSuite, void * inCo
 
     memset(dac_cert_span.data(), 0, dac_cert_span.size());
     err = example_dac_provider->GetDeviceAttestationCert(dac_cert_span);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Extract public key from DAC, prior to signature verification
     P256PublicKey dac_public_key;
     err = ExtractPubkeyFromX509Cert(dac_cert_span, dac_public_key);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, dac_public_key.Length() == kExpectedDacPublicKey.size());
-    NL_TEST_ASSERT(inSuite, 0 == memcmp(dac_public_key.ConstBytes(), kExpectedDacPublicKey.data(), kExpectedDacPublicKey.size()));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(dac_public_key.Length(), kExpectedDacPublicKey.size());
+    EXPECT_EQ(memcmp(dac_public_key.ConstBytes(), kExpectedDacPublicKey.data(), kExpectedDacPublicKey.size()), 0);
 
     // Verify round trip signature
     err = dac_public_key.ECDSA_validate_msg_signature(&kExampleMessage[0], sizeof(kExampleMessage), da_signature);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 }
 
 static void OnAttestationInformationVerificationCallback(void * context, const DeviceAttestationVerifier::AttestationInfo & info,
@@ -156,7 +161,7 @@ static void OnAttestationInformationVerificationCallback(void * context, const D
     *pResult                                = result;
 }
 
-static void TestDACVerifierExample_AttestationInfoVerification(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationCredentials, TestDACVerifierExample_AttestationInfoVerification)
 {
     uint8_t attestationElementsTestVector[] = {
         0x15, 0x30, 0x01, 0xeb, 0x30, 0x81, 0xe8, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x07, 0x02, 0xa0, 0x81,
@@ -191,20 +196,20 @@ static void TestDACVerifierExample_AttestationInfoVerification(nlTestSuite * inS
 
     // Make sure default verifier exists and is not implemented on at least one method
     DeviceAttestationVerifier * default_verifier = GetDeviceAttestationVerifier();
-    NL_TEST_ASSERT(inSuite, default_verifier != nullptr);
+    ASSERT_NE(default_verifier, nullptr);
 
     AttestationVerificationResult attestationResult = AttestationVerificationResult::kSuccess;
     ByteSpan emptyByteSpan;
     attestationResult = default_verifier->ValidateCertificationDeclarationSignature(ByteSpan(), emptyByteSpan);
-    NL_TEST_ASSERT(inSuite, attestationResult == AttestationVerificationResult::kNotImplemented);
+    EXPECT_EQ(attestationResult, AttestationVerificationResult::kNotImplemented);
 
     DeviceAttestationVerifier * example_dac_verifier = GetDefaultDACVerifier(GetTestAttestationTrustStore());
-    NL_TEST_ASSERT(inSuite, example_dac_verifier != nullptr);
-    NL_TEST_ASSERT(inSuite, default_verifier != example_dac_verifier);
+    ASSERT_NE(example_dac_verifier, nullptr);
+    EXPECT_NE(default_verifier, example_dac_verifier);
 
     SetDeviceAttestationVerifier(example_dac_verifier);
     default_verifier = GetDeviceAttestationVerifier();
-    NL_TEST_ASSERT(inSuite, default_verifier == example_dac_verifier);
+    EXPECT_EQ(default_verifier, example_dac_verifier);
 
     attestationResult = AttestationVerificationResult::kNotImplemented;
     Callback::Callback<DeviceAttestationVerifier::OnAttestationInformationVerification> attestationInformationVerificationCallback(
@@ -216,10 +221,10 @@ static void TestDACVerifierExample_AttestationInfoVerification(nlTestSuite * inS
         static_cast<VendorId>(0xFFF1), 0x8000);
     default_verifier->VerifyAttestationInformation(info, &attestationInformationVerificationCallback);
 
-    NL_TEST_ASSERT(inSuite, attestationResult == AttestationVerificationResult::kSuccess);
+    EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 }
 
-static void TestDACVerifierExample_CertDeclarationVerification(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationCredentials, TestDACVerifierExample_CertDeclarationVerification)
 {
     // -> format_version = 1
     // -> vendor_id = 0xFFF1
@@ -258,11 +263,11 @@ static void TestDACVerifierExample_CertDeclarationVerification(nlTestSuite * inS
 
     // Replace default verifier with example verifier
     DeviceAttestationVerifier * example_dac_verifier = GetDefaultDACVerifier(GetTestAttestationTrustStore());
-    NL_TEST_ASSERT(inSuite, example_dac_verifier != nullptr);
+    ASSERT_NE(example_dac_verifier, nullptr);
 
     SetDeviceAttestationVerifier(example_dac_verifier);
     DeviceAttestationVerifier * default_verifier = GetDeviceAttestationVerifier();
-    NL_TEST_ASSERT(inSuite, default_verifier == example_dac_verifier);
+    EXPECT_EQ(default_verifier, example_dac_verifier);
 
     // Check for CD presence
     uint8_t cd_data_buf[kMaxCMSSignedCDMessage] = { 0 };
@@ -271,9 +276,9 @@ static void TestDACVerifierExample_CertDeclarationVerification(nlTestSuite * inS
     ByteSpan cd_payload;
     AttestationVerificationResult attestation_result =
         default_verifier->ValidateCertificationDeclarationSignature(ByteSpan(sTest_CD), cd_payload);
-    NL_TEST_ASSERT(inSuite, attestation_result == AttestationVerificationResult::kSuccess);
+    EXPECT_EQ(attestation_result, AttestationVerificationResult::kSuccess);
 
-    NL_TEST_ASSERT(inSuite, cd_payload.data_equal(ByteSpan(sTestCMS_CDContent)));
+    EXPECT_TRUE(cd_payload.data_equal(ByteSpan(sTestCMS_CDContent)));
 
     DeviceInfoForAttestation deviceInfo{
         .vendorId     = sTestCMS_CertElements.VendorId,
@@ -285,10 +290,10 @@ static void TestDACVerifierExample_CertDeclarationVerification(nlTestSuite * inS
         .paaVendorId  = sTestCMS_CertElements.VendorId,
     };
     attestation_result = default_verifier->ValidateCertificateDeclarationPayload(cd_payload, ByteSpan(), deviceInfo);
-    NL_TEST_ASSERT(inSuite, attestation_result == AttestationVerificationResult::kSuccess);
+    EXPECT_EQ(attestation_result, AttestationVerificationResult::kSuccess);
 }
 
-static void TestDACVerifierExample_NocsrInformationVerification(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationCredentials, TestDACVerifierExample_NocsrInformationVerification)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -335,25 +340,25 @@ static void TestDACVerifierExample_NocsrInformationVerification(nlTestSuite * in
                                                  0x8d, 0x85, 0xfb, 0xd7, 0xa0, 0x7c, 0x8e, 0x83, 0x7d, 0xa4, 0xd5, 0xa8, 0xb9 };
 
     DeviceAttestationVerifier * exampleDacVerifier = GetDefaultDACVerifier(GetTestAttestationTrustStore());
-    NL_TEST_ASSERT(inSuite, exampleDacVerifier != nullptr);
+    ASSERT_NE(exampleDacVerifier, nullptr);
 
     P256PublicKey dacPubkey;
-    NL_TEST_ASSERT(inSuite, sizeof(attestationPublicKey) == dacPubkey.Length());
+    EXPECT_EQ(sizeof(attestationPublicKey), dacPubkey.Length());
     memcpy(dacPubkey.Bytes(), attestationPublicKey, dacPubkey.Length());
 
     err = exampleDacVerifier->VerifyNodeOperationalCSRInformation(
         ByteSpan(nocsrElementsTestVector), ByteSpan(attestationChallengeTestVector), ByteSpan(attestationSignatureTestVector),
         dacPubkey, ByteSpan(csrNonceTestVector));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // now test with invalid signature
     err = exampleDacVerifier->VerifyNodeOperationalCSRInformation(
         ByteSpan(nocsrElementsTestVector), ByteSpan(attestationChallengeTestVector), ByteSpan(wrongAttestationSignatureTestVector),
         dacPubkey, ByteSpan(csrNonceTestVector));
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_SIGNATURE);
+    EXPECT_EQ(err, CHIP_ERROR_INVALID_SIGNATURE);
 }
 
-static void TestAttestationTrustStore(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDeviceAttestationCredentials, TestAttestationTrustStore)
 {
     // SKID to trigger CHIP_ERROR_INVALID_ARGUMENT
     ByteSpan kPaaFFF1BadSkidSpan1{ TestCerts::sTestCert_PAA_FFF1_Cert.data(), TestCerts::sTestCert_PAA_FFF1_Cert.size() - 1 };
@@ -383,7 +388,7 @@ static void TestAttestationTrustStore(nlTestSuite * inSuite, void * inContext)
     };
 
     const AttestationTrustStore * testAttestationTrustStore = GetTestAttestationTrustStore();
-    NL_TEST_ASSERT(inSuite, testAttestationTrustStore != nullptr);
+    ASSERT_NE(testAttestationTrustStore, nullptr);
 
     for (const auto & testCase : kTestCases)
     {
@@ -397,68 +402,12 @@ static void TestAttestationTrustStore(nlTestSuite * inSuite, void * inContext)
 
         // Try to obtain cert
         CHIP_ERROR result = testAttestationTrustStore->GetProductAttestationAuthorityCert(testCase.skidSpan, paaCertSpan);
-        NL_TEST_ASSERT(inSuite, result == testCase.expectedResult);
+        EXPECT_EQ(result, testCase.expectedResult);
 
         // In success cases, make sure the cert matches expectation.
         if (testCase.expectedResult == CHIP_NO_ERROR)
         {
-            NL_TEST_ASSERT(inSuite, paaCertSpan.data_equal(testCase.expectedCertSpan) == true);
+            EXPECT_TRUE(paaCertSpan.data_equal(testCase.expectedCertSpan));
         }
     }
 }
-
-/**
- *  Set up the test suite.
- */
-int TestDeviceAttestation_Setup(void * inContext)
-{
-    CHIP_ERROR error = chip::Platform::MemoryInit();
-
-    if (error != CHIP_NO_ERROR)
-    {
-        return FAILURE;
-    }
-
-    return SUCCESS;
-}
-
-/**
- *  Tear down the test suite.
- */
-int TestDeviceAttestation_Teardown(void * inContext)
-{
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-/**
- *   Test Suite. It lists all the test functions.
- */
-// clang-format off
-static const nlTest sTests[] = {
-    NL_TEST_DEF("Test Example Device Attestation Credentials Providers", TestDACProvidersExample_Providers),
-    NL_TEST_DEF("Test Example Device Attestation Signature", TestDACProvidersExample_Signature),
-    NL_TEST_DEF("Test the 'for testing' Paa Root Store", TestAttestationTrustStore),
-    NL_TEST_DEF("Test Example Device Attestation Information Verification", TestDACVerifierExample_AttestationInfoVerification),
-    NL_TEST_DEF("Test Example Device Attestation Certification Declaration Verification", TestDACVerifierExample_CertDeclarationVerification),
-    NL_TEST_DEF("Test Example Device Attestation Node Operational CSR Information Verification", TestDACVerifierExample_NocsrInformationVerification),
-    NL_TEST_SENTINEL()
-};
-// clang-format on
-
-int TestDeviceAttestation()
-{
-    // clang-format off
-    nlTestSuite theSuite =
-    {
-        "Device Attestation Credentials",
-        &sTests[0],
-        TestDeviceAttestation_Setup,
-        TestDeviceAttestation_Teardown
-    };
-    // clang-format on
-    nlTestRunner(&theSuite, nullptr);
-    return (nlTestRunnerStats(&theSuite));
-}
-
-CHIP_REGISTER_TEST_SUITE(TestDeviceAttestation);

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -22,7 +22,7 @@
  */
 
 #include <errno.h>
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 #include <lib/core/CHIPCore.h>
 
@@ -36,8 +36,7 @@
 #include <lib/asn1/ASN1.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
-#include <lib/support/UnitTestExtendedAssertions.h>
-#include <lib/support/UnitTestRegistration.h>
+
 #include <platform/ConfigurationManager.h>
 
 #include <lib/support/BytesToHex.h>
@@ -83,7 +82,7 @@ private:
 /**
  * Load a single test fabric with with the Root01:ICA01:Node01_01 identity.
  */
-static CHIP_ERROR LoadTestFabric_Node01_01(nlTestSuite * inSuite, FabricTable & fabricTable, bool doCommit)
+static CHIP_ERROR LoadTestFabric_Node01_01(FabricTable & fabricTable, bool doCommit)
 {
     Crypto::P256SerializedKeypair opKeysSerialized;
     static Crypto::P256Keypair opKey_Node01_01;
@@ -114,7 +113,7 @@ static CHIP_ERROR LoadTestFabric_Node01_01(nlTestSuite * inSuite, FabricTable & 
     return CHIP_NO_ERROR;
 }
 
-static CHIP_ERROR LoadTestFabric_Node01_02(nlTestSuite * inSuite, FabricTable & fabricTable, bool doCommit)
+static CHIP_ERROR LoadTestFabric_Node01_02(FabricTable & fabricTable, bool doCommit)
 {
     Crypto::P256SerializedKeypair opKeysSerialized;
     FabricIndex fabricIndex;
@@ -147,7 +146,7 @@ static CHIP_ERROR LoadTestFabric_Node01_02(nlTestSuite * inSuite, FabricTable & 
 /**
  * Load a single test fabric with with the Root02:ICA02:Node02_01 identity.
  */
-static CHIP_ERROR LoadTestFabric_Node02_01(nlTestSuite * inSuite, FabricTable & fabricTable, bool doCommit,
+static CHIP_ERROR LoadTestFabric_Node02_01(FabricTable & fabricTable, bool doCommit,
                                            FabricTable::AdvertiseIdentity advertiseIdentity = FabricTable::AdvertiseIdentity::Yes)
 {
     Crypto::P256SerializedKeypair opKeysSerialized;
@@ -163,55 +162,67 @@ static CHIP_ERROR LoadTestFabric_Node02_01(nlTestSuite * inSuite, FabricTable & 
     ByteSpan icacSpan(TestCerts::sTestCert_ICA02_Chip);
     ByteSpan nocSpan(TestCerts::sTestCert_Node02_01_Chip);
 
-    NL_TEST_ASSERT(inSuite,
-                   opKeysSerialized.SetLength(TestCerts::sTestCert_Node02_01_PublicKey.size() +
-                                              TestCerts::sTestCert_Node02_01_PrivateKey.size()) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, opKey_Node02_01.Deserialize(opKeysSerialized) == CHIP_NO_ERROR);
+    EXPECT_EQ(opKeysSerialized.SetLength(TestCerts::sTestCert_Node02_01_PublicKey.size() +
+                                         TestCerts::sTestCert_Node02_01_PrivateKey.size()),
+              CHIP_NO_ERROR);
+    EXPECT_EQ(opKey_Node02_01.Deserialize(opKeysSerialized), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcacSpan) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcacSpan), CHIP_NO_ERROR);
 
     CHIP_ERROR err =
         fabricTable.AddNewPendingFabricWithProvidedOpKey(nocSpan, icacSpan, VendorId::TestVendor1, &opKey_Node02_01,
                                                          /*isExistingOpKeyExternallyOwned =*/true, &fabricIndex, advertiseIdentity);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     if (doCommit)
     {
         err = fabricTable.CommitPendingFabricData();
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
     }
 
     return err;
 }
-void TestLastKnownGoodTimeInit(nlTestSuite * inSuite, void * inContext)
+
+struct TestFabricTable : public ::testing::Test
+{
+
+    static void SetUpTestSuite()
+    {
+        DeviceLayer::SetConfigurationMgr(&DeviceLayer::ConfigurationManagerImpl::GetDefaultInstance());
+        ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
+    }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+TEST_F(TestFabricTable, TestLastKnownGoodTimeInit)
 {
     // Fabric table init should init Last Known Good Time to the firmware build time.
     chip::TestPersistentStorageDelegate testStorage;
     ScopedFabricTable fabricTableHolder;
 
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
     System::Clock::Seconds32 lastKnownGoodChipEpochTime;
 
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
-    NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodChipEpochTime) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodChipEpochTime), CHIP_NO_ERROR);
     System::Clock::Seconds32 firmwareBuildTime;
-    NL_TEST_ASSERT(inSuite, DeviceLayer::ConfigurationMgr().GetFirmwareBuildChipEpochTime(firmwareBuildTime) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, lastKnownGoodChipEpochTime == firmwareBuildTime);
+    EXPECT_EQ(DeviceLayer::ConfigurationMgr().GetFirmwareBuildChipEpochTime(firmwareBuildTime), CHIP_NO_ERROR);
+    EXPECT_EQ(lastKnownGoodChipEpochTime, firmwareBuildTime);
 }
 
-void TestCollidingFabrics(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestCollidingFabrics)
 {
     chip::TestPersistentStorageDelegate testStorage;
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
     //
     // Start by loading NOCs for two nodes on the same fabric. The second one should fail since the FabricTable by default
     // doesn't permit colliding fabrics.
     //
-    NL_TEST_ASSERT(inSuite, LoadTestFabric_Node01_01(inSuite, fabricTable, /* doCommit = */ true) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, LoadTestFabric_Node01_02(inSuite, fabricTable, /* doCommit = */ true) != CHIP_NO_ERROR);
+    EXPECT_EQ(LoadTestFabric_Node01_01(fabricTable, /* doCommit = */ true), CHIP_NO_ERROR);
+    EXPECT_NE(LoadTestFabric_Node01_02(fabricTable, /* doCommit = */ true), CHIP_NO_ERROR);
 
     //
     // Revert the partially added NOC from the last call, permit colliding fabrics in the FabricTable and try again.
@@ -219,12 +230,12 @@ void TestCollidingFabrics(nlTestSuite * inSuite, void * inContext)
     //
     fabricTable.RevertPendingFabricData();
     fabricTable.PermitCollidingFabrics();
-    NL_TEST_ASSERT(inSuite, LoadTestFabric_Node01_02(inSuite, fabricTable, /* doCommit = */ true) == CHIP_NO_ERROR);
+    EXPECT_EQ(LoadTestFabric_Node01_02(fabricTable, /* doCommit = */ true), CHIP_NO_ERROR);
 
     ByteSpan rcacSpan(TestCerts::sTestCert_Root01_Chip);
     Credentials::P256PublicKeySpan rootPublicKeySpan;
 
-    NL_TEST_ASSERT(inSuite, Credentials::ExtractPublicKeyFromChipCert(rcacSpan, rootPublicKeySpan) == CHIP_NO_ERROR);
+    EXPECT_EQ(Credentials::ExtractPublicKeyFromChipCert(rcacSpan, rootPublicKeySpan), CHIP_NO_ERROR);
 
     //
     // Ensure we can find both node identities in the FabricTable.
@@ -235,8 +246,8 @@ void TestCollidingFabrics(nlTestSuite * inSuite, void * inContext)
         NodeId nodeId;
         FabricId fabricId;
 
-        NL_TEST_ASSERT(inSuite, ExtractNodeIdFabricIdFromOpCert(origNocSpan, &nodeId, &fabricId) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, fabricTable.FindIdentity(rootPublicKeySpan, fabricId, nodeId) != nullptr);
+        EXPECT_EQ(ExtractNodeIdFabricIdFromOpCert(origNocSpan, &nodeId, &fabricId), CHIP_NO_ERROR);
+        EXPECT_NE(fabricTable.FindIdentity(rootPublicKeySpan, fabricId, nodeId), nullptr);
     }
 
     {
@@ -245,12 +256,12 @@ void TestCollidingFabrics(nlTestSuite * inSuite, void * inContext)
         NodeId nodeId;
         FabricId fabricId;
 
-        NL_TEST_ASSERT(inSuite, ExtractNodeIdFabricIdFromOpCert(origNocSpan, &nodeId, &fabricId) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, fabricTable.FindIdentity(rootPublicKeySpan, fabricId, nodeId) != nullptr);
+        EXPECT_EQ(ExtractNodeIdFabricIdFromOpCert(origNocSpan, &nodeId, &fabricId), CHIP_NO_ERROR);
+        EXPECT_NE(fabricTable.FindIdentity(rootPublicKeySpan, fabricId, nodeId), nullptr);
     }
 }
 
-void TestUpdateLastKnownGoodTime(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestUpdateLastKnownGoodTime)
 {
     // Adding a fabric should advance Last Known Good Time if any certificate's
     // NotBefore time is later than the build time, and else should leave it
@@ -259,7 +270,7 @@ void TestUpdateLastKnownGoodTime(nlTestSuite * inSuite, void * inContext)
     // Test certs all have this NotBefore: Oct 15 14:23:43 2020 GMT
     const ASN1::ASN1UniversalTime asn1Expected = { 2020, 10, 15, 14, 23, 43 };
     uint32_t testCertNotBeforeSeconds;
-    NL_TEST_ASSERT(inSuite, Credentials::ASN1ToChipEpochTime(asn1Expected, testCertNotBeforeSeconds) == CHIP_NO_ERROR);
+    EXPECT_EQ(Credentials::ASN1ToChipEpochTime(asn1Expected, testCertNotBeforeSeconds), CHIP_NO_ERROR);
     System::Clock::Seconds32 testCertNotBeforeTime = System::Clock::Seconds32(testCertNotBeforeSeconds);
 
     // Test that certificate NotBefore times that are before the Firmware build time
@@ -270,22 +281,22 @@ void TestUpdateLastKnownGoodTime(nlTestSuite * inSuite, void * inContext)
     for (auto buildTime : afterNotBeforeBuildTimes)
     {
         // Set build time to the desired value.
-        NL_TEST_ASSERT(inSuite, DeviceLayer::ConfigurationMgr().SetFirmwareBuildChipEpochTime(buildTime) == CHIP_NO_ERROR);
+        EXPECT_EQ(DeviceLayer::ConfigurationMgr().SetFirmwareBuildChipEpochTime(buildTime), CHIP_NO_ERROR);
         chip::TestPersistentStorageDelegate testStorage;
 
         {
             // Initialize a fabric table.
             ScopedFabricTable fabricTableHolder;
-            NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
             FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
             // Read back Last Known Good Time, which will have been initialized to firmware build time.
             System::Clock::Seconds32 lastKnownGoodTime;
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == buildTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, buildTime);
 
             // Load a test fabric, but do not commit.
-            NL_TEST_ASSERT(inSuite, LoadTestFabric_Node01_01(inSuite, fabricTable, /* doCommit = */ false) == CHIP_NO_ERROR);
+            EXPECT_EQ(LoadTestFabric_Node01_01(fabricTable, /* doCommit = */ false), CHIP_NO_ERROR);
 
             // Read Last Known Good Time and verify that it hasn't moved forward.
             // This test case was written after the test certs' NotBefore time and we
@@ -293,17 +304,17 @@ void TestUpdateLastKnownGoodTime(nlTestSuite * inSuite, void * inContext)
             // Therefore, we expect that build time is after NotBefore and so Last
             // Known Good Time will be set to the later of these, build time, even
             // after installing the new fabric.
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == buildTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, buildTime);
 
             // Verify that calling the fail-safe roll back interface does not change
             // last known good time, as it hadn't been updated in the first place.
             fabricTable.RevertPendingFabricData();
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == buildTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, buildTime);
 
             // Now reload the test fabric and commit this time.
-            NL_TEST_ASSERT(inSuite, LoadTestFabric_Node01_01(inSuite, fabricTable, /* doCommit = */ true) == CHIP_NO_ERROR);
+            EXPECT_EQ(LoadTestFabric_Node01_01(fabricTable, /* doCommit = */ true), CHIP_NO_ERROR);
 
             // Read Last Known Good Time and verify that it hasn't moved forward.
             // This test case was written after the test certs' NotBefore time and we
@@ -311,25 +322,25 @@ void TestUpdateLastKnownGoodTime(nlTestSuite * inSuite, void * inContext)
             // Therefore, we expect that build time is after NotBefore and so Last
             // Known Good Time will be set to the later of these, build time, even
             // after installing the new fabric.
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == buildTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, buildTime);
 
             // Call revert again.  Since we've committed, this is a no-op.
             // Last known good time should again be unchanged.
             fabricTable.RevertPendingFabricData();
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == buildTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, buildTime);
         }
         {
             // Test reloading last known good time from persistence.
             ScopedFabricTable fabricTableHolder;
-            NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
             FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
             // Verify that last known good time was retained.
             System::Clock::Seconds32 lastKnownGoodTime;
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == buildTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, buildTime);
         }
     }
 
@@ -343,75 +354,75 @@ void TestUpdateLastKnownGoodTime(nlTestSuite * inSuite, void * inContext)
     for (auto buildTime : beforeNotBeforeBuildTimes)
     {
         // Set build time to the desired value.
-        NL_TEST_ASSERT(inSuite, DeviceLayer::ConfigurationMgr().SetFirmwareBuildChipEpochTime(buildTime) == CHIP_NO_ERROR);
+        EXPECT_EQ(DeviceLayer::ConfigurationMgr().SetFirmwareBuildChipEpochTime(buildTime), CHIP_NO_ERROR);
         chip::TestPersistentStorageDelegate testStorage;
         {
             // Initialize a fabric table.
             ScopedFabricTable fabricTableHolder;
-            NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
             FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
             // Load a test fabric, but do not commit.
-            NL_TEST_ASSERT(inSuite, LoadTestFabric_Node01_01(inSuite, fabricTable, /* doCommit = */ false) == CHIP_NO_ERROR);
+            EXPECT_EQ(LoadTestFabric_Node01_01(fabricTable, /* doCommit = */ false), CHIP_NO_ERROR);
 
             // Read Last Known Good Time and verify that it is now set to the certificate
             // NotBefore time, as this should be at or after firmware build time.
             System::Clock::Seconds32 lastKnownGoodTime;
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == testCertNotBeforeTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, testCertNotBeforeTime);
 
             // Now test revert.  Last known good time should change back to the
             // previous value.
             fabricTable.RevertPendingFabricData();
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == buildTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, buildTime);
         }
         {
             // Test reloading last known good time from persistence.
             ScopedFabricTable fabricTableHolder;
-            NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
             FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
             // Verify that the original last known good time was retained, since
             // we reverted before.
             System::Clock::Seconds32 lastKnownGoodTime;
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
         }
         {
             // Now test loading a fabric and committing.
             ScopedFabricTable fabricTableHolder;
-            NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
             FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
-            NL_TEST_ASSERT(inSuite, LoadTestFabric_Node01_01(inSuite, fabricTable, /* doCommit = */ true) == CHIP_NO_ERROR);
+            EXPECT_EQ(LoadTestFabric_Node01_01(fabricTable, /* doCommit = */ true), CHIP_NO_ERROR);
 
             // Read Last Known Good Time and verify that it is now set to the certificate
             // NotBefore time, as this should be at or after firmware build time.
             System::Clock::Seconds32 lastKnownGoodTime;
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == testCertNotBeforeTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, testCertNotBeforeTime);
 
             // Now test revert, which will be a no-op because we already
             // committed.  Verify that Last Known Good time is retained.
             fabricTable.RevertPendingFabricData();
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == testCertNotBeforeTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, testCertNotBeforeTime);
         }
         {
             // Test reloading last known good time from persistence.
             ScopedFabricTable fabricTableHolder;
-            NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
             FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
             // Verify that the new last known good time was retained, since
             // we committed.
             System::Clock::Seconds32 lastKnownGoodTime;
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == testCertNotBeforeTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, testCertNotBeforeTime);
         }
     }
 }
 
-void TestSetLastKnownGoodTime(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestSetLastKnownGoodTime)
 {
     // It is desirable for nodes to set Last Known Good Time whenever a good
     // time source is available, including cases where this would set the time
@@ -422,7 +433,7 @@ void TestSetLastKnownGoodTime(nlTestSuite * inSuite, void * inContext)
     // Test certs all have this NotBefore: Oct 15 14:23:43 2020 GMT
     const ASN1::ASN1UniversalTime asn1Expected = { 2020, 10, 15, 14, 23, 43 };
     uint32_t testCertNotBeforeSeconds;
-    NL_TEST_ASSERT(inSuite, Credentials::ASN1ToChipEpochTime(asn1Expected, testCertNotBeforeSeconds) == CHIP_NO_ERROR);
+    EXPECT_EQ(Credentials::ASN1ToChipEpochTime(asn1Expected, testCertNotBeforeSeconds), CHIP_NO_ERROR);
     System::Clock::Seconds32 testCertNotBeforeTime = System::Clock::Seconds32(testCertNotBeforeSeconds);
 
     // Iterate over two cases: one with build time prior to our certificates' NotBefore, one with build time after.
@@ -432,77 +443,77 @@ void TestSetLastKnownGoodTime(nlTestSuite * inSuite, void * inContext)
     for (auto buildTime : testCaseFirmwareBuildTimes)
     {
         // Set build time to the desired value.
-        NL_TEST_ASSERT(inSuite, DeviceLayer::ConfigurationMgr().SetFirmwareBuildChipEpochTime(buildTime) == CHIP_NO_ERROR);
+        EXPECT_EQ(DeviceLayer::ConfigurationMgr().SetFirmwareBuildChipEpochTime(buildTime), CHIP_NO_ERROR);
         chip::TestPersistentStorageDelegate testStorage;
         System::Clock::Seconds32 newTime;
         {
             // Initialize a fabric table.
             ScopedFabricTable fabricTableHolder;
-            NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
             FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
             // Load a test fabric
-            NL_TEST_ASSERT(inSuite, LoadTestFabric_Node01_01(inSuite, fabricTable, /* doCommit= */ true) == CHIP_NO_ERROR);
+            EXPECT_EQ(LoadTestFabric_Node01_01(fabricTable, /* doCommit= */ true), CHIP_NO_ERROR);
 
             // Verify the Last Known Good Time matches our expected initial value.
             System::Clock::Seconds32 initialLastKnownGoodTime =
                 buildTime > testCertNotBeforeTime ? buildTime : testCertNotBeforeTime;
             System::Clock::Seconds32 lastKnownGoodTime;
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == initialLastKnownGoodTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, initialLastKnownGoodTime);
 
             // Read Last Known Good Time and verify that it hasn't moved forward, since
             // build time is later than the test certs' NotBefore times.
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == initialLastKnownGoodTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, initialLastKnownGoodTime);
 
             // Attempt to set a Last Known Good Time that is before the firmware build time.  This should fail.
             newTime = System::Clock::Seconds32(buildTime.count() - 1000);
-            NL_TEST_ASSERT(inSuite, fabricTable.SetLastKnownGoodChipEpochTime(newTime) != CHIP_NO_ERROR);
+            EXPECT_NE(fabricTable.SetLastKnownGoodChipEpochTime(newTime), CHIP_NO_ERROR);
 
             // Verify Last Known Good Time is unchanged.
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == initialLastKnownGoodTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, initialLastKnownGoodTime);
 
             // Attempt to set a Last Known Good Time that is before our certificates' NotBefore times.  This should fail.
             newTime = System::Clock::Seconds32(testCertNotBeforeTime.count() - 1000);
-            NL_TEST_ASSERT(inSuite, fabricTable.SetLastKnownGoodChipEpochTime(newTime) != CHIP_NO_ERROR);
+            EXPECT_NE(fabricTable.SetLastKnownGoodChipEpochTime(newTime), CHIP_NO_ERROR);
 
             // Verify Last Known Good Time is unchanged.
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == initialLastKnownGoodTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, initialLastKnownGoodTime);
 
             // Attempt to set a Last Known Good Time that at our current value.
-            NL_TEST_ASSERT(inSuite, fabricTable.SetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.SetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
 
             // Verify Last Known Good Time is unchanged.
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == initialLastKnownGoodTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, initialLastKnownGoodTime);
 
             // Attempt to set Last Known Good Times that is after our current value.
             newTime = System::Clock::Seconds32(initialLastKnownGoodTime.count() + 1000);
-            NL_TEST_ASSERT(inSuite, fabricTable.SetLastKnownGoodChipEpochTime(newTime) == CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.SetLastKnownGoodChipEpochTime(newTime), CHIP_NO_ERROR);
 
             // Verify Last Known Good Time is updated.
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == newTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, newTime);
         }
         {
             // Verify that Last Known Good Time was persisted.
 
             ScopedFabricTable fabricTableHolder;
-            NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
             FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
             System::Clock::Seconds32 lastKnownGoodTime;
-            NL_TEST_ASSERT(inSuite, fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT(inSuite, lastKnownGoodTime == newTime);
+            EXPECT_EQ(fabricTable.GetLastKnownGoodChipEpochTime(lastKnownGoodTime), CHIP_NO_ERROR);
+            EXPECT_EQ(lastKnownGoodTime, newTime);
         }
     }
 }
 
 // Test adding 2 fabrics, updating 1, removing 1
-void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestBasicAddNocUpdateNocFlow)
 {
     Credentials::TestOnlyLocalCertificateAuthority fabric11CertAuthority;
     Credentials::TestOnlyLocalCertificateAuthority fabric44CertAuthority;
@@ -513,25 +524,25 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
     // storage.SetLoggingLevel(chip::TestPersistentStorageDelegate::LoggingLevel::kLogMutation);
 
     // Initialize test CA and a Fabric 11 externally owned key
-    NL_TEST_ASSERT(inSuite, fabric11CertAuthority.Init().IsSuccess());
-    NL_TEST_ASSERT(inSuite, fabric44CertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabric11CertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabric44CertAuthority.Init().IsSuccess());
 
     constexpr uint16_t kVendorId = 0xFFF1u;
 
     chip::Crypto::P256Keypair fabric11Node55Keypair; // Fabric ID 11,
-    NL_TEST_ASSERT(inSuite, fabric11Node55Keypair.Initialize(Crypto::ECPKeyTarget::ECDSA) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabric11Node55Keypair.Initialize(Crypto::ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
     // Initialize a fabric table.
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-    NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+    EXPECT_EQ(fabricTable.FabricCount(), 0);
 
     {
         FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-        NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-        NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 1);
+        EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+        EXPECT_EQ(nextFabricIndex, 1);
     }
 
     size_t numFabricsIterated = 0;
@@ -542,10 +553,10 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
     {
         FabricId fabricId = 11;
         NodeId nodeId     = 55;
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabric11CertAuthority.SetIncludeIcac(false)
-                                   .GenerateNocChain(fabricId, nodeId, fabric11Node55Keypair.Pubkey())
-                                   .GetStatus());
+        EXPECT_EQ(fabric11CertAuthority.SetIncludeIcac(false)
+                      .GenerateNocChain(fabricId, nodeId, fabric11Node55Keypair.Pubkey())
+                      .GetStatus(),
+                  CHIP_NO_ERROR);
         ByteSpan rcac = fabric11CertAuthority.GetRcac();
         ByteSpan noc  = fabric11CertAuthority.GetNoc();
 
@@ -562,48 +573,48 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 0);
-            NL_TEST_ASSERT(inSuite, saw1 == false);
+            EXPECT_EQ(numFabricsIterated, 0u);
+            EXPECT_FALSE(saw1);
         }
 
         uint8_t rcacBuf[Credentials::kMaxCHIPCertLength];
         {
             // No pending root cert yet.
             MutableByteSpan fetchedSpan{ rcacBuf };
-            NL_TEST_ASSERT(inSuite, fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan) == CHIP_ERROR_NOT_FOUND);
+            EXPECT_EQ(fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan), CHIP_ERROR_NOT_FOUND);
         }
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         {
             // Now have a pending root cert.
             MutableByteSpan fetchedSpan{ rcacBuf };
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan));
-            NL_TEST_ASSERT(inSuite, fetchedSpan.data_equal(rcac));
+            EXPECT_EQ(fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan), CHIP_NO_ERROR);
+            EXPECT_TRUE(fetchedSpan.data_equal(rcac));
         }
 
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
         bool keyIsExternallyOwned  = true;
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithProvidedOpKey(noc, ByteSpan{}, kVendorId, &fabric11Node55Keypair,
-                                                                                keyIsExternallyOwned, &newFabricIndex));
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 1);
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithProvidedOpKey(noc, ByteSpan{}, kVendorId, &fabric11Node55Keypair,
+                                                                   keyIsExternallyOwned, &newFabricIndex),
+                  CHIP_NO_ERROR);
+        EXPECT_EQ(newFabricIndex, 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
         {
             // No more pending root cert; it's associated with a fabric now.
             MutableByteSpan fetchedSpan{ rcacBuf };
-            NL_TEST_ASSERT(inSuite, fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan) == CHIP_ERROR_NOT_FOUND);
+            EXPECT_EQ(fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan), CHIP_ERROR_NOT_FOUND);
         }
 
         // No storage yet
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageKeysAtStart);
+        EXPECT_EQ(storage.GetNumKeys(), numStorageKeysAtStart);
 
         // Next fabric index has not been updated yet.
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 1);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 1);
         }
 
         // Validate iterator sees pending
@@ -615,56 +626,51 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == nodeId);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == fabricId);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), nodeId);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), fabricId);
                     saw1 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_TRUE(saw1);
         }
 
         // Commit, now storage should have keys
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == (numStorageKeysAtStart + 4)); // 2 opcerts + fabric metadata + index
+        EXPECT_EQ(storage.GetNumKeys(), (numStorageKeysAtStart + 4)); // 2 opcerts + fabric metadata + index
 
         // Next fabric index has been updated.
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 2);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 2);
         }
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+        ASSERT_NE(fabricInfo, nullptr);
+        Credentials::ChipCertificateSet certificates;
+        EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+        EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+        Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == newFabricIndex);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == nodeId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == fabricId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), newFabricIndex);
+        EXPECT_EQ(fabricInfo->GetNodeId(), nodeId);
+        EXPECT_EQ(fabricInfo->GetFabricId(), fabricId);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-            Crypto::P256PublicKey rootPublicKeyOfFabric;
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric));
-            NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-        }
+        Crypto::P256PublicKey rootPublicKeyOfFabric;
+        EXPECT_EQ(fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+        EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
         // Validate that fabric has the correct operational key by verifying a signature
         Crypto::P256ECDSASignature sig;
         uint8_t message[] = { 'm', 's', 'g' };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig));
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabric11Node55Keypair.Pubkey().ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+        EXPECT_EQ(fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+        EXPECT_EQ(fabric11Node55Keypair.Pubkey().ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
 
         // Validate iterator sees committed
         {
@@ -675,14 +681,14 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == nodeId);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == fabricId);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), nodeId);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), fabricId);
                     saw1 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_TRUE(saw1);
         }
     }
 
@@ -695,75 +701,70 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabric44CertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                  CHIP_NO_ERROR);
         ByteSpan rcac = fabric44CertAuthority.GetRcac();
         ByteSpan icac = fabric44CertAuthority.GetIcac();
         ByteSpan noc  = fabric44CertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
 
         // Next fabric index should still be the same as before.
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 2);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 2);
         }
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 2);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
+        EXPECT_EQ(newFabricIndex, 2);
         // No storage yet
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageAfterFirstAdd);
+        EXPECT_EQ(storage.GetNumKeys(), numStorageAfterFirstAdd);
         // Next fabric index has not been updated yet.
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 2);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 2);
         }
 
         // Commit, now storage should have keys
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
 
-        NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(),
-                              (numStorageAfterFirstAdd + 5)); // 3 opcerts + fabric metadata + 1 operational key
+        EXPECT_EQ(storage.GetNumKeys(),
+                  (numStorageAfterFirstAdd + 5)); // 3 opcerts + fabric metadata + 1 operational key
 
         // Next fabric index has been updated.
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 3);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 3);
         }
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+        ASSERT_NE(fabricInfo, nullptr);
+        Credentials::ChipCertificateSet certificates;
+        EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+        EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+        Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == newFabricIndex);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == nodeId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == fabricId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), newFabricIndex);
+        EXPECT_EQ(fabricInfo->GetNodeId(), nodeId);
+        EXPECT_EQ(fabricInfo->GetFabricId(), fabricId);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-            Crypto::P256PublicKey rootPublicKeyOfFabric;
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric));
-            NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-        }
+        Crypto::P256PublicKey rootPublicKeyOfFabric;
+        EXPECT_EQ(fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+        EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
         // Validate that fabric has the correct operational key by verifying a signature
         {
@@ -771,10 +772,10 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
             uint8_t message[] = { 'm', 's', 'g' };
 
             Crypto::P256PublicKey nocPubKey;
-            NL_TEST_ASSERT_SUCCESS(inSuite, VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), nocPubKey));
+            EXPECT_EQ(VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), nocPubKey), CHIP_NO_ERROR);
 
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig));
-            NL_TEST_ASSERT_SUCCESS(inSuite, nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+            EXPECT_EQ(fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+            EXPECT_EQ(nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
         }
 
         // Verify we can now see 2 fabrics with the iterator
@@ -787,21 +788,21 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 55);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 11);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 55u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 11u);
                     saw1 = true;
                 }
                 if (iterFabricInfo.GetFabricIndex() == 2)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 999);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 44);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 999u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 44u);
                     saw2 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 2);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
-            NL_TEST_ASSERT(inSuite, saw2 == true);
+            EXPECT_EQ(numFabricsIterated, 2u);
+            EXPECT_TRUE(saw1);
+            EXPECT_TRUE(saw2);
         }
     }
 
@@ -817,22 +818,21 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
         MutableByteSpan csrSpan{ csrBuf };
 
         // Make sure to tag fabric index to pending opkey: otherwise the UpdateNOC fails
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AllocatePendingOperationalKey(chip::MakeOptional(static_cast<FabricIndex>(2)), csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::MakeOptional(static_cast<FabricIndex>(2)), csrSpan),
+                  CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                  CHIP_NO_ERROR);
         ByteSpan rcac = fabric44CertAuthority.GetRcac();
         ByteSpan noc  = fabric44CertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
-        NL_TEST_ASSERT_SUCCESS(
-            inSuite,
-            fabricTable.UpdatePendingFabricWithOperationalKeystore(2, noc, ByteSpan{}, FabricTable::AdvertiseIdentity::No));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
+        EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(2, noc, ByteSpan{}, FabricTable::AdvertiseIdentity::No),
+                  CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
 
         // No storage yet
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageAfterSecondAdd);
+        EXPECT_EQ(storage.GetNumKeys(), numStorageAfterSecondAdd);
 
         // Validate iterator sees the pending data
         {
@@ -844,52 +844,48 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 55);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 11);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.ShouldAdvertiseIdentity());
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 55u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 11u);
+                    EXPECT_TRUE(iterFabricInfo.ShouldAdvertiseIdentity());
                     saw1 = true;
                 }
                 if (iterFabricInfo.GetFabricIndex() == 2)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 1000);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 44);
-                    NL_TEST_ASSERT(inSuite, !iterFabricInfo.ShouldAdvertiseIdentity());
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 1000u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 44u);
+                    EXPECT_FALSE(iterFabricInfo.ShouldAdvertiseIdentity());
                     saw2 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 2);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
-            NL_TEST_ASSERT(inSuite, saw2 == true);
+            EXPECT_EQ(numFabricsIterated, 2u);
+            EXPECT_TRUE(saw1);
+            EXPECT_TRUE(saw2);
         }
 
         // Commit, now storage should have keys
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
 
-        NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(), (numStorageAfterSecondAdd - 1)); // ICAC got deleted
+        EXPECT_EQ(storage.GetNumKeys(), (numStorageAfterSecondAdd - 1)); // ICAC got deleted
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+        ASSERT_NE(fabricInfo, nullptr);
+        Credentials::ChipCertificateSet certificates;
+        EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+        EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+        Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == fabricIndex);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == nodeId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == fabricId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), fabricIndex);
+        EXPECT_EQ(fabricInfo->GetNodeId(), nodeId);
+        EXPECT_EQ(fabricInfo->GetFabricId(), fabricId);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-            Crypto::P256PublicKey rootPublicKeyOfFabric;
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(fabricIndex, rootPublicKeyOfFabric));
-            NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-        }
+        Crypto::P256PublicKey rootPublicKeyOfFabric;
+        EXPECT_EQ(fabricTable.FetchRootPubkey(fabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+        EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
         // Validate that fabric has the correct operational key by verifying a signature
         {
@@ -897,10 +893,10 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
             uint8_t message[] = { 'm', 's', 'g' };
 
             Crypto::P256PublicKey nocPubKey;
-            NL_TEST_ASSERT_SUCCESS(inSuite, VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), nocPubKey));
+            EXPECT_EQ(VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), nocPubKey), CHIP_NO_ERROR);
 
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(fabricIndex, ByteSpan{ message }, sig));
-            NL_TEST_ASSERT_SUCCESS(inSuite, nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+            EXPECT_EQ(fabricTable.SignWithOpKeypair(fabricIndex, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+            EXPECT_EQ(nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
         }
 
         // Validate iterator sees the committed update
@@ -913,28 +909,28 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 55);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 11);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 55u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 11u);
                     saw1 = true;
                 }
                 if (iterFabricInfo.GetFabricIndex() == 2)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 1000);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 44);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 1000u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 44u);
                     saw2 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 2);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
-            NL_TEST_ASSERT(inSuite, saw2 == true);
+            EXPECT_EQ(numFabricsIterated, 2u);
+            EXPECT_TRUE(saw1);
+            EXPECT_TRUE(saw2);
         }
 
         // Next fabric index has stayed the same.
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 3);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 3);
         }
     }
 
@@ -942,31 +938,28 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
 
     // Sequence 4: Rename fabric index 2, applies immediately when nothing pending
     {
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SetFabricLabel(2, "roboto"_span));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
+        EXPECT_EQ(fabricTable.SetFabricLabel(2, "roboto"_span), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
 
-        NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(), numStorageAfterUpdate); // Number of keys unchanged
+        EXPECT_EQ(storage.GetNumKeys(), numStorageAfterUpdate); // Number of keys unchanged
 
         // Validate basic contents
         {
             const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
-            NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-            if (fabricInfo != nullptr)
-            {
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 2);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 1000);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 44);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().data_equal(CharSpan{ "roboto", strlen("roboto") }));
-            }
+            ASSERT_NE(fabricInfo, nullptr);
+            EXPECT_EQ(fabricInfo->GetFabricIndex(), 2);
+            EXPECT_EQ(fabricInfo->GetNodeId(), 1000u);
+            EXPECT_EQ(fabricInfo->GetFabricId(), 44u);
+            EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+            EXPECT_TRUE(fabricInfo->GetFabricLabel().data_equal(CharSpan{ "roboto", strlen("roboto") }));
         }
 
         // Next fabric index has stayed the same.
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 3);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 3);
         }
     }
 
@@ -974,52 +967,48 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
     {
         // Remove the fabric: no commit needed
         {
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.Delete(1));
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+            EXPECT_EQ(fabricTable.FabricCount(), 2);
+            EXPECT_EQ(fabricTable.Delete(1), CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.FabricCount(), 1);
 
-            NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(), (numStorageAfterUpdate - 3)); // Deleted NOC, RCAC, Metadata
+            EXPECT_EQ(storage.GetNumKeys(), (numStorageAfterUpdate - 3)); // Deleted NOC, RCAC, Metadata
         }
 
         // Next fabric index has stayed the same.
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 3);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 3);
         }
 
         // Validate contents of Fabric Index 2 is still OK
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 2);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 1000);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 44);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().data_equal(CharSpan{ "roboto", strlen("roboto") }));
+        ASSERT_NE(fabricInfo, nullptr);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 2);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 1000u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 44u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_TRUE(fabricInfo->GetFabricLabel().data_equal(CharSpan{ "roboto", strlen("roboto") }));
 
-            Crypto::P256PublicKey rootPublicKeyOfFabric;
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(2, rootPublicKeyOfFabric));
-        }
+        Crypto::P256PublicKey rootPublicKeyOfFabric;
+        EXPECT_EQ(fabricTable.FetchRootPubkey(2, rootPublicKeyOfFabric), CHIP_NO_ERROR);
 
         // Validate that fabric has the correct operational key by verifying a signature
         {
             uint8_t nocBuf[Credentials::kMaxCHIPCertLength];
             MutableByteSpan nocSpan{ nocBuf };
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchNOCCert(2, nocSpan));
+            EXPECT_EQ(fabricTable.FetchNOCCert(2, nocSpan), CHIP_NO_ERROR);
 
             Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(nocSpan, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
+            EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+            EXPECT_EQ(certificates.LoadCert(nocSpan, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
             Crypto::P256PublicKey nocPubKey(certificates.GetCertSet()[0].mPublicKey);
 
             Crypto::P256ECDSASignature sig;
             uint8_t message[] = { 'm', 's', 'g' };
 
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(2, ByteSpan{ message }, sig));
-            NL_TEST_ASSERT_SUCCESS(inSuite, nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+            EXPECT_EQ(fabricTable.SignWithOpKeypair(2, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+            EXPECT_EQ(nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
         }
 
         // Validate iterator only sees the remaining fabric
@@ -1036,34 +1025,34 @@ void TestBasicAddNocUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
                 }
                 if (iterFabricInfo.GetFabricIndex() == 2)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 1000);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 44);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 1000u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 44u);
                     saw2 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == false);
-            NL_TEST_ASSERT(inSuite, saw2 == true);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_FALSE(saw1);
+            EXPECT_TRUE(saw2);
         }
     }
 }
 
-void TestAddMultipleSameRootDifferentFabricId(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestAddMultipleSameRootDifferentFabricId)
 {
     Credentials::TestOnlyLocalCertificateAuthority fabricCertAuthority;
 
     chip::TestPersistentStorageDelegate storage;
-    NL_TEST_ASSERT(inSuite, fabricCertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabricCertAuthority.Init().IsSuccess());
 
     constexpr uint16_t kVendorId = 0xFFF1u;
 
     // Initialize a fabric table.
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-    NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+    EXPECT_EQ(fabricTable.FabricCount(), 0);
 
     uint8_t rcac1Buf[kMaxCHIPCertLength];
     MutableByteSpan rcac1Span{ rcac1Buf };
@@ -1075,10 +1064,9 @@ void TestAddMultipleSameRootDifferentFabricId(nlTestSuite * inSuite, void * inCo
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
         ByteSpan rcac = fabricCertAuthority.GetRcac();
         // Keep a copy for second scope check
         CopySpanToMutableSpan(rcac, rcac1Span);
@@ -1086,30 +1074,26 @@ void TestAddMultipleSameRootDifferentFabricId(nlTestSuite * inSuite, void * inCo
         ByteSpan icac = fabricCertAuthority.GetIcac();
         ByteSpan noc  = fabricCertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 1);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(newFabricIndex, 1);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 1);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 55);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 1111);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
-        }
+        ASSERT_NE(fabricInfo, nullptr);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 1);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 55u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 1111u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
     }
     size_t numStorageKeysAfterFirstAdd = storage.GetNumKeys();
-    NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 7); // Metadata, index, 3 certs, 1 opkey, last known good time
+    EXPECT_EQ(numStorageKeysAfterFirstAdd, 7u); // Metadata, index, 3 certs, 1 opkey, last known good time
 
     // Second scope: add FabricID 2222, node ID 66, same root as first
     {
@@ -1118,59 +1102,54 @@ void TestAddMultipleSameRootDifferentFabricId(nlTestSuite * inSuite, void * inCo
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
         ByteSpan rcac2 = fabricCertAuthority.GetRcac();
-        NL_TEST_ASSERT(inSuite, rcac2.data_equal(rcac1Span));
+        EXPECT_TRUE(rcac2.data_equal(rcac1Span));
 
         ByteSpan icac = fabricCertAuthority.GetIcac();
         ByteSpan noc  = fabricCertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac2));
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac2), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 2);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
+        EXPECT_EQ(newFabricIndex, 2);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 2);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 66);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 2222);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
-        }
+        ASSERT_NE(fabricInfo, nullptr);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 2);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 66u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 2222u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
     }
     size_t numStorageKeysAfterSecondAdd = storage.GetNumKeys();
-    NL_TEST_ASSERT(inSuite, numStorageKeysAfterSecondAdd == (numStorageKeysAfterFirstAdd + 5)); // Add 3 certs, 1 metadata, 1 opkey
+    EXPECT_EQ(numStorageKeysAfterSecondAdd, (numStorageKeysAfterFirstAdd + 5)); // Add 3 certs, 1 metadata, 1 opkey
 }
 
-void TestAddMultipleSameFabricIdDifferentRoot(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestAddMultipleSameFabricIdDifferentRoot)
 {
     Credentials::TestOnlyLocalCertificateAuthority fabricCertAuthority1;
     Credentials::TestOnlyLocalCertificateAuthority fabricCertAuthority2;
 
     chip::TestPersistentStorageDelegate storage;
-    NL_TEST_ASSERT(inSuite, fabricCertAuthority1.Init().IsSuccess());
-    NL_TEST_ASSERT(inSuite, fabricCertAuthority2.Init().IsSuccess());
+    EXPECT_TRUE(fabricCertAuthority1.Init().IsSuccess());
+    EXPECT_TRUE(fabricCertAuthority2.Init().IsSuccess());
 
     constexpr uint16_t kVendorId = 0xFFF1u;
 
     // Initialize a fabric table.
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-    NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+    EXPECT_EQ(fabricTable.FabricCount(), 0);
 
     uint8_t rcac1Buf[kMaxCHIPCertLength];
     MutableByteSpan rcac1Span{ rcac1Buf };
@@ -1182,10 +1161,9 @@ void TestAddMultipleSameFabricIdDifferentRoot(nlTestSuite * inSuite, void * inCo
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricCertAuthority1.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabricCertAuthority1.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
         ByteSpan rcac = fabricCertAuthority1.GetRcac();
         // Keep a copy for second scope check
         CopySpanToMutableSpan(rcac, rcac1Span);
@@ -1193,30 +1171,26 @@ void TestAddMultipleSameFabricIdDifferentRoot(nlTestSuite * inSuite, void * inCo
         ByteSpan icac = fabricCertAuthority1.GetIcac();
         ByteSpan noc  = fabricCertAuthority1.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 1);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(newFabricIndex, 1);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 1);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 55);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 1111);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
-        }
+        ASSERT_NE(fabricInfo, nullptr);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 1);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 55u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 1111u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
     }
     size_t numStorageKeysAfterFirstAdd = storage.GetNumKeys();
-    NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 7); // Metadata, index, 3 certs, 1 opkey, last known good time
+    EXPECT_EQ(numStorageKeysAfterFirstAdd, 7u); // Metadata, index, 3 certs, 1 opkey, last known good time
 
     // Second scope: add FabricID 1111, node ID 66, different root from first
     {
@@ -1225,43 +1199,38 @@ void TestAddMultipleSameFabricIdDifferentRoot(nlTestSuite * inSuite, void * inCo
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricCertAuthority2.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabricCertAuthority2.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
         ByteSpan rcac2 = fabricCertAuthority2.GetRcac();
-        NL_TEST_ASSERT(inSuite, !rcac2.data_equal(rcac1Span));
+        EXPECT_FALSE(rcac2.data_equal(rcac1Span));
 
         ByteSpan icac = fabricCertAuthority2.GetIcac();
         ByteSpan noc  = fabricCertAuthority2.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac2));
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac2), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 2);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
+        EXPECT_EQ(newFabricIndex, 2);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 2);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 66);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 1111);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
-        }
+        ASSERT_NE(fabricInfo, nullptr);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 2);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 66u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 1111u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
     }
     size_t numStorageKeysAfterSecondAdd = storage.GetNumKeys();
-    NL_TEST_ASSERT(inSuite, numStorageKeysAfterSecondAdd == (numStorageKeysAfterFirstAdd + 5)); // Add 3 certs, 1 metadata, 1 opkey
+    EXPECT_EQ(numStorageKeysAfterSecondAdd, (numStorageKeysAfterFirstAdd + 5)); // Add 3 certs, 1 metadata, 1 opkey
 }
 
-void TestPersistence(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestPersistence)
 {
     /**
      *
@@ -1287,7 +1256,7 @@ void TestPersistence(nlTestSuite * inSuite, void * inContext)
 
     chip::TestPersistentStorageDelegate storage;
 
-    NL_TEST_ASSERT(inSuite, fabricCertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabricCertAuthority.Init().IsSuccess());
 
     constexpr uint16_t kVendorId = 0xFFF1u;
 
@@ -1295,10 +1264,10 @@ void TestPersistence(nlTestSuite * inSuite, void * inContext)
     {
         // Initialize a FabricTable
         ScopedFabricTable fabricTableHolder;
-        NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
         FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
 
         // Add Fabric 1111 Node Id 55
         {
@@ -1307,55 +1276,50 @@ void TestPersistence(nlTestSuite * inSuite, void * inContext)
 
             uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
             MutableByteSpan csrSpan{ csrBuf };
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+            EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-            NL_TEST_ASSERT_SUCCESS(
-                inSuite, fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+            EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                      CHIP_NO_ERROR);
             ByteSpan rcac = fabricCertAuthority.GetRcac();
             ByteSpan icac = fabricCertAuthority.GetIcac();
             ByteSpan noc  = fabricCertAuthority.GetNoc();
 
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+            EXPECT_EQ(fabricTable.FabricCount(), 0);
+            EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
             FabricIndex newFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex));
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-            NL_TEST_ASSERT(inSuite, newFabricIndex == 1);
+            EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.FabricCount(), 1);
+            EXPECT_EQ(newFabricIndex, 1);
 
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+            EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
             // Validate contents
             const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-            NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-            if (fabricInfo != nullptr)
-            {
-                Credentials::ChipCertificateSet certificates;
-                NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-                NL_TEST_ASSERT_SUCCESS(inSuite,
-                                       certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-                Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+            ASSERT_NE(fabricInfo, nullptr);
+            Credentials::ChipCertificateSet certificates;
+            EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+            EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 1);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 55);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 1111);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+            EXPECT_EQ(fabricInfo->GetFabricIndex(), 1);
+            EXPECT_EQ(fabricInfo->GetNodeId(), 55u);
+            EXPECT_EQ(fabricInfo->GetFabricId(), 1111u);
+            EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+            EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-                Crypto::P256PublicKey rootPublicKeyOfFabric;
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric));
-                NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-            }
+            Crypto::P256PublicKey rootPublicKeyOfFabric;
+            EXPECT_EQ(fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+            EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
             // Validate that fabric has the correct operational key by verifying a signature
             {
                 Crypto::P256ECDSASignature sig;
                 uint8_t message[] = { 'm', 's', 'g' };
 
-                NL_TEST_ASSERT_SUCCESS(inSuite, VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), fIdx1PublicKey));
+                EXPECT_EQ(VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), fIdx1PublicKey), CHIP_NO_ERROR);
 
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig));
-                NL_TEST_ASSERT_SUCCESS(inSuite, fIdx1PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+                EXPECT_EQ(fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+                EXPECT_EQ(fIdx1PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
             }
         }
 
@@ -1366,58 +1330,54 @@ void TestPersistence(nlTestSuite * inSuite, void * inContext)
 
             uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
             MutableByteSpan csrSpan{ csrBuf };
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+            EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-            NL_TEST_ASSERT_SUCCESS(
-                inSuite, fabricCertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+            EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                      CHIP_NO_ERROR);
             ByteSpan rcac = fabricCertAuthority.GetRcac();
             ByteSpan noc  = fabricCertAuthority.GetNoc();
 
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+            EXPECT_EQ(fabricTable.FabricCount(), 1);
+            EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
             FabricIndex newFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT_SUCCESS(
-                inSuite, fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, ByteSpan{}, kVendorId, &newFabricIndex));
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
-            NL_TEST_ASSERT(inSuite, newFabricIndex == 2);
+            EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, ByteSpan{}, kVendorId, &newFabricIndex),
+                      CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.FabricCount(), 2);
+            EXPECT_EQ(newFabricIndex, 2);
 
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+            EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
             // Validate contents
             const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
-            NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-            if (fabricInfo != nullptr)
-            {
-                Credentials::ChipCertificateSet certificates;
-                NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-                NL_TEST_ASSERT_SUCCESS(inSuite,
-                                       certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-                Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+            ASSERT_NE(fabricInfo, nullptr);
+            Credentials::ChipCertificateSet certificates;
+            EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+            EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 2);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 66);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 2222);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+            EXPECT_EQ(fabricInfo->GetFabricIndex(), 2);
+            EXPECT_EQ(fabricInfo->GetNodeId(), 66u);
+            EXPECT_EQ(fabricInfo->GetFabricId(), 2222u);
+            EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+            EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-                Crypto::P256PublicKey rootPublicKeyOfFabric;
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric));
-                NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-            }
+            Crypto::P256PublicKey rootPublicKeyOfFabric;
+            EXPECT_EQ(fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+            EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
             // Validate that fabric has the correct operational key by verifying a signature
             {
                 Crypto::P256ECDSASignature sig;
                 uint8_t message[] = { 'm', 's', 'g' };
 
-                NL_TEST_ASSERT_SUCCESS(inSuite, VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), fIdx2PublicKey));
+                EXPECT_EQ(VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), fIdx2PublicKey), CHIP_NO_ERROR);
 
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig));
-                NL_TEST_ASSERT_SUCCESS(inSuite, fIdx2PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+                EXPECT_EQ(fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+                EXPECT_EQ(fIdx2PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
             }
         }
 
-        NL_TEST_ASSERT(inSuite, fabricTable.FabricCount() == 2);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
 
         // Verify we can now see 2 fabrics with the iterator
         {
@@ -1429,44 +1389,44 @@ void TestPersistence(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 55);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 1111);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 55u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 1111u);
                     saw1 = true;
                 }
                 if (iterFabricInfo.GetFabricIndex() == 2)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 66);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 2222);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 66u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 2222u);
                     saw2 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 2);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
-            NL_TEST_ASSERT(inSuite, saw2 == true);
+            EXPECT_EQ(numFabricsIterated, 2u);
+            EXPECT_TRUE(saw1);
+            EXPECT_TRUE(saw2);
         }
 
         // Next fabric index should now be 3, since we added 1 and 2 above.
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 3);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 3);
         }
     }
 
     // Global: Last known good time + fabric index = 2
     // Fabric 1111: Metadata, 1 opkey, RCAC/ICAC/NOC = 5
     // Fabric 2222: Metadata, 1 opkey, RCAC/NOC = 4
-    NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == (2 + 5 + 4));
+    EXPECT_EQ(storage.GetNumKeys(), (2u + 5u + 4u));
 
     // Second scope: Validate that a fresh FabricTable loads the previously committed fabrics on Init.
     {
         // Initialize a FabricTable
         ScopedFabricTable fabricTableHolder;
-        NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
         FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
 
         // Verify we can see 2 fabrics with the iterator
         {
@@ -1478,57 +1438,53 @@ void TestPersistence(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 55);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 1111);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 55u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 1111u);
                     saw1 = true;
                 }
                 if (iterFabricInfo.GetFabricIndex() == 2)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 66);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 2222);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 66u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 2222u);
                     saw2 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 2);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
-            NL_TEST_ASSERT(inSuite, saw2 == true);
+            EXPECT_EQ(numFabricsIterated, 2u);
+            EXPECT_TRUE(saw1);
+            EXPECT_TRUE(saw2);
         }
 
         // Validate contents of Fabric 2222
         {
             uint8_t rcacBuf[Credentials::kMaxCHIPCertLength];
             MutableByteSpan rcacSpan{ rcacBuf };
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootCert(2, rcacSpan));
+            EXPECT_EQ(fabricTable.FetchRootCert(2, rcacSpan), CHIP_NO_ERROR);
 
             const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
-            NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-            if (fabricInfo != nullptr)
-            {
-                Credentials::ChipCertificateSet certificates;
-                NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-                NL_TEST_ASSERT_SUCCESS(inSuite,
-                                       certificates.LoadCert(rcacSpan, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-                Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+            ASSERT_NE(fabricInfo, nullptr);
+            Credentials::ChipCertificateSet certificates;
+            EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+            EXPECT_EQ(certificates.LoadCert(rcacSpan, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 2);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 66);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 2222);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+            EXPECT_EQ(fabricInfo->GetFabricIndex(), 2);
+            EXPECT_EQ(fabricInfo->GetNodeId(), 66u);
+            EXPECT_EQ(fabricInfo->GetFabricId(), 2222u);
+            EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+            EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-                Crypto::P256PublicKey rootPublicKeyOfFabric;
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(2, rootPublicKeyOfFabric));
-                NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-            }
+            Crypto::P256PublicKey rootPublicKeyOfFabric;
+            EXPECT_EQ(fabricTable.FetchRootPubkey(2, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+            EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
             // Validate that fabric has the correct operational key by verifying a signature
             {
                 Crypto::P256ECDSASignature sig;
                 uint8_t message[] = { 'm', 's', 'g' };
 
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(2, ByteSpan{ message }, sig));
-                NL_TEST_ASSERT_SUCCESS(inSuite, fIdx2PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+                EXPECT_EQ(fabricTable.SignWithOpKeypair(2, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+                EXPECT_EQ(fIdx2PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
             }
         }
 
@@ -1536,36 +1492,32 @@ void TestPersistence(nlTestSuite * inSuite, void * inContext)
         {
             uint8_t rcacBuf[Credentials::kMaxCHIPCertLength];
             MutableByteSpan rcacSpan{ rcacBuf };
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootCert(1, rcacSpan));
+            EXPECT_EQ(fabricTable.FetchRootCert(1, rcacSpan), CHIP_NO_ERROR);
 
             const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-            NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-            if (fabricInfo != nullptr)
-            {
-                Credentials::ChipCertificateSet certificates;
-                NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-                NL_TEST_ASSERT_SUCCESS(inSuite,
-                                       certificates.LoadCert(rcacSpan, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-                Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+            ASSERT_NE(fabricInfo, nullptr);
+            Credentials::ChipCertificateSet certificates;
+            EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+            EXPECT_EQ(certificates.LoadCert(rcacSpan, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 1);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 55);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 1111);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+            EXPECT_EQ(fabricInfo->GetFabricIndex(), 1);
+            EXPECT_EQ(fabricInfo->GetNodeId(), 55u);
+            EXPECT_EQ(fabricInfo->GetFabricId(), 1111u);
+            EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+            EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-                Crypto::P256PublicKey rootPublicKeyOfFabric;
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(1, rootPublicKeyOfFabric));
-                NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-            }
+            Crypto::P256PublicKey rootPublicKeyOfFabric;
+            EXPECT_EQ(fabricTable.FetchRootPubkey(1, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+            EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
             // Validate that fabric has the correct operational key by verifying a signature
             {
                 Crypto::P256ECDSASignature sig;
                 uint8_t message[] = { 'm', 's', 'g' };
 
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(1, ByteSpan{ message }, sig));
-                NL_TEST_ASSERT_SUCCESS(inSuite, fIdx1PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+                EXPECT_EQ(fabricTable.SignWithOpKeypair(1, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+                EXPECT_EQ(fIdx1PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
             }
 
             // Validate that signing with Fabric index 2 fails to verify with fabric index 1
@@ -1573,40 +1525,39 @@ void TestPersistence(nlTestSuite * inSuite, void * inContext)
                 Crypto::P256ECDSASignature sig;
                 uint8_t message[] = { 'm', 's', 'g' };
 
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(2, ByteSpan{ message }, sig));
-                NL_TEST_ASSERT(inSuite,
-                               fIdx1PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig) ==
-                                   CHIP_ERROR_INVALID_SIGNATURE);
+                EXPECT_EQ(fabricTable.SignWithOpKeypair(2, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+                EXPECT_EQ(fIdx1PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig),
+                          CHIP_ERROR_INVALID_SIGNATURE);
             }
         }
 
         // Validate that next fabric index is still 3;
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 3);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 3);
         }
     }
 }
 
-void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestAddNocFailSafe)
 {
     Credentials::TestOnlyLocalCertificateAuthority fabric11CertAuthority;
     Credentials::TestOnlyLocalCertificateAuthority fabric44CertAuthority;
 
     chip::TestPersistentStorageDelegate storage;
 
-    NL_TEST_ASSERT(inSuite, fabric11CertAuthority.Init().IsSuccess());
-    NL_TEST_ASSERT(inSuite, fabric44CertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabric11CertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabric44CertAuthority.Init().IsSuccess());
 
     constexpr uint16_t kVendorId = 0xFFF1u;
 
     // Initialize a fabric table.
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-    NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+    EXPECT_EQ(fabricTable.FabricCount(), 0);
 
     size_t numFabricsIterated = 0;
 
@@ -1619,30 +1570,30 @@ void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabric11CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabric11CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                  CHIP_NO_ERROR);
         ByteSpan rcac = fabric11CertAuthority.GetRcac();
         ByteSpan noc  = fabric11CertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
 
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 1);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 1);
         }
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, ByteSpan{}, kVendorId, &newFabricIndex));
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 1);
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, ByteSpan{}, kVendorId, &newFabricIndex),
+                  CHIP_NO_ERROR);
+        EXPECT_EQ(newFabricIndex, 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
 
         // No storage yet
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageKeysAtStart); // Nothing yet
+        EXPECT_EQ(storage.GetNumKeys(), numStorageKeysAtStart); // Nothing yet
 
         // Validate iterator sees pending
         {
@@ -1653,23 +1604,23 @@ void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == nodeId);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == fabricId);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), nodeId);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), fabricId);
                     saw1 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_TRUE(saw1);
         }
 
         // Revert, should see nothing yet
         fabricTable.RevertPendingFabricData();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
 
         // No started except fabric index metadata
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == (numStorageKeysAtStart + 1));
+        EXPECT_EQ(storage.GetNumKeys(), (numStorageKeysAtStart + 1));
 
         // Validate iterator sees nothing
         {
@@ -1684,15 +1635,15 @@ void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 0);
-            NL_TEST_ASSERT(inSuite, saw1 == false);
+            EXPECT_EQ(numFabricsIterated, 0u);
+            EXPECT_FALSE(saw1);
         }
 
         // Validate next fabric index has not changed.
         {
             FabricIndex nextFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT(inSuite, fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex) == CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, nextFabricIndex, 1);
+            EXPECT_EQ(fabricTable.PeekFabricIndexForNextAddition(nextFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(nextFabricIndex, 1);
         }
     }
 
@@ -1705,54 +1656,49 @@ void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabric44CertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                  CHIP_NO_ERROR);
         ByteSpan rcac = fabric44CertAuthority.GetRcac();
         ByteSpan icac = fabric44CertAuthority.GetIcac();
         ByteSpan noc  = fabric44CertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(newFabricIndex, 1);
         // No storage yet
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageAfterRevert);
+        EXPECT_EQ(storage.GetNumKeys(), numStorageAfterRevert);
 
         // Commit, now storage should have keys
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
 
-        NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(),
-                              (numStorageAfterRevert + 5)); // 3 opcerts + fabric metadata + 1 operational key
+        EXPECT_EQ(storage.GetNumKeys(),
+                  (numStorageAfterRevert + 5)); // 3 opcerts + fabric metadata + 1 operational key
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+        ASSERT_NE(fabricInfo, nullptr);
+        Credentials::ChipCertificateSet certificates;
+        EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+        EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+        Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == newFabricIndex);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == nodeId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == fabricId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), newFabricIndex);
+        EXPECT_EQ(fabricInfo->GetNodeId(), nodeId);
+        EXPECT_EQ(fabricInfo->GetFabricId(), fabricId);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-            Crypto::P256PublicKey rootPublicKeyOfFabric;
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric));
-            NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-        }
+        Crypto::P256PublicKey rootPublicKeyOfFabric;
+        EXPECT_EQ(fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+        EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
         // Validate that fabric has the correct operational key by verifying a signature
         {
@@ -1760,10 +1706,10 @@ void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
             uint8_t message[] = { 'm', 's', 'g' };
 
             Crypto::P256PublicKey nocPubKey;
-            NL_TEST_ASSERT_SUCCESS(inSuite, VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), nocPubKey));
+            EXPECT_EQ(VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), nocPubKey), CHIP_NO_ERROR);
 
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig));
-            NL_TEST_ASSERT_SUCCESS(inSuite, nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+            EXPECT_EQ(fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+            EXPECT_EQ(nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
         }
 
         // Verify we can now see the fabric with the iterator
@@ -1775,14 +1721,14 @@ void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 999);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 44);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 999u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 44u);
                     saw1 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_TRUE(saw1);
         }
     }
 
@@ -1795,8 +1741,8 @@ void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
         fabricTable.RevertPendingFabricData();
 
         // No change of storage
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageAfterAdd);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(storage.GetNumKeys(), numStorageAfterAdd);
 
         // Verify we can still see the fabric with the iterator
         {
@@ -1807,19 +1753,19 @@ void TestAddNocFailSafe(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 999);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 44);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 999u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 44u);
                     saw1 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_TRUE(saw1);
         }
     }
 }
 
-void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestUpdateNocFailSafe)
 {
     Credentials::TestOnlyLocalCertificateAuthority fabric11CertAuthority;
     Credentials::TestOnlyLocalCertificateAuthority fabric44CertAuthority;
@@ -1828,17 +1774,17 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
 
     storage.SetLoggingLevel(chip::TestPersistentStorageDelegate::LoggingLevel::kLogMutation);
 
-    NL_TEST_ASSERT(inSuite, fabric11CertAuthority.Init().IsSuccess());
-    NL_TEST_ASSERT(inSuite, fabric44CertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabric11CertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabric44CertAuthority.Init().IsSuccess());
 
     constexpr uint16_t kVendorId = 0xFFF1u;
 
     // Initialize a fabric table.
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-    NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+    EXPECT_EQ(fabricTable.FabricCount(), 0);
 
     size_t numFabricsIterated = 0;
 
@@ -1851,54 +1797,49 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabric44CertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                  CHIP_NO_ERROR);
         ByteSpan rcac = fabric44CertAuthority.GetRcac();
         ByteSpan icac = fabric44CertAuthority.GetIcac();
         ByteSpan noc  = fabric44CertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(newFabricIndex, 1);
         // No storage yet
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageKeysAtStart);
+        EXPECT_EQ(storage.GetNumKeys(), numStorageKeysAtStart);
 
         // Commit, now storage should have keys
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
 
-        NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(),
-                              (numStorageKeysAtStart + 6)); // 3 opcerts + fabric metadata + 1 operational key + LKGT + fabric index
+        EXPECT_EQ(storage.GetNumKeys(),
+                  (numStorageKeysAtStart + 6)); // 3 opcerts + fabric metadata + 1 operational key + LKGT + fabric index
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+        ASSERT_NE(fabricInfo, nullptr);
+        Credentials::ChipCertificateSet certificates;
+        EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+        EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+        Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == newFabricIndex);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == nodeId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == fabricId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), newFabricIndex);
+        EXPECT_EQ(fabricInfo->GetNodeId(), nodeId);
+        EXPECT_EQ(fabricInfo->GetFabricId(), fabricId);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-            Crypto::P256PublicKey rootPublicKeyOfFabric;
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric));
-            NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-        }
+        Crypto::P256PublicKey rootPublicKeyOfFabric;
+        EXPECT_EQ(fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+        EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
         // Validate that fabric has the correct operational key by verifying a signature
         {
@@ -1906,10 +1847,10 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
             uint8_t message[] = { 'm', 's', 'g' };
 
             Crypto::P256PublicKey nocPubKey;
-            NL_TEST_ASSERT_SUCCESS(inSuite, VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), nocPubKey));
+            EXPECT_EQ(VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), nocPubKey), CHIP_NO_ERROR);
 
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig));
-            NL_TEST_ASSERT_SUCCESS(inSuite, nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+            EXPECT_EQ(fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+            EXPECT_EQ(nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
         }
 
         // Verify we can now see the fabric with the iterator
@@ -1921,14 +1862,14 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 999);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 44);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 999u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 44u);
                     saw1 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_TRUE(saw1);
         }
     }
 
@@ -1944,20 +1885,20 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
         MutableByteSpan csrSpan{ csrBuf };
 
         // Make sure to tag fabric index to pending opkey: otherwise the UpdateNOC fails
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AllocatePendingOperationalKey(chip::MakeOptional(static_cast<FabricIndex>(1)), csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::MakeOptional(static_cast<FabricIndex>(1)), csrSpan),
+                  CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                  CHIP_NO_ERROR);
         ByteSpan rcac = fabric44CertAuthority.GetRcac();
         ByteSpan noc  = fabric44CertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.UpdatePendingFabricWithOperationalKeystore(1, noc, ByteSpan{}));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(1, noc, ByteSpan{}), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
 
         // No storage yet
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageAfterAdd);
+        EXPECT_EQ(storage.GetNumKeys(), numStorageAfterAdd);
 
         // Validate iterator sees the pending data
         {
@@ -1968,62 +1909,58 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 1000);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 44);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.ShouldAdvertiseIdentity());
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 1000u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 44u);
+                    EXPECT_TRUE(iterFabricInfo.ShouldAdvertiseIdentity());
                     saw1 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_TRUE(saw1);
         }
 
         // Revert, should see Node ID 999 again
         fabricTable.RevertPendingFabricData();
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
 
-        NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(), numStorageAfterAdd);
+        EXPECT_EQ(storage.GetNumKeys(), numStorageAfterAdd);
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
+        ASSERT_NE(fabricInfo, nullptr);
         {
             Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
+            EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+            EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
             Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == fabricIndex);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 999);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 44);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+            EXPECT_EQ(fabricInfo->GetFabricIndex(), fabricIndex);
+            EXPECT_EQ(fabricInfo->GetNodeId(), 999u);
+            EXPECT_EQ(fabricInfo->GetFabricId(), 44u);
+            EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+            EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
             Crypto::P256PublicKey rootPublicKeyOfFabric;
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(fabricIndex, rootPublicKeyOfFabric));
-            NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
+            EXPECT_EQ(fabricTable.FetchRootPubkey(fabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+            EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
         }
 
         // Validate that fabric has the correct operational key by verifying a signature
         {
             uint8_t nocBuf[Credentials::kMaxCHIPCertLength];
             MutableByteSpan nocSpan{ nocBuf };
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchNOCCert(1, nocSpan));
-
+            EXPECT_EQ(fabricTable.FetchNOCCert(1, nocSpan), CHIP_NO_ERROR);
             Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(nocSpan, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
+            EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+            EXPECT_EQ(certificates.LoadCert(nocSpan, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
             Crypto::P256PublicKey nocPubKey(certificates.GetCertSet()[0].mPublicKey);
 
             Crypto::P256ECDSASignature sig;
             uint8_t message[] = { 'm', 's', 'g' };
 
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(fabricIndex, ByteSpan{ message }, sig));
-            NL_TEST_ASSERT_SUCCESS(inSuite, nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+            EXPECT_EQ(fabricTable.SignWithOpKeypair(fabricIndex, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+            EXPECT_EQ(nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
         }
 
         // Validate iterator sees the previous fabric
@@ -2035,14 +1972,14 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 999);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 44);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 999u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 44u);
                     saw1 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_TRUE(saw1);
         }
     }
 
@@ -2056,20 +1993,20 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
         MutableByteSpan csrSpan{ csrBuf };
 
         // Make sure to tag fabric index to pending opkey: otherwise the UpdateNOC fails
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AllocatePendingOperationalKey(chip::MakeOptional(static_cast<FabricIndex>(1)), csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::MakeOptional(static_cast<FabricIndex>(1)), csrSpan),
+                  CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                  CHIP_NO_ERROR);
         ByteSpan rcac = fabric44CertAuthority.GetRcac();
         ByteSpan noc  = fabric44CertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.UpdatePendingFabricWithOperationalKeystore(1, noc, ByteSpan{}));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(1, noc, ByteSpan{}), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
 
         // No storage yet
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageAfterAdd);
+        EXPECT_EQ(storage.GetNumKeys(), numStorageAfterAdd);
 
         // Validate iterator sees the pending data
         {
@@ -2080,55 +2017,51 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 1001);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 44);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.ShouldAdvertiseIdentity());
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 1001u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 44u);
+                    EXPECT_TRUE(iterFabricInfo.ShouldAdvertiseIdentity());
                     saw1 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_TRUE(saw1);
         }
 
         // Commit, should see Node ID 1001, and 1 less cert in the storage
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT_EQUALS(inSuite, storage.GetNumKeys(), numStorageAfterAdd - 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(storage.GetNumKeys(), numStorageAfterAdd - 1);
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+        ASSERT_NE(fabricInfo, nullptr);
+        Credentials::ChipCertificateSet certificates;
+        EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+        EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+        Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == fabricIndex);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 1001);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 44);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), fabricIndex);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 1001u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 44u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-            Crypto::P256PublicKey rootPublicKeyOfFabric;
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(fabricIndex, rootPublicKeyOfFabric));
-            NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-        }
+        Crypto::P256PublicKey rootPublicKeyOfFabric;
+        EXPECT_EQ(fabricTable.FetchRootPubkey(fabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+        EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
         // Validate that fabric has the correct operational key by verifying a signature
         {
             Crypto::P256PublicKey nocPubKey;
-            NL_TEST_ASSERT_SUCCESS(inSuite, VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), nocPubKey));
+            EXPECT_EQ(VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), nocPubKey), CHIP_NO_ERROR);
 
             Crypto::P256ECDSASignature sig;
             uint8_t message[] = { 'm', 's', 'g' };
 
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(fabricIndex, ByteSpan{ message }, sig));
-            NL_TEST_ASSERT_SUCCESS(inSuite, nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+            EXPECT_EQ(fabricTable.SignWithOpKeypair(fabricIndex, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+            EXPECT_EQ(nocPubKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
         }
 
         // Validate iterator sees the updated fabric
@@ -2140,32 +2073,32 @@ void TestUpdateNocFailSafe(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 1001);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 44);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 1001u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 44u);
                     saw1 = true;
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_TRUE(saw1);
         }
     }
 }
 
-void TestAddRootCertFailSafe(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestAddRootCertFailSafe)
 {
     Credentials::TestOnlyLocalCertificateAuthority fabric11CertAuthority;
 
     chip::TestPersistentStorageDelegate storage;
 
-    NL_TEST_ASSERT(inSuite, fabric11CertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabric11CertAuthority.Init().IsSuccess());
 
     // Initialize a fabric table.
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-    NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+    EXPECT_EQ(fabricTable.FabricCount(), 0);
 
     // Add a root cert, see that pending works, and that revert works
     {
@@ -2175,15 +2108,15 @@ void TestAddRootCertFailSafe(nlTestSuite * inSuite, void * inContext)
         {
             // No pending root cert yet.
             MutableByteSpan fetchedSpan{ rcacBuf };
-            NL_TEST_ASSERT(inSuite, fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan) == CHIP_ERROR_NOT_FOUND);
+            EXPECT_EQ(fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan), CHIP_ERROR_NOT_FOUND);
         }
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         {
             // Now have a pending root cert.
             MutableByteSpan fetchedSpan{ rcacBuf };
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan));
-            NL_TEST_ASSERT(inSuite, fetchedSpan.data_equal(rcac));
+            EXPECT_EQ(fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan), CHIP_NO_ERROR);
+            EXPECT_TRUE(fetchedSpan.data_equal(rcac));
         }
 
         // Revert
@@ -2192,31 +2125,31 @@ void TestAddRootCertFailSafe(nlTestSuite * inSuite, void * inContext)
         {
             // No pending root cert anymore.
             MutableByteSpan fetchedSpan{ rcacBuf };
-            NL_TEST_ASSERT(inSuite, fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan) == CHIP_ERROR_NOT_FOUND);
+            EXPECT_EQ(fabricTable.FetchPendingNonFabricAssociatedRootCert(fetchedSpan), CHIP_ERROR_NOT_FOUND);
         }
     }
 }
 
-void TestSequenceErrors(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestSequenceErrors)
 {
     // TODO: Write test
 }
 
-void TestFabricLabelChange(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestFabricLabelChange)
 {
     Credentials::TestOnlyLocalCertificateAuthority fabricCertAuthority;
 
     chip::TestPersistentStorageDelegate storage;
-    NL_TEST_ASSERT(inSuite, fabricCertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabricCertAuthority.Init().IsSuccess());
 
     constexpr uint16_t kVendorId = 0xFFF1u;
 
     // Initialize a fabric table.
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-    NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+    EXPECT_EQ(fabricTable.FabricCount(), 0);
 
     // First scope: add FabricID 1111, node ID 55
     {
@@ -2225,68 +2158,63 @@ void TestFabricLabelChange(nlTestSuite * inSuite, void * inContext)
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
         ByteSpan rcac = fabricCertAuthority.GetRcac();
         ByteSpan icac = fabricCertAuthority.GetIcac();
         ByteSpan noc  = fabricCertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 1);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(newFabricIndex, 1);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 1);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 55);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 1111);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
-        }
+        ASSERT_NE(fabricInfo, nullptr);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 1);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 55u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 1111u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
     }
     size_t numStorageKeysAfterFirstAdd = storage.GetNumKeys();
-    NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 7); // Metadata, index, 3 certs, 1 opkey, last known good time
+    EXPECT_EQ(numStorageKeysAfterFirstAdd, 7u); // Metadata, index, 3 certs, 1 opkey, last known good time
 
     // Second scope: set FabricLabel to "acme fabric", make sure it cannot be reverted
     {
         // Fabric label starts unset from prior scope
         CharSpan fabricLabel = "placeholder"_span;
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.GetFabricLabel(1, fabricLabel));
-        NL_TEST_ASSERT(inSuite, fabricLabel.size() == 0);
+        EXPECT_EQ(fabricTable.GetFabricLabel(1, fabricLabel), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricLabel.size(), 0u);
 
         // Set a valid name
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SetFabricLabel(1, "acme fabric"_span));
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.GetFabricLabel(1, fabricLabel));
-        NL_TEST_ASSERT(inSuite, fabricLabel.data_equal("acme fabric"_span) == true);
+        EXPECT_EQ(fabricTable.SetFabricLabel(1, "acme fabric"_span), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.GetFabricLabel(1, fabricLabel), CHIP_NO_ERROR);
+        EXPECT_TRUE(fabricLabel.data_equal("acme fabric"_span));
 
         // Revert pending fabric data. Should not revert name since nothing pending.
         fabricTable.RevertPendingFabricData();
 
         fabricLabel = "placeholder"_span;
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.GetFabricLabel(1, fabricLabel));
-        NL_TEST_ASSERT(inSuite, fabricLabel.data_equal("acme fabric"_span) == true);
+        EXPECT_EQ(fabricTable.GetFabricLabel(1, fabricLabel), CHIP_NO_ERROR);
+        EXPECT_TRUE(fabricLabel.data_equal("acme fabric"_span));
 
         // Verify we fail to set too large a label (> kFabricLabelMaxLengthInBytes)
         CharSpan fabricLabelTooBig = "012345678901234567890123456789123456"_span;
-        NL_TEST_ASSERT(inSuite, fabricLabelTooBig.size() > chip::kFabricLabelMaxLengthInBytes);
+        EXPECT_GT(fabricLabelTooBig.size(), chip::kFabricLabelMaxLengthInBytes);
 
-        NL_TEST_ASSERT(inSuite, fabricTable.SetFabricLabel(1, fabricLabelTooBig) == CHIP_ERROR_INVALID_ARGUMENT);
+        EXPECT_EQ(fabricTable.SetFabricLabel(1, fabricLabelTooBig), CHIP_ERROR_INVALID_ARGUMENT);
 
         fabricLabel = "placeholder"_span;
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.GetFabricLabel(1, fabricLabel));
-        NL_TEST_ASSERT(inSuite, fabricLabel.data_equal("acme fabric"_span) == true);
+        EXPECT_EQ(fabricTable.GetFabricLabel(1, fabricLabel), CHIP_NO_ERROR);
+        EXPECT_TRUE(fabricLabel.data_equal("acme fabric"_span));
     }
 
     // Third scope: set fabric label after an update, it sticks, but then goes back after revert
@@ -2296,156 +2224,144 @@ void TestFabricLabelChange(nlTestSuite * inSuite, void * inContext)
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AllocatePendingOperationalKey(chip::MakeOptional(static_cast<FabricIndex>(1)), csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::MakeOptional(static_cast<FabricIndex>(1)), csrSpan),
+                  CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
         ByteSpan icac = fabricCertAuthority.GetIcac();
         ByteSpan noc  = fabricCertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.UpdatePendingFabricWithOperationalKeystore(1, noc, icac));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(1, noc, icac), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
 
         // Validate contents prior to change/revert
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
 
-        if (fabricInfo != nullptr)
-        {
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 1);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 66);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 1111);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
+        ASSERT_NE(fabricInfo, nullptr);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 1);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 66u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 1111u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
 
-            CharSpan fabricLabel = fabricInfo->GetFabricLabel();
-            NL_TEST_ASSERT(inSuite, fabricLabel.data_equal("acme fabric"_span) == true);
-        }
+        CharSpan fabricLabel = fabricInfo->GetFabricLabel();
+        EXPECT_TRUE(fabricLabel.data_equal("acme fabric"_span));
 
         // Update fabric label
-        CharSpan fabricLabel = "placeholder"_span;
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SetFabricLabel(1, "roboto fabric"_span));
+        fabricLabel = "placeholder"_span;
+        EXPECT_EQ(fabricTable.SetFabricLabel(1, "roboto fabric"_span), CHIP_NO_ERROR);
 
         fabricLabel = "placeholder"_span;
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.GetFabricLabel(1, fabricLabel));
-        NL_TEST_ASSERT(inSuite, fabricLabel.data_equal("roboto fabric"_span) == true);
+        EXPECT_EQ(fabricTable.GetFabricLabel(1, fabricLabel), CHIP_NO_ERROR);
+        EXPECT_TRUE(fabricLabel.data_equal("roboto fabric"_span));
 
         // Revert pending fabric data. Should revert name to "acme fabric"
         fabricTable.RevertPendingFabricData();
 
         fabricLabel = "placeholder"_span;
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.GetFabricLabel(1, fabricLabel));
-        NL_TEST_ASSERT(inSuite, fabricLabel.data_equal("acme fabric"_span) == true);
+        EXPECT_EQ(fabricTable.GetFabricLabel(1, fabricLabel), CHIP_NO_ERROR);
+        EXPECT_TRUE(fabricLabel.data_equal("acme fabric"_span));
     }
 }
 
-void TestCompressedFabricId(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestCompressedFabricId)
 {
     // TODO: Write test
 }
 
-void TestFabricLookup(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestFabricLookup)
 {
     // Initialize a fabric table.
     chip::TestPersistentStorageDelegate testStorage;
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
-    NL_TEST_ASSERT(inSuite, LoadTestFabric_Node01_01(inSuite, fabricTable, /* doCommit = */ true) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite,
-                   LoadTestFabric_Node02_01(inSuite, fabricTable, /* doCommit = */ true, FabricTable::AdvertiseIdentity::No) ==
-                       CHIP_NO_ERROR);
+    EXPECT_EQ(LoadTestFabric_Node01_01(fabricTable, /* doCommit = */ true), CHIP_NO_ERROR);
+    EXPECT_EQ(LoadTestFabric_Node02_01(fabricTable, /* doCommit = */ true, FabricTable::AdvertiseIdentity::No), CHIP_NO_ERROR);
 
     // Attempt lookup of the Root01 fabric.
     {
         Crypto::P256PublicKey key;
-        NL_TEST_ASSERT(inSuite, key.Length() >= TestCerts::sTestCert_Root01_PublicKey.size());
+        EXPECT_GE(key.Length(), TestCerts::sTestCert_Root01_PublicKey.size());
         if (key.Length() < TestCerts::sTestCert_Root01_PublicKey.size())
         {
             return;
         }
         memcpy(key.Bytes(), TestCerts::sTestCert_Root01_PublicKey.data(), TestCerts::sTestCert_Root01_PublicKey.size());
         auto fabricInfo = fabricTable.FindFabric(key, 0xFAB000000000001D);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo == nullptr)
-        {
-            return;
-        }
-        NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 1);
-        NL_TEST_ASSERT(inSuite, fabricInfo->ShouldAdvertiseIdentity());
+        ASSERT_NE(fabricInfo, nullptr);
+
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 1);
+        EXPECT_TRUE(fabricInfo->ShouldAdvertiseIdentity());
     }
 
     // Attempt lookup of the Root02 fabric.
     {
         Crypto::P256PublicKey key;
-        NL_TEST_ASSERT(inSuite, key.Length() >= TestCerts::sTestCert_Root02_PublicKey.size());
+        EXPECT_GE(key.Length(), TestCerts::sTestCert_Root02_PublicKey.size());
         if (key.Length() < TestCerts::sTestCert_Root02_PublicKey.size())
         {
             return;
         }
         memcpy(key.Bytes(), TestCerts::sTestCert_Root02_PublicKey.data(), TestCerts::sTestCert_Root02_PublicKey.size());
         auto fabricInfo = fabricTable.FindFabric(key, 0xFAB000000000001D);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo == nullptr)
-        {
-            return;
-        }
-        NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 2);
-        NL_TEST_ASSERT(inSuite, !fabricInfo->ShouldAdvertiseIdentity());
+        ASSERT_NE(fabricInfo, nullptr);
+
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 2);
+        EXPECT_FALSE(fabricInfo->ShouldAdvertiseIdentity());
     }
 
     // Attempt lookup of FabricIndex 0 --> should always fail.
     {
-        NL_TEST_ASSERT(inSuite, fabricTable.FindFabricWithIndex(0) == nullptr);
+        EXPECT_EQ(fabricTable.FindFabricWithIndex(0), nullptr);
     }
 }
 
-void TestFetchCATs(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestFetchCATs)
 {
     // Initialize a fabric table.
     chip::TestPersistentStorageDelegate testStorage;
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&testStorage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&testStorage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
-    NL_TEST_ASSERT(inSuite, LoadTestFabric_Node01_01(inSuite, fabricTable, /* doCommit = */ true) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, LoadTestFabric_Node02_01(inSuite, fabricTable, /* doCommit = */ true) == CHIP_NO_ERROR);
+    EXPECT_EQ(LoadTestFabric_Node01_01(fabricTable, /* doCommit = */ true), CHIP_NO_ERROR);
+    EXPECT_EQ(LoadTestFabric_Node02_01(fabricTable, /* doCommit = */ true), CHIP_NO_ERROR);
 
     // Attempt Fetching fabric index 1 CATs and verify contents.
     {
         CATValues cats;
-        NL_TEST_ASSERT(inSuite, fabricTable.FetchCATs(1, cats) == CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FetchCATs(1, cats), CHIP_NO_ERROR);
         // Test fabric NOCs don't contain any CATs.
-        NL_TEST_ASSERT(inSuite, cats == kUndefinedCATs);
+        EXPECT_EQ(cats, kUndefinedCATs);
     }
 
     // Attempt Fetching fabric index 2 CATs and verify contents.
     {
         CATValues cats;
-        NL_TEST_ASSERT(inSuite, fabricTable.FetchCATs(2, cats) == CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FetchCATs(2, cats), CHIP_NO_ERROR);
         // Test fabric NOCs don't contain any CATs.
-        NL_TEST_ASSERT(inSuite, cats == kUndefinedCATs);
+        EXPECT_EQ(cats, kUndefinedCATs);
     }
 
     // TODO(#20335): Add test cases for NOCs that actually embed CATs
 }
 
 // Validate that adding the same fabric twice fails (same root, same FabricId)
-void TestAddNocRootCollision(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestAddNocRootCollision)
 {
     Credentials::TestOnlyLocalCertificateAuthority fabricCertAuthority;
 
     chip::TestPersistentStorageDelegate storage;
-    NL_TEST_ASSERT(inSuite, fabricCertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabricCertAuthority.Init().IsSuccess());
 
     constexpr uint16_t kVendorId = 0xFFF1u;
 
     // Initialize a fabric table.
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-    NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+    EXPECT_EQ(fabricTable.FabricCount(), 0);
 
     // First scope: add FabricID 1111, node ID 55
     {
@@ -2454,51 +2370,46 @@ void TestAddNocRootCollision(nlTestSuite * inSuite, void * inContext)
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
         ByteSpan rcac = fabricCertAuthority.GetRcac();
         ByteSpan icac = fabricCertAuthority.GetIcac();
         ByteSpan noc  = fabricCertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex,
-                                                                                      FabricTable::AdvertiseIdentity::No));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 1);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex,
+                                                                         FabricTable::AdvertiseIdentity::No),
+                  CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(newFabricIndex, 1);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            NL_TEST_ASSERT(inSuite, !fabricInfo->ShouldAdvertiseIdentity());
+        ASSERT_NE(fabricInfo, nullptr);
+        EXPECT_FALSE(fabricInfo->ShouldAdvertiseIdentity());
 
-            Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+        Credentials::ChipCertificateSet certificates;
+        EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+        EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+        Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 1);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 55);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 1111);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 1);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 55u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 1111u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-            Crypto::P256PublicKey rootPublicKeyOfFabric;
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric));
-            NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-        }
+        Crypto::P256PublicKey rootPublicKeyOfFabric;
+        EXPECT_EQ(fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+        EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
     }
     size_t numStorageKeysAfterFirstAdd = storage.GetNumKeys();
-    NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 7); // Metadata, index, 3 certs, 1 opkey, last known good time
+    EXPECT_EQ(numStorageKeysAfterFirstAdd, 7u); // Metadata, index, 3 certs, 1 opkey, last known good time
 
     // Second scope: add FabricID 1111, node ID 55 *again* --> Collision of Root/FabricID with existing
     {
@@ -2507,51 +2418,45 @@ void TestAddNocRootCollision(nlTestSuite * inSuite, void * inContext)
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
         ByteSpan rcac = fabricCertAuthority.GetRcac();
         ByteSpan icac = fabricCertAuthority.GetIcac();
         ByteSpan noc  = fabricCertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
-        NL_TEST_ASSERT(inSuite,
-                       fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex) ==
-                           CHIP_ERROR_FABRIC_EXISTS);
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex),
+                  CHIP_ERROR_FABRIC_EXISTS);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
 
         CHIP_ERROR err = fabricTable.CommitPendingFabricData();
         printf("err = %" CHIP_ERROR_FORMAT "\n", err.Format());
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
+        EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
 
         // Validate contents of Fabric index 1 still valid
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+        ASSERT_NE(fabricInfo, nullptr);
+        Credentials::ChipCertificateSet certificates;
+        EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+        EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+        Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 1);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 55);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 1111);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 1);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 55u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 1111u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-            Crypto::P256PublicKey rootPublicKeyOfFabric;
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(1, rootPublicKeyOfFabric));
-            NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-        }
+        Crypto::P256PublicKey rootPublicKeyOfFabric;
+        EXPECT_EQ(fabricTable.FetchRootPubkey(1, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+        EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
     }
 
     // Ensure no new persisted keys after failed colliding add
-    NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageKeysAfterFirstAdd);
+    EXPECT_EQ(storage.GetNumKeys(), numStorageKeysAfterFirstAdd);
 
     // Third scope: add FabricID 2222, node ID 55 --> Not colliding, should work. The failing commit above]
     // should have been enough of a revert that this scope succeeds without any additional revert.
@@ -2561,70 +2466,64 @@ void TestAddNocRootCollision(nlTestSuite * inSuite, void * inContext)
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
         ByteSpan rcac = fabricCertAuthority.GetRcac();
         ByteSpan icac = fabricCertAuthority.GetIcac();
         ByteSpan noc  = fabricCertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 2);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 2);
+        EXPECT_EQ(newFabricIndex, 2);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            NL_TEST_ASSERT(inSuite, fabricInfo->ShouldAdvertiseIdentity());
+        ASSERT_NE(fabricInfo, nullptr);
+        EXPECT_TRUE(fabricInfo->ShouldAdvertiseIdentity());
 
-            Credentials::ChipCertificateSet certificates;
-            NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+        Credentials::ChipCertificateSet certificates;
+        EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+        EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+        Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 2);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 55);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 2222);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 2);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 55u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 2222u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-            Crypto::P256PublicKey rootPublicKeyOfFabric;
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric));
-            NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-        }
+        Crypto::P256PublicKey rootPublicKeyOfFabric;
+        EXPECT_EQ(fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+        EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
     }
     size_t numStorageKeysAfterSecondAdd = storage.GetNumKeys();
 
-    NL_TEST_ASSERT(inSuite, numStorageKeysAfterSecondAdd == (numStorageKeysAfterFirstAdd + 5)); // Metadata, 3 certs, 1 opkey
+    EXPECT_EQ(numStorageKeysAfterSecondAdd, (numStorageKeysAfterFirstAdd + 5)); // Metadata, 3 certs, 1 opkey
 }
 
-void TestInvalidChaining(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestInvalidChaining)
 {
     Credentials::TestOnlyLocalCertificateAuthority fabricCertAuthority;
     Credentials::TestOnlyLocalCertificateAuthority differentCertAuthority;
 
     chip::TestPersistentStorageDelegate storage;
-    NL_TEST_ASSERT(inSuite, fabricCertAuthority.Init().IsSuccess());
-    NL_TEST_ASSERT(inSuite, differentCertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabricCertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(differentCertAuthority.Init().IsSuccess());
 
     constexpr uint16_t kVendorId = 0xFFF1u;
 
     // Initialize a fabric table.
     ScopedFabricTable fabricTableHolder;
-    NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+    EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-    NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+    EXPECT_EQ(fabricTable.FabricCount(), 0);
 
     // Try to add fabric with either the NOC not chaining properly, or ICAC not chaining properly, fail,
     // then succeed with proper chaining
@@ -2634,13 +2533,12 @@ void TestInvalidChaining(nlTestSuite * inSuite, void * inContext)
 
         uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
         MutableByteSpan csrSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
         // Generate same cert chain from two different roots
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               differentCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
+        EXPECT_EQ(differentCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                  CHIP_NO_ERROR);
 
         ByteSpan rcac = fabricCertAuthority.GetRcac();
         ByteSpan icac = fabricCertAuthority.GetIcac();
@@ -2649,23 +2547,23 @@ void TestInvalidChaining(nlTestSuite * inSuite, void * inContext)
         ByteSpan otherIcac = differentCertAuthority.GetIcac();
         ByteSpan otherNoc  = differentCertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
 
         // Add with NOC not chaining to ICAC: fail
         {
             FabricIndex newFabricIndex = kUndefinedFabricIndex;
             CHIP_ERROR err = fabricTable.AddNewPendingFabricWithOperationalKeystore(otherNoc, icac, kVendorId, &newFabricIndex);
-            NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+            EXPECT_NE(err, CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.FabricCount(), 0);
         }
 
         // Add with ICAC not chaining to root: fail
         {
             FabricIndex newFabricIndex = kUndefinedFabricIndex;
             CHIP_ERROR err = fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, otherIcac, kVendorId, &newFabricIndex);
-            NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+            EXPECT_NE(err, CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.FabricCount(), 0);
         }
 
         // Add with NOC and ICAC chaining together, but not to root: fail
@@ -2673,8 +2571,8 @@ void TestInvalidChaining(nlTestSuite * inSuite, void * inContext)
             FabricIndex newFabricIndex = kUndefinedFabricIndex;
             CHIP_ERROR err =
                 fabricTable.AddNewPendingFabricWithOperationalKeystore(otherNoc, otherIcac, kVendorId, &newFabricIndex);
-            NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+            EXPECT_NE(err, CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.FabricCount(), 0);
         }
 
         // Revert state, start tests without ICAC
@@ -2683,52 +2581,48 @@ void TestInvalidChaining(nlTestSuite * inSuite, void * inContext)
         // Generate same cert chain from two different roots
 
         csrSpan = MutableByteSpan{ csrBuf };
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricCertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
-        NL_TEST_ASSERT_SUCCESS(
-            inSuite, differentCertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
+        EXPECT_EQ(differentCertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                  CHIP_NO_ERROR);
 
         rcac = fabricCertAuthority.GetRcac();
         noc  = fabricCertAuthority.GetNoc();
 
         otherNoc = differentCertAuthority.GetNoc();
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
 
         // Add with NOC not chaining to RCAC: fail
         {
             FabricIndex newFabricIndex = kUndefinedFabricIndex;
             CHIP_ERROR err =
                 fabricTable.AddNewPendingFabricWithOperationalKeystore(otherNoc, ByteSpan{}, kVendorId, &newFabricIndex);
-            NL_TEST_ASSERT(inSuite, err != CHIP_NO_ERROR);
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+            EXPECT_NE(err, CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.FabricCount(), 0);
         }
 
         // Add properly now
         FabricIndex newFabricIndex = kUndefinedFabricIndex;
-        NL_TEST_ASSERT_SUCCESS(inSuite,
-                               fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, ByteSpan{}, kVendorId, &newFabricIndex));
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-        NL_TEST_ASSERT(inSuite, newFabricIndex == 1);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, ByteSpan{}, kVendorId, &newFabricIndex),
+                  CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(newFabricIndex, 1);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
         // Validate contents
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-        NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-        if (fabricInfo != nullptr)
-        {
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 1);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 55);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 1111);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-            NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
-        }
+        ASSERT_NE(fabricInfo, nullptr);
+        EXPECT_EQ(fabricInfo->GetFabricIndex(), 1);
+        EXPECT_EQ(fabricInfo->GetNodeId(), 55u);
+        EXPECT_EQ(fabricInfo->GetFabricId(), 1111u);
+        EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+        EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
     }
 }
 
-void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestEphemeralKeys)
 {
     // Initialize a fabric table with operational keystore
     {
@@ -2736,18 +2630,18 @@ void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
 
         // Initialize a FabricTable
         ScopedFabricTable fabricTableHolder;
-        NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
         FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
         Crypto::P256ECDSASignature sig;
         uint8_t message[] = { 'm', 's', 'g' };
 
         Crypto::P256Keypair * ephemeralKeypair = fabricTable.AllocateEphemeralKeypairForCASE();
-        NL_TEST_ASSERT(inSuite, ephemeralKeypair != nullptr);
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize(Crypto::ECPKeyTarget::ECDSA));
+        ASSERT_NE(ephemeralKeypair, nullptr);
+        EXPECT_EQ(ephemeralKeypair->Initialize(Crypto::ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDSA_sign_msg(message, sizeof(message), sig));
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Pubkey().ECDSA_validate_msg_signature(message, sizeof(message), sig));
+        EXPECT_EQ(ephemeralKeypair->ECDSA_sign_msg(message, sizeof(message), sig), CHIP_NO_ERROR);
+        EXPECT_EQ(ephemeralKeypair->Pubkey().ECDSA_validate_msg_signature(message, sizeof(message), sig), CHIP_NO_ERROR);
 
         fabricTable.ReleaseEphemeralKeypair(ephemeralKeypair);
     }
@@ -2757,24 +2651,24 @@ void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
         chip::TestPersistentStorageDelegate storage;
 
         chip::Credentials::PersistentStorageOpCertStore opCertStore;
-        NL_TEST_ASSERT_SUCCESS(inSuite, opCertStore.Init(&storage));
+        EXPECT_EQ(opCertStore.Init(&storage), CHIP_NO_ERROR);
 
         FabricTable fabricTable;
         FabricTable::InitParams initParams;
         initParams.storage     = &storage;
         initParams.opCertStore = &opCertStore;
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.Init(initParams));
+        EXPECT_EQ(fabricTable.Init(initParams), CHIP_NO_ERROR);
 
         Crypto::P256ECDSASignature sig;
         uint8_t message[] = { 'm', 's', 'g' };
 
         Crypto::P256Keypair * ephemeralKeypair = fabricTable.AllocateEphemeralKeypairForCASE();
-        NL_TEST_ASSERT(inSuite, ephemeralKeypair != nullptr);
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize(Crypto::ECPKeyTarget::ECDSA));
+        ASSERT_NE(ephemeralKeypair, nullptr);
+        EXPECT_EQ(ephemeralKeypair->Initialize(Crypto::ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDSA_sign_msg(message, sizeof(message), sig));
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Pubkey().ECDSA_validate_msg_signature(message, sizeof(message), sig));
+        EXPECT_EQ(ephemeralKeypair->ECDSA_sign_msg(message, sizeof(message), sig), CHIP_NO_ERROR);
+        EXPECT_EQ(ephemeralKeypair->Pubkey().ECDSA_validate_msg_signature(message, sizeof(message), sig), CHIP_NO_ERROR);
 
         fabricTable.ReleaseEphemeralKeypair(ephemeralKeypair);
 
@@ -2783,7 +2677,7 @@ void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
     }
 }
 
-void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestFabricTable, TestCommitMarker)
 {
     Crypto::P256PublicKey fIdx1PublicKey;
     Crypto::P256PublicKey fIdx2PublicKey;
@@ -2795,7 +2689,7 @@ void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
     // Log verbosity on this test helps debug significantly
     storage.SetLoggingLevel(chip::TestPersistentStorageDelegate::LoggingLevel::kLogMutationAndReads);
 
-    NL_TEST_ASSERT(inSuite, fabricCertAuthority.Init().IsSuccess());
+    EXPECT_TRUE(fabricCertAuthority.Init().IsSuccess());
 
     constexpr uint16_t kVendorId = 0xFFF1u;
 
@@ -2808,11 +2702,11 @@ void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
     {
         // Initialize a fabric table
         ScopedFabricTable fabricTableHolder;
-        NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
         FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-        NL_TEST_ASSERT(inSuite, fabricTable.GetDeletedFabricFromCommitMarker() == kUndefinedFabricIndex);
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
+        EXPECT_EQ(fabricTable.GetDeletedFabricFromCommitMarker(), kUndefinedFabricIndex);
+        EXPECT_EQ(fabricTable.FabricCount(), 0);
 
         // Add Fabric 1111 Node Id 55
         {
@@ -2821,60 +2715,55 @@ void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
 
             uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
             MutableByteSpan csrSpan{ csrBuf };
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+            EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-            NL_TEST_ASSERT_SUCCESS(
-                inSuite, fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+            EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                      CHIP_NO_ERROR);
             ByteSpan rcac = fabricCertAuthority.GetRcac();
             ByteSpan icac = fabricCertAuthority.GetIcac();
             ByteSpan noc  = fabricCertAuthority.GetNoc();
 
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 0);
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+            EXPECT_EQ(fabricTable.FabricCount(), 0);
+            EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
             FabricIndex newFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT_SUCCESS(inSuite,
-                                   fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex));
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-            NL_TEST_ASSERT(inSuite, newFabricIndex == 1);
+            EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.FabricCount(), 1);
+            EXPECT_EQ(newFabricIndex, 1);
 
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.CommitPendingFabricData());
+            EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
 
             // Validate contents
             const auto * fabricInfo = fabricTable.FindFabricWithIndex(1);
-            NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-            if (fabricInfo != nullptr)
-            {
-                Credentials::ChipCertificateSet certificates;
-                NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-                NL_TEST_ASSERT_SUCCESS(inSuite,
-                                       certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-                Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+            ASSERT_NE(fabricInfo, nullptr);
+            Credentials::ChipCertificateSet certificates;
+            EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+            EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 1);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 55);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 1111);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+            EXPECT_EQ(fabricInfo->GetFabricIndex(), 1);
+            EXPECT_EQ(fabricInfo->GetNodeId(), 55u);
+            EXPECT_EQ(fabricInfo->GetFabricId(), 1111u);
+            EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+            EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-                Crypto::P256PublicKey rootPublicKeyOfFabric;
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric));
-                NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-            }
+            Crypto::P256PublicKey rootPublicKeyOfFabric;
+            EXPECT_EQ(fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+            EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
             // Validate that fabric has the correct operational key by verifying a signature
             {
                 Crypto::P256ECDSASignature sig;
                 uint8_t message[] = { 'm', 's', 'g' };
 
-                NL_TEST_ASSERT_SUCCESS(inSuite, VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), fIdx1PublicKey));
+                EXPECT_EQ(VerifyCertificateSigningRequest(csrSpan.data(), csrSpan.size(), fIdx1PublicKey), CHIP_NO_ERROR);
 
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig));
-                NL_TEST_ASSERT_SUCCESS(inSuite, fIdx1PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig));
+                EXPECT_EQ(fabricTable.SignWithOpKeypair(newFabricIndex, ByteSpan{ message }, sig), CHIP_NO_ERROR);
+                EXPECT_EQ(fIdx1PublicKey.ECDSA_validate_msg_signature(&message[0], sizeof(message), sig), CHIP_NO_ERROR);
             }
         }
         numStorageKeysAfterFirstAdd = storage.GetNumKeys();
 
-        NL_TEST_ASSERT(inSuite, numStorageKeysAfterFirstAdd == 7); // Metadata, index, 3 certs, 1 opkey, last known good time
+        EXPECT_EQ(numStorageKeysAfterFirstAdd, 7u); // Metadata, index, 3 certs, 1 opkey, last known good time
 
         // The following test requires test methods not available on all builds.
         // TODO: Debug why some CI jobs don't set it properly.
@@ -2887,53 +2776,49 @@ void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
 
             uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
             MutableByteSpan csrSpan{ csrBuf };
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan));
+            EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-            NL_TEST_ASSERT_SUCCESS(
-                inSuite, fabricCertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus());
+            EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                      CHIP_NO_ERROR);
             ByteSpan rcac = fabricCertAuthority.GetRcac();
             ByteSpan noc  = fabricCertAuthority.GetNoc();
 
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
-            NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcac));
+            EXPECT_EQ(fabricTable.FabricCount(), 1);
+            EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
             FabricIndex newFabricIndex = kUndefinedFabricIndex;
-            NL_TEST_ASSERT_SUCCESS(
-                inSuite, fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, ByteSpan{}, kVendorId, &newFabricIndex));
-            NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 2);
-            NL_TEST_ASSERT(inSuite, newFabricIndex == 2);
+            EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, ByteSpan{}, kVendorId, &newFabricIndex),
+                      CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.FabricCount(), 2);
+            EXPECT_EQ(newFabricIndex, 2);
 
             // Validate contents of pending
             const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
-            NL_TEST_ASSERT(inSuite, fabricInfo != nullptr);
-            if (fabricInfo != nullptr)
-            {
-                Credentials::ChipCertificateSet certificates;
-                NL_TEST_ASSERT_SUCCESS(inSuite, certificates.Init(1));
-                NL_TEST_ASSERT_SUCCESS(inSuite,
-                                       certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)));
-                Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
+            ASSERT_NE(fabricInfo, nullptr);
+            Credentials::ChipCertificateSet certificates;
+            EXPECT_EQ(certificates.Init(1), CHIP_NO_ERROR);
+            EXPECT_EQ(certificates.LoadCert(rcac, BitFlags<CertDecodeFlags>(CertDecodeFlags::kIsTrustAnchor)), CHIP_NO_ERROR);
+            Crypto::P256PublicKey rcacPublicKey(certificates.GetCertSet()[0].mPublicKey);
 
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricIndex() == 2);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetNodeId() == 66);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricId() == 2222);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetVendorId() == kVendorId);
-                NL_TEST_ASSERT(inSuite, fabricInfo->GetFabricLabel().size() == 0);
+            EXPECT_EQ(fabricInfo->GetFabricIndex(), 2);
+            EXPECT_EQ(fabricInfo->GetNodeId(), 66u);
+            EXPECT_EQ(fabricInfo->GetFabricId(), 2222u);
+            EXPECT_EQ(fabricInfo->GetVendorId(), kVendorId);
+            EXPECT_EQ(fabricInfo->GetFabricLabel().size(), 0u);
 
-                Crypto::P256PublicKey rootPublicKeyOfFabric;
-                NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric));
-                NL_TEST_ASSERT(inSuite, rootPublicKeyOfFabric.Matches(rcacPublicKey));
-            }
+            Crypto::P256PublicKey rootPublicKeyOfFabric;
+            EXPECT_EQ(fabricTable.FetchRootPubkey(newFabricIndex, rootPublicKeyOfFabric), CHIP_NO_ERROR);
+            EXPECT_TRUE(rootPublicKeyOfFabric.Matches(rcacPublicKey));
 
             // Make sure no additional storage yet
-            NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageKeysAfterFirstAdd);
+            EXPECT_EQ(storage.GetNumKeys(), numStorageKeysAfterFirstAdd);
 
             // --> FORCE AN ERROR ON COMMIT that will BYPASS commit clean-up (similar to reboot during commit)
             fabricTable.SetForceAbortCommitForTest(true);
-            NL_TEST_ASSERT(inSuite, fabricTable.CommitPendingFabricData() == CHIP_ERROR_INTERNAL);
+            EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_ERROR_INTERNAL);
 
             // Check that there are more keys now, partially committed: at least a Commit Marker (+1)
             // and some more keys from the aborted process.
-            NL_TEST_ASSERT(inSuite, storage.GetNumKeys() > (numStorageKeysAfterFirstAdd + 1));
+            EXPECT_GT(storage.GetNumKeys(), (numStorageKeysAfterFirstAdd + 1));
         }
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
     }
@@ -2945,19 +2830,19 @@ void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
         // Initialize a FabricTable again. Make sure it succeeds in initing.
         ScopedFabricTable fabricTableHolder;
 
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() > (numStorageKeysAfterFirstAdd + 1));
+        EXPECT_GT(storage.GetNumKeys(), (numStorageKeysAfterFirstAdd + 1));
 
-        NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
         FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
         // Make sure that after init, the fabricTable has only 1 fabric
-        NL_TEST_ASSERT_EQUALS(inSuite, fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
 
         // Make sure it caught the last partially committed fabric
-        NL_TEST_ASSERT(inSuite, fabricTable.GetDeletedFabricFromCommitMarker() == 2);
+        EXPECT_EQ(fabricTable.GetDeletedFabricFromCommitMarker(), 2);
 
         // Second read must return kUndefinedFabricIndex
-        NL_TEST_ASSERT(inSuite, fabricTable.GetDeletedFabricFromCommitMarker() == kUndefinedFabricIndex);
+        EXPECT_EQ(fabricTable.GetDeletedFabricFromCommitMarker(), kUndefinedFabricIndex);
 
         {
             // Here we would do other clean-ups (e.g. see Server.cpp that uses the above) and then
@@ -2966,7 +2851,7 @@ void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
         }
 
         // Make sure that all other pending storage got deleted
-        NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == numStorageKeysAfterFirstAdd);
+        EXPECT_EQ(storage.GetNumKeys(), numStorageKeysAfterFirstAdd);
 
         // Verify we can only see 1 fabric with the iterator
         {
@@ -2978,8 +2863,8 @@ void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
                 ++numFabricsIterated;
                 if (iterFabricInfo.GetFabricIndex() == 1)
                 {
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetNodeId() == 55);
-                    NL_TEST_ASSERT(inSuite, iterFabricInfo.GetFabricId() == 1111);
+                    EXPECT_EQ(iterFabricInfo.GetNodeId(), 55u);
+                    EXPECT_EQ(iterFabricInfo.GetFabricId(), 1111u);
                     saw1 = true;
                 }
                 if (iterFabricInfo.GetFabricIndex() == 2)
@@ -2988,90 +2873,12 @@ void TestCommitMarker(nlTestSuite * inSuite, void * inContext)
                 }
             }
 
-            NL_TEST_ASSERT(inSuite, numFabricsIterated == 1);
-            NL_TEST_ASSERT(inSuite, saw1 == true);
-            NL_TEST_ASSERT(inSuite, saw2 == false);
+            EXPECT_EQ(numFabricsIterated, 1u);
+            EXPECT_TRUE(saw1);
+            EXPECT_FALSE(saw2);
         }
     }
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 }
 
-// Test Suite
-
-/**
- *  Test Suite that lists all the test functions.
- */
-// clang-format off
-static const nlTest sTests[] =
-{
-    NL_TEST_DEF("Last Known Good Time Init", TestLastKnownGoodTimeInit),
-    NL_TEST_DEF("Update Last Known Good Time", TestUpdateLastKnownGoodTime),
-    NL_TEST_DEF("Set Last Known Good Time", TestSetLastKnownGoodTime),
-    NL_TEST_DEF("Test basic AddNOC flow", TestBasicAddNocUpdateNocFlow),
-    NL_TEST_DEF("Test adding multiple fabrics that chain to same root, different fabric ID", TestAddMultipleSameRootDifferentFabricId),
-    NL_TEST_DEF("Test adding multiple fabrics that chain to different roots, same fabric ID", TestAddMultipleSameFabricIdDifferentRoot),
-    NL_TEST_DEF("Validate fabrics are loaded from persistence at FabricTable::init", TestPersistence),
-    NL_TEST_DEF("Test fail-safe handling during AddNOC", TestAddNocFailSafe),
-    NL_TEST_DEF("Test fail-safe handling during UpdateNoc", TestUpdateNocFailSafe),
-    NL_TEST_DEF("Test fail-safe handling for root cert", TestAddRootCertFailSafe),
-    NL_TEST_DEF("Test interlock sequencing errors", TestSequenceErrors),
-    NL_TEST_DEF("Test fabric label changes", TestFabricLabelChange),
-    NL_TEST_DEF("Test compressed fabric ID is properly generated", TestCompressedFabricId),
-    NL_TEST_DEF("Test fabric lookup by <root public key, fabric ID>", TestFabricLookup),
-    NL_TEST_DEF("Test Fetching CATs", TestFetchCATs),
-    NL_TEST_DEF("Test AddNOC root collision", TestAddNocRootCollision),
-    NL_TEST_DEF("Test invalid chaining in AddNOC and UpdateNOC", TestInvalidChaining),
-    NL_TEST_DEF("Test ephemeral keys allocation", TestEphemeralKeys),
-    NL_TEST_DEF("Test proper detection of Commit Marker on init", TestCommitMarker),
-    NL_TEST_DEF("Test colliding fabrics in the fabric table", TestCollidingFabrics),
-
-    NL_TEST_SENTINEL()
-};
-
-// clang-format on
-
-int TestFabricTable_Setup(void * inContext);
-int TestFabricTable_Teardown(void * inContext);
-
-// clang-format off
-static nlTestSuite sSuite =
-{
-    "Test-CHIP-FabricTable",
-    &sTests[0],
-    TestFabricTable_Setup,
-    TestFabricTable_Teardown,
-};
-// clang-format on
-
-/**
- *  Set up the test suite.
- */
-int TestFabricTable_Setup(void * inContext)
-{
-    DeviceLayer::SetConfigurationMgr(&DeviceLayer::ConfigurationManagerImpl::GetDefaultInstance());
-    return chip::Platform::MemoryInit() == CHIP_NO_ERROR ? SUCCESS : FAILURE;
-}
-
-/**
- *  Tear down the test suite.
- */
-int TestFabricTable_Teardown(void * inContext)
-{
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
 } // namespace
-
-/**
- *  Main
- */
-int TestFabricTable()
-{
-    // Run test suit against one context
-    nlTestRunner(&sSuite, nullptr);
-
-    return (nlTestRunnerStats(&sSuite));
-}
-
-CHIP_REGISTER_TEST_SUITE(TestFabricTable)

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -18,11 +18,10 @@
 
 #include <credentials/GroupDataProviderImpl.h>
 #include <crypto/DefaultSessionKeystore.h>
+#include <gtest/gtest.h>
 #include <lib/core/TLV.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
-#include <lib/support/UnitTestRegistration.h>
-#include <nlunit-test.h>
 #include <platform/KeyValueStoreManager.h>
 #include <set>
 #include <string.h>
@@ -187,41 +186,100 @@ bool CompareKeySets(const KeySet & retrievedKeySet, const KeySet & keyset2)
     return true;
 }
 
-void TestStorageDelegate(nlTestSuite * apSuite, void * apContext)
+struct TestGroupDataProvider : public ::testing::Test
+{
+
+    static chip::TestPersistentStorageDelegate sDelegate;
+    static chip::Crypto::DefaultSessionKeystore sSessionKeystore;
+    static GroupDataProviderImpl sProvider;
+
+    constexpr static EpochKey kEpochKeys0[] = {
+        { 0x0000000000000000, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
+        { 0x1111111111111111, { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f } },
+        { 0x2222222222222222, { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f } }
+    };
+    constexpr static EpochKey kEpochKeys1[] = {
+        { 0x3333333333333333, { 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f } },
+        { 0x4444444444444444, { 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f } },
+        { 0x5555555555555555, { 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f } },
+    };
+    constexpr static EpochKey kEpochKeys2[] = {
+        { 0xaaaaaaaaaaaaaaaa, { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf } },
+        { 0xbbbbbbbbbbbbbbbb, { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf } },
+        { 0xcccccccccccccccc, { 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf } },
+    };
+    constexpr static EpochKey kEpochKeys3[] = {
+        { 0xdddddddddddddddd, { 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf } },
+        { 0xeeeeeeeeeeeeeeee, { 0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef } },
+        { 0xffffffffffffffff, { 0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff } },
+    };
+    static void SetUpTestSuite()
+    {
+
+        EXPECT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
+
+        // Initialize Group Data Provider
+        sProvider.SetStorageDelegate(&sDelegate);
+        sProvider.SetSessionKeystore(&sSessionKeystore);
+        sProvider.SetListener(&chip::app::TestGroups::sListener);
+        EXPECT_EQ(sProvider.Init(), CHIP_NO_ERROR);
+        SetGroupDataProvider(&sProvider);
+
+        memcpy(chip::app::TestGroups::kKeySet0.epoch_keys, kEpochKeys0, sizeof(kEpochKeys0));
+        memcpy(chip::app::TestGroups::kKeySet1.epoch_keys, kEpochKeys1, sizeof(kEpochKeys1));
+        memcpy(chip::app::TestGroups::kKeySet2.epoch_keys, kEpochKeys2, sizeof(kEpochKeys2));
+        memcpy(chip::app::TestGroups::kKeySet3.epoch_keys, kEpochKeys3, sizeof(kEpochKeys3));
+    }
+    static void TearDownTestSuite()
+    {
+        GroupDataProvider * provider = GetGroupDataProvider();
+        if (nullptr != provider)
+        {
+            provider->Finish();
+        }
+        chip::Platform::MemoryShutdown();
+    }
+};
+
+chip::TestPersistentStorageDelegate TestGroupDataProvider::sDelegate;
+chip::Crypto::DefaultSessionKeystore TestGroupDataProvider::sSessionKeystore;
+GroupDataProviderImpl TestGroupDataProvider::sProvider(kMaxGroupsPerFabric, kMaxGroupKeysPerFabric);
+
+TEST_F(TestGroupDataProvider, TestStorageDelegate)
 {
     chip::TestPersistentStorageDelegate delegate;
 
     char out[128];
     uint16_t size = static_cast<uint16_t>(sizeof(out));
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND == delegate.SyncGetKeyValue(kKey1, out, size));
+    EXPECT_EQ(CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND, delegate.SyncGetKeyValue(kKey1, out, size));
 
     size = static_cast<uint16_t>(kSize1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == delegate.SyncSetKeyValue(kKey1, kValue1, size));
+    EXPECT_EQ(delegate.SyncSetKeyValue(kKey1, kValue1, size), CHIP_NO_ERROR);
 
     size = static_cast<uint16_t>(sizeof(out));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == delegate.SyncGetKeyValue(kKey1, out, size));
-    NL_TEST_ASSERT(apSuite, size == kSize1);
-    NL_TEST_ASSERT(apSuite, !memcmp(out, kValue1, kSize1));
+    EXPECT_EQ(delegate.SyncGetKeyValue(kKey1, out, size), CHIP_NO_ERROR);
+    EXPECT_EQ(size, kSize1);
+    EXPECT_FALSE(memcmp(out, kValue1, kSize1));
 
     size = static_cast<uint16_t>(kSize2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == delegate.SyncSetKeyValue(kKey1, kValue2, size));
+    EXPECT_EQ(delegate.SyncSetKeyValue(kKey1, kValue2, size), CHIP_NO_ERROR);
 
     size = static_cast<uint16_t>(sizeof(out));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == delegate.SyncGetKeyValue(kKey1, out, size));
-    NL_TEST_ASSERT(apSuite, size == kSize2);
-    NL_TEST_ASSERT(apSuite, !memcmp(out, kValue2, kSize2));
+    EXPECT_EQ(delegate.SyncGetKeyValue(kKey1, out, size), CHIP_NO_ERROR);
+    EXPECT_EQ(size, kSize2);
+    EXPECT_FALSE(memcmp(out, kValue2, kSize2));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == delegate.SyncDeleteKeyValue(kKey1));
+    EXPECT_EQ(delegate.SyncDeleteKeyValue(kKey1), CHIP_NO_ERROR);
 
     size = static_cast<uint16_t>(sizeof(out));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND == delegate.SyncGetKeyValue(kKey1, out, size));
+    EXPECT_EQ(CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND, delegate.SyncGetKeyValue(kKey1, out, size));
 }
 
-void TestGroupInfo(nlTestSuite * apSuite, void * apContext)
+TEST_F(TestGroupDataProvider, TestGroupInfo)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, provider);
+    EXPECT_TRUE(provider);
 
     // Reset test
     ResetProvider(provider);
@@ -233,114 +291,114 @@ void TestGroupInfo(nlTestSuite * apSuite, void * apContext)
     sListener.Reset();
 
     // Out-of-order
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_ARGUMENT == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_1));
+    EXPECT_EQ(CHIP_ERROR_INVALID_ARGUMENT, provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_1));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo2_1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo2_2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 2, kGroupInfo2_3));
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo2_1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo2_2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 2, kGroupInfo2_3), CHIP_NO_ERROR);
 
     // Duplicated
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupInfoAt(kFabric1, 3, kGroupInfo1_1));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupInfoAt(kFabric2, 3, kGroupInfo2_3));
+    EXPECT_EQ(CHIP_ERROR_DUPLICATE_KEY_ID, provider->SetGroupInfoAt(kFabric1, 3, kGroupInfo1_1));
+    EXPECT_EQ(CHIP_ERROR_DUPLICATE_KEY_ID, provider->SetGroupInfoAt(kFabric2, 3, kGroupInfo2_3));
 
     // Get Group Info
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_INDEX == provider->GetGroupInfoAt(kUndefinedFabricIndex, 0, group));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupInfoAt(kFabric2, 999, group));
+    EXPECT_EQ(CHIP_ERROR_INVALID_FABRIC_INDEX, provider->GetGroupInfoAt(kUndefinedFabricIndex, 0, group));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupInfoAt(kFabric2, 999, group));
 
-    NL_TEST_ASSERT(apSuite, sListener.latest == kGroupInfo2_3);
-    NL_TEST_ASSERT(apSuite, 6 == sListener.added_count);
-    NL_TEST_ASSERT(apSuite, 0 == sListener.removed_count);
+    EXPECT_EQ(sListener.latest, kGroupInfo2_3);
+    EXPECT_EQ(sListener.added_count, 6u);
+    EXPECT_EQ(sListener.removed_count, 0u);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 2, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 1, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 0, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 1, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 0, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 2, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_3);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 2, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo2_3);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 1, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo2_2);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 0, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo2_1);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric1, 1, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo1_2);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric1, 0, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo1_1);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric1, 2, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo1_3);
 
     // Remove Groups
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveGroupInfo(kFabric1, kGroup3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveGroupInfoAt(kFabric2, 0));
-    NL_TEST_ASSERT(apSuite, sListener.latest == kGroupInfo2_1);
-    NL_TEST_ASSERT(apSuite, 6 == sListener.added_count);
-    NL_TEST_ASSERT(apSuite, 2 == sListener.removed_count);
+    EXPECT_EQ(provider->RemoveGroupInfo(kFabric1, kGroup3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->RemoveGroupInfoAt(kFabric2, 0), CHIP_NO_ERROR);
+    EXPECT_EQ(sListener.latest, kGroupInfo2_1);
+    EXPECT_EQ(sListener.added_count, 6u);
+    EXPECT_EQ(sListener.removed_count, 2u);
 
     // Remaining entries shift up
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupInfoAt(kFabric2, 2, group));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 1, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 0, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 1, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 0, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_1);
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupInfoAt(kFabric1, 3, group));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupInfoAt(kFabric2, 2, group));
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 1, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo2_3);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 0, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo2_2);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric1, 1, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo1_2);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric1, 0, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo1_1);
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupInfoAt(kFabric1, 3, group));
 
     // Overwrite with new group
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo3_4));
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo3_4), CHIP_NO_ERROR);
     // Replace existing group (implicit group remove)
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo3_4));
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo3_4), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 2, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo3_4);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric1, 2, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo3_4);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 0, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo3_4);
-    NL_TEST_ASSERT(apSuite, sListener.latest == kGroupInfo3_4);
-    NL_TEST_ASSERT(apSuite, 8 == sListener.added_count);
-    NL_TEST_ASSERT(apSuite, 3 == sListener.removed_count);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 0, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo3_4);
+    EXPECT_EQ(sListener.latest, kGroupInfo3_4);
+    EXPECT_EQ(sListener.added_count, 8u);
+    EXPECT_EQ(sListener.removed_count, 3u);
 
     // Overwrite existing group, index must match
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo2_2));
+    EXPECT_EQ(CHIP_ERROR_DUPLICATE_KEY_ID, provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_1));
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo2_2), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo3_4));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo1_3));
+    EXPECT_EQ(CHIP_ERROR_DUPLICATE_KEY_ID, provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo3_4));
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo1_3), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 1, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_2);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric1, 1, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo2_2);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 1, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_3);
-    NL_TEST_ASSERT(apSuite, sListener.latest == kGroupInfo3_4);
-    NL_TEST_ASSERT(apSuite, 8 == sListener.added_count);
-    NL_TEST_ASSERT(apSuite, 3 == sListener.removed_count);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 1, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo1_3);
+    EXPECT_EQ(sListener.latest, kGroupInfo3_4);
+    EXPECT_EQ(sListener.added_count, 8u);
+    EXPECT_EQ(sListener.removed_count, 3u);
 
     // By group_id
 
     // Override existing
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfo(kFabric1, kGroupInfo3_5));
+    EXPECT_EQ(provider->SetGroupInfo(kFabric1, kGroupInfo3_5), CHIP_NO_ERROR);
     // New group
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfo(kFabric2, kGroupInfo3_2));
+    EXPECT_EQ(provider->SetGroupInfo(kFabric2, kGroupInfo3_2), CHIP_NO_ERROR);
     // Not found
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupInfo(kFabric2, kGroup5, group));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupInfo(kFabric2, kGroup5, group));
     // Existing
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfo(kFabric2, kGroup2, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo3_2);
-    NL_TEST_ASSERT(apSuite, sListener.latest == kGroupInfo3_2);
-    NL_TEST_ASSERT(apSuite, 9 == sListener.added_count);
-    NL_TEST_ASSERT(apSuite, 3 == sListener.removed_count);
+    EXPECT_EQ(provider->GetGroupInfo(kFabric2, kGroup2, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo3_2);
+    EXPECT_EQ(sListener.latest, kGroupInfo3_2);
+    EXPECT_EQ(sListener.added_count, 9u);
+    EXPECT_EQ(sListener.removed_count, 3u);
 }
 
-void TestGroupInfoIterator(nlTestSuite * apSuite, void * apContext)
+TEST_F(TestGroupDataProvider, TestGroupInfoIterator)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, provider);
+    EXPECT_TRUE(provider);
 
     // Reset test
     ResetProvider(provider);
@@ -349,12 +407,12 @@ void TestGroupInfoIterator(nlTestSuite * apSuite, void * apContext)
 
     // Set Group Info
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo2_1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo2_3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 2, kGroupInfo2_2));
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo2_1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo2_3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 2, kGroupInfo2_2), CHIP_NO_ERROR);
 
     // Iterate fabric 1
 
@@ -363,17 +421,14 @@ void TestGroupInfoIterator(nlTestSuite * apSuite, void * apContext)
 
     auto it  = provider->IterateGroupInfo(kFabric1);
     size_t i = 0;
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
+    ASSERT_TRUE(it);
+    EXPECT_EQ(expected_f1_count, it->Count());
+    while (it->Next(group) && i < expected_f1_count)
     {
-        NL_TEST_ASSERT(apSuite, expected_f1_count == it->Count());
-        while (it->Next(group) && i < expected_f1_count)
-        {
-            NL_TEST_ASSERT(apSuite, expected_f1[i++] == group);
-        }
-        NL_TEST_ASSERT(apSuite, i == it->Count());
-        it->Release();
+        EXPECT_EQ(expected_f1[i++], group);
     }
+    EXPECT_EQ(i, it->Count());
+    it->Release();
 
     // Iterate fabric 2
 
@@ -381,24 +436,21 @@ void TestGroupInfoIterator(nlTestSuite * apSuite, void * apContext)
     size_t expected_f2_count = sizeof(expected_f2) / sizeof(GroupInfo);
 
     it = provider->IterateGroupInfo(kFabric2);
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
+    ASSERT_TRUE(it);
+    i = 0;
+    EXPECT_EQ(expected_f2_count, it->Count());
+    while (it->Next(group) && i < expected_f2_count)
     {
-        i = 0;
-        NL_TEST_ASSERT(apSuite, expected_f2_count == it->Count());
-        while (it->Next(group) && i < expected_f2_count)
-        {
-            NL_TEST_ASSERT(apSuite, expected_f2[i++] == group);
-        }
-        NL_TEST_ASSERT(apSuite, i == it->Count());
-        it->Release();
+        EXPECT_EQ(expected_f2[i++], group);
     }
+    EXPECT_EQ(i, it->Count());
+    it->Release();
 }
 
-void TestEndpoints(nlTestSuite * apSuite, void * apContext)
+TEST_F(TestGroupDataProvider, TestEndpoints)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, provider);
+    EXPECT_TRUE(provider);
 
     // Reset test
     ResetProvider(provider);
@@ -407,92 +459,92 @@ void TestEndpoints(nlTestSuite * apSuite, void * apContext)
 
     // Existing groups
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_3));
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_3), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3));
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
 
     // New groups
 
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup2, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup4, kEndpointId3));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric2, kGroup1, kEndpointId0));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric2, kGroup2, kEndpointId1));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric2, kGroup4, kEndpointId3));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup2, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup4, kEndpointId3));
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup1, kEndpointId0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup2, kEndpointId1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup4, kEndpointId3), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup2, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup4, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup1, kEndpointId0));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup2, kEndpointId1));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup4, kEndpointId3));
 
     // Remove
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->RemoveEndpoint(kFabric1, kGroup1, kEndpointId4));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveEndpoint(kFabric1, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveEndpoint(kFabric1, kGroup2, kEndpointId3));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->RemoveEndpoint(kFabric1, kGroup1, kEndpointId4));
+    EXPECT_EQ(provider->RemoveEndpoint(kFabric1, kGroup1, kEndpointId0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->RemoveEndpoint(kFabric1, kGroup2, kEndpointId3), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->RemoveEndpoint(kFabric2, kGroup5, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveEndpoint(kFabric2, kGroup2, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveEndpoint(kFabric2, kGroup3, kEndpointId2));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->RemoveEndpoint(kFabric2, kGroup5, kEndpointId0));
+    EXPECT_EQ(provider->RemoveEndpoint(kFabric2, kGroup2, kEndpointId1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->RemoveEndpoint(kFabric2, kGroup3, kEndpointId2), CHIP_NO_ERROR);
 
     // Check removed
 
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
 
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup2, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup4, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup1, kEndpointId0));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric2, kGroup2, kEndpointId1));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup4, kEndpointId3));
 
     // Remove All
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup3, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup4, kEndpointId3));
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup3, kEndpointId3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup4, kEndpointId3), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup3, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup4, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup3, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup4, kEndpointId3));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveEndpoint(kFabric1, kEndpointId3));
+    EXPECT_EQ(provider->RemoveEndpoint(kFabric1, kEndpointId3), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup3, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup4, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId3));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup3, kEndpointId3));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup4, kEndpointId3));
 }
 
-void TestEndpointIterator(nlTestSuite * apSuite, void * apContext)
+TEST_F(TestGroupDataProvider, TestEndpointIterator)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, provider);
+    EXPECT_TRUE(provider);
 
     // Reset test
     ResetProvider(provider);
@@ -501,18 +553,18 @@ void TestEndpointIterator(nlTestSuite * apSuite, void * apContext)
 
     // Set Endpoints
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId4));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3));
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId4), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId4));
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId4), CHIP_NO_ERROR);
 
     // Iterate fabric 1
 
@@ -523,20 +575,17 @@ void TestEndpointIterator(nlTestSuite * apSuite, void * apContext)
 
     auto it      = provider->IterateEndpoints(kFabric1);
     size_t count = 0;
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
+    ASSERT_TRUE(it);
+    GroupEndpoint output;
+    EXPECT_EQ(expected_f1.size(), it->Count());
+    while (it->Next(output) && count < expected_f1.size())
     {
-        GroupEndpoint output;
-        NL_TEST_ASSERT(apSuite, expected_f1.size() == it->Count());
-        while (it->Next(output) && count < expected_f1.size())
-        {
-            std::pair<chip::GroupId, chip::EndpointId> mapping(output.group_id, output.endpoint_id);
-            NL_TEST_ASSERT(apSuite, expected_f1.count(mapping) > 0);
-            count++;
-        }
-        NL_TEST_ASSERT(apSuite, count == it->Count());
-        it->Release();
+        std::pair<chip::GroupId, chip::EndpointId> mapping(output.group_id, output.endpoint_id);
+        EXPECT_GT(expected_f1.count(mapping), 0u);
+        count++;
     }
+    EXPECT_EQ(count, it->Count());
+    it->Release();
 
     // Iterate fabric 2
 
@@ -546,27 +595,23 @@ void TestEndpointIterator(nlTestSuite * apSuite, void * apContext)
     };
 
     it = provider->IterateEndpoints(kFabric2);
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
+    ASSERT_TRUE(it);
+    count = 0;
+    EXPECT_EQ(expected_f2.size(), it->Count());
+    while (it->Next(output) && count < expected_f2.size())
     {
-        count = 0;
-        GroupEndpoint output;
-        NL_TEST_ASSERT(apSuite, expected_f2.size() == it->Count());
-        while (it->Next(output) && count < expected_f2.size())
-        {
-            std::pair<chip::GroupId, chip::EndpointId> mapping(output.group_id, output.endpoint_id);
-            NL_TEST_ASSERT(apSuite, expected_f2.count(mapping) > 0);
-            count++;
-        }
-        NL_TEST_ASSERT(apSuite, count == it->Count());
-        it->Release();
+        std::pair<chip::GroupId, chip::EndpointId> mapping(output.group_id, output.endpoint_id);
+        EXPECT_GT(expected_f2.count(mapping), 0u);
+        count++;
     }
+    EXPECT_EQ(count, it->Count());
+    it->Release();
 }
 
-void TestGroupKeys(nlTestSuite * apSuite, void * apContext)
+TEST_F(TestGroupDataProvider, TestGroupKeys)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, provider);
+    EXPECT_TRUE(provider);
 
     // Reset test
     ResetProvider(provider);
@@ -576,101 +621,101 @@ void TestGroupKeys(nlTestSuite * apSuite, void * apContext)
     // Set Group Info
 
     // Out-of-order
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_ARGUMENT == provider->SetGroupKeyAt(kFabric1, 2, kGroup1Keyset0));
+    EXPECT_EQ(CHIP_ERROR_INVALID_ARGUMENT, provider->SetGroupKeyAt(kFabric1, 2, kGroup1Keyset0));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 0, kGroup1Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 1, kGroup1Keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 2, kGroup1Keyset2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 3, kGroup1Keyset3));
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 0, kGroup1Keyset0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 1, kGroup1Keyset1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 2, kGroup1Keyset2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 3, kGroup1Keyset3), CHIP_NO_ERROR);
     // Duplicated
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupKeyAt(kFabric1, 4, kGroup1Keyset2));
+    EXPECT_EQ(CHIP_ERROR_DUPLICATE_KEY_ID, provider->SetGroupKeyAt(kFabric1, 4, kGroup1Keyset2));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 1, kGroup2Keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 2, kGroup2Keyset2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 3, kGroup2Keyset3));
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 1, kGroup2Keyset1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 2, kGroup2Keyset2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 3, kGroup2Keyset3), CHIP_NO_ERROR);
     // Duplicated
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupKeyAt(kFabric2, 4, kGroup2Keyset0));
+    EXPECT_EQ(CHIP_ERROR_DUPLICATE_KEY_ID, provider->SetGroupKeyAt(kFabric2, 4, kGroup2Keyset0));
 
     // Get Group Info
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_INVALID_FABRIC_INDEX == provider->GetGroupKeyAt(kUndefinedFabricIndex, 0, pair));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupKeyAt(kFabric2, 999, pair));
+    EXPECT_EQ(CHIP_ERROR_INVALID_FABRIC_INDEX, provider->GetGroupKeyAt(kUndefinedFabricIndex, 0, pair));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupKeyAt(kFabric2, 999, pair));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 3, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 2, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 1, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 0, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset0);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric1, 3, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup1Keyset3);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric1, 2, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup1Keyset2);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric1, 1, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup1Keyset1);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric1, 0, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup1Keyset0);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 3, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 2, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 1, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 0, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset0);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 3, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup2Keyset3);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 2, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup2Keyset2);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 1, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup2Keyset1);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 0, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup2Keyset0);
 
     // Remove Groups (remaining entries shift up)
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveGroupKeyAt(kFabric1, 2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveGroupKeyAt(kFabric2, 0));
+    EXPECT_EQ(provider->RemoveGroupKeyAt(kFabric1, 2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->RemoveGroupKeyAt(kFabric2, 0), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupKeyAt(kFabric1, 3, pair));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 2, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 1, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 0, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup1Keyset0);
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupKeyAt(kFabric1, 3, pair));
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric1, 2, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup1Keyset3);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric1, 1, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup1Keyset1);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric1, 0, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup1Keyset0);
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupKeyAt(kFabric2, 3, pair));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 2, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 1, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 0, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset1);
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupKeyAt(kFabric2, 3, pair));
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 2, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup2Keyset3);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 1, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup2Keyset2);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 0, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup2Keyset1);
 
     // Overwrite, (group_id, keyset_id) must be unique
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupKeyAt(kFabric1, 2, kGroup1Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 2, kGroup3Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_DUPLICATE_KEY_ID == provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 0, kGroup3Keyset1));
+    EXPECT_EQ(CHIP_ERROR_DUPLICATE_KEY_ID, provider->SetGroupKeyAt(kFabric1, 2, kGroup1Keyset0));
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 2, kGroup3Keyset0), CHIP_NO_ERROR);
+    EXPECT_EQ(CHIP_ERROR_DUPLICATE_KEY_ID, provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset2));
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 0, kGroup3Keyset1), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric1, 2, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup3Keyset0);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric1, 2, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup3Keyset0);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 0, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup3Keyset1);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 0, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup3Keyset1);
 
     // Remove all
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveGroupKeys(kFabric1));
+    EXPECT_EQ(provider->RemoveGroupKeys(kFabric1), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupKeyAt(kFabric1, 3, pair));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupKeyAt(kFabric1, 2, pair));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupKeyAt(kFabric1, 1, pair));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupKeyAt(kFabric1, 0, pair));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupKeyAt(kFabric1, 3, pair));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupKeyAt(kFabric1, 2, pair));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupKeyAt(kFabric1, 1, pair));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupKeyAt(kFabric1, 0, pair));
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupKeyAt(kFabric2, 3, pair));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 2, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 1, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup2Keyset2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupKeyAt(kFabric2, 0, pair));
-    NL_TEST_ASSERT(apSuite, pair == kGroup3Keyset1);
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupKeyAt(kFabric2, 3, pair));
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 2, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup2Keyset3);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 1, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup2Keyset2);
+    EXPECT_EQ(provider->GetGroupKeyAt(kFabric2, 0, pair), CHIP_NO_ERROR);
+    EXPECT_EQ(pair, kGroup3Keyset1);
 }
 
-void TestGroupKeyIterator(nlTestSuite * apSuite, void * apContext)
+TEST_F(TestGroupDataProvider, TestGroupKeyIterator)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, provider);
+    EXPECT_TRUE(provider);
 
     // Reset test
     ResetProvider(provider);
@@ -679,17 +724,17 @@ void TestGroupKeyIterator(nlTestSuite * apSuite, void * apContext)
 
     // Set Group Info
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 0, kGroup3Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 1, kGroup3Keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 2, kGroup3Keyset2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 3, kGroup3Keyset3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 4, kGroup1Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR != provider->SetGroupKeyAt(kFabric1, 5, kGroup1Keyset1));
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 0, kGroup3Keyset0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 1, kGroup3Keyset1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 2, kGroup3Keyset2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 3, kGroup3Keyset3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 4, kGroup1Keyset0), CHIP_NO_ERROR);
+    EXPECT_NE(CHIP_NO_ERROR, provider->SetGroupKeyAt(kFabric1, 5, kGroup1Keyset1));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 1, kGroup2Keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 2, kGroup2Keyset2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 3, kGroup2Keyset3));
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 1, kGroup2Keyset1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 2, kGroup2Keyset2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 3, kGroup2Keyset3), CHIP_NO_ERROR);
 
     // Iterate fabric 1
 
@@ -698,17 +743,14 @@ void TestGroupKeyIterator(nlTestSuite * apSuite, void * apContext)
 
     auto it      = provider->IterateGroupKeys(kFabric1);
     size_t count = 0;
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
+    ASSERT_TRUE(it);
+    EXPECT_EQ(expected_f1_count, it->Count());
+    while (it->Next(pair) && count < expected_f1_count)
     {
-        NL_TEST_ASSERT(apSuite, expected_f1_count == it->Count());
-        while (it->Next(pair) && count < expected_f1_count)
-        {
-            NL_TEST_ASSERT(apSuite, expected_f1[count++] == pair);
-        }
-        NL_TEST_ASSERT(apSuite, count == it->Count());
-        it->Release();
+        EXPECT_EQ(expected_f1[count++], pair);
     }
+    EXPECT_EQ(count, it->Count());
+    it->Release();
 
     // Iterate fabric 2
 
@@ -716,24 +758,21 @@ void TestGroupKeyIterator(nlTestSuite * apSuite, void * apContext)
     size_t expected_f2_count = sizeof(expected_f2) / sizeof(GroupKey);
 
     it = provider->IterateGroupKeys(kFabric2);
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
+    ASSERT_TRUE(it);
+    count = 0;
+    EXPECT_EQ(expected_f2_count, it->Count());
+    while (it->Next(pair) && count < expected_f2_count)
     {
-        count = 0;
-        NL_TEST_ASSERT(apSuite, expected_f2_count == it->Count());
-        while (it->Next(pair) && count < expected_f2_count)
-        {
-            NL_TEST_ASSERT(apSuite, expected_f2[count++] == pair);
-        }
-        NL_TEST_ASSERT(apSuite, count == it->Count());
-        it->Release();
+        EXPECT_EQ(expected_f2[count++], pair);
     }
+    EXPECT_EQ(count, it->Count());
+    it->Release();
 }
 
-void TestKeySets(nlTestSuite * apSuite, void * apContext)
+TEST_F(TestGroupDataProvider, TestKeySets)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, provider);
+    EXPECT_TRUE(provider);
 
     // Reset test
     ResetProvider(provider);
@@ -742,104 +781,104 @@ void TestKeySets(nlTestSuite * apSuite, void * apContext)
 
     // Add KeySets
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR != provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet4));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet1));
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet3), CHIP_NO_ERROR);
+    EXPECT_NE(CHIP_NO_ERROR, provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet4));
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet1), CHIP_NO_ERROR);
 
     // Get KeySets
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId3, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet3));
+    EXPECT_EQ(provider->GetKeySet(kFabric1, kKeysetId3, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet3));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
+    EXPECT_EQ(provider->GetKeySet(kFabric1, kKeysetId1, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet1));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
+    EXPECT_EQ(provider->GetKeySet(kFabric1, kKeysetId0, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet0));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId2, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet2));
+    EXPECT_EQ(provider->GetKeySet(kFabric1, kKeysetId2, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet2));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId3, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet3));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId3, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet3));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId2, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet2));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId2, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet2));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId1, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet1));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId0, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet0));
 
     // Remove Keysets
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->RemoveKeySet(kFabric1, 0xffff));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->RemoveKeySet(kFabric1, 0xffff));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric1, kKeysetId1)); // First
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric1, kKeysetId3)); // Last
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric2, kKeysetId2)); // Middle
+    EXPECT_EQ(provider->RemoveKeySet(kFabric1, kKeysetId1), CHIP_NO_ERROR); // First
+    EXPECT_EQ(provider->RemoveKeySet(kFabric1, kKeysetId3), CHIP_NO_ERROR); // Last
+    EXPECT_EQ(provider->RemoveKeySet(kFabric2, kKeysetId2), CHIP_NO_ERROR); // Middle
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId3, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric1, kKeysetId3, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric1, kKeysetId1, keyset));
+    EXPECT_EQ(provider->GetKeySet(kFabric1, kKeysetId0, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet0));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId2, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet2));
+    EXPECT_EQ(provider->GetKeySet(kFabric1, kKeysetId2, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet2));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId3, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet3));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId3, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet3));
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric2, kKeysetId2, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric2, kKeysetId2, keyset));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId1, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet1));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId0, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet0));
 
     // Remove all
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->RemoveKeySet(kFabric1, kKeysetId3));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->RemoveKeySet(kFabric1, kKeysetId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric1, kKeysetId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric1, kKeysetId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric2, kKeysetId3));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->RemoveKeySet(kFabric2, kKeysetId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric2, kKeysetId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric2, kKeysetId0));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->RemoveKeySet(kFabric1, kKeysetId3));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->RemoveKeySet(kFabric1, kKeysetId1));
+    EXPECT_EQ(provider->RemoveKeySet(kFabric1, kKeysetId0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->RemoveKeySet(kFabric1, kKeysetId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->RemoveKeySet(kFabric2, kKeysetId3), CHIP_NO_ERROR);
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->RemoveKeySet(kFabric2, kKeysetId2));
+    EXPECT_EQ(provider->RemoveKeySet(kFabric2, kKeysetId1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->RemoveKeySet(kFabric2, kKeysetId0), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId3, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, kKeysetId2, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric2, kKeysetId3, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric2, kKeysetId2, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric1, kKeysetId3, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric1, kKeysetId1, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric1, kKeysetId0, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric1, kKeysetId2, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric2, kKeysetId3, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric2, kKeysetId2, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric2, kKeysetId1, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric2, kKeysetId0, keyset));
 }
 
-void TestIpk(nlTestSuite * apSuite, void * apContext)
+TEST_F(TestGroupDataProvider, TestIpk)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, provider);
+    EXPECT_TRUE(provider);
 
     // Reset test
     ResetProvider(provider);
 
     // Make sure IPK set is not found on a fresh provider
     KeySet ipkOperationalKeySet;
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetIpkKeySet(kFabric1, ipkOperationalKeySet));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetIpkKeySet(kFabric1, ipkOperationalKeySet));
 
     // Add a non-IPK key, make sure the IPK set is not found
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet3));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetIpkKeySet(kFabric1, ipkOperationalKeySet));
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet3), CHIP_NO_ERROR);
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetIpkKeySet(kFabric1, ipkOperationalKeySet));
 
     const uint8_t kIpkEpochKeyFromSpec[] = { 0x23, 0x5b, 0xf7, 0xe6, 0x28, 0x23, 0xd3, 0x58,
                                              0xdc, 0xa4, 0xba, 0x50, 0xb1, 0x53, 0x5f, 0x4b };
@@ -849,55 +888,51 @@ void TestIpk(nlTestSuite * apSuite, void * apContext)
     memcpy(&fabric1KeySet0.epoch_keys[0].key, &kIpkEpochKeyFromSpec[0], sizeof(kIpkEpochKeyFromSpec));
 
     // Set a single IPK, validate key derivation follows spec
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, fabric1KeySet0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetIpkKeySet(kFabric1, ipkOperationalKeySet));
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, fabric1KeySet0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->GetIpkKeySet(kFabric1, ipkOperationalKeySet), CHIP_NO_ERROR);
 
     // Make sure the derived key matches spec test vector
     const uint8_t kExpectedIpkFromSpec[] = { 0xa6, 0xf5, 0x30, 0x6b, 0xaf, 0x6d, 0x05, 0x0a,
                                              0xf2, 0x3b, 0xa4, 0xbd, 0x6b, 0x9d, 0xd9, 0x60 };
 
-    NL_TEST_ASSERT(apSuite, 0 == ipkOperationalKeySet.keyset_id);
-    NL_TEST_ASSERT(apSuite, 1 == ipkOperationalKeySet.num_keys_used);
-    NL_TEST_ASSERT(apSuite, SecurityPolicy::kTrustFirst == ipkOperationalKeySet.policy);
-    NL_TEST_ASSERT(apSuite, 1234 == ipkOperationalKeySet.epoch_keys[0].start_time);
-    NL_TEST_ASSERT(apSuite,
-                   0 == memcmp(ipkOperationalKeySet.epoch_keys[0].key, kExpectedIpkFromSpec, sizeof(kExpectedIpkFromSpec)));
+    EXPECT_EQ(ipkOperationalKeySet.keyset_id, 0u);
+    EXPECT_EQ(ipkOperationalKeySet.num_keys_used, 1u);
+    EXPECT_EQ(SecurityPolicy::kTrustFirst, ipkOperationalKeySet.policy);
+    EXPECT_EQ(ipkOperationalKeySet.epoch_keys[0].start_time, 1234u);
+    EXPECT_EQ(memcmp(ipkOperationalKeySet.epoch_keys[0].key, kExpectedIpkFromSpec, sizeof(kExpectedIpkFromSpec)), 0);
 
     // Remove IPK, verify removal
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveKeySet(kFabric1, kKeysetId0));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetIpkKeySet(kFabric1, ipkOperationalKeySet));
+    EXPECT_EQ(provider->RemoveKeySet(kFabric1, kKeysetId0), CHIP_NO_ERROR);
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetIpkKeySet(kFabric1, ipkOperationalKeySet));
 
     // Set a single IPK with the SetSingleIpkEpochKey helper, validate key derivation follows spec
-    NL_TEST_ASSERT(
-        apSuite,
-        CHIP_NO_ERROR ==
-            chip::Credentials::SetSingleIpkEpochKey(provider, kFabric1, ByteSpan(kIpkEpochKeyFromSpec), kCompressedFabricId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetIpkKeySet(kFabric1, ipkOperationalKeySet));
+    EXPECT_EQ(chip::Credentials::SetSingleIpkEpochKey(provider, kFabric1, ByteSpan(kIpkEpochKeyFromSpec), kCompressedFabricId1),
+              CHIP_NO_ERROR);
+    EXPECT_EQ(provider->GetIpkKeySet(kFabric1, ipkOperationalKeySet), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, 0 == ipkOperationalKeySet.keyset_id);
-    NL_TEST_ASSERT(apSuite, 1 == ipkOperationalKeySet.num_keys_used);
-    NL_TEST_ASSERT(apSuite, SecurityPolicy::kTrustFirst == ipkOperationalKeySet.policy);
-    NL_TEST_ASSERT(apSuite, 0 == ipkOperationalKeySet.epoch_keys[0].start_time); // default time is zero for SetSingleIpkEpochKey
-    NL_TEST_ASSERT(apSuite,
-                   0 == memcmp(ipkOperationalKeySet.epoch_keys[0].key, kExpectedIpkFromSpec, sizeof(kExpectedIpkFromSpec)));
+    EXPECT_EQ(ipkOperationalKeySet.keyset_id, 0u);
+    EXPECT_EQ(ipkOperationalKeySet.num_keys_used, 1u);
+    EXPECT_EQ(SecurityPolicy::kTrustFirst, ipkOperationalKeySet.policy);
+    EXPECT_EQ(ipkOperationalKeySet.epoch_keys[0].start_time, 0u); // default time is zero for SetSingleIpkEpochKey
+    EXPECT_EQ(memcmp(ipkOperationalKeySet.epoch_keys[0].key, kExpectedIpkFromSpec, sizeof(kExpectedIpkFromSpec)), 0);
 }
 
-void TestKeySetIterator(nlTestSuite * apSuite, void * apContext)
+TEST_F(TestGroupDataProvider, TestKeySetIterator)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, provider);
+    EXPECT_TRUE(provider);
 
     // Reset test
     ResetProvider(provider);
 
     // Add data to iterate
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet1));
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet1), CHIP_NO_ERROR);
 
     // Iterate Fabric 1
 
@@ -908,48 +943,42 @@ void TestKeySetIterator(nlTestSuite * apSuite, void * apContext)
     };
 
     auto it = provider->IterateKeySets(kFabric1);
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
-    {
-        size_t count = 0;
-        NL_TEST_ASSERT(apSuite, expected_f1.size() == it->Count());
+    ASSERT_TRUE(it);
+    size_t count = 0;
+    EXPECT_EQ(expected_f1.size(), it->Count());
 
-        while (it->Next(keyset) && count < expected_f1.size())
-        {
-            NL_TEST_ASSERT(apSuite, expected_f1.count(keyset.keyset_id) > 0);
-            NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, expected_f1[keyset.keyset_id]));
-            count++;
-        }
-        NL_TEST_ASSERT(apSuite, count == expected_f1.size());
-        it->Release();
+    while (it->Next(keyset) && count < expected_f1.size())
+    {
+        EXPECT_GT(expected_f1.count(keyset.keyset_id), 0u);
+        EXPECT_TRUE(CompareKeySets(keyset, expected_f1[keyset.keyset_id]));
+        count++;
     }
+    EXPECT_EQ(count, expected_f1.size());
+    it->Release();
 
     // Iterate Fabric 2
 
     std::map<uint16_t, const KeySet> expected_f2{ { kKeysetId1, kKeySet1 }, { kKeysetId2, kKeySet2 }, { kKeysetId3, kKeySet3 } };
 
     it = provider->IterateKeySets(kFabric2);
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
-    {
-        size_t count = 0;
-        NL_TEST_ASSERT(apSuite, expected_f2.size() == it->Count());
+    ASSERT_TRUE(it);
+    count = 0;
+    EXPECT_EQ(expected_f2.size(), it->Count());
 
-        while (it->Next(keyset) && count < expected_f2.size())
-        {
-            NL_TEST_ASSERT(apSuite, expected_f2.count(keyset.keyset_id) > 0);
-            NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, expected_f2[keyset.keyset_id]));
-            count++;
-        }
-        NL_TEST_ASSERT(apSuite, count == expected_f2.size());
-        it->Release();
+    while (it->Next(keyset) && count < expected_f2.size())
+    {
+        EXPECT_GT(expected_f2.count(keyset.keyset_id), 0u);
+        EXPECT_TRUE(CompareKeySets(keyset, expected_f2[keyset.keyset_id]));
+        count++;
     }
+    EXPECT_EQ(count, expected_f2.size());
+    it->Release();
 }
 
-void TestPerFabricData(nlTestSuite * apSuite, void * apContext)
+TEST_F(TestGroupDataProvider, TestPerFabricData)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, provider);
+    EXPECT_TRUE(provider);
 
     // Reset test
     ResetProvider(provider);
@@ -957,163 +986,163 @@ void TestPerFabricData(nlTestSuite * apSuite, void * apContext)
     // Group Info
     GroupInfo group;
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo2_1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo2_3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 2, kGroupInfo2_2));
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo2_1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo2_3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 2, kGroupInfo2_2), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 0, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 1, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_2);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric1, 2, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo1_1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 0, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_1);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 1, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_3);
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 2, group));
-    NL_TEST_ASSERT(apSuite, group == kGroupInfo2_2);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric1, 0, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo1_3);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric1, 1, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo1_2);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric1, 2, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo1_1);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 0, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo2_1);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 1, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo2_3);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 2, group), CHIP_NO_ERROR);
+    EXPECT_EQ(group, kGroupInfo2_2);
 
     // Endpoints
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId4));
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId4), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup1, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId4));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId2));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId1));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId0));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId1));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId4));
 
     // Keys
 
     KeySet keyset;
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet0));
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet0), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId0, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet0));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId1, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet1));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId2, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet2));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId2, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet2));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId2, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet2));
+    EXPECT_EQ(provider->GetKeySet(kFabric1, kKeysetId2, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet2));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
+    EXPECT_EQ(provider->GetKeySet(kFabric1, kKeysetId1, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet1));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric1, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
+    EXPECT_EQ(provider->GetKeySet(kFabric1, kKeysetId0, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet0));
 
     //
     // Remove Fabric
     //
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->RemoveFabric(kFabric1));
+    EXPECT_EQ(provider->RemoveFabric(kFabric1), CHIP_NO_ERROR);
 
     // Endpoints
 
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup1, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, !provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, provider->HasEndpoint(kFabric2, kGroup3, kEndpointId4));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId0));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId1));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup1, kEndpointId2));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId1));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId2));
+    EXPECT_FALSE(provider->HasEndpoint(kFabric1, kGroup2, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId0));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId1));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId2));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId3));
+    EXPECT_TRUE(provider->HasEndpoint(kFabric2, kGroup3, kEndpointId4));
 
     // Group Info
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupInfoAt(kFabric1, 0, group));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupInfoAt(kFabric1, 1, group));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetGroupInfoAt(kFabric1, 2, group));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 0, group));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 1, group));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetGroupInfoAt(kFabric2, 2, group));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupInfoAt(kFabric1, 0, group));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupInfoAt(kFabric1, 1, group));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetGroupInfoAt(kFabric1, 2, group));
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 0, group), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 1, group), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->GetGroupInfoAt(kFabric2, 2, group), CHIP_NO_ERROR);
 
     // Keys
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId1, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet1));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId1, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet1));
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->GetKeySet(kFabric2, kKeysetId0, keyset));
-    NL_TEST_ASSERT(apSuite, CompareKeySets(keyset, kKeySet0));
+    EXPECT_EQ(provider->GetKeySet(kFabric2, kKeysetId0, keyset), CHIP_NO_ERROR);
+    EXPECT_TRUE(CompareKeySets(keyset, kKeySet0));
 
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, 202, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, 404, keyset));
-    NL_TEST_ASSERT(apSuite, CHIP_ERROR_NOT_FOUND == provider->GetKeySet(kFabric1, 606, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric1, 202, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric1, 404, keyset));
+    EXPECT_EQ(CHIP_ERROR_NOT_FOUND, provider->GetKeySet(kFabric1, 606, keyset));
 }
 
-void TestGroupDecryption(nlTestSuite * apSuite, void * apContext)
+TEST_F(TestGroupDataProvider, TestGroupDecryption)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
-    NL_TEST_ASSERT(apSuite, provider);
+    EXPECT_TRUE(provider);
 
     // Reset test
     ResetProvider(provider);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo2_1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo2_3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupInfoAt(kFabric2, 2, kGroupInfo2_2));
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 0, kGroupInfo1_3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 1, kGroupInfo1_2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric1, 2, kGroupInfo1_1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 0, kGroupInfo2_1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 1, kGroupInfo2_3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupInfoAt(kFabric2, 2, kGroupInfo2_2), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup1, kEndpointId4));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3));
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup1, kEndpointId4), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric1, kGroup2, kEndpointId3), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId3));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->AddEndpoint(kFabric2, kGroup3, kEndpointId4));
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId3), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->AddEndpoint(kFabric2, kGroup3, kEndpointId4), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet3));
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric1, kCompressedFabricId1, kKeySet2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetKeySet(kFabric2, kCompressedFabricId2, kKeySet3), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 0, kGroup1Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 1, kGroup1Keyset2));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 2, kGroup3Keyset0));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric1, 3, kGroup3Keyset2));
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 0, kGroup1Keyset0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 1, kGroup1Keyset2), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 2, kGroup3Keyset0), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric1, 3, kGroup3Keyset2), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset1));
-    NL_TEST_ASSERT(apSuite, CHIP_NO_ERROR == provider->SetGroupKeyAt(kFabric2, 1, kGroup2Keyset3));
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 0, kGroup2Keyset1), CHIP_NO_ERROR);
+    EXPECT_EQ(provider->SetGroupKeyAt(kFabric2, 1, kGroup2Keyset3), CHIP_NO_ERROR);
 
     const size_t kMessageLength            = 10;
     const uint8_t kMessage[kMessageLength] = { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9 };
@@ -1140,17 +1169,15 @@ void TestGroupDecryption(nlTestSuite * apSuite, void * apContext)
 
     // Get the key context
     Crypto::SymmetricKeyContext * key_context = provider->GetKeyContext(kFabric2, kGroup2);
-    NL_TEST_ASSERT(apSuite, nullptr != key_context);
+    ASSERT_NE(nullptr, key_context);
     uint16_t session_id = key_context->GetKeyHash();
 
     // Encrypt the message
-    NL_TEST_ASSERT(
-        apSuite,
-        CHIP_NO_ERROR ==
-            key_context->MessageEncrypt(plaintext, ByteSpan(aad, sizeof(aad)), ByteSpan(nonce, sizeof(nonce)), tag, ciphertext));
+    EXPECT_EQ(key_context->MessageEncrypt(plaintext, ByteSpan(aad, sizeof(aad)), ByteSpan(nonce, sizeof(nonce)), tag, ciphertext),
+              CHIP_NO_ERROR);
 
     // The ciphertext must be different to the original message
-    NL_TEST_ASSERT(apSuite, memcmp(ciphertext.data(), kMessage, sizeof(kMessage)));
+    EXPECT_TRUE(memcmp(ciphertext.data(), kMessage, sizeof(kMessage)));
     key_context->Release();
 
     //
@@ -1164,126 +1191,36 @@ void TestGroupDecryption(nlTestSuite * apSuite, void * apContext)
     auto it      = provider->IterateGroupSessions(session_id);
     size_t count = 0, total = 0;
 
-    NL_TEST_ASSERT(apSuite, it);
-    if (it)
+    ASSERT_TRUE(it);
+    total = it->Count();
+    EXPECT_EQ(expected.size(), total);
+    while (it->Next(session))
     {
-        total = it->Count();
-        NL_TEST_ASSERT(apSuite, expected.size() == total);
-        while (it->Next(session))
+        std::pair<FabricIndex, GroupId> found(session.fabric_index, session.group_id);
+        EXPECT_GT(expected.count(found), 0u);
+        ASSERT_NE(session.keyContext, nullptr);
+        // Assert aboves doesn't actually exit, we call continue so that we can call it->Release() outside of
+        // loop.
+        if (session.keyContext == nullptr)
         {
-            std::pair<FabricIndex, GroupId> found(session.fabric_index, session.group_id);
-            NL_TEST_ASSERT(apSuite, expected.count(found) > 0);
-            NL_TEST_ASSERT(apSuite, session.keyContext != nullptr);
-            // Assert aboves doesn't actually exit, we call continue so that we can call it->Release() outside of
-            // loop.
-            if (session.keyContext == nullptr)
-            {
-                continue;
-            }
-
-            // Decrypt the ciphertext
-            NL_TEST_ASSERT(apSuite,
-                           CHIP_NO_ERROR ==
-                               session.keyContext->MessageDecrypt(ciphertext, ByteSpan(aad, sizeof(aad)),
-                                                                  ByteSpan(nonce, sizeof(nonce)), tag, plaintext));
-
-            // The new plaintext must match the original message
-            NL_TEST_ASSERT(apSuite, 0 == memcmp(plaintext.data(), kMessage, sizeof(kMessage)));
-            count++;
+            continue;
         }
-        NL_TEST_ASSERT(apSuite, count == total);
-        it->Release();
+
+        // Decrypt the ciphertext
+        EXPECT_EQ(session.keyContext->MessageDecrypt(ciphertext, ByteSpan(aad, sizeof(aad)), ByteSpan(nonce, sizeof(nonce)), tag,
+                                                     plaintext),
+                  CHIP_NO_ERROR);
+
+        // The new plaintext must match the original message
+        EXPECT_EQ(memcmp(plaintext.data(), kMessage, sizeof(kMessage)), 0);
+        count++;
     }
+    EXPECT_EQ(count, total);
+    it->Release();
 }
 
 } // namespace TestGroups
 } // namespace app
 } // namespace chip
 
-namespace {
-
-static chip::TestPersistentStorageDelegate sDelegate;
-static chip::Crypto::DefaultSessionKeystore sSessionKeystore;
-static GroupDataProviderImpl sProvider(chip::app::TestGroups::kMaxGroupsPerFabric, chip::app::TestGroups::kMaxGroupKeysPerFabric);
-
-static EpochKey kEpochKeys0[] = {
-    { 0x0000000000000000, { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
-    { 0x1111111111111111, { 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f } },
-    { 0x2222222222222222, { 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f } }
-};
-static EpochKey kEpochKeys1[] = {
-    { 0x3333333333333333, { 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f } },
-    { 0x4444444444444444, { 0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f } },
-    { 0x5555555555555555, { 0x50, 0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f } },
-};
-static EpochKey kEpochKeys2[] = {
-    { 0xaaaaaaaaaaaaaaaa, { 0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf } },
-    { 0xbbbbbbbbbbbbbbbb, { 0xb0, 0xb1, 0xb2, 0xb3, 0xb4, 0xb5, 0xb6, 0xb7, 0xb8, 0xb9, 0xba, 0xbb, 0xbc, 0xbd, 0xbe, 0xbf } },
-    { 0xcccccccccccccccc, { 0xc0, 0xc1, 0xc2, 0xc3, 0xc4, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcc, 0xcd, 0xce, 0xcf } },
-};
-static EpochKey kEpochKeys3[] = {
-    { 0xdddddddddddddddd, { 0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8, 0xd9, 0xda, 0xdb, 0xdc, 0xdd, 0xde, 0xdf } },
-    { 0xeeeeeeeeeeeeeeee, { 0xe0, 0xe1, 0xe2, 0xe3, 0xe4, 0xe5, 0xe6, 0xe7, 0xe8, 0xe9, 0xea, 0xeb, 0xec, 0xed, 0xee, 0xef } },
-    { 0xffffffffffffffff, { 0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff } },
-};
-
-/**
- *  Set up the test suite.
- */
-int Test_Setup(void * inContext)
-{
-    VerifyOrReturnError(CHIP_NO_ERROR == chip::Platform::MemoryInit(), FAILURE);
-
-    // Initialize Group Data Provider
-    sProvider.SetStorageDelegate(&sDelegate);
-    sProvider.SetSessionKeystore(&sSessionKeystore);
-    sProvider.SetListener(&chip::app::TestGroups::sListener);
-    VerifyOrReturnError(CHIP_NO_ERROR == sProvider.Init(), FAILURE);
-    SetGroupDataProvider(&sProvider);
-
-    memcpy(chip::app::TestGroups::kKeySet0.epoch_keys, kEpochKeys0, sizeof(kEpochKeys0));
-    memcpy(chip::app::TestGroups::kKeySet1.epoch_keys, kEpochKeys1, sizeof(kEpochKeys1));
-    memcpy(chip::app::TestGroups::kKeySet2.epoch_keys, kEpochKeys2, sizeof(kEpochKeys2));
-    memcpy(chip::app::TestGroups::kKeySet3.epoch_keys, kEpochKeys3, sizeof(kEpochKeys3));
-
-    return SUCCESS;
-}
-
-/**
- *  Tear down the test suite.
- */
-int Test_Teardown(void * inContext)
-{
-    GroupDataProvider * provider = GetGroupDataProvider();
-    if (nullptr != provider)
-    {
-        provider->Finish();
-    }
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-const nlTest sTests[] = { NL_TEST_DEF("TestStorageDelegate", chip::app::TestGroups::TestStorageDelegate),
-                          NL_TEST_DEF("TestGroupInfo", chip::app::TestGroups::TestGroupInfo),
-                          NL_TEST_DEF("TestGroupInfoIterator", chip::app::TestGroups::TestGroupInfoIterator),
-                          NL_TEST_DEF("TestEndpoints", chip::app::TestGroups::TestEndpoints),
-                          NL_TEST_DEF("TestEndpointIterator", chip::app::TestGroups::TestEndpointIterator),
-                          NL_TEST_DEF("TestGroupKeys", chip::app::TestGroups::TestGroupKeys),
-                          NL_TEST_DEF("TestGroupKeyIterator", chip::app::TestGroups::TestGroupKeyIterator),
-                          NL_TEST_DEF("TestKeySets", chip::app::TestGroups::TestKeySets),
-                          NL_TEST_DEF("TestKeySetIterator", chip::app::TestGroups::TestKeySetIterator),
-                          NL_TEST_DEF("TestIpk", chip::app::TestGroups::TestIpk),
-                          NL_TEST_DEF("TestPerFabricData", chip::app::TestGroups::TestPerFabricData),
-                          NL_TEST_DEF("TestGroupDecryption", chip::app::TestGroups::TestGroupDecryption),
-                          NL_TEST_SENTINEL() };
-} // namespace
-
-int TestGroups()
-{
-    nlTestSuite theSuite = { "GroupDataProvider", &sTests[0], &Test_Setup, &Test_Teardown };
-
-    nlTestRunner(&theSuite, nullptr);
-    return (nlTestRunnerStats(&theSuite));
-}
-
-CHIP_REGISTER_TEST_SUITE(TestGroups)
+namespace {} // namespace

--- a/src/credentials/tests/TestPersistentStorageOpCertStore.cpp
+++ b/src/credentials/tests/TestPersistentStorageOpCertStore.cpp
@@ -19,13 +19,12 @@
 #include <inttypes.h>
 
 #include <credentials/PersistentStorageOpCertStore.h>
+#include <gtest/gtest.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/Span.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
-#include <lib/support/UnitTestRegistration.h>
-#include <nlunit-test.h>
 
 using namespace chip;
 using namespace chip::Credentials;
@@ -47,19 +46,25 @@ const ByteSpan kTestIcacSpan{ kTestIcacBuf };
 const uint8_t kTestNocBuf[] = { 'n', 'o', 'c' };
 const ByteSpan kTestNocSpan{ kTestNocBuf };
 
-void TestAddNocFlow(nlTestSuite * inSuite, void * inContext)
+struct TestPersistentStorageOpCertStore : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+TEST_F(TestPersistentStorageOpCertStore, TestAddNocFlow)
 {
     TestPersistentStorageDelegate storageDelegate;
     PersistentStorageOpCertStore opCertStore;
 
     // Failure before Init
     CHIP_ERROR err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex1, kTestRcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u);
 
     // Init succeeds
     err = opCertStore.Init(&storageDelegate);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Manually add existing root for the FabricIndex, should fail AddNewTrustedRootCertForFabric for
     // same fabric but succeed GetCertificate.
@@ -67,53 +72,52 @@ void TestAddNocFlow(nlTestSuite * inSuite, void * inContext)
 
     err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricRCAC(kFabricIndex1).KeyName(), kTestRcacBufExists,
                                           sizeof(kTestRcacBufExists));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 1);
-    NL_TEST_ASSERT(inSuite,
-                   opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kRcac) == true); //< From manual add
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 1u);
+    EXPECT_TRUE(opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kRcac)); //< From manual add
 
     err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex1, kTestRcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
 
     uint8_t largeBuf[400];
     MutableByteSpan largeSpan{ largeBuf };
 
     err = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
+    EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
 
     largeSpan = MutableByteSpan{ largeBuf };
 
     err = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacBufExists }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacBufExists }));
 
     // Adding root for another FabricIndex should work
     err = opCertStore.AddNewTrustedRootCertForFabric(kUndefinedFabricIndex, kTestRcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);
+    EXPECT_EQ(err, CHIP_ERROR_INVALID_FABRIC_INDEX);
 
     err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex2, kTestRcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 1); //< Storage count did not yet increase
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 1u); //< Storage count did not yet increase
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_TRUE(opCertStore.HasPendingRootCert());
 
     // Should be able to read pending RCAC right away
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex2, CertChainElement::kRcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
 
     // Trying to commit with pending RCAC but no NOC should fail but leave everything as-is
     err = opCertStore.CommitOpCertsForFabric(kFabricIndex2);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_TRUE(opCertStore.HasPendingRootCert());
 
     // Trying to do AddNewOpCertsForFabric for fabric different that with pending RCAC should fail
     err = opCertStore.AddNewOpCertsForFabric(kOtherFabricIndex, kTestNocSpan, kTestIcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
+    EXPECT_EQ(err, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_TRUE(opCertStore.HasPendingRootCert());
 
     // Clear other bad cases from storage for now
     storageDelegate.ClearStorage();
@@ -125,128 +129,127 @@ void TestAddNocFlow(nlTestSuite * inSuite, void * inContext)
 
     err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex2).KeyName(), kTestIcacBufExists,
                                           sizeof(kTestIcacBufExists));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 1);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 1u);
 
     err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex2).KeyName(), kTestNocBufExists,
                                           sizeof(kTestNocBufExists));
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 2);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 2u);
 
-    NL_TEST_ASSERT(inSuite,
-                   opCertStore.HasCertificateForFabric(kFabricIndex2, CertChainElement::kIcac) == true);         //< From manual add
-    NL_TEST_ASSERT(inSuite, opCertStore.HasCertificateForFabric(kFabricIndex2, CertChainElement::kNoc) == true); //< From manual add
+    EXPECT_TRUE(opCertStore.HasCertificateForFabric(kFabricIndex2, CertChainElement::kIcac)); //< From manual add
+    EXPECT_TRUE(opCertStore.HasCertificateForFabric(kFabricIndex2, CertChainElement::kNoc));  //< From manual add
 
     err = opCertStore.AddNewOpCertsForFabric(kFabricIndex2, kTestNocSpan, kTestIcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_TRUE(opCertStore.HasPendingRootCert());
 
     storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex2).KeyName());
     storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex2).KeyName());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u);
 
     // Trying to do AddNewOpCertsForFabric for same fabric as that with pending RCAC should succeed
     err = opCertStore.AddNewOpCertsForFabric(kFabricIndex2, kTestNocSpan, kTestIcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(opCertStore.HasPendingNocChain());
+    EXPECT_TRUE(opCertStore.HasPendingRootCert());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
 
     // Should be able to get the pending cert even if not in persisted storage
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex2, CertChainElement::kIcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
 
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex2, CertChainElement::kNoc, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
 
     // Trying to do AddNewOpCertsForFabric a second time after success before commit should fail,
     // but leave state as-is
     err = opCertStore.AddNewOpCertsForFabric(kFabricIndex2, kTestNocSpan, kTestIcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_TRUE(opCertStore.HasPendingNocChain());
+    EXPECT_TRUE(opCertStore.HasPendingRootCert());
 
     // Should be able to get the pending cert even if not in persisted storage, after an API error
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex2, CertChainElement::kIcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
 
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex2, CertChainElement::kNoc, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
 
     // Trying to commit with wrong FabricIndex should fail
     err = opCertStore.CommitOpCertsForFabric(kOtherFabricIndex);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
+    EXPECT_EQ(err, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    EXPECT_TRUE(opCertStore.HasPendingNocChain());
+    EXPECT_TRUE(opCertStore.HasPendingRootCert());
 
     // Commiting new certs should succeed on correct fabric
     err = opCertStore.CommitOpCertsForFabric(kFabricIndex2);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
 
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3); //< All certs now committed
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u); //< All certs now committed
 
     // Should be able to get the committed certs
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex2, CertChainElement::kRcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
 
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex2, CertChainElement::kIcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
 
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex2, CertChainElement::kNoc, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
 
     opCertStore.Finish();
 }
 
-void TestUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestPersistentStorageOpCertStore, TestUpdateNocFlow)
 {
     TestPersistentStorageDelegate storageDelegate;
     PersistentStorageOpCertStore opCertStore;
 
     // Failure before Init
     CHIP_ERROR err = opCertStore.UpdateOpCertsForFabric(kFabricIndex1, kTestNocSpan, kTestIcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u);
 
     // Init succeeds
     err = opCertStore.Init(&storageDelegate);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Add a new pending trusted root to test for UpdateOpCertsForFabric failure on new root present
     err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex1, kTestRcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
+    EXPECT_TRUE(opCertStore.HasPendingRootCert());
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
 
     // Trying to do an UpdateOpCertsForFabric with new root pending should fail
     err = opCertStore.UpdateOpCertsForFabric(kFabricIndex1, kTestNocSpan, kTestIcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_TRUE(opCertStore.HasPendingRootCert());
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
 
     // Revert state for next tests
     opCertStore.RevertPendingOpCerts();
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
 
     // Manually add root, ICAC and NOC to validate update since existing chain required
     const uint8_t kTestRcacBufExists[] = { 'r', 'c', 'a', 'c', ' ', 'e', 'x', 'i', 's', 't', 's' };
@@ -259,385 +262,382 @@ void TestUpdateNocFlow(nlTestSuite * inSuite, void * inContext)
     {
         err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricRCAC(kFabricIndex1).KeyName(), kTestRcacBufExists,
                                               sizeof(kTestRcacBufExists));
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 1);
-        NL_TEST_ASSERT(inSuite,
-                       opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kRcac) == true); //< From manual add
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 1u);
+        EXPECT_TRUE(opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kRcac)); //< From manual add
 
         err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex1).KeyName(), kTestIcacBufExists,
                                               sizeof(kTestIcacBufExists));
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 2);
-        NL_TEST_ASSERT(inSuite,
-                       opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kIcac) == true); //< From manual add
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 2u);
+        EXPECT_TRUE(opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kIcac)); //< From manual add
 
         err = storageDelegate.SyncSetKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex1).KeyName(), kTestNocBufExists,
                                               sizeof(kTestNocBufExists));
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3);
-        NL_TEST_ASSERT(inSuite,
-                       opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kNoc) == true); //< From manual add
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 3u);
+        EXPECT_TRUE(opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kNoc)); //< From manual add
 
         // Test that we can manually stored certs
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacBufExists }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacBufExists }));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestIcacBufExists }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestIcacBufExists }));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestNocBufExists }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestNocBufExists }));
     }
 
     // Update fails on fabric with wrong FabricIndex
     err = opCertStore.UpdateOpCertsForFabric(kOtherFabricIndex, kTestNocSpan, kTestIcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
 
     // Update succeeds on fabric with existing data
     err = opCertStore.UpdateOpCertsForFabric(kFabricIndex1, kTestNocSpan, kTestIcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain() == true);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_TRUE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u);
 
     // Can read back existing root unchanged
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacBufExists }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacBufExists }));
 
     // NOC chain elements see the pending updated certs
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestIcacBuf }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestIcacBuf }));
 
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestNocBuf }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestNocBuf }));
 
     // Trying update again fails
     err = opCertStore.UpdateOpCertsForFabric(kFabricIndex1, kTestNocSpan, kTestIcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain() == true);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_TRUE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u);
 
     // Trying to add a new root after update, before commit/revert fails
     err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex1, kTestRcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain() == true);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_TRUE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u);
 
     // Trying to add new opcerts for any fabric after update, before commit/revert fails
     err = opCertStore.AddNewOpCertsForFabric(kFabricIndex1, kTestNocSpan, kTestIcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
 
     err = opCertStore.AddNewOpCertsForFabric(kFabricIndex2, kTestNocSpan, kTestIcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
 
     // Committing writes the new values (we even "background-remove" the old ICAC/NOC before commit)
     storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricICAC(kFabricIndex1).KeyName());
     storageDelegate.SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricNOC(kFabricIndex1).KeyName());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 1); //< Root remains
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 1u); //< Root remains
 
     err = opCertStore.CommitOpCertsForFabric(kFabricIndex1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3); //< All certs now committed
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u); //< All certs now committed
 
     // Should be able to get the committed cert even if not in persisted storage, after an API error
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacBufExists }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacBufExists }));
 
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
 
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
 
     // Calling revert doesn't undo the work we just did
     opCertStore.RevertPendingOpCerts();
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3); //< All certs now committed
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u); //< All certs now committed
 
     // Verify the revert after commit left all data alone
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacBufExists }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacBufExists }));
 
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
 
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
 
     // Verify that RemoveOpCertsForFabric fails on fabric with no data
     err = opCertStore.RemoveOpCertsForFabric(kFabricIndex2);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_FABRIC_INDEX);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3);
+    EXPECT_EQ(err, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u);
 
     // Verify that RemoveOpCertsForFabric works for fabric we just updated
     err = opCertStore.RemoveOpCertsForFabric(kFabricIndex1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); // All keys gone
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); // All keys gone
 
     opCertStore.Finish();
 }
 
-void TestReverts(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestPersistentStorageOpCertStore, TestReverts)
 {
     TestPersistentStorageDelegate storageDelegate;
     PersistentStorageOpCertStore opCertStore;
 
     // Failure before Init
     CHIP_ERROR err = opCertStore.RemoveOpCertsForFabric(kFabricIndex1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0);
+    EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u);
 
     // Init succeeds
     err = opCertStore.Init(&storageDelegate);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Add a new pending trusted root
     uint8_t largeBuf[400];
     MutableByteSpan largeSpan{ largeBuf };
 
     err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex1, kTestRcacSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
+    EXPECT_TRUE(opCertStore.HasPendingRootCert());
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
 
     // Verify we can see the new trusted root
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, largeSpan.data_equal(kTestRcacSpan));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_TRUE(largeSpan.data_equal(kTestRcacSpan));
 
     // Verify that after revert, we can't see the root anymore
     opCertStore.RevertPendingOpCerts();
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
 
     largeSpan = MutableByteSpan{ largeBuf };
     err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
+    EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
 
     {
         // Add new root again, to then test review of AddNewTrustedCertificates
         err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex1, kTestRcacSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_FALSE(opCertStore.HasPendingNocChain());
 
         // Add NOC chain
         err = opCertStore.AddNewOpCertsForFabric(kFabricIndex1, kTestNocSpan, kTestIcacSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(opCertStore.HasPendingNocChain());
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
     }
 
     // Make sure we can see all pending certs before revert
     {
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(kTestRcacSpan));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(kTestRcacSpan));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(kTestIcacSpan));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(kTestIcacSpan));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(kTestNocSpan));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(kTestNocSpan));
     }
 
     // Revert
     opCertStore.RevertPendingOpCerts();
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
 
     // Verify that after revert, we can't see the root or chain anymore
     {
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
+        EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
+        EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
+        EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
     }
 
     // Start again to add a new set, but then let's commit
     {
         // Add new root again, to then test review of AddNewTrustedCertificates
         err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex1, kTestRcacSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_FALSE(opCertStore.HasPendingNocChain());
 
         // Add NOC chain
         err = opCertStore.AddNewOpCertsForFabric(kFabricIndex1, kTestNocSpan, kTestIcacSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(opCertStore.HasPendingNocChain());
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
     }
 
     // Commiting new certs should succeed on correct fabric
     err = opCertStore.CommitOpCertsForFabric(kFabricIndex1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
 
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3); //< All certs now committed
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u); //< All certs now committed
 
     // Should be able to get the committed certs
     {
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
     }
 
     const uint8_t kNewNoc[] = { 'n', 'o', 'c', ' ', 'n', 'e', 'w' };
 
     // Updating certs should work (NO ICAC)
     err = opCertStore.UpdateOpCertsForFabric(kFabricIndex1, ByteSpan{ kNewNoc }, ByteSpan{});
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3); //< No change to keys
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_TRUE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u); //< No change to keys
 
     // Should see committed root, pending NOC, absent ICAC
     {
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kIcac));
+        EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
+        EXPECT_FALSE(opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kIcac));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kNewNoc }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kNewNoc }));
     }
 
     // Revert, should be back at previous state
     opCertStore.RevertPendingOpCerts();
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3); //< Storage count did not yet change
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u); //< Storage count did not yet change
 
     // Should be able to get the previously committed certs
     {
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestIcacSpan }));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestNocSpan }));
     }
 
     // Try again to update with missing ICAC and commit
     err = opCertStore.UpdateOpCertsForFabric(kFabricIndex1, ByteSpan{ kNewNoc }, ByteSpan{});
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3); //< No change to keys
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_TRUE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u); //< No change to keys
 
     err = opCertStore.CommitOpCertsForFabric(kFabricIndex1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 2); //< ICAC cert should be gone
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 2u); //< ICAC cert should be gone
 
     // Should see committed root, new NOC, absent ICAC
     {
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
-        NL_TEST_ASSERT(inSuite, opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kRcac));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
+        EXPECT_TRUE(opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kRcac));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kIcac));
+        EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
+        EXPECT_FALSE(opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kIcac));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kNewNoc }));
-        NL_TEST_ASSERT(inSuite, opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kNoc));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kNewNoc }));
+        EXPECT_TRUE(opCertStore.HasCertificateForFabric(kFabricIndex1, CertChainElement::kNoc));
     }
 
     opCertStore.Finish();
 }
 
-void TestRevertAddNoc(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestPersistentStorageOpCertStore, TestRevertAddNoc)
 {
     TestPersistentStorageDelegate storageDelegate;
     PersistentStorageOpCertStore opCertStore;
 
     // Init succeeds
     CHIP_ERROR err = opCertStore.Init(&storageDelegate);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Add a new pending trusted root
     uint8_t largeBuf[400];
@@ -646,63 +646,63 @@ void TestRevertAddNoc(nlTestSuite * inSuite, void * inContext)
     {
         // Add new root
         err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex1, kTestRcacSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_FALSE(opCertStore.HasPendingNocChain());
 
         // Add NOC chain, with NO ICAC
         err = opCertStore.AddNewOpCertsForFabric(kFabricIndex1, kTestNocSpan, ByteSpan{});
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(opCertStore.HasPendingNocChain());
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
     }
 
     // Make sure we get expected pending state before revert
     {
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(kTestRcacSpan));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(kTestRcacSpan));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
+        EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(kTestNocSpan));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(kTestNocSpan));
     }
 
     // Revert using RemoveOpCertsForFabric
     err = opCertStore.RemoveOpCertsForFabric(kFabricIndex1);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
 
     // Add again, and commit
     {
         // Add new root
         err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex1, kTestRcacSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_FALSE(opCertStore.HasPendingNocChain());
 
         // Add NOC chain, with NO ICAC
         err = opCertStore.AddNewOpCertsForFabric(kFabricIndex1, kTestNocSpan, ByteSpan{});
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(opCertStore.HasPendingNocChain());
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
 
         err = opCertStore.CommitOpCertsForFabric(kFabricIndex1);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 2); //< We have RCAC, NOC, no ICAC
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_FALSE(opCertStore.HasPendingRootCert());
+        EXPECT_FALSE(opCertStore.HasPendingNocChain());
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 2u); //< We have RCAC, NOC, no ICAC
     }
 
     // Update to add an ICAC
@@ -711,65 +711,65 @@ void TestRevertAddNoc(nlTestSuite * inSuite, void * inContext)
 
     // Updating certs should work (NO ICAC)
     err = opCertStore.UpdateOpCertsForFabric(kFabricIndex1, ByteSpan{ kNewNoc }, ByteSpan{ kNewIcac });
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 2); //< No change to keys
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_TRUE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 2u); //< No change to keys
 
     // Should see committed root, pending NOC, pending ICAC
     {
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kNewIcac }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kNewIcac }));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kNewNoc }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kNewNoc }));
     }
 
     // Commit, should see the new ICAC appear.
     err = opCertStore.CommitOpCertsForFabric(kFabricIndex1);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 3); //< We have RCAC, NOC, ICAC
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    EXPECT_FALSE(opCertStore.HasPendingRootCert());
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 3u); //< We have RCAC, NOC, ICAC
 
     // Should see committed root, new NOC, new ICAC
     {
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kTestRcacSpan }));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kNewIcac }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kNewIcac }));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(ByteSpan{ kNewNoc }));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(ByteSpan{ kNewNoc }));
     }
 
     opCertStore.Finish();
 }
 
-void TestRevertPendingOpCertsExceptRoot(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestPersistentStorageOpCertStore, TestRevertPendingOpCertsExceptRoot)
 {
     TestPersistentStorageDelegate storageDelegate;
     PersistentStorageOpCertStore opCertStore;
 
     // Init succeeds
     CHIP_ERROR err = opCertStore.Init(&storageDelegate);
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Add a new pending trusted root
     uint8_t largeBuf[400];
@@ -778,111 +778,66 @@ void TestRevertPendingOpCertsExceptRoot(nlTestSuite * inSuite, void * inContext)
     {
         // Add new root
         err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex1, kTestRcacSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_FALSE(opCertStore.HasPendingNocChain());
 
         // Add NOC chain, with NO ICAC
         err = opCertStore.AddNewOpCertsForFabric(kFabricIndex1, kTestNocSpan, ByteSpan{});
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(opCertStore.HasPendingNocChain());
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
     }
 
     // Make sure we get expected pending state before revert
     {
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kRcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(kTestRcacSpan));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(kTestRcacSpan));
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kIcac, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_NOT_FOUND);
+        EXPECT_EQ(err, CHIP_ERROR_NOT_FOUND);
 
         largeSpan = MutableByteSpan{ largeBuf };
         err       = opCertStore.GetCertificate(kFabricIndex1, CertChainElement::kNoc, largeSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, largeSpan.data_equal(kTestNocSpan));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(largeSpan.data_equal(kTestNocSpan));
     }
 
     // Revert using RevertPendingOpCertsExceptRoot
     opCertStore.RevertPendingOpCertsExceptRoot();
-    NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-    NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-    NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+    EXPECT_TRUE(opCertStore.HasPendingRootCert());
+    EXPECT_FALSE(opCertStore.HasPendingNocChain());
+    EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
 
     // Add again, and commit
     {
         // Add new root: should fail, since it should still be pending
         err = opCertStore.AddNewTrustedRootCertForFabric(kFabricIndex1, kTestRcacSpan);
-        NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INCORRECT_STATE);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
+        EXPECT_EQ(err, CHIP_ERROR_INCORRECT_STATE);
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_FALSE(opCertStore.HasPendingNocChain());
 
         // Add NOC chain, with NO ICAC
         err = opCertStore.AddNewOpCertsForFabric(kFabricIndex1, kTestNocSpan, ByteSpan{});
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingNocChain());
-        NL_TEST_ASSERT(inSuite, opCertStore.HasPendingRootCert() == true);
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 0); //< Storage count did not yet increase
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_TRUE(opCertStore.HasPendingNocChain());
+        EXPECT_TRUE(opCertStore.HasPendingRootCert());
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 0u); //< Storage count did not yet increase
 
         err = opCertStore.CommitOpCertsForFabric(kFabricIndex1);
-        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingRootCert());
-        NL_TEST_ASSERT(inSuite, !opCertStore.HasPendingNocChain());
-        NL_TEST_ASSERT(inSuite, storageDelegate.GetNumKeys() == 2); //< We have RCAC, NOC, no ICAC
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+        EXPECT_FALSE(opCertStore.HasPendingRootCert());
+        EXPECT_FALSE(opCertStore.HasPendingNocChain());
+        EXPECT_EQ(storageDelegate.GetNumKeys(), 2u); //< We have RCAC, NOC, no ICAC
     }
 
     opCertStore.Finish();
 }
 
-/**
- *   Test Suite. It lists all the test functions.
- */
-static const nlTest sTests[] = {
-    NL_TEST_DEF("Test AddNOC-like flows PersistentStorageOpCertStore", TestAddNocFlow),
-    NL_TEST_DEF("Test UpdateNOC-like flows PersistentStorageOpCertStore", TestUpdateNocFlow),
-    NL_TEST_DEF("Test revert operations of PersistentStorageOpCertStore", TestReverts),
-    NL_TEST_DEF("Test revert operations with AddNOC of PersistentStorageOpCertStore", TestRevertAddNoc),
-    NL_TEST_DEF("Test revert operations using RevertPendingOpCertsExceptRoot", TestRevertPendingOpCertsExceptRoot),
-    NL_TEST_SENTINEL()
-};
-
-/**
- *  Set up the test suite.
- */
-int Test_Setup(void * inContext)
-{
-    CHIP_ERROR error = chip::Platform::MemoryInit();
-    VerifyOrReturnError(error == CHIP_NO_ERROR, FAILURE);
-    return SUCCESS;
-}
-
-/**
- *  Tear down the test suite.
- */
-int Test_Teardown(void * inContext)
-{
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
 } // namespace
-
-/**
- *  Main
- */
-int TestPersistentStorageOpCertStore()
-{
-    nlTestSuite theSuite = { "PersistentStorageOpCertStore tests", &sTests[0], Test_Setup, Test_Teardown };
-
-    // Run test suite against one context.
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestPersistentStorageOpCertStore)

--- a/src/test_driver/openiotsdk/unit-tests/test_components.txt
+++ b/src/test_driver/openiotsdk/unit-tests/test_components.txt
@@ -7,6 +7,7 @@ MinimalMdnsRecordsTests
 MinimalMdnsRespondersTests
 CoreTests
 MdnsTests
+CredentialsTest
 PlatformTests
 TestShell
 SetupPayloadTests

--- a/src/test_driver/openiotsdk/unit-tests/test_components_nl.txt
+++ b/src/test_driver/openiotsdk/unit-tests/test_components_nl.txt
@@ -1,6 +1,5 @@
 AppTests
 BDXTests
-CredentialsTest
 DataModelTests
 InetLayerTests
 MessagingLayerTests


### PR DESCRIPTION
## Problem
The problem was described in #29342. 

## Changes
These changes are another piece of replacing the nl-unit test with the pigweed-unit test. I changed tests for the credentials. I didn't introduce any changes to the logic of tests; I only replaced one framework with another. 
