### PR TITLE
Replace `DispatchSessionEvent` with `NotifySessionHang` on sessions.

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -485,7 +485,7 @@ void ExchangeContext::NotifyResponseTimeout(bool aCloseIfNeeded)
             {
                 mSession->AsSecureSession()->MarkAsDefunct();
             }
-            mSession->DispatchSessionEvent(&SessionDelegate::OnSessionHang);
+            mSession->NotifySessionHang();
         }
     }
 

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -158,7 +158,7 @@ void ReliableMessageMgr::ExecuteActions()
                 {
                     session->AsSecureSession()->MarkAsDefunct();
                 }
-                session->DispatchSessionEvent(&SessionDelegate::OnSessionHang);
+                session->NotifySessionHang();
             }
 
             // Do not StartTimer, we will schedule the timer at the end of the timer handler.

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -114,7 +114,7 @@ public:
 
     Transport::Session * operator->() const { return &mSession.Value().Get(); }
 
-    // There is not delegate, nothing to do here
+    // There is no delegate, nothing to do here
     virtual void OnSessionHang() {}
 
 protected:

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -115,7 +115,7 @@ public:
     Transport::Session * operator->() const { return &mSession.Value().Get(); }
 
     // There is not delegate, nothing to do here
-    virtual void DispatchSessionEvent(SessionDelegate::Event event) {}
+    virtual void OnSessionHang() {}
 
 protected:
     // Helper for use by the Grab methods.
@@ -147,7 +147,7 @@ public:
             SessionHolder::ShiftToSession(session);
     }
 
-    void DispatchSessionEvent(SessionDelegate::Event event) override { (mDelegate.*event)(); }
+    void OnSessionHang() override { mDelegate.OnSessionHang(); }
 
 private:
     SessionDelegate & mDelegate;
@@ -237,7 +237,7 @@ public:
     void SetTCPConnection(ActiveTCPConnectionState * conn) { mTCPConnection = conn; }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
-    void DispatchSessionEvent(SessionDelegate::Event event)
+    void NotifySessionHang()
     {
         // Holders might remove themselves when notified.
         auto holder = mHolders.begin();
@@ -245,7 +245,7 @@ public:
         {
             auto cur = holder;
             ++holder;
-            cur->DispatchSessionEvent(event);
+            cur->OnSessionHang();
         }
     }
 

--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -51,8 +51,6 @@ public:
      */
     virtual NewSessionHandlingPolicy GetNewSessionHandlingPolicy() { return NewSessionHandlingPolicy::kShiftToNewSession; }
 
-    using Event = void (SessionDelegate::*)();
-
     /**
      * @brief
      *   Called when a session is releasing. Callees SHALL NOT make synchronous calls into SessionManager to allocate a new session.


### PR DESCRIPTION
Only a single event was ever dispatched and the pattern of passing in pointers to member methods was not used anywhere else and resulted in fairly unique code.

Spelling out the `NotifySessionHang` explicitly seems to simplify maintainability.

