### PR TITLE
examples: Remove requires in main components for esp32 examples

### DIFF
--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -96,8 +96,8 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/time-synchronization-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/valve-configuration-and-control-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/dishwasher-alarm-server"
-            		      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/laundry-washer-controls-server"
-		                  "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/laundry-washer-controls-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/laundry-washer-controls-server"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/laundry-washer-controls-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/laundry-dryer-controls-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/src"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/energy-preference-server"
@@ -136,20 +136,9 @@ if (CONFIG_ENABLE_ICD_SERVER)
     list(APPEND SRC_DIRS_LIST "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/icd")
 endif()
 
-set(PRIV_REQUIRES_LIST chip QRCode bt app_update nvs_flash spi_flash openthread)
-
-if(${IDF_TARGET} STREQUAL "esp32")
-    list(APPEND PRIV_REQUIRES_LIST spidriver screen-framework)
-endif()
-
-if(CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM)
-    list(APPEND PRIV_REQUIRES_LIST led_strip)
-endif()
-
 idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}
                        SRC_DIRS ${SRC_DIRS_LIST}
-                       EXCLUDE_SRCS ${EXCLUDE_SRCS}
-                       PRIV_REQUIRES ${PRIV_REQUIRES_LIST})
+                       EXCLUDE_SRCS ${EXCLUDE_SRCS})
 
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 

--- a/examples/all-clusters-minimal-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-minimal-app/esp32/main/CMakeLists.txt
@@ -82,7 +82,7 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/door-lock-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/occupancy-sensor-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/device-energy-management-server"
-                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/energy-evse-server"                      
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/energy-evse-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/ethernet-network-diagnostics-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/localization-configuration-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/time-format-localization-server"
@@ -118,19 +118,8 @@ set(SRC_DIRS_LIST  "${SRC_DIRS_LIST}"
 )
 endif (CONFIG_ENABLE_PW_RPC)
 
-set(PRIV_REQUIRES_LIST chip QRCode bt driver app_update nvs_flash spi_flash openthread)
-
-if(${IDF_TARGET} STREQUAL "esp32")
-    list(APPEND PRIV_REQUIRES_LIST spidriver screen-framework)
-endif()
-
-if(CONFIG_DEVICE_TYPE_ESP32_C3_DEVKITM)
-    list(APPEND PRIV_REQUIRES_LIST led_strip)
-endif()
-
 idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}
-                       SRC_DIRS ${SRC_DIRS_LIST}
-                       PRIV_REQUIRES ${PRIV_REQUIRES_LIST})
+                       SRC_DIRS ${SRC_DIRS_LIST})
 
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 

--- a/examples/bridge-app/esp32/main/CMakeLists.txt
+++ b/examples/bridge-app/esp32/main/CMakeLists.txt
@@ -48,8 +48,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/operational-credentials-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/general-commissioning-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/common"
-                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/providers"
-                      PRIV_REQUIRES chip QRCode bt nvs_flash)
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/providers")
 
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 

--- a/examples/chef/esp32/main/CMakeLists.txt
+++ b/examples/chef/esp32/main/CMakeLists.txt
@@ -118,7 +118,6 @@ endif (CONFIG_ENABLE_PW_RPC)
 idf_component_register(PRIV_INCLUDE_DIRS
                       "${CHIP_SHELL_DIR}/shell_common/include"
                       "${PRIV_INCLUDE_DIRS_LIST}"
-                      PRIV_REQUIRES chip nvs_flash bt console mbedtls QRCode tft screen-framework spidriver
                       SRC_DIRS ${SRC_DIRS_LIST})
 
 include("${CHIP_ROOT}/build/chip/esp32/esp32_codegen.cmake")

--- a/examples/energy-management-app/esp32/main/CMakeLists.txt
+++ b/examples/energy-management-app/esp32/main/CMakeLists.txt
@@ -72,12 +72,6 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/electrical-power-measurement-server"
 )
 
-set(PRIV_REQUIRES_LIST chip QRCode bt led_strip app_update openthread driver nvs_flash spi_flash)
-
-if(${IDF_TARGET} STREQUAL "esp32")
-    list(APPEND PRIV_REQUIRES_LIST spidriver screen-framework)
-endif()
-
 
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build
@@ -103,8 +97,7 @@ set(SRC_DIRS_LIST  "${SRC_DIRS_LIST}"
 endif (CONFIG_ENABLE_PW_RPC)
 
 idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}
-                       SRC_DIRS ${SRC_DIRS_LIST}
-                       PRIV_REQUIRES ${PRIV_REQUIRES_LIST})
+                       SRC_DIRS ${SRC_DIRS_LIST})
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 
 include("${CHIP_ROOT}/build/chip/esp32/esp32_codegen.cmake")

--- a/examples/light-switch-app/esp32/main/CMakeLists.txt
+++ b/examples/light-switch-app/esp32/main/CMakeLists.txt
@@ -59,8 +59,8 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/groups-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/group-key-mgmt-server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/time-synchronization-server"
-                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/icd-management-server"
-                      PRIV_REQUIRES chip QRCode bt app_update driver nvs_flash spi_flash)
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/icd-management-server")
+
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 
 include("${CHIP_ROOT}/build/chip/esp32/esp32_codegen.cmake")

--- a/examples/lighting-app/esp32/main/CMakeLists.txt
+++ b/examples/lighting-app/esp32/main/CMakeLists.txt
@@ -67,13 +67,6 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/scenes-server"
 )
 
