### PR TITLE
Replace nl-unit-test with pigweed for system user_directed_commissioning

### DIFF
--- a/src/protocols/user_directed_commissioning/tests/BUILD.gn
+++ b/src/protocols/user_directed_commissioning/tests/BUILD.gn
@@ -12,11 +12,10 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/nlunit_test.gni")
 
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
-chip_test_suite_using_nltest("tests") {
+chip_test_suite("tests") {
   output_name = "libUserDirectedCommissioningTests"
 
   test_sources = [ "TestUdcMessages.cpp" ]
@@ -24,9 +23,7 @@ chip_test_suite_using_nltest("tests") {
   public_deps = [
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
-    "${chip_root}/src/lib/support:testing_nlunit",
     "${chip_root}/src/protocols",
-    "${nlunit_test_root}:nlunit-test",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -1,6 +1,6 @@
 #include <protocols/user_directed_commissioning/UserDirectedCommissioning.h>
 
-#include <nlunit-test.h>
+#include <gtest/gtest.h>
 
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/dnssd/TxtFields.h>
@@ -8,8 +8,6 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/UnitTestContext.h>
-#include <lib/support/UnitTestRegistration.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/MessageHeader.h>
 #include <transport/raw/UDP.h>
@@ -20,6 +18,13 @@ using namespace chip;
 using namespace chip::Protocols::UserDirectedCommissioning;
 using namespace chip::Dnssd;
 using namespace chip::Dnssd::Internal;
+
+struct TestUdcMessages : public ::testing::Test
+{
+
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
 
 ByteSpan GetSpan(char * key)
 {
@@ -57,20 +62,20 @@ public:
 
 using DeviceTransportMgr = TransportMgr<Transport::UDP>;
 
-void TestUDCServerClients(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestUdcMessages, TestUDCServerClients)
 {
     UserDirectedCommissioningServer udcServer;
     const char * instanceName1 = "servertest1";
 
     // test setting UDC Clients
-    NL_TEST_ASSERT(inSuite, nullptr == udcServer.GetUDCClients().FindUDCClientState(instanceName1));
+    EXPECT_EQ(nullptr, udcServer.GetUDCClients().FindUDCClientState(instanceName1));
     udcServer.SetUDCClientProcessingState((char *) instanceName1, UDCClientProcessingState::kUserDeclined);
     UDCClientState * state = udcServer.GetUDCClients().FindUDCClientState(instanceName1);
-    NL_TEST_EXIT_ON_FAILED_ASSERT(inSuite, nullptr != state);
-    NL_TEST_ASSERT(inSuite, UDCClientProcessingState::kUserDeclined == state->GetUDCClientProcessingState());
+    ASSERT_NE(nullptr, state);
+    EXPECT_EQ(UDCClientProcessingState::kUserDeclined, state->GetUDCClientProcessingState());
 }
 
-void TestUDCServerUserConfirmationProvider(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestUdcMessages, TestUDCServerUserConfirmationProvider)
 {
     UserDirectedCommissioningServer udcServer;
     TestCallback testCallback;
@@ -104,13 +109,13 @@ void TestUDCServerUserConfirmationProvider(nlTestSuite * inSuite, void * inConte
     udcServer.OnCommissionableNodeFound(nodeData2);
     udcServer.OnCommissionableNodeFound(nodeData1);
     state = udcServer.GetUDCClients().FindUDCClientState(instanceName1);
-    NL_TEST_EXIT_ON_FAILED_ASSERT(inSuite, nullptr != state);
-    NL_TEST_ASSERT(inSuite, UDCClientProcessingState::kUserDeclined == state->GetUDCClientProcessingState());
+    ASSERT_NE(nullptr, state);
+    EXPECT_EQ(UDCClientProcessingState::kUserDeclined, state->GetUDCClientProcessingState());
     // test other fields on UDCClientState
-    NL_TEST_ASSERT(inSuite, 0 == strcmp(state->GetInstanceName(), instanceName1));
+    EXPECT_STREQ(state->GetInstanceName(), instanceName1);
     // check that instance2 was found
     state = udcServer.GetUDCClients().FindUDCClientState(instanceName2);
-    NL_TEST_ASSERT(inSuite, nullptr == state);
+    EXPECT_EQ(nullptr, state);
 
     // test current state check
     udcServer.SetUDCClientProcessingState((char *) instanceName1, UDCClientProcessingState::kUserDeclined);
@@ -118,28 +123,31 @@ void TestUDCServerUserConfirmationProvider(nlTestSuite * inSuite, void * inConte
     udcServer.OnCommissionableNodeFound(nodeData2);
     udcServer.OnCommissionableNodeFound(nodeData1);
     state = udcServer.GetUDCClients().FindUDCClientState(instanceName1);
-    NL_TEST_EXIT_ON_FAILED_ASSERT(inSuite, nullptr != state);
-    NL_TEST_ASSERT(inSuite, UDCClientProcessingState::kUserDeclined == state->GetUDCClientProcessingState());
+    ASSERT_NE(nullptr, state);
+    EXPECT_EQ(UDCClientProcessingState::kUserDeclined, state->GetUDCClientProcessingState());
     state = udcServer.GetUDCClients().FindUDCClientState(instanceName2);
-    NL_TEST_EXIT_ON_FAILED_ASSERT(inSuite, nullptr != state);
-    NL_TEST_ASSERT(inSuite, UDCClientProcessingState::kPromptingUser == state->GetUDCClientProcessingState());
+    ASSERT_NE(nullptr, state);
+    EXPECT_EQ(UDCClientProcessingState::kPromptingUser, state->GetUDCClientProcessingState());
     // test other fields on UDCClientState
-    NL_TEST_ASSERT(inSuite, 0 == strcmp(state->GetInstanceName(), instanceName2));
-    NL_TEST_ASSERT(inSuite, 0 == strcmp(state->GetDeviceName(), deviceName2));
-    NL_TEST_ASSERT(inSuite, state->GetLongDiscriminator() == disc2);
+    EXPECT_STREQ(state->GetInstanceName(), instanceName2);
+    EXPECT_STREQ(state->GetDeviceName(), deviceName2);
+    EXPECT_EQ(state->GetLongDiscriminator(), disc2);
 
     // test non-empty UserConfirmationProvider
     udcServer.SetUserConfirmationProvider(&testCallback);
     udcServer.SetUDCClientProcessingState((char *) instanceName1, UDCClientProcessingState::kUserDeclined);
     udcServer.SetUDCClientProcessingState((char *) instanceName2, UDCClientProcessingState::kDiscoveringNode);
     udcServer.OnCommissionableNodeFound(nodeData1);
-    NL_TEST_ASSERT(inSuite, !testCallback.mOnUserDirectedCommissioningRequestCalled);
+    EXPECT_FALSE(testCallback.mOnUserDirectedCommissioningRequestCalled);
     udcServer.OnCommissionableNodeFound(nodeData2);
-    NL_TEST_ASSERT(inSuite, testCallback.mOnUserDirectedCommissioningRequestCalled);
-    NL_TEST_ASSERT(inSuite, 0 == strcmp(testCallback.mState.GetInstanceName(), instanceName2));
+    EXPECT_TRUE(testCallback.mOnUserDirectedCommissioningRequestCalled);
+    EXPECT_STREQ(testCallback.mState.GetInstanceName(), instanceName2);
 }
 
-void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
+#if false
+// TODO Fix test below
+// the following test case is not reliable (fails on mac, clang platforms for example)
+TEST_F(TestUdcMessages, TestUDCServerInstanceNameResolver)
 {
     UserDirectedCommissioningServer udcServer;
     UserDirectedCommissioningClient udcClient;
@@ -171,11 +179,11 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
 
     // check if the state is set for the instance name sent
     state = udcServer.GetUDCClients().FindUDCClientState(nameBuffer);
-    NL_TEST_EXIT_ON_FAILED_ASSERT(inSuite, nullptr != state);
-    NL_TEST_ASSERT(inSuite, UDCClientProcessingState::kDiscoveringNode == state->GetUDCClientProcessingState());
+    ASSERT_NE(nullptr, state);
+    EXPECT_EQ(UDCClientProcessingState::kDiscoveringNode, state->GetUDCClientProcessingState());
 
     // check if a callback happened
-    NL_TEST_ASSERT(inSuite, testCallback.mFindCommissionableNodeCalled);
+    EXPECT_TRUE(testCallback.mFindCommissionableNodeCalled);
 
     // reset callback tracker so we can confirm that when the
     // same instance name is received, there is no callback
@@ -190,7 +198,7 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
     mUdcTransportMgr->HandleMessageReceived(peerAddress, std::move(payloadBuf));
 
     // verify it was not called
-    NL_TEST_ASSERT(inSuite, !testCallback.mFindCommissionableNodeCalled);
+    EXPECT_FALSE(testCallback.mFindCommissionableNodeCalled);
 
     // next, reset the cache state and confirm the callback
     udcServer.ResetUDCClientProcessingStates();
@@ -204,10 +212,12 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
     mUdcTransportMgr->HandleMessageReceived(peerAddress, std::move(payloadBuf));
 
     // verify it was called
-    NL_TEST_ASSERT(inSuite, testCallback.mFindCommissionableNodeCalled);
+    EXPECT_TRUE(testCallback.mFindCommissionableNodeCalled);
 }
 
-void TestUserDirectedCommissioningClientMessage(nlTestSuite * inSuite, void * inContext)
+#endif
+
+TEST_F(TestUdcMessages, TestUserDirectedCommissioningClientMessage)
 {
     char nameBuffer[Dnssd::Commission::kInstanceNameMaxLength + 1] = "Chris";
     System::PacketBufferHandle payloadBuf = MessagePacketBuffer::NewWithData(nameBuffer, strlen(nameBuffer));
@@ -219,15 +229,15 @@ void TestUserDirectedCommissioningClientMessage(nlTestSuite * inSuite, void * in
     // check the packet header fields
     PacketHeader packetHeader;
     packetHeader.DecodeAndConsume(payloadBuf);
-    NL_TEST_ASSERT(inSuite, !packetHeader.IsEncrypted());
+    EXPECT_FALSE(packetHeader.IsEncrypted());
 
     // check the payload header fields
     PayloadHeader payloadHeader;
     payloadHeader.DecodeAndConsume(payloadBuf);
-    NL_TEST_ASSERT(inSuite, payloadHeader.GetMessageType() == to_underlying(MsgType::IdentificationDeclaration));
-    NL_TEST_ASSERT(inSuite, payloadHeader.GetProtocolID() == Protocols::UserDirectedCommissioning::Id);
-    NL_TEST_ASSERT(inSuite, !payloadHeader.NeedsAck());
-    NL_TEST_ASSERT(inSuite, payloadHeader.IsInitiator());
+    EXPECT_EQ(payloadHeader.GetMessageType(), to_underlying(MsgType::IdentificationDeclaration));
+    EXPECT_EQ(payloadHeader.GetProtocolID(), Protocols::UserDirectedCommissioning::Id);
+    EXPECT_FALSE(payloadHeader.NeedsAck());
+    EXPECT_TRUE(payloadHeader.IsInitiator());
 
     // check the payload
     char instanceName[Dnssd::Commission::kInstanceNameMaxLength + 1];
@@ -235,13 +245,13 @@ void TestUserDirectedCommissioningClientMessage(nlTestSuite * inSuite, void * in
     payloadBuf->Read(Uint8::from_char(instanceName), instanceNameLength);
     instanceName[instanceNameLength] = '\0';
     ChipLogProgress(Inet, "UDC instance=%s", instanceName);
-    NL_TEST_ASSERT(inSuite, strcmp(instanceName, nameBuffer) == 0);
+    EXPECT_STREQ(instanceName, nameBuffer);
 
     // verify no errors
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 }
 
-void TestUDCClients(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestUdcMessages, TestUDCClients)
 {
     UDCClients<3> mUdcClients;
     const char * instanceName1 = "test1";
@@ -251,39 +261,39 @@ void TestUDCClients(nlTestSuite * inSuite, void * inContext)
 
     // test base case
     UDCClientState * state = mUdcClients.FindUDCClientState(instanceName1);
-    NL_TEST_ASSERT(inSuite, state == nullptr);
+    ASSERT_EQ(state, nullptr);
 
     // test max size
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == mUdcClients.CreateNewUDCClientState(instanceName1, &state));
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == mUdcClients.CreateNewUDCClientState(instanceName2, &state));
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == mUdcClients.CreateNewUDCClientState(instanceName3, &state));
-    NL_TEST_ASSERT(inSuite, CHIP_ERROR_NO_MEMORY == mUdcClients.CreateNewUDCClientState(instanceName4, &state));
+    EXPECT_EQ(CHIP_NO_ERROR, mUdcClients.CreateNewUDCClientState(instanceName1, &state));
+    EXPECT_EQ(CHIP_NO_ERROR, mUdcClients.CreateNewUDCClientState(instanceName2, &state));
+    EXPECT_EQ(CHIP_NO_ERROR, mUdcClients.CreateNewUDCClientState(instanceName3, &state));
+    EXPECT_EQ(CHIP_ERROR_NO_MEMORY, mUdcClients.CreateNewUDCClientState(instanceName4, &state));
 
     // test reset
     mUdcClients.ResetUDCClientStates();
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == mUdcClients.CreateNewUDCClientState(instanceName4, &state));
+    EXPECT_EQ(CHIP_NO_ERROR, mUdcClients.CreateNewUDCClientState(instanceName4, &state));
 
     // test find
-    NL_TEST_ASSERT(inSuite, nullptr == mUdcClients.FindUDCClientState(instanceName1));
-    NL_TEST_ASSERT(inSuite, nullptr == mUdcClients.FindUDCClientState(instanceName2));
-    NL_TEST_ASSERT(inSuite, nullptr == mUdcClients.FindUDCClientState(instanceName3));
+    EXPECT_EQ(nullptr, mUdcClients.FindUDCClientState(instanceName1));
+    EXPECT_EQ(nullptr, mUdcClients.FindUDCClientState(instanceName2));
+    EXPECT_EQ(nullptr, mUdcClients.FindUDCClientState(instanceName3));
     state = mUdcClients.FindUDCClientState(instanceName4);
-    NL_TEST_ASSERT(inSuite, nullptr != state);
+    ASSERT_NE(nullptr, state);
 
     // test expiry
     state->Reset();
-    NL_TEST_ASSERT(inSuite, nullptr == mUdcClients.FindUDCClientState(instanceName4));
+    EXPECT_EQ(nullptr, mUdcClients.FindUDCClientState(instanceName4));
 
     // test re-activation
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == mUdcClients.CreateNewUDCClientState(instanceName4, &state));
+    EXPECT_EQ(CHIP_NO_ERROR, mUdcClients.CreateNewUDCClientState(instanceName4, &state));
     System::Clock::Timestamp expirationTime = state->GetExpirationTime();
     state->SetExpirationTime(expirationTime - System::Clock::Milliseconds64(1));
-    NL_TEST_ASSERT(inSuite, (expirationTime - System::Clock::Milliseconds64(1)) == state->GetExpirationTime());
+    EXPECT_EQ((expirationTime - System::Clock::Milliseconds64(1)), state->GetExpirationTime());
     mUdcClients.MarkUDCClientActive(state);
-    NL_TEST_ASSERT(inSuite, (expirationTime - System::Clock::Milliseconds64(1)) < state->GetExpirationTime());
+    EXPECT_LT((expirationTime - System::Clock::Milliseconds64(1)), state->GetExpirationTime());
 }
 
-void TestUDCClientState(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestUdcMessages, TestUDCClientState)
 {
     UDCClients<3> mUdcClients;
     const char * instanceName1 = "test1";
@@ -314,56 +324,56 @@ void TestUDCClientState(nlTestSuite * inSuite, void * inContext)
     rotatingIdLongLen      = Encoding::HexToBytes(reinterpret_cast<const char *>(value.data()), value.size(), rotatingIdLong,
                                                   chip::Dnssd::kMaxRotatingIdLen * 2);
 
-    NL_TEST_ASSERT(inSuite, rotatingIdLongLen > chip::Dnssd::kMaxRotatingIdLen);
+    EXPECT_GT(rotatingIdLongLen, chip::Dnssd::kMaxRotatingIdLen);
 
     // test base case
     UDCClientState * state = mUdcClients.FindUDCClientState(instanceName1);
-    NL_TEST_ASSERT(inSuite, state == nullptr);
+    ASSERT_EQ(state, nullptr);
 
     // add a default state
-    NL_TEST_ASSERT(inSuite, CHIP_NO_ERROR == mUdcClients.CreateNewUDCClientState(instanceName1, &state));
+    EXPECT_EQ(CHIP_NO_ERROR, mUdcClients.CreateNewUDCClientState(instanceName1, &state));
 
     // get the state
     state = mUdcClients.FindUDCClientState(instanceName1);
-    NL_TEST_EXIT_ON_FAILED_ASSERT(inSuite, nullptr != state);
-    NL_TEST_ASSERT(inSuite, strcmp(state->GetInstanceName(), instanceName1) == 0);
+    ASSERT_NE(nullptr, state);
+    EXPECT_STREQ(state->GetInstanceName(), instanceName1);
 
     state->SetPeerAddress(chip::Transport::PeerAddress::UDP(address, port));
-    NL_TEST_ASSERT(inSuite, port == state->GetPeerAddress().GetPort());
+    EXPECT_EQ(port, state->GetPeerAddress().GetPort());
 
     state->SetDeviceName(deviceName);
-    NL_TEST_ASSERT(inSuite, strcmp(state->GetDeviceName(), deviceName) == 0);
+    EXPECT_STREQ(state->GetDeviceName(), deviceName);
 
     state->SetLongDiscriminator(longDiscriminator);
-    NL_TEST_ASSERT(inSuite, longDiscriminator == state->GetLongDiscriminator());
+    EXPECT_EQ(longDiscriminator, state->GetLongDiscriminator());
 
     state->SetVendorId(vendorId);
-    NL_TEST_ASSERT(inSuite, vendorId == state->GetVendorId());
+    EXPECT_EQ(vendorId, state->GetVendorId());
 
     state->SetProductId(productId);
-    NL_TEST_ASSERT(inSuite, productId == state->GetProductId());
+    EXPECT_EQ(productId, state->GetProductId());
 
     state->SetRotatingId(rotatingId, rotatingIdLen);
-    NL_TEST_ASSERT(inSuite, rotatingIdLen == state->GetRotatingIdLength());
+    EXPECT_EQ(rotatingIdLen, state->GetRotatingIdLength());
 
     const uint8_t * testRotatingId = state->GetRotatingId();
     for (size_t i = 0; i < rotatingIdLen; i++)
     {
-        NL_TEST_ASSERT(inSuite, testRotatingId[i] == rotatingId[i]);
+        EXPECT_EQ(testRotatingId[i], rotatingId[i]);
     }
 
     state->SetRotatingId(rotatingIdLong, rotatingIdLongLen);
 
-    NL_TEST_ASSERT(inSuite, chip::Dnssd::kMaxRotatingIdLen == state->GetRotatingIdLength());
+    EXPECT_EQ(chip::Dnssd::kMaxRotatingIdLen, state->GetRotatingIdLength());
 
     const uint8_t * testRotatingIdLong = state->GetRotatingId();
     for (size_t i = 0; i < chip::Dnssd::kMaxRotatingIdLen; i++)
     {
-        NL_TEST_ASSERT(inSuite, testRotatingIdLong[i] == rotatingIdLong[i]);
+        EXPECT_EQ(testRotatingIdLong[i], rotatingIdLong[i]);
     }
 }
 
-void TestUDCIdentificationDeclaration(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestUdcMessages, TestUDCIdentificationDeclaration)
 {
     IdentificationDeclaration id;
     IdentificationDeclaration idOut;
@@ -412,25 +422,25 @@ void TestUDCIdentificationDeclaration(nlTestSuite * inSuite, void * inContext)
     id.SetCommissionerPasscode(true);
     id.SetCommissionerPasscodeReady(true);
 
-    NL_TEST_ASSERT(inSuite, id.HasDiscoveryInfo());
-    NL_TEST_ASSERT(inSuite, strcmp(id.GetInstanceName(), instanceName) == 0);
-    NL_TEST_ASSERT(inSuite, vendorId == id.GetVendorId());
-    NL_TEST_ASSERT(inSuite, productId == id.GetProductId());
-    NL_TEST_ASSERT(inSuite, port == id.GetCdPort());
-    NL_TEST_ASSERT(inSuite, strcmp(id.GetDeviceName(), deviceName) == 0);
-    NL_TEST_ASSERT(inSuite, rotatingIdLen == id.GetRotatingIdLength());
-    NL_TEST_ASSERT(inSuite, memcmp(id.GetRotatingId(), rotatingId, rotatingIdLen) == 0);
-    NL_TEST_ASSERT(inSuite, pairingHint == id.GetPairingHint());
-    NL_TEST_ASSERT(inSuite, strcmp(id.GetPairingInst(), pairingInst) == 0);
+    EXPECT_TRUE(id.HasDiscoveryInfo());
+    EXPECT_STREQ(id.GetInstanceName(), instanceName);
+    EXPECT_EQ(vendorId, id.GetVendorId());
+    EXPECT_EQ(productId, id.GetProductId());
+    EXPECT_EQ(port, id.GetCdPort());
+    EXPECT_STREQ(id.GetDeviceName(), deviceName);
+    EXPECT_EQ(rotatingIdLen, id.GetRotatingIdLength());
+    EXPECT_EQ(memcmp(id.GetRotatingId(), rotatingId, rotatingIdLen), 0);
+    EXPECT_EQ(pairingHint, id.GetPairingHint());
+    EXPECT_STREQ(id.GetPairingInst(), pairingInst);
 
-    NL_TEST_ASSERT(inSuite, id.GetNumTargetAppInfos() == 3);
-    NL_TEST_ASSERT(inSuite, id.GetTargetAppInfo(0, appInfo) && appInfo.vendorId == 1 && appInfo.productId == 9);
-    NL_TEST_ASSERT(inSuite, id.GetTargetAppInfo(1, appInfo) && appInfo.vendorId == 2 && appInfo.productId == 8);
-    NL_TEST_ASSERT(inSuite, id.GetTargetAppInfo(2, appInfo) && appInfo.vendorId == 3 && appInfo.productId == 7);
-    NL_TEST_ASSERT(inSuite, id.GetNoPasscode() == true);
-    NL_TEST_ASSERT(inSuite, id.GetCdUponPasscodeDialog() == true);
-    NL_TEST_ASSERT(inSuite, id.GetCommissionerPasscode() == true);
-    NL_TEST_ASSERT(inSuite, id.GetCommissionerPasscodeReady() == true);
+    EXPECT_EQ(id.GetNumTargetAppInfos(), 3);
+    EXPECT_TRUE(id.GetTargetAppInfo(0, appInfo) && appInfo.vendorId == 1 && appInfo.productId == 9);
+    EXPECT_TRUE(id.GetTargetAppInfo(1, appInfo) && appInfo.vendorId == 2 && appInfo.productId == 8);
+    EXPECT_TRUE(id.GetTargetAppInfo(2, appInfo) && appInfo.vendorId == 3 && appInfo.productId == 7);
+    EXPECT_EQ(id.GetNoPasscode(), true);
+    EXPECT_EQ(id.GetCdUponPasscodeDialog(), true);
+    EXPECT_EQ(id.GetCommissionerPasscode(), true);
+    EXPECT_EQ(id.GetCommissionerPasscodeReady(), true);
 
     // TODO: add an ip
 
@@ -440,32 +450,32 @@ void TestUDCIdentificationDeclaration(nlTestSuite * inSuite, void * inContext)
     // next, parse this object
     idOut.ReadPayload(idBuffer, sizeof(idBuffer));
 
-    NL_TEST_ASSERT(inSuite, idOut.HasDiscoveryInfo());
-    NL_TEST_ASSERT(inSuite, strcmp(idOut.GetInstanceName(), instanceName) == 0);
-    NL_TEST_ASSERT(inSuite, vendorId == idOut.GetVendorId());
-    NL_TEST_ASSERT(inSuite, productId == idOut.GetProductId());
-    NL_TEST_ASSERT(inSuite, port == idOut.GetCdPort());
-    NL_TEST_ASSERT(inSuite, strcmp(idOut.GetDeviceName(), deviceName) == 0);
-    NL_TEST_ASSERT(inSuite, rotatingIdLen == idOut.GetRotatingIdLength());
-    NL_TEST_ASSERT(inSuite, memcmp(idOut.GetRotatingId(), rotatingId, rotatingIdLen) == 0);
-    NL_TEST_ASSERT(inSuite, strcmp(idOut.GetPairingInst(), pairingInst) == 0);
-    NL_TEST_ASSERT(inSuite, pairingHint == idOut.GetPairingHint());
+    EXPECT_TRUE(idOut.HasDiscoveryInfo());
+    EXPECT_STREQ(idOut.GetInstanceName(), instanceName);
+    EXPECT_EQ(vendorId, idOut.GetVendorId());
+    EXPECT_EQ(productId, idOut.GetProductId());
+    EXPECT_EQ(port, idOut.GetCdPort());
+    EXPECT_STREQ(idOut.GetDeviceName(), deviceName);
+    EXPECT_EQ(rotatingIdLen, idOut.GetRotatingIdLength());
+    EXPECT_EQ(memcmp(idOut.GetRotatingId(), rotatingId, rotatingIdLen), 0);
+    EXPECT_STREQ(idOut.GetPairingInst(), pairingInst);
+    EXPECT_EQ(pairingHint, idOut.GetPairingHint());
 
-    NL_TEST_ASSERT(inSuite, id.GetNumTargetAppInfos() == idOut.GetNumTargetAppInfos());
-    NL_TEST_ASSERT(inSuite, idOut.GetTargetAppInfo(0, appInfo) && appInfo.vendorId == 1 && appInfo.productId == 9);
-    NL_TEST_ASSERT(inSuite, idOut.GetTargetAppInfo(1, appInfo) && appInfo.vendorId == 2 && appInfo.productId == 8);
-    NL_TEST_ASSERT(inSuite, idOut.GetTargetAppInfo(2, appInfo) && appInfo.vendorId == 3 && appInfo.productId == 7);
+    EXPECT_EQ(id.GetNumTargetAppInfos(), idOut.GetNumTargetAppInfos());
+    EXPECT_TRUE(idOut.GetTargetAppInfo(0, appInfo) && appInfo.vendorId == 1 && appInfo.productId == 9);
+    EXPECT_TRUE(idOut.GetTargetAppInfo(1, appInfo) && appInfo.vendorId == 2 && appInfo.productId == 8);
+    EXPECT_TRUE(idOut.GetTargetAppInfo(2, appInfo) && appInfo.vendorId == 3 && appInfo.productId == 7);
 
-    NL_TEST_ASSERT(inSuite, id.GetNoPasscode() == idOut.GetNoPasscode());
-    NL_TEST_ASSERT(inSuite, id.GetCdUponPasscodeDialog() == idOut.GetCdUponPasscodeDialog());
-    NL_TEST_ASSERT(inSuite, id.GetCommissionerPasscode() == idOut.GetCommissionerPasscode());
-    NL_TEST_ASSERT(inSuite, id.GetCommissionerPasscodeReady() == idOut.GetCommissionerPasscodeReady());
+    EXPECT_EQ(id.GetNoPasscode(), idOut.GetNoPasscode());
+    EXPECT_EQ(id.GetCdUponPasscodeDialog(), idOut.GetCdUponPasscodeDialog());
+    EXPECT_EQ(id.GetCommissionerPasscode(), idOut.GetCommissionerPasscode());
+    EXPECT_EQ(id.GetCommissionerPasscodeReady(), idOut.GetCommissionerPasscodeReady());
 
     // TODO: remove following "force-fail" debug line
     // NL_TEST_ASSERT(inSuite, rotatingIdLen != id.GetRotatingIdLength());
 }
 
-void TestUDCCommissionerDeclaration(nlTestSuite * inSuite, void * inContext)
+TEST_F(TestUdcMessages, TestUDCCommissionerDeclaration)
 {
     CommissionerDeclaration id;
     CommissionerDeclaration idOut;
@@ -479,12 +489,12 @@ void TestUDCCommissionerDeclaration(nlTestSuite * inSuite, void * inContext)
     id.SetCommissionerPasscode(true);
     id.SetQRCodeDisplayed(true);
 
-    NL_TEST_ASSERT(inSuite, errorCode == id.GetErrorCode());
-    NL_TEST_ASSERT(inSuite, id.GetNeedsPasscode() == true);
-    NL_TEST_ASSERT(inSuite, id.GetNoAppsFound() == true);
-    NL_TEST_ASSERT(inSuite, id.GetPasscodeDialogDisplayed() == true);
-    NL_TEST_ASSERT(inSuite, id.GetCommissionerPasscode() == true);
-    NL_TEST_ASSERT(inSuite, id.GetQRCodeDisplayed() == true);
+    EXPECT_EQ(errorCode, id.GetErrorCode());
+    EXPECT_EQ(id.GetNeedsPasscode(), true);
+    EXPECT_EQ(id.GetNoAppsFound(), true);
+    EXPECT_EQ(id.GetPasscodeDialogDisplayed(), true);
+    EXPECT_EQ(id.GetCommissionerPasscode(), true);
+    EXPECT_EQ(id.GetQRCodeDisplayed(), true);
 
     uint8_t idBuffer[500];
     id.WritePayload(idBuffer, sizeof(idBuffer));
@@ -492,75 +502,10 @@ void TestUDCCommissionerDeclaration(nlTestSuite * inSuite, void * inContext)
     // next, parse this object
     idOut.ReadPayload(idBuffer, sizeof(idBuffer));
 
-    NL_TEST_ASSERT(inSuite, errorCode == idOut.GetErrorCode());
-    NL_TEST_ASSERT(inSuite, id.GetNeedsPasscode() == idOut.GetNeedsPasscode());
-    NL_TEST_ASSERT(inSuite, id.GetNoAppsFound() == idOut.GetNoAppsFound());
-    NL_TEST_ASSERT(inSuite, id.GetPasscodeDialogDisplayed() == idOut.GetPasscodeDialogDisplayed());
-    NL_TEST_ASSERT(inSuite, id.GetCommissionerPasscode() == idOut.GetCommissionerPasscode());
-    NL_TEST_ASSERT(inSuite, id.GetQRCodeDisplayed() == idOut.GetQRCodeDisplayed());
+    EXPECT_EQ(errorCode, idOut.GetErrorCode());
+    EXPECT_EQ(id.GetNeedsPasscode(), idOut.GetNeedsPasscode());
+    EXPECT_EQ(id.GetNoAppsFound(), idOut.GetNoAppsFound());
+    EXPECT_EQ(id.GetPasscodeDialogDisplayed(), idOut.GetPasscodeDialogDisplayed());
+    EXPECT_EQ(id.GetCommissionerPasscode(), idOut.GetCommissionerPasscode());
+    EXPECT_EQ(id.GetQRCodeDisplayed(), idOut.GetQRCodeDisplayed());
 }
-
-// Test Suite
-
-/**
- *  Test Suite that lists all the test functions.
- */
-// clang-format off
-static const nlTest sTests[] =
-{
-    NL_TEST_DEF("TestUDCServerClients", TestUDCServerClients),
-    NL_TEST_DEF("TestUDCServerUserConfirmationProvider", TestUDCServerUserConfirmationProvider),
-    // the following test case is not reliable (fails on mac, clang platforms for example)
-    // NL_TEST_DEF("TestUDCServerInstanceNameResolver", TestUDCServerInstanceNameResolver),
-    NL_TEST_DEF("TestUserDirectedCommissioningClientMessage", TestUserDirectedCommissioningClientMessage),
-    NL_TEST_DEF("TestUDCClients", TestUDCClients),
-    NL_TEST_DEF("TestUDCClientState", TestUDCClientState),
-    NL_TEST_DEF("TestUDCIdentificationDeclaration", TestUDCIdentificationDeclaration),
-    NL_TEST_DEF("TestUDCCommissionerDeclaration", TestUDCCommissionerDeclaration),
-
-    NL_TEST_SENTINEL()
-};
-// clang-format on
-
-/**
- *  Set up the test suite.
- */
-static int TestSetup(void * inContext)
-{
-    CHIP_ERROR error = chip::Platform::MemoryInit();
-    if (error != CHIP_NO_ERROR)
-        return FAILURE;
-    return SUCCESS;
-}
-
-/**
- *  Tear down the test suite.
- */
-static int TestTeardown(void * inContext)
-{
-    chip::Platform::MemoryShutdown();
-    return SUCCESS;
-}
-
-// clang-format off
-static nlTestSuite sSuite =
-{
-    "Test-CHIP-UdcMessages",
-    &sTests[0],
-    TestSetup,
-    TestTeardown,
-};
-// clang-format on
-
-/**
- *  Main
- */
-int TestUdcMessages()
-{
-    // Run test suit against one context
-    nlTestRunner(&sSuite, nullptr);
-
-    return (nlTestRunnerStats(&sSuite));
-}
-
-CHIP_REGISTER_TEST_SUITE(TestUdcMessages)

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -144,7 +144,7 @@ TEST_F(TestUdcMessages, TestUDCServerUserConfirmationProvider)
     EXPECT_STREQ(testCallback.mState.GetInstanceName(), instanceName2);
 }
 
-#if false
+#if 0
 // TODO Fix test below
 // the following test case is not reliable (fails on mac, clang platforms for example)
 TEST_F(TestUdcMessages, TestUDCServerInstanceNameResolver)

--- a/src/test_driver/openiotsdk/unit-tests/test_components.txt
+++ b/src/test_driver/openiotsdk/unit-tests/test_components.txt
@@ -12,3 +12,4 @@ PlatformTests
 TestShell
 SetupPayloadTests
 SupportTests
+UserDirectedCommissioningTests

--- a/src/test_driver/openiotsdk/unit-tests/test_components_nl.txt
+++ b/src/test_driver/openiotsdk/unit-tests/test_components_nl.txt
@@ -9,4 +9,3 @@ SecureChannelTests
 SetupPayloadTestsNL
 SupportTestsNL
 TransportLayerTests
-UserDirectedCommissioningTests


### PR DESCRIPTION
## Problem
The problem was described in #29342. 

## Changes
These changes are another piece of replacing the nl-unit test with the pigweed-unit test. I changed tests for the `user_directed_commissioning`. I didn't introduce any changes to the logic of tests; I only replaced one framework with another. 
