### PR TITLE
Replace nl-unit-test with pigweed for interaction_model

### DIFF
--- a/src/protocols/interaction_model/tests/BUILD.gn
+++ b/src/protocols/interaction_model/tests/BUILD.gn
@@ -14,11 +14,10 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
-chip_test_suite_using_nltest("tests") {
+chip_test_suite("tests") {
   output_name = "libInteractionModelTests"
 
   test_sources = [ "TestStatusCode.cpp" ]
@@ -26,9 +25,7 @@ chip_test_suite_using_nltest("tests") {
   public_deps = [
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
-    "${chip_root}/src/lib/support:testing_nlunit",
     "${chip_root}/src/protocols/interaction_model",
-    "${nlunit_test_root}:nlunit-test",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/protocols/interaction_model/tests/TestStatusCode.cpp
+++ b/src/protocols/interaction_model/tests/TestStatusCode.cpp
@@ -18,54 +18,51 @@
 
 #include <stdint.h>
 
+#include <gtest/gtest.h>
 #include <lib/core/Optional.h>
-#include <lib/support/UnitTestExtendedAssertions.h>
-#include <lib/support/UnitTestRegistration.h>
 #include <protocols/interaction_model/StatusCode.h>
-
-#include <nlunit-test.h>
 
 using namespace ::chip;
 using namespace ::chip::Protocols::InteractionModel;
 
 namespace {
 
-void TestStatusBasicValues(nlTestSuite * inSuite, void * inContext)
+TEST(TestStatusCode, TestStatusBasicValues)
 {
-    NL_TEST_ASSERT_EQUALS(inSuite, static_cast<int>(Status::Success), 0);
-    NL_TEST_ASSERT_EQUALS(inSuite, static_cast<int>(Status::Failure), 1);
-    NL_TEST_ASSERT_EQUALS(inSuite, static_cast<int>(Status::UnsupportedEndpoint), 0x7f);
-    NL_TEST_ASSERT_EQUALS(inSuite, static_cast<int>(Status::InvalidInState), 0xcb);
+    EXPECT_EQ(static_cast<int>(Status::Success), 0);
+    EXPECT_EQ(static_cast<int>(Status::Failure), 1);
+    EXPECT_EQ(static_cast<int>(Status::UnsupportedEndpoint), 0x7f);
+    EXPECT_EQ(static_cast<int>(Status::InvalidInState), 0xcb);
 }
 
-void TestClusterStatusCode(nlTestSuite * inSuite, void * inContext)
+TEST(TestStatusCode, TestClusterStatusCode)
 {
     // Basic usage as a Status.
     {
         ClusterStatusCode status_code_success{ Status::Success };
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, Status::Success);
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetStatus(), Status::Success);
-        NL_TEST_ASSERT(inSuite, !status_code_success.HasClusterSpecificCode());
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetClusterSpecificCode(), chip::NullOptional);
-        NL_TEST_ASSERT(inSuite, status_code_success.IsSuccess());
+        EXPECT_EQ(status_code_success, Status::Success);
+        EXPECT_EQ(status_code_success.GetStatus(), Status::Success);
+        EXPECT_FALSE(status_code_success.HasClusterSpecificCode());
+        EXPECT_EQ(status_code_success.GetClusterSpecificCode(), chip::NullOptional);
+        EXPECT_TRUE(status_code_success.IsSuccess());
 
         ClusterStatusCode status_code_failure{ Status::Failure };
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, Status::Failure);
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure.GetStatus(), Status::Failure);
-        NL_TEST_ASSERT(inSuite, !status_code_failure.HasClusterSpecificCode());
-        NL_TEST_ASSERT(inSuite, !status_code_failure.IsSuccess());
+        EXPECT_EQ(status_code_failure, Status::Failure);
+        EXPECT_EQ(status_code_failure.GetStatus(), Status::Failure);
+        EXPECT_FALSE(status_code_failure.HasClusterSpecificCode());
+        EXPECT_FALSE(status_code_failure.IsSuccess());
 
         ClusterStatusCode status_code_unsupported_ep{ Status::UnsupportedEndpoint };
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep, Status::UnsupportedEndpoint);
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_unsupported_ep.GetStatus(), Status::UnsupportedEndpoint);
-        NL_TEST_ASSERT(inSuite, !status_code_unsupported_ep.HasClusterSpecificCode());
-        NL_TEST_ASSERT(inSuite, !status_code_unsupported_ep.IsSuccess());
+        EXPECT_EQ(status_code_unsupported_ep, Status::UnsupportedEndpoint);
+        EXPECT_EQ(status_code_unsupported_ep.GetStatus(), Status::UnsupportedEndpoint);
+        EXPECT_FALSE(status_code_unsupported_ep.HasClusterSpecificCode());
+        EXPECT_FALSE(status_code_unsupported_ep.IsSuccess());
 
         ClusterStatusCode status_code_invalid_in_state{ Status::InvalidInState };
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state, Status::InvalidInState);
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_invalid_in_state.GetStatus(), Status::InvalidInState);
-        NL_TEST_ASSERT(inSuite, !status_code_invalid_in_state.HasClusterSpecificCode());
-        NL_TEST_ASSERT(inSuite, !status_code_invalid_in_state.IsSuccess());
+        EXPECT_EQ(status_code_invalid_in_state, Status::InvalidInState);
+        EXPECT_EQ(status_code_invalid_in_state.GetStatus(), Status::InvalidInState);
+        EXPECT_FALSE(status_code_invalid_in_state.HasClusterSpecificCode());
+        EXPECT_FALSE(status_code_invalid_in_state.IsSuccess());
     }
 
     enum RobotoClusterStatus : uint8_t
