### PR TITLE
Make sure reference counting is correct when calling abort on a failed Paring handshake.

### DIFF
--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -242,7 +242,7 @@ void PairingSession::Clear()
         // ExchangeContext::Abort will auto-release the underlying values. Since
         // we are using reference counted handles, we Retain to increase the
         // reference count before Abort, so that Abort() just closes without
-        // invalidagint context reference counts
+        // invalidating handle reference counts
         const uint32_t referenceCount = mExchangeCtxt.Value()->GetReferenceCount();
         mExchangeCtxt.Value()->Retain();
         mExchangeCtxt.Value()->Abort();

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -25,7 +25,6 @@
 #include <credentials/GroupDataProviderImpl.h>
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <crypto/DefaultSessionKeystore.h>
-#include <errno.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/core/DataModelTypes.h>
@@ -464,6 +463,9 @@ void TestCASESession::SecurePairingStartTest(nlTestSuite * inSuite, void * inCon
     ServiceEvents(ctx);
 
     loopback.mMessageSendError = CHIP_NO_ERROR;
+
+    context->Release();
+    context1->Release();
 }
 
 void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, SessionManager & sessionManager,
@@ -1123,6 +1125,8 @@ void TestCASESession::SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuit
     // Sanity check that pairing did not complete.
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 0);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 0);
+
+    contextCommissioner->Release();
 }
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
@@ -1206,6 +1210,8 @@ void TestCASESession::Sigma1BadDestinationIdTest(nlTestSuite * inSuite, void * i
 
     ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(MsgType::CASE_Sigma1);
     caseSession.Clear();
+
+    ctx.GetExchangeManager().CloseAllContextsForDelegate(&delegate);
 }
 
 } // namespace chip

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -244,6 +244,9 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     loopback.mMessageSendError = CHIP_NO_ERROR;
+
+    context->Release();
+    context1->Release();
 }
 
 void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, SessionManager & sessionManager,


### PR DESCRIPTION
ExchangeContext::Abort() already calls Release(). Since ExchangeHandles are used, maintain the ReferenceCount the same by increasing it before calling abort. Cleanup is to be handled by ExchangeHandles.