### PR TITLE
[Inet] Fix setting for CLOEXEC flag at socket creation

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -505,7 +505,7 @@ int GetIOCTLSocket()
 #endif
         {
             s = socket(AF_INET, SOCK_STREAM, 0);
-            fcntl(s, O_CLOEXEC);
+            fcntl(s, F_SETFD, O_CLOEXEC);
         }
 
         if (!__sync_bool_compare_and_swap(&sIOCTLSocket, -1, s))

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -500,7 +500,7 @@ int GetIOCTLSocket()
     {
         int s;
 #ifdef SOCK_CLOEXEC
-        s = socket(AF_INET, SOCK_STREAM, SOCK_CLOEXEC);
+        s = socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
         if (s < 0)
 #endif
         {


### PR DESCRIPTION
Hello maintainers,

This PR fixes the setting for the `CLOEXEC` flag at the creation of the socket.

The first commit fixes the setting at socket creation by moving the flag to the proper parameter (`type` instead of `protocol`).

The second commit fixes the setting after the socket is created by adding the missing command `F_SETFD`.

Fell free to double check my changes.

Regards,
Gaël
