### PR TITLE
Adding to .clang-format command to insert newline EOF

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -106,6 +106,7 @@ SpacesInSquareBrackets: false
 Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
+InsertNewlineAtEOF: true
 ---
 Language: ObjC
 BasedOnStyle: WebKit


### PR DESCRIPTION
- The option `InsertNewlineAtEOF` was recently added to clang 16.0; released in March 2023. 

- Apparently it is not backwards compatible with older clang versions

- restyled-io uses clang 18.0, so it should be ok for CI/CV
