### PR TITLE
Add some better logging around PASE session setup in Matter.framework.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -616,6 +616,8 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
                                    newNodeID:(NSNumber *)newNodeID
                                        error:(NSError * __autoreleasing *)error
 {
+    MTR_LOG_DEFAULT("Setting up commissioning session for device ID 0x%016llX with setup payload %@", newNodeID.unsignedLongLongValue, payload);
+
     [[MTRMetricsCollector sharedInstance] resetMetrics];
 
     // Track overall commissioning
@@ -663,6 +665,8 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
                                             newNodeID:(NSNumber *)newNodeID
                                                 error:(NSError * __autoreleasing *)error
 {
+    MTR_LOG_DEFAULT("Setting up commissioning session for already-discovered device %@ and device ID 0x%016llX with setup payload %@", discoveredDevice, newNodeID.unsignedLongLongValue, payload);
+
     [[MTRMetricsCollector sharedInstance] resetMetrics];
 
     // Track overall commissioning
@@ -912,7 +916,10 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         return [[MTRBaseDevice alloc] initWithPASEDevice:deviceProxy controller:self];
     };
 
-    return [self syncRunOnWorkQueueWithReturnValue:block error:error];
+    MTRBaseDevice * device = [self syncRunOnWorkQueueWithReturnValue:block error:error];
+    MTR_LOG_DEFAULT("Getting device being commissioned with node ID 0x%016llX: %@ (error: %@)",
+        nodeID.unsignedLongLongValue, device, (error ? *error : nil));
+    return device;
 }
 
 - (MTRBaseDevice *)baseDeviceForNodeID:(NSNumber *)nodeID

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -28,6 +28,8 @@ typedef NS_OPTIONS(NSUInteger, MTRDiscoveryCapabilities) {
     MTRDiscoveryCapabilitiesBLE = 1 << 1, // Device supports BLE
     MTRDiscoveryCapabilitiesOnNetwork = 1 << 2, // Device supports On Network setup
 
+    // If new values are added here, update the "description" method to include them.
+
     MTRDiscoveryCapabilitiesAllMask
     = MTRDiscoveryCapabilitiesSoftAP | MTRDiscoveryCapabilitiesBLE | MTRDiscoveryCapabilitiesOnNetwork,
 };

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -245,6 +245,26 @@
     return payload;
 }
 
+- (NSString *)description
+{
+    NSMutableArray<NSString *> * capabilities = [NSMutableArray array];
+    if (self.discoveryCapabilities & MTRDiscoveryCapabilitiesSoftAP) {
+        [capabilities addObject:@"SoftAP"];
+    }
+    if (self.discoveryCapabilities & MTRDiscoveryCapabilitiesBLE) {
+        [capabilities addObject:@"BLE"];
+    }
+    if (self.discoveryCapabilities & MTRDiscoveryCapabilitiesOnNetwork) {
+        [capabilities addObject:@"OnNetwork"];
+    }
+    if (capabilities.count == 0) {
+        [capabilities addObject:@"Unknown"];
+    }
+
+    return [NSString stringWithFormat:@"<MTRSetupPayload: discriminator=0x%x hasShortDiscriminator=%@ discoveryCapabilities=%@>",
+                     self.discriminator.unsignedIntValue, self.hasShortDiscriminator ? @"YES" : @"NO", [capabilities componentsJoinedByString:@"|"]];
+}
+
 #pragma mark - NSSecureCoding
 
 static NSString * const MTRSetupPayloadCodingKeyVersion = @"MTRSP.ck.version";

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -95,6 +95,16 @@ static MTRBaseDevice * GetConnectedDevice(void)
 {
     XCTAssertEqual(error.code, 0);
 
+    NSError * getDeviceError = nil;
+    __auto_type * device = [controller deviceBeingCommissionedWithNodeID:@(kDeviceId) error:&getDeviceError];
+    XCTAssertNil(getDeviceError);
+    XCTAssertNotNil(device);
+
+    // Now check that getting with some other random id fails.
+    device = [controller deviceBeingCommissionedWithNodeID:@(kDeviceId + 1) error:&getDeviceError];
+    XCTAssertNil(device);
+    XCTAssertNotNil(getDeviceError);
+
     __auto_type * params = [[MTRCommissioningParameters alloc] init];
     params.countryCode = @("au");
 


### PR DESCRIPTION
Log the device ID being used.
