### PR TITLE
[Silabs] Add missing space at the end of `--icd` macro

### DIFF
--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -193,7 +193,7 @@ else
                 shift
                 ;;
             --icd)
-                optArgs+="chip_enable_icd_server=true chip_openthread_ftd=false sl_enable_test_event_trigger=true"
+                optArgs+="chip_enable_icd_server=true chip_openthread_ftd=false sl_enable_test_event_trigger=true "
                 shift
                 ;;
             --low-power)


### PR DESCRIPTION
#### Description
When the `sl_enable_test_event_trigger`  was added to the `--icd` macro, the space at the end was removed.
PR adds the space back.


#### Tests
Built an app using the `--icd` macro