@@ -77,18 +74,16 @@ void TestClusterStatusCode(nlTestSuite * inSuite, void * inContext)
     // Cluster-specific usage.
     {
         ClusterStatusCode status_code_success = ClusterStatusCode::ClusterSpecificSuccess(RobotoClusterStatus::kSauceSuccess);
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success, Status::Success);
-        NL_TEST_ASSERT(inSuite, status_code_success.HasClusterSpecificCode());
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_success.GetClusterSpecificCode(),
-                              static_cast<uint8_t>(RobotoClusterStatus::kSauceSuccess));
-        NL_TEST_ASSERT(inSuite, status_code_success.IsSuccess());
+        EXPECT_EQ(status_code_success, Status::Success);
+        EXPECT_TRUE(status_code_success.HasClusterSpecificCode());
+        EXPECT_EQ(status_code_success.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoClusterStatus::kSauceSuccess));
+        EXPECT_TRUE(status_code_success.IsSuccess());
 
         ClusterStatusCode status_code_failure = ClusterStatusCode::ClusterSpecificFailure(RobotoClusterStatus::kSandwichError);
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure, Status::Failure);
-        NL_TEST_ASSERT(inSuite, status_code_failure.HasClusterSpecificCode());
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure.GetClusterSpecificCode(),
-                              static_cast<uint8_t>(RobotoClusterStatus::kSandwichError));
-        NL_TEST_ASSERT(inSuite, !status_code_failure.IsSuccess());
+        EXPECT_EQ(status_code_failure, Status::Failure);
+        EXPECT_TRUE(status_code_failure.HasClusterSpecificCode());
+        EXPECT_EQ(status_code_failure.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoClusterStatus::kSandwichError));
+        EXPECT_FALSE(status_code_failure.IsSuccess());
     }
 
     // Copy/Assignment
@@ -96,40 +91,19 @@ void TestClusterStatusCode(nlTestSuite * inSuite, void * inContext)
         ClusterStatusCode status_code_failure1 = ClusterStatusCode::ClusterSpecificFailure(RobotoClusterStatus::kSandwichError);
         ClusterStatusCode status_code_failure2(status_code_failure1);
 
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure1, status_code_failure2);
-        NL_TEST_ASSERT(inSuite, status_code_failure1.HasClusterSpecificCode());
-        NL_TEST_ASSERT(inSuite, status_code_failure2.HasClusterSpecificCode());
+        EXPECT_EQ(status_code_failure1, status_code_failure2);
+        EXPECT_TRUE(status_code_failure1.HasClusterSpecificCode());
+        EXPECT_TRUE(status_code_failure2.HasClusterSpecificCode());
 
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure1.GetClusterSpecificCode(),
-                              static_cast<uint8_t>(RobotoClusterStatus::kSandwichError));
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure2.GetClusterSpecificCode(),
-                              static_cast<uint8_t>(RobotoClusterStatus::kSandwichError));
+        EXPECT_EQ(status_code_failure1.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoClusterStatus::kSandwichError));
+        EXPECT_EQ(status_code_failure2.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoClusterStatus::kSandwichError));
 
         ClusterStatusCode status_code_failure3{ Status::InvalidCommand };
-        NL_TEST_ASSERT(inSuite, status_code_failure2 != status_code_failure3);
+        EXPECT_NE(status_code_failure2, status_code_failure3);
 
         status_code_failure3 = status_code_failure2;
-        NL_TEST_ASSERT_EQUALS(inSuite, status_code_failure2, status_code_failure3);
+        EXPECT_EQ(status_code_failure2, status_code_failure3);
     }
 }
 
-// clang-format off
-const nlTest sTests[] =
-{
-    NL_TEST_DEF("TestStatusBasicValues", TestStatusBasicValues),
-    NL_TEST_DEF("TestClusterStatusCode", TestClusterStatusCode),
-    NL_TEST_SENTINEL()
-};
-// clang-format on
-
-nlTestSuite sSuite = { "Test IM Status Code abstractions", &sTests[0], nullptr, nullptr };
 } // namespace
-
-int TestClusterStatusCode()
-{
-    nlTestRunner(&sSuite, nullptr);
-
-    return (nlTestRunnerStats(&sSuite));
-}
-
-CHIP_REGISTER_TEST_SUITE(TestClusterStatusCode)


### PR DESCRIPTION
## Problem
The problem was described in #29342. 

## Changes
These changes are another piece of replacing the nl-unit test with the pigweed-unit test. I changed tests for the `interaction_model`. I didn't introduce any changes to the logic of tests; I only replaced one framework with another. 

