### PR TITLE
Make ClusterStateCache use less memory when not storing attribute values.

### DIFF
--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -27,14 +27,14 @@ namespace app {
 namespace {
 
 // Determine how much space a StatusIB takes up on the wire.
-size_t SizeOfStatusIB(const StatusIB & aStatus)
+uint32_t SizeOfStatusIB(const StatusIB & aStatus)
 {
     // 1 byte: anonymous tag control byte for struct.
     // 1 byte: control byte for uint8 value.
     // 1 byte: context-specific tag for uint8 value.
     // 1 byte: the uint8 value.
     // 1 byte: end of container.
-    size_t size = 5;
+    uint32_t size = 5;
 
     if (aStatus.mClusterStatus.HasValue())
     {
@@ -49,7 +49,8 @@ size_t SizeOfStatusIB(const StatusIB & aStatus)
 
 } // anonymous namespace
 
-CHIP_ERROR ClusterStateCache::GetElementTLVSize(TLV::TLVReader * apData, size_t & aSize)
+template <bool CanEnableDataCaching>
+CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::GetElementTLVSize(TLV::TLVReader * apData, uint32_t & aSize)
 {
     Platform::ScopedMemoryBufferWithSize<uint8_t> backingBuffer;
     TLV::TLVReader reader;
@@ -64,8 +65,9 @@ CHIP_ERROR ClusterStateCache::GetElementTLVSize(TLV::TLVReader * apData, size_t 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ClusterStateCache::UpdateCache(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
-                                          const StatusIB & aStatus)
+template <bool CanEnableDataCaching>
+CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::UpdateCache(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
+                                                                 const StatusIB & aStatus)
 {
     AttributeState state;
     bool endpointIsNew = false;
@@ -82,24 +84,32 @@ CHIP_ERROR ClusterStateCache::UpdateCache(const ConcreteDataAttributePath & aPat
 
     if (apData)
     {
-        size_t elementSize = 0;
+        uint32_t elementSize = 0;
         ReturnErrorOnFailure(GetElementTLVSize(apData, elementSize));
 
-        if (mCacheData)
+        if constexpr (CanEnableDataCaching)
         {
-            Platform::ScopedMemoryBufferWithSize<uint8_t> backingBuffer;
-            backingBuffer.Calloc(elementSize);
-            VerifyOrReturnError(backingBuffer.Get() != nullptr, CHIP_ERROR_NO_MEMORY);
-            TLV::ScopedBufferTLVWriter writer(std::move(backingBuffer), elementSize);
-            ReturnErrorOnFailure(writer.CopyElement(TLV::AnonymousTag(), *apData));
-            ReturnErrorOnFailure(writer.Finalize(backingBuffer));
+            if (mCacheData)
+            {
+                Platform::ScopedMemoryBufferWithSize<uint8_t> backingBuffer;
+                backingBuffer.Calloc(elementSize);
+                VerifyOrReturnError(backingBuffer.Get() != nullptr, CHIP_ERROR_NO_MEMORY);
+                TLV::ScopedBufferTLVWriter writer(std::move(backingBuffer), elementSize);
+                ReturnErrorOnFailure(writer.CopyElement(TLV::AnonymousTag(), *apData));
+                ReturnErrorOnFailure(writer.Finalize(backingBuffer));
 
-            state.Set<AttributeData>(std::move(backingBuffer));
+                state.template Set<AttributeData>(std::move(backingBuffer));
+            }
+            else
+            {
+                state.template Set<uint32_t>(elementSize);
+            }
         }
         else
         {
-            state.Set<size_t>(elementSize);
+            state = elementSize;
         }
+
         //
         // Clear out the committed data version and only set it again once we have received all data for this cluster.
         // Otherwise, we may have incomplete data that looks like it's complete since it has a valid data version.
@@ -132,13 +142,20 @@ CHIP_ERROR ClusterStateCache::UpdateCache(const ConcreteDataAttributePath & aPat
     }
     else
     {
-        if (mCacheData)
+        if constexpr (CanEnableDataCaching)
         {
-            state.Set<StatusIB>(aStatus);
+            if (mCacheData)
+            {
+                state.template Set<StatusIB>(aStatus);
+            }
+            else
+            {
+                state.template Set<uint32_t>(SizeOfStatusIB(aStatus));
+            }
         }
         else
         {
-            state.Set<size_t>(SizeOfStatusIB(aStatus));
+            state = SizeOfStatusIB(aStatus);
         }
     }
 
@@ -161,7 +178,9 @@ CHIP_ERROR ClusterStateCache::UpdateCache(const ConcreteDataAttributePath & aPat
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ClusterStateCache::UpdateEventCache(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus)
+template <bool CanEnableDataCaching>
+CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::UpdateEventCache(const EventHeader & aEventHeader, TLV::TLVReader * apData,
+                                                                      const StatusIB * apStatus)
 {
     if (apData)
     {
@@ -208,7 +227,8 @@ CHIP_ERROR ClusterStateCache::UpdateEventCache(const EventHeader & aEventHeader,
     return CHIP_NO_ERROR;
 }
 
-void ClusterStateCache::OnReportBegin()
+template <bool CanEnableDataCaching>
+void ClusterStateCacheT<CanEnableDataCaching>::OnReportBegin()
 {
     mLastReportDataPath = ConcreteClusterPath(kInvalidEndpointId, kInvalidClusterId);
     mChangedAttributeSet.clear();
@@ -216,7 +236,8 @@ void ClusterStateCache::OnReportBegin()
     mCallback.OnReportBegin();
 }
 
-void ClusterStateCache::CommitPendingDataVersion()
+template <bool CanEnableDataCaching>
+void ClusterStateCacheT<CanEnableDataCaching>::CommitPendingDataVersion()
 {
     if (!mLastReportDataPath.IsValidConcreteClusterPath())
     {
@@ -231,7 +252,8 @@ void ClusterStateCache::CommitPendingDataVersion()
     }
 }
 
-void ClusterStateCache::OnReportEnd()
+template <bool CanEnableDataCaching>
+void ClusterStateCacheT<CanEnableDataCaching>::OnReportEnd()
 {
     CommitPendingDataVersion();
     mLastReportDataPath = ConcreteClusterPath(kInvalidEndpointId, kInvalidClusterId);
@@ -260,26 +282,37 @@ void ClusterStateCache::OnReportEnd()
     mCallback.OnReportEnd();
 }
 
-CHIP_ERROR ClusterStateCache::Get(const ConcreteAttributePath & path, TLV::TLVReader & reader) const
+template <bool CanEnableDataCaching>
+CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::Get(const ConcreteAttributePath & path, TLV::TLVReader & reader) const
 {
-    CHIP_ERROR err;
-    auto attributeState = GetAttributeState(path.mEndpointId, path.mClusterId, path.mAttributeId, err);
-    ReturnErrorOnFailure(err);
-    if (attributeState->Is<StatusIB>())
+    if constexpr (CanEnableDataCaching)
     {
-        return CHIP_ERROR_IM_STATUS_CODE_RECEIVED;
-    }
+        CHIP_ERROR err;
+        auto attributeState = GetAttributeState(path.mEndpointId, path.mClusterId, path.mAttributeId, err);
+        ReturnErrorOnFailure(err);
 
-    if (!attributeState->Is<AttributeData>())
+        if (attributeState->template Is<StatusIB>())
+        {
+            return CHIP_ERROR_IM_STATUS_CODE_RECEIVED;
+        }
+
+        if (!attributeState->template Is<AttributeData>())
+        {
+            return CHIP_ERROR_KEY_NOT_FOUND;
+        }
+
+        reader.Init(attributeState->template Get<AttributeData>().Get(),
+                    attributeState->template Get<AttributeData>().AllocatedSize());
+        return reader.Next();
+    }
+    else
     {
         return CHIP_ERROR_KEY_NOT_FOUND;
     }
-
-    reader.Init(attributeState->Get<AttributeData>().Get(), attributeState->Get<AttributeData>().AllocatedSize());
-    return reader.Next();
 }
 
-CHIP_ERROR ClusterStateCache::Get(EventNumber eventNumber, TLV::TLVReader & reader) const
+template <bool CanEnableDataCaching>
+CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::Get(EventNumber eventNumber, TLV::TLVReader & reader) const
 {
     CHIP_ERROR err;
 
@@ -295,7 +328,9 @@ CHIP_ERROR ClusterStateCache::Get(EventNumber eventNumber, TLV::TLVReader & read
     return CHIP_NO_ERROR;
 }
 
-const ClusterStateCache::EndpointState * ClusterStateCache::GetEndpointState(EndpointId endpointId, CHIP_ERROR & err) const
+template <bool CanEnableDataCaching>
+const typename ClusterStateCacheT<CanEnableDataCaching>::EndpointState *
+ClusterStateCacheT<CanEnableDataCaching>::GetEndpointState(EndpointId endpointId, CHIP_ERROR & err) const
 {
     auto endpointIter = mCache.find(endpointId);
     if (endpointIter == mCache.end())
@@ -308,8 +343,9 @@ const ClusterStateCache::EndpointState * ClusterStateCache::GetEndpointState(End
     return &endpointIter->second;
 }
 
-const ClusterStateCache::ClusterState * ClusterStateCache::GetClusterState(EndpointId endpointId, ClusterId clusterId,
-                                                                           CHIP_ERROR & err) const
+template <bool CanEnableDataCaching>
+const typename ClusterStateCacheT<CanEnableDataCaching>::ClusterState *
+ClusterStateCacheT<CanEnableDataCaching>::GetClusterState(EndpointId endpointId, ClusterId clusterId, CHIP_ERROR & err) const
 {
     auto endpointState = GetEndpointState(endpointId, err);
     if (err != CHIP_NO_ERROR)
@@ -328,8 +364,10 @@ const ClusterStateCache::ClusterState * ClusterStateCache::GetClusterState(Endpo
     return &clusterState->second;
 }
 
-const ClusterStateCache::AttributeState * ClusterStateCache::GetAttributeState(EndpointId endpointId, ClusterId clusterId,
-                                                                               AttributeId attributeId, CHIP_ERROR & err) const
+template <bool CanEnableDataCaching>
+const typename ClusterStateCacheT<CanEnableDataCaching>::AttributeState *
+ClusterStateCacheT<CanEnableDataCaching>::GetAttributeState(EndpointId endpointId, ClusterId clusterId, AttributeId attributeId,
+                                                            CHIP_ERROR & err) const
 {
     auto clusterState = GetClusterState(endpointId, clusterId, err);
     if (err != CHIP_NO_ERROR)
@@ -348,7 +386,9 @@ const ClusterStateCache::AttributeState * ClusterStateCache::GetAttributeState(E
     return &attributeState->second;
 }
 
-const ClusterStateCache::EventData * ClusterStateCache::GetEventData(EventNumber eventNumber, CHIP_ERROR & err) const
+template <bool CanEnableDataCaching>
+const typename ClusterStateCacheT<CanEnableDataCaching>::EventData *
+ClusterStateCacheT<CanEnableDataCaching>::GetEventData(EventNumber eventNumber, CHIP_ERROR & err) const
 {
     EventData compareKey;
 
@@ -364,7 +404,9 @@ const ClusterStateCache::EventData * ClusterStateCache::GetEventData(EventNumber
     return &(*eventData);
 }
 
-void ClusterStateCache::OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus)
+template <bool CanEnableDataCaching>
+void ClusterStateCacheT<CanEnableDataCaching>::OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
+                                                               const StatusIB & aStatus)
 {
     //
     // Since the cache itself is a ReadClient::Callback, it may be incorrectly passed in directly when registering with the
@@ -394,7 +436,9 @@ void ClusterStateCache::OnAttributeData(const ConcreteDataAttributePath & aPath,
     mCallback.OnAttributeData(aPath, apData ? &dataSnapshot : nullptr, aStatus);
 }
 
-CHIP_ERROR ClusterStateCache::GetVersion(const ConcreteClusterPath & aPath, Optional<DataVersion> & aVersion) const
+template <bool CanEnableDataCaching>
+CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::GetVersion(const ConcreteClusterPath & aPath,
+                                                                Optional<DataVersion> & aVersion) const
 {
     VerifyOrReturnError(aPath.IsValidConcreteClusterPath(), CHIP_ERROR_INVALID_ARGUMENT);
     CHIP_ERROR err;
@@ -404,7 +448,9 @@ CHIP_ERROR ClusterStateCache::GetVersion(const ConcreteClusterPath & aPath, Opti
     return CHIP_NO_ERROR;
 }
 
-void ClusterStateCache::OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus)
+template <bool CanEnableDataCaching>
+void ClusterStateCacheT<CanEnableDataCaching>::OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData,
+                                                           const StatusIB * apStatus)
 {
     VerifyOrDie(apData != nullptr || apStatus != nullptr);
 
@@ -418,23 +464,32 @@ void ClusterStateCache::OnEventData(const EventHeader & aEventHeader, TLV::TLVRe
     mCallback.OnEventData(aEventHeader, apData ? &dataSnapshot : nullptr, apStatus);
 }
 
-CHIP_ERROR ClusterStateCache::GetStatus(const ConcreteAttributePath & path, StatusIB & status) const
+template <bool CanEnableDataCaching>
+CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::GetStatus(const ConcreteAttributePath & path, StatusIB & status) const
 {
-    CHIP_ERROR err;
+    if constexpr (CanEnableDataCaching)
+    {
+        CHIP_ERROR err;
 
-    auto attributeState = GetAttributeState(path.mEndpointId, path.mClusterId, path.mAttributeId, err);
-    ReturnErrorOnFailure(err);
+        auto attributeState = GetAttributeState(path.mEndpointId, path.mClusterId, path.mAttributeId, err);
+        ReturnErrorOnFailure(err);
 
-    if (!attributeState->Is<StatusIB>())
+        if (!attributeState->template Is<StatusIB>())
+        {
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+
+        status = attributeState->template Get<StatusIB>();
+        return CHIP_NO_ERROR;
+    }
+    else
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-
-    status = attributeState->Get<StatusIB>();
-    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ClusterStateCache::GetStatus(const ConcreteEventPath & path, StatusIB & status) const
+template <bool CanEnableDataCaching>
+CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::GetStatus(const ConcreteEventPath & path, StatusIB & status) const
 {
     auto statusIter = mEventStatusCache.find(path);
     if (statusIter == mEventStatusCache.end())
@@ -446,7 +501,8 @@ CHIP_ERROR ClusterStateCache::GetStatus(const ConcreteEventPath & path, StatusIB
     return CHIP_NO_ERROR;
 }
 
-void ClusterStateCache::GetSortedFilters(std::vector<std::pair<DataVersionFilter, size_t>> & aVector) const
+template <bool CanEnableDataCaching>
+void ClusterStateCacheT<CanEnableDataCaching>::GetSortedFilters(std::vector<std::pair<DataVersionFilter, size_t>> & aVector) const
 {
     for (auto const & endpointIter : mCache)
     {
@@ -463,26 +519,33 @@ void ClusterStateCache::GetSortedFilters(std::vector<std::pair<DataVersionFilter
 
             for (auto const & attributeIter : clusterIter.second.mAttributes)
             {
-                if (attributeIter.second.Is<StatusIB>())
+                if constexpr (CanEnableDataCaching)
                 {
-                    clusterSize += SizeOfStatusIB(attributeIter.second.Get<StatusIB>());
-                }
-                else if (attributeIter.second.Is<size_t>())
-                {
-                    clusterSize += attributeIter.second.Get<size_t>();
+                    if (attributeIter.second.template Is<StatusIB>())
+                    {
+                        clusterSize += SizeOfStatusIB(attributeIter.second.template Get<StatusIB>());
+                    }
+                    else if (attributeIter.second.template Is<uint32_t>())
+                    {
+                        clusterSize += attributeIter.second.template Get<uint32_t>();
+                    }
+                    else
+                    {
+                        VerifyOrDie(attributeIter.second.template Is<AttributeData>());
+                        TLV::TLVReader bufReader;
+                        bufReader.Init(attributeIter.second.template Get<AttributeData>().Get(),
+                                       attributeIter.second.template Get<AttributeData>().AllocatedSize());
+                        ReturnOnFailure(bufReader.Next());
+                        // Skip to the end of the element.
+                        ReturnOnFailure(bufReader.Skip());
+
+                        // Compute the amount of value data
+                        clusterSize += bufReader.GetLengthRead();
+                    }
                 }
                 else
                 {
-                    VerifyOrDie(attributeIter.second.Is<AttributeData>());
-                    TLV::TLVReader bufReader;
-                    bufReader.Init(attributeIter.second.Get<AttributeData>().Get(),
-                                   attributeIter.second.Get<AttributeData>().AllocatedSize());
-                    ReturnOnFailure(bufReader.Next());
-                    // Skip to the end of the element.
-                    ReturnOnFailure(bufReader.Skip());
-
-                    // Compute the amount of value data
-                    clusterSize += bufReader.GetLengthRead();
+                    clusterSize += attributeIter.second;
                 }
             }
 
@@ -505,9 +568,10 @@ void ClusterStateCache::GetSortedFilters(std::vector<std::pair<DataVersionFilter
               });
 }
 
-CHIP_ERROR ClusterStateCache::OnUpdateDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
-                                                            const Span<AttributePathParams> & aAttributePaths,
-                                                            bool & aEncodedDataVersionList)
+template <bool CanEnableDataCaching>
+CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::OnUpdateDataVersionFilterList(
+    DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder, const Span<AttributePathParams> & aAttributePaths,
+    bool & aEncodedDataVersionList)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVWriter backup;
@@ -587,7 +651,8 @@ exit:
     return err;
 }
 
-CHIP_ERROR ClusterStateCache::GetLastReportDataPath(ConcreteClusterPath & aPath)
+template <bool CanEnableDataCaching>
+CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::GetLastReportDataPath(ConcreteClusterPath & aPath)
 {
     if (mLastReportDataPath.IsValidConcreteClusterPath())
     {
@@ -596,5 +661,10 @@ CHIP_ERROR ClusterStateCache::GetLastReportDataPath(ConcreteClusterPath & aPath)
     }
     return CHIP_ERROR_INCORRECT_STATE;
 }
+
+// Ensure that our out-of-line template methods actually get compiled.
+template class ClusterStateCacheT<true>;
+template class ClusterStateCacheT<false>;
+
 } // namespace app
 } // namespace chip

--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -462,28 +462,27 @@ void ClusterStateCacheT<CanEnableDataCaching>::OnEventData(const EventHeader & a
     mCallback.OnEventData(aEventHeader, apData ? &dataSnapshot : nullptr, apStatus);
 }
 
-template <bool CanEnableDataCaching>
-CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::GetStatus(const ConcreteAttributePath & path, StatusIB & status) const
+template <>
+CHIP_ERROR ClusterStateCacheT<true>::GetStatus(const ConcreteAttributePath & path, StatusIB & status) const
 {
-    if constexpr (CanEnableDataCaching)
-    {
-        CHIP_ERROR err;
+    CHIP_ERROR err;
 
-        auto attributeState = GetAttributeState(path.mEndpointId, path.mClusterId, path.mAttributeId, err);
-        ReturnErrorOnFailure(err);
+    auto attributeState = GetAttributeState(path.mEndpointId, path.mClusterId, path.mAttributeId, err);
+    ReturnErrorOnFailure(err);
 
-        if (!attributeState->template Is<StatusIB>())
-        {
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
-
-        status = attributeState->template Get<StatusIB>();
-        return CHIP_NO_ERROR;
-    }
-    else
+    if (!attributeState->template Is<StatusIB>())
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
+
+    status = attributeState->template Get<StatusIB>();
+    return CHIP_NO_ERROR;
+}
+
+template <>
+CHIP_ERROR ClusterStateCacheT<false>::GetStatus(const ConcreteAttributePath & path, StatusIB & status) const
+{
+    return CHIP_ERROR_INVALID_ARGUMENT;
 }
 
 template <bool CanEnableDataCaching>


### PR DESCRIPTION
ClusterStateCache has a "no storing values" mode, but in that mode it still uses 24 bytes per attribute to store just the data size.  For a typical device with a few hundred attributes, this adds up to multiple KB of RAM; across many devices it really starts to add up.

Introduce a compile-time switch that lets us optimize the storage when we know we're not storing the data.

This still keeps the old "enable storing data at compile time but turn it off at runtime" API, both for API compat and because it might reduce codesize for some consumers who care about that more than RAM.
