### PR TITLE
[ESP32] Compilation fix when IPV4 is disabled.

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -118,7 +118,11 @@ chip_gn_arg_append("chip_config_network_layer_ble"           "false")
 endif()
 
 if(CONFIG_DISABLE_IPV4)
-    chip_gn_arg_append("chip_inet_config_enable_ipv4"        "false")
+    if(NOT CONFIG_LWIP_IPV4)
+        chip_gn_arg_append("chip_inet_config_enable_ipv4"        "false")
+    else()
+	message(FATAL_ERROR "Please also disable config option CONFIG_LWIP_IPV4")
+    endif()
 endif()
 
 if(CONFIG_DISABLE_READ_CLIENT)

--- a/docs/guides/esp32/README.md
+++ b/docs/guides/esp32/README.md
@@ -19,3 +19,4 @@ example on ESP32 series of SoCs
 -   [Generating and Using ESP Secure Cert Partition](secure_cert_partition.md)
 -   [BLE Settings](ble_settings.md)
 -   [Providers](providers.md)
+-   [Configuration Options](config_options.md)

--- a/docs/guides/esp32/config_options.md
+++ b/docs/guides/esp32/config_options.md
@@ -1,6 +1,6 @@
 # Configuration options
 
-This file lists down few config options to be enabled in through menuconfig for
+This file lists down few config options to be configured through menuconfig for
 specific scenarios.
 
 ### Building with IPV4 Disabled

--- a/docs/guides/esp32/config_options.md
+++ b/docs/guides/esp32/config_options.md
@@ -5,7 +5,7 @@ specific scenarios.
 
 ### Building with IPV4 Disabled
 
