### PR TITLE
[Android] Fix ChipCluster subscribe issue

### DIFF
--- a/scripts/py_matter_idl/matter_idl/generators/java/ChipClusters_java.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/java/ChipClusters_java.jinja
@@ -217,7 +217,7 @@ public class ChipClusters {
         long attributeId,
         int minInterval,
         int maxInterval) {
-      ReportCallbackJni jniCallback = new ReportCallbackJni(callback, callback, null);
+      ReportCallbackJni jniCallback = new ReportCallbackJni(callback, callback, callback);
       ChipAttributePath path = ChipAttributePath.newInstance(endpointId, clusterId, attributeId);
       ChipInteractionClient.subscribe(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, minInterval, maxInterval, false, true, timeoutMillis.orElse(0L).intValue(), null);
     }
@@ -250,7 +250,7 @@ public class ChipClusters {
     }
   }
 
-  abstract static class ReportCallbackImpl implements ReportCallback, SubscriptionEstablishedCallback {
+  abstract static class ReportCallbackImpl implements ReportCallback, SubscriptionEstablishedCallback, ResubscriptionAttemptCallback {
     private BaseAttributeCallback callback;
     private ChipAttributePath path;
 
@@ -307,6 +307,9 @@ public class ChipClusters {
     public void onSubscriptionEstablished(long subscriptionId) {
       callback.onSubscriptionEstablished(subscriptionId);
     }
+
+    @Override
+    public void onResubscriptionAttempt(long terminationCause, long nextResubscribeIntervalMsec) {}
 
     public abstract void onSuccess(byte[] tlv);
   }
@@ -551,6 +554,7 @@ public class ChipClusters {
           public void onSuccess(byte[] tlv) {
             {%- set encodable = attribute.definition | asEncodable(typeLookup) %}
             {{encode_value_without_optional(cluster, encodable, 0)}} value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, {{attribute.definition.name | constcase}}_ATTRIBUTE_ID, minInterval, maxInterval);
     }

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ChipClusters.java
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ChipClusters.java
@@ -140,7 +140,7 @@ public class ChipClusters {
         long attributeId,
         int minInterval,
         int maxInterval) {
-      ReportCallbackJni jniCallback = new ReportCallbackJni(callback, callback, null);
+      ReportCallbackJni jniCallback = new ReportCallbackJni(callback, callback, callback);
       ChipAttributePath path = ChipAttributePath.newInstance(endpointId, clusterId, attributeId);
       ChipInteractionClient.subscribe(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, minInterval, maxInterval, false, true, timeoutMillis.orElse(0L).intValue(), null);
     }
@@ -173,7 +173,7 @@ public class ChipClusters {
     }
   }
 
-  abstract static class ReportCallbackImpl implements ReportCallback, SubscriptionEstablishedCallback {
+  abstract static class ReportCallbackImpl implements ReportCallback, SubscriptionEstablishedCallback, ResubscriptionAttemptCallback {
     private BaseAttributeCallback callback;
     private ChipAttributePath path;
 
@@ -230,6 +230,9 @@ public class ChipClusters {
     public void onSubscriptionEstablished(long subscriptionId) {
       callback.onSubscriptionEstablished(subscriptionId);
     }
+
+    @Override
+    public void onResubscriptionAttempt(long terminationCause, long nextResubscribeIntervalMsec) {}
 
     public abstract void onSuccess(byte[] tlv);
   }
@@ -334,6 +337,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SOME_INTEGER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -385,6 +389,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.SecondClusterFabricDescriptorStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FABRICS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -410,6 +415,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SOME_BYTES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -461,6 +467,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SOME_ENUM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -495,6 +502,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPTIONS_ATTRIBUTE_ID, minInterval, maxInterval);
     }

--- a/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
@@ -140,7 +140,7 @@ public class ChipClusters {
         long attributeId,
         int minInterval,
         int maxInterval) {
-      ReportCallbackJni jniCallback = new ReportCallbackJni(callback, callback, null);
+      ReportCallbackJni jniCallback = new ReportCallbackJni(callback, callback, callback);
       ChipAttributePath path = ChipAttributePath.newInstance(endpointId, clusterId, attributeId);
       ChipInteractionClient.subscribe(0, jniCallback.getCallbackHandle(), devicePtr, Arrays.asList(path), null, null, minInterval, maxInterval, false, true, timeoutMillis.orElse(0L).intValue(), null);
     }
@@ -173,7 +173,7 @@ public class ChipClusters {
     }
   }
 
-  abstract static class ReportCallbackImpl implements ReportCallback, SubscriptionEstablishedCallback {
+  abstract static class ReportCallbackImpl implements ReportCallback, SubscriptionEstablishedCallback, ResubscriptionAttemptCallback {
     private BaseAttributeCallback callback;
     private ChipAttributePath path;
 
@@ -230,6 +230,9 @@ public class ChipClusters {
     public void onSubscriptionEstablished(long subscriptionId) {
       callback.onSubscriptionEstablished(subscriptionId);
     }
+
+    @Override
+    public void onResubscriptionAttempt(long terminationCause, long nextResubscribeIntervalMsec) {}
 
     public abstract void onSuccess(byte[] tlv);
   }
@@ -401,6 +404,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, IDENTIFY_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -426,6 +430,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, IDENTIFY_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -451,6 +456,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -476,6 +482,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -501,6 +508,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -526,6 +534,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -551,6 +560,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -576,6 +586,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -854,6 +865,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NAME_SUPPORT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -879,6 +891,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -904,6 +917,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -929,6 +943,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -954,6 +969,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -979,6 +995,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1004,6 +1021,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1191,6 +1209,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_OFF_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1216,6 +1235,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GLOBAL_SCENE_CONTROL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1250,6 +1270,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1284,6 +1305,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OFF_WAIT_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1318,6 +1340,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_UP_ON_OFF_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1343,6 +1366,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1368,6 +1392,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1393,6 +1418,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1418,6 +1444,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1443,6 +1470,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1468,6 +1496,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1532,6 +1561,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SWITCH_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1566,6 +1596,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SWITCH_ACTIONS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1591,6 +1622,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1616,6 +1648,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1641,6 +1674,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1666,6 +1700,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1691,6 +1726,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -1716,6 +1752,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2084,6 +2121,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2109,6 +2147,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REMAINING_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2134,6 +2173,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2159,6 +2199,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2184,6 +2225,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_FREQUENCY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2209,6 +2251,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_FREQUENCY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2234,6 +2277,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_FREQUENCY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2268,6 +2312,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPTIONS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2302,6 +2347,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_OFF_TRANSITION_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2336,6 +2382,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2370,6 +2417,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_TRANSITION_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2404,6 +2452,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OFF_TRANSITION_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2438,6 +2487,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEFAULT_MOVE_RATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2472,6 +2522,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_UP_CURRENT_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2497,6 +2548,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2522,6 +2574,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2547,6 +2600,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2572,6 +2626,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2597,6 +2652,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2622,6 +2678,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2702,6 +2759,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_TEXT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2736,6 +2794,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DESCRIPTION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2770,6 +2829,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INACTIVE_TEXT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2804,6 +2864,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OUT_OF_SERVICE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2829,6 +2890,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POLARITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2863,6 +2925,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRESENT_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2897,6 +2960,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RELIABILITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2922,6 +2986,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STATUS_FLAGS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2947,6 +3012,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, APPLICATION_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2972,6 +3038,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -2997,6 +3064,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3022,6 +3090,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3047,6 +3116,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3072,6 +3142,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3097,6 +3168,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3159,6 +3231,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3184,6 +3257,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3209,6 +3283,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3234,6 +3309,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3259,6 +3335,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3284,6 +3361,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3371,6 +3449,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.DescriptorClusterDeviceTypeStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEVICE_TYPE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3396,6 +3475,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SERVER_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3421,6 +3501,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLIENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3446,6 +3527,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PARTS_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3471,6 +3553,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.DescriptorClusterSemanticTagStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TAG_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3496,6 +3579,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3521,6 +3605,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3546,6 +3631,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3571,6 +3657,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3596,6 +3683,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3621,6 +3709,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3702,6 +3791,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.BindingClusterTargetStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BINDING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3727,6 +3817,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3752,6 +3843,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3777,6 +3869,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3802,6 +3895,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3827,6 +3921,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3852,6 +3947,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3941,6 +4037,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.AccessControlClusterAccessControlEntryStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -3980,6 +4077,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.AccessControlClusterAccessControlExtensionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EXTENSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4005,6 +4103,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUBJECTS_PER_ACCESS_CONTROL_ENTRY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4030,6 +4129,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TARGETS_PER_ACCESS_CONTROL_ENTRY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4055,6 +4155,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCESS_CONTROL_ENTRIES_PER_FABRIC_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4080,6 +4181,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4105,6 +4207,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4130,6 +4233,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4155,6 +4259,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4180,6 +4285,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4205,6 +4311,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4586,6 +4693,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ActionsClusterActionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTION_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4611,6 +4719,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ActionsClusterEndpointListStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENDPOINT_LISTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4636,6 +4745,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SETUP_U_R_L_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4661,6 +4771,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4686,6 +4797,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4711,6 +4823,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4736,6 +4849,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4761,6 +4875,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4786,6 +4901,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4895,6 +5011,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DATA_MODEL_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4920,6 +5037,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, VENDOR_NAME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4945,6 +5063,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, VENDOR_I_D_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4970,6 +5089,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRODUCT_NAME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -4995,6 +5115,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRODUCT_I_D_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5029,6 +5150,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NODE_LABEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5063,6 +5185,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LOCATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5088,6 +5211,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, HARDWARE_VERSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5113,6 +5237,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, HARDWARE_VERSION_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5138,6 +5263,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SOFTWARE_VERSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5163,6 +5289,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SOFTWARE_VERSION_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5188,6 +5315,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MANUFACTURING_DATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5213,6 +5341,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PART_NUMBER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5238,6 +5367,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRODUCT_U_R_L_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5263,6 +5393,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRODUCT_LABEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5288,6 +5419,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SERIAL_NUMBER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5322,6 +5454,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LOCAL_CONFIG_DISABLED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5347,6 +5480,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REACHABLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5372,6 +5506,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNIQUE_I_D_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5397,6 +5532,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             ChipStructs.BasicInformationClusterCapabilityMinimaStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CAPABILITY_MINIMA_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5422,6 +5558,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             ChipStructs.BasicInformationClusterProductAppearanceStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRODUCT_APPEARANCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5447,6 +5584,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SPECIFICATION_VERSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5472,6 +5610,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_PATHS_PER_INVOKE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5497,6 +5636,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5522,6 +5662,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5547,6 +5688,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5572,6 +5714,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5597,6 +5740,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5622,6 +5766,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5864,6 +6009,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5889,6 +6035,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5914,6 +6061,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5939,6 +6087,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5964,6 +6113,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -5989,6 +6139,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6113,6 +6264,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.OtaSoftwareUpdateRequestorClusterProviderLocation> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEFAULT_O_T_A_PROVIDERS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6138,6 +6290,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UPDATE_POSSIBLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6163,6 +6316,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UPDATE_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6188,6 +6342,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UPDATE_STATE_PROGRESS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6213,6 +6368,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6238,6 +6394,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6263,6 +6420,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6288,6 +6446,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6313,6 +6472,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6338,6 +6498,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6415,6 +6576,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_LOCALE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6440,6 +6602,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<String> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_LOCALES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6465,6 +6628,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6490,6 +6654,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6515,6 +6680,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6540,6 +6706,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6565,6 +6732,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6590,6 +6758,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6668,6 +6837,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, HOUR_FORMAT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6702,6 +6872,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_CALENDAR_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6727,6 +6898,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_CALENDAR_TYPES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6752,6 +6924,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6777,6 +6950,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6802,6 +6976,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6827,6 +7002,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6852,6 +7028,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6877,6 +7054,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6949,6 +7127,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TEMPERATURE_UNIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6974,6 +7153,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -6999,6 +7179,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7024,6 +7205,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7049,6 +7231,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7074,6 +7257,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7099,6 +7283,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7166,6 +7351,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SOURCES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7191,6 +7377,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7216,6 +7403,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7241,6 +7429,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7266,6 +7455,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7291,6 +7481,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7316,6 +7507,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7458,6 +7650,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STATUS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7483,6 +7676,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ORDER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7508,6 +7702,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DESCRIPTION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7533,6 +7728,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WIRED_ASSESSED_INPUT_VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7558,6 +7754,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WIRED_ASSESSED_INPUT_FREQUENCY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7583,6 +7780,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WIRED_CURRENT_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7608,6 +7806,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WIRED_ASSESSED_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7633,6 +7832,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WIRED_NOMINAL_VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7658,6 +7858,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WIRED_MAXIMUM_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7683,6 +7884,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WIRED_PRESENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7708,6 +7910,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_WIRED_FAULTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7733,6 +7936,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7758,6 +7962,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_PERCENT_REMAINING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7783,6 +7988,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_TIME_REMAINING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7808,6 +8014,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_CHARGE_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7833,6 +8040,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_REPLACEMENT_NEEDED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7858,6 +8066,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_REPLACEABILITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7883,6 +8092,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_PRESENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7908,6 +8118,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_BAT_FAULTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7933,6 +8144,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_REPLACEMENT_DESCRIPTION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7958,6 +8170,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_COMMON_DESIGNATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -7983,6 +8196,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_A_N_S_I_DESIGNATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8008,6 +8222,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_I_E_C_DESIGNATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8033,6 +8248,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_APPROVED_CHEMISTRY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8058,6 +8274,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_CAPACITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8083,6 +8300,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_QUANTITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8108,6 +8326,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_CHARGE_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8133,6 +8352,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_TIME_TO_FULL_CHARGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8158,6 +8378,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_FUNCTIONAL_WHILE_CHARGING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8183,6 +8404,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BAT_CHARGING_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8208,6 +8430,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_BAT_CHARGE_FAULTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8233,6 +8456,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENDPOINT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8258,6 +8482,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8283,6 +8508,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8308,6 +8534,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8333,6 +8560,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8358,6 +8586,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8383,6 +8612,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8594,6 +8824,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BREADCRUMB_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8619,6 +8850,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             ChipStructs.GeneralCommissioningClusterBasicCommissioningInfo value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BASIC_COMMISSIONING_INFO_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8644,6 +8876,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REGULATORY_CONFIG_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8669,6 +8902,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LOCATION_CAPABILITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8694,6 +8928,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTS_CONCURRENT_CONNECTION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8719,6 +8954,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8744,6 +8980,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8769,6 +9006,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8794,6 +9032,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8819,6 +9058,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -8844,6 +9084,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9365,6 +9606,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_NETWORKS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9390,6 +9632,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.NetworkCommissioningClusterNetworkInfoStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NETWORKS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9415,6 +9658,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SCAN_MAX_TIME_SECONDS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9440,6 +9684,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CONNECT_MAX_TIME_SECONDS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9474,6 +9719,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INTERFACE_ENABLED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9499,6 +9745,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAST_NETWORKING_STATUS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9524,6 +9771,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAST_NETWORK_I_D_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9549,6 +9797,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAST_CONNECT_ERROR_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9574,6 +9823,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_WI_FI_BANDS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9599,6 +9849,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_THREAD_FEATURES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9624,6 +9875,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, THREAD_VERSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9649,6 +9901,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9674,6 +9927,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9699,6 +9953,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9724,6 +9979,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9749,6 +10005,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9774,6 +10031,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9899,6 +10157,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9924,6 +10183,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9949,6 +10209,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9974,6 +10235,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -9999,6 +10261,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10024,6 +10287,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10214,6 +10478,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.GeneralDiagnosticsClusterNetworkInterface> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NETWORK_INTERFACES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10239,6 +10504,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REBOOT_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10264,6 +10530,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UP_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10289,6 +10556,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TOTAL_OPERATIONAL_HOURS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10314,6 +10582,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BOOT_REASON_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10339,6 +10608,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_HARDWARE_FAULTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10364,6 +10634,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_RADIO_FAULTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10389,6 +10660,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_NETWORK_FAULTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10414,6 +10686,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TEST_EVENT_TRIGGERS_ENABLED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10439,6 +10712,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10464,6 +10738,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10489,6 +10764,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10514,6 +10790,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10539,6 +10816,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10564,6 +10842,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10650,6 +10929,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.SoftwareDiagnosticsClusterThreadMetricsStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, THREAD_METRICS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10675,6 +10955,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_HEAP_FREE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10700,6 +10981,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_HEAP_USED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10725,6 +11007,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_HEAP_HIGH_WATERMARK_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10750,6 +11033,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10775,6 +11059,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10800,6 +11085,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10825,6 +11111,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10850,6 +11137,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -10875,6 +11163,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11096,6 +11385,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CHANNEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11121,6 +11411,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ROUTING_ROLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11146,6 +11437,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NETWORK_NAME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11171,6 +11463,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PAN_ID_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11196,6 +11489,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EXTENDED_PAN_ID_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11221,6 +11515,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MESH_LOCAL_PREFIX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11246,6 +11541,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OVERRUN_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11271,6 +11567,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ThreadNetworkDiagnosticsClusterNeighborTableStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NEIGHBOR_TABLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11296,6 +11593,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ThreadNetworkDiagnosticsClusterRouteTableStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ROUTE_TABLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11321,6 +11619,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PARTITION_ID_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11346,6 +11645,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WEIGHTING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11371,6 +11671,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DATA_VERSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11396,6 +11697,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STABLE_DATA_VERSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11421,6 +11723,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEADER_ROUTER_ID_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11446,6 +11749,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DETACHED_ROLE_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11471,6 +11775,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CHILD_ROLE_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11496,6 +11801,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ROUTER_ROLE_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11521,6 +11827,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEADER_ROLE_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11546,6 +11853,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTACH_ATTEMPT_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11571,6 +11879,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PARTITION_ID_CHANGE_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11596,6 +11905,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BETTER_PARTITION_ATTACH_ATTEMPT_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11621,6 +11931,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PARENT_CHANGE_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11646,6 +11957,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_TOTAL_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11671,6 +11983,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_UNICAST_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11696,6 +12009,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_BROADCAST_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11721,6 +12035,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_ACK_REQUESTED_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11746,6 +12061,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_ACKED_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11771,6 +12087,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_NO_ACK_REQUESTED_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11796,6 +12113,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_DATA_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11821,6 +12139,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_DATA_POLL_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11846,6 +12165,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_BEACON_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11871,6 +12191,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_BEACON_REQUEST_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11896,6 +12217,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_OTHER_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11921,6 +12243,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_RETRY_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11946,6 +12269,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_DIRECT_MAX_RETRY_EXPIRY_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11971,6 +12295,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_INDIRECT_MAX_RETRY_EXPIRY_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -11996,6 +12321,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_ERR_CCA_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12021,6 +12347,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_ERR_ABORT_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12046,6 +12373,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_ERR_BUSY_CHANNEL_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12071,6 +12399,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_TOTAL_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12096,6 +12425,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_UNICAST_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12121,6 +12451,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_BROADCAST_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12146,6 +12477,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_DATA_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12171,6 +12503,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_DATA_POLL_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12196,6 +12529,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_BEACON_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12221,6 +12555,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_BEACON_REQUEST_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12246,6 +12581,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_OTHER_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12271,6 +12607,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_ADDRESS_FILTERED_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12296,6 +12633,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_DEST_ADDR_FILTERED_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12321,6 +12659,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_DUPLICATED_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12346,6 +12685,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_ERR_NO_FRAME_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12371,6 +12711,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_ERR_UNKNOWN_NEIGHBOR_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12396,6 +12737,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_ERR_INVALID_SRC_ADDR_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12421,6 +12763,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_ERR_SEC_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12446,6 +12789,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_ERR_FCS_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12471,6 +12815,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RX_ERR_OTHER_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12496,6 +12841,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_TIMESTAMP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12521,6 +12867,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PENDING_TIMESTAMP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12546,6 +12893,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DELAY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12571,6 +12919,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.ThreadNetworkDiagnosticsClusterSecurityPolicy value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SECURITY_POLICY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12596,6 +12945,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CHANNEL_PAGE0_MASK_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12621,6 +12971,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.ThreadNetworkDiagnosticsClusterOperationalDatasetComponents value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATIONAL_DATASET_COMPONENTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12646,6 +12997,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_NETWORK_FAULTS_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12671,6 +13023,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12696,6 +13049,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12721,6 +13075,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12746,6 +13101,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12771,6 +13127,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12796,6 +13153,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12939,6 +13297,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BSSID_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12964,6 +13323,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SECURITY_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -12989,6 +13349,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WI_FI_VERSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13014,6 +13375,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CHANNEL_NUMBER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13039,6 +13401,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RSSI_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13064,6 +13427,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BEACON_LOST_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13089,6 +13453,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BEACON_RX_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13114,6 +13479,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PACKET_MULTICAST_RX_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13139,6 +13505,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PACKET_MULTICAST_TX_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13164,6 +13531,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PACKET_UNICAST_RX_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13189,6 +13557,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PACKET_UNICAST_TX_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13214,6 +13583,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_MAX_RATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13239,6 +13609,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OVERRUN_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13264,6 +13635,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13289,6 +13661,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13314,6 +13687,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13339,6 +13713,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13364,6 +13739,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13389,6 +13765,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13488,6 +13865,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, P_H_Y_RATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13513,6 +13891,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FULL_DUPLEX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13538,6 +13917,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PACKET_RX_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13563,6 +13943,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PACKET_TX_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13588,6 +13969,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TX_ERR_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13613,6 +13995,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLLISION_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13638,6 +14021,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OVERRUN_COUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13663,6 +14047,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CARRIER_DETECT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13688,6 +14073,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TIME_SINCE_RESET_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13713,6 +14099,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13738,6 +14125,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13763,6 +14151,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13788,6 +14177,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13813,6 +14203,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -13838,6 +14229,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14059,6 +14451,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, U_T_C_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14084,6 +14477,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GRANULARITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14109,6 +14503,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TIME_SOURCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14134,6 +14529,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.TimeSynchronizationClusterTrustedTimeSourceStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TRUSTED_TIME_SOURCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14159,6 +14555,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEFAULT_N_T_P_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14184,6 +14581,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.TimeSynchronizationClusterTimeZoneStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TIME_ZONE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14209,6 +14607,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.TimeSynchronizationClusterDSTOffsetStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, D_S_T_OFFSET_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14234,6 +14633,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LOCAL_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14259,6 +14659,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TIME_ZONE_DATABASE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14284,6 +14685,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, N_T_P_SERVER_AVAILABLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14309,6 +14711,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TIME_ZONE_LIST_MAX_SIZE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14334,6 +14737,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, D_S_T_OFFSET_LIST_MAX_SIZE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14359,6 +14763,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTS_D_N_S_RESOLVE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14384,6 +14789,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14409,6 +14815,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14434,6 +14841,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14459,6 +14867,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14484,6 +14893,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14509,6 +14919,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14591,6 +15002,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, VENDOR_NAME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14616,6 +15028,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, VENDOR_I_D_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14641,6 +15054,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRODUCT_NAME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14675,6 +15089,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NODE_LABEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14700,6 +15115,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, HARDWARE_VERSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14725,6 +15141,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, HARDWARE_VERSION_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14750,6 +15167,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SOFTWARE_VERSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14775,6 +15193,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SOFTWARE_VERSION_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14800,6 +15219,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MANUFACTURING_DATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14825,6 +15245,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PART_NUMBER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14850,6 +15271,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRODUCT_U_R_L_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14875,6 +15297,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRODUCT_LABEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14900,6 +15323,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SERIAL_NUMBER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14925,6 +15349,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REACHABLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14950,6 +15375,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNIQUE_I_D_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -14975,6 +15401,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             ChipStructs.BridgedDeviceBasicInformationClusterProductAppearanceStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRODUCT_APPEARANCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15000,6 +15427,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15025,6 +15453,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15050,6 +15479,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15075,6 +15505,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15100,6 +15531,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15125,6 +15557,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15190,6 +15623,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_POSITIONS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15215,6 +15649,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_POSITION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15240,6 +15675,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MULTI_PRESS_MAX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15265,6 +15701,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15290,6 +15727,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15315,6 +15753,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15340,6 +15779,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15365,6 +15805,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15390,6 +15831,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15526,6 +15968,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WINDOW_STATUS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15551,6 +15994,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ADMIN_FABRIC_INDEX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15576,6 +16020,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ADMIN_VENDOR_ID_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15601,6 +16046,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15626,6 +16072,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15651,6 +16098,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15676,6 +16124,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15701,6 +16150,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -15726,6 +16176,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16151,6 +16602,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.OperationalCredentialsClusterNOCStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, N_O_CS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16181,6 +16633,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.OperationalCredentialsClusterFabricDescriptorStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FABRICS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16206,6 +16659,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_FABRICS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16231,6 +16685,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COMMISSIONED_FABRICS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16256,6 +16711,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<byte[]> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TRUSTED_ROOT_CERTIFICATES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16281,6 +16737,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_FABRIC_INDEX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16306,6 +16763,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16331,6 +16789,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16356,6 +16815,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16381,6 +16841,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16406,6 +16867,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16431,6 +16893,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16623,6 +17086,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.GroupKeyManagementClusterGroupKeyMapStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GROUP_KEY_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16653,6 +17117,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.GroupKeyManagementClusterGroupInfoMapStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GROUP_TABLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16678,6 +17143,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_GROUPS_PER_FABRIC_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16703,6 +17169,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_GROUP_KEYS_PER_FABRIC_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16728,6 +17195,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16753,6 +17221,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16778,6 +17247,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16803,6 +17273,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16828,6 +17299,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16853,6 +17325,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16920,6 +17393,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.FixedLabelClusterLabelStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LABEL_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16945,6 +17419,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16970,6 +17445,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -16995,6 +17471,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17020,6 +17497,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17045,6 +17523,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17070,6 +17549,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17146,6 +17626,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.UserLabelClusterLabelStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LABEL_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17171,6 +17652,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17196,6 +17678,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17221,6 +17704,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17246,6 +17730,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17271,6 +17756,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17296,6 +17782,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17358,6 +17845,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17383,6 +17871,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17408,6 +17897,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17433,6 +17923,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17458,6 +17949,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17483,6 +17975,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17545,6 +18038,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17570,6 +18064,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17595,6 +18090,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17620,6 +18116,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17645,6 +18142,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17670,6 +18168,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17732,6 +18231,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17757,6 +18257,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17782,6 +18283,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17807,6 +18309,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17832,6 +18335,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17857,6 +18361,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17920,6 +18425,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STATE_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17945,6 +18451,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17970,6 +18477,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -17995,6 +18503,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18020,6 +18529,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18045,6 +18555,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18070,6 +18581,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18249,6 +18761,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, IDLE_MODE_DURATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18274,6 +18787,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_MODE_DURATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18299,6 +18813,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_MODE_THRESHOLD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18329,6 +18844,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.IcdManagementClusterMonitoringRegistrationStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REGISTERED_CLIENTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18354,6 +18870,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, I_C_D_COUNTER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18379,6 +18896,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLIENTS_SUPPORTED_PER_FABRIC_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18404,6 +18922,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, USER_ACTIVE_MODE_TRIGGER_HINT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18429,6 +18948,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, USER_ACTIVE_MODE_TRIGGER_INSTRUCTION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18454,6 +18974,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATING_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18479,6 +19000,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18504,6 +19026,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18529,6 +19052,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18554,6 +19078,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18579,6 +19104,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18604,6 +19130,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18745,6 +19272,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SET_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18770,6 +19298,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TIME_REMAINING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18795,6 +19324,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TIMER_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18820,6 +19350,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18845,6 +19376,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18870,6 +19402,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18895,6 +19428,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18920,6 +19454,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -18945,6 +19480,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19141,6 +19677,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable List<String> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PHASE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19166,6 +19703,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_PHASE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19191,6 +19729,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COUNTDOWN_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19216,6 +19755,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.OvenCavityOperationalStateClusterOperationalStateStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATIONAL_STATE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19241,6 +19781,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATIONAL_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19266,6 +19807,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             ChipStructs.OvenCavityOperationalStateClusterErrorStateStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATIONAL_ERROR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19291,6 +19833,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19316,6 +19859,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19341,6 +19885,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19366,6 +19911,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19391,6 +19937,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19416,6 +19963,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19535,6 +20083,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.OvenModeClusterModeOptionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_MODES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19560,6 +20109,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19594,6 +20144,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_UP_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19628,6 +20179,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19653,6 +20205,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19678,6 +20231,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19703,6 +20257,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19728,6 +20283,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19753,6 +20309,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19778,6 +20335,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19850,6 +20408,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_DRYNESS_LEVELS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19884,6 +20443,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SELECTED_DRYNESS_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19909,6 +20469,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19934,6 +20495,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19959,6 +20521,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -19984,6 +20547,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20009,6 +20573,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20034,6 +20599,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20138,6 +20704,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DESCRIPTION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20163,6 +20730,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STANDARD_NAMESPACE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20188,6 +20756,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ModeSelectClusterModeOptionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_MODES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20213,6 +20782,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20247,6 +20817,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_UP_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20281,6 +20852,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20306,6 +20878,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20331,6 +20904,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20356,6 +20930,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20381,6 +20956,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20406,6 +20982,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20431,6 +21008,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20550,6 +21128,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.LaundryWasherModeClusterModeOptionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_MODES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20575,6 +21154,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20609,6 +21189,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_UP_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20643,6 +21224,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20668,6 +21250,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20693,6 +21276,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20718,6 +21302,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20743,6 +21328,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20768,6 +21354,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20793,6 +21380,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20912,6 +21500,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.RefrigeratorAndTemperatureControlledCabinetModeClusterModeOptionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_MODES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20937,6 +21526,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -20971,6 +21561,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_UP_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21005,6 +21596,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21030,6 +21622,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21055,6 +21648,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21080,6 +21674,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21105,6 +21700,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21130,6 +21726,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21155,6 +21752,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21233,6 +21831,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<String> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SPIN_SPEEDS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21267,6 +21866,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SPIN_SPEED_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21301,6 +21901,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_RINSES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21326,6 +21927,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_RINSES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21351,6 +21953,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21376,6 +21979,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21401,6 +22005,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21426,6 +22031,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21451,6 +22057,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21476,6 +22083,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21585,6 +22193,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.RvcRunModeClusterModeOptionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_MODES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21610,6 +22219,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21635,6 +22245,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21660,6 +22271,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21685,6 +22297,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21710,6 +22323,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21735,6 +22349,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21760,6 +22375,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21869,6 +22485,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.RvcCleanModeClusterModeOptionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_MODES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21894,6 +22511,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21919,6 +22537,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21944,6 +22563,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21969,6 +22589,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -21994,6 +22615,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22019,6 +22641,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22044,6 +22667,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22140,6 +22764,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TEMPERATURE_SETPOINT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22165,6 +22790,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_TEMPERATURE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22190,6 +22816,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_TEMPERATURE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22215,6 +22842,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STEP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22240,6 +22868,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SELECTED_TEMPERATURE_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22265,6 +22894,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<String> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_TEMPERATURE_LEVELS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22290,6 +22920,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22315,6 +22946,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22340,6 +22972,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22365,6 +22998,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22390,6 +23024,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22415,6 +23050,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22480,6 +23116,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MASK_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22505,6 +23142,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22530,6 +23168,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22555,6 +23194,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22580,6 +23220,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22605,6 +23246,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22630,6 +23272,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22655,6 +23298,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22680,6 +23324,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22799,6 +23444,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.DishwasherModeClusterModeOptionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_MODES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22824,6 +23470,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22858,6 +23505,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_UP_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22892,6 +23540,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22917,6 +23566,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22942,6 +23592,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22967,6 +23618,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -22992,6 +23644,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23017,6 +23670,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23042,6 +23696,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23105,6 +23760,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AIR_QUALITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23130,6 +23786,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23155,6 +23812,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23180,6 +23838,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23205,6 +23864,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23230,6 +23890,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23255,6 +23916,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23346,6 +24008,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EXPRESSED_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23371,6 +24034,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SMOKE_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23396,6 +24060,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, C_O_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23421,6 +24086,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BATTERY_ALERT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23446,6 +24112,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEVICE_MUTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23471,6 +24138,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TEST_IN_PROGRESS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23496,6 +24164,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, HARDWARE_FAULT_ALERT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23521,6 +24190,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, END_OF_SERVICE_ALERT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23546,6 +24216,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INTERCONNECT_SMOKE_ALARM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23571,6 +24242,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INTERCONNECT_C_O_ALARM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23596,6 +24268,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CONTAMINATION_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23630,6 +24303,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SMOKE_SENSITIVITY_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23655,6 +24329,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EXPIRY_DATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23680,6 +24355,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23705,6 +24381,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23730,6 +24407,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23755,6 +24433,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23780,6 +24459,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23805,6 +24485,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23911,6 +24592,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MASK_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23936,6 +24618,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LATCH_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23961,6 +24644,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -23986,6 +24670,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24011,6 +24696,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24036,6 +24722,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24061,6 +24748,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24086,6 +24774,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24111,6 +24800,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24136,6 +24826,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24204,6 +24895,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.MicrowaveOvenModeClusterModeOptionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_MODES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24229,6 +24921,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24254,6 +24947,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24279,6 +24973,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24304,6 +24999,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24329,6 +25025,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24354,6 +25051,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24379,6 +25077,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24510,6 +25209,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COOK_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24535,6 +25235,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_COOK_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24560,6 +25261,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POWER_SETTING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24585,6 +25287,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24610,6 +25313,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24635,6 +25339,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POWER_STEP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24660,6 +25365,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_WATTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24685,6 +25391,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SELECTED_WATT_INDEX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24710,6 +25417,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WATT_RATING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24735,6 +25443,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24760,6 +25469,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24785,6 +25495,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24810,6 +25521,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24835,6 +25547,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -24860,6 +25573,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25056,6 +25770,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable List<String> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PHASE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25081,6 +25796,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_PHASE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25106,6 +25822,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COUNTDOWN_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25131,6 +25848,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.OperationalStateClusterOperationalStateStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATIONAL_STATE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25156,6 +25874,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATIONAL_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25181,6 +25900,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             ChipStructs.OperationalStateClusterErrorStateStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATIONAL_ERROR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25206,6 +25926,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25231,6 +25952,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25256,6 +25978,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25281,6 +26004,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25306,6 +26030,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25331,6 +26056,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25501,6 +26227,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable List<String> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PHASE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25526,6 +26253,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_PHASE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25551,6 +26279,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COUNTDOWN_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25576,6 +26305,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.RvcOperationalStateClusterOperationalStateStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATIONAL_STATE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25601,6 +26331,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATIONAL_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25626,6 +26357,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             ChipStructs.RvcOperationalStateClusterErrorStateStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATIONAL_ERROR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25651,6 +26383,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25676,6 +26409,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25701,6 +26435,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25726,6 +26461,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25751,6 +26487,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -25776,6 +26513,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26278,6 +27016,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAST_CONFIGURED_BY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26303,6 +27042,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SCENE_TABLE_SIZE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26333,6 +27073,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ScenesManagementClusterSceneInfoStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FABRIC_SCENE_INFO_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26358,6 +27099,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26383,6 +27125,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26408,6 +27151,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26433,6 +27177,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26458,6 +27203,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26483,6 +27229,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26575,6 +27322,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CONDITION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26600,6 +27348,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEGRADATION_DIRECTION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26625,6 +27374,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CHANGE_INDICATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26650,6 +27400,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, IN_PLACE_INDICATOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26684,6 +27435,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAST_CHANGED_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26709,6 +27461,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.HepaFilterMonitoringClusterReplacementProductStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REPLACEMENT_PRODUCT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26734,6 +27487,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26759,6 +27513,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26784,6 +27539,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26809,6 +27565,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26834,6 +27591,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26859,6 +27617,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26951,6 +27710,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CONDITION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -26976,6 +27736,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEGRADATION_DIRECTION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27001,6 +27762,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CHANGE_INDICATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27026,6 +27788,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, IN_PLACE_INDICATOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27060,6 +27823,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAST_CHANGED_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27085,6 +27849,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ActivatedCarbonFilterMonitoringClusterReplacementProductStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REPLACEMENT_PRODUCT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27110,6 +27875,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27135,6 +27901,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27160,6 +27927,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27185,6 +27953,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27210,6 +27979,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27235,6 +28005,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27354,6 +28125,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_SENSITIVITY_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27379,6 +28151,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_SENSITIVITY_LEVELS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27404,6 +28177,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEFAULT_SENSITIVITY_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27429,6 +28203,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALARMS_ACTIVE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27454,6 +28229,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALARMS_SUPPRESSED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27479,6 +28255,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALARMS_ENABLED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27504,6 +28281,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALARMS_SUPPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27529,6 +28307,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SENSOR_FAULT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27554,6 +28333,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27579,6 +28359,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27604,6 +28385,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27629,6 +28411,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27654,6 +28437,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27679,6 +28463,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27824,6 +28609,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPEN_DURATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27858,6 +28644,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEFAULT_OPEN_DURATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27883,6 +28670,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AUTO_CLOSE_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27908,6 +28696,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REMAINING_DURATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27933,6 +28722,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27958,6 +28748,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TARGET_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -27983,6 +28774,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28008,6 +28800,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TARGET_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28042,6 +28835,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEFAULT_OPEN_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28067,6 +28861,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, VALVE_FAULT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28092,6 +28887,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEVEL_STEP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28117,6 +28913,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28142,6 +28939,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28167,6 +28965,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28192,6 +28991,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28217,6 +29017,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28242,6 +29043,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28391,6 +29193,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POWER_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28416,6 +29219,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_MEASUREMENT_TYPES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28441,6 +29245,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ElectricalPowerMeasurementClusterMeasurementAccuracyStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCURACY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28466,6 +29271,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ElectricalPowerMeasurementClusterMeasurementRangeStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RANGES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28491,6 +29297,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28516,6 +29323,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28541,6 +29349,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REACTIVE_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28566,6 +29375,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, APPARENT_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28591,6 +29401,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28616,6 +29427,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REACTIVE_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28641,6 +29453,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, APPARENT_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28666,6 +29479,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, R_M_S_VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28691,6 +29505,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, R_M_S_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28716,6 +29531,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, R_M_S_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28741,6 +29557,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FREQUENCY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28766,6 +29583,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable List<ChipStructs.ElectricalPowerMeasurementClusterHarmonicMeasurementStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, HARMONIC_CURRENTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28791,6 +29609,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable List<ChipStructs.ElectricalPowerMeasurementClusterHarmonicMeasurementStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, HARMONIC_PHASES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28816,6 +29635,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POWER_FACTOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28841,6 +29661,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NEUTRAL_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28866,6 +29687,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28891,6 +29713,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28916,6 +29739,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28941,6 +29765,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28966,6 +29791,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -28991,6 +29817,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29083,6 +29910,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             ChipStructs.ElectricalEnergyMeasurementClusterMeasurementAccuracyStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCURACY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29108,6 +29936,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.ElectricalEnergyMeasurementClusterEnergyMeasurementStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CUMULATIVE_ENERGY_IMPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29133,6 +29962,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.ElectricalEnergyMeasurementClusterEnergyMeasurementStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CUMULATIVE_ENERGY_EXPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29158,6 +29988,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.ElectricalEnergyMeasurementClusterEnergyMeasurementStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PERIODIC_ENERGY_IMPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29183,6 +30014,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.ElectricalEnergyMeasurementClusterEnergyMeasurementStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PERIODIC_ENERGY_EXPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29208,6 +30040,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.ElectricalEnergyMeasurementClusterCumulativeEnergyResetStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CUMULATIVE_ENERGY_RESET_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29233,6 +30066,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29258,6 +30092,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29283,6 +30118,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29308,6 +30144,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29333,6 +30170,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29358,6 +30196,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29540,6 +30379,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.DemandResponseLoadControlClusterLoadControlProgramStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LOAD_CONTROL_PROGRAMS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29565,6 +30405,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_LOAD_CONTROL_PROGRAMS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29590,6 +30431,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.DemandResponseLoadControlClusterLoadControlEventStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29615,6 +30457,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.DemandResponseLoadControlClusterLoadControlEventStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_EVENTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29640,6 +30483,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_EVENTS_PER_PROGRAM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29665,6 +30509,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_TRANSITIONS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29699,6 +30544,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEFAULT_RANDOM_START_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29733,6 +30579,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEFAULT_RANDOM_DURATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29758,6 +30605,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29783,6 +30631,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29808,6 +30657,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29833,6 +30683,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29858,6 +30709,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -29883,6 +30735,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30019,6 +30872,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.MessagesClusterMessageStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MESSAGES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30044,6 +30898,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<byte[]> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_MESSAGE_I_DS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30069,6 +30924,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30094,6 +30950,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30119,6 +30976,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30144,6 +31002,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30169,6 +31028,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30194,6 +31054,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30448,6 +31309,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, E_S_A_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30473,6 +31335,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, E_S_A_CAN_GENERATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30498,6 +31361,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, E_S_A_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30523,6 +31387,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ABS_MIN_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30548,6 +31413,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ABS_MAX_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30573,6 +31439,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable List<ChipStructs.DeviceEnergyManagementClusterPowerAdjustStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POWER_ADJUSTMENT_CAPABILITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30598,6 +31465,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.DeviceEnergyManagementClusterForecastStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FORECAST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30623,6 +31491,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPT_OUT_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30648,6 +31517,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30673,6 +31543,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30698,6 +31569,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30723,6 +31595,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30748,6 +31621,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -30773,6 +31647,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31047,6 +31922,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31072,6 +31948,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPLY_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31097,6 +31974,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FAULT_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31122,6 +32000,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CHARGING_ENABLED_UNTIL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31147,6 +32026,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DISCHARGING_ENABLED_UNTIL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31172,6 +32052,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CIRCUIT_CAPACITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31197,6 +32078,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MINIMUM_CHARGE_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31222,6 +32104,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAXIMUM_CHARGE_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31247,6 +32130,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAXIMUM_DISCHARGE_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31281,6 +32165,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, USER_MAXIMUM_CHARGE_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31315,6 +32200,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RANDOMIZATION_DELAY_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31340,6 +32226,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NEXT_CHARGE_START_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31365,6 +32252,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NEXT_CHARGE_TARGET_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31390,6 +32278,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NEXT_CHARGE_REQUIRED_ENERGY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31415,6 +32304,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NEXT_CHARGE_TARGET_SO_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31449,6 +32339,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, APPROXIMATE_E_V_EFFICIENCY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31474,6 +32365,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STATE_OF_CHARGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31499,6 +32391,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BATTERY_CAPACITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31524,6 +32417,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, VEHICLE_I_D_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31549,6 +32443,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SESSION_I_D_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31574,6 +32469,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SESSION_DURATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31599,6 +32495,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SESSION_ENERGY_CHARGED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31624,6 +32521,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SESSION_ENERGY_DISCHARGED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31649,6 +32547,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31674,6 +32573,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31699,6 +32599,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31724,6 +32625,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31749,6 +32651,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31774,6 +32677,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31853,6 +32757,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.EnergyPreferenceClusterBalanceStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENERGY_BALANCES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31887,6 +32792,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_ENERGY_BALANCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31912,6 +32818,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENERGY_PRIORITIES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31937,6 +32844,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.EnergyPreferenceClusterBalanceStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LOW_POWER_MODE_SENSITIVITIES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31971,6 +32879,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_LOW_POWER_MODE_SENSITIVITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -31996,6 +32905,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32021,6 +32931,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32046,6 +32957,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32071,6 +32983,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32096,6 +33009,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32121,6 +33035,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32193,6 +33108,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVAILABLE_ENDPOINTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32218,6 +33134,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_ENDPOINTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32243,6 +33160,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32268,6 +33186,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32293,6 +33212,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32318,6 +33238,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32343,6 +33264,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32368,6 +33290,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32487,6 +33410,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.EnergyEvseModeClusterModeOptionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_MODES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32512,6 +33436,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32546,6 +33471,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_UP_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32580,6 +33506,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32605,6 +33532,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32630,6 +33558,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32655,6 +33584,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32680,6 +33610,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32705,6 +33636,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32730,6 +33662,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32849,6 +33782,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.DeviceEnergyManagementModeClusterModeOptionStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_MODES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32874,6 +33808,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32908,6 +33843,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_UP_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32942,6 +33878,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32967,6 +33904,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -32992,6 +33930,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -33017,6 +33956,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -33042,6 +33982,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -33067,6 +34008,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -33092,6 +34034,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34031,6 +34974,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LOCK_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34056,6 +35000,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LOCK_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34081,6 +35026,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTUATOR_ENABLED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34106,6 +35052,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DOOR_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34140,6 +35087,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DOOR_OPEN_EVENTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34174,6 +35122,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DOOR_CLOSED_EVENTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34208,6 +35157,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPEN_PERIOD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34233,6 +35183,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_TOTAL_USERS_SUPPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34258,6 +35209,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_P_I_N_USERS_SUPPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34283,6 +35235,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_R_F_I_D_USERS_SUPPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34308,6 +35261,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_WEEK_DAY_SCHEDULES_SUPPORTED_PER_USER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34333,6 +35287,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_YEAR_DAY_SCHEDULES_SUPPORTED_PER_USER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34358,6 +35313,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_HOLIDAY_SCHEDULES_SUPPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34383,6 +35339,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_P_I_N_CODE_LENGTH_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34408,6 +35365,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_P_I_N_CODE_LENGTH_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34433,6 +35391,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_R_F_I_D_CODE_LENGTH_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34458,6 +35417,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_R_F_I_D_CODE_LENGTH_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34483,6 +35443,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CREDENTIAL_RULES_SUPPORT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34508,6 +35469,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_CREDENTIALS_SUPPORTED_PER_USER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34542,6 +35504,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LANGUAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34576,6 +35539,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, L_E_D_SETTINGS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34610,6 +35574,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AUTO_RELOCK_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34644,6 +35609,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SOUND_VOLUME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34678,6 +35644,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATING_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34703,6 +35670,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_OPERATING_MODES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34728,6 +35696,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DEFAULT_CONFIGURATION_REGISTER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34762,6 +35731,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENABLE_LOCAL_PROGRAMMING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34796,6 +35766,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENABLE_ONE_TOUCH_LOCKING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34830,6 +35801,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENABLE_INSIDE_STATUS_L_E_D_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34864,6 +35836,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENABLE_PRIVACY_MODE_BUTTON_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34898,6 +35871,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LOCAL_PROGRAMMING_FEATURES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34932,6 +35906,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WRONG_CODE_ENTRY_LIMIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -34966,6 +35941,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, USER_CODE_TEMPORARY_DISABLE_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35000,6 +35976,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SEND_P_I_N_OVER_THE_AIR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35034,6 +36011,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REQUIRE_P_I_NFOR_REMOTE_OPERATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35068,6 +36046,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EXPIRING_USER_TIMEOUT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35093,6 +36072,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALIRO_READER_VERIFICATION_KEY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35118,6 +36098,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALIRO_READER_GROUP_IDENTIFIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35143,6 +36124,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALIRO_READER_GROUP_SUB_IDENTIFIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35168,6 +36150,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<byte[]> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALIRO_EXPEDITED_TRANSACTION_SUPPORTED_PROTOCOL_VERSIONS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35193,6 +36176,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALIRO_GROUP_RESOLVING_KEY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35218,6 +36202,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<byte[]> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALIRO_SUPPORTED_B_L_E_U_W_B_PROTOCOL_VERSIONS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35243,6 +36228,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALIRO_B_L_E_ADVERTISING_VERSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35268,6 +36254,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_ALIRO_CREDENTIAL_ISSUER_KEYS_SUPPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35293,6 +36280,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_ALIRO_ENDPOINT_KEYS_SUPPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35318,6 +36306,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35343,6 +36332,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35368,6 +36358,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35393,6 +36384,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35418,6 +36410,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35443,6 +36436,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35687,6 +36681,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35712,6 +36707,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PHYSICAL_CLOSED_LIMIT_LIFT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35737,6 +36733,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PHYSICAL_CLOSED_LIMIT_TILT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35762,6 +36759,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_POSITION_LIFT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35787,6 +36785,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_POSITION_TILT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35812,6 +36811,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_ACTUATIONS_LIFT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35837,6 +36837,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_ACTUATIONS_TILT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35862,6 +36863,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CONFIG_STATUS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35887,6 +36889,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_POSITION_LIFT_PERCENTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35912,6 +36915,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_POSITION_TILT_PERCENTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35937,6 +36941,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATIONAL_STATUS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35962,6 +36967,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TARGET_POSITION_LIFT_PERCENT100THS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -35987,6 +36993,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TARGET_POSITION_TILT_PERCENT100THS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36012,6 +37019,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, END_PRODUCT_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36037,6 +37045,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_POSITION_LIFT_PERCENT100THS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36062,6 +37071,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_POSITION_TILT_PERCENT100THS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36087,6 +37097,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INSTALLED_OPEN_LIMIT_LIFT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36112,6 +37123,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INSTALLED_CLOSED_LIMIT_LIFT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36137,6 +37149,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INSTALLED_OPEN_LIMIT_TILT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36162,6 +37175,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INSTALLED_CLOSED_LIMIT_TILT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36196,6 +37210,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36221,6 +37236,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SAFETY_STATUS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36246,6 +37262,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36271,6 +37288,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36296,6 +37314,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36321,6 +37340,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36346,6 +37366,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36371,6 +37392,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36479,6 +37501,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BARRIER_MOVING_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36504,6 +37527,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BARRIER_SAFETY_STATUS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36529,6 +37553,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BARRIER_CAPABILITIES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36563,6 +37588,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BARRIER_OPEN_EVENTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36597,6 +37623,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BARRIER_CLOSE_EVENTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36631,6 +37658,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BARRIER_COMMAND_OPEN_EVENTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36665,6 +37693,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BARRIER_COMMAND_CLOSE_EVENTS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36699,6 +37728,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BARRIER_OPEN_PERIOD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36733,6 +37763,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BARRIER_CLOSE_PERIOD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36758,6 +37789,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BARRIER_POSITION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36783,6 +37815,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36808,6 +37841,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36833,6 +37867,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36858,6 +37893,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36883,6 +37919,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -36908,6 +37945,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37065,6 +38103,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_PRESSURE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37090,6 +38129,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_SPEED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37115,6 +38155,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_FLOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37140,6 +38181,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_CONST_PRESSURE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37165,6 +38207,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_CONST_PRESSURE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37190,6 +38233,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_COMP_PRESSURE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37215,6 +38259,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_COMP_PRESSURE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37240,6 +38285,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_CONST_SPEED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37265,6 +38311,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_CONST_SPEED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37290,6 +38337,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_CONST_FLOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37315,6 +38363,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_CONST_FLOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37340,6 +38389,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_CONST_TEMP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37365,6 +38415,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_CONST_TEMP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37390,6 +38441,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PUMP_STATUS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37415,6 +38467,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EFFECTIVE_OPERATION_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37440,6 +38493,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EFFECTIVE_CONTROL_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37465,6 +38519,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CAPACITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37490,6 +38545,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SPEED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37524,6 +38580,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LIFETIME_RUNNING_HOURS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37549,6 +38606,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37583,6 +38641,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LIFETIME_ENERGY_CONSUMED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37617,6 +38676,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPERATION_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37651,6 +38711,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CONTROL_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37676,6 +38737,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37701,6 +38763,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37726,6 +38789,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37751,6 +38815,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37776,6 +38841,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -37801,6 +38867,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38269,6 +39336,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LOCAL_TEMPERATURE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38294,6 +39362,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OUTDOOR_TEMPERATURE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38319,6 +39388,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OCCUPANCY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38344,6 +39414,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ABS_MIN_HEAT_SETPOINT_LIMIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38369,6 +39440,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ABS_MAX_HEAT_SETPOINT_LIMIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38394,6 +39466,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ABS_MIN_COOL_SETPOINT_LIMIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38419,6 +39492,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ABS_MAX_COOL_SETPOINT_LIMIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38444,6 +39518,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, P_I_COOLING_DEMAND_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38469,6 +39544,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, P_I_HEATING_DEMAND_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38503,6 +39579,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, H_V_A_C_SYSTEM_TYPE_CONFIGURATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38537,6 +39614,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LOCAL_TEMPERATURE_CALIBRATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38571,6 +39649,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OCCUPIED_COOLING_SETPOINT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38605,6 +39684,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OCCUPIED_HEATING_SETPOINT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38639,6 +39719,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNOCCUPIED_COOLING_SETPOINT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38673,6 +39754,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNOCCUPIED_HEATING_SETPOINT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38707,6 +39789,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_HEAT_SETPOINT_LIMIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38741,6 +39824,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_HEAT_SETPOINT_LIMIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38775,6 +39859,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_COOL_SETPOINT_LIMIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38809,6 +39894,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_COOL_SETPOINT_LIMIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38843,6 +39929,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_SETPOINT_DEAD_BAND_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38877,6 +39964,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REMOTE_SENSING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38911,6 +39999,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CONTROL_SEQUENCE_OF_OPERATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38945,6 +40034,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SYSTEM_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38970,6 +40060,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, THERMOSTAT_RUNNING_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -38995,6 +40086,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_OF_WEEK_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39020,6 +40112,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_WEEKLY_TRANSITIONS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39045,6 +40138,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_DAILY_TRANSITIONS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39079,6 +40173,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TEMPERATURE_SETPOINT_HOLD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39113,6 +40208,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TEMPERATURE_SETPOINT_HOLD_DURATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39147,6 +40243,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, THERMOSTAT_PROGRAMMING_OPERATION_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39172,6 +40269,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, THERMOSTAT_RUNNING_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39197,6 +40295,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SETPOINT_CHANGE_SOURCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39222,6 +40321,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SETPOINT_CHANGE_AMOUNT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39247,6 +40347,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SETPOINT_CHANGE_SOURCE_TIMESTAMP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39281,6 +40382,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OCCUPIED_SETBACK_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39306,6 +40408,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OCCUPIED_SETBACK_MIN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39331,6 +40434,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OCCUPIED_SETBACK_MAX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39365,6 +40469,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNOCCUPIED_SETBACK_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39390,6 +40495,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNOCCUPIED_SETBACK_MIN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39415,6 +40521,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNOCCUPIED_SETBACK_MAX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39449,6 +40556,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EMERGENCY_HEAT_DELTA_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39483,6 +40591,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, A_C_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39517,6 +40626,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, A_C_CAPACITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39551,6 +40661,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, A_C_REFRIGERANT_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39585,6 +40696,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, A_C_COMPRESSOR_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39619,6 +40731,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, A_C_ERROR_CODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39653,6 +40766,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, A_C_LOUVER_POSITION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39678,6 +40792,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, A_C_COIL_TEMPERATURE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39712,6 +40827,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, A_C_CAPACITYFORMAT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39737,6 +40853,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ThermostatClusterPresetTypeStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRESET_TYPES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39762,6 +40879,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ThermostatClusterScheduleTypeStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SCHEDULE_TYPES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39787,6 +40905,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_PRESETS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39812,6 +40931,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_SCHEDULES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39837,6 +40957,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_SCHEDULE_TRANSITIONS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39862,6 +40983,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_SCHEDULE_TRANSITION_PER_DAY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39887,6 +41009,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_PRESET_HANDLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39912,6 +41035,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_SCHEDULE_HANDLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39946,6 +41070,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ThermostatClusterPresetStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRESETS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -39980,6 +41105,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ThermostatClusterScheduleStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SCHEDULES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40005,6 +41131,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRESETS_SCHEDULES_EDITABLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40030,6 +41157,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TEMPERATURE_SETPOINT_HOLD_POLICY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40055,6 +41183,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SETPOINT_HOLD_EXPIRY_TIMESTAMP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40080,6 +41209,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.ThermostatClusterQueuedPresetStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, QUEUED_PRESET_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40105,6 +41235,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40130,6 +41261,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40155,6 +41287,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40180,6 +41313,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40205,6 +41339,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40230,6 +41365,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40349,6 +41485,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FAN_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40374,6 +41511,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FAN_MODE_SEQUENCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40408,6 +41546,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PERCENT_SETTING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40433,6 +41572,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PERCENT_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40458,6 +41598,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SPEED_MAX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40492,6 +41633,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SPEED_SETTING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40517,6 +41659,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SPEED_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40542,6 +41685,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ROCK_SUPPORT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40576,6 +41720,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ROCK_SETTING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40601,6 +41746,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WIND_SUPPORT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40635,6 +41781,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WIND_SETTING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40669,6 +41816,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AIRFLOW_DIRECTION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40694,6 +41842,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40719,6 +41868,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40744,6 +41894,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40769,6 +41920,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40794,6 +41946,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40819,6 +41972,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40893,6 +42047,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TEMPERATURE_DISPLAY_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40927,6 +42082,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, KEYPAD_LOCKOUT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40961,6 +42117,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SCHEDULE_PROGRAMMING_VISIBILITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -40986,6 +42143,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -41011,6 +42169,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -41036,6 +42195,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -41061,6 +42221,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -41086,6 +42247,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -41111,6 +42273,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -41937,6 +43100,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_HUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -41962,6 +43126,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_SATURATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -41987,6 +43152,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REMAINING_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42012,6 +43178,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_X_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42037,6 +43204,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_Y_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42062,6 +43230,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DRIFT_COMPENSATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42087,6 +43256,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COMPENSATION_TEXT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42112,6 +43282,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_TEMPERATURE_MIREDS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42137,6 +43308,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42171,6 +43343,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OPTIONS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42196,6 +43369,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NUMBER_OF_PRIMARIES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42221,6 +43395,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY1_X_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42246,6 +43421,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY1_Y_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42271,6 +43447,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY1_INTENSITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42296,6 +43473,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY2_X_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42321,6 +43499,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY2_Y_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42346,6 +43525,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY2_INTENSITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42371,6 +43551,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY3_X_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42396,6 +43577,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY3_Y_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42421,6 +43603,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY3_INTENSITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42446,6 +43629,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY4_X_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42471,6 +43655,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY4_Y_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42496,6 +43681,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY4_INTENSITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42521,6 +43707,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY5_X_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42546,6 +43733,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY5_Y_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42571,6 +43759,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY5_INTENSITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42596,6 +43785,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY6_X_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42621,6 +43811,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY6_Y_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42646,6 +43837,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRIMARY6_INTENSITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42680,6 +43872,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WHITE_POINT_X_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42714,6 +43907,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WHITE_POINT_Y_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42748,6 +43942,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_POINT_R_X_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42782,6 +43977,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_POINT_R_Y_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42816,6 +44012,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_POINT_R_INTENSITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42850,6 +44047,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_POINT_G_X_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42884,6 +44082,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_POINT_G_Y_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42918,6 +44117,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_POINT_G_INTENSITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42952,6 +44152,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_POINT_B_X_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -42986,6 +44187,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_POINT_B_Y_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43020,6 +44222,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_POINT_B_INTENSITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43045,6 +44248,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENHANCED_CURRENT_HUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43070,6 +44274,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENHANCED_COLOR_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43095,6 +44300,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_LOOP_ACTIVE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43120,6 +44326,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_LOOP_DIRECTION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43145,6 +44352,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_LOOP_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43170,6 +44378,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_LOOP_START_ENHANCED_HUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43195,6 +44404,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_LOOP_STORED_ENHANCED_HUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43220,6 +44430,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_CAPABILITIES_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43245,6 +44456,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_TEMP_PHYSICAL_MIN_MIREDS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43270,6 +44482,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COLOR_TEMP_PHYSICAL_MAX_MIREDS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43295,6 +44508,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, COUPLE_COLOR_TEMP_TO_LEVEL_MIN_MIREDS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43329,6 +44543,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_UP_COLOR_TEMPERATURE_MIREDS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43354,6 +44569,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43379,6 +44595,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43404,6 +44621,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43429,6 +44647,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43454,6 +44673,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43479,6 +44699,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43575,6 +44796,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PHYSICAL_MIN_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43600,6 +44822,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PHYSICAL_MAX_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43625,6 +44848,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BALLAST_STATUS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43659,6 +44883,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43693,6 +44918,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_LEVEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43727,6 +44953,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INTRINSIC_BALLAST_FACTOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43761,6 +44988,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BALLAST_FACTOR_ADJUSTMENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43786,6 +45014,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAMP_QUANTITY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43820,6 +45049,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAMP_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43854,6 +45084,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAMP_MANUFACTURER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43888,6 +45119,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAMP_RATED_HOURS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43922,6 +45154,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAMP_BURN_HOURS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43956,6 +45189,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAMP_ALARM_MODE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -43990,6 +45224,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LAMP_BURN_HOURS_TRIP_POINT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44015,6 +45250,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44040,6 +45276,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44065,6 +45302,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44090,6 +45328,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44115,6 +45354,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44140,6 +45380,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44223,6 +45464,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44248,6 +45490,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44273,6 +45516,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44298,6 +45542,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TOLERANCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44323,6 +45568,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LIGHT_SENSOR_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44348,6 +45594,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44373,6 +45620,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44398,6 +45646,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44423,6 +45672,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44448,6 +45698,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44473,6 +45724,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44551,6 +45803,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44576,6 +45829,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44601,6 +45855,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44626,6 +45881,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TOLERANCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44651,6 +45907,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44676,6 +45933,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44701,6 +45959,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44726,6 +45985,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44751,6 +46011,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44776,6 +46037,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44871,6 +46133,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44896,6 +46159,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44921,6 +46185,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44946,6 +46211,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TOLERANCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44971,6 +46237,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SCALED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -44996,6 +46263,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_SCALED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45021,6 +46289,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_SCALED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45046,6 +46315,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SCALED_TOLERANCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45071,6 +46341,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SCALE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45096,6 +46367,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45121,6 +46393,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45146,6 +46419,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45171,6 +46445,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45196,6 +46471,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45221,6 +46497,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45299,6 +46576,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45324,6 +46602,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45349,6 +46628,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45374,6 +46654,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TOLERANCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45399,6 +46680,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45424,6 +46706,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45449,6 +46732,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45474,6 +46758,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45499,6 +46784,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45524,6 +46810,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45602,6 +46889,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45627,6 +46915,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45652,6 +46941,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45677,6 +46967,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TOLERANCE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45702,6 +46993,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45727,6 +47019,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45752,6 +47045,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45777,6 +47071,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45802,6 +47097,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45827,6 +47123,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45901,6 +47198,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OCCUPANCY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45926,6 +47224,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OCCUPANCY_SENSOR_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45951,6 +47250,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OCCUPANCY_SENSOR_TYPE_BITMAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -45985,6 +47285,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, P_I_R_OCCUPIED_TO_UNOCCUPIED_DELAY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46019,6 +47320,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, P_I_R_UNOCCUPIED_TO_OCCUPIED_DELAY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46053,6 +47355,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, P_I_R_UNOCCUPIED_TO_OCCUPIED_THRESHOLD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46087,6 +47390,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ULTRASONIC_OCCUPIED_TO_UNOCCUPIED_DELAY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46121,6 +47425,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ULTRASONIC_UNOCCUPIED_TO_OCCUPIED_DELAY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46155,6 +47460,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ULTRASONIC_UNOCCUPIED_TO_OCCUPIED_THRESHOLD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46189,6 +47495,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PHYSICAL_CONTACT_OCCUPIED_TO_UNOCCUPIED_DELAY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46223,6 +47530,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PHYSICAL_CONTACT_UNOCCUPIED_TO_OCCUPIED_DELAY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46257,6 +47565,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PHYSICAL_CONTACT_UNOCCUPIED_TO_OCCUPIED_THRESHOLD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46282,6 +47591,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46307,6 +47617,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46332,6 +47643,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46357,6 +47669,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46382,6 +47695,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46407,6 +47721,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46500,6 +47815,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46525,6 +47841,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46550,6 +47867,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46575,6 +47893,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46600,6 +47919,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46625,6 +47945,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46650,6 +47971,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46675,6 +47997,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNCERTAINTY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46700,6 +48023,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_UNIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46725,6 +48049,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_MEDIUM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46750,6 +48075,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEVEL_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46775,6 +48101,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46800,6 +48127,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46825,6 +48153,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46850,6 +48179,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46875,6 +48205,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46900,6 +48231,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -46993,6 +48325,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47018,6 +48351,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47043,6 +48377,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47068,6 +48403,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47093,6 +48429,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47118,6 +48455,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47143,6 +48481,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47168,6 +48507,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNCERTAINTY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47193,6 +48533,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_UNIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47218,6 +48559,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_MEDIUM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47243,6 +48585,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEVEL_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47268,6 +48611,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47293,6 +48637,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47318,6 +48663,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47343,6 +48689,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47368,6 +48715,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47393,6 +48741,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47486,6 +48835,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47511,6 +48861,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47536,6 +48887,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47561,6 +48913,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47586,6 +48939,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47611,6 +48965,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47636,6 +48991,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47661,6 +49017,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNCERTAINTY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47686,6 +49043,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_UNIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47711,6 +49069,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_MEDIUM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47736,6 +49095,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEVEL_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47761,6 +49121,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47786,6 +49147,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47811,6 +49173,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47836,6 +49199,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47861,6 +49225,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47886,6 +49251,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -47979,6 +49345,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48004,6 +49371,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48029,6 +49397,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48054,6 +49423,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48079,6 +49449,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48104,6 +49475,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48129,6 +49501,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48154,6 +49527,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNCERTAINTY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48179,6 +49553,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_UNIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48204,6 +49579,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_MEDIUM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48229,6 +49605,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEVEL_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48254,6 +49631,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48279,6 +49657,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48304,6 +49683,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48329,6 +49709,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48354,6 +49735,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48379,6 +49761,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48472,6 +49855,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48497,6 +49881,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48522,6 +49907,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48547,6 +49933,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48572,6 +49959,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48597,6 +49985,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48622,6 +50011,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48647,6 +50037,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNCERTAINTY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48672,6 +50063,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_UNIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48697,6 +50089,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_MEDIUM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48722,6 +50115,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEVEL_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48747,6 +50141,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48772,6 +50167,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48797,6 +50193,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48822,6 +50219,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48847,6 +50245,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48872,6 +50271,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48965,6 +50365,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -48990,6 +50391,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49015,6 +50417,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49040,6 +50443,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49065,6 +50469,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49090,6 +50495,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49115,6 +50521,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49140,6 +50547,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNCERTAINTY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49165,6 +50573,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_UNIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49190,6 +50599,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_MEDIUM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49215,6 +50625,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEVEL_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49240,6 +50651,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49265,6 +50677,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49290,6 +50703,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49315,6 +50729,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49340,6 +50755,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49365,6 +50781,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49458,6 +50875,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49483,6 +50901,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49508,6 +50927,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49533,6 +50953,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49558,6 +50979,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49583,6 +51005,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49608,6 +51031,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49633,6 +51057,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNCERTAINTY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49658,6 +51083,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_UNIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49683,6 +51109,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_MEDIUM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49708,6 +51135,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEVEL_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49733,6 +51161,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49758,6 +51187,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49783,6 +51213,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49808,6 +51239,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49833,6 +51265,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49858,6 +51291,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49951,6 +51385,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -49976,6 +51411,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50001,6 +51437,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50026,6 +51463,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50051,6 +51489,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50076,6 +51515,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50101,6 +51541,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50126,6 +51567,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNCERTAINTY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50151,6 +51593,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_UNIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50176,6 +51619,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_MEDIUM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50201,6 +51645,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEVEL_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50226,6 +51671,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50251,6 +51697,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50276,6 +51723,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50301,6 +51749,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50326,6 +51775,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50351,6 +51801,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50444,6 +51895,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50469,6 +51921,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50494,6 +51947,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50519,6 +51973,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50544,6 +51999,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50569,6 +52025,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50594,6 +52051,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50619,6 +52077,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNCERTAINTY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50644,6 +52103,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_UNIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50669,6 +52129,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_MEDIUM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50694,6 +52155,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEVEL_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50719,6 +52181,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50744,6 +52207,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50769,6 +52233,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50794,6 +52259,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50819,6 +52285,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50844,6 +52311,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50937,6 +52405,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50962,6 +52431,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MIN_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -50987,6 +52457,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MAX_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51012,6 +52483,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51037,6 +52509,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PEAK_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51062,6 +52535,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51087,6 +52561,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_MEASURED_VALUE_WINDOW_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51112,6 +52587,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNCERTAINTY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51137,6 +52613,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_UNIT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51162,6 +52639,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_MEDIUM_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51187,6 +52665,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LEVEL_VALUE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51212,6 +52691,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51237,6 +52717,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51262,6 +52743,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51287,6 +52769,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51312,6 +52795,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51337,6 +52821,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51401,6 +52886,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, M_A_C_ADDRESS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51426,6 +52912,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LINK_LOCAL_ADDRESS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51451,6 +52938,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51476,6 +52964,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51501,6 +52990,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51526,6 +53016,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51551,6 +53042,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51576,6 +53068,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51867,6 +53360,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ChannelClusterChannelInfoStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CHANNEL_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51892,6 +53386,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.ChannelClusterLineupInfoStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LINEUP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51917,6 +53412,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.ChannelClusterChannelInfoStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_CHANNEL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51942,6 +53438,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51967,6 +53464,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -51992,6 +53490,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52017,6 +53516,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52042,6 +53542,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52067,6 +53568,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52180,6 +53682,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.TargetNavigatorClusterTargetInfoStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TARGET_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52205,6 +53708,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_TARGET_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52230,6 +53734,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52255,6 +53760,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52280,6 +53786,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52305,6 +53812,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52330,6 +53838,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52355,6 +53864,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52911,6 +54421,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_STATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52936,6 +54447,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, START_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52961,6 +54473,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DURATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -52986,6 +54499,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.MediaPlaybackClusterPlaybackPositionStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SAMPLED_POSITION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53011,6 +54525,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PLAYBACK_SPEED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53036,6 +54551,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SEEK_RANGE_END_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53061,6 +54577,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SEEK_RANGE_START_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53086,6 +54603,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.MediaPlaybackClusterTrackStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_AUDIO_TRACK_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53111,6 +54629,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable List<ChipStructs.MediaPlaybackClusterTrackStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVAILABLE_AUDIO_TRACKS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53136,6 +54655,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.MediaPlaybackClusterTrackStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_TEXT_TRACK_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53161,6 +54681,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable List<ChipStructs.MediaPlaybackClusterTrackStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVAILABLE_TEXT_TRACKS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53186,6 +54707,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53211,6 +54733,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53236,6 +54759,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53261,6 +54785,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53286,6 +54811,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53311,6 +54837,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53455,6 +54982,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.MediaInputClusterInputInfoStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INPUT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53480,6 +55008,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_INPUT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53505,6 +55034,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53530,6 +55060,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53555,6 +55086,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53580,6 +55112,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53605,6 +55138,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53630,6 +55164,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53708,6 +55243,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53733,6 +55269,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53758,6 +55295,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53783,6 +55321,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53808,6 +55347,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53833,6 +55373,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53929,6 +55470,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53954,6 +55496,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -53979,6 +55522,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54004,6 +55548,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54029,6 +55574,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54054,6 +55600,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54224,6 +55771,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<String> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPT_HEADER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54249,6 +55797,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SUPPORTED_STREAMING_PROTOCOLS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54274,6 +55823,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54299,6 +55849,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54324,6 +55875,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54349,6 +55901,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54374,6 +55927,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54399,6 +55953,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54511,6 +56066,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.AudioOutputClusterOutputInfoStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OUTPUT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54536,6 +56092,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_OUTPUT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54561,6 +56118,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54586,6 +56144,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54611,6 +56170,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54636,6 +56196,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54661,6 +56222,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54686,6 +56248,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54877,6 +56440,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CATALOG_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54902,6 +56466,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.ApplicationLauncherClusterApplicationEPStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_APP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54927,6 +56492,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54952,6 +56518,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -54977,6 +56544,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55002,6 +56570,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55027,6 +56596,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55052,6 +56622,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55130,6 +56701,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, VENDOR_NAME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55155,6 +56727,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, VENDOR_I_D_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55180,6 +56753,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, APPLICATION_NAME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55205,6 +56779,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PRODUCT_I_D_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55230,6 +56805,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             ChipStructs.ApplicationBasicClusterApplicationStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, APPLICATION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55255,6 +56831,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STATUS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55280,6 +56857,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, APPLICATION_VERSION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55305,6 +56883,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ALLOWED_VENDOR_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55330,6 +56909,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55355,6 +56935,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55380,6 +56961,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55405,6 +56987,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55430,6 +57013,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55455,6 +57039,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55590,6 +57175,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55615,6 +57201,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55640,6 +57227,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55665,6 +57253,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55690,6 +57279,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55715,6 +57305,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -55995,6 +57586,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENABLED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56020,6 +57612,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ContentControlClusterRatingNameStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_DEMAND_RATINGS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56045,6 +57638,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ON_DEMAND_RATING_THRESHOLD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56070,6 +57664,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.ContentControlClusterRatingNameStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SCHEDULED_CONTENT_RATINGS_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56095,6 +57690,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SCHEDULED_CONTENT_RATING_THRESHOLD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56120,6 +57716,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, SCREEN_DAILY_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56145,6 +57742,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REMAINING_SCREEN_TIME_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56170,6 +57768,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BLOCK_UNRATED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56195,6 +57794,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56220,6 +57820,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56245,6 +57846,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56270,6 +57872,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56295,6 +57898,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56320,6 +57924,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56434,6 +58039,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56459,6 +58065,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56484,6 +58091,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56509,6 +58117,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56534,6 +58143,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56559,6 +58169,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56793,6 +58404,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASUREMENT_TYPE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56818,6 +58430,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56843,6 +58456,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_VOLTAGE_MIN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56868,6 +58482,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_VOLTAGE_MAX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56893,6 +58508,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56918,6 +58534,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_CURRENT_MIN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56943,6 +58560,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_CURRENT_MAX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56968,6 +58586,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -56993,6 +58612,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_POWER_MIN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57018,6 +58638,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_POWER_MAX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57043,6 +58664,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_VOLTAGE_MULTIPLIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57068,6 +58690,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_VOLTAGE_DIVISOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57093,6 +58716,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_CURRENT_MULTIPLIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57118,6 +58742,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_CURRENT_DIVISOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57143,6 +58768,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_POWER_MULTIPLIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57168,6 +58794,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, DC_POWER_DIVISOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57193,6 +58820,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_FREQUENCY_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57218,6 +58846,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_FREQUENCY_MIN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57243,6 +58872,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_FREQUENCY_MAX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57268,6 +58898,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NEUTRAL_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57293,6 +58924,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TOTAL_ACTIVE_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57318,6 +58950,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TOTAL_REACTIVE_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57343,6 +58976,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TOTAL_APPARENT_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57368,6 +59002,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED1ST_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57393,6 +59028,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED3RD_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57418,6 +59054,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED5TH_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57443,6 +59080,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED7TH_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57468,6 +59106,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED9TH_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57493,6 +59132,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED11TH_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57518,6 +59158,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_PHASE1ST_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57543,6 +59184,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_PHASE3RD_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57568,6 +59210,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_PHASE5TH_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57593,6 +59236,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_PHASE7TH_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57618,6 +59262,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_PHASE9TH_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57643,6 +59288,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEASURED_PHASE11TH_HARMONIC_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57668,6 +59314,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_FREQUENCY_MULTIPLIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57693,6 +59340,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_FREQUENCY_DIVISOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57718,6 +59366,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POWER_MULTIPLIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57743,6 +59392,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POWER_DIVISOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57768,6 +59418,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, HARMONIC_CURRENT_MULTIPLIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57793,6 +59444,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, PHASE_HARMONIC_CURRENT_MULTIPLIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57818,6 +59470,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INSTANTANEOUS_VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57843,6 +59496,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INSTANTANEOUS_LINE_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57868,6 +59522,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INSTANTANEOUS_ACTIVE_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57893,6 +59548,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INSTANTANEOUS_REACTIVE_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57918,6 +59574,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INSTANTANEOUS_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57943,6 +59600,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57968,6 +59626,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_MIN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -57993,6 +59652,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_MAX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58018,6 +59678,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_CURRENT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58043,6 +59704,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_CURRENT_MIN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58068,6 +59730,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_CURRENT_MAX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58093,6 +59756,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58118,6 +59782,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_POWER_MIN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58143,6 +59808,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_POWER_MAX_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58168,6 +59834,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REACTIVE_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58193,6 +59860,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, APPARENT_POWER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58218,6 +59886,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POWER_FACTOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58252,6 +59921,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_RMS_VOLTAGE_MEASUREMENT_PERIOD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58286,6 +59956,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_RMS_UNDER_VOLTAGE_COUNTER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58320,6 +59991,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_EXTREME_OVER_VOLTAGE_PERIOD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58354,6 +60026,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_EXTREME_UNDER_VOLTAGE_PERIOD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58388,6 +60061,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_SAG_PERIOD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58422,6 +60096,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_SWELL_PERIOD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58447,6 +60122,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_VOLTAGE_MULTIPLIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58472,6 +60148,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_VOLTAGE_DIVISOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58497,6 +60174,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_CURRENT_MULTIPLIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58522,6 +60200,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_CURRENT_DIVISOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58547,6 +60226,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_POWER_MULTIPLIER_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58572,6 +60252,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_POWER_DIVISOR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58606,6 +60287,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OVERLOAD_ALARMS_MASK_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58631,6 +60313,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, VOLTAGE_OVERLOAD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58656,6 +60339,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CURRENT_OVERLOAD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58690,6 +60374,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_OVERLOAD_ALARMS_MASK_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58715,6 +60400,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_VOLTAGE_OVERLOAD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58740,6 +60426,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_CURRENT_OVERLOAD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58765,6 +60452,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_ACTIVE_POWER_OVERLOAD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58790,6 +60478,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AC_REACTIVE_POWER_OVERLOAD_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58815,6 +60504,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_RMS_OVER_VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58840,6 +60530,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_RMS_UNDER_VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58865,6 +60556,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_EXTREME_OVER_VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58890,6 +60582,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_EXTREME_UNDER_VOLTAGE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58915,6 +60608,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_SAG_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58940,6 +60634,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_SWELL_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58965,6 +60660,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LINE_CURRENT_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -58990,6 +60686,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_CURRENT_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59015,6 +60712,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REACTIVE_CURRENT_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59040,6 +60738,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59065,6 +60764,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_MIN_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59090,6 +60790,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_MAX_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59115,6 +60816,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_CURRENT_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59140,6 +60842,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_CURRENT_MIN_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59165,6 +60868,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_CURRENT_MAX_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59190,6 +60894,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_POWER_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59215,6 +60920,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_POWER_MIN_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59240,6 +60946,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_POWER_MAX_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59265,6 +60972,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REACTIVE_POWER_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59290,6 +60998,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, APPARENT_POWER_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59315,6 +61024,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POWER_FACTOR_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59340,6 +61050,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_RMS_VOLTAGE_MEASUREMENT_PERIOD_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59365,6 +61076,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_RMS_OVER_VOLTAGE_COUNTER_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59390,6 +61102,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_RMS_UNDER_VOLTAGE_COUNTER_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59415,6 +61128,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_EXTREME_OVER_VOLTAGE_PERIOD_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59440,6 +61154,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_EXTREME_UNDER_VOLTAGE_PERIOD_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59465,6 +61180,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_SAG_PERIOD_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59490,6 +61206,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_SWELL_PERIOD_PHASE_B_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59515,6 +61232,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LINE_CURRENT_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59540,6 +61258,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_CURRENT_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59565,6 +61284,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REACTIVE_CURRENT_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59590,6 +61310,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59615,6 +61336,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_MIN_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59640,6 +61362,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_MAX_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59665,6 +61388,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_CURRENT_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59690,6 +61414,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_CURRENT_MIN_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59715,6 +61440,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_CURRENT_MAX_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59740,6 +61466,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_POWER_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59765,6 +61492,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_POWER_MIN_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59790,6 +61518,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACTIVE_POWER_MAX_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59815,6 +61544,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, REACTIVE_POWER_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59840,6 +61570,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, APPARENT_POWER_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59865,6 +61596,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, POWER_FACTOR_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59890,6 +61622,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_RMS_VOLTAGE_MEASUREMENT_PERIOD_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59915,6 +61648,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_RMS_OVER_VOLTAGE_COUNTER_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59940,6 +61674,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, AVERAGE_RMS_UNDER_VOLTAGE_COUNTER_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59965,6 +61700,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_EXTREME_OVER_VOLTAGE_PERIOD_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -59990,6 +61726,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_EXTREME_UNDER_VOLTAGE_PERIOD_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -60015,6 +61752,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_SAG_PERIOD_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -60040,6 +61778,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RMS_VOLTAGE_SWELL_PERIOD_PHASE_C_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -60065,6 +61804,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -60090,6 +61830,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -60115,6 +61856,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -60140,6 +61882,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -60165,6 +61908,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -60190,6 +61934,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61592,6 +63337,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BOOLEAN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61626,6 +63372,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BITMAP8_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61660,6 +63407,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BITMAP16_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61694,6 +63442,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BITMAP32_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61728,6 +63477,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, BITMAP64_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61762,6 +63512,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT8U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61796,6 +63547,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT16U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61830,6 +63582,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT24U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61864,6 +63617,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT32U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61898,6 +63652,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT40U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61932,6 +63687,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT48U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -61966,6 +63722,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT56U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62000,6 +63757,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT64U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62034,6 +63792,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT8S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62068,6 +63827,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT16S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62102,6 +63862,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT24S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62136,6 +63897,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT32S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62170,6 +63932,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT40S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62204,6 +63967,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT48S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62238,6 +64002,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT56S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62272,6 +64037,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, INT64S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62306,6 +64072,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENUM8_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62340,6 +64107,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENUM16_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62374,6 +64142,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FLOAT_SINGLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62408,6 +64177,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Double value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FLOAT_DOUBLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62442,6 +64212,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, OCTET_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62476,6 +64247,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Integer> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LIST_INT8U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62510,6 +64282,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<byte[]> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LIST_OCTET_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62544,6 +64317,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.UnitTestingClusterTestListStructOctet> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LIST_STRUCT_OCTET_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62578,6 +64352,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LONG_OCTET_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62612,6 +64387,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CHAR_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62646,6 +64422,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LONG_CHAR_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62680,6 +64457,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EPOCH_US_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62714,6 +64492,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EPOCH_S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62748,6 +64527,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, VENDOR_ID_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62782,6 +64562,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.UnitTestingClusterNullablesAndOptionalsStruct> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LIST_NULLABLES_AND_OPTIONALS_STRUCT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62816,6 +64597,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ENUM_ATTR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62850,6 +64632,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             ChipStructs.UnitTestingClusterSimpleStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, STRUCT_ATTR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62884,6 +64667,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RANGE_RESTRICTED_INT8U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62918,6 +64702,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RANGE_RESTRICTED_INT8S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62952,6 +64737,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RANGE_RESTRICTED_INT16U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -62986,6 +64772,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, RANGE_RESTRICTED_INT16S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63020,6 +64807,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<byte[]> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LIST_LONG_OCTET_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63059,6 +64847,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<ChipStructs.UnitTestingClusterTestFabricScoped> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, LIST_FABRIC_SCOPED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63089,6 +64878,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, TIMED_WRITE_BOOLEAN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63123,6 +64913,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERAL_ERROR_BOOLEAN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63157,6 +64948,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_ERROR_BOOLEAN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63191,6 +64983,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, UNSUPPORTED_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63225,6 +65018,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_BOOLEAN_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63259,6 +65053,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_BITMAP8_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63293,6 +65088,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_BITMAP16_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63327,6 +65123,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_BITMAP32_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63361,6 +65158,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_BITMAP64_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63395,6 +65193,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT8U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63429,6 +65228,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT16U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63463,6 +65263,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT24U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63497,6 +65298,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT32U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63531,6 +65333,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT40U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63565,6 +65368,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT48U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63599,6 +65403,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT56U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63633,6 +65438,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT64U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63667,6 +65473,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT8S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63701,6 +65508,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT16S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63735,6 +65543,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT24S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63769,6 +65578,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT32S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63803,6 +65613,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT40S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63837,6 +65648,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT48S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63871,6 +65683,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT56S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63905,6 +65718,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_INT64S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63939,6 +65753,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_ENUM8_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -63973,6 +65788,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_ENUM16_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64007,6 +65823,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Float value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_FLOAT_SINGLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64041,6 +65858,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Double value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_FLOAT_DOUBLE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64075,6 +65893,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable byte[] value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_OCTET_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64109,6 +65928,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable String value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_CHAR_STRING_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64143,6 +65963,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_ENUM_ATTR_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64177,6 +65998,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable ChipStructs.UnitTestingClusterSimpleStruct value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_STRUCT_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64211,6 +66033,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_RANGE_RESTRICTED_INT8U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64245,6 +66068,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_RANGE_RESTRICTED_INT8S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64279,6 +66103,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_RANGE_RESTRICTED_INT16U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64313,6 +66138,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             @Nullable Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, NULLABLE_RANGE_RESTRICTED_INT16S_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64347,6 +66173,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, WRITE_ONLY_INT8U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64381,6 +66208,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, MEI_INT8U_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64406,6 +66234,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64431,6 +66260,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64456,6 +66286,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64481,6 +66312,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64506,6 +66338,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64531,6 +66364,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64657,6 +66491,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64682,6 +66517,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64707,6 +66543,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64732,6 +66569,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64757,6 +66595,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64782,6 +66621,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64908,6 +66748,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Boolean value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FLIP_FLOP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64933,6 +66774,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, GENERATED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64958,6 +66800,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -64983,6 +66826,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, EVENT_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -65008,6 +66852,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             List<Long> value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, ATTRIBUTE_LIST_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -65033,6 +66878,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, FEATURE_MAP_ATTRIBUTE_ID, minInterval, maxInterval);
     }
@@ -65058,6 +66904,7 @@ public class ChipClusters {
           @Override
           public void onSuccess(byte[] tlv) {
             Integer value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
           }
         }, CLUSTER_REVISION_ATTRIBUTE_ID, minInterval, maxInterval);
     }


### PR DESCRIPTION
Fix #33176 

-- For generated cluster subscribe API, we have not yet passed the value to the upper layer via onSuccess, we modify ChipCluster script where we call callback.onSuccess in onSuccess to fix this issue.
-- Add onResubscriptionAttempt callback as well.