### PR TITLE
Add python platform for perfetto submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -309,7 +309,7 @@
 	path = third_party/perfetto/repo
 	url = https://github.com/google/perfetto.git
 	branch = master
-	platforms = linux,android,darwin
+	platforms = linux,android,darwin,python
 [submodule "third_party/asr/components"]
 	path = third_party/asr/components
 	url = https://github.com/asriot/asriot_components.git

--- a/scripts/checkout_submodules.py
+++ b/scripts/checkout_submodules.py
@@ -50,6 +50,7 @@ ALL_PLATFORMS = set([
     'genio',
     'openiotsdk',
     'silabs_docker',
+    'python',
 ])
 
 Module = namedtuple('Module', 'name path platforms recursive')


### PR DESCRIPTION
We need this to compile the python wheel, which is not strictly one of the host platforms. Adding a python platform designation so we can specify this submodule without pulling in the other host platform dependencies.