-Enable the options below through `idf.py menuconfig` and build the app.
+Configure below options through `idf.py menuconfig` and build the app.
 
 ```
 CONFIG_DISABLE_IPV4=y

--- a/docs/guides/esp32/config_options.md
+++ b/docs/guides/esp32/config_options.md
@@ -1,0 +1,13 @@
+# Configuration options
+
+This file lists down few config options to be enabled in through menuconfig for
+specific scenarios.
+
+### Building with IPV4 Disabled
+
+Enable the options below through `idf.py menuconfig` and build the app.
+
+```
+CONFIG_DISABLE_IPV4=y
+CONFIG_LWIP_IPV4=n
+```

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -706,9 +706,13 @@ def main() -> int:
                 if sys.platform == "darwin":
                     shell.run_cmd(
                         "sed -i '' 's/#\\ CONFIG_DISABLE_IPV4\\ is\\ not\\ set/CONFIG_DISABLE_IPV4=y/g' sdkconfig ")
+                    shell.run_cmd(
+                        "sed -i '' 's/CONFIG_LWIP_IPV4=y/#\\ CONFIG_LWIP_IPV4\\ is\\ not\\ set/g' sdkconfig ")
                 else:
                     shell.run_cmd(
                         "sed -i 's/#\\ CONFIG_DISABLE_IPV4\\ is\\ not\\ set/CONFIG_DISABLE_IPV4=y/g' sdkconfig ")
+                    shell.run_cmd(
+                        "sed -i 's/CONFIG_LWIP_IPV4=y/#\\ CONFIG_LWIP_IPV4\\ is\\ not\\ set/g' sdkconfig ")
 
             shell.run_cmd("idf.py build")
             shell.run_cmd("idf.py build flashing_script")

--- a/examples/chef/esp32/sdkconfig.defaults
+++ b/examples/chef/esp32/sdkconfig.defaults
@@ -39,6 +39,9 @@ CONFIG_LWIP_IPV6_AUTOCONFIG=y
 # disable IPV4
 # CONFIG_DISABLE_IPV4 is not set
 
+# lwip IPV4 config
+CONFIG_LWIP_IPV4=y
+
 # Use a custom partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"

--- a/examples/chef/esp32/sdkconfig_rpc.defaults
+++ b/examples/chef/esp32/sdkconfig_rpc.defaults
@@ -36,6 +36,9 @@ CONFIG_LWIP_IPV6_AUTOCONFIG=y
 # disable IPV4
 # CONFIG_DISABLE_IPV4 is not set
 
+# lwip configuration
+CONFIG_LWIP_IPV4=y
+
 # Use a custom partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"

--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -197,6 +197,7 @@ public:
         return pw::OkStatus();
     }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_IPV4
     pw::Status GetIP4Address(const pw_protobuf_Empty & request, chip_rpc_IP4Address & response) override
     {
         esp_netif_ip_info_t ip_info;
@@ -204,6 +205,7 @@ public:
         snprintf(response.address, sizeof(response.address), IPSTR, IP2STR(&ip_info.ip));
         return pw::OkStatus();
     }
+#endif
 
     pw::Status GetIP6Address(const pw_protobuf_Empty & request, chip_rpc_IP6Address & response) override
     {

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -197,6 +197,8 @@ class Esp32Builder(Builder):
         if not self.enable_ipv4:
             self._Execute(
                 ['bash', '-c', 'echo -e "\\nCONFIG_DISABLE_IPV4=y\\n" >>%s' % shlex.quote(defaults_out)])
+            self._Execute(
+                ['bash', '-c', 'echo -e "\\nCONFIG_LWIP_IPV4=n\\n" >>%s' % shlex.quote(defaults_out)])
 
         if self.enable_insights_trace:
             insights_flag = 'y'

--- a/scripts/build/testdata/dry_run_esp32-m5stack-all-clusters-minimal-rpc-ipv6only.txt
+++ b/scripts/build/testdata/dry_run_esp32-m5stack-all-clusters-minimal-rpc-ipv6only.txt
@@ -10,6 +10,8 @@ rm -f examples/all-clusters-minimal-app/esp32/sdkconfig
 
 bash -c 'echo -e "\nCONFIG_DISABLE_IPV4=y\n" >>{out}/esp32-m5stack-all-clusters-minimal-rpc-ipv6only/sdkconfig.defaults'
 
+bash -c 'echo -e "\nCONFIG_LWIP_IPV4=n\n" >>{out}/esp32-m5stack-all-clusters-minimal-rpc-ipv6only/sdkconfig.defaults'
+
 bash -c 'echo -e "\nCONFIG_ESP_INSIGHTS_ENABLED=n\nCONFIG_ENABLE_ESP_INSIGHTS_TRACE=n\n" >>{out}/esp32-m5stack-all-clusters-minimal-rpc-ipv6only/sdkconfig.defaults'
 
 bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 

--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/chip.gni")
 
+import("${chip_root}/src/inet/inet.gni")
 import("${chip_root}/src/platform/device.gni")
 
 assert(chip_device_platform == "esp32")
@@ -36,6 +37,7 @@ declare_args() {
 
 defines = [
   "CHIP_CONFIG_SOFTWARE_VERSION_NUMBER=${chip_config_software_version_number}",
+  "CHIP_DEVICE_CONFIG_ENABLE_IPV4=${chip_inet_config_enable_ipv4}",
 ]
 
 static_library("ESP32") {

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -999,7 +999,7 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
                 // If the station interface has been assigned an IPv4 address, and has
                 // an IPv4 gateway, then presume that the device has IPv4 Internet
                 // connectivity.
-#if LWIP_IPV4
+#if CHIP_DEVICE_CONFIG_ENABLE_IPV4
                 if (!ip4_addr_isany_val(*netif_ip4_addr(netif)) && !ip4_addr_isany_val(*netif_ip4_gw(netif)))
                 {
                     haveIPv4Conn = true;

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -999,6 +999,7 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
                 // If the station interface has been assigned an IPv4 address, and has
                 // an IPv4 gateway, then presume that the device has IPv4 Internet
                 // connectivity.
+#if LWIP_IPV4
                 if (!ip4_addr_isany_val(*netif_ip4_addr(netif)) && !ip4_addr_isany_val(*netif_ip4_gw(netif)))
                 {
                     haveIPv4Conn = true;
@@ -1013,6 +1014,7 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
                         IPAddress::FromString(addrStr, addr);
                     }
                 }
+#endif
 
                 // Search among the IPv6 addresses assigned to the interface for a Global Unicast
                 // address (2000::/3) that is in the valid state.  If such an address is found...


### PR DESCRIPTION
**Problem:**
The compilation failed when `CONFIG_DISABLE_IPV4=y` and `CONFIG_LWIP_IPV4=n` were set through menuconfig as mentioned [here](https://github.com/espressif/esp-matter/issues/714).
Same failure was observed in building connectedhomeip esp32 examples with these above options.

**Change Overview:**
Fixed the compilation for IPV4 for ESP32.

**Testing**
Tested the lighting-app esp32 with above options enabled.