### PR TITLE
[nrfconnect] Introduced several improvements for the factory data management

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -147,9 +147,9 @@ config CHIP_FACTORY_DATA_ROTATING_DEVICE_UID_MAX_LEN
 
 config CHIP_FACTORY_DATA_WRITE_PROTECT
 	bool "Enable Factory Data write protection"
-	select FPROTECT
+	imply FPROTECT
 	depends on CHIP_FACTORY_DATA
-	default y if CHIP_FACTORY_DATA
+	default y if SOC_SERIES_NRF53X || SOC_SERIES_NRF52X
 	help
 		Enables the write protection of the Factory Data partition in the flash memory.
 		This is a recommended feature, but it requires the Settings partition size to be

--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -106,7 +106,6 @@ config CHIP_MALLOC_SYS_HEAP
 config CHIP_FACTORY_DATA
 	bool "Factory data provider"
 	select ZCBOR
-	imply FPROTECT
 	help
 	  Enables the default nRF Connect factory data provider implementation that
 	  supports reading the factory data encoded in the CBOR format from the
@@ -147,9 +146,9 @@ config CHIP_FACTORY_DATA_ROTATING_DEVICE_UID_MAX_LEN
 
 config CHIP_FACTORY_DATA_WRITE_PROTECT
 	bool "Enable Factory Data write protection"
-	imply FPROTECT
+	select FPROTECT
 	depends on CHIP_FACTORY_DATA
-	default y if SOC_SERIES_NRF53X || SOC_SERIES_NRF52X
+	default y
 	help
 		Enables the write protection of the Factory Data partition in the flash memory.
 		This is a recommended feature, but it requires the Settings partition size to be

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -432,7 +432,9 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetUserKey(const char * userKe
 
 // Fully instantiate the template class in whatever compilation unit includes this file.
 template class FactoryDataProvider<InternalFlashFactoryData>;
+#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
 template class FactoryDataProvider<ExternalFlashFactoryData>;
+#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -432,9 +432,10 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetUserKey(const char * userKe
 
 // Fully instantiate the template class in whatever compilation unit includes this file.
 template class FactoryDataProvider<InternalFlashFactoryData>;
-#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
+#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1 && (defined(CONFIG_CHIP_QSPI_NOR) || defined(CONFIG_CHIP_SPI_NOR))
 template class FactoryDataProvider<ExternalFlashFactoryData>;
-#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
+#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1 (defined(CONFIG_CHIP_QSPI_NOR) ||
+       // defined(CONFIG_CHIP_SPI_NOR))
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -66,8 +66,8 @@ struct InternalFlashFactoryData
     // the application code at runtime anyway.
     constexpr size_t FactoryDataBlockBegin()
     {
-        // calculate the nearest multiple of CONFIG_FPROTECT_BLOCK_SIZE smaller than PM_FACTORY_DATA_ADDRESS
-        return PM_FACTORY_DATA_ADDRESS & (-CONFIG_FPROTECT_BLOCK_SIZE);
+        // calculate the nearest multiple of CONFIG_FPROTECT_BLOCK_SIZE smaller than FACTORY_DATA_ADDRESS
+        return FACTORY_DATA_ADDRESS & (-CONFIG_FPROTECT_BLOCK_SIZE);
     }
 
     constexpr size_t FactoryDataBlockSize()
@@ -75,7 +75,7 @@ struct InternalFlashFactoryData
         // calculate the factory data end address rounded up to the nearest multiple of CONFIG_FPROTECT_BLOCK_SIZE
         // and make sure we do not overlap with settings partition
         constexpr size_t kFactoryDataBlockEnd =
-            (PM_FACTORY_DATA_ADDRESS + PM_FACTORY_DATA_SIZE + CONFIG_FPROTECT_BLOCK_SIZE - 1) & (-CONFIG_FPROTECT_BLOCK_SIZE);
+            (FACTORY_DATA_ADDRESS + FACTORY_DATA_SIZE + CONFIG_FPROTECT_BLOCK_SIZE - 1) & (-CONFIG_FPROTECT_BLOCK_SIZE);
         static_assert(kFactoryDataBlockEnd <= PM_SETTINGS_STORAGE_ADDRESS,
                       "FPROTECT memory block, which contains factory data"
                       "partition overlaps with the settings partition."
@@ -88,7 +88,7 @@ struct InternalFlashFactoryData
     CHIP_ERROR ProtectFactoryDataPartitionAgainstWrite()
     {
 #ifdef CONFIG_FPROTECT
-        int ret = fprotect_area(FACTORY_DATA_ADDRESS, FACTORY_DATA_SIZE);
+        int ret = fprotect_area(FactoryDataBlockBegin(), FactoryDataBlockSize());
         return System::MapErrorZephyr(ret);
 #else
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -99,7 +99,7 @@ struct InternalFlashFactoryData
 #endif
 };
 
-#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
+#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1 && (defined(CONFIG_CHIP_QSPI_NOR) || defined(CONFIG_CHIP_SPI_NOR))
 struct ExternalFlashFactoryData
 {
     CHIP_ERROR GetFactoryDataPartition(uint8_t *& data, size_t & dataSize)
@@ -122,7 +122,8 @@ struct ExternalFlashFactoryData
     const struct device * mFlashDevice = DEVICE_DT_GET(DT_CHOSEN(nordic_pm_ext_flash));
     uint8_t mFactoryDataBuffer[FACTORY_DATA_SIZE];
 };
-#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
+#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1 && (defined(CONFIG_CHIP_QSPI_NOR) ||
+       // defined(CONFIG_CHIP_SPI_NOR))
 
 class FactoryDataProviderBase : public chip::Credentials::DeviceAttestationCredentialsProvider,
                                 public CommissionableDataProvider,


### PR DESCRIPTION
Added following improvements for the nRFConnect factory data implementation:
* enabled assigning of the FactoryDataProvider concrete types to the generic pointer
* allowed to generate and support factory data on the device that is not based on the Partition Manager

