### PR TITLE
Switched to pw_unit_test in src/lib/dnssd/minimal_mdns/responders/

### DIFF
--- a/src/lib/dnssd/minimal_mdns/responders/tests/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/BUILD.gn
@@ -14,11 +14,10 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
-chip_test_suite_using_nltest("tests") {
+chip_test_suite("tests") {
   output_name = "libMinimalMdnsRespondersTests"
 
   test_sources = [
@@ -34,7 +33,5 @@ chip_test_suite_using_nltest("tests") {
     "${chip_root}/src/lib/dnssd/minimal_mdns",
     "${chip_root}/src/lib/dnssd/minimal_mdns:default_policy",
     "${chip_root}/src/lib/dnssd/minimal_mdns/responders",
-    "${chip_root}/src/lib/support:testing_nlunit",
-    "${nlunit_test_root}:nlunit-test",
   ]
 }

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
@@ -63,7 +63,7 @@ public:
     static void SetUpTestSuite()
     {
         mdns::Minimal::SetDefaultAddressPolicy();
-        VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+        ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
     }
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
 };

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
@@ -20,9 +20,8 @@
 
 #include <lib/dnssd/minimal_mdns/AddressPolicy_DefaultImpl.h>
 #include <lib/support/CHIPMem.h>
-#include <lib/support/UnitTestRegistration.h>
 
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 namespace {
 
@@ -37,17 +36,13 @@ const QNamePart kNames[] = { "some", "test", "local" };
 class IPResponseAccumulator : public ResponderDelegate
 {
 public:
-    IPResponseAccumulator(nlTestSuite * suite) : mSuite(suite) {}
     void AddResponse(const ResourceRecord & record) override
     {
 
-        NL_TEST_ASSERT(mSuite, (record.GetType() == QType::A) || (record.GetType() == QType::AAAA));
-        NL_TEST_ASSERT(mSuite, record.GetClass() == QClass::IN_FLUSH);
-        NL_TEST_ASSERT(mSuite, record.GetName() == kNames);
+        EXPECT_TRUE((record.GetType() == QType::A) || (record.GetType() == QType::AAAA));
+        EXPECT_EQ(record.GetClass(), QClass::IN_FLUSH);
+        EXPECT_EQ(record.GetName(), kNames);
     }
-
-private:
-    nlTestSuite * mSuite;
 };
 
 InterfaceId FindValidInterfaceId()
@@ -62,19 +57,30 @@ InterfaceId FindValidInterfaceId()
     return InterfaceId::Null();
 }
 
+class TestIPResponder : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite()
+    {
+        mdns::Minimal::SetDefaultAddressPolicy();
+        VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR);
+    }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
 #if INET_CONFIG_ENABLE_IPV4
-void TestIPv4(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestIPResponder, TestIPv4)
 {
     IPAddress ipAddress;
-    NL_TEST_ASSERT(inSuite, IPAddress::FromString("10.20.30.40", ipAddress));
+    EXPECT_TRUE(IPAddress::FromString("10.20.30.40", ipAddress));
 
     IPv4Responder responder(kNames);
 
-    NL_TEST_ASSERT(inSuite, responder.GetQClass() == QClass::IN);
-    NL_TEST_ASSERT(inSuite, responder.GetQType() == QType::A);
-    NL_TEST_ASSERT(inSuite, responder.GetQName() == kNames);
+    EXPECT_EQ(responder.GetQClass(), QClass::IN);
+    EXPECT_EQ(responder.GetQType(), QType::A);
+    EXPECT_EQ(responder.GetQName(), kNames);
 
-    IPResponseAccumulator acc(inSuite);
+    IPResponseAccumulator acc;
     chip::Inet::IPPacketInfo packetInfo;
 
     packetInfo.SrcAddress  = ipAddress;
@@ -87,18 +93,18 @@ void TestIPv4(nlTestSuite * inSuite, void * inContext)
 }
 #endif // INET_CONFIG_ENABLE_IPV4
 
