### PR TITLE
Convert a few more items to std::optional

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -80,7 +80,7 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
     }
 
     if (binding.type == MATTER_UNICAST_BINDING && binding.local == 1 &&
-        (!binding.clusterId.HasValue() || binding.clusterId.Value() == Clusters::OnOff::Id))
+        binding.clusterId.value_or(Clusters::OnOff::Id) == Clusters::OnOff::Id)
     {
         auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
             ChipLogProgress(NotSpecified, "OnOff command succeeds");

--- a/examples/all-clusters-app/ameba/main/BindingHandler.cpp
+++ b/examples/all-clusters-app/ameba/main/BindingHandler.cpp
@@ -194,7 +194,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.emplace(6);       // Hardcoded to OnOff cluster for now
+    entry->clusterId.emplace(6);        // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/all-clusters-app/ameba/main/BindingHandler.cpp
+++ b/examples/all-clusters-app/ameba/main/BindingHandler.cpp
@@ -194,7 +194,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.SetValue(6);       // Hardcoded to OnOff cluster for now
+    entry->clusterId.emplace(6);       // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
@@ -210,7 +210,7 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
     entry->nodeId                  = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
     entry->remote                  = atoi(argv[2]);
-    entry->clusterId.SetValue(6); // Hardcode to OnOff cluster for now
+    entry->clusterId.emplace(6); // Hardcode to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
+++ b/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
@@ -81,7 +81,7 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
     }
 
     if (binding.type == MATTER_UNICAST_BINDING && binding.local == 1 &&
-        (!binding.clusterId.HasValue() || binding.clusterId.Value() == Clusters::OnOff::Id))
+        binding.clusterId.value_or(Clusters::OnOff::Id) == Clusters::OnOff::Id)
     {
         auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
             ChipLogProgress(NotSpecified, "OnOff command succeeds");

--- a/examples/light-switch-app/ameba/main/BindingHandler.cpp
+++ b/examples/light-switch-app/ameba/main/BindingHandler.cpp
@@ -250,7 +250,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.emplace(6);       // Hardcoded to OnOff cluster for now
+    entry->clusterId.emplace(6);        // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/light-switch-app/ameba/main/BindingHandler.cpp
+++ b/examples/light-switch-app/ameba/main/BindingHandler.cpp
@@ -250,7 +250,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.SetValue(6);       // Hardcoded to OnOff cluster for now
+    entry->clusterId.emplace(6);       // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
@@ -266,7 +266,7 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
     entry->nodeId                  = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
     entry->remote                  = atoi(argv[2]);
-    entry->clusterId.SetValue(6); // Hardcode to OnOff cluster for now
+    entry->clusterId.emplace(6); // Hardcode to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/light-switch-app/asr/src/BindingHandler.cpp
+++ b/examples/light-switch-app/asr/src/BindingHandler.cpp
@@ -280,7 +280,7 @@ void BindingHandler::PrintBindingTable()
             \t+ ClusterId %d \n \
             \t+ RemoteEndpointId %d \n \
             \t+ NodeId %d",
-                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(-1), (int) entry.remote,
+                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId), (int) entry.remote,
                     (int) entry.nodeId);
             break;
         case MATTER_MULTICAST_BINDING:

--- a/examples/light-switch-app/asr/src/BindingHandler.cpp
+++ b/examples/light-switch-app/asr/src/BindingHandler.cpp
@@ -280,8 +280,8 @@ void BindingHandler::PrintBindingTable()
             \t+ ClusterId %d \n \
             \t+ RemoteEndpointId %d \n \
             \t+ NodeId %d",
-                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId), (int) entry.remote,
-                    (int) entry.nodeId);
+                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId),
+                    (int) entry.remote, (int) entry.nodeId);
             break;
         case MATTER_MULTICAST_BINDING:
             ASR_LOG("[%d] GROUP:", i++);

--- a/examples/light-switch-app/asr/src/BindingHandler.cpp
+++ b/examples/light-switch-app/asr/src/BindingHandler.cpp
@@ -280,7 +280,7 @@ void BindingHandler::PrintBindingTable()
             \t+ ClusterId %d \n \
             \t+ RemoteEndpointId %d \n \
             \t+ NodeId %d",
