### PR TITLE
[Chip-tool] Not register LIT at default

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -136,7 +136,7 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
         params.SetDSTOffsets(mDSTOffsetList);
     }
 
-    if (!mSkipICDRegistration.ValueOr(false))
+    if (!mSkipICDRegistration.ValueOr(true))
     {
         params.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -136,7 +136,7 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
         params.SetDSTOffsets(mDSTOffsetList);
     }
 
-    if (mICDRegistration.ValueOr(true))
+    if (mICDRegistration.ValueOr(false))
     {
         params.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -136,7 +136,7 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
         params.SetDSTOffsets(mDSTOffsetList);
     }
 
-    if (!mSkipICDRegistration.ValueOr(true))
+    if (mICDRegistration.ValueOr(true))
     {
         params.SetICDRegistrationStrategy(ICDRegistrationStrategy::kBeforeComplete);
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -65,8 +65,8 @@ public:
                     "Bypass the attestation verifier. If not provided or false, the attestation verifier is not bypassed."
                     " If true, the commissioning will continue in case of attestation verification failure.");
         AddArgument("case-auth-tags", 1, UINT32_MAX, &mCASEAuthTags, "The CATs to be encoded in the NOC sent to the commissionee");
-        AddArgument("skip-icd-registration", 0, 1, &mSkipICDRegistration,
-                    "Skip registering for check-ins from ICDs during commissioning. Default: true");
+        AddArgument("icd-registration", 0, 1, &mICDRegistration,
+                    "registering for check-ins from ICDs during commissioning. Default: false");
         AddArgument("icd-check-in-nodeid", 0, UINT64_MAX, &mICDCheckInNodeId,
                     "The check-in node id for the ICD, default: node id of the commissioner.");
         AddArgument("icd-monitored-subject", 0, UINT64_MAX, &mICDMonitoredSubject,
@@ -233,7 +233,7 @@ private:
     chip::Optional<bool> mBypassAttestationVerifier;
     chip::Optional<std::vector<uint32_t>> mCASEAuthTags;
     chip::Optional<char *> mCountryCode;
-    chip::Optional<bool> mSkipICDRegistration;
+    chip::Optional<bool> mICDRegistration;
     chip::Optional<NodeId> mICDCheckInNodeId;
     chip::Optional<chip::ByteSpan> mICDSymmetricKey;
     chip::Optional<uint64_t> mICDMonitoredSubject;

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -66,7 +66,7 @@ public:
                     " If true, the commissioning will continue in case of attestation verification failure.");
         AddArgument("case-auth-tags", 1, UINT32_MAX, &mCASEAuthTags, "The CATs to be encoded in the NOC sent to the commissionee");
         AddArgument("skip-icd-registration", 0, 1, &mSkipICDRegistration,
-                    "Skip registering for check-ins from ICDs during commissioning. Default: false");
+                    "Skip registering for check-ins from ICDs during commissioning. Default: true");
         AddArgument("icd-check-in-nodeid", 0, UINT64_MAX, &mICDCheckInNodeId,
                     "The check-in node id for the ICD, default: node id of the commissioner.");
         AddArgument("icd-monitored-subject", 0, UINT64_MAX, &mICDMonitoredSubject,

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -66,7 +66,7 @@ public:
                     " If true, the commissioning will continue in case of attestation verification failure.");
         AddArgument("case-auth-tags", 1, UINT32_MAX, &mCASEAuthTags, "The CATs to be encoded in the NOC sent to the commissionee");
         AddArgument("icd-registration", 0, 1, &mICDRegistration,
-                    "registering for check-ins from ICDs during commissioning. Default: false");
+                    "Whether to register for check-ins from ICDs during commissioning. Default: false");
         AddArgument("icd-check-in-nodeid", 0, UINT64_MAX, &mICDCheckInNodeId,
                     "The check-in node id for the ICD, default: node id of the commissioner.");
         AddArgument("icd-monitored-subject", 0, UINT64_MAX, &mICDMonitoredSubject,

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -373,7 +373,7 @@ class TestDefinition:
                                          dependencies=[apps_register], timeout_seconds=timeout_seconds)
             else:
                 pairing_cmd = paths.chip_tool_with_python_cmd + \
