### PR TITLE
Fix reference cycle between controller and data store in Matter.framework.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -83,6 +83,9 @@ jobs:
                           -enableUndefinedBehaviorSanitizer YES
                     - flavor: tsan
                       arguments: -enableThreadSanitizer YES
+                    # "leaks" does not seem to be very compatible with asan or tsan
+                    - flavor: leaks
+                      defines: ENABLE_LEAK_DETECTION=1
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
@@ -22,6 +22,7 @@
 
 #include <lib/core/CASEAuthTag.h>
 #include <lib/core/NodeId.h>
+#include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 
 // FIXME: Are these good key strings? https://github.com/project-chip/connectedhomeip/issues/28973
@@ -158,10 +159,7 @@ static bool IsValidCATNumber(id _Nullable value)
 {
     __block NSDictionary<NSString *, id> * dataStoreSecureLocalValues = nil;
     MTRDeviceController * controller = _controller;
-    if (controller == nil) {
-        // Not expected; no way to call delegate without controller.
-        return;
-    }
+    VerifyOrReturn(controller != nil); // No way to call delegate without controller.
 
     dispatch_sync(_storageDelegateQueue, ^{
         if ([self->_storageDelegate respondsToSelector:@selector(valuesForController:securityLevel:sharingType:)]) {
@@ -187,10 +185,7 @@ static bool IsValidCATNumber(id _Nullable value)
 - (void)storeResumptionInfo:(MTRCASESessionResumptionInfo *)resumptionInfo
 {
     MTRDeviceController * controller = _controller;
-    if (controller == nil) {
-        // Not expected; no way to call delegate without controller.
-        return;
-    }
+    VerifyOrReturn(controller != nil); // No way to call delegate without controller.
 
     auto * oldInfo = [self findResumptionInfoByNodeID:resumptionInfo.nodeID];
     dispatch_sync(_storageDelegateQueue, ^{
@@ -228,10 +223,7 @@ static bool IsValidCATNumber(id _Nullable value)
 - (void)clearAllResumptionInfo
 {
     MTRDeviceController * controller = _controller;
-    if (controller == nil) {
-        // Not expected; no way to call delegate without controller.
-        return;
-    }
+    VerifyOrReturn(controller != nil); // No way to call delegate without controller.
 
     // Can we do less dispatch?  We would need to have a version of
     // _findResumptionInfoWithKey that assumes we are already on the right queue.
@@ -257,10 +249,7 @@ static bool IsValidCATNumber(id _Nullable value)
 - (CHIP_ERROR)storeLastLocallyUsedNOC:(MTRCertificateTLVBytes)noc
 {
     MTRDeviceController * controller = _controller;
-    if (controller == nil) {
-        // Not expected; no way to call delegate without controller.
-        return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
-    }
+    VerifyOrReturnError(controller != nil, CHIP_ERROR_PERSISTED_STORAGE_FAILED); // No way to call delegate without controller.
 
     __block BOOL ok;
     dispatch_sync(_storageDelegateQueue, ^{
@@ -276,10 +265,7 @@ static bool IsValidCATNumber(id _Nullable value)
 - (MTRCertificateTLVBytes _Nullable)fetchLastLocallyUsedNOC
 {
     MTRDeviceController * controller = _controller;
-    if (controller == nil) {
-        // Not expected; no way to call delegate without controller.
-        return nil;
-    }
+    VerifyOrReturnValue(controller != nil, nil); // No way to call delegate without controller.
 
     __block id data;
     dispatch_sync(_storageDelegateQueue, ^{
@@ -305,10 +291,7 @@ static bool IsValidCATNumber(id _Nullable value)
 - (nullable MTRCASESessionResumptionInfo *)_findResumptionInfoWithKey:(nullable NSString *)key
 {
     MTRDeviceController * controller = _controller;
-    if (controller == nil) {
-        // Not expected; no way to call delegate without controller.
-        return nil;
-    }
+    VerifyOrReturnValue(controller != nil, nil); // No way to call delegate without controller.
 
     // key could be nil if [NSString stringWithFormat] returns nil for some reason.
     if (key == nil) {
@@ -358,10 +341,7 @@ static bool IsValidCATNumber(id _Nullable value)
 - (id)_fetchAttributeCacheValueForKey:(NSString *)key expectedClass:(Class)expectedClass;
 {
     MTRDeviceController * controller = _controller;
-    if (controller == nil) {
-        // Not expected; no way to call delegate without controller.
-        return nil;
-    }
+    VerifyOrReturnValue(controller != nil, nil); // No way to call delegate without controller.
 
     id data;
     @autoreleasepool {
@@ -384,10 +364,7 @@ static bool IsValidCATNumber(id _Nullable value)
 - (BOOL)_storeAttributeCacheValue:(id)value forKey:(NSString *)key
 {
     MTRDeviceController * controller = _controller;
-    if (controller == nil) {
-        // Not expected; no way to call delegate without controller.
-        return NO;
-    }
+    VerifyOrReturnValue(controller != nil, NO); // No way to call delegate without controller.
 
     return [_storageDelegate controller:controller
                              storeValue:value
@@ -399,10 +376,7 @@ static bool IsValidCATNumber(id _Nullable value)
 - (BOOL)_bulkStoreAttributeCacheValues:(NSDictionary<NSString *, id<NSSecureCoding>> *)values
 {
     MTRDeviceController * controller = _controller;
-    if (controller == nil) {
-        // Not expected; no way to call delegate without controller.
-        return NO;
-    }
+    VerifyOrReturnValue(controller != nil, NO); // No way to call delegate without controller.
 
     return [_storageDelegate controller:controller
                             storeValues:values
@@ -413,10 +387,7 @@ static bool IsValidCATNumber(id _Nullable value)
 - (BOOL)_removeAttributeCacheValueForKey:(NSString *)key
 {
     MTRDeviceController * controller = _controller;
-    if (controller == nil) {
-        // Not expected; no way to call delegate without controller.
-        return NO;
-    }
+    VerifyOrReturnValue(controller != nil, NO); // No way to call delegate without controller.
 
     return [_storageDelegate controller:controller
                       removeValueForKey:key

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -16,14 +16,12 @@
 
 #import <Matter/Matter.h>
 
-// system dependencies
-#import <XCTest/XCTest.h>
-
 #import "MTRDeviceControllerLocalTestStorage.h"
 #import "MTRDeviceTestDelegate.h"
 #import "MTRDevice_Internal.h"
 #import "MTRErrorTestUtils.h"
 #import "MTRFabricInfoChecker.h"
+#import "MTRTestCase.h"
 #import "MTRTestDeclarations.h"
 #import "MTRTestKeys.h"
 #import "MTRTestPerControllerStorage.h"
@@ -177,7 +175,7 @@ static const uint16_t kTestVendorId = 0xFFF1u;
 
 @end
 
-@interface MTRPerControllerStorageTests : XCTestCase
+@interface MTRPerControllerStorageTests : MTRTestCase
 @end
 
 @implementation MTRPerControllerStorageTests {
@@ -353,6 +351,8 @@ static const uint16_t kTestVendorId = 0xFFF1u;
 
 - (void)test001_BasicControllerStartup
 {
+    self.detectLeaks = YES;
+
     __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
@@ -401,6 +401,8 @@ static const uint16_t kTestVendorId = 0xFFF1u;
 
 - (void)test002_TryStartingTwoControllersWithSameNodeID
 {
+    self.detectLeaks = YES;
+
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.h
@@ -1,0 +1,28 @@
+/**
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MTRTestCase : XCTestCase
+// It would be nice to do the leak-detection automatically, but running "leaks"
+// on every single sub-test is slow, and some of our tests seem to have leaks
+// outside Matter.framework.  So have it be opt-in for now, and improve later.
+@property (nonatomic) BOOL detectLeaks;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
@@ -1,0 +1,42 @@
+/**
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+
+#import "MTRTestCase.h"
+
+@implementation MTRTestCase
+
+/**
+ * Unfortunately, doing this in "+ (void)tearDown" (the global suite teardown)
+ * does not trigger a test failure even if the XCTAssertEqual fails.
+ */
+- (void)tearDown
+{
+#if defined(ENABLE_LEAK_DETECTION) && ENABLE_LEAK_DETECTION
+    if (_detectLeaks) {
+        int pid = getpid();
+        __auto_type * cmd = [NSString stringWithFormat:@"leaks %d", pid];
+        int ret = system(cmd.UTF8String);
+        XCTAssertEqual(ret, 0, "LEAKS DETECTED");
+    }
+#endif
+
+    [super tearDown];
+}
+
+@end

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
@@ -27,6 +27,7 @@
  */
 - (void)tearDown
 {
+#if 0
 #if defined(ENABLE_LEAK_DETECTION) && ENABLE_LEAK_DETECTION
     if (_detectLeaks) {
         int pid = getpid();
@@ -34,6 +35,7 @@
         int ret = system(cmd.UTF8String);
         XCTAssertEqual(ret, 0, "LEAKS DETECTED");
     }
+#endif
 #endif
 
     [super tearDown];

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		512431282BA0C8BF000BC136 /* SetMRPParametersCommand.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5124311C2BA0C09A000BC136 /* SetMRPParametersCommand.mm */; };
 		512431292BA0C8BF000BC136 /* ResetMRPParametersCommand.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5124311A2BA0C09A000BC136 /* ResetMRPParametersCommand.mm */; };
 		5129BCFD26A9EE3300122DDF /* MTRError.h in Headers */ = {isa = PBXBuildFile; fileRef = 5129BCFC26A9EE3300122DDF /* MTRError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5131BF662BE2E1B000D5D6BC /* MTRTestCase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5131BF642BE2E1B000D5D6BC /* MTRTestCase.mm */; };
 		51339B1F2A0DA64D00C798C1 /* MTRCertificateValidityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51339B1E2A0DA64D00C798C1 /* MTRCertificateValidityTests.m */; };
 		5136661328067D550025EDAE /* MTRDeviceController_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5136660F28067D540025EDAE /* MTRDeviceController_Internal.h */; };
 		5136661428067D550025EDAE /* MTRDeviceControllerFactory.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5136661028067D540025EDAE /* MTRDeviceControllerFactory.mm */; };
@@ -549,6 +550,8 @@
 		5124311B2BA0C09A000BC136 /* SetMRPParametersCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SetMRPParametersCommand.h; sourceTree = "<group>"; };
 		5124311C2BA0C09A000BC136 /* SetMRPParametersCommand.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SetMRPParametersCommand.mm; sourceTree = "<group>"; };
 		5129BCFC26A9EE3300122DDF /* MTRError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRError.h; sourceTree = "<group>"; };
+		5131BF642BE2E1B000D5D6BC /* MTRTestCase.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRTestCase.mm; sourceTree = "<group>"; };
+		5131BF652BE2E1B000D5D6BC /* MTRTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRTestCase.h; sourceTree = "<group>"; };
 		51339B1E2A0DA64D00C798C1 /* MTRCertificateValidityTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRCertificateValidityTests.m; sourceTree = "<group>"; };
 		5136660F28067D540025EDAE /* MTRDeviceController_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceController_Internal.h; sourceTree = "<group>"; };
 		5136661028067D540025EDAE /* MTRDeviceControllerFactory.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceControllerFactory.mm; sourceTree = "<group>"; };
@@ -1119,6 +1122,8 @@
 		51189FC72A33ACE900184508 /* TestHelpers */ = {
 			isa = PBXGroup;
 			children = (
+				5131BF652BE2E1B000D5D6BC /* MTRTestCase.h */,
+				5131BF642BE2E1B000D5D6BC /* MTRTestCase.mm */,
 				D437613F285BDC0D0051FEA2 /* MTRTestKeys.h */,
 				51C8E3F72825CDB600D47D00 /* MTRTestKeys.m */,
 				D4376140285BDC0D0051FEA2 /* MTRTestStorage.h */,
@@ -1974,6 +1979,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				51742B4E29CB6B88009974FE /* MTRPairingTests.m in Sources */,
+				5131BF662BE2E1B000D5D6BC /* MTRTestCase.mm in Sources */,
 				51669AF02913204400F4AA36 /* MTRBackwardsCompatTests.m in Sources */,
 				51D10D2E2808E2CA00E8CA3D /* MTRTestStorage.m in Sources */,
 				51D0B12A2B61766F006E3511 /* MTRServerEndpointTests.m in Sources */,


### PR DESCRIPTION
Also adds some leak detection to unit tests in CI that would have caught this.