-                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.Value(), (int) entry.remote,
+                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(-1), (int) entry.remote,
                     (int) entry.nodeId);
             break;
         case MATTER_MULTICAST_BINDING:

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -248,7 +248,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.SetValue(6);       // Hardcoded to OnOff cluster for now
+    entry->clusterId.emplace(6);       // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
@@ -264,7 +264,7 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
     entry->nodeId                  = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
     entry->remote                  = atoi(argv[2]);
-    entry->clusterId.SetValue(6); // Hardcode to OnOff cluster for now
+    entry->clusterId.emplace(6); // Hardcode to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -248,7 +248,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.emplace(6);       // Hardcoded to OnOff cluster for now
+    entry->clusterId.emplace(6);        // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/light-switch-app/genio/src/BindingHandler.cpp
+++ b/examples/light-switch-app/genio/src/BindingHandler.cpp
@@ -247,7 +247,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.SetValue(6);       // Hardcoded to OnOff cluster for now
+    entry->clusterId.emplace(6);       // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
@@ -263,7 +263,7 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
     entry->nodeId                  = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
     entry->remote                  = atoi(argv[2]);
-    entry->clusterId.SetValue(6); // Hardcode to OnOff cluster for now
+    entry->clusterId.emplace(6); // Hardcode to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/light-switch-app/genio/src/BindingHandler.cpp
+++ b/examples/light-switch-app/genio/src/BindingHandler.cpp
@@ -247,7 +247,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.emplace(6);       // Hardcoded to OnOff cluster for now
+    entry->clusterId.emplace(6);        // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/light-switch-app/infineon/cyw30739/src/AppShellCommands.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/AppShellCommands.cpp
@@ -365,7 +365,7 @@ CHIP_ERROR GroupBindCommandHandler(int argc, char ** argv)
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
-    entry->clusterId.SetValue(atoi(argv[3]));
+    entry->clusterId.emplace(atoi(argv[3]));
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingHandler::BindingWorkerHandler, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
@@ -384,7 +384,7 @@ CHIP_ERROR UnicastBindCommandHandler(int argc, char ** argv)
     entry->fabricIndex             = atoi(argv[0]);
     entry->nodeId                  = atoi(argv[1]);
     entry->remote                  = atoi(argv[2]);
-    entry->clusterId.SetValue(atoi(argv[3]));
+    entry->clusterId.emplace(atoi(argv[3]));
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingHandler::BindingWorkerHandler, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
@@ -306,8 +306,8 @@ void BindingHandler::PrintBindingTable()
             \t+ ClusterId %d \n \
             \t+ RemoteEndpointId %d \n \
             \t+ NodeId %d \n",
-                   (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId), (int) entry.remote,
-                   (int) entry.nodeId);
+                   (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId),
+                   (int) entry.remote, (int) entry.nodeId);
             break;
         case MATTER_MULTICAST_BINDING:
             printf("[%d] GROUP:", i++);

--- a/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
@@ -306,7 +306,7 @@ void BindingHandler::PrintBindingTable()
             \t+ ClusterId %d \n \
             \t+ RemoteEndpointId %d \n \
             \t+ NodeId %d \n",
-                   (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(-1), (int) entry.remote,
+                   (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId), (int) entry.remote,
                    (int) entry.nodeId);
             break;
         case MATTER_MULTICAST_BINDING:

--- a/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
@@ -306,7 +306,7 @@ void BindingHandler::PrintBindingTable()
             \t+ ClusterId %d \n \
             \t+ RemoteEndpointId %d \n \
             \t+ NodeId %d \n",
-                   (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.Value(), (int) entry.remote,
+                   (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(-1), (int) entry.remote,
                    (int) entry.nodeId);
             break;
         case MATTER_MULTICAST_BINDING:

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -284,7 +284,7 @@ void BindingHandler::PrintBindingTable()
             \t+ ClusterId %d \n \
             \t+ RemoteEndpointId %d \n \
             \t+ NodeId %d",
-                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.Value(), (int) entry.remote,
+                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(-1), (int) entry.remote,
                     (int) entry.nodeId);
             break;
         case MATTER_MULTICAST_BINDING:

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -284,7 +284,7 @@ void BindingHandler::PrintBindingTable()
             \t+ ClusterId %d \n \
             \t+ RemoteEndpointId %d \n \
             \t+ NodeId %d",
-                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(-1), (int) entry.remote,
+                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId), (int) entry.remote,
                     (int) entry.nodeId);
             break;
         case MATTER_MULTICAST_BINDING:

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -284,8 +284,8 @@ void BindingHandler::PrintBindingTable()
             \t+ ClusterId %d \n \
             \t+ RemoteEndpointId %d \n \
             \t+ NodeId %d",
