### PR TITLE
Switched to pw_unit_test in src/lib/dnssd/minimal_mdns/records/

### DIFF
--- a/src/lib/dnssd/minimal_mdns/records/tests/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/records/tests/BUILD.gn
@@ -14,11 +14,10 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
-chip_test_suite_using_nltest("tests") {
+chip_test_suite("tests") {
   output_name = "libMinimalMdnsRecordsTests"
 
   test_sources = [
@@ -34,7 +33,5 @@ chip_test_suite_using_nltest("tests") {
   public_deps = [
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/dnssd/minimal_mdns/records",
-    "${chip_root}/src/lib/support:testing_nlunit",
-    "${nlunit_test_root}:nlunit-test",
   ]
 }

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecord.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecord.cpp
@@ -16,10 +16,9 @@
  *    limitations under the License.
  */
 
-#include <lib/dnssd/minimal_mdns/records/ResourceRecord.h>
-#include <lib/support/UnitTestRegistration.h>
+#include <gtest/gtest.h>
 
-#include <nlunit-test.h>
+#include <lib/dnssd/minimal_mdns/records/ResourceRecord.h>
 
 namespace {
 
@@ -41,7 +40,7 @@ private:
     const char * mData;
 };
 
-void CanWriteSimpleRecord(nlTestSuite * inSuite, void * inContext)
+TEST(TestResourceRecord, CanWriteSimpleRecord)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
@@ -68,15 +67,15 @@ void CanWriteSimpleRecord(nlTestSuite * inSuite, void * inContext)
         's',  'o',  'm',  'e',  'd', 'a', 't', 'a',
     };
 
-    NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAnswer, writer));
-    NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == 1);
-    NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 0);
-    NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 0);
-    NL_TEST_ASSERT(inSuite, output.Needed() == sizeof(expectedOutput));
-    NL_TEST_ASSERT(inSuite, memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)) == 0);
+    EXPECT_TRUE(record.Append(header, ResourceType::kAnswer, writer));
+    EXPECT_EQ(header.GetAnswerCount(), 1);
+    EXPECT_EQ(header.GetAuthorityCount(), 0);
+    EXPECT_EQ(header.GetAdditionalCount(), 0);
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
 }
 
-void CanWriteMultipleRecords(nlTestSuite * inSuite, void * inContext)
+TEST(TestResourceRecord, CanWriteMultipleRecords)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
@@ -118,26 +117,26 @@ void CanWriteMultipleRecords(nlTestSuite * inSuite, void * inContext)
         'x',  'y',  'z',
     };
 
-    NL_TEST_ASSERT(inSuite, record1.Append(header, ResourceType::kAnswer, writer));
-    NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == 1);
-    NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 0);
-    NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 0);
+    EXPECT_TRUE(record1.Append(header, ResourceType::kAnswer, writer));
+    EXPECT_EQ(header.GetAnswerCount(), 1);
+    EXPECT_EQ(header.GetAuthorityCount(), 0);
+    EXPECT_EQ(header.GetAdditionalCount(), 0);
 
-    NL_TEST_ASSERT(inSuite, record2.Append(header, ResourceType::kAuthority, writer));
-    NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == 1);
-    NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 1);
-    NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 0);
+    EXPECT_TRUE(record2.Append(header, ResourceType::kAuthority, writer));
+    EXPECT_EQ(header.GetAnswerCount(), 1);
+    EXPECT_EQ(header.GetAuthorityCount(), 1);
+    EXPECT_EQ(header.GetAdditionalCount(), 0);
 
-    NL_TEST_ASSERT(inSuite, record3.Append(header, ResourceType::kAdditional, writer));
-    NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == 1);
-    NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 1);
-    NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 1);
+    EXPECT_TRUE(record3.Append(header, ResourceType::kAdditional, writer));
+    EXPECT_EQ(header.GetAnswerCount(), 1);
+    EXPECT_EQ(header.GetAuthorityCount(), 1);
+    EXPECT_EQ(header.GetAdditionalCount(), 1);
 
