### PR TITLE
Remove the kDNSServiceFlagsTimeout flag when calling DNSServiceGetAdd…

### DIFF
--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -173,7 +173,7 @@ CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t inte
     ChipLogProgress(Discovery, "Registering service %s on host %s with port %u and type: %s on interface id: %" PRIu32,
                     StringOrNullMarker(name), StringOrNullMarker(hostname), port, StringOrNullMarker(type), interfaceId);
 
-    const DNSServiceFlags registerFlags = kDNSServiceFlagsNoAutoRename;
+    constexpr DNSServiceFlags registerFlags = kDNSServiceFlagsNoAutoRename;
     RegisterContext * sdCtx             = nullptr;
     if (CHIP_NO_ERROR == MdnsContexts::GetInstance().GetRegisterContextOfTypeAndName(type, name, &sdCtx))
     {

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -174,7 +174,7 @@ CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t inte
                     StringOrNullMarker(name), StringOrNullMarker(hostname), port, StringOrNullMarker(type), interfaceId);
 
     const DNSServiceFlags registerFlags = kDNSServiceFlagsNoAutoRename;
-    RegisterContext * sdCtx = nullptr;
+    RegisterContext * sdCtx             = nullptr;
     if (CHIP_NO_ERROR == MdnsContexts::GetInstance().GetRegisterContextOfTypeAndName(type, name, &sdCtx))
     {
         auto err = DNSServiceUpdateRecord(sdCtx->serviceRef, nullptr, registerFlags, record.size(), record.data(), 0 /* ttl */);
@@ -329,8 +329,8 @@ static void GetAddrInfo(ResolveContext * sdCtx)
 
         ResolveContextWithType * contextWithType =
             (interface.first.isSRPResult) ? &sdCtx->resolveContextWithSRPType : &sdCtx->resolveContextWithNonSRPType;
-        auto err =
-            DNSServiceGetAddrInfo(&sdRefCopy, kDNSServiceFlagsShareConnection, interfaceId, protocol, hostname, OnGetAddrInfo, contextWithType);
+        auto err = DNSServiceGetAddrInfo(&sdRefCopy, kDNSServiceFlagsShareConnection, interfaceId, protocol, hostname,
+                                         OnGetAddrInfo, contextWithType);
         VerifyOrReturn(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));
         interface.second.isDNSLookUpRequested = true;
     }
@@ -367,7 +367,8 @@ static CHIP_ERROR ResolveWithContext(ResolveContext * sdCtx, uint32_t interfaceI
 {
     auto sdRef = sdCtx->serviceRef; // Mandatory copy because of kDNSServiceFlagsShareConnection
 
-    auto err = DNSServiceResolve(&sdRef, kDNSServiceFlagsShareConnection, interfaceId, name, type, domain, OnResolve, contextWithType);
+    auto err =
+        DNSServiceResolve(&sdRef, kDNSServiceFlagsShareConnection, interfaceId, name, type, domain, OnResolve, contextWithType);
     VerifyOrReturnError(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));
     return CHIP_NO_ERROR;
 }

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -174,7 +174,7 @@ CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t inte
                     StringOrNullMarker(name), StringOrNullMarker(hostname), port, StringOrNullMarker(type), interfaceId);
 
     constexpr DNSServiceFlags registerFlags = kDNSServiceFlagsNoAutoRename;
-    RegisterContext * sdCtx             = nullptr;
+    RegisterContext * sdCtx                 = nullptr;
     if (CHIP_NO_ERROR == MdnsContexts::GetInstance().GetRegisterContextOfTypeAndName(type, name, &sdCtx))
     {
         auto err = DNSServiceUpdateRecord(sdCtx->serviceRef, nullptr, registerFlags, record.size(), record.data(), 0 /* ttl */);

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -41,12 +41,6 @@ constexpr char kSRPDot[] = "default.service.arpa.";
 // The extra time in milliseconds that we will wait for the resolution on the SRP domain to complete.
 constexpr uint16_t kSRPTimeoutInMsec = 250;
 
-constexpr DNSServiceFlags kRegisterFlags        = kDNSServiceFlagsNoAutoRename;
-constexpr DNSServiceFlags kBrowseFlags          = kDNSServiceFlagsShareConnection;
-constexpr DNSServiceFlags kGetAddrInfoFlags     = kDNSServiceFlagsShareConnection;
-constexpr DNSServiceFlags kResolveFlags         = kDNSServiceFlagsShareConnection;
-constexpr DNSServiceFlags kReconfirmRecordFlags = 0;
-
 bool IsSupportedProtocol(DnssdServiceProtocol protocol)
 {
     return (protocol == DnssdServiceProtocol::kDnssdProtocolUdp) || (protocol == DnssdServiceProtocol::kDnssdProtocolTcp);
@@ -179,10 +173,11 @@ CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t inte
     ChipLogProgress(Discovery, "Registering service %s on host %s with port %u and type: %s on interface id: %" PRIu32,
                     StringOrNullMarker(name), StringOrNullMarker(hostname), port, StringOrNullMarker(type), interfaceId);
 
+    DNSServiceFlags registerFlags = kDNSServiceFlagsNoAutoRename;
     RegisterContext * sdCtx = nullptr;
     if (CHIP_NO_ERROR == MdnsContexts::GetInstance().GetRegisterContextOfTypeAndName(type, name, &sdCtx))
     {
-        auto err = DNSServiceUpdateRecord(sdCtx->serviceRef, nullptr, kRegisterFlags, record.size(), record.data(), 0 /* ttl */);
+        auto err = DNSServiceUpdateRecord(sdCtx->serviceRef, nullptr, registerFlags, record.size(), record.data(), 0 /* ttl */);
         VerifyOrReturnError(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));
         return CHIP_NO_ERROR;
     }
@@ -194,7 +189,7 @@ CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t inte
     VerifyOrReturnError(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));
 
     DNSServiceRef sdRef;
-    err = DNSServiceRegister(&sdRef, kRegisterFlags, interfaceId, name, type, kLocalDot, hostname, htons(port), record.size(),
+    err = DNSServiceRegister(&sdRef, registerFlags, interfaceId, name, type, kLocalDot, hostname, htons(port), record.size(),
                              record.data(), OnRegister, sdCtx);
     VerifyOrReturnError(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));
 
@@ -213,7 +208,7 @@ CHIP_ERROR BrowseOnDomain(BrowseHandler * sdCtx, uint32_t interfaceId, const cha
 {
     auto sdRef = sdCtx->serviceRef; // Mandatory copy because of kDNSServiceFlagsShareConnection
 
-    auto err = DNSServiceBrowse(&sdRef, kBrowseFlags, interfaceId, type, domain, OnBrowse, sdCtx);
+    auto err = DNSServiceBrowse(&sdRef, kDNSServiceFlagsShareConnection, interfaceId, type, domain, OnBrowse, sdCtx);
     VerifyOrReturnError(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));
     return CHIP_NO_ERROR;
 }
@@ -335,7 +330,7 @@ static void GetAddrInfo(ResolveContext * sdCtx)
         ResolveContextWithType * contextWithType =
             (interface.first.isSRPResult) ? &sdCtx->resolveContextWithSRPType : &sdCtx->resolveContextWithNonSRPType;
         auto err =
-            DNSServiceGetAddrInfo(&sdRefCopy, kGetAddrInfoFlags, interfaceId, protocol, hostname, OnGetAddrInfo, contextWithType);
+            DNSServiceGetAddrInfo(&sdRefCopy, kDNSServiceFlagsShareConnection, interfaceId, protocol, hostname, OnGetAddrInfo, contextWithType);
         VerifyOrReturn(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));
         interface.second.isDNSLookUpRequested = true;
     }
@@ -372,7 +367,7 @@ static CHIP_ERROR ResolveWithContext(ResolveContext * sdCtx, uint32_t interfaceI
 {
     auto sdRef = sdCtx->serviceRef; // Mandatory copy because of kDNSServiceFlagsShareConnection
 
-    auto err = DNSServiceResolve(&sdRef, kResolveFlags, interfaceId, name, type, domain, OnResolve, contextWithType);
+    auto err = DNSServiceResolve(&sdRef, kDNSServiceFlagsShareConnection, interfaceId, name, type, domain, OnResolve, contextWithType);
     VerifyOrReturnError(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));
     return CHIP_NO_ERROR;
 }
@@ -655,7 +650,7 @@ CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    auto error = DNSServiceReconfirmRecord(kReconfirmRecordFlags, interfaceId, fullname.c_str(), rrtype, rrclass, rdlen, rdata);
+    auto error = DNSServiceReconfirmRecord(0 /* DNSServiceFlags */, interfaceId, fullname.c_str(), rrtype, rrclass, rdlen, rdata);
     LogOnFailure(__func__, error);
 
     return Error::ToChipError(error);

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -43,7 +43,7 @@ constexpr uint16_t kSRPTimeoutInMsec = 250;
 
 constexpr DNSServiceFlags kRegisterFlags        = kDNSServiceFlagsNoAutoRename;
 constexpr DNSServiceFlags kBrowseFlags          = kDNSServiceFlagsShareConnection;
-constexpr DNSServiceFlags kGetAddrInfoFlags     = kDNSServiceFlagsTimeout | kDNSServiceFlagsShareConnection;
+constexpr DNSServiceFlags kGetAddrInfoFlags     = kDNSServiceFlagsShareConnection;
 constexpr DNSServiceFlags kResolveFlags         = kDNSServiceFlagsShareConnection;
 constexpr DNSServiceFlags kReconfirmRecordFlags = 0;
 

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -173,7 +173,7 @@ CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t inte
     ChipLogProgress(Discovery, "Registering service %s on host %s with port %u and type: %s on interface id: %" PRIu32,
                     StringOrNullMarker(name), StringOrNullMarker(hostname), port, StringOrNullMarker(type), interfaceId);
 
-    DNSServiceFlags registerFlags = kDNSServiceFlagsNoAutoRename;
+    const DNSServiceFlags registerFlags = kDNSServiceFlagsNoAutoRename;
     RegisterContext * sdCtx = nullptr;
     if (CHIP_NO_ERROR == MdnsContexts::GetInstance().GetRegisterContextOfTypeAndName(type, name, &sdCtx))
     {


### PR DESCRIPTION
…rInfo

- We should not be terminating the queries if we do not get anything back quickly The queries should be running until we get something back

Fixes: #33051 