-                    ['pairing', 'code', TEST_NODE_ID, setupCode, '--skip-icd-registration', '0']
+                    ['pairing', 'code', TEST_NODE_ID, setupCode, '--skip-icd-registration', 'false']
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \
                     ['--server_arguments', 'interactive server' +

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -372,7 +372,7 @@ class TestDefinition:
                     runner.RunSubprocess(python_cmd, name='CHIP_REPL_YAML_TESTER',
                                          dependencies=[apps_register], timeout_seconds=timeout_seconds)
             else:
-                pairing_cmd = paths.chip_tool_with_python_cmd + ['pairing', 'code', TEST_NODE_ID, setupCode]
+                pairing_cmd = paths.chip_tool_with_python_cmd + ['skip-icd-registration', 0, 'pairing', 'code', TEST_NODE_ID, setupCode]
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \
                     ['--server_arguments', 'interactive server' +

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -373,7 +373,7 @@ class TestDefinition:
                                          dependencies=[apps_register], timeout_seconds=timeout_seconds)
             else:
                 pairing_cmd = paths.chip_tool_with_python_cmd + \
-                    ['pairing', 'code', TEST_NODE_ID, setupCode, 'skip-icd-registration', '0']
+                    ['pairing', 'code', TEST_NODE_ID, setupCode, '--skip-icd-registration', '0']
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \
                     ['--server_arguments', 'interactive server' +

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -373,7 +373,7 @@ class TestDefinition:
                                          dependencies=[apps_register], timeout_seconds=timeout_seconds)
             else:
                 pairing_cmd = paths.chip_tool_with_python_cmd + \
-                    ['pairing', 'code', TEST_NODE_ID, setupCode, '--skip-icd-registration', 'false']
+                    ['pairing', 'code', TEST_NODE_ID, setupCode, '--icd-registration', 'false']
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \
                     ['--server_arguments', 'interactive server' +

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -373,7 +373,7 @@ class TestDefinition:
                                          dependencies=[apps_register], timeout_seconds=timeout_seconds)
             else:
                 pairing_cmd = paths.chip_tool_with_python_cmd + \
-                    ['skip-icd-registration', 0, 'pairing', 'code', TEST_NODE_ID, setupCode]
+                    ['skip-icd-registration', '0', 'pairing', 'code', TEST_NODE_ID, setupCode]
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \
                     ['--server_arguments', 'interactive server' +

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -372,7 +372,8 @@ class TestDefinition:
                     runner.RunSubprocess(python_cmd, name='CHIP_REPL_YAML_TESTER',
                                          dependencies=[apps_register], timeout_seconds=timeout_seconds)
             else:
-                pairing_cmd = paths.chip_tool_with_python_cmd + ['skip-icd-registration', 0, 'pairing', 'code', TEST_NODE_ID, setupCode]
+                pairing_cmd = paths.chip_tool_with_python_cmd + \
+                    ['skip-icd-registration', 0, 'pairing', 'code', TEST_NODE_ID, setupCode]
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \
                     ['--server_arguments', 'interactive server' +

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -374,7 +374,7 @@ class TestDefinition:
             else:
                 pairing_cmd = paths.chip_tool_with_python_cmd + ['pairing', 'code', TEST_NODE_ID, setupCode]
                 if self.target == TestTarget.LIT_ICD and test_runtime == TestRunTime.CHIP_TOOL_PYTHON:
-                    pairing_cmd += ['--icd-registration', 'true']     
+                    pairing_cmd += ['--icd-registration', 'true']
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \
                     ['--server_arguments', 'interactive server' +

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -373,7 +373,7 @@ class TestDefinition:
                                          dependencies=[apps_register], timeout_seconds=timeout_seconds)
             else:
                 pairing_cmd = paths.chip_tool_with_python_cmd + \
-                    ['pairing', 'code', TEST_NODE_ID, setupCode, '--icd-registration', 'false']
+                    ['pairing', 'code', TEST_NODE_ID, setupCode, '--icd-registration', 'true']
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \
                     ['--server_arguments', 'interactive server' +

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -374,6 +374,8 @@ class TestDefinition:
             else:
                 pairing_cmd = paths.chip_tool_with_python_cmd + \
                     ['pairing', 'code', TEST_NODE_ID, setupCode, '--icd-registration', 'true']
+                if self.target == TestTarget.LIT_ICD:
+                    pairing_cmd += ['--icd-registration', 'true']     
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \
                     ['--server_arguments', 'interactive server' +

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -373,8 +373,8 @@ class TestDefinition:
                                          dependencies=[apps_register], timeout_seconds=timeout_seconds)
             else:
                 pairing_cmd = paths.chip_tool_with_python_cmd + \
-                    ['pairing', 'code', TEST_NODE_ID, setupCode, '--icd-registration', 'true']
-                if self.target == TestTarget.LIT_ICD:
+                    ['pairing', 'code', TEST_NODE_ID, setupCode]
+                if self.target == TestTarget.LIT_ICD and test_runtime == TestRunTime.CHIP_TOOL_PYTHON:
                     pairing_cmd += ['--icd-registration', 'true']     
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -373,7 +373,7 @@ class TestDefinition:
                                          dependencies=[apps_register], timeout_seconds=timeout_seconds)
             else:
                 pairing_cmd = paths.chip_tool_with_python_cmd + \
-                    ['skip-icd-registration', '0', 'pairing', 'code', TEST_NODE_ID, setupCode]
+                    ['pairing', 'code', TEST_NODE_ID, setupCode, 'skip-icd-registration', '0']
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
                 server_args = ['--server_path', paths.chip_tool[-1]] + \
                     ['--server_arguments', 'interactive server' +

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -372,8 +372,7 @@ class TestDefinition:
                     runner.RunSubprocess(python_cmd, name='CHIP_REPL_YAML_TESTER',
                                          dependencies=[apps_register], timeout_seconds=timeout_seconds)
             else:
-                pairing_cmd = paths.chip_tool_with_python_cmd + \
-                    ['pairing', 'code', TEST_NODE_ID, setupCode]
+                pairing_cmd = paths.chip_tool_with_python_cmd + ['pairing', 'code', TEST_NODE_ID, setupCode]
                 if self.target == TestTarget.LIT_ICD and test_runtime == TestRunTime.CHIP_TOOL_PYTHON:
                     pairing_cmd += ['--icd-registration', 'true']     
                 test_cmd = paths.chip_tool_with_python_cmd + ['tests', self.run_name] + ['--PICS', pics_file]


### PR DESCRIPTION
Per https://github.com/project-chip/connectedhomeip/issues/31992, at default, chip-tool would register LIT unless skip-icd-registration is false.
