### PR TITLE
[ESP32] Add custom MRP configs for the esp32 platform

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -1229,4 +1229,62 @@ menu "CHIP Device Layer"
 
     endmenu
 
+    menu "Message Reliable Protocol Options"
+        config MRP_LOCAL_ACTIVE_RETRY_INTERVAL_FOR_THREAD
+            int "MRP local active retry interval for Thread network in milliseconds"
+            depends on OPENTHREAD_ENABLED
+            range 0 3600000
+            default 800
+            help
+                Base retry interval of the present Thread node when it is in the active state.
+
+        config MRP_LOCAL_ACTIVE_RETRY_INTERVAL_FOR_WIFI_ETHERNET
+            int "MRP local active retry interval for WIFI or ETHERNET network in milliseconds"
+            depends on !OPENTHREAD_ENABLED
+            range 0 3600000
+            default 300
+            help
+                Base retry interval of the present node (WIFI or ETHERNET) when it is in the active state.
+
+        config MRP_LOCAL_IDLE_RETRY_INTERVAL_FOR_THREAD
+            int "MRP local idle retry interval for Thread network in milliseconds"
+            depends on OPENTHREAD_ENABLED
+            range 0 3600000
+            default 800
+            help
+                Base retry interval of the present Thread node when it is in the idle state.
+
+        config MRP_LOCAL_IDLE_RETRY_INTERVAL_FOR_WIFI_ETHERNET
+            int "MRP local idle retry interval for WIFI or ETHERNET network in milliseconds"
+            depends on !OPENTHREAD_ENABLED
+            range 0 3600000
+            default 500
+            help
+                Base retry interval of the present node (WIFI or ETHERNET) when it is in the idle state.
+
+        config MRP_RETRY_INTERVAL_SENDER_BOOST_FOR_THREAD
+            int "MRP retransmission delta timeout for Thread network in milliseconds"
+            depends on OPENTHREAD_ENABLED
+            range 0 3600000
+            default 500
+            help
+                A constant value added to the calculated retransmission timeout.
+
+        config MRP_RETRY_INTERVAL_SENDER_BOOST_FOR_WIFI_ETHERNET
+            int "MRP retransmission delta timeout for WIFI or ETHERNET network in milliseconds"
+            depends on !OPENTHREAD_ENABLED
+            range 0 3600000
+            default 0
+            help
+                A constant value added to the calculated retransmission timeout.
+
+        config MRP_MAX_RETRANS
+            int "MRP retransmission maximum count"
+            range 1 10
+            default 4
+            help
+                The maximum number of retransmissions before giving up.
+
+    endmenu
+
 endmenu

--- a/src/platform/ESP32/CHIPPlatformConfig.h
+++ b/src/platform/ESP32/CHIPPlatformConfig.h
@@ -107,3 +107,37 @@
 // Enable CONFIG_BUILD_FOR_HOST_UNIT_TEST when building CHIP test binaries
 #define CONFIG_BUILD_FOR_HOST_UNIT_TEST 1
 #endif
+
+#ifndef CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
+#if CHIP_ENABLE_OPENTHREAD
+#define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL                                                                                \
+    chip::System::Clock::Milliseconds32(CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL_FOR_THREAD)
+#else
+#define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL                                                                                \
+    chip::System::Clock::Milliseconds32(CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL_FOR_WIFI_ETHERNET)
+#endif // CHIP_ENABLE_OPENTHREAD
+#endif // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
+
+#ifndef CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
+#if CHIP_ENABLE_OPENTHREAD
+#define CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL                                                                                  \
+    chip::System::Clock::Milliseconds32(CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL_FOR_THREAD)
+#else
+#define CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL                                                                                  \
+    chip::System::Clock::Milliseconds32(CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL_FOR_WIFI_ETHERNET)
+#endif // CHIP_ENABLE_OPENTHREAD
+#endif // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
+
+#ifndef CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST
+#if CHIP_ENABLE_OPENTHREAD
+#define CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST                                                                                \
+    chip::System::Clock::Milliseconds32(CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST_FOR_THREAD)
+#else
+#define CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST                                                                                \
+    chip::System::Clock::Milliseconds32(CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST_FOR_WIFI_ETHERNET)
+#endif // CHIP_ENABLE_OPENTHREAD
+#endif // CHIP_CONFIG_MRP_RETRY_INTERVAL_SENDER_BOOST
+
+#ifndef CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS
+#define CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS CONFIG_MRP_MAX_RETRANS
+#endif // CHIP_CONFIG_RMP_DEFAULT_MAX_RETRANS


### PR DESCRIPTION
The esp32 platform requires some custom MRP configs to work for Thread and WI-FI.
