### PR TITLE
Support building chip-tool with python3.12

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -49,7 +49,7 @@ colorama==0.4.6
     #   west
 coloredlogs==15.0.1
     # via -r requirements.all.txt
-construct==2.10.54
+construct==2.10.70
     # via
     #   -r requirements.esp32.txt
     #   esp-coredump
@@ -208,7 +208,7 @@ python-socketio==4.6.1
     # via -r requirements.esp32.txt
 pytz==2022.7.1
     # via pandas
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   esptool
     #   idf-component-manager
@@ -296,4 +296,3 @@ setuptools==68.0.0
 # Higher versions depend on proto-plus, which break
 # nanopb code generation (due to name conflict of the 'proto' module)
 google-api-core==2.17.0
-

--- a/scripts/setup/requirements.esp32.txt
+++ b/scripts/setup/requirements.esp32.txt
@@ -9,7 +9,7 @@ reedsolo>=1.5.3,<=1.5.4
 bitarray==2.6.0
 bitstring>=3.1.6,<4
 ecdsa>=0.16.0
-construct==2.10.54
+construct>=2.10.70
 python-socketio<5
 itsdangerous<2.1 ; python_version < "3.11"
 esp_idf_monitor==1.1.1


### PR DESCRIPTION
This updates 2 python packages to versions compatible with python3.12, fixing the following errors when running
`./scripts/examples/gn_build_example.sh examples/chip-tool BUILDFOLDER`:

1. `pyyaml` 6.0 build error: `AttributeError: cython_sources`, addressed [here](https://github.com/yaml/pyyaml/pull/702)
2. `construct` import error:

   ``` File "/tmp/pip-install-ifgk4tul/construct_6d60304f85e249759f6c184ea89f1317/construct/core.py", line 3, in <module> import struct, io, binascii, itertools, collections, pickle, sys, os, tempfile, hashlib, importlib, imp ModuleNotFoundError: No module named 'imp' ```

   this was fixed [here](https://github.com/construct/construct/commit/91cc0c65f5f8ceace2ee59da5068da92519a99c9), in version `v2.10.57` of `construct`. I'm just updating to latest though.

Now running `./scripts/examples/gn_build_example.sh examples/chip-tool BUILDFOLDER` succeeds when the host python is python3.12.

> [!NOTE]  
>
> SiLabs patched their fork for `prompt-toolkit` (already upstreamed though):
> https://github.com/SiliconLabs/matter/pull/147/files
> Nordic's fork needs that patch too, they'll get it after upmerging.

Fixes #32589.