-set(PRIV_REQUIRES_LIST chip QRCode bt led_strip app_update openthread driver nvs_flash spi_flash)
-
-if(${IDF_TARGET} STREQUAL "esp32")
-    list(APPEND PRIV_REQUIRES_LIST spidriver screen-framework)
-endif()
-
-
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build
 set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
@@ -98,8 +91,7 @@ set(SRC_DIRS_LIST  "${SRC_DIRS_LIST}"
 endif (CONFIG_ENABLE_PW_RPC)
 
 idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}
-                       SRC_DIRS ${SRC_DIRS_LIST}
-                       PRIV_REQUIRES ${PRIV_REQUIRES_LIST})
+                       SRC_DIRS ${SRC_DIRS_LIST})
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 
 include("${CHIP_ROOT}/build/chip/esp32/esp32_codegen.cmake")

--- a/examples/lock-app/esp32/main/CMakeLists.txt
+++ b/examples/lock-app/esp32/main/CMakeLists.txt
@@ -74,8 +74,8 @@ idf_component_register(INCLUDE_DIRS
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/door-lock-server"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/identify-server"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/groups-server"
-                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/icd-management-server"
-                     PRIV_REQUIRES bt chip QRCode nvs_flash driver)
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/icd-management-server")
+
 add_dependencies(${COMPONENT_LIB} app-codegen)
 
 set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")

--- a/examples/ota-provider-app/esp32/main/CMakeLists.txt
+++ b/examples/ota-provider-app/esp32/main/CMakeLists.txt
@@ -53,8 +53,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/common"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/providers"
                       EXCLUDE_SRCS
-                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp"
-                      PRIV_REQUIRES chip QRCode bt console spiffs spi_flash nvs_flash)
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp")
 
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 include("${CHIP_ROOT}/build/chip/esp32/esp32_codegen.cmake")

--- a/examples/ota-requestor-app/esp32/main/CMakeLists.txt
+++ b/examples/ota-requestor-app/esp32/main/CMakeLists.txt
@@ -62,8 +62,6 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/providers"
 )
 
-set(PRIV_REQUIRES_LIST chip QRCode bt console app_update nvs_flash)
-
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build
 set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
@@ -88,8 +86,7 @@ set(SRC_DIRS_LIST  "${SRC_DIRS_LIST}"
 endif (CONFIG_ENABLE_PW_RPC)
 
 idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}
-                       SRC_DIRS ${SRC_DIRS_LIST}
-                       PRIV_REQUIRES ${PRIV_REQUIRES_LIST})
+                       SRC_DIRS ${SRC_DIRS_LIST})
 
 include("${CHIP_ROOT}/build/chip/esp32/esp32_codegen.cmake")
 chip_app_component_codegen("${CHIP_ROOT}/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter")

--- a/examples/persistent-storage/esp32/main/CMakeLists.txt
+++ b/examples/persistent-storage/esp32/main/CMakeLists.txt
@@ -20,8 +20,7 @@ idf_component_register(PRIV_INCLUDE_DIRS
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/persistent-storage"
                       SRC_DIRS
                       "${CMAKE_CURRENT_LIST_DIR}"
-                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/persistent-storage"
-                      PRIV_REQUIRES chip nvs_flash)
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/persistent-storage")
 
 set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 17)
 target_compile_options(${COMPONENT_LIB} PRIVATE "-DCHIP_HAVE_CONFIG_H")

--- a/examples/pigweed-app/esp32/main/CMakeLists.txt
+++ b/examples/pigweed-app/esp32/main/CMakeLists.txt
@@ -33,8 +33,7 @@ idf_component_register(INCLUDE_DIRS
                      "${CMAKE_CURRENT_LIST_DIR}"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32"
                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed"
-                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32"
-                      PRIV_REQUIRES bt chip)
+                     "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/common/pigweed/esp32")
 
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")

--- a/examples/shell/esp32/main/CMakeLists.txt
+++ b/examples/shell/esp32/main/CMakeLists.txt
@@ -22,5 +22,4 @@ set(CHIP_SHELL_DIR "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/she
 idf_component_register(SRCS main.cpp
                       "${CHIP_SHELL_DIR}/shell_common/globals.cpp"
                       PRIV_INCLUDE_DIRS
-                      "${CHIP_SHELL_DIR}/shell_common/include"
-                      PRIV_REQUIRES chip nvs_flash bt)
+                      "${CHIP_SHELL_DIR}/shell_common/include")

--- a/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/main/CMakeLists.txt
@@ -55,8 +55,6 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/providers"
 )
 
-set(PRIV_REQUIRES_LIST chip QRCode bt nvs_flash espcoredump)
-
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build
 set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
@@ -82,7 +80,6 @@ endif (CONFIG_ENABLE_PW_RPC)
 
 idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}
                        SRC_DIRS ${SRC_DIRS_LIST}
-                       PRIV_REQUIRES ${PRIV_REQUIRES_LIST}
                        EMBED_FILES diagnostic_logs/end_user_support.log diagnostic_logs/network_diag.log)
 
 include("${CHIP_ROOT}/build/chip/esp32/esp32_codegen.cmake")


### PR DESCRIPTION
We don't need to add any requires in main component for esp32 examples. See [main-component-requirements](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/build-system.html?highlight=component%20requires#main-component-requirements)

Remove requires for all the esp32 examples.

