### PR TITLE
[Darwin] Add optional concurrent execution to MTRAsyncWorkQueue

### DIFF
--- a/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.h
+++ b/src/darwin/Framework/CHIP/MTRAsyncWorkQueue.h
@@ -192,6 +192,17 @@ MTR_TESTABLE
 /// is lost.
 - (instancetype)initWithContext:(ContextType)context;
 
+/// Creates a work queue with the given context object and a queue width.
+///
+/// The queue will call readyHandler on up to "width" number of work items
+/// concurrently. Once "width" number of work items have started, no other
+/// work items will get a readyHandler call until one of the running work items
+/// has called its completion block with MTRAsyncWorkComplete.
+///
+/// This allows the a MTRAsyncWorkQueue object to manage a pool of
+/// resources that can be use concurrently at any given time.
+- (instancetype)initWithContext:(ContextType)context width:(NSUInteger)width;
+
 /// Enqueues the specified work item, making it eligible for execution.
 ///
 /// Once a work item is enqueued, ownership of it passes to the queue and

--- a/src/darwin/Framework/CHIPTests/MTRAsyncWorkQueueTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRAsyncWorkQueueTests.m
@@ -544,13 +544,17 @@
 
     [self waitForExpectations:@[ first3WorkItemsExecutedExpectation ] timeout:2];
     // the before-sleep counter should have reached 3 immediately as they all run concurrently.
+    os_unfair_lock_lock(&counterLock);
     XCTAssertEqual(afterSleepCounter, 0);
+    os_unfair_lock_unlock(&counterLock);
 
     [self waitForExpectations:@[ lastWorkItemWaitedExpectation, first3WorkItemsSleptExpectation ] timeout:2];
 
     // see that all 3 first items ran and slept
+    os_unfair_lock_lock(&counterLock);
     XCTAssertEqual(beforeSleepCounter, 3);
     XCTAssertEqual(afterSleepCounter, 3);
+    os_unfair_lock_unlock(&counterLock);
 }
 
 @end

--- a/src/darwin/Framework/CHIPTests/MTRAsyncWorkQueueTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRAsyncWorkQueueTests.m
@@ -508,10 +508,12 @@
         }
         os_unfair_lock_unlock(&counterLock);
         sleep(1);
+        os_unfair_lock_lock(&counterLock);
         afterSleepCounter++;
         if (afterSleepCounter == 3) {
             [first3WorkItemsSleptExpectation fulfill];
         }
+        os_unfair_lock_unlock(&counterLock);
         completion(MTRAsyncWorkComplete);
     };
 
@@ -533,9 +535,8 @@
     workItemLast.readyHandler = ^(id context, NSInteger retryCount, MTRAsyncWorkCompletionBlock completion) {
         // expect this to have waited until at least one of the above items finished after sleep() and incremented counter
         os_unfair_lock_lock(&counterLock);
-        if (afterSleepCounter > 0) {
-            [lastWorkItemWaitedExpectation fulfill];
-        }
+        XCTAssert(afterSleepCounter > 0);
+        [lastWorkItemWaitedExpectation fulfill];
         os_unfair_lock_unlock(&counterLock);
         completion(MTRAsyncWorkComplete);
     };

