### PR TITLE
Stop talking about "pairing" in logs.

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -533,7 +533,7 @@ void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error)
 
     if (CHIP_NO_ERROR == error)
     {
-        ChipLogProgress(Controller, "Pairing with commissionee successful, stopping discovery");
+        ChipLogProgress(Controller, "PASE session established with commissionee. Stopping discovery.");
         ResetDiscoveryState();
         mRemoteId = kUndefinedNodeId;
         if (pairingDelegate != nullptr)

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -93,7 +93,11 @@ void MTRDeviceControllerDelegateBridge::OnStatusUpdate(chip::Controller::DeviceP
 
 void MTRDeviceControllerDelegateBridge::OnPairingComplete(CHIP_ERROR error)
 {
-    MTR_LOG_DEFAULT("DeviceControllerDelegate Pairing complete. Status %s", chip::ErrorStr(error));
+    if (error == CHIP_NO_ERROR) {
+        MTR_LOG_DEFAULT("MTRDeviceControllerDelegate PASE session establishment succeeded.");
+    } else {
+        MTR_LOG_ERROR("MTRDeviceControllerDelegate PASE session establishment failed: %" CHIP_ERROR_FORMAT, error.Format());
+    }
     MATTER_LOG_METRIC_END(kMetricSetupPASESession, error);
 
     id<MTRDeviceControllerDelegate> strongDelegate = mDelegate;


### PR DESCRIPTION
"Pairing" means "PASE establishment" sometimes, "commissioning" sometimes.  We should not use the term, and just be clearer about which process we mean so people reading logs don't get confused.
