### PR TITLE
[Linux]DGSW_2_3 fails CurrentHeapUsed is greater than CurrentHeapHighWatermark

### DIFF
--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -248,7 +248,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapUsed(uint64_t & currentHeap
     currentHeapUsed = mallocInfo.uordblks;
 
     // Update the maximum heap high watermark if the current heap usage exceeds it.
-    if (currentHeapUsed > maxHeapHighWatermark) {
+    if (currentHeapUsed > maxHeapHighWatermark)
+    {
         maxHeapHighWatermark = currentHeapUsed;
     }
     return CHIP_NO_ERROR;
@@ -269,7 +270,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
     // the hard disk, called swap space, and free up that page of memory. So it is impossible
     // to know accurately peak physical memory it use.
     // Update the maximum heap high watermark if the current heap usage exceeds it.
-    if (static_cast<ssize_t>(mallocInfo.uordblks) > static_cast<ssize_t>(maxHeapHighWatermark)) {
+    if (static_cast<ssize_t>(mallocInfo.uordblks) > static_cast<ssize_t>(maxHeapHighWatermark))
+    {
         maxHeapHighWatermark = mallocInfo.uordblks;
     }
 
@@ -288,7 +290,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
     // On Linux, the write operation is non-op since we always rely on the mallinfo system
     // function to get the current heap memory.
     struct mallinfo mallocInfo = mallinfo();
-    maxHeapHighWatermark =  mallocInfo.uordblks;
+    maxHeapHighWatermark       = mallocInfo.uordblks;
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -270,7 +270,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
     // the hard disk, called swap space, and free up that page of memory. So it is impossible
     // to know accurately peak physical memory it use.
     // Update the maximum heap high watermark if the current heap usage exceeds it.
-    if (static_cast<ssize_t>(mallocInfo.uordblks) > static_cast<ssize_t>(maxHeapHighWatermark))
+    if (mallocInfo.uordblks > static_cast<int>(maxHeapHighWatermark))
     {
         maxHeapHighWatermark = mallocInfo.uordblks;
     }

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -267,7 +267,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
     // has been used by the Node.
     // On Linux, since it uses virtual memory, whereby a page of memory could be copied to
     // the hard disk, called swap space, and free up that page of memory. So it is impossible
-    // to know accurately peak physical memory it use. 
+    // to know accurately peak physical memory it use.
     // Update the maximum heap high watermark if the current heap usage exceeds it.
     if (static_cast<ssize_t>(mallocInfo.uordblks) > static_cast<ssize_t>(maxHeapHighWatermark)) {
         maxHeapHighWatermark = mallocInfo.uordblks;

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -74,6 +74,9 @@ enum class WiFiStatsCountType
     kWiFiOverrunCount
 };
 
+// Static variable to store the maximum heap size
+static size_t maxHeapHighWatermark = 0;
+
 CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
 {
     CHIP_ERROR err          = CHIP_ERROR_READ_FAILED;
@@ -244,6 +247,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapUsed(uint64_t & currentHeap
     // the current running program.
     currentHeapUsed = mallocInfo.uordblks;
 
+    // Update the maximum heap high watermark if the current heap usage exceeds it.
+    if (currentHeapUsed > maxHeapHighWatermark) {
+        maxHeapHighWatermark = currentHeapUsed;
+    }
     return CHIP_NO_ERROR;
 #endif
 }
@@ -260,9 +267,14 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
     // has been used by the Node.
     // On Linux, since it uses virtual memory, whereby a page of memory could be copied to
     // the hard disk, called swap space, and free up that page of memory. So it is impossible
-    // to know accurately peak physical memory it use. We just return the current heap memory
-    // being used by the current running program.
-    currentHeapHighWatermark = mallocInfo.uordblks;
+    // to know accurately peak physical memory it use. 
+    // Update the maximum heap high watermark if the current heap usage exceeds it.
+    if (static_cast<ssize_t>(mallocInfo.uordblks) > static_cast<ssize_t>(maxHeapHighWatermark)) {
+        maxHeapHighWatermark = mallocInfo.uordblks;
+    }
+
+    // Set the current heap high watermark.
+    currentHeapHighWatermark = maxHeapHighWatermark;
 
     return CHIP_NO_ERROR;
 #endif
@@ -275,6 +287,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
 
     // On Linux, the write operation is non-op since we always rely on the mallinfo system
     // function to get the current heap memory.
+    struct mallinfo mallocInfo = mallinfo();
+    maxHeapHighWatermark =  mallocInfo.uordblks;
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
Issue:
  dgsw_2_03 fails CurrentHeapUsed is greater than CurrentHeapHighWatermark

Description of Fix/Solution:
   Took a Static variable to store the maximum heap size, updating the maximum heap size if the current heap usage exceeds it.
 

