### PR TITLE
Fix leaks of keys in Matter.framework unit tests.

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
@@ -163,7 +163,7 @@ static MTRDeviceController * sController = nil;
 
     __auto_type * operationalCertificate = [self issueOperationalCertificateForNode:@(kDeviceId)
                                                                operationalPublicKey:operationalPublicKey];
-    // Release no-longer-needed key key before we do anything else.
+    // Release no-longer-needed key before we do anything else.
     CFRelease(operationalPublicKey);
     XCTAssertNotNil(operationalCertificate);
 

--- a/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
@@ -163,6 +163,8 @@ static MTRDeviceController * sController = nil;
 
     __auto_type * operationalCertificate = [self issueOperationalCertificateForNode:@(kDeviceId)
                                                                operationalPublicKey:operationalPublicKey];
+    // Release no-longer-needed key key before we do anything else.
+    CFRelease(operationalPublicKey);
     XCTAssertNotNil(operationalCertificate);
 
     __auto_type * certChain = [[MTROperationalCertificateChain alloc] initWithOperationalCertificate:operationalCertificate

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -158,6 +158,8 @@ static const uint16_t kTestVendorId = 0xFFF1u;
                                                                            nodeID:self.nextNodeID
                                                             caseAuthenticatedTags:nil
                                                                             error:&error];
+    // Release no-longer-needed key key before we do anything else.
+    CFRelease(publicKey);
     XCTAssertNil(error);
     XCTAssertNotNil(operationalCert);
 

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -158,7 +158,7 @@ static const uint16_t kTestVendorId = 0xFFF1u;
                                                                            nodeID:self.nextNodeID
                                                             caseAuthenticatedTags:nil
                                                                             error:&error];
-    // Release no-longer-needed key key before we do anything else.
+    // Release no-longer-needed key before we do anything else.
     CFRelease(publicKey);
     XCTAssertNil(error);
     XCTAssertNotNil(operationalCert);


### PR DESCRIPTION
We need to CFRelease the return from SecKeyCreateWithData, and we were not doing that.
