### PR TITLE
Remove dead code from BLE layer class

### DIFF
--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -229,9 +229,6 @@ public:
     void * mAppState                 = nullptr;
     BleLayerDelegate * mBleTransport = nullptr;
 
-    typedef void (*BleConnectionReceivedFunct)(BLEEndPoint * newEndPoint);
-    BleConnectionReceivedFunct OnChipBleConnectReceived;
-
     // Public functions:
     BleLayer();
 

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -299,10 +299,6 @@ public:
     /// Call when an outstanding GATT indication receives a positive receipt confirmation.
     bool HandleIndicationConfirmation(BLE_CONNECTION_OBJECT connObj, const ChipBleUUID * svcId, const ChipBleUUID * charId);
 
-    /// Call when a GATT read request is received.
-    bool HandleReadReceived(BLE_CONNECTION_OBJECT connObj, BLE_READ_REQUEST_CONTEXT requestContext, const ChipBleUUID * svcId,
-                            const ChipBleUUID * charId);
-
     /**< Platform must call this function when any previous operation undertaken by the BleLayer via BleAdapter
      *   fails, such as a characteristic write request or subscribe attempt, or when a BLE connection is closed.
      *

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -79,8 +79,6 @@ namespace DeviceLayer {
 namespace Internal {
 
 #if CONFIG_ENABLE_ESP32_BLE_CONTROLLER
-void HandleIncomingBleConnection(Ble::BLEEndPoint * bleEP);
-
 enum class BleScanState : uint8_t
 {
     kNotScanning,

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -220,8 +220,6 @@ CHIP_ERROR BLEManagerImpl::_Init()
 #if CONFIG_ENABLE_ESP32_BLE_CONTROLLER
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART && !mIsCentral);
     mFlags.Set(Flags::kFastAdvertisingEnabled, !mIsCentral);
-    OnChipBleConnectReceived = HandleIncomingBleConnection;
-
 #else
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
@@ -740,11 +738,6 @@ void BLEManagerImpl::ConnectDevice(esp_bd_addr_t & addr, esp_ble_addr_type_t add
     {
         ChipLogError(Ble, "Failed to connect to rc=%d", rc);
     }
-}
-
-void HandleIncomingBleConnection(BLEEndPoint * bleEP)
-{
-    ChipLogProgress(DeviceLayer, "CHIPoBLE connection received");
 }
 #endif
 

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -200,11 +200,6 @@ void BLEManagerImpl::ConnectDevice(const ble_addr_t & addr, uint16_t timeout)
         ChipLogError(Ble, "Failed to connect to rc=%d", rc);
     }
 }
-
-void HandleIncomingBleConnection(BLEEndPoint * bleEP)
-{
-    ChipLogProgress(DeviceLayer, "CHIPoBLE connection received");
-}
 #endif
 
 CHIP_ERROR BLEManagerImpl::_Init()
@@ -237,12 +232,11 @@ CHIP_ERROR BLEManagerImpl::_Init()
 #if CONFIG_ENABLE_ESP32_BLE_CONTROLLER
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART && !mIsCentral);
     mFlags.Set(Flags::kFastAdvertisingEnabled, !mIsCentral);
-    OnChipBleConnectReceived = HandleIncomingBleConnection;
 #else
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
-
 #endif
+
     mNumGAPCons = 0;
     memset(reinterpret_cast<void *>(mCons), 0, sizeof(mCons));
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
@@ -265,10 +259,6 @@ void BLEManagerImpl::_Shutdown()
     // selectively setting kGATTServiceStarted flag, in order to notify the state machine to stop the CHIPoBLE GATT service
     mFlags.ClearAll().Set(Flags::kGATTServiceStarted);
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
-
-#if CONFIG_ENABLE_ESP32_BLE_CONTROLLER
-    OnChipBleConnectReceived = nullptr;
-#endif // CONFIG_ENABLE_ESP32_BLE_CONTROLLER
 
     PlatformMgr().ScheduleWork(DriveBLEState, 0);
 }

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -81,11 +81,6 @@ const ChipBleUUID ChipUUID_CHIPoBLEChar_TX = { { 0x18, 0xEE, 0x2E, 0xF5, 0x26, 0
 
 BLEManagerImpl BLEManagerImpl::sInstance;
 
-void HandleIncomingBleConnection(BLEEndPoint * bleEP)
-{
-    ChipLogProgress(DeviceLayer, "CHIPoBluez con rcvd");
-}
-
 CHIP_ERROR BLEManagerImpl::_Init()
 {
     CHIP_ERROR err;
@@ -98,8 +93,6 @@ CHIP_ERROR BLEManagerImpl::_Init()
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
 
     memset(mDeviceName, 0, sizeof(mDeviceName));
-
-    OnChipBleConnectReceived = HandleIncomingBleConnection;
 
     DeviceLayer::SystemLayer().ScheduleLambda([this] { DriveBLEState(); });
 

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -39,8 +39,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-void HandleIncomingBleConnection(Ble::BLEEndPoint * bleEP);
-
 enum class BleScanState : uint8_t
 {
     kNotScanning,

--- a/src/platform/cc13xx_26xx/BLEManagerImpl.cpp
+++ b/src/platform/cc13xx_26xx/BLEManagerImpl.cpp
@@ -118,8 +118,7 @@ CHIP_ERROR BLEManagerImpl::_Init(void)
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
 
-    mServiceMode             = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
-    OnChipBleConnectReceived = HandleIncomingBleConnection;
+    mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
 
     err = CreateEventHandler();
     return err;
@@ -365,11 +364,6 @@ bool BLEManagerImpl::SendReadResponse(BLE_CONNECTION_OBJECT conId, BLE_READ_REQU
 {
     /* Unsupported on TI peripheral device implementation */
     return false;
