### PR TITLE
Add comments in SessionHandle explaining its intent

### DIFF
--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -47,7 +47,7 @@ class Session;
  *    active.
  *
  *    A `SessionHandle` exists to guarantee that the object it points to will not be released while allowing passing
- *    the handle as a reference, to not incur refeference-counted Retain/Release extra calls.
+ *    the handle as a reference, to not incur extra reference-counted Retain/Release calls.
  *
  *    Example code that breaks assumptions (hard to reason about/maintain):
  *

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -84,6 +84,8 @@ class Session;
  *
  *   To meet the requirements of "you should not store this", the Handle has additional restrictions
  *   preventing modification (no assignment or copy constructor) and allows only move.
+ *   NOTE: `move` should likely also not be allowed, however we need to have the ability to
+ *         return such objects from method calls, so it is currently allowed.
  *
  */
 class SessionHandle

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -82,6 +82,9 @@ class Session;
  *         Process(&handle);  // reference is now safe to use.
  *      }
  *
+ *   To meet the requirements of "you should not store this", the Handle has additional restrictions
+ *   preventing modification (no assignment or copy constructor) and allows only move.
+ *
  */
 class SessionHandle
 {

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -64,7 +64,7 @@ class Session;
  *
  *       void Process(ReferenceCountedHandle<Session> &handle) {
  *          Foo::GetInstance()->ResetSession(); // this changes the passed in handle
- *          // trying to use "&handle" here may point to something else alltogether.
+ *          // trying to use "&handle" here may point to something else altogether.
  *       }
  *
  *   Above would be fixed if we would pass in the handles by value, however that adds extra code

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -46,7 +46,7 @@ class Session;
  *    won't be able to be grabbed by any SessionHolder. SessionHandle->IsActiveSession can be used to check if the session is
  *    active.
  *
- *    A `SessionHandle` exists to guarante that the object it points to will not be released while allowing passing
+ *    A `SessionHandle` exists to guarantee that the object it points to will not be released while allowing passing
  *    the handle as a reference, to not incur refeference-counted Retain/Release extra calls.
  *
  *    Example code that breaks assumptions (hard to reason about/maintain):


### PR DESCRIPTION
Why we actually have both ReferenceCountedHandle and SessionHandle was unclear to me. Adding some comments explaining now that I believe I understand it better.

