### PR TITLE
[zephyr] Added several improvements to the BLEMgr implementation

### DIFF
--- a/src/platform/Zephyr/BLEAdvertisingArbiter.cpp
+++ b/src/platform/Zephyr/BLEAdvertisingArbiter.cpp
@@ -29,6 +29,9 @@ namespace {
 // List of advertising requests ordered by priority
 sys_slist_t sRequests;
 
+bool sIsInitialized;
+uint8_t sBtId;
+
 // Cast an intrusive list node to the containing request object
 const BLEAdvertisingArbiter::Request & ToRequest(const sys_snode_t * node)
 {
@@ -55,8 +58,9 @@ CHIP_ERROR RestartAdvertising()
     ReturnErrorOnFailure(System::MapErrorZephyr(bt_le_adv_stop()));
     ReturnErrorCodeIf(sys_slist_is_empty(&sRequests), CHIP_NO_ERROR);
 
-    const Request & top          = ToRequest(sys_slist_peek_head(&sRequests));
-    const bt_le_adv_param params = BT_LE_ADV_PARAM_INIT(top.options, top.minInterval, top.maxInterval, nullptr);
+    const Request & top    = ToRequest(sys_slist_peek_head(&sRequests));
+    bt_le_adv_param params = BT_LE_ADV_PARAM_INIT(top.options, top.minInterval, top.maxInterval, nullptr);
+    params.id              = sBtId;
     const int result = bt_le_adv_start(&params, top.advertisingData.data(), top.advertisingData.size(), top.scanResponseData.data(),
                                        top.scanResponseData.size());
 
@@ -70,8 +74,26 @@ CHIP_ERROR RestartAdvertising()
 
 } // namespace
 
+CHIP_ERROR Init(uint8_t btId)
+{
+    if (sIsInitialized)
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    sBtId          = btId;
+    sIsInitialized = true;
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR InsertRequest(Request & request)
 {
+    if (!sIsInitialized)
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
     CancelRequest(request);
 
     sys_snode_t * prev = nullptr;
@@ -109,6 +131,11 @@ CHIP_ERROR InsertRequest(Request & request)
 
 void CancelRequest(Request & request)
 {
+    if (!sIsInitialized)
+    {
+        return;
+    }
+
     const bool isTopPriority = (sys_slist_peek_head(&sRequests) == &request);
     VerifyOrReturn(sys_slist_find_and_remove(&sRequests, &request));
 

--- a/src/platform/Zephyr/BLEAdvertisingArbiter.cpp
+++ b/src/platform/Zephyr/BLEAdvertisingArbiter.cpp
@@ -29,8 +29,8 @@ namespace {
 // List of advertising requests ordered by priority
 sys_slist_t sRequests;
 
-bool sIsInitialized;
-uint8_t sBtId;
+bool sIsInitialized = false;
+uint8_t sBtId       = 0;
 
 // Cast an intrusive list node to the containing request object
 const BLEAdvertisingArbiter::Request & ToRequest(const sys_snode_t * node)

--- a/src/platform/Zephyr/BLEAdvertisingArbiter.h
+++ b/src/platform/Zephyr/BLEAdvertisingArbiter.h
@@ -62,6 +62,17 @@ struct Request : public sys_snode_t
 };
 
 /**
+ * @brief Initialize BLE advertising arbiter
+ *
+ * @note This method must be called before trying to insert or cancel any requests.
+ *
+ * @param btId   Local Bluetooth LE identifier to be used for the advertising parameters.
+ * @return error    If the module is already initialized.
+ * @return success  Otherwise.
+ */
+CHIP_ERROR Init(uint8_t btId);
+
+/**
  * @brief Request BLE advertising
  *
  * Add the request to the internal list of competing requests. If the request
@@ -73,6 +84,9 @@ struct Request : public sys_snode_t
  *
  * @note This method does not take ownership of the request object so the object
  *       must not get destroyed before it is cancelled.
+ *
+ * @note The arbiter module has to be initialized using Init() method before
+ *       invoking this method.
  *
  * @param request   Reference to advertising request that contains priority and
  *                  other advertising parameters.
@@ -93,6 +107,9 @@ CHIP_ERROR InsertRequest(Request & request);
  *
  * An attempt to cancel a request that has not been registered at the
  * advertising arbiter is a no-op. That is, it returns immediately.
+ *
+ * @note The arbiter module has to be initialized using Init() method before
+ *       invoking this method.
  *
  * @param request   Reference to advertising request that contains priority and
  *                  other advertising parameters.

--- a/src/platform/Zephyr/BLEAdvertisingArbiter.h
+++ b/src/platform/Zephyr/BLEAdvertisingArbiter.h
@@ -66,7 +66,8 @@ struct Request : public sys_snode_t
  *
  * @note This method must be called before trying to insert or cancel any requests.
  *
- * @param btId   Local Bluetooth LE identifier to be used for the advertising parameters.
+ * @param btId   Local Bluetooth LE identifier to be used for the advertising parameters. Currently Bluetooth LE identifier used in
+ * this method will be used for all advertising requests and changing it dynamically is not supported.
  * @return error    If the module is already initialized.
  * @return success  Otherwise.
  */

--- a/src/platform/Zephyr/BLEManagerImpl.h
+++ b/src/platform/Zephyr/BLEManagerImpl.h
@@ -125,6 +125,8 @@ private:
     bool SetSubscribed(bt_conn * conn);
     bool UnsetSubscribed(bt_conn * conn);
     uint32_t GetAdvertisingInterval();
+    CHIP_ERROR RegisterGattService();
+    CHIP_ERROR UnregisterGattService();
 
     static void DriveBLEState(intptr_t arg);
 

--- a/src/platform/Zephyr/BLEManagerImpl.h
+++ b/src/platform/Zephyr/BLEManagerImpl.h
@@ -97,7 +97,7 @@ private:
     struct ServiceData;
 
     BitFlags<Flags> mFlags;
-    uint16_t mGAPConns;
+    uint16_t mMatterConnNum;
     CHIPoBLEServiceMode mServiceMode;
     bool mSubscribedConns[CONFIG_BT_MAX_CONN];
     bt_gatt_indicate_params mIndicateParams[CONFIG_BT_MAX_CONN];
@@ -106,6 +106,8 @@ private:
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
     PacketBufferHandle c3CharDataBufferHandle;
 #endif
+    // The summarized number of Bluetooth LE connections related to the device (including these not related to Matter service).
+    uint16_t mTotalConnNum;
 
     void DriveBLEState(void);
     CHIP_ERROR PrepareAdvertisingRequest();


### PR DESCRIPTION
Added several improvements to the Zephyr BLEMgr, that allows to:

- Support Bluetooth LE bonding and more than one Bluetooth LE identity, what enables using different type of Bluetooth LE address than static random (for non-Matter related BLE services)
- Filtering Zephyr BLE events to not handle them in the BLEMgr if there are not related to CHIPoBLE service, but they come from the other services that can be used on the device
- Restart Bluetooth LE advertising in case of failures, as so far if the first attempt fails the API does not allow to try again later (returned state is enabled, but it is actually not working).

