### PR TITLE
Include what you use for some chef files

### DIFF
--- a/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
+++ b/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
@@ -20,9 +20,8 @@
 #ifdef MATTER_DM_PLUGIN_DOOR_LOCK_SERVER
 #include "chef-lock-manager.h"
 
-#include <iostream>
 #include <algorithm>
-
+#include <iostream>
 
 using chip::to_underlying;
 

--- a/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
+++ b/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
@@ -15,11 +15,14 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <iostream>
 #include <lib/support/logging/CHIPLogging.h>
 
 #ifdef MATTER_DM_PLUGIN_DOOR_LOCK_SERVER
 #include "chef-lock-manager.h"
+
+#include <iostream>
+#include <algorithm>
+
 
 using chip::to_underlying;
 

--- a/examples/chef/common/clusters/door-lock/chef-lock-manager.h
+++ b/examples/chef/common/clusters/door-lock/chef-lock-manager.h
@@ -20,7 +20,9 @@
 
 #include "chef-lock-endpoint.h"
 #include <app/clusters/door-lock-server/door-lock-server.h>
+
 #include <cstdint>
+#include <vector>
 
 class LockManager
 {

--- a/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.h
+++ b/examples/chef/common/clusters/target-navigator/TargetNavigatorManager.h
@@ -19,6 +19,7 @@
 
 #include <app/clusters/target-navigator-server/target-navigator-server.h>
 
+#include <list>
 #include <string>
 
 class TargetNavigatorManager : public chip::app::Clusters::TargetNavigator::Delegate

--- a/examples/chef/esp32/main/QRCodeScreen.cpp
+++ b/examples/chef/esp32/main/QRCodeScreen.cpp
@@ -43,6 +43,7 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
 #include <string>
+#include <vector>
 
 // TODO need sensible library tag when put in library
 extern const char TAG[];


### PR DESCRIPTION
Got chef compilation failures like:

```
...
examples/chef/common/clusters/target-navigator/TargetNavigatorManager.h:31:37: error: expected ‘)’ before ‘<’ token
31 |     TargetNavigatorManager(std::list<std::string> targets, uint8_t currentTarget);
```

and it turns out chef was using a lot of STL without validating that those includes actually were made. Applied a few that I found during a simple grep. Hopefully this at least makes things compile.