-void TestIPv6(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestIPResponder, TestIPv6)
 {
     IPAddress ipAddress;
-    NL_TEST_ASSERT(inSuite, IPAddress::FromString("fe80::224:32ff:aabb:ccdd", ipAddress));
+    EXPECT_TRUE(IPAddress::FromString("fe80::224:32ff:aabb:ccdd", ipAddress));
 
     IPv6Responder responder(kNames);
 
-    NL_TEST_ASSERT(inSuite, responder.GetQClass() == QClass::IN);
-    NL_TEST_ASSERT(inSuite, responder.GetQType() == QType::AAAA);
-    NL_TEST_ASSERT(inSuite, responder.GetQName() == kNames);
+    EXPECT_EQ(responder.GetQClass(), QClass::IN);
+    EXPECT_EQ(responder.GetQType(), QType::AAAA);
+    EXPECT_EQ(responder.GetQName(), kNames);
 
-    IPResponseAccumulator acc(inSuite);
+    IPResponseAccumulator acc;
     chip::Inet::IPPacketInfo packetInfo;
 
     packetInfo.SrcAddress  = ipAddress;
@@ -110,36 +116,4 @@ void TestIPv6(nlTestSuite * inSuite, void * inContext)
     responder.AddAllResponses(&packetInfo, &acc, ResponseConfiguration());
 }
 
-int Setup(void * inContext)
-{
-    mdns::Minimal::SetDefaultAddressPolicy();
-
-    CHIP_ERROR error = chip::Platform::MemoryInit();
-
-    return (error == CHIP_NO_ERROR) ? SUCCESS : FAILURE;
-}
-
-int Teardown(void * inContext)
-{
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-const nlTest sTests[] = {
-#if INET_CONFIG_ENABLE_IPV4
-    NL_TEST_DEF("TestIPv4", TestIPv4), //
-#endif                                 // INET_CONFIG_ENABLE_IPV4
-    NL_TEST_DEF("TestIPv6", TestIPv6), //
-    NL_TEST_SENTINEL()                 //
-};
-
 } // namespace
-
-int TestIP()
-{
-    nlTestSuite theSuite = { "IP", sTests, &Setup, &Teardown };
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestIP)

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
@@ -20,9 +20,8 @@
 
 #include <lib/dnssd/minimal_mdns/Parser.h>
 #include <lib/dnssd/minimal_mdns/RecordData.h>
