### PR TITLE
[Bloat report]: Report zip file reading exception without failing everything.

### DIFF
--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -167,7 +167,7 @@ class SizeContext:
                 try:
                     self.db.add_sizes_from_zipfile(io.BytesIO(blob),
                                                    {'artifact': i})
-                except:
+                except Exception:
                     # Report in case the zipfile is invalid, however do not fail
                     # all the rest (behave as if artifact download has failed)
                     traceback.print_last()

--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -20,6 +20,7 @@ import io
 import logging
 import re
 import sys
+import traceback
 from typing import Dict
 
 import fastcore  # type: ignore
@@ -163,8 +164,13 @@ class SizeContext:
         for i in required_artifact_ids:
             blob = self.gh.download_artifact(i)
             if blob:
-                self.db.add_sizes_from_zipfile(io.BytesIO(blob),
-                                               {'artifact': i})
+                try:
+                    self.db.add_sizes_from_zipfile(io.BytesIO(blob),
+                                                   {'artifact': i})
+                except:
+                    # Report in case the zipfile is invalid, however do not fail
+                    # all the rest (behave as if artifact download has failed)
+                    traceback.print_last()
 
     def read_inputs(self):
         """Read size report from github and/or local files."""


### PR DESCRIPTION
Without this, we seem to periodically fail bloat action with:

```
Traceback (most recent call last):
785  File "/__w/connectedhomeip/connectedhomeip/scripts/tools/memory/gh_report.py", line 418, in <module>
786    sys.exit(main(sys.argv))
787  File "/__w/connectedhomeip/connectedhomeip/scripts/tools/memory/gh_report.py", line 412, in main
788    raise exception
789  File "/__w/connectedhomeip/connectedhomeip/scripts/tools/memory/gh_report.py", line 402, in main
790    szc.read_inputs()
791  File "/__w/connectedhomeip/connectedhomeip/scripts/tools/memory/gh_report.py", line 172, in read_inputs
792    self.add_sizes_from_github()
793  File "/__w/connectedhomeip/connectedhomeip/scripts/tools/memory/gh_report.py", line 166, in add_sizes_from_github
794    self.db.add_sizes_from_zipfile(io.BytesIO(blob),
795  File "/__w/connectedhomeip/connectedhomeip/scripts/tools/memory/memdf/sizedb.py", line 117, in add_sizes_from_zipfile
796    with zipfile.ZipFile(f, 'r') as zip_file:
797  File "/usr/lib/python3.9/zipfile.py", line 1257, in __init__
798    self._RealGetContents()
799  File "/usr/lib/python3.9/zipfile.py", line 1324, in _RealGetContents
800    raise BadZipFile("File is not a zip file")
801  zipfile.BadZipFile: File is not a zip file
```

Let the reporter just update whatever it can.