### PR TITLE
Cherrypick fix for macos-latest github actions move

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -371,7 +371,7 @@ jobs:
 
     build_darwin:
         name: Build on Darwin (clang, python_lib, simulated)
-        runs-on: macos-latest
+        runs-on: macos-13
         if: github.actor != 'restyled-io[bot]'
 
         steps:

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -49,7 +49,7 @@ jobs:
             LSAN_OPTIONS: detect_leaks=1 malloc_context_size=40 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
         if: github.actor != 'restyled-io[bot]'
-        runs-on: macos-latest
+        runs-on: macos-13
 
         steps:
             - name: Checkout

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -32,7 +32,7 @@ jobs:
         name: Build Darwin
 
         if: github.actor != 'restyled-io[bot]'
-        runs-on: macos-latest
+        runs-on: macos-13
 
         steps:
             - name: Checkout

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -72,7 +72,7 @@ jobs:
 
     build_darwin_fuzzing:
         name: Build on Darwin
-        runs-on: macos-latest
+        runs-on: macos-13
         if: github.actor != 'restyled-io[bot]'
 
         steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -299,7 +299,7 @@ jobs:
             LSAN_OPTIONS: detect_leaks=1 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
         if: github.actor != 'restyled-io[bot]'
-        runs-on: macos-latest
+        runs-on: macos-13
 
         steps:
             - name: Checkout
@@ -501,7 +501,7 @@ jobs:
             TSAN_OPTIONS: "halt_on_error=1"
 
         if: github.actor != 'restyled-io[bot]' && false
-        runs-on: macos-latest
+        runs-on: macos-13
 
         steps:
             - name: Checkout

--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -49,7 +49,7 @@ colorama==0.4.6
     #   west
 coloredlogs==15.0.1
     # via -r requirements.all.txt
-construct==2.10.70
+construct==2.10.54
     # via
     #   -r requirements.esp32.txt
     #   esp-coredump

--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -49,7 +49,7 @@ colorama==0.4.6
     #   west
 coloredlogs==15.0.1
     # via -r requirements.all.txt
-construct==2.10.54
+construct==2.10.70
     # via
     #   -r requirements.esp32.txt
     #   esp-coredump


### PR DESCRIPTION
This cherrypicks #33142 to 1.2

Also adds a few extra fixes since this branch seems more sensitive:
  - change some more files to be macos-13 instead of macos-latest
  
Attempted to also update construct version, however unfortunately espressif fixes the version to a previous one.