### PR TITLE
chef: Use -u flag to force linking non-weak functions for esp32 example

### DIFF
--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -235,3 +235,7 @@ void emberAfWakeOnLanClusterInitCallback(EndpointId endpoint)
     WakeOnLan::SetDefaultDelegate(endpoint, &wakeOnLanManager);
 }
 #endif
+
+// No-op function, used to force linking this file,
+// instead of the weak functions from other files
+extern "C" void chef_include_stubs_impl(void) {}

--- a/examples/chef/esp32/main/CMakeLists.txt
+++ b/examples/chef/esp32/main/CMakeLists.txt
@@ -121,6 +121,9 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       PRIV_REQUIRES chip nvs_flash bt console mbedtls QRCode tft screen-framework spidriver
                       SRC_DIRS ${SRC_DIRS_LIST})
 
+# Forces the linker to include common/stubs.cpp
+target_link_libraries(${COMPONENT_LIB} INTERFACE "-u chef_include_stubs_impl")
+
 include("${CHIP_ROOT}/build/chip/esp32/esp32_codegen.cmake")
 chip_app_component_codegen("${CHEF}/devices/${SAMPLE_NAME}.matter")
 chip_app_component_zapgen("${CHEF}/devices/${SAMPLE_NAME}.zap")


### PR DESCRIPTION
Add a function and use -u flag to force linking the chef stubs.cpp file to ensure the non-weak functions be linked.

Fixes #33165