### PR TITLE
[Silabs] Add Apptask behavior for the LIT ICD app

### DIFF
--- a/examples/lit-icd-app/silabs/include/AppTask.h
+++ b/examples/lit-icd-app/silabs/include/AppTask.h
@@ -28,6 +28,7 @@
 
 #include "AppEvent.h"
 #include "BaseApplication.h"
+#include <app/icd/server/ICDStateObserver.h>
 #include <ble/Ble.h>
 #include <cmsis_os2.h>
 #include <lib/core/CHIPError.h>
@@ -49,11 +50,12 @@
  * AppTask Declaration
  *********************************************************/
 
-class AppTask : public BaseApplication
+class AppTask : public BaseApplication, public chip::app::ICDStateObserver
 {
 
 public:
-    AppTask() = default;
+    AppTask()          = default;
+    virtual ~AppTask() = default;
 
     static AppTask & GetAppTask() { return sAppTask; }
 
@@ -75,6 +77,28 @@ public:
      *                  SL_SIMPLE_BUTTON_RELEASED or SL_SIMPLE_BUTTON_DISABLED
      */
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
+
+    /**
+     * @brief When the ICD enters ActiveMode, update LCD to reflect the ICD current state.
+     *        Set LCD to ActiveMode UI.
+     */
+    void OnEnterActiveMode();
+
+    /**
+     * @brief When the ICD enters IdleMode, update LCD to reflect the ICD current state.
+     *        Set LCD to IdleMode UI.
+     */
+    void OnEnterIdleMode();
+
+    /**
+     * @brief AppTask has no action to do on this ICD event. Do nothing.
+     */
+    void OnTransitionToIdle(){};
+
+    /**
+     * @brief AppTask has no action to do on this ICD event. Do nothing.
+     */
+    void OnICDModeChange(){};
 
 private:
     static AppTask sAppTask;

--- a/examples/lit-icd-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/lit-icd-app/silabs/include/CHIPProjectConfig.h
@@ -86,3 +86,10 @@
  * A size, in bytes, of the individual debug event logging buffer.
  */
 #define CHIP_DEVICE_CONFIG_EVENT_LOGGING_DEBUG_BUFFER_SIZE (512)
+
+/**
+ * @brief CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE
+ *
+ * Increase default(2) by 1 to account for the AppTask registering
+ */
+#define CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE 3

--- a/examples/lit-icd-app/silabs/src/AppTask.cpp
+++ b/examples/lit-icd-app/silabs/src/AppTask.cpp
@@ -33,16 +33,17 @@
 #endif // QR_CODE_ENABLED
 #endif // DISPLAY_ENABLED
 
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 #include <assert.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/silabs/platformAbstraction/SilabsPlatform.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
-
-#include <platform/silabs/platformAbstraction/SilabsPlatform.h>
 
 /**********************************************************
  * Defines and Constants
@@ -103,6 +104,8 @@ void AppTask::AppTaskMain(void * pvParameter)
         appError(err);
     }
 
+    chip::Server::GetInstance().GetICDManager().RegisterObserver(&sAppTask);
+
 #if !(defined(CHIP_CONFIG_ENABLE_ICD_SERVER) && CHIP_CONFIG_ENABLE_ICD_SERVER)
     sAppTask.StartStatusLEDTimer();
 #endif
@@ -122,7 +125,28 @@ void AppTask::AppTaskMain(void * pvParameter)
 void AppTask::ApplicationEventHandler(AppEvent * aEvent)
 {
     VerifyOrReturn(aEvent->Type == AppEvent::kEventType_Button);
-    // TODO - trigger some application event
+    VerifyOrReturn(aEvent->ButtonEvent.Action == static_cast<uint8_t>(SilabsPlatform::ButtonAction::ButtonPressed));
+
+    // Simple Application logic that toggles the BoleanState StateValue attribute.
+    // DO NOT COPY for product logic. LIT ICD app is a test app with very simple application logic to enable testing.
+    // The goal of the app is just to enable testing of LIT ICD features without impacting product sample apps.
+    PlatformMgr().ScheduleWork([](intptr_t) {
+        bool state = true;
+
+        Protocols::InteractionModel::Status status = chip::app::Clusters::BooleanState::Attributes::StateValue::Get(1, &state);
+        if (status != Protocols::InteractionModel::Status::Success)
+        {
+            // Failed to read StateValue. Default to true (open state)
+            state = true;
+            ChipLogError(NotSpecified, "ERR: reading boolean status value %x", to_underlying(status));
+        }
+
+        status = chip::app::Clusters::BooleanState::Attributes::StateValue::Set(1, !state);
+        if (status != Protocols::InteractionModel::Status::Success)
+        {
+            ChipLogError(NotSpecified, "ERR: updating boolean status value %x", to_underlying(status));
+        }
+    });
 }
 
 void AppTask::ButtonEventHandler(uint8_t button, uint8_t btnAction)
@@ -141,4 +165,16 @@ void AppTask::ButtonEventHandler(uint8_t button, uint8_t btnAction)
         button_event.Handler = BaseApplication::ButtonHandler;
         sAppTask.PostEvent(&button_event);
     }
+}
+
+// DO NOT COPY for product logic. LIT ICD app is a test app with very simple application logic to enable testing.
+void AppTask::OnEnterActiveMode()
+{
+    sAppTask.GetLCD().WriteDemoUI(true);
+}
+
+// DO NOT COPY for product logic. LIT ICD app is a test app with very simple application logic to enable testing.
+void AppTask::OnEnterIdleMode()
+{
+    sAppTask.GetLCD().WriteDemoUI(false);
 }


### PR DESCRIPTION
#### Description 
PR adds application behavior to the Silabs LIT ICD app to be able to visualize when the device is idle or active.
PR also adds a button action to udpate the bolean state cluster.

**Note to reviewers:** Application logic is very simple because the LIT ICD app is a test app. It is not meant to be used as product app.

#### Tests
Manual tests to make sure the device has the correct UI based on its state.