-#include <lib/support/UnitTestRegistration.h>
 
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 namespace {
 
@@ -39,13 +38,13 @@ const QNamePart kTargetNames[] = { "point", "to", "this" };
 class PtrResponseAccumulator : public ResponderDelegate
 {
 public:
-    PtrResponseAccumulator(nlTestSuite * suite, const uint32_t expectedTtl) : mSuite(suite), mExpectedTtl(expectedTtl) {}
+    PtrResponseAccumulator(const uint32_t expectedTtl) : mExpectedTtl(expectedTtl) {}
     void AddResponse(const ResourceRecord & record) override
     {
 
-        NL_TEST_ASSERT(mSuite, record.GetType() == QType::PTR);
-        NL_TEST_ASSERT(mSuite, record.GetClass() == QClass::IN);
-        NL_TEST_ASSERT(mSuite, record.GetName() == kNames);
+        EXPECT_EQ(record.GetType(), QType::PTR);
+        EXPECT_EQ(record.GetClass(), QClass::IN);
+        EXPECT_EQ(record.GetName(), kNames);
 
         if (record.GetType() == QType::PTR)
         {
@@ -58,44 +57,43 @@ public:
             HeaderRef hdr(headerBuffer);
             hdr.Clear();
 
-            NL_TEST_ASSERT(mSuite, record.Append(hdr, ResourceType::kAnswer, writer));
+            EXPECT_TRUE(record.Append(hdr, ResourceType::kAnswer, writer));
 
             ResourceData data;
             SerializedQNameIterator target;
             const uint8_t * start = buffer;
 
-            NL_TEST_ASSERT(mSuite, out.Fit());
+            EXPECT_TRUE(out.Fit());
 
             BytesRange validDataRange(buffer, buffer + out.Needed());
 
-            NL_TEST_ASSERT(mSuite, data.Parse(validDataRange, &start));
-            NL_TEST_ASSERT(mSuite, start == (buffer + out.Needed()));
-            NL_TEST_ASSERT(mSuite, data.GetName() == FullQName(kNames));
-            NL_TEST_ASSERT(mSuite, data.GetType() == QType::PTR);
-            NL_TEST_ASSERT(mSuite, data.GetTtlSeconds() == mExpectedTtl);
+            EXPECT_TRUE(data.Parse(validDataRange, &start));
+            EXPECT_EQ(start, (buffer + out.Needed()));
+            EXPECT_EQ(data.GetName(), FullQName(kNames));
+            EXPECT_EQ(data.GetType(), QType::PTR);
+            EXPECT_EQ(data.GetTtlSeconds(), mExpectedTtl);
 
-            NL_TEST_ASSERT(mSuite, ParsePtrRecord(data.GetData(), validDataRange, &target));
-            NL_TEST_ASSERT(mSuite, target == FullQName(kTargetNames));
+            EXPECT_TRUE(ParsePtrRecord(data.GetData(), validDataRange, &target));
+            EXPECT_EQ(target, FullQName(kTargetNames));
         }
     }
 
 private:
-    nlTestSuite * mSuite;
     const uint32_t mExpectedTtl;
 };
 
-void TestPtrResponse(nlTestSuite * inSuite, void * inContext)
+TEST(TestPtrResponder, TestPtrResponse)
 {
     IPAddress ipAddress;
-    NL_TEST_ASSERT(inSuite, IPAddress::FromString("2607:f8b0:4005:804::200e", ipAddress));
+    EXPECT_TRUE(IPAddress::FromString("2607:f8b0:4005:804::200e", ipAddress));
 
     PtrResponder responder(kNames, kTargetNames);
 
-    NL_TEST_ASSERT(inSuite, responder.GetQClass() == QClass::IN);
-    NL_TEST_ASSERT(inSuite, responder.GetQType() == QType::PTR);
-    NL_TEST_ASSERT(inSuite, responder.GetQName() == kNames);
+    EXPECT_EQ(responder.GetQClass(), QClass::IN);
+    EXPECT_EQ(responder.GetQType(), QType::PTR);
+    EXPECT_EQ(responder.GetQName(), kNames);
 
-    PtrResponseAccumulator acc(inSuite, ResourceRecord::kDefaultTtl);
+    PtrResponseAccumulator acc(ResourceRecord::kDefaultTtl);
     chip::Inet::IPPacketInfo packetInfo;
 
     packetInfo.SrcAddress  = ipAddress;
@@ -107,18 +105,18 @@ void TestPtrResponse(nlTestSuite * inSuite, void * inContext)
     responder.AddAllResponses(&packetInfo, &acc, ResponseConfiguration());
 }
 
-void TestPtrResponseOverrideTtl(nlTestSuite * inSuite, void * inContext)
+TEST(TestPtrResponder, TestPtrResponseOverrideTtl)
 {
     IPAddress ipAddress;
-    NL_TEST_ASSERT(inSuite, IPAddress::FromString("2607:f8b0:4005:804::200e", ipAddress));
+    EXPECT_TRUE(IPAddress::FromString("2607:f8b0:4005:804::200e", ipAddress));
 
     PtrResponder responder(kNames, kTargetNames);
 
-    NL_TEST_ASSERT(inSuite, responder.GetQClass() == QClass::IN);
-    NL_TEST_ASSERT(inSuite, responder.GetQType() == QType::PTR);
-    NL_TEST_ASSERT(inSuite, responder.GetQName() == kNames);
+    EXPECT_EQ(responder.GetQClass(), QClass::IN);
+    EXPECT_EQ(responder.GetQType(), QType::PTR);
+    EXPECT_EQ(responder.GetQName(), kNames);
 
-    PtrResponseAccumulator acc(inSuite, 123);
+    PtrResponseAccumulator acc(123);
     chip::Inet::IPPacketInfo packetInfo;
 
     packetInfo.SrcAddress  = ipAddress;
@@ -129,20 +127,4 @@ void TestPtrResponseOverrideTtl(nlTestSuite * inSuite, void * inContext)
 
     responder.AddAllResponses(&packetInfo, &acc, ResponseConfiguration().SetTtlSecondsOverride(123));
 }
-
-const nlTest sTests[] = {
-    NL_TEST_DEF("TestPtrResponse", TestPtrResponse),                       //
-    NL_TEST_DEF("TestPtrResponseOverrideTtl", TestPtrResponseOverrideTtl), //
-    NL_TEST_SENTINEL()                                                     //
-};
-
 } // namespace
-
-int TestPtr()
-{
-    nlTestSuite theSuite = { "IP", sTests, nullptr, nullptr };
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestPtr)

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestQueryResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestQueryResponder.cpp
@@ -20,9 +20,7 @@
 
 #include <lib/dnssd/minimal_mdns/records/Ptr.h>
 
-#include <lib/support/UnitTestRegistration.h>
-
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 namespace {
 
@@ -44,13 +42,12 @@ public:
 class DnssdReplyAccumulator : public ResponderDelegate
 {
 public:
-    DnssdReplyAccumulator(nlTestSuite * suite) : mSuite(suite) {}
     void AddResponse(const ResourceRecord & record) override
     {
 
-        NL_TEST_ASSERT(mSuite, record.GetType() == QType::PTR);
-        NL_TEST_ASSERT(mSuite, record.GetClass() == QClass::IN);
-        NL_TEST_ASSERT(mSuite, record.GetName() == kDnsSdname);
+        EXPECT_EQ(record.GetType(), QType::PTR);
+        EXPECT_EQ(record.GetClass(), QClass::IN);
+        EXPECT_EQ(record.GetName(), kDnsSdname);
 
         mCaptures.push_back(reinterpret_cast<const PtrResourceRecord &>(record).GetPtr());
     }
@@ -58,11 +55,10 @@ public:
     std::vector<FullQName> & Captures() { return mCaptures; }
 
 private:
-    nlTestSuite * mSuite;
     std::vector<FullQName> mCaptures;
 };
 
-void CanIterateOverResponders(nlTestSuite * inSuite, void * inContext)
+TEST(TestQueryResponder, CanIterateOverResponders)
 {
     QueryResponder<10> responder;
 
@@ -70,24 +66,24 @@ void CanIterateOverResponders(nlTestSuite * inSuite, void * inContext)
     EmptyResponder empty2(kName2);
     EmptyResponder empty3(kName2);
 
-    NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty1).SetReportInServiceListing(true).IsValid());
-    NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty2).SetReportInServiceListing(true).IsValid());
-    NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty3).SetReportInServiceListing(true).IsValid());
+    EXPECT_TRUE(responder.AddResponder(&empty1).SetReportInServiceListing(true).IsValid());
+    EXPECT_TRUE(responder.AddResponder(&empty2).SetReportInServiceListing(true).IsValid());
+    EXPECT_TRUE(responder.AddResponder(&empty3).SetReportInServiceListing(true).IsValid());
 
     int idx = 0;
     QueryResponderRecordFilter noFilter;
     for (auto it = responder.begin(&noFilter); it != responder.end(); it++, idx++)
     {
         FullQName qName = it->responder->GetQName();
-        NL_TEST_ASSERT(inSuite, (idx != 0) || (qName == kDnsSdname));
-        NL_TEST_ASSERT(inSuite, (idx != 1) || (qName == kName1));
-        NL_TEST_ASSERT(inSuite, (idx != 2) || (qName == kName2));
-        NL_TEST_ASSERT(inSuite, (idx != 3) || (qName == kName2));
+        EXPECT_TRUE((idx != 0) || (qName == kDnsSdname));
+        EXPECT_TRUE((idx != 1) || (qName == kName1));
+        EXPECT_TRUE((idx != 2) || (qName == kName2));
+        EXPECT_TRUE((idx != 3) || (qName == kName2));
     }
-    NL_TEST_ASSERT(inSuite, idx == 4);
+    EXPECT_EQ(idx, 4);
 }
 
-void RespondsToDnsSdQueries(nlTestSuite * inSuite, void * inContext)
+TEST(TestQueryResponder, RespondsToDnsSdQueries)
 {
     QueryResponder<10> responder;
     QueryResponderRecordFilter noFilter;
@@ -97,44 +93,44 @@ void RespondsToDnsSdQueries(nlTestSuite * inSuite, void * inContext)
     EmptyResponder empty3(kName1);
     EmptyResponder empty4(kName1);
 
-    NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty1).IsValid());
-    NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty2).SetReportInServiceListing(true).IsValid());
-    NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty3).SetReportInServiceListing(true).IsValid());
-    NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty4).IsValid());
+    EXPECT_TRUE(responder.AddResponder(&empty1).IsValid());
+    EXPECT_TRUE(responder.AddResponder(&empty2).SetReportInServiceListing(true).IsValid());
+    EXPECT_TRUE(responder.AddResponder(&empty3).SetReportInServiceListing(true).IsValid());
+    EXPECT_TRUE(responder.AddResponder(&empty4).IsValid());
 
     // It reports itself inside the iterator
-    NL_TEST_ASSERT(inSuite, &(*responder.begin(&noFilter)->responder) == &responder);
+    EXPECT_EQ(&(*responder.begin(&noFilter)->responder), &responder);
 
     // It reponds dnssd PTR answers
-    NL_TEST_ASSERT(inSuite, responder.GetQClass() == QClass::IN);
-    NL_TEST_ASSERT(inSuite, responder.GetQType() == QType::PTR);
-    NL_TEST_ASSERT(inSuite, responder.GetQName() == kDnsSdname);
+    EXPECT_EQ(responder.GetQClass(), QClass::IN);
+    EXPECT_EQ(responder.GetQType(), QType::PTR);
+    EXPECT_EQ(responder.GetQName(), kDnsSdname);
 
-    DnssdReplyAccumulator accumulator(inSuite);
+    DnssdReplyAccumulator accumulator;
     responder.AddAllResponses(nullptr, &accumulator, ResponseConfiguration());
 
-    NL_TEST_ASSERT(inSuite, accumulator.Captures().size() == 2);
+    EXPECT_EQ(accumulator.Captures().size(), 2u);
     if (accumulator.Captures().size() == 2)
     {
-        NL_TEST_ASSERT(inSuite, accumulator.Captures()[0] == kName2);
-        NL_TEST_ASSERT(inSuite, accumulator.Captures()[1] == kName1);
+        EXPECT_EQ(accumulator.Captures()[0], kName2);
+        EXPECT_EQ(accumulator.Captures()[1], kName1);
     }
 }
 
-void LimitedStorage(nlTestSuite * inSuite, void * inContext)
+TEST(TestQueryResponder, LimitedStorage)
 {
     QueryResponder<3> responder;
 
     EmptyResponder empty1(kName1);
     EmptyResponder empty2(kName2);
 
-    NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty1).SetReportInServiceListing(true).IsValid());
-    NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty2).SetReportInServiceListing(true).IsValid());
+    EXPECT_TRUE(responder.AddResponder(&empty1).SetReportInServiceListing(true).IsValid());
+    EXPECT_TRUE(responder.AddResponder(&empty2).SetReportInServiceListing(true).IsValid());
 
     for (int i = 0; i < 100; i++)
     {
         EmptyResponder emptyX(kName1);
-        NL_TEST_ASSERT(inSuite, !responder.AddResponder(&emptyX).SetReportInServiceListing(true).IsValid());
+        EXPECT_FALSE(responder.AddResponder(&emptyX).SetReportInServiceListing(true).IsValid());
     }
 
     int idx = 0;
@@ -142,48 +138,30 @@ void LimitedStorage(nlTestSuite * inSuite, void * inContext)
     for (auto it = responder.begin(&noFilter); it != responder.end(); it++, idx++)
     {
         FullQName qName = it->responder->GetQName();
-        NL_TEST_ASSERT(inSuite, (idx != 0) || (qName == kDnsSdname));
-        NL_TEST_ASSERT(inSuite, (idx != 1) || (qName == kName1));
-        NL_TEST_ASSERT(inSuite, (idx != 2) || (qName == kName2));
+        EXPECT_TRUE((idx != 0) || (qName == kDnsSdname));
+        EXPECT_TRUE((idx != 1) || (qName == kName1));
+        EXPECT_TRUE((idx != 2) || (qName == kName2));
     }
-    NL_TEST_ASSERT(inSuite, idx == 3);
+    EXPECT_EQ(idx, 3);
 }
 
-void NonDiscoverableService(nlTestSuite * inSuite, void * inContext)
+TEST(TestQueryResponder, NonDiscoverableService)
 {
     QueryResponder<3> responder;
 
     EmptyResponder empty1(kName1);
     EmptyResponder empty2(kName2);
 
-    NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty1).IsValid());
-    NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty2).SetReportInServiceListing(true).IsValid());
+    EXPECT_TRUE(responder.AddResponder(&empty1).IsValid());
+    EXPECT_TRUE(responder.AddResponder(&empty2).SetReportInServiceListing(true).IsValid());
 
-    DnssdReplyAccumulator accumulator(inSuite);
+    DnssdReplyAccumulator accumulator;
     responder.AddAllResponses(nullptr, &accumulator, ResponseConfiguration());
 
-    NL_TEST_ASSERT(inSuite, accumulator.Captures().size() == 1);
+    EXPECT_EQ(accumulator.Captures().size(), 1u);
     if (accumulator.Captures().size() == 1)
     {
-        NL_TEST_ASSERT(inSuite, accumulator.Captures()[0] == kName2);
+        EXPECT_EQ(accumulator.Captures()[0], kName2);
     }
 }
-
-const nlTest sTests[] = {
-    NL_TEST_DEF("CanIterateOverResponders", CanIterateOverResponders), //
-    NL_TEST_DEF("RespondsToDnsSdQueries", RespondsToDnsSdQueries),     //
-    NL_TEST_DEF("LimitedStorage", LimitedStorage),                     //
-    NL_TEST_DEF("NonDiscoverableService", NonDiscoverableService),     //
-    NL_TEST_SENTINEL()                                                 //
-};
-
 } // namespace
-
-int TestQueryResponder()
-{
-    nlTestSuite theSuite = { "QueryResponder", sTests, nullptr, nullptr };
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestQueryResponder)

--- a/src/test_driver/openiotsdk/unit-tests/test_components.txt
+++ b/src/test_driver/openiotsdk/unit-tests/test_components.txt
@@ -1,2 +1,3 @@
 accesstest
+MinimalMdnsRespondersTests
 PlatformTests

--- a/src/test_driver/openiotsdk/unit-tests/test_components_nl.txt
+++ b/src/test_driver/openiotsdk/unit-tests/test_components_nl.txt
@@ -10,7 +10,6 @@ MdnsTests
 MessagingLayerTests
 MinimalMdnsCoreTests
 MinimalMdnsRecordsTests
-MinimalMdnsRespondersTests
 RawTransportTests
 RetransmitTests
 SecureChannelTests


### PR DESCRIPTION
This used to be part of https://github.com/project-chip/connectedhomeip/pull/33045, but was split into smaller pieces to make review easier.