### PR TITLE
Check for changes to data_model directory without a sha update - Issue #31571

### DIFF
--- a/.github/workflows/check-data-model-directory-updates.yaml
+++ b/.github/workflows/check-data-model-directory-updates.yaml
@@ -26,6 +26,6 @@ jobs:
     if: "git diff --name-only HEAD^..HEAD data_model/ | grep -q spec_sha"
     steps:
       - name: Error Message
-        run: echo This pull request attempts to update data_model directory, but is missing updates to spec_sha file with the latest version of the sha.
+        run: echo This pull request attempts to update data_model directory, but is missing updates to spec_sha file with the latest version of the sha. Files in the data_model directory are generated automatically and should not be updated manually.
       - name: Fail Job
         run: exit 1

--- a/.github/workflows/check-data-model-directory-updates.yaml
+++ b/.github/workflows/check-data-model-directory-updates.yaml
@@ -12,3 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+name: Check for changes to data_model directory without a sha update 
+
+on:
+  pull_request:
+    branches-ignore:
+      - 'dependabot/**'
+    paths:
+      - "data_model/**"
+
+jobs:
+  check-submodule-update-label:
+    name: Check for changes to data_model directory without a sha update
+    runs-on: ubuntu-latest
+    if: "git diff --name-only HEAD^..HEAD data_model/ | grep -q spec_sha"
+    steps:
+      - name: Error Message
+        run: echo This pull request attempts to update data_model directory, but is missing updates to spec_sha file with the latest version of the sha.
+      - name: Fail Job
+        run: exit 1

--- a/.github/workflows/check-data-model-directory-updates.yaml
+++ b/.github/workflows/check-data-model-directory-updates.yaml
@@ -16,8 +16,6 @@ name: Check for changes to data_model directory without a sha update
 
 on:
   pull_request:
-    branches-ignore:
-      - 'dependabot/**'
     paths:
       - "data_model/**"
 

--- a/.github/workflows/check-data-model-directory-updates.yaml
+++ b/.github/workflows/check-data-model-directory-updates.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+


### PR DESCRIPTION
Work for Issue #31571 

Workflow that runs on pull request - Enforce no changes to the data_model directory without a sha update, else result in failure of the check.

Files Worked:
- .github/workflows/check-data-model-directory-updates.yaml
