### PR TITLE
Replaced nlunit-test with pw_unit_test in src/lib/dnssd/platform/

### DIFF
--- a/src/lib/dnssd/platform/tests/BUILD.gn
+++ b/src/lib/dnssd/platform/tests/BUILD.gn
@@ -14,19 +14,14 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
-chip_test_suite_using_nltest("tests") {
+chip_test_suite("tests") {
   output_name = "libMdnsFakePlatformTests"
   if (chip_device_platform == "fake") {
     test_sources = [ "TestPlatform.cpp" ]
 
-    public_deps = [
-      "${chip_root}/src/lib/dnssd",
-      "${chip_root}/src/lib/support:testing_nlunit",
-      "${nlunit_test_root}:nlunit-test",
-    ]
+    public_deps = [ "${chip_root}/src/lib/dnssd" ]
   }
 }

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -156,12 +156,21 @@ test::ExpectedCall commissionableLargeEnhanced = test::ExpectedCall()
 class TestDnssdPlatform : public ::testing::Test
 {
 public:
-    static void SetUpTestSuite() { VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR); }
+    static void SetUpTestSuite()
+    {
+        ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
+        DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
+        EXPECT_EQ(mdnsPlatform.Init(DeviceLayer::UDPEndPointManager()), CHIP_NO_ERROR);
+        EXPECT_EQ(mdnsPlatform.RemoveServices(), CHIP_NO_ERROR);
+    }
+
     static void TearDownTestSuite()
     {
         DiscoveryImplPlatform::GetInstance().Shutdown();
         chip::Platform::MemoryShutdown();
     }
+
+    void TearDown() override { test::Reset(); }
 };
 
 TEST_F(TestDnssdPlatform, TestStub)
@@ -171,8 +180,6 @@ TEST_F(TestDnssdPlatform, TestStub)
     // without an expected event.
     ChipLogError(Discovery, "Test platform returns error correctly");
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    EXPECT_EQ(mdnsPlatform.Init(DeviceLayer::UDPEndPointManager()), CHIP_NO_ERROR);
-    EXPECT_EQ(mdnsPlatform.RemoveServices(), CHIP_NO_ERROR);
     OperationalAdvertisingParameters params;
     EXPECT_EQ(mdnsPlatform.Advertise(params), CHIP_ERROR_UNEXPECTED_EVENT);
 }
@@ -180,10 +187,7 @@ TEST_F(TestDnssdPlatform, TestStub)
 TEST_F(TestDnssdPlatform, TestOperational)
 {
     ChipLogError(Discovery, "Test operational");
-    test::Reset();
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    EXPECT_EQ(mdnsPlatform.Init(DeviceLayer::UDPEndPointManager()), CHIP_NO_ERROR);
-    EXPECT_EQ(mdnsPlatform.RemoveServices(), CHIP_NO_ERROR);
 
     operationalCall1.callType = test::CallType::kStart;
     EXPECT_EQ(test::AddExpectedCall(operationalCall1), CHIP_NO_ERROR);
@@ -201,10 +205,7 @@ TEST_F(TestDnssdPlatform, TestOperational)
 TEST_F(TestDnssdPlatform, TestCommissionableNode)
 {
     ChipLogError(Discovery, "Test commissionable");
-    test::Reset();
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    EXPECT_EQ(mdnsPlatform.Init(DeviceLayer::UDPEndPointManager()), CHIP_NO_ERROR);
-    EXPECT_EQ(mdnsPlatform.RemoveServices(), CHIP_NO_ERROR);
 
     commissionableSmall.callType = test::CallType::kStart;
     EXPECT_EQ(

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -18,12 +18,12 @@
 
 #include <lib/core/PeerId.h>
 #include <lib/dnssd/Discovery_ImplPlatform.h>
-#include <lib/support/UnitTestRegistration.h>
+
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/fake/DnssdImpl.h>
 
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 #if CHIP_DEVICE_LAYER_TARGET_FAKE != 1
 #error "This test is designed for use only with the fake platform"
@@ -152,102 +152,86 @@ test::ExpectedCall commissionableLargeEnhanced = test::ExpectedCall()
                                                      .AddSubtype("_V555")
                                                      .AddSubtype("_T70000")
                                                      .AddSubtype("_CM");
-void TestStub(nlTestSuite * inSuite, void * inContext)
+
+class TestDnssdPlatform : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite() { VerifyOrDie(chip::Platform::MemoryInit() == CHIP_NO_ERROR); }
+    static void TearDownTestSuite()
+    {
+        DiscoveryImplPlatform::GetInstance().Shutdown();
+        chip::Platform::MemoryShutdown();
+    }
+};
+
+TEST_F(TestDnssdPlatform, TestStub)
 {
     // This is a test of the fake platform impl. We want
     // We want the platform to return unexpected event if it gets a start
     // without an expected event.
     ChipLogError(Discovery, "Test platform returns error correctly");
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(DeviceLayer::UDPEndPointManager()) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.Init(DeviceLayer::UDPEndPointManager()), CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.RemoveServices(), CHIP_NO_ERROR);
     OperationalAdvertisingParameters params;
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(params) == CHIP_ERROR_UNEXPECTED_EVENT);
+    EXPECT_EQ(mdnsPlatform.Advertise(params), CHIP_ERROR_UNEXPECTED_EVENT);
 }
 
-void TestOperational(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDnssdPlatform, TestOperational)
 {
     ChipLogError(Discovery, "Test operational");
     test::Reset();
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(DeviceLayer::UDPEndPointManager()) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.Init(DeviceLayer::UDPEndPointManager()), CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.RemoveServices(), CHIP_NO_ERROR);
 
     operationalCall1.callType = test::CallType::kStart;
-    NL_TEST_ASSERT(inSuite, test::AddExpectedCall(operationalCall1) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(operationalParams1) == CHIP_NO_ERROR);
+    EXPECT_EQ(test::AddExpectedCall(operationalCall1), CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.Advertise(operationalParams1), CHIP_NO_ERROR);
 
     // Next call to advertise should call start again with just the new data.
     test::Reset();
     operationalCall2.callType = test::CallType::kStart;
-    NL_TEST_ASSERT(inSuite, test::AddExpectedCall(operationalCall2) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(operationalParams2) == CHIP_NO_ERROR);
+    EXPECT_EQ(test::AddExpectedCall(operationalCall2), CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.Advertise(operationalParams2), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.FinalizeServiceUpdate() == CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.FinalizeServiceUpdate(), CHIP_NO_ERROR);
 }
 
-void TestCommissionableNode(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestDnssdPlatform, TestCommissionableNode)
 {
     ChipLogError(Discovery, "Test commissionable");
     test::Reset();
     DiscoveryImplPlatform & mdnsPlatform = DiscoveryImplPlatform::GetInstance();
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Init(DeviceLayer::UDPEndPointManager()) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.RemoveServices() == CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.Init(DeviceLayer::UDPEndPointManager()), CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.RemoveServices(), CHIP_NO_ERROR);
 
     commissionableSmall.callType = test::CallType::kStart;
-    NL_TEST_ASSERT(inSuite,
-                   mdnsPlatform.GetCommissionableInstanceName(commissionableSmall.instanceName,
-                                                              sizeof(commissionableSmall.instanceName)) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, test::AddExpectedCall(commissionableSmall) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(commissionableNodeParamsSmall) == CHIP_NO_ERROR);
+    EXPECT_EQ(
+        mdnsPlatform.GetCommissionableInstanceName(commissionableSmall.instanceName, sizeof(commissionableSmall.instanceName)),
+        CHIP_NO_ERROR);
+    EXPECT_EQ(test::AddExpectedCall(commissionableSmall), CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.Advertise(commissionableNodeParamsSmall), CHIP_NO_ERROR);
 
     // TODO: Right now, platform impl doesn't stop commissionable node before starting a new one. Add stop call here once that is
     // fixed.
     test::Reset();
     commissionableLargeBasic.callType = test::CallType::kStart;
-    NL_TEST_ASSERT(inSuite,
-                   mdnsPlatform.GetCommissionableInstanceName(commissionableLargeBasic.instanceName,
-                                                              sizeof(commissionableLargeBasic.instanceName)) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, test::AddExpectedCall(commissionableLargeBasic) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(commissionableNodeParamsLargeBasic) == CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.GetCommissionableInstanceName(commissionableLargeBasic.instanceName,
+                                                         sizeof(commissionableLargeBasic.instanceName)),
+              CHIP_NO_ERROR);
+    EXPECT_EQ(test::AddExpectedCall(commissionableLargeBasic), CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.Advertise(commissionableNodeParamsLargeBasic), CHIP_NO_ERROR);
 
     test::Reset();
     commissionableLargeEnhanced.callType = test::CallType::kStart;
-    NL_TEST_ASSERT(inSuite,
-                   mdnsPlatform.GetCommissionableInstanceName(commissionableLargeEnhanced.instanceName,
-                                                              sizeof(commissionableLargeEnhanced.instanceName)) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, test::AddExpectedCall(commissionableLargeEnhanced) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.Advertise(commissionableNodeParamsLargeEnhanced) == CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.GetCommissionableInstanceName(commissionableLargeEnhanced.instanceName,
+                                                         sizeof(commissionableLargeEnhanced.instanceName)),
+              CHIP_NO_ERROR);
+    EXPECT_EQ(test::AddExpectedCall(commissionableLargeEnhanced), CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.Advertise(commissionableNodeParamsLargeEnhanced), CHIP_NO_ERROR);
 
-    NL_TEST_ASSERT(inSuite, mdnsPlatform.FinalizeServiceUpdate() == CHIP_NO_ERROR);
+    EXPECT_EQ(mdnsPlatform.FinalizeServiceUpdate(), CHIP_NO_ERROR);
 }
-
-int TestSetup(void * inContext)
-{
-    return chip::Platform::MemoryInit() == CHIP_NO_ERROR ? SUCCESS : FAILURE;
-}
-
-int TestTeardown(void * inContext)
-{
-    DiscoveryImplPlatform::GetInstance().Shutdown();
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-const nlTest sTests[] = {
-    NL_TEST_DEF("TestStub", TestStub),                             //
-    NL_TEST_DEF("TestOperational", TestOperational),               //
-    NL_TEST_DEF("TestCommissionableNode", TestCommissionableNode), //
-    NL_TEST_SENTINEL()                                             //
-};
 
 } // namespace
-
-int TestDnssdPlatform()
-{
-    nlTestSuite theSuite = { "DnssdPlatform", &sTests[0], &TestSetup, &TestTeardown };
-    nlTestRunner(&theSuite, nullptr);
-    return nlTestRunnerStats(&theSuite);
-}
-
-CHIP_REGISTER_TEST_SUITE(TestDnssdPlatform)


### PR DESCRIPTION
This used to be part of https://github.com/project-chip/connectedhomeip/pull/33045, but was split into smaller pieces to make review easier.