### PR TITLE
Disable TCP on the MCU based platforms by default.

### DIFF
--- a/config/ameba/args.gni
+++ b/config/ameba/args.gni
@@ -28,7 +28,7 @@ lwip_platform = "external"
 
 chip_build_tests = false
 
-chip_inet_config_enable_tcp_endpoint = true
+chip_inet_config_enable_tcp_endpoint = false
 chip_inet_config_enable_udp_endpoint = true
 
 chip_config_network_layer_ble = true

--- a/config/beken/args.gni
+++ b/config/beken/args.gni
@@ -26,7 +26,7 @@ lwip_platform = "external"
 
 chip_build_tests = false
 
-chip_inet_config_enable_tcp_endpoint = true
+chip_inet_config_enable_tcp_endpoint = false
 chip_inet_config_enable_udp_endpoint = true
 
 chip_config_network_layer_ble = true

--- a/config/esp32/args.gni
+++ b/config/esp32/args.gni
@@ -26,7 +26,7 @@ lwip_platform = "external"
 
 #Enabling this causes some error
 #chip_inet_config_enable_tun_endpoint = false
-chip_inet_config_enable_tcp_endpoint = true
+chip_inet_config_enable_tcp_endpoint = false
 chip_inet_config_enable_udp_endpoint = true
 
 custom_toolchain = "//third_party/connectedhomeip/config/esp32/toolchain:esp32"

--- a/config/genio/args.gni
+++ b/config/genio/args.gni
@@ -24,7 +24,7 @@ lwip_platform = "external"
 
 chip_build_tests = true
 
-chip_inet_config_enable_tcp_endpoint = true
+chip_inet_config_enable_tcp_endpoint = false
 chip_inet_config_enable_udp_endpoint = true
 
 custom_toolchain = "//third_party/connectedhomeip/config/genio/toolchain:genio"

--- a/config/mbed/chip-gn/args.gni
+++ b/config/mbed/chip-gn/args.gni
@@ -21,7 +21,7 @@ chip_system_project_config_include = ""
 chip_device_project_config_include = ""
 
 chip_inet_config_enable_udp_endpoint = true
-chip_inet_config_enable_tcp_endpoint = true
+chip_inet_config_enable_tcp_endpoint = false
 
 custom_toolchain = "${chip_root}/config/mbed/chip-gn/toolchain:mbed"
 mbedtls_target = "${chip_root}/config/mbed/chip-gn/mbedtls:mbedtls"

--- a/examples/lighting-app/beken/args.gni
+++ b/examples/lighting-app/beken/args.gni
@@ -29,7 +29,7 @@ lwip_platform = "external"
 
 chip_build_tests = false
 
-chip_inet_config_enable_tcp_endpoint = true
+chip_inet_config_enable_tcp_endpoint = false
 chip_inet_config_enable_udp_endpoint = true
 
 chip_config_network_layer_ble = true

--- a/src/platform/ASR/args.gni
+++ b/src/platform/ASR/args.gni
@@ -25,5 +25,5 @@ lwip_platform = "asr"
 chip_build_tests = false
 
 chip_inet_config_enable_ipv4 = true
-chip_inet_config_enable_tcp_endpoint = true
+chip_inet_config_enable_tcp_endpoint = false
 chip_inet_config_enable_udp_endpoint = true

--- a/src/platform/Ameba/args.gni
+++ b/src/platform/Ameba/args.gni
@@ -21,5 +21,5 @@ mbedtls_target = "//mbedtls:mbedtls"
 
 chip_build_tests = false
 chip_inet_config_enable_tun_endpoint = false
-chip_inet_config_enable_tcp_endpoint = true
+chip_inet_config_enable_tcp_endpoint = false
 chip_inet_config_enable_udp_endpoint = true

--- a/src/platform/Beken/args.gni
+++ b/src/platform/Beken/args.gni
@@ -21,5 +21,5 @@ mbedtls_target = "//mbedtls:mbedtls"
 
 chip_build_tests = false
 chip_inet_config_enable_tun_endpoint = false
-chip_inet_config_enable_tcp_endpoint = true
+chip_inet_config_enable_tcp_endpoint = false
 chip_inet_config_enable_udp_endpoint = true

--- a/src/platform/bouffalolab/BL602/args.gni
+++ b/src/platform/bouffalolab/BL602/args.gni
@@ -29,5 +29,5 @@ lwip_platform = "bl602"
 chip_build_tests = false
 chip_inet_config_enable_dns_resolver = false
 chip_inet_config_enable_tun_endpoint = false
-chip_inet_config_enable_tcp_endpoint = true
+chip_inet_config_enable_tcp_endpoint = false
 chip_inet_config_enable_udp_endpoint = true


### PR DESCRIPTION
Some of the MCU based platforms had TCP enabled on them without having to use it.
Disabling the flag before landing the TCP PR #30339 to avoid increase in code size.
We can assess the need to enable TCP on these platforms later.


