### PR TITLE
Fix wrong exception print

### DIFF
--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -170,7 +170,7 @@ class SizeContext:
                 except Exception:
                     # Report in case the zipfile is invalid, however do not fail
                     # all the rest (behave as if artifact download has failed)
-                    traceback.print_last()
+                    traceback.print_exc()
 
     def read_inputs(self):
         """Read size report from github and/or local files."""


### PR DESCRIPTION
We still fail gh_sizes:

```
...
    raise BadZipFile("File is not a zip file")
792zipfile.BadZipFile: File is not a zip file
793During handling of the above exception, another exception occurred:
794Traceback (most recent call last):
795  File "/__w/connectedhomeip/connectedhomeip/scripts/tools/memory/gh_report.py", line 424, in <module>
796    sys.exit(main(sys.argv))
797  File "/__w/connectedhomeip/connectedhomeip/scripts/tools/memory/gh_report.py", line 418, in main
798    raise exception
799  File "/__w/connectedhomeip/connectedhomeip/scripts/tools/memory/gh_report.py", line 408, in main
800    szc.read_inputs()
801  File "/__w/connectedhomeip/connectedhomeip/scripts/tools/memory/gh_report.py", line 178, in read_inputs
802    self.add_sizes_from_github()
803  File "/__w/connectedhomeip/connectedhomeip/scripts/tools/memory/gh_report.py", line 173, in add_sizes_from_github
804    traceback.print_last()
805  File "/usr/lib/python3.9/traceback.py", line 173, in print_last
806    raise ValueError("no last exception")
807ValueError: no last exception
```