### PR TITLE
[v1.1-cherrypick] ESP32: Drop Invalid RA packets (#33060)

### DIFF
--- a/src/platform/ESP32/route_hook/ESP32RouteHook.c
+++ b/src/platform/ESP32/route_hook/ESP32RouteHook.c
@@ -65,6 +65,11 @@ static void ra_recv_handler(struct netif * netif, const uint8_t * icmp_payload, 
     {
         uint8_t opt_type = icmp_payload[0];
         uint8_t opt_len  = (uint8_t)(icmp_payload[1] << 3);
+        if (opt_len == 0 || opt_len > payload_len)
+        {
+            ESP_LOGE(TAG, "Invalid ND6 option length");
+            break;
+        }
 
         if (opt_type == ND6_OPTION_TYPE_ROUTE_INFO && opt_len >= sizeof(route_option_t) - sizeof(ip6_addr_p_t) &&
             !is_self_address(netif, src_addr) && payload_len >= opt_len)


### PR DESCRIPTION
 Cherrypick ESP32: Drop Invalid RA packets (#33060) to 1.1 branch

