### PR TITLE
Fix off-by-one in reference lookbehind checks for QName iterators.

### DIFF
--- a/src/lib/dnssd/minimal_mdns/core/QName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/QName.cpp
@@ -61,7 +61,7 @@ bool SerializedQNameIterator::Next(bool followIndirectPointers)
             }
 
             size_t offset = static_cast<size_t>(((*mCurrentPosition & 0x3F) << 8) | *(mCurrentPosition + 1));
-            if (offset > mLookBehindMax)
+            if (offset >= mLookBehindMax)
             {
                 // Potential infinite recursion.
                 mIsValid = false;

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestQName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestQName.cpp
@@ -135,7 +135,7 @@ TEST(TestQName, InvalidReferencing)
 
     {
         // Infinite recursion
-        static const uint8_t kData[] = "\03test\xc0\x00";
+        static const uint8_t kData[] = "\04test\xc0\x00";
         SerializedQNameIterator it   = AsSerializedQName(kData);
 
         EXPECT_TRUE(it.Next());
@@ -145,7 +145,7 @@ TEST(TestQName, InvalidReferencing)
 
     {
         // Infinite recursion by referencing own element (inside the stream)
-        static const uint8_t kData[] = "\03test\xc0\x05";
+        static const uint8_t kData[] = "\04test\xc0\x05";
         SerializedQNameIterator it   = AsSerializedQName(kData);
 
         EXPECT_TRUE(it.Next());
@@ -164,7 +164,7 @@ TEST(TestQName, InvalidReferencing)
 
     {
         // Reference that goes forwad instead of backward
-        static const uint8_t kData[] = "\03test\xc0\x07";
+        static const uint8_t kData[] = "\04test\xc0\x07";
         SerializedQNameIterator it   = AsSerializedQName(kData);
 
         EXPECT_TRUE(it.Next());


### PR DESCRIPTION
Unit test sizes for the string `test` were off by one which masked a off-by-one comparison in QName handling.

Update unit test and comparisons. This will disallow backward references to "self" for qnames.