--- a/src/darwin/Framework/CHIPTests/MTRAsyncWorkQueueTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRAsyncWorkQueueTests.m
@@ -491,4 +491,65 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
+- (void)testItemsConcurrently
+{
+    MTRAsyncWorkQueue * workQueue = [[MTRAsyncWorkQueue alloc] initWithContext:NSNull.null width:3];
+
+    XCTestExpectation * first3WorkItemsExecutedExpectation = [self expectationWithDescription:@"First 3 work items executed"];
+    XCTestExpectation * first3WorkItemsSleptExpectation = [self expectationWithDescription:@"First 3 work items slept"];
+    __block os_unfair_lock counterLock = OS_UNFAIR_LOCK_INIT;
+    __block int beforeSleepCounter = 0;
+    __block int afterSleepCounter = 0;
+    __auto_type sleep1ReadyHandler = ^(id context, NSInteger retryCount, MTRAsyncWorkCompletionBlock completion) {
+        os_unfair_lock_lock(&counterLock);
+        beforeSleepCounter++;
+        if (beforeSleepCounter == 3) {
+            [first3WorkItemsExecutedExpectation fulfill];
+        }
+        os_unfair_lock_unlock(&counterLock);
+        sleep(1);
+        afterSleepCounter++;
+        if (afterSleepCounter == 3) {
+            [first3WorkItemsSleptExpectation fulfill];
+        }
+        completion(MTRAsyncWorkComplete);
+    };
+
+    MTRAsyncWorkItem * workItem1 = [[MTRAsyncWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
+    workItem1.readyHandler = sleep1ReadyHandler;
+    [workQueue enqueueWorkItem:workItem1 descriptionWithFormat:@"work item %d", 1];
+
+    MTRAsyncWorkItem * workItem2 = [[MTRAsyncWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
+    workItem2.readyHandler = sleep1ReadyHandler;
+    [workQueue enqueueWorkItem:workItem2 descriptionWithFormat:@"work item %d", 2];
+
+    MTRAsyncWorkItem * workItem3 = [[MTRAsyncWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
+    workItem3.readyHandler = sleep1ReadyHandler;
+    [workQueue enqueueWorkItem:workItem3 descriptionWithFormat:@"work item %d", 3];
+
+    // This is the item after the first 3, and should onl execute when one of them finished
+    XCTestExpectation * lastWorkItemWaitedExpectation = [self expectationWithDescription:@"Last work item waited properly"];
+    MTRAsyncWorkItem * workItemLast = [[MTRAsyncWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
+    workItemLast.readyHandler = ^(id context, NSInteger retryCount, MTRAsyncWorkCompletionBlock completion) {
+        // expect this to have waited until at least one of the above items finished after sleep() and incremented counter
+        os_unfair_lock_lock(&counterLock);
+        if (afterSleepCounter > 0) {
+            [lastWorkItemWaitedExpectation fulfill];
+        }
+        os_unfair_lock_unlock(&counterLock);
+        completion(MTRAsyncWorkComplete);
+    };
+    [workQueue enqueueWorkItem:workItemLast description:@"last work item"];
+
+    [self waitForExpectations:@[ first3WorkItemsExecutedExpectation ] timeout:2];
+    // the before-sleep counter should have reached 3 immediately as they all run concurrently.
+    XCTAssertEqual(afterSleepCounter, 0);
+
+    [self waitForExpectations:@[ lastWorkItemWaitedExpectation, first3WorkItemsSleptExpectation ] timeout:2];
+
+    // see that all 3 first items ran and slept
+    XCTAssertEqual(beforeSleepCounter, 3);
+    XCTAssertEqual(afterSleepCounter, 3);
+}
+
 @end

--- a/src/darwin/Framework/CHIPTests/MTRAsyncWorkQueueTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRAsyncWorkQueueTests.m
@@ -527,7 +527,7 @@
     workItem3.readyHandler = sleep1ReadyHandler;
     [workQueue enqueueWorkItem:workItem3 descriptionWithFormat:@"work item %d", 3];
 
-    // This is the item after the first 3, and should onl execute when one of them finished
+    // This is the item after the first 3, and should only execute when one of them finished
     XCTestExpectation * lastWorkItemWaitedExpectation = [self expectationWithDescription:@"Last work item waited properly"];
     MTRAsyncWorkItem * workItemLast = [[MTRAsyncWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
     workItemLast.readyHandler = ^(id context, NSInteger retryCount, MTRAsyncWorkCompletionBlock completion) {


### PR DESCRIPTION
This adds an optional initializer to MTRAsyncWorkQueue to allow for concurrent execution of work items.