### PR TITLE
Add python checkout for arm64 to be fixed as well to fix macos-latest to arm64

### DIFF
--- a/scripts/setup/python.json
+++ b/scripts/setup/python.json
@@ -2,7 +2,7 @@
     "packages": [
         {
             "path": "infra/3pp/tools/cpython3/${platform}",
-            "platforms": ["mac-amd64", "windows-amd64"],
+            "platforms": ["mac-amd64", "mac-arm64", "windows-amd64"],
             "tags": ["version:2@3.9.5.chromium.19"]
         }
     ]


### PR DESCRIPTION
Looking to see if fixing python makes Darwin compile.