### PR TITLE
[v1.2] [ESP32] Platform Event when ble is deinitialized (#33186)

### DIFF
--- a/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
+++ b/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
@@ -41,6 +41,10 @@ void CommonDeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, i
 {
     switch (event->Type)
     {
+    case DeviceEventType::kBLEDeinitialized:
+        ESP_LOGI(TAG, "BLE is deinitialized");
+        break;
+
     case DeviceEventType::kInternetConnectivityChange:
         OnInternetConnectivityChange(event);
         break;

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -239,6 +239,11 @@ enum PublicEventTypes
      * sending messages to other nodes.
      */
     kServerReady,
+
+    /**
+     * Signals that BLE is deinitialized.
+     */
+    kBLEDeinitialized,
 };
 
 /**

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -979,17 +979,20 @@ void BLEManagerImpl::ClaimBLEMemory(System::Layer *, void *)
 
         VerifyOrReturn(err == ESP_OK, ChipLogError(DeviceLayer, "BLE deinit failed"));
         ChipLogProgress(DeviceLayer, "BLE deinit successful and memory reclaimed");
-        // TODO: post an event when ble is deinitialized and memory is added to heap
+
+        ChipDeviceEvent event;
+        event.Type = DeviceEventType::kBLEDeinitialized;
+        VerifyOrDo(CHIP_NO_ERROR == PlatformMgr().PostEvent(&event), ChipLogError(DeviceLayer, "Failed to post BLE deinit event"));
     }
 }
 
 CHIP_ERROR BLEManagerImpl::DeinitBLE()
 {
+    esp_err_t err = ESP_OK;
     VerifyOrReturnError(ble_hs_is_enabled(), CHIP_ERROR_INCORRECT_STATE, ChipLogProgress(DeviceLayer, "BLE already deinited"));
     VerifyOrReturnError(0 == nimble_port_stop(), MapBLEError(ESP_FAIL), ChipLogError(DeviceLayer, "nimble_port_stop() failed"));
 
-    esp_err_t err = nimble_port_deinit();
-    VerifyOrReturnError(err == ESP_OK, MapBLEError(err));
+    nimble_port_deinit();
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
     err = esp_nimble_hci_and_controller_deinit();


### PR DESCRIPTION
Cherry-picking 040e5bfd0f6096750633d5cdce204f96a58cdaec (MR #33186) on v1.2-branch