### PR TITLE
Add missing logging handler for embedded platforms for testing with Pigweed

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -350,6 +350,7 @@ pw_static_library("pw_tests_wrapper") {
   public_deps = [
     "$dir_pw_log:impl",
     "$dir_pw_unit_test",
+    "$dir_pw_unit_test:logging",
   ]
   sources = [
     "UnitTest.cpp",

--- a/src/lib/support/UnitTest.cpp
+++ b/src/lib/support/UnitTest.cpp
@@ -1,12 +1,16 @@
 #include "UnitTest.h"
 
 #include "pw_unit_test/framework.h"
+#include "pw_unit_test/logging_event_handler.h"
 
 namespace chip {
 namespace test {
 
 int RunAllTests()
 {
+    testing::InitGoogleTest(nullptr, nullptr);
+    pw::unit_test::LoggingEventHandler handler;
+    pw::unit_test::RegisterEventHandler(&handler);
     return RUN_ALL_TESTS();
 }
 

--- a/src/lib/support/UnitTest.cpp
+++ b/src/lib/support/UnitTest.cpp
@@ -8,7 +8,7 @@ namespace test {
 
 int RunAllTests()
 {
-    testing::InitGoogleTest(nullptr, nullptr);
+    testing::InitGoogleTest(nullptr, static_cast<char **>(nullptr));
     pw::unit_test::LoggingEventHandler handler;
     pw::unit_test::RegisterEventHandler(&handler);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
## Problem

There was a missing initialisation of `LoggingEventHandler` for embedded platforms. This caused tests for the nrfconnect to run and report an error, but didn't print the correct messages.

## Changes
Add initialization like in [pigweed main](https://github.com/google/pigweed/blob/c6e83c173d13b52d9542700bf40743d2548fe9a2/pw_unit_test/logging_main.cc#L18)