### PR TITLE
update handup time setting for WebSocketServer to fix socket closed issue

### DIFF
--- a/examples/common/websocket-server/WebSocketServer.cpp
+++ b/examples/common/websocket-server/WebSocketServer.cpp
@@ -178,7 +178,7 @@ CHIP_ERROR WebSocketServer::Run(chip::Optional<uint16_t> port, WebSocketServerDe
     info.protocols                    = protocols;
     static const lws_retry_bo_t retry = {
         .secs_since_valid_ping   = 400,
-        .secs_since_valid_hangup = 400,
+        .secs_since_valid_hangup = 420,
     };
     info.retry_and_idle_policy = &retry;
 


### PR DESCRIPTION
set secs_since_valid_hangup larger than secs_since_valid_ping, otherwise the socket will be close directlly after 400s and no ping sent out

Fixes #31357 
may fixe the connection issue

Fixes #30546
improve the changes