-}
-
-void BLEManagerImpl::HandleIncomingBleConnection(BLEEndPoint * bleEP)
-{
-    BLEMGR_LOG("BLEMGR: HandleIncomingBleConnection");
 }
 
 // ===== Helper Members that implement the Low level BLE Stack behavior.

--- a/src/platform/cc13xx_26xx/cc13x4_26x4/BLEManagerImpl.h
+++ b/src/platform/cc13xx_26xx/cc13x4_26x4/BLEManagerImpl.h
@@ -317,8 +317,6 @@ private:
     void ClearPendingBLEParamUpdate(uint16_t connHandle);
     void UpdateBLERPA(void);
 
-    static void HandleIncomingBleConnection(Ble::BLEEndPoint * bleEP);
-
     /* Static helper function */
     static void EventHandler(void * arg);
     static CHIP_ERROR DriveBLEState(void);

--- a/src/platform/webos/BLEManagerImpl.cpp
+++ b/src/platform/webos/BLEManagerImpl.cpp
@@ -68,11 +68,6 @@ const ChipBleUUID ChipUUID_CHIPoBLEChar_TX = { { 0x18, 0xEE, 0x2E, 0xF5, 0x26, 0
 
 BLEManagerImpl BLEManagerImpl::sInstance;
 
-void HandleIncomingBleConnection(BLEEndPoint * bleEP)
-{
-    ChipLogProgress(DeviceLayer, "con rcvd");
-}
-
 void BLEManagerImpl::InitConnectionData()
 {
     /* Initialize Hashmap */
@@ -114,8 +109,6 @@ CHIP_ERROR BLEManagerImpl::_Init()
     mFlags.Set(Flags::kFastAdvertisingEnabled, true);
 
     memset(mDeviceName, 0, sizeof(mDeviceName));
-
-    OnChipBleConnectReceived = HandleIncomingBleConnection;
 
     ret = MainLoop::Instance().Init(_BleInitialize);
     VerifyOrExit(ret != false, err = CHIP_ERROR_INTERNAL);

--- a/src/platform/webos/BLEManagerImpl.h
+++ b/src/platform/webos/BLEManagerImpl.h
@@ -37,8 +37,6 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-void HandleIncomingBleConnection(Ble::BLEEndPoint * bleEP);
-
 enum class BleScanState : uint8_t
 {
     kNotScanning,

--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -46,8 +46,8 @@ void BLEBase::ClearState()
     if (mBleLayer)
     {
         mBleLayer->CancelBleIncompleteConnection();
-        mBleLayer->mBleTransport            = nullptr;
-        mBleLayer                           = nullptr;
+        mBleLayer->mBleTransport = nullptr;
+        mBleLayer                = nullptr;
     }
 
     if (mBleEndPoint)

--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -46,7 +46,6 @@ void BLEBase::ClearState()
     if (mBleLayer)
     {
         mBleLayer->CancelBleIncompleteConnection();
-        mBleLayer->OnChipBleConnectReceived = nullptr;
         mBleLayer->mBleTransport            = nullptr;
         mBleLayer                           = nullptr;
     }
@@ -77,7 +76,6 @@ CHIP_ERROR BLEBase::Init(const BleListenParameters & param)
     {
         ChipLogDetail(Inet, "BLEBase::Init - not overriding transport");
     }
-    mBleLayer->OnChipBleConnectReceived = nullptr;
 
     mState = State::kInitialized;
 


### PR DESCRIPTION
### Problem

It seems that the `OnChipBleConnectReceived` is only set, but it is not used anywhere.

### Testing

CI will check for build breaks.