### PR TITLE
[OpenThread] Disable IPv6 interface during erasing persistent info.

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1212,6 +1212,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ErasePersistentInfo(v
     ChipLogProgress(DeviceLayer, "Erasing Thread persistent info...");
     Impl()->LockThreadStack();
     otThreadSetEnabled(mOTInst, false);
+    otIp6SetEnabled(mOTInst, false);
     otInstanceErasePersistentInfo(mOTInst);
     Impl()->UnlockThreadStack();
 }


### PR DESCRIPTION
Apart from disabling Thread, and erasing Persistent Info, we should disable the IPv6 interface as well and block receiving further packets. Otherwise, if we don't reboot the device after erasing Thread persistent data, we can get a packet and as a result, it causes an assert during processing AES_ECB (because crypto keys have been removed).