-                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId), (int) entry.remote,
-                    (int) entry.nodeId);
+                    (int) entry.fabricIndex, (int) entry.local, (int) entry.clusterId.value_or(kInvalidClusterId),
+                    (int) entry.remote, (int) entry.nodeId);
             break;
         case MATTER_MULTICAST_BINDING:
             LOG_INF("[%d] GROUP:", i++);

--- a/examples/light-switch-app/silabs/src/ShellCommands.cpp
+++ b/examples/light-switch-app/silabs/src/ShellCommands.cpp
@@ -143,7 +143,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.SetValue(6);       // Hardcoded to OnOff cluster for now
+    entry->clusterId.emplace(6);        // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
@@ -159,7 +159,7 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
     entry->nodeId                  = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
     entry->remote                  = atoi(argv[2]);
-    entry->clusterId.SetValue(6); // Hardcode to OnOff cluster for now
+    entry->clusterId.emplace(6); // Hardcode to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/light-switch-app/telink/src/binding-handler.cpp
+++ b/examples/light-switch-app/telink/src/binding-handler.cpp
@@ -243,7 +243,7 @@ CHIP_ERROR BindingGroupBindCommandHandler(int argc, char ** argv)
     entry->fabricIndex             = atoi(argv[0]);
     entry->groupId                 = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
-    entry->clusterId.SetValue(6);       // Hardcoded to OnOff cluster for now
+    entry->clusterId.emplace(6);        // Hardcoded to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;
@@ -259,7 +259,7 @@ CHIP_ERROR BindingUnicastBindCommandHandler(int argc, char ** argv)
     entry->nodeId                  = atoi(argv[1]);
     entry->local                   = 1; // Hardcoded to endpoint 1 for now
     entry->remote                  = atoi(argv[2]);
-    entry->clusterId.SetValue(6); // Hardcode to OnOff cluster for now
+    entry->clusterId.emplace(6); // Hardcode to OnOff cluster for now
 
     DeviceLayer::PlatformMgr().ScheduleWork(BindingWorkerFunction, reinterpret_cast<intptr_t>(entry));
     return CHIP_NO_ERROR;

--- a/examples/tv-casting-app/linux/CastingShellCommands.cpp
+++ b/examples/tv-casting-app/linux/CastingShellCommands.cpp
@@ -91,7 +91,7 @@ void PrintBindings()
                         "Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64
                         " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                         binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
-                        binding.remote, ChipLogValueMEI(binding.clusterId.ValueOr(0)));
+                        binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
     }
 }
 

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -294,7 +294,7 @@ void PrintBindings()
                         "Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64
                         " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                         binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
-                        binding.remote, ChipLogValueMEI(binding.clusterId.ValueOr(0)));
+                        binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
     }
 }
 

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -312,7 +312,7 @@ void CastingServer::ReadServerClustersForNode(NodeId nodeId)
                         "Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64
                         " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                         binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
