### PR TITLE
Ignore virtual-device-app build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Build System
 out/
+/examples/virtual-device-app/android/App/buildSrc/build/
 /src/test_driver/nrfconnect/build/
 /src/darwin/Framework/build/
 


### PR DESCRIPTION
### Problem

When building tests on Linux, the `/examples/virtual-device-app/android/App/buildSrc/build` is created which taints git tree.