### PR TITLE
[Python] Fix OnRead[Event|Attribute]DataCallback for Arm64 Apple Patform devices

### DIFF
--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -71,10 +71,10 @@ struct __attribute__((packed)) DataVersionFilter
 using OnReadAttributeDataCallback       = void (*)(PyObject * appContext, chip::DataVersion version, chip::EndpointId endpointId,
                                              chip::ClusterId clusterId, chip::AttributeId attributeId,
                                              std::underlying_type_t<Protocols::InteractionModel::Status> imstatus, uint8_t * data,
-                                             uint32_t dataLen);
+                                             size_t dataLen);
 using OnReadEventDataCallback           = void (*)(PyObject * appContext, chip::EndpointId endpointId, chip::ClusterId clusterId,
                                          chip::EventId eventId, chip::EventNumber eventNumber, uint8_t priority, uint64_t timestamp,
-                                         uint8_t timestampType, uint8_t * data, uint32_t dataLen,
+                                         uint8_t timestampType, uint8_t * data, size_t dataLen,
                                          std::underlying_type_t<Protocols::InteractionModel::Status> imstatus);
 using OnSubscriptionEstablishedCallback = void (*)(PyObject * appContext, SubscriptionId subscriptionId);
 using OnResubscriptionAttemptedCallback = void (*)(PyObject * appContext, PyChipError aTerminationCause,
@@ -114,7 +114,7 @@ public:
         VerifyOrDie(!aPath.IsListItemOperation());
         size_t bufferLen                  = (apData == nullptr ? 0 : apData->GetRemainingLength() + apData->GetLengthRead());
         std::unique_ptr<uint8_t[]> buffer = std::unique_ptr<uint8_t[]>(apData == nullptr ? nullptr : new uint8_t[bufferLen]);
-        uint32_t size                     = 0;
+        size_t size                       = 0;
         // When the apData is nullptr, means we did not receive a valid attribute data from server, status will be some error
         // status.
         if (apData != nullptr)
@@ -166,7 +166,7 @@ public:
     void OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus) override
     {
         uint8_t buffer[CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE];
-        uint32_t size  = 0;
+        size_t size    = 0;
         CHIP_ERROR err = CHIP_NO_ERROR;
         // When the apData is nullptr, means we did not receive a valid event data from server, status will be some error
         // status.


### PR DESCRIPTION
On M1/Arm64 macOS systems, the OnReadEventDataCallback often returned an invalid status, e.g.:
ValueError: 16 is not a valid Status

Use size_t consistently to fix this issue.

