### PR TITLE
v1.3 Commissioner Generated Passcode field for iOS tv-casting-app

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
@@ -70,6 +70,7 @@
 - (uint16_t)vendorId;
 - (uint16_t)productId;
 - (uint32_t)deviceType;
+- (bool)supportsCommissionerGeneratedPasscode;
 - (NSArray * _Nonnull)ipAddresses;
 
 /**

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
@@ -89,8 +89,8 @@ static const NSInteger kMinCommissioningWindowTimeoutSec = matter::casting::core
 
 - (NSString * _Nonnull)description
 {
-    return [NSString stringWithFormat:@"%@ with Product ID: %hu and Vendor ID: %hu. Resolved IPAddr?: %@",
-                     self.deviceName, self.productId, self.vendorId, self.ipAddresses != nil && self.ipAddresses.count > 0 ? @"YES" : @"NO"];
+    return [NSString stringWithFormat:@"%@ with Product ID: %hu and Vendor ID: %hu. Resolved IPAddr?: %@. Supports Commissioner Generated Passcode?: %@.",
+                     self.deviceName, self.productId, self.vendorId, self.ipAddresses != nil && self.ipAddresses.count > 0 ? @"YES" : @"NO", self.supportsCommissionerGeneratedPasscode ? @"YES" : @"NO"];
 }
 
 - (NSString * _Nonnull)identifier
@@ -116,6 +116,11 @@ static const NSInteger kMinCommissioningWindowTimeoutSec = matter::casting::core
 - (uint32_t)deviceType
 {
     return _cppCastingPlayer->GetDeviceType();
+}
+
+- (bool)supportsCommissionerGeneratedPasscode
+{
+    return _cppCastingPlayer->GetSupportsCommissionerGeneratedPasscode();
 }
 
 - (NSArray * _Nonnull)ipAddresses

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCDiscoveryExampleView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCDiscoveryExampleView.swift
@@ -63,9 +63,11 @@ struct MCDiscoveryExampleView: View {
                         },
                         label: {
                             Text(castingPlayer.description)
+                                .frame(minHeight: 50)
+                                .padding()
                         }
                     )
-                    .frame(width: 350, height: 50, alignment: .center)
+                    .frame(width: 350, alignment: .center)
                     .border(Color.black, width: 1)
                     .background(Color.blue)
                     .foregroundColor(Color.white)


### PR DESCRIPTION
Updated iOS tv-casting-app UX with Supports Commissioner Generated Passcode attribute for each discovered CastingPlayer. Created a getter function for this attribute. 

**Change summary**

1.	Added supportsCommissionerGeneratedPasscode() member method to connectedhomeip/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h and .mm MCCastingPlayer class. 
2.	Updated the apps UX in 

**Testing**

Verified and tested locally with the iOS tv-casting-app example app. The example apps discovers CastingPlayers and displays the Supports Commissioner Generated Passcode field for each discovered CastingPlayer in the tv-casting-app UX.


