### PR TITLE
[Silabs] Bring Event queue based processing to wifi ncp apps

### DIFF
--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -423,7 +423,7 @@ static int32_t wfx_rsi_init(void)
 
     SILABS_LOG("%s: WLAN: MAC %02x:%02x:%02x %02x:%02x:%02x", __func__, wfx_rsi.sta_mac.octet[0], wfx_rsi.sta_mac.octet[1],
                wfx_rsi.sta_mac.octet[2], wfx_rsi.sta_mac.octet[3], wfx_rsi.sta_mac.octet[4], wfx_rsi.sta_mac.octet[5]);
-    
+
     // Create the message queue
     sWifiEventQueue = osMessageQueueNew(WFX_QUEUE_SIZE, sizeof(WfxEvent_t), NULL);
     if (sWifiEventQueue == NULL)
@@ -665,7 +665,7 @@ void HandleDHCPPolling()
 /** ResetDHCPNotificationFlags
  *  @brief Reset the flags that are used to notify the application about DHCP connectivity
  *         and emits a WFX_EVT_STA_DO_DHCP event to trigger DHCP polling checks. Helper function for ProcessEvent.
- */ 
+ */
 void ResetDHCPNotificationFlags()
 {
     WfxEvent_t outEvent;
@@ -680,7 +680,7 @@ void ResetDHCPNotificationFlags()
     WfxPostEvent(&outEvent);
 }
 
-/** 
+/**
  * @brief Post the WfxEvent to tue WiFiEventQueue to be process by the wfx_rsi_task
  */
 void WfxPostEvent(WfxEvent_t * event)

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -28,13 +28,10 @@
 #include "sl_status.h"
 #include <cmsis_os2.h>
 
-#include "silabs_utils.h"
-#include "wfx_host_events.h"
-#include "rsi_driver.h"
-#include "rsi_wlan_non_rom.h"
 #include "rsi_bootup_config.h"
 #include "rsi_common_apis.h"
 #include "rsi_data_types.h"
+#include "rsi_driver.h"
 #include "rsi_error.h"
 #include "rsi_nwk.h"
 #include "rsi_socket.h"
@@ -42,6 +39,9 @@
 #include "rsi_wlan.h"
 #include "rsi_wlan_apis.h"
 #include "rsi_wlan_config.h"
+#include "rsi_wlan_non_rom.h"
+#include "silabs_utils.h"
+#include "wfx_host_events.h"
 
 #include "dhcp_client.h"
 #include "lwip/nd6.h"
@@ -317,7 +317,7 @@ static void wfx_rsi_join_fail_cb(uint16_t status, uint8_t * buf, uint32_t len)
     wfx_rsi.join_retries += 1;
     wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED);
     is_wifi_disconnection_event = true;
-    WfxEvent.eventType = WFX_EVT_STA_START_JOIN;
+    WfxEvent.eventType          = WFX_EVT_STA_START_JOIN;
     WfxPostEvent(&WfxEvent);
 }
 /*************************************************************************************
@@ -747,8 +747,7 @@ void ProcessEvent(WfxEvent_t inEvent)
             {
                 scan = &scan_rsp.scan_info[x];
                 // is it a scan all or target scan
-                if (!wfx_rsi.scan_ssid ||
-                    (wfx_rsi.scan_ssid && strcmp(wfx_rsi.scan_ssid, (char *) scan->ssid) == CMP_SUCCESS))
+                if (!wfx_rsi.scan_ssid || (wfx_rsi.scan_ssid && strcmp(wfx_rsi.scan_ssid, (char *) scan->ssid) == CMP_SUCCESS))
                 {
                     strncpy(ap.ssid, (char *) scan->ssid, MIN(sizeof(ap.ssid), sizeof(scan->ssid)));
                     ap.security = scan->security_mode;

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -27,6 +27,8 @@
 
 #include "sl_status.h"
 #include <cmsis_os2.h>
+// TODO Fix include order issue #33120
+#include "wfx_host_events.h"
 
 #include "rsi_bootup_config.h"
 #include "rsi_common_apis.h"
@@ -41,7 +43,6 @@
 #include "rsi_wlan_config.h"
 #include "rsi_wlan_non_rom.h"
 #include "silabs_utils.h"
-#include "wfx_host_events.h"
 
 #include "dhcp_client.h"
 #include "lwip/nd6.h"

--- a/examples/platform/silabs/wfx_rsi.h
+++ b/examples/platform/silabs/wfx_rsi.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <event_groups.h>
+#include <wfx_host_events.h>
 
 #ifndef RSI_BLE_ENABLE
 #define RSI_BLE_ENABLE (1)
@@ -69,11 +70,6 @@ typedef struct WfxEvent_s
     void * eventData; // event data TODO: confirm needed
 } WfxEvent_t;
 
-/// WfxPostEvent
-/// @brief Allows to allocate an event to the WFX task event queue from outside of sl_wifi_if.c
-/// @param event The event that will be allocated to the event queue
-void WfxPostEvent(WfxEvent_t * event);
-
 typedef struct wfx_rsi_s
 {
     // TODO: Change tp WfxEventType_e once the event queue is implemented
@@ -124,6 +120,11 @@ int32_t wfx_rsi_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_
 int32_t wfx_rsi_power_save();
 #endif /* SLI_SI917 */
 #endif /* SL_ICD_ENABLED */
+
+/// WfxPostEvent
+/// @brief Allows to allocate an event to the WFX task event queue from outside of sl_wifi_if.c
+/// @param event The event that will be allocated to the event queue
+void WfxPostEvent(WfxEvent_t * event);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Optimize wifi NCP event processing by utilizing a queue.
This brings similar optimization done for our WIFi SoC in #32572, with the end goal of merging both code paths.