-    NL_TEST_ASSERT(inSuite, output.Needed() == sizeof(expectedOutput));
-    NL_TEST_ASSERT(inSuite, memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)) == 0);
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
 }
 
-void RecordOrderIsEnforced(nlTestSuite * inSuite, void * inContext)
+TEST(TestResourceRecord, RecordOrderIsEnforced)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
@@ -151,15 +150,15 @@ void RecordOrderIsEnforced(nlTestSuite * inSuite, void * inContext)
 
     header.Clear();
     header.SetAuthorityCount(1);
-    NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAnswer, writer) == false);
+    EXPECT_EQ(record.Append(header, ResourceType::kAnswer, writer), false);
 
     header.Clear();
     header.SetAdditionalCount(1);
-    NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAnswer, writer) == false);
-    NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAuthority, writer) == false);
+    EXPECT_EQ(record.Append(header, ResourceType::kAnswer, writer), false);
+    EXPECT_EQ(record.Append(header, ResourceType::kAuthority, writer), false);
 }
 
-void ErrorsOutOnSmallBuffers(nlTestSuite * inSuite, void * inContext)
+TEST(TestResourceRecord, ErrorsOutOnSmallBuffers)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[123];
@@ -191,23 +190,23 @@ void ErrorsOutOnSmallBuffers(nlTestSuite * inSuite, void * inContext)
         BufferWriter output(dataBuffer, i);
         RecordWriter writer(&output);
 
-        NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAnswer, writer) == false);
+        EXPECT_EQ(record.Append(header, ResourceType::kAnswer, writer), false);
 
         // header untouched
-        NL_TEST_ASSERT(inSuite, memcmp(headerBuffer, clearHeader, HeaderRef::kSizeBytes) == 0);
+        EXPECT_EQ(memcmp(headerBuffer, clearHeader, HeaderRef::kSizeBytes), 0);
     }
 
     memset(dataBuffer, 0, sizeof(dataBuffer));
     BufferWriter output(dataBuffer, sizeof(expectedOutput));
     RecordWriter writer(&output);
 
-    NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAnswer, writer));
-    NL_TEST_ASSERT(inSuite, output.Needed() == sizeof(expectedOutput));
-    NL_TEST_ASSERT(inSuite, memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)) == 0);
-    NL_TEST_ASSERT(inSuite, memcmp(headerBuffer, clearHeader, HeaderRef::kSizeBytes) != 0);
+    EXPECT_TRUE(record.Append(header, ResourceType::kAnswer, writer));
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
+    EXPECT_NE(memcmp(headerBuffer, clearHeader, HeaderRef::kSizeBytes), 0);
 }
 
-void RecordCount(nlTestSuite * inSuite, void * inContext)
+TEST(TestResourceRecord, RecordCount)
 {
     constexpr int kAppendCount = 10;
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
@@ -223,10 +222,10 @@ void RecordCount(nlTestSuite * inSuite, void * inContext)
         BufferWriter output(dataBuffer, sizeof(dataBuffer));
         RecordWriter writer(&output);
 
-        NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAnswer, writer));
-        NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == i + 1);
-        NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 0);
-        NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 0);
+        EXPECT_TRUE(record.Append(header, ResourceType::kAnswer, writer));
+        EXPECT_EQ(header.GetAnswerCount(), i + 1);
+        EXPECT_EQ(header.GetAuthorityCount(), 0);
+        EXPECT_EQ(header.GetAdditionalCount(), 0);
     }
 
     for (int i = 0; i < kAppendCount; i++)
@@ -234,10 +233,10 @@ void RecordCount(nlTestSuite * inSuite, void * inContext)
         BufferWriter output(dataBuffer, sizeof(dataBuffer));
         RecordWriter writer(&output);
 
-        NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAuthority, writer));
-        NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == kAppendCount);
-        NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == i + 1);
-        NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 0);
+        EXPECT_TRUE(record.Append(header, ResourceType::kAuthority, writer));
+        EXPECT_EQ(header.GetAnswerCount(), kAppendCount);
+        EXPECT_EQ(header.GetAuthorityCount(), i + 1);
+        EXPECT_EQ(header.GetAdditionalCount(), 0);
     }
 
     for (int i = 0; i < kAppendCount; i++)