-                        binding.remote, ChipLogValueMEI(binding.clusterId.ValueOr(0)));
+                        binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
         if (binding.type == MATTER_UNICAST_BINDING && nodeId == binding.nodeId)
         {
             if (!mActiveTargetVideoPlayerInfo.HasEndpoint(binding.remote))
@@ -584,7 +584,7 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
                     "CastingServer::DeviceEventCallback Read cached binding type=%d fabrixIndex=%d nodeId=0x" ChipLogFormatX64
                     " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                     binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
-                    binding.remote, ChipLogValueMEI(binding.clusterId.ValueOr(0)));
+                    binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
                 if (binding.type == MATTER_UNICAST_BINDING && event->BindingsChanged.fabricIndex == binding.fabricIndex)
                 {
                     ChipLogProgress(
@@ -675,7 +675,7 @@ NodeId CastingServer::GetVideoPlayerNodeForFabricIndex(FabricIndex fabricIndex)
                         "Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64
                         " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                         binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
-                        binding.remote, ChipLogValueMEI(binding.clusterId.ValueOr(0)));
+                        binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
         if (binding.type == MATTER_UNICAST_BINDING && fabricIndex == binding.fabricIndex)
         {
             ChipLogProgress(NotSpecified, "GetVideoPlayerNodeForFabricIndex nodeId=0x" ChipLogFormatX64,
@@ -701,7 +701,7 @@ FabricIndex CastingServer::GetVideoPlayerFabricIndexForNode(NodeId nodeId)
                         "Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64
                         " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                         binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
-                        binding.remote, ChipLogValueMEI(binding.clusterId.ValueOr(0)));
+                        binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
         if (binding.type == MATTER_UNICAST_BINDING && nodeId == binding.nodeId)
         {
             ChipLogProgress(NotSpecified, "GetVideoPlayerFabricIndexForNode fabricIndex=%d nodeId=0x" ChipLogFormatX64,

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -155,7 +155,7 @@ void ChipDeviceEventHandler::HandleBindingsChangedViaCluster(const chip::DeviceL
                             "nodeId=0x" ChipLogFormatX64
                             " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                             binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
-                            binding.remote, ChipLogValueMEI(binding.clusterId.ValueOr(0)));
+                            binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
             if (binding.type == MATTER_UNICAST_BINDING && event->BindingsChanged.fabricIndex == binding.fabricIndex)
             {
                 ChipLogProgress(AppServer,

--- a/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
@@ -86,7 +86,7 @@ CHIP_ERROR EndpointListLoader::Load()
                         "Binding type=%d fab=%d nodeId=0x" ChipLogFormatX64
                         " groupId=%d local endpoint=%d remote endpoint=%d cluster=" ChipLogFormatMEI,
                         binding.type, binding.fabricIndex, ChipLogValueX64(binding.nodeId), binding.groupId, binding.local,
-                        binding.remote, ChipLogValueMEI(binding.clusterId.ValueOr(0)));
+                        binding.remote, ChipLogValueMEI(binding.clusterId.value_or(0)));
         if (binding.type == MATTER_UNICAST_BINDING && CastingPlayer::GetTargetCastingPlayer()->GetNodeId() == binding.nodeId)
         {
             // if we discovered a new Endpoint from the bindings, read its EndpointAttributes

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -185,7 +185,7 @@ CHIP_ERROR BindingManager::NotifyBoundClusterChanged(EndpointId endpoint, Cluste
 
     for (auto iter = BindingTable::GetInstance().begin(); iter != BindingTable::GetInstance().end(); ++iter)
     {
-        if (iter->local == endpoint && (!iter->clusterId.has_value() || *(iter->clusterId) == cluster))
+        if (iter->local == endpoint && (iter->clusterId.value_or(cluster) == cluster))
         {
             if (iter->type == MATTER_UNICAST_BINDING)
             {

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -185,7 +185,7 @@ CHIP_ERROR BindingManager::NotifyBoundClusterChanged(EndpointId endpoint, Cluste
 
     for (auto iter = BindingTable::GetInstance().begin(); iter != BindingTable::GetInstance().end(); ++iter)
     {
-        if (iter->local == endpoint && (!iter->clusterId.HasValue() || iter->clusterId.Value() == cluster))
+        if (iter->local == endpoint && (!iter->clusterId.has_value() || *(iter->clusterId) == cluster))
         {
             if (iter->type == MATTER_UNICAST_BINDING)
             {

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -125,12 +125,12 @@ CHIP_ERROR CreateBindingEntry(const TargetStructType & entry, EndpointId localEn
 
     if (entry.group.HasValue())
     {
-        bindingEntry = EmberBindingTableEntry::ForGroup(entry.fabricIndex, entry.group.Value(), localEndpoint, entry.cluster);
+        bindingEntry = EmberBindingTableEntry::ForGroup(entry.fabricIndex, entry.group.Value(), localEndpoint, entry.cluster.std_optional());
     }
     else
     {
         bindingEntry = EmberBindingTableEntry::ForNode(entry.fabricIndex, entry.node.Value(), localEndpoint, entry.endpoint.Value(),
-                                                       entry.cluster);
+                                                       entry.cluster.std_optional());
     }
 
     return AddBindingEntry(bindingEntry);
@@ -159,7 +159,7 @@ CHIP_ERROR BindingTableAccess::ReadBindingTable(EndpointId endpoint, AttributeVa
                     .node        = MakeOptional(entry.nodeId),
                     .group       = NullOptional,
                     .endpoint    = MakeOptional(entry.remote),
-                    .cluster     = entry.clusterId,
+                    .cluster     = FromStdOptional(entry.clusterId),
                     .fabricIndex = entry.fabricIndex,
                 };
                 ReturnErrorOnFailure(subEncoder.Encode(value));
@@ -170,7 +170,7 @@ CHIP_ERROR BindingTableAccess::ReadBindingTable(EndpointId endpoint, AttributeVa
                     .node        = NullOptional,
                     .group       = MakeOptional(entry.groupId),
                     .endpoint    = NullOptional,
-                    .cluster     = entry.clusterId,
+                    .cluster     = FromStdOptional(entry.clusterId),
                     .fabricIndex = entry.fabricIndex,
                 };
                 ReturnErrorOnFailure(subEncoder.Encode(value));

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -125,7 +125,8 @@ CHIP_ERROR CreateBindingEntry(const TargetStructType & entry, EndpointId localEn
 
     if (entry.group.HasValue())
     {
-        bindingEntry = EmberBindingTableEntry::ForGroup(entry.fabricIndex, entry.group.Value(), localEndpoint, entry.cluster.std_optional());
+        bindingEntry =
+            EmberBindingTableEntry::ForGroup(entry.fabricIndex, entry.group.Value(), localEndpoint, entry.cluster.std_optional());
     }
     else
     {

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -84,7 +84,7 @@ struct GroupTableCodec
         TLV::TLVType inner;
         ReturnErrorOnFailure(writer.StartContainer(TagEndpoints(), TLV::kTLVType_Array, inner));
         GroupDataProvider::GroupEndpoint mapping;
-        auto iter = mProvider->IterateEndpoints(mFabric, MakeOptional(mInfo.group_id));
+        auto iter = mProvider->IterateEndpoints(mFabric, std::make_optional(mInfo.group_id));
         if (nullptr != iter)
         {
             while (iter->Next(mapping))

--- a/src/app/tests/TestBindingTable.cpp
+++ b/src/app/tests/TestBindingTable.cpp
@@ -23,7 +23,6 @@
 #include <nlunit-test.h>
 
 using chip::BindingTable;
-using chip::NullOptional;
 
 namespace {
 
@@ -46,9 +45,9 @@ void TestAdd(nlTestSuite * aSuite, void * aContext)
     NL_TEST_ASSERT(aSuite, table.Add(unusedEntry) == CHIP_ERROR_INVALID_ARGUMENT);
     for (uint8_t i = 0; i < MATTER_BINDING_TABLE_SIZE; i++)
     {
-        NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(0, i, 0, 0, NullOptional)) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(0, i, 0, 0, std::nullopt)) == CHIP_NO_ERROR);
     }
-    NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(0, 0, 0, 0, NullOptional)) == CHIP_ERROR_NO_MEMORY);
+    NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(0, 0, 0, 0, std::nullopt)) == CHIP_ERROR_NO_MEMORY);
     NL_TEST_ASSERT(aSuite, table.Size() == MATTER_BINDING_TABLE_SIZE);
 
     auto iter = table.begin();
@@ -67,7 +66,7 @@ void TestRemoveThenAdd(nlTestSuite * aSuite, void * aContext)
     BindingTable table;
     chip::TestPersistentStorageDelegate testStorage;
     table.SetPersistentStorage(&testStorage);
-    NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(0, 0, 0, 0, NullOptional)) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(0, 0, 0, 0, std::nullopt)) == CHIP_NO_ERROR);
     auto iter = table.begin();
     NL_TEST_ASSERT(aSuite, table.RemoveAt(iter) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(aSuite, iter == table.end());
@@ -75,7 +74,7 @@ void TestRemoveThenAdd(nlTestSuite * aSuite, void * aContext)
     NL_TEST_ASSERT(aSuite, table.begin() == table.end());
     for (uint8_t i = 0; i < MATTER_BINDING_TABLE_SIZE; i++)
     {
-        NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(0, i, 0, 0, NullOptional)) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(0, i, 0, 0, std::nullopt)) == CHIP_NO_ERROR);
     }
     iter = table.begin();
     ++iter;
@@ -87,7 +86,7 @@ void TestRemoveThenAdd(nlTestSuite * aSuite, void * aContext)
     ++iterCheck;
     NL_TEST_ASSERT(aSuite, iter == iterCheck);
 
-    NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(0, 1, 0, 0, NullOptional)) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(0, 1, 0, 0, std::nullopt)) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(aSuite, table.Size() == MATTER_BINDING_TABLE_SIZE);
     iter = table.begin();
     for (uint8_t i = 0; i < MATTER_BINDING_TABLE_SIZE - 1; i++)
@@ -137,10 +136,10 @@ void TestPersistentStorage(nlTestSuite * aSuite, void * aContext)
     BindingTable table;
     chip::Optional<chip::ClusterId> cluster = chip::MakeOptional<chip::ClusterId>(static_cast<chip::ClusterId>(UINT16_MAX + 6));
     std::vector<EmberBindingTableEntry> expected = {
-        EmberBindingTableEntry::ForNode(0, 0, 0, 0, NullOptional),
-        EmberBindingTableEntry::ForNode(1, 1, 0, 0, cluster),
-        EmberBindingTableEntry::ForGroup(2, 2, 0, NullOptional),
-        EmberBindingTableEntry::ForGroup(3, 3, 0, cluster),
+        EmberBindingTableEntry::ForNode(0, 0, 0, 0, std::nullopt),
+        EmberBindingTableEntry::ForNode(1, 1, 0, 0, cluster.std_optional()),
+        EmberBindingTableEntry::ForGroup(2, 2, 0, std::nullopt),
+        EmberBindingTableEntry::ForGroup(3, 3, 0, cluster.std_optional()),
     };
     table.SetPersistentStorage(&testStorage);
     NL_TEST_ASSERT(aSuite, table.Add(expected[0]) == CHIP_NO_ERROR);
@@ -151,7 +150,7 @@ void TestPersistentStorage(nlTestSuite * aSuite, void * aContext)
 
     // Verify storage untouched if add fails
     testStorage.AddPoisonKey(chip::DefaultStorageKeyAllocator::BindingTableEntry(4).KeyName());
-    NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(4, 4, 0, 0, NullOptional)) != CHIP_NO_ERROR);
+    NL_TEST_ASSERT(aSuite, table.Add(EmberBindingTableEntry::ForNode(4, 4, 0, 0, std::nullopt)) != CHIP_NO_ERROR);
     VerifyRestored(aSuite, testStorage, expected);
     testStorage.ClearPoisonKeys();
 

--- a/src/app/tests/TestPendingNotificationMap.cpp
+++ b/src/app/tests/TestPendingNotificationMap.cpp
@@ -46,7 +46,7 @@ void CreateDefaultFullBindingTable(BindingTable & table)
 {
     for (uint8_t i = 0; i < MATTER_BINDING_TABLE_SIZE; i++)
     {
-        table.Add(EmberBindingTableEntry::ForNode(i / 10, i % 5, 0, 0, MakeOptional<ClusterId>(i)));
+        table.Add(EmberBindingTableEntry::ForNode(i / 10, i % 5, 0, 0, std::make_optional<ClusterId>(i)));
     }
 }
 

--- a/src/app/util/binding-table.cpp
+++ b/src/app/util/binding-table.cpp
@@ -97,9 +97,9 @@ CHIP_ERROR BindingTable::SaveEntryToStorage(uint8_t index, uint8_t nextIndex)
     ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::TLVType::kTLVType_Structure, container));
     ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kTagFabricIndex), entry.fabricIndex));
     ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kTagLocalEndpoint), entry.local));
-    if (entry.clusterId.HasValue())
+    if (entry.clusterId.has_value())
     {
-        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kTagCluster), entry.clusterId.Value()));
+        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(kTagCluster), *entry.clusterId));
     }
     if (entry.type == MATTER_UNICAST_BINDING)
     {
@@ -202,12 +202,12 @@ CHIP_ERROR BindingTable::LoadEntryFromStorage(uint8_t index, uint8_t & nextIndex
     {
         ClusterId clusterId;
         ReturnErrorOnFailure(reader.Get(clusterId));
-        entry.clusterId.SetValue(clusterId);
+        entry.clusterId.emplace(clusterId);
         ReturnErrorOnFailure(reader.Next());
     }
     else
     {
-        entry.clusterId = NullOptional;
+        entry.clusterId = std::nullopt;
     }
     if (reader.GetTag() == TLV::ContextTag(kTagRemoteEndpoint))
     {

--- a/src/app/util/types_stub.h
+++ b/src/app/util/types_stub.h
@@ -19,9 +19,10 @@
 
 #include <string.h> // For mem* functions.
 
+#include <optional>
+
 #include <app/util/basic-types.h>
 #include <lib/core/NodeId.h>
-#include <lib/core/Optional.h>
 
 static_assert(sizeof(chip::NodeId) == sizeof(uint64_t), "Unexpected node if size");
 
@@ -74,7 +75,7 @@ typedef uint16_t EmberPanId;
 struct EmberBindingTableEntry
 {
     static EmberBindingTableEntry ForNode(chip::FabricIndex fabric, chip::NodeId node, chip::EndpointId localEndpoint,
-                                          chip::EndpointId remoteEndpoint, chip::Optional<chip::ClusterId> cluster)
+                                          chip::EndpointId remoteEndpoint, std::optional<chip::ClusterId> cluster)
     {
         EmberBindingTableEntry entry = {
             .type        = MATTER_UNICAST_BINDING,
@@ -88,7 +89,7 @@ struct EmberBindingTableEntry
     }
 
     static EmberBindingTableEntry ForGroup(chip::FabricIndex fabric, chip::GroupId group, chip::EndpointId localEndpoint,
-                                           chip::Optional<chip::ClusterId> cluster)
+                                           std::optional<chip::ClusterId> cluster)
     {
         EmberBindingTableEntry entry = {
             .type        = MATTER_MULTICAST_BINDING,
@@ -114,7 +115,7 @@ struct EmberBindingTableEntry
      * that a binding can be used to to send messages with any cluster ID, not
      * just that listed in the binding.
      */
-    chip::Optional<chip::ClusterId> clusterId;
+    std::optional<chip::ClusterId> clusterId;
     /** The endpoint on the remote node (specified by \c identifier). */
     chip::EndpointId remote;
     /** A 64-bit destination identifier.  This is either:

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-#include <algorithm>
+#include <optional>
 #include <stdint.h>
 #include <sys/types.h>
 
@@ -253,7 +253,7 @@ public:
      *  @retval An instance of EndpointIterator on success
      *  @retval nullptr if no iterator instances are available.
      */
-    virtual EndpointIterator * IterateEndpoints(FabricIndex fabric_index, Optional<GroupId> group_id = NullOptional) = 0;
+    virtual EndpointIterator * IterateEndpoints(FabricIndex fabric_index, std::optional<GroupId> group_id = std::nullopt) = 0;
 
     //
     // Group-Key map

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -1208,27 +1208,27 @@ void GroupDataProviderImpl::GroupInfoIteratorImpl::Release()
 }
 
 GroupDataProvider::EndpointIterator * GroupDataProviderImpl::IterateEndpoints(chip::FabricIndex fabric_index,
-                                                                              Optional<GroupId> group_id)
+                                                                              std::optional<GroupId> group_id)
 {
     VerifyOrReturnError(IsInitialized(), nullptr);
     return mEndpointIterators.CreateObject(*this, fabric_index, group_id);
 }
 
 GroupDataProviderImpl::EndpointIteratorImpl::EndpointIteratorImpl(GroupDataProviderImpl & provider, chip::FabricIndex fabric_index,
-                                                                  Optional<GroupId> group_id) :
+                                                                  std::optional<GroupId> group_id) :
     mProvider(provider),
     mFabric(fabric_index)
 {
     FabricData fabric(fabric_index);
     VerifyOrReturn(CHIP_NO_ERROR == fabric.Load(provider.mStorage));
 
-    if (group_id.HasValue())
+    if (group_id.has_value())
     {
-        GroupData group(fabric_index, group_id.Value());
+        GroupData group(fabric_index, *group_id);
         VerifyOrReturn(CHIP_NO_ERROR == group.Load(provider.mStorage));
 
-        mGroup         = group_id.Value();
-        mFirstGroup    = group_id.Value();
+        mGroup         = *group_id;
+        mFirstGroup    = *group_id;
         mGroupCount    = 1;
         mEndpoint      = group.first_endpoint;
         mEndpointCount = group.endpoint_count;

--- a/src/credentials/GroupDataProviderImpl.h
+++ b/src/credentials/GroupDataProviderImpl.h
@@ -68,7 +68,7 @@ public:
     CHIP_ERROR RemoveEndpoint(FabricIndex fabric_index, EndpointId endpoint_id) override;
     // Iterators
     GroupInfoIterator * IterateGroupInfo(FabricIndex fabric_index) override;
-    EndpointIterator * IterateEndpoints(FabricIndex fabric_index, Optional<GroupId> group_id = NullOptional) override;
+    EndpointIterator * IterateEndpoints(FabricIndex fabric_index, std::optional<GroupId> group_id = std::nullopt) override;
 
     //
     // Group-Key map
@@ -133,7 +133,7 @@ protected:
     class EndpointIteratorImpl : public EndpointIterator
     {
     public:
-        EndpointIteratorImpl(GroupDataProviderImpl & provider, FabricIndex fabric_index, Optional<GroupId> group_id);
+        EndpointIteratorImpl(GroupDataProviderImpl & provider, FabricIndex fabric_index, std::optional<GroupId> group_id);
         size_t Count() override;
         bool Next(GroupEndpoint & output) override;
         void Release() override;

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -162,6 +162,18 @@ public:
         new (&mValue.mData) T(value);
     }
 
+    constexpr void SetValue(std::optional<T> & value)
+    {
+        if (value.has_value())
+        {
+            SetValue(*value);
+        }
+        else
+        {
+            ClearValue();
+        }
+    }
+
     /** Make the optional contain a specific value */
     constexpr void SetValue(T && value)
     {
@@ -242,6 +254,13 @@ template <class T>
 constexpr Optional<std::decay_t<T>> MakeOptional(T && value)
 {
     return Optional<std::decay_t<T>>(InPlace, std::forward<T>(value));
+}
+
+template <class T>
+constexpr Optional<T> FromStdOptional(const std::optional<T> &value)
+{
+    VerifyOrReturnValue(value.has_value(), NullOptional);
+    return MakeOptional(*value);
 }
 
 template <class T, class... Args>

--- a/src/lib/core/Optional.h
+++ b/src/lib/core/Optional.h
@@ -257,7 +257,7 @@ constexpr Optional<std::decay_t<T>> MakeOptional(T && value)
 }
 
 template <class T>
-constexpr Optional<T> FromStdOptional(const std::optional<T> &value)
+constexpr Optional<T> FromStdOptional(const std::optional<T> & value)
 {
     VerifyOrReturnValue(value.has_value(), NullOptional);
     return MakeOptional(*value);

--- a/src/lib/dnssd/minimal_mdns/responders/Responder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/Responder.h
@@ -21,7 +21,9 @@
 #include <lib/dnssd/minimal_mdns/records/ResourceRecord.h>
 
 #include <inet/IPPacketInfo.h>
-#include <lib/core/Optional.h>
+
+#include <optional>
+#include <cstdint>
 
 namespace mdns {
 namespace Minimal {
@@ -34,28 +36,26 @@ public:
     ResponseConfiguration() {}
     ~ResponseConfiguration() = default;
 
-    chip::Optional<uint32_t> GetTtlSecondsOverride() const { return mTtlSecondsOverride; }
-    ResponseConfiguration & SetTtlSecondsOverride(chip::Optional<uint32_t> override)
+    std::optional<uint32_t> GetTtlSecondsOverride() const { return mTtlSecondsOverride; }
+    ResponseConfiguration & SetTtlSecondsOverride(std::optional<uint32_t> override)
     {
         mTtlSecondsOverride = override;
         return *this;
     }
 
-    ResponseConfiguration & SetTtlSecondsOverride(uint32_t value) { return SetTtlSecondsOverride(chip::MakeOptional(value)); }
-    ResponseConfiguration & ClearTtlSecondsOverride() { return SetTtlSecondsOverride(chip::NullOptional); }
+    ResponseConfiguration & SetTtlSecondsOverride(uint32_t value) { return SetTtlSecondsOverride(std::make_optional(value)); }
+    ResponseConfiguration & ClearTtlSecondsOverride() { return SetTtlSecondsOverride(std::nullopt); }
 
     /// Applies any adjustments to resource records before they are being serialized
     /// to some form of reply.
     void Adjust(ResourceRecord & record) const
     {
-        if (mTtlSecondsOverride.HasValue())
-        {
-            record.SetTtl(mTtlSecondsOverride.Value());
-        }
+        VerifyOrReturn(mTtlSecondsOverride.has_value());
+        record.SetTtl(*mTtlSecondsOverride);
     }
 
 private:
-    chip::Optional<uint32_t> mTtlSecondsOverride;
+    std::optional<uint32_t> mTtlSecondsOverride;
 };
 
 // Delegates that responders can write themselves to

--- a/src/lib/dnssd/minimal_mdns/responders/Responder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/Responder.h
@@ -22,8 +22,8 @@
 
 #include <inet/IPPacketInfo.h>
 
-#include <optional>
 #include <cstdint>
+#include <optional>
 
 namespace mdns {
 namespace Minimal {


### PR DESCRIPTION
To assess the impact of such a conversion.

I expect at some point we have to do some different mass conversion by aliasing chip::Optional to std::optional and see the sideffects (and keep a legacy copy for incompatible items).