### PR TITLE
[NXP] Add Python requirements file

### DIFF
--- a/scripts/setup/requirements.nxp.txt
+++ b/scripts/setup/requirements.nxp.txt
@@ -1,0 +1,3 @@
+jsonschema>=4.17.0
+pycrypto>=2.6.1
+pycryptodome>=3.20.0


### PR DESCRIPTION
Add a `requirements.txt` file for NXP platform. Additional Python modules are needed by several scripts.