@@ -245,47 +244,27 @@ void RecordCount(nlTestSuite * inSuite, void * inContext)
         BufferWriter output(dataBuffer, sizeof(dataBuffer));
         RecordWriter writer(&output);
 
-        NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAdditional, writer));
-        NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == kAppendCount);
-        NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == kAppendCount);
-        NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == i + 1);
+        EXPECT_TRUE(record.Append(header, ResourceType::kAdditional, writer));
+        EXPECT_EQ(header.GetAnswerCount(), kAppendCount);
+        EXPECT_EQ(header.GetAuthorityCount(), kAppendCount);
+        EXPECT_EQ(header.GetAdditionalCount(), i + 1);
     }
 }
-void CacheFlushBit(nlTestSuite * inSuite, void * inContext)
+TEST(TestResourceRecord, CacheFlushBit)
 {
     FakeResourceRecord record("somedata");
     // No cache flush bit by default.
-    NL_TEST_ASSERT(inSuite, record.GetClass() == QClass::IN);
-    NL_TEST_ASSERT(inSuite, record.GetCacheFlush() == false);
+    EXPECT_EQ(record.GetClass(), QClass::IN);
+    EXPECT_EQ(record.GetCacheFlush(), false);
 
     // Check we can set flush bit and the class marker reflects that.
     record.SetCacheFlush(true);
-    NL_TEST_ASSERT(inSuite, record.GetClass() == QClass::IN_FLUSH);
-    NL_TEST_ASSERT(inSuite, record.GetCacheFlush() == true);
+    EXPECT_EQ(record.GetClass(), QClass::IN_FLUSH);
+    EXPECT_EQ(record.GetCacheFlush(), true);
 
     // Check we can unset.
     record.SetCacheFlush(false);
-    NL_TEST_ASSERT(inSuite, record.GetClass() == QClass::IN);
-    NL_TEST_ASSERT(inSuite, record.GetCacheFlush() == false);
+    EXPECT_EQ(record.GetClass(), QClass::IN);
+    EXPECT_EQ(record.GetCacheFlush(), false);
 }
-
-const nlTest sTests[] = {
-    NL_TEST_DEF("CanWriteSimpleRecord", CanWriteSimpleRecord),       //
-    NL_TEST_DEF("CanWriteMultipleRecords", CanWriteMultipleRecords), //
-    NL_TEST_DEF("RecordOrderIsEnforced", RecordOrderIsEnforced),     //
-    NL_TEST_DEF("ErrorsOutOnSmallBuffers", ErrorsOutOnSmallBuffers), //
-    NL_TEST_DEF("RecordCount", RecordCount),                         //
-    NL_TEST_DEF("CacheFlushBit", CacheFlushBit),                     //
-    NL_TEST_SENTINEL()                                               //
-};
-
 } // namespace
-
-int TestResourceRecord()
-{
-    nlTestSuite theSuite = { "ResourceRecord", sTests, nullptr, nullptr };
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestResourceRecord)

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordIP.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordIP.cpp
@@ -15,10 +15,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <lib/dnssd/minimal_mdns/records/IP.h>
-#include <lib/support/UnitTestRegistration.h>
 
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
+
+#include <lib/dnssd/minimal_mdns/records/IP.h>
 
 namespace {
 
@@ -30,11 +30,11 @@ using namespace chip::Encoding::BigEndian;
 const QNamePart kNames[] = { "some", "test", "local" };
 
 #if INET_CONFIG_ENABLE_IPV4
-void WriteIPv4(nlTestSuite * inSuite, void * inContext)
+TEST(TestResourceRecordIP, WriteIPv4)
 {
     IPAddress ipAddress;
 
-    NL_TEST_ASSERT(inSuite, IPAddress::FromString("10.20.30.40", ipAddress));
+    EXPECT_TRUE(IPAddress::FromString("10.20.30.40", ipAddress));
 
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
@@ -63,12 +63,12 @@ void WriteIPv4(nlTestSuite * inSuite, void * inContext)
             10, 20,  30,  40             // IP Address
         };
 
-        NL_TEST_ASSERT(inSuite, ipResourceRecord.Append(header, ResourceType::kAnswer, writer));
-        NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == 1);
-        NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 0);
-        NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 0);
-        NL_TEST_ASSERT(inSuite, output.Needed() == sizeof(expectedOutput));
-        NL_TEST_ASSERT(inSuite, memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)) == 0);
+        EXPECT_TRUE(ipResourceRecord.Append(header, ResourceType::kAnswer, writer));
+        EXPECT_EQ(header.GetAnswerCount(), 1);
+        EXPECT_EQ(header.GetAuthorityCount(), 0);
+        EXPECT_EQ(header.GetAdditionalCount(), 0);
+        EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+        EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
     }
 
     {
@@ -93,12 +93,12 @@ void WriteIPv4(nlTestSuite * inSuite, void * inContext)
             10, 20,  30,  40             // IP Address
         };
 
-        NL_TEST_ASSERT(inSuite, ipResourceRecord.Append(header, ResourceType::kAuthority, writer));
-        NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == 0);
-        NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 1);
-        NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 0);
-        NL_TEST_ASSERT(inSuite, output.Needed() == sizeof(expectedOutput));
-        NL_TEST_ASSERT(inSuite, memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)) == 0);
+        EXPECT_TRUE(ipResourceRecord.Append(header, ResourceType::kAuthority, writer));
+        EXPECT_EQ(header.GetAnswerCount(), 0);
+        EXPECT_EQ(header.GetAuthorityCount(), 1);
+        EXPECT_EQ(header.GetAdditionalCount(), 0);
+        EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+        EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
     }
 
     {
@@ -123,21 +123,21 @@ void WriteIPv4(nlTestSuite * inSuite, void * inContext)
             10, 20,  30,   40              // IP Address
         };
 
-        NL_TEST_ASSERT(inSuite, ipResourceRecord.Append(header, ResourceType::kAdditional, writer));
-        NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == 0);
-        NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 0);
-        NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 1);
-        NL_TEST_ASSERT(inSuite, output.Needed() == sizeof(expectedOutput));
-        NL_TEST_ASSERT(inSuite, memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)) == 0);
+        EXPECT_TRUE(ipResourceRecord.Append(header, ResourceType::kAdditional, writer));
+        EXPECT_EQ(header.GetAnswerCount(), 0);
+        EXPECT_EQ(header.GetAuthorityCount(), 0);
+        EXPECT_EQ(header.GetAdditionalCount(), 1);
+        EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+        EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
     }
 }
 #endif // INET_CONFIG_ENABLE_IPV4
 
-void WriteIPv6(nlTestSuite * inSuite, void * inContext)
+TEST(TestResourceRecordIP, WriteIPv6)
 {
     IPAddress ipAddress;
 
-    NL_TEST_ASSERT(inSuite, IPAddress::FromString("fe80::224:32ff:fe19:359b", ipAddress));
+    EXPECT_TRUE(IPAddress::FromString("fe80::224:32ff:fe19:359b", ipAddress));
 
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
@@ -167,31 +167,11 @@ void WriteIPv6(nlTestSuite * inSuite, void * inContext)
                                        0xfe, 0x19, 0x35, 0x9b
     };
 
-    NL_TEST_ASSERT(inSuite, ipResourceRecord.Append(header, ResourceType::kAnswer, writer));
-    NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == 1);
-    NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 0);
-    NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 0);
-    NL_TEST_ASSERT(inSuite, output.Needed() == sizeof(expectedOutput));
-    NL_TEST_ASSERT(inSuite, memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)) == 0);
+    EXPECT_TRUE(ipResourceRecord.Append(header, ResourceType::kAnswer, writer));
+    EXPECT_EQ(header.GetAnswerCount(), 1);
+    EXPECT_EQ(header.GetAuthorityCount(), 0);
+    EXPECT_EQ(header.GetAdditionalCount(), 0);
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
 }
-
-const nlTest sTests[] = {
-#if INET_CONFIG_ENABLE_IPV4
-    NL_TEST_DEF("IPV4", WriteIPv4), //
-#endif                              // INET_CONFIG_ENABLE_IPV4
-    NL_TEST_DEF("IPV6", WriteIPv6), //
-    NL_TEST_SENTINEL()              //
-};
-
 } // namespace
-
-int TestIPResourceRecord()
-{
-
-    nlTestSuite theSuite = { "IPResourceRecord", sTests, nullptr, nullptr };
-    nlTestRunner(&theSuite, nullptr);
-
-    return (nlTestRunnerStats(&theSuite));
-}
-
-CHIP_REGISTER_TEST_SUITE(TestIPResourceRecord)

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordPtr.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordPtr.cpp
@@ -14,11 +14,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#include <gtest/gtest.h>
+
 #include <lib/dnssd/minimal_mdns/records/Ptr.h>
-
-#include <lib/support/UnitTestRegistration.h>
-
-#include <nlunit-test.h>
 
 namespace {
 
@@ -26,7 +25,7 @@ using namespace chip;
 using namespace mdns::Minimal;
 using namespace chip::Encoding;
 
-void TestPtrResourceRecord(nlTestSuite * inSuite, void * inContext)
+TEST(TestResourceRecordPtr, TestPtrResourceRecord)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
@@ -59,26 +58,11 @@ void TestPtrResourceRecord(nlTestSuite * inSuite, void * inContext)
         0                           // QNAME ends
     };
 
-    NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAnswer, writer));
-    NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == 1);
-    NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 0);
-    NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 0);
-    NL_TEST_ASSERT(inSuite, output.Needed() == sizeof(expectedOutput));
-    NL_TEST_ASSERT(inSuite, memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)) == 0);
+    EXPECT_TRUE(record.Append(header, ResourceType::kAnswer, writer));
+    EXPECT_EQ(header.GetAnswerCount(), 1);
+    EXPECT_EQ(header.GetAuthorityCount(), 0);
+    EXPECT_EQ(header.GetAdditionalCount(), 0);
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
 }
-
-const nlTest sTests[] = {
-    NL_TEST_DEF("TestPtrResourceRecord", TestPtrResourceRecord), //
-    NL_TEST_SENTINEL()                                           //
-};
-
 } // namespace
-
-int TestPtrResourceRecord()
-{
-    nlTestSuite theSuite = { "PtrResourceRecord", sTests, nullptr, nullptr };
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestPtrResourceRecord)

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordSrv.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordSrv.cpp
@@ -14,11 +14,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#include <gtest/gtest.h>
+
 #include <lib/dnssd/minimal_mdns/records/Srv.h>
-
-#include <lib/support/UnitTestRegistration.h>
-
-#include <nlunit-test.h>
 
 namespace {
 
@@ -26,7 +25,7 @@ using namespace chip;
 using namespace chip::Encoding;
 using namespace mdns::Minimal;
 
-void TestSrv(nlTestSuite * inSuite, void * inContext)
+TEST(TestResourceRecordSrv, TestSrv)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
@@ -45,10 +44,10 @@ void TestSrv(nlTestSuite * inSuite, void * inContext)
 
     header.Clear();
 
-    NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAdditional, writer));
-    NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == 0);
-    NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 0);
-    NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 1);
+    EXPECT_TRUE(record.Append(header, ResourceType::kAdditional, writer));
+    EXPECT_EQ(header.GetAnswerCount(), 0);
+    EXPECT_EQ(header.GetAuthorityCount(), 0);
+    EXPECT_EQ(header.GetAdditionalCount(), 1);
 
     const uint8_t expectedOutput[] = {
         4,    's',  'o', 'm', 'e',           // QNAME part: some
@@ -68,22 +67,7 @@ void TestSrv(nlTestSuite * inSuite, void * inContext)
         0                                    // QNAME ends
     };
 
-    NL_TEST_ASSERT(inSuite, output.Needed() == sizeof(expectedOutput));
-    NL_TEST_ASSERT(inSuite, memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)) == 0);
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
 }
-
-const nlTest sTests[] = {
-    NL_TEST_DEF("TestSrv", TestSrv), //
-    NL_TEST_SENTINEL()               //
-};
-
 } // namespace
-
-int TestSrv()
-{
-    nlTestSuite theSuite = { "Srv", sTests, nullptr, nullptr };
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestSrv)

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordTxt.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordTxt.cpp
@@ -14,11 +14,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#include <gtest/gtest.h>
+
 #include <lib/dnssd/minimal_mdns/records/Txt.h>
-
-#include <lib/support/UnitTestRegistration.h>
-
-#include <nlunit-test.h>
 
 namespace {
 
@@ -26,7 +25,7 @@ using namespace chip;
 using namespace chip::Encoding;
 using namespace mdns::Minimal;
 
-void TestTxt(nlTestSuite * inSuite, void * inContext)
+TEST(TestResourceRecordTxt, TestTxt)
 {
     uint8_t headerBuffer[HeaderRef::kSizeBytes];
     uint8_t dataBuffer[128];
@@ -41,14 +40,14 @@ void TestTxt(nlTestSuite * inSuite, void * inContext)
 
     TxtResourceRecord record(kName, kData);
     record.SetTtl(128);
-    NL_TEST_ASSERT(inSuite, record.GetNumEntries() == 3);
+    EXPECT_EQ(record.GetNumEntries(), 3u);
 
     header.Clear();
 
-    NL_TEST_ASSERT(inSuite, record.Append(header, ResourceType::kAdditional, writer));
-    NL_TEST_ASSERT(inSuite, header.GetAnswerCount() == 0);
-    NL_TEST_ASSERT(inSuite, header.GetAuthorityCount() == 0);
-    NL_TEST_ASSERT(inSuite, header.GetAdditionalCount() == 1);
+    EXPECT_TRUE(record.Append(header, ResourceType::kAdditional, writer));
+    EXPECT_EQ(header.GetAnswerCount(), 0);
+    EXPECT_EQ(header.GetAuthorityCount(), 0);
+    EXPECT_EQ(header.GetAdditionalCount(), 1);
 
     const uint8_t expectedOutput[] = {
         4, 's', 'o', 'm', 'e',                // QNAME part: some
@@ -64,22 +63,7 @@ void TestTxt(nlTestSuite * inSuite, void * inContext)
         4, 'f', 'l', 'a', 'g'                 // ENTRY: flag
     };
 
-    NL_TEST_ASSERT(inSuite, output.Needed() == sizeof(expectedOutput));
-    NL_TEST_ASSERT(inSuite, memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)) == 0);
+    EXPECT_EQ(output.Needed(), sizeof(expectedOutput));
+    EXPECT_EQ(memcmp(dataBuffer, expectedOutput, sizeof(expectedOutput)), 0);
 }
-
-const nlTest sTests[] = {
-    NL_TEST_DEF("TestTxt", TestTxt), //
-    NL_TEST_SENTINEL()               //
-};
-
 } // namespace
-
-int TestTxt()
-{
-    nlTestSuite theSuite = { "Txt", sTests, nullptr, nullptr };
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestTxt)

--- a/src/test_driver/openiotsdk/unit-tests/test_components.txt
+++ b/src/test_driver/openiotsdk/unit-tests/test_components.txt
@@ -1,2 +1,3 @@
 accesstest
+MinimalMdnsRecordsTests
 PlatformTests

--- a/src/test_driver/openiotsdk/unit-tests/test_components_nl.txt
+++ b/src/test_driver/openiotsdk/unit-tests/test_components_nl.txt
@@ -9,7 +9,6 @@ InetLayerTests
 MdnsTests
 MessagingLayerTests
 MinimalMdnsCoreTests
-MinimalMdnsRecordsTests
 MinimalMdnsRespondersTests
 RawTransportTests
 RetransmitTests


### PR DESCRIPTION
This used to be part of https://github.com/project-chip/connectedhomeip/pull/33045, but was split into smaller pieces to make review easier.