### PR TITLE
Fix builds to macos-13 rather than latest due to bootstrap python incompatibilities

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -371,7 +371,7 @@ jobs:
 
     build_darwin:
         name: Build on Darwin (clang, python_lib, simulated)
-        runs-on: macos-latest
+        runs-on: macos-13
         if: github.actor != 'restyled-io[bot]'
 
         steps:

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -68,7 +68,7 @@ jobs:
 
     build_darwin_fuzzing:
         name: Build on Darwin
-        runs-on: macos-latest
+        runs-on: macos-13
         if: github.actor != 'restyled-io[bot]'
 
         steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -330,7 +330,7 @@ jobs:
             LSAN_OPTIONS: detect_leaks=1 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
         if: github.actor != 'restyled-io[bot]'
-        runs-on: macos-latest
+        runs-on: macos-13
 
         steps:
             - name: Checkout
@@ -588,7 +588,7 @@ jobs:
             TSAN_OPTIONS: "halt_on_error=1"
 
         if: github.actor != 'restyled-io[bot]' && false
-        runs-on: macos-latest
+        runs-on: macos-13
 
         steps:
             - name: Checkout


### PR DESCRIPTION
Builds seem to fail with `AttributeError: cython_sources` which seems to point at an incompatibility between PyYaml and python 3.12 (pyyaml seems to claim compatibility up to python 3.11 so far)

Preliminary investigation of failures seem to indicate:
  - CI passed when `macos-latest` was pointing to `macos-12` (odd, since 13 also existed)
  - When github moved the label to point to `macos-14-arm64` we started having failures

So this may be python version or architecture version or both.

Unclear if this is the correct fix since we presumably want to ensure darwin code compiles on the latest release of the platform, however for now validating the claim that runner version is at fault for build failures.