### PR TITLE
[Silabs] Sync SilabsConfig.h with reserved keys from side project

### DIFF
--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -112,6 +112,11 @@ public:
     static constexpr Key KConfigKey_ProductLabel           = SilabsConfigKey(kMatterFactory_KeyBase, 0x10);
     static constexpr Key kConfigKey_ProductURL             = SilabsConfigKey(kMatterFactory_KeyBase, 0x11);
     static constexpr Key kConfigKey_PartNumber             = SilabsConfigKey(kMatterFactory_KeyBase, 0x12);
+    static constexpr Key kConfigKey_CACerts                = SilabsConfigKey(kMatterFactory_KeyBase, 0x13);
+    static constexpr Key kConfigKey_DeviceCerts            = SilabsConfigKey(kMatterFactory_KeyBase, 0x14);
+    static constexpr Key kConfigKey_hostname               = SilabsConfigKey(kMatterFactory_KeyBase, 0x15);
+    static constexpr Key kConfigKey_clientid               = SilabsConfigKey(kMatterFactory_KeyBase, 0x16);
+    static constexpr Key kConfigKey_Test_Event_Trigger_Key = SilabsConfigKey(kMatterFactory_KeyBase, 0x17);
     static constexpr Key kConfigKey_UniqueId               = SilabsConfigKey(kMatterFactory_KeyBase, 0x1F);
     static constexpr Key kConfigKey_Creds_KeyId            = SilabsConfigKey(kMatterFactory_KeyBase, 0x20);
     static constexpr Key kConfigKey_Creds_Base_Addr        = SilabsConfigKey(kMatterFactory_KeyBase, 0x21);
@@ -121,7 +126,11 @@ public:
     static constexpr Key kConfigKey_Creds_PAI_Size         = SilabsConfigKey(kMatterFactory_KeyBase, 0x25);
     static constexpr Key kConfigKey_Creds_CD_Offset        = SilabsConfigKey(kMatterFactory_KeyBase, 0x26);
     static constexpr Key kConfigKey_Creds_CD_Size          = SilabsConfigKey(kMatterFactory_KeyBase, 0x27);
-    static constexpr Key kConfigKey_Test_Event_Trigger_Key = SilabsConfigKey(kMatterFactory_KeyBase, 0x28);
+    static constexpr Key kConfigKey_Provision_Request      = SilabsConfigKey(kMatterFactory_KeyBase, 0x28);
+    static constexpr Key kConfigKey_Provision_Version      = SilabsConfigKey(kMatterFactory_KeyBase, 0x29);
+
+    static constexpr Key kOtaTlvEncryption_KeyId = SilabsConfigKey(kMatterFactory_KeyBase, 0x30);
+
     // Matter Config Keys
     static constexpr Key kConfigKey_ServiceConfig         = SilabsConfigKey(kMatterConfig_KeyBase, 0x01);
     static constexpr Key kConfigKey_PairedAccountId       = SilabsConfigKey(kMatterConfig_KeyBase, 0x02);
@@ -162,7 +171,7 @@ public:
 
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_MatterFactory = SilabsConfigKey(kMatterFactory_KeyBase, 0x00);
-    static constexpr Key kMaxConfigKey_MatterFactory = SilabsConfigKey(kMatterFactory_KeyBase, 0x2F);
+    static constexpr Key kMaxConfigKey_MatterFactory = SilabsConfigKey(kMatterFactory_KeyBase, 0x30);
     static constexpr Key kMinConfigKey_MatterConfig  = SilabsConfigKey(kMatterConfig_KeyBase, 0x00);
     static constexpr Key kMaxConfigKey_MatterConfig  = SilabsConfigKey(kMatterConfig_KeyBase, 0x22);
 


### PR DESCRIPTION
not yet upstreamed to the CSA repo.

- Move recently added `Test_Event_Trigger_Key` to an unused slot as there was a conflict
- upstreaming it now to prevent more key placement conflicts during the 1.4 development

