### PR TITLE
Cherrypick into 1.3: `Fix off-by-one in look checks for QName iterators.`

### DIFF
--- a/src/lib/dnssd/minimal_mdns/core/QName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/QName.cpp
@@ -61,7 +61,7 @@ bool SerializedQNameIterator::Next(bool followIndirectPointers)
             }
 
             size_t offset = static_cast<size_t>(((*mCurrentPosition & 0x3F) << 8) | *(mCurrentPosition + 1));
-            if (offset > mLookBehindMax)
+            if (offset >= mLookBehindMax)
             {
                 // Potential infinite recursion.
                 mIsValid = false;

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestQName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestQName.cpp
@@ -136,7 +136,7 @@ void InvalidReferencing(nlTestSuite * inSuite, void * inContext)
 
     {
         // Infinite recursion
-        static const uint8_t kData[] = "\03test\xc0\x00";
+        static const uint8_t kData[] = "\04test\xc0\x00";
         SerializedQNameIterator it   = AsSerializedQName(kData);
 
         NL_TEST_ASSERT(inSuite, it.Next());
@@ -146,7 +146,7 @@ void InvalidReferencing(nlTestSuite * inSuite, void * inContext)
 
     {
         // Infinite recursion by referencing own element (inside the stream)
-        static const uint8_t kData[] = "\03test\xc0\x05";
+        static const uint8_t kData[] = "\04test\xc0\x05";
         SerializedQNameIterator it   = AsSerializedQName(kData);
 
         NL_TEST_ASSERT(inSuite, it.Next());
@@ -165,7 +165,7 @@ void InvalidReferencing(nlTestSuite * inSuite, void * inContext)
 
     {
         // Reference that goes forwad instead of backward
-        static const uint8_t kData[] = "\03test\xc0\x07";
+        static const uint8_t kData[] = "\04test\xc0\x07";
         SerializedQNameIterator it   = AsSerializedQName(kData);
 
         NL_TEST_ASSERT(inSuite, it.Next());


### PR DESCRIPTION
This cherrypicks #33273

Unit test sizes for the string `test` were off by one which masked a off-by-one comparison in QName handling.
Update unit test and comparisons. This will disallow backward references to "self" for qnames.

