### PR TITLE
Allow to build chip-cert with boringssl

### DIFF
--- a/build/chip/tools.gni
+++ b/build/chip/tools.gni
@@ -19,7 +19,7 @@ declare_args() {
   chip_build_tools = current_os != "freertos" && current_os != "android" &&
                      chip_device_platform != "fake"
   chip_can_build_cert_tool =
-      chip_crypto == "openssl" ||
+      chip_crypto == "openssl" || chip_crypto == "boringssl" ||
       (chip_crypto == "" &&
        (current_os != "android" && current_os != "freertos" &&
         current_os != "zephyr" && current_os != "mbed" &&


### PR DESCRIPTION
Currently when trying to build chip-cert with boringssl gn doesn't generate a ninja target. This is since `chip_can_build_cert_tool` gets set to false.

Allow to build with boringssl just like with openssl.

Credits to @andy31415 for the right pointers!