### PR TITLE
Add GenerateRefreshKey

### DIFF
--- a/src/app/icd/client/DefaultCheckInDelegate.cpp
+++ b/src/app/icd/client/DefaultCheckInDelegate.cpp
@@ -40,7 +40,7 @@ void DefaultCheckInDelegate::OnCheckInComplete(const ICDClientInfo & clientInfo)
         clientInfo.start_icd_counter, clientInfo.offset, ChipLogValueScopedNodeId(clientInfo.peer_node));
 }
 
-CHIP_ERROR DefaultCheckInDelegate::OnCreateRefreshKey(RefreshKeySender::RefreshKeyBuffer & newKey)
+CHIP_ERROR DefaultCheckInDelegate::GenerateRefreshKey(RefreshKeySender::RefreshKeyBuffer & newKey)
 {
     return Crypto::DRBG_get_bytes(newKey.Bytes(), newKey.Capacity());
 }
@@ -49,7 +49,7 @@ RefreshKeySender * DefaultCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & cl
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     RefreshKeySender::RefreshKeyBuffer newKey;
-    err = CreateSymmetricKey(newKey);
+    err = GenerateRefreshKey(newKey);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(ICD, "Generation of new key failed: %" CHIP_ERROR_FORMAT, err.Format());

--- a/src/app/icd/client/DefaultCheckInDelegate.cpp
+++ b/src/app/icd/client/DefaultCheckInDelegate.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <app/icd/client/DefaultCheckInDelegate.h>
-#include <app/icd/client/RefreshKeySender.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/icd/client/DefaultCheckInDelegate.cpp
+++ b/src/app/icd/client/DefaultCheckInDelegate.cpp
@@ -40,12 +40,16 @@ void DefaultCheckInDelegate::OnCheckInComplete(const ICDClientInfo & clientInfo)
         clientInfo.start_icd_counter, clientInfo.offset, ChipLogValueScopedNodeId(clientInfo.peer_node));
 }
 
+CHIP_ERROR DefaultCheckInDelegate::OnCreateRefreshKey(RefreshKeySender::RefreshKeyBuffer & newKey)
+{
+    return Crypto::DRBG_get_bytes(newKey.Bytes(), newKey.Capacity());
+}
+
 RefreshKeySender * DefaultCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & clientInfo, ICDClientStorage * clientStorage)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     RefreshKeySender::RefreshKeyBuffer newKey;
-
-    err = Crypto::DRBG_get_bytes(newKey.Bytes(), newKey.Capacity());
+    err = CreateSymmetricKey(newKey);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(ICD, "Generation of new key failed: %" CHIP_ERROR_FORMAT, err.Format());

--- a/src/app/icd/client/DefaultCheckInDelegate.h
+++ b/src/app/icd/client/DefaultCheckInDelegate.h
@@ -33,6 +33,17 @@ public:
     virtual ~DefaultCheckInDelegate() {}
     CHIP_ERROR Init(ICDClientStorage * storage, InteractionModelEngine * engine);
     void OnCheckInComplete(const ICDClientInfo & clientInfo) override;
+
+    /**
+     * @brief Callback used to let the application to generate the new ICD symmetric key
+     *
+     * If not implemented by application, it would use Crypto::DRBG_get_bytes at default.
+     *
+     * @param[inout] newKey sensitive data buffer with type Crypto::SensitiveDataBuffer<Crypto::kAES_CCM128_Key_Length> 
+     * @param[out] CHIP_ERROR CHIP_ERROR_INVALID_ARGUMENT
+     *                        CHIP_ERROR_INTERNAL
+     */
+    virtual CHIP_ERROR OnCreateRefreshKey(RefreshKeySender::RefreshKeyBuffer & newKey);
     RefreshKeySender * OnKeyRefreshNeeded(ICDClientInfo & clientInfo, ICDClientStorage * clientStorage) override;
     void OnKeyRefreshDone(RefreshKeySender * refreshKeySender, CHIP_ERROR error) override;
 

--- a/src/app/icd/client/DefaultCheckInDelegate.h
+++ b/src/app/icd/client/DefaultCheckInDelegate.h
@@ -43,7 +43,7 @@ public:
      * @param[out] CHIP_ERROR CHIP_ERROR_INVALID_ARGUMENT
      *                        CHIP_ERROR_INTERNAL
      */
-    virtual CHIP_ERROR OnCreateRefreshKey(RefreshKeySender::RefreshKeyBuffer & newKey);
+    virtual CHIP_ERROR GenerateRefreshKey(RefreshKeySender::RefreshKeyBuffer & newKey);
     RefreshKeySender * OnKeyRefreshNeeded(ICDClientInfo & clientInfo, ICDClientStorage * clientStorage) override;
     void OnKeyRefreshDone(RefreshKeySender * refreshKeySender, CHIP_ERROR error) override;
 

--- a/src/app/icd/client/DefaultCheckInDelegate.h
+++ b/src/app/icd/client/DefaultCheckInDelegate.h
@@ -39,7 +39,7 @@ public:
      *
      * If this calback is not overridden, Crypto::DRBG_get_bytes will be used to generated the key.
      *
-     * @param[inout] newKey sensitive data buffer with type Crypto::SensitiveDataBuffer<Crypto::kAES_CCM128_Key_Length> 
+     * @param[inout] newKey sensitive data buffer with type Crypto::SensitiveDataBuffer<Crypto::kAES_CCM128_Key_Length>
      * @param[out] CHIP_ERROR CHIP_ERROR_INVALID_ARGUMENT
      *                        CHIP_ERROR_INTERNAL
      */

--- a/src/app/icd/client/DefaultCheckInDelegate.h
+++ b/src/app/icd/client/DefaultCheckInDelegate.h
@@ -35,7 +35,7 @@ public:
     void OnCheckInComplete(const ICDClientInfo & clientInfo) override;
 
     /**
-     * @brief Callback used to let the application to generate the new ICD symmetric key
+     * @brief Callback used to let the application generate the new ICD symmetric key
      *
      * If not implemented by application, it would use Crypto::DRBG_get_bytes at default.
      *

--- a/src/app/icd/client/DefaultCheckInDelegate.h
+++ b/src/app/icd/client/DefaultCheckInDelegate.h
@@ -20,6 +20,7 @@
 
 #include <app/icd/client/CheckInDelegate.h>
 #include <app/icd/client/ICDClientStorage.h>
+#include <app/icd/client/RefreshKeySender.h>
 
 namespace chip {
 namespace app {

--- a/src/app/icd/client/DefaultCheckInDelegate.h
+++ b/src/app/icd/client/DefaultCheckInDelegate.h
@@ -37,7 +37,7 @@ public:
     /**
      * @brief Callback used to let the application generate the new ICD symmetric key
      *
-     * If not implemented by application, it would use Crypto::DRBG_get_bytes at default.
+     * If this calback is not overridden, Crypto::DRBG_get_bytes will be used to generated the key.
      *
      * @param[inout] newKey sensitive data buffer with type Crypto::SensitiveDataBuffer<Crypto::kAES_CCM128_Key_Length> 
      * @param[out] CHIP_ERROR CHIP_ERROR_INVALID_ARGUMENT


### PR DESCRIPTION
In order to provide a way to generate the unique key for application when using DefaultCheckInDelegate, for example, c++ chip-tool, we can create virtual GenerateRefreshKey method.
