### PR TITLE
Linux tv-casting-app v1.3 IdentificationDeclaration message

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
@@ -327,8 +327,9 @@ class CastingPlayerArrayAdapter extends ArrayAdapter<CastingPlayer> {
               TAG,
               "OnClickListener.onClick() called for CastingPlayer with deviceId: "
                   + castingPlayer.getDeviceId());
-          DiscoveryExampleFragment.Callback callback1 = (DiscoveryExampleFragment.Callback) context;
-          callback1.handleConnectionButtonClicked(castingPlayer);
+          DiscoveryExampleFragment.Callback onClickCallback =
+              (DiscoveryExampleFragment.Callback) context;
+          onClickCallback.handleConnectionButtonClicked(castingPlayer);
         };
     playerDescription.setOnClickListener(clickListener);
     return view;

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -80,6 +80,9 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
 
     MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.SetUp(env, jSuccessCallback);
     MatterCastingPlayerJNIMgr().mConnectionFailureHandler.SetUp(env, jFailureCallback);
+
+    // TODO: In the following PRs. Removed desiredEndpointFilter to fix Android app build issue. Replace desiredEndpointFilter with
+    // optional IdentificationDeclarationOptions. Add optional CommissionerDeclarationHandler callback parameter.
     castingPlayer->VerifyOrEstablishConnection(
         [](CHIP_ERROR err, CastingPlayer * playerPtr) {
             ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::verifyOrEstablishConnection() ConnectCallback called");
@@ -96,7 +99,7 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
                 MatterCastingPlayerJNIMgr().mConnectionFailureHandler.Handle(err);
             }
         },
-        static_cast<unsigned long long int>(commissioningWindowTimeoutSec), desiredEndpointFilter);
+        static_cast<unsigned long long int>(commissioningWindowTimeoutSec));
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -83,7 +83,9 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
         CHIP_ERROR result = idOptions.addTargetAppInfo(targetAppInfo);
         if (result != CHIP_NO_ERROR)
         {
-            ChipLogError(AppServer, "MatterCastingPlayer-JNI::verifyOrEstablishConnection() failed to add targetAppInfo: %" CHIP_ERROR_FORMAT, result.Format());
+            ChipLogError(AppServer,
+                         "MatterCastingPlayer-JNI::verifyOrEstablishConnection() failed to add targetAppInfo: %" CHIP_ERROR_FORMAT,
+                         result.Format());
         }
     }
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
@@ -62,8 +62,7 @@ static const NSInteger kMinCommissioningWindowTimeoutSec = matter::casting::core
             targetAppInfo.productId = desiredEndpointFilter.productId;
 
             CHIP_ERROR result = idOptions.addTargetAppInfo(targetAppInfo);
-            if (result != CHIP_NO_ERROR)
-            {
+            if (result != CHIP_NO_ERROR) {
                 ChipLogError(AppServer, "MCCastingPlayer.verifyOrEstablishConnectionWithCompletionBlock failed to add targetAppInfo: %" CHIP_ERROR_FORMAT, result.Format());
             }
         }

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
@@ -58,13 +58,14 @@ static const NSInteger kMinCommissioningWindowTimeoutSec = matter::casting::core
             cppDesiredEndpointFilter.productId = desiredEndpointFilter.productId;
         }
 
+        // TODO: In the following PRs. Removed desiredEndpointFilter to fix iOS app build issue. Replace desiredEndpointFilter with optional IdentificationDeclarationOptions. Add optional CommissionerDeclarationHandler callback parameter.
         _cppCastingPlayer->VerifyOrEstablishConnection(
             [completion](CHIP_ERROR err, matter::casting::core::CastingPlayer * castingPlayer) {
                 dispatch_queue_t clientQueue = [[MCCastingApp getSharedInstance] getClientQueue];
                 dispatch_async(clientQueue, ^{
                     completion(err == CHIP_NO_ERROR ? nil : [MCErrorUtils NSErrorFromChipError:err]);
                 });
-            }, timeout, cppDesiredEndpointFilter);
+            }, timeout);
     });
 }
 

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -252,20 +252,28 @@ CHIP_ERROR CommandHandler(int argc, char ** argv)
         {
             if (strcmp(argv[2], "cgp") == 0)
             {
-                // Attempt Commissioner-Generated Passcode (cgp) commissioning flow only if the CastingPlayer indicates support for it.
+                // Attempt Commissioner-Generated Passcode (cgp) commissioning flow only if the CastingPlayer indicates support for
+                // it.
                 if (targetCastingPlayer->GetSupportsCommissionerGeneratedPasscode())
                 {
-                    ChipLogProgress(AppServer, "CommandHandler() request %lu cgp. Attempting the Commissioner-Generated Passcode commissioning flow", index);
+                    ChipLogProgress(
+                        AppServer,
+                        "CommandHandler() request %lu cgp. Attempting the Commissioner-Generated Passcode commissioning flow",
+                        index);
                     idOptions.mCommissionerPasscode = true;
-                } else 
+                }
+                else
                 {
-                    ChipLogError(AppServer, "CommandHandler() request %lu cgp. Selected CastingPLayer does not support the Commissioner-Generated Passcode commissioning flow", index);
+                    ChipLogError(AppServer,
+                                 "CommandHandler() request %lu cgp. Selected CastingPLayer does not support the "
+                                 "Commissioner-Generated Passcode commissioning flow",
+                                 index);
                 }
             }
         }
         chip::Protocols::UserDirectedCommissioning::TargetAppInfo targetAppInfo;
         targetAppInfo.vendorId = kDesiredEndpointVendorId;
-        CHIP_ERROR result = idOptions.addTargetAppInfo(targetAppInfo);
+        CHIP_ERROR result      = idOptions.addTargetAppInfo(targetAppInfo);
         if (result != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "CommandHandler() request, failed to add targetAppInfo: %" CHIP_ERROR_FORMAT, result.Format());
@@ -308,8 +316,9 @@ CHIP_ERROR PrintAllCommands()
     streamer_printf(sout, "  stop-discovery       Stop Discovery of Casting Players. Usage: cast stop-discovery\r\n");
     streamer_printf(
         sout, "  request <index>      Request connecting to discovered Casting Player with [index]. Usage: cast request 0\r\n");
-    streamer_printf(
-        sout, "  request <index> cgp  Request connecting to discovered Casting Player with [index] using the Commissioner-Generated Passcode commissioning flow. Usage: cast request 0 cgp\r\n");
+    streamer_printf(sout,
+                    "  request <index> cgp  Request connecting to discovered Casting Player with [index] using the "
+                    "Commissioner-Generated Passcode commissioning flow. Usage: cast request 0 cgp\r\n");
     streamer_printf(sout, "\r\n");
 
     return CHIP_NO_ERROR;

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -51,8 +51,8 @@ void DiscoveryDelegateImpl::HandleOnAdded(matter::casting::memory::Strong<matter
         ChipLogProgress(AppServer, "Select discovered Casting Player (start index = 0) to request commissioning");
         ChipLogProgress(AppServer, "Include the cgp flag to attempt the Commissioner-Generated Passcode commissioning flow");
 
-        ChipLogProgress(AppServer, "Example1: cast request 0");
-        ChipLogProgress(AppServer, "Example2: cast request 0 cgp");
+        ChipLogProgress(AppServer, "Example1 Commissionee Passcode: cast request 0");
+        ChipLogProgress(AppServer, "Example2 Commissioner Passcode: cast request 0 cgp");
     }
     ChipLogProgress(AppServer, "Discovered CastingPlayer #%d", commissionersCount);
     ++commissionersCount;
@@ -314,8 +314,9 @@ CHIP_ERROR PrintAllCommands()
         "  delete-fabric <index>     Delete a fabric from the casting client's fabric store. Usage: cast delete-fabric 1\r\n");
     streamer_printf(sout, "  discover             Discover Casting Players. Usage: cast discover\r\n");
     streamer_printf(sout, "  stop-discovery       Stop Discovery of Casting Players. Usage: cast stop-discovery\r\n");
-    streamer_printf(
-        sout, "  request <index>      Request connecting to discovered Casting Player with [index]. Usage: cast request 0\r\n");
+    streamer_printf(sout,
+                    "  request <index>      Request connecting to discovered Casting Player with [index] using the "
+                    "Commissionee-Generated Passcode commissioning flow. Usage: cast request 0\r\n");
     streamer_printf(sout,
                     "  request <index> cgp  Request connecting to discovered Casting Player with [index] using the "
                     "Commissioner-Generated Passcode commissioning flow. Usage: cast request 0 cgp\r\n");

--- a/examples/tv-casting-app/linux/simple-app-helper.h
+++ b/examples/tv-casting-app/linux/simple-app-helper.h
@@ -20,6 +20,7 @@
 
 #include "core/CastingPlayer.h"
 #include "core/CastingPlayerDiscovery.h"
+#include "core/IdentificationDeclarationOptions.h"
 #include "core/Types.h"
 #include <platform/CHIPDeviceLayer.h>
 

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -106,6 +106,7 @@ chip_data_model("tv-casting-common") {
     "core/CastingPlayerDiscovery.cpp",
     "core/CastingPlayerDiscovery.h",
     "core/Command.h",
+    "core/CommissionerDeclarationHandler.cpp",
     "core/Endpoint.cpp",
     "core/Endpoint.h",
     "core/Types.h",

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -18,6 +18,7 @@
 
 #include "CastingApp.h"
 
+#include "CommissionerDeclarationHandler.h"
 #include "support/CastingStore.h"
 #include "support/ChipDeviceEventHandler.h"
 
@@ -117,6 +118,10 @@ CHIP_ERROR CastingApp::Start()
             });
     }
 
+    // Set a handler for Commissioner's CommissionerDeclaration messages.
+    chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(
+        CommissionerDeclarationHandler::GetInstance());
+
     return CHIP_NO_ERROR;
 }
 
@@ -152,6 +157,8 @@ CHIP_ERROR CastingApp::Stop()
     chip::Server::GetInstance().Shutdown();
 
     mState = CASTING_APP_NOT_RUNNING; // CastingApp stopped successfully, set state to NOT_RUNNING
+
+    chip::Server::GetInstance().GetUserDirectedCommissioningClient()->RemoveCommissionerDeclarationHandler();
 
     return CHIP_NO_ERROR;
 }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -118,10 +118,6 @@ CHIP_ERROR CastingApp::Start()
             });
     }
 
-    // Set a handler for Commissioner's CommissionerDeclaration messages.
-    chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(
-        CommissionerDeclarationHandler::GetInstance());
-
     return CHIP_NO_ERROR;
 }
 
@@ -144,6 +140,10 @@ CHIP_ERROR CastingApp::PostStartRegistrations()
     // Register DeviceEvent Handler
     ReturnErrorOnFailure(chip::DeviceLayer::PlatformMgrImpl().AddEventHandler(ChipDeviceEventHandler::Handle, 0));
 
+    // Set a handler for Commissioner's CommissionerDeclaration messages.
+    chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(
+        CommissionerDeclarationHandler::GetInstance());
+
     mState = CASTING_APP_RUNNING; // CastingApp started successfully, set state to RUNNING
     return CHIP_NO_ERROR;
 }
@@ -153,12 +153,13 @@ CHIP_ERROR CastingApp::Stop()
     ChipLogProgress(Discovery, "CastingApp::Stop() called");
     VerifyOrReturnError(mState == CASTING_APP_RUNNING, CHIP_ERROR_INCORRECT_STATE);
 
+    // Remove the handler previously set for Commissioner's CommissionerDeclaration messages.
+    chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(nullptr);
+
     // Shutdown the Matter server
     chip::Server::GetInstance().Shutdown();
 
     mState = CASTING_APP_NOT_RUNNING; // CastingApp stopped successfully, set state to NOT_RUNNING
-
-    chip::Server::GetInstance().GetUserDirectedCommissioningClient()->RemoveCommissionerDeclarationHandler();
 
     return CHIP_NO_ERROR;
 }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -100,6 +100,9 @@ CHIP_ERROR CastingApp::Start()
     // reconnect (or verify connection) to the CastingPlayer that the app was connected to before being stopped, if any
     if (CastingPlayer::GetTargetCastingPlayer() != nullptr)
     {
+        ChipLogProgress(
+            Discovery,
+            "CastingApp::Start() calling VerifyOrEstablishConnection() to reconnect (or verify connection) to a CastingPlayer");
         CastingPlayer::GetTargetCastingPlayer()->VerifyOrEstablishConnection(
             [](CHIP_ERROR err, matter::casting::core::CastingPlayer * castingPlayer) {
                 if (err != CHIP_NO_ERROR)

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -140,9 +140,11 @@ CHIP_ERROR CastingApp::PostStartRegistrations()
     // Register DeviceEvent Handler
     ReturnErrorOnFailure(chip::DeviceLayer::PlatformMgrImpl().AddEventHandler(ChipDeviceEventHandler::Handle, 0));
 
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // Set a handler for Commissioner's CommissionerDeclaration messages.
     chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(
         CommissionerDeclarationHandler::GetInstance());
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
     mState = CASTING_APP_RUNNING; // CastingApp started successfully, set state to RUNNING
     return CHIP_NO_ERROR;
@@ -153,8 +155,10 @@ CHIP_ERROR CastingApp::Stop()
     ChipLogProgress(Discovery, "CastingApp::Stop() called");
     VerifyOrReturnError(mState == CASTING_APP_RUNNING, CHIP_ERROR_INCORRECT_STATE);
 
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // Remove the handler previously set for Commissioner's CommissionerDeclaration messages.
     chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(nullptr);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 
     // Shutdown the Matter server
     chip::Server::GetInstance().Shutdown();

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -254,7 +254,9 @@ void CastingPlayer::FindOrEstablishSession(void * clientContext, chip::OnDeviceC
         connectionContext->mOnConnectionFailureCallback);
 }
 
-bool CastingPlayer::ContainsDesiredTargetApp(core::CastingPlayer * cachedCastingPlayer, std::vector<chip::Protocols::UserDirectedCommissioning::TargetAppInfo> desiredTargetApps)
+bool CastingPlayer::ContainsDesiredTargetApp(
+    core::CastingPlayer * cachedCastingPlayer,
+    std::vector<chip::Protocols::UserDirectedCommissioning::TargetAppInfo> desiredTargetApps)
 {
     std::vector<memory::Strong<Endpoint>> cachedEndpoints = cachedCastingPlayer->GetEndpoints();
     for (size_t i = 0; i < desiredTargetApps.size(); i++)

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -95,14 +95,8 @@ using ConnectCallback = std::function<void(CHIP_ERROR, CastingPlayer *)>;
 class CastingPlayer : public std::enable_shared_from_this<CastingPlayer>
 {
 public:
-    CastingPlayer(CastingPlayerAttributes playerAttributes)
-    {
-        mAttributes                     = playerAttributes;
-    }
-    ~CastingPlayer()
-    {
-        delete mCommissionerDeclarationHandler;
-    }
+    CastingPlayer(CastingPlayerAttributes playerAttributes) { mAttributes = playerAttributes; }
+    ~CastingPlayer() { delete mCommissionerDeclarationHandler; }
 
     /**
      * @brief Get the CastingPlayer object targeted currently (may not be connected)
@@ -217,7 +211,7 @@ private:
      * Flag to indicate whether or not the Commissionee has obtained the Commissioner Passcode from the user and is therefore ready
      * for commissioning.
      */
-    bool mUdcCommissionerPasscodeReady = false;
+    bool mUdcCommissionerPasscodeReady                               = false;
     CommissionerDeclarationHandler * mCommissionerDeclarationHandler = new CommissionerDeclarationHandler();
     static CastingPlayer * mTargetCastingPlayer;
     unsigned long long int mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
@@ -245,9 +239,11 @@ private:
 
     /**
      * @brief Checks if the cachedCastingPlayer contains at least one Endpoint/TargetApp described in the desiredTargetApps list.
-     * @return true - cachedCastingPlayer contains at least one endpoints with matching (non-default) values for vendorID and productID as described in the desiredTargetApps list, false otherwise.
+     * @return true - cachedCastingPlayer contains at least one endpoints with matching (non-default) values for vendorID and
+     * productID as described in the desiredTargetApps list, false otherwise.
      */
-    bool ContainsDesiredTargetApp(core::CastingPlayer * cachedCastingPlayer, std::vector<chip::Protocols::UserDirectedCommissioning::TargetAppInfo> desiredTargetApps);
+    bool ContainsDesiredTargetApp(core::CastingPlayer * cachedCastingPlayer,
+                                  std::vector<chip::Protocols::UserDirectedCommissioning::TargetAppInfo> desiredTargetApps);
 
     // ChipDeviceEventHandler handles chip::DeviceLayer::ChipDeviceEvent events and helps the CastingPlayer class commission with
     // and connect to a CastingPlayer

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -96,7 +96,6 @@ class CastingPlayer : public std::enable_shared_from_this<CastingPlayer>
 {
 public:
     CastingPlayer(CastingPlayerAttributes playerAttributes) { mAttributes = playerAttributes; }
-    ~CastingPlayer() { delete mCommissionerDeclarationHandler; }
 
     /**
      * @brief Get the CastingPlayer object targeted currently (may not be connected)
@@ -203,16 +202,6 @@ private:
     ConnectionState mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
     CastingPlayerAttributes mAttributes;
     IdentificationDeclarationOptions mIdOptions;
-    /**
-     * Flag to indicate whether or not the Commissionee (tv-casting-app) is enabled for the Commissioner-Generated Passcode flow.
-     */
-    bool mUdcCommissionerPasscodeEnabled = false;
-    /**
-     * Flag to indicate whether or not the Commissionee has obtained the Commissioner Passcode from the user and is therefore ready
-     * for commissioning.
-     */
-    bool mUdcCommissionerPasscodeReady                               = false;
-    CommissionerDeclarationHandler * mCommissionerDeclarationHandler = new CommissionerDeclarationHandler();
     static CastingPlayer * mTargetCastingPlayer;
     unsigned long long int mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
     ConnectCallback mOnCompleted                          = {};
@@ -222,11 +211,6 @@ private:
      * @brief Sends the user directed commissioning request to this CastingPlayer
      */
     CHIP_ERROR SendUserDirectedCommissioningRequest();
-
-    /**
-     * @brief Builds an IdentificationDeclaration message to be sent to this CastingPlayer
-     */
-    chip::Protocols::UserDirectedCommissioning::IdentificationDeclaration buildIdentificationDeclarationMessage();
 
     /**
      * @brief Selects an IP Address to send the UDC request to.

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
@@ -37,8 +37,8 @@ CommissionerDeclarationHandler * CommissionerDeclarationHandler::GetInstance()
 
 // TODO: In the following PRs. Implement setHandler() for CommissionerDeclaration messages and expose messages to higher layers for
 // Linux, Android and iOS.
-void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(const chip::Transport::PeerAddress & source,
-                                        chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)
+void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(
+    const chip::Transport::PeerAddress & source, chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)
 {
     ChipLogProgress(AppServer, "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() called TODO: handle message");
     cd.DebugLog();

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
@@ -1,0 +1,49 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "CommissionerDeclarationHandler.h"
+
+#include "Types.h"
+
+namespace matter {
+namespace casting {
+namespace core {
+
+CommissionerDeclarationHandler * CommissionerDeclarationHandler::sCommissionerDeclarationHandler_ = nullptr;
+
+CommissionerDeclarationHandler * CommissionerDeclarationHandler::GetInstance()
+{
+    if (sCommissionerDeclarationHandler_ == nullptr)
+    {
+        sCommissionerDeclarationHandler_ = new CommissionerDeclarationHandler();
+    }
+    return sCommissionerDeclarationHandler_;
+}
+
+// TODO: In the following PRs. Implement setHandler() for CommissionerDeclaration messages and expose messages to higher layers for
+// Linux, Android and iOS.
+void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(const chip::Transport::PeerAddress & source,
+                                        chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)
+{
+    ChipLogProgress(AppServer, "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() called TODO: handle message");
+    cd.DebugLog();
+}
+
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
@@ -24,16 +24,25 @@ namespace matter {
 namespace casting {
 namespace core {
 
-// TODO: In the following PRs. This is work in progress, call higer levels with the CommissionerDeclaration info.
+/**
+ * @brief React to the Commissioner's CommissionerDeclaration messages with this singleton. This is the common handler across Linux,
+ * Android and iOS.
+ */
 class CommissionerDeclarationHandler : public chip::Protocols::UserDirectedCommissioning::CommissionerDeclarationHandler
 {
 public:
+    CommissionerDeclarationHandler(const CommissionerDeclarationHandler &) = delete;
+    void operator=(const CommissionerDeclarationHandler &)                 = delete;
+
+    static CommissionerDeclarationHandler * GetInstance();
+
     void OnCommissionerDeclarationMessage(const chip::Transport::PeerAddress & source,
-                                          chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd) override
-    {
-        ChipLogProgress(AppServer, "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() called");
-        cd.DebugLog();
-    }
+                                          chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd) override;
+
+private:
+    static CommissionerDeclarationHandler * sCommissionerDeclarationHandler_;
+    CommissionerDeclarationHandler() {}
+    ~CommissionerDeclarationHandler() {}
 };
 
 }; // namespace core

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "Types.h"
+
+namespace matter {
+namespace casting {
+namespace core {
+
+// TODO: In the following PRs. This is work in progress, call higer levels with the CommissionerDeclaration info.
+class CommissionerDeclarationHandler : public chip::Protocols::UserDirectedCommissioning::CommissionerDeclarationHandler
+{
+public:
+    void OnCommissionerDeclarationMessage(const chip::Transport::PeerAddress & source,
+                                          chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd) override
+    {
+        ChipLogProgress(AppServer, "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() called");
+        cd.DebugLog();
+    }
+};
+
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
@@ -25,8 +25,7 @@ namespace casting {
 namespace core {
 
 /**
- * @brief React to the Commissioner's CommissionerDeclaration messages with this singleton. This is the common handler across Linux,
- * Android and iOS.
+ * @brief React to the Commissioner's CommissionerDeclaration messages with this singleton.
  */
 class CommissionerDeclarationHandler : public chip::Protocols::UserDirectedCommissioning::CommissionerDeclarationHandler
 {

--- a/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
+++ b/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
@@ -1,0 +1,91 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "Types.h"
+#include <vector>
+
+namespace matter {
+namespace casting {
+namespace core {
+
+/**
+ * This class contains the optional parameters used in the IdentificationDeclaration Message, sent by the Commissionee to the
+ * Commissioner. The options specify information relating to the requested UDC commissioning session.
+ */
+class IdentificationDeclarationOptions
+{
+public:
+    /**
+     * Feature: Target Content Application
+     * Flag to instruct the Commissioner not to display a Passcode input dialog, and instead send a CommissionerDeclaration message
+     * if a commissioning Passcode is needed.
+     */
+    bool mNoPasscode = false;
+    /**
+     * Feature: Coordinate Passcode Dialogs
+     * Flag to instruct the Commissioner to send a CommissionerDeclaration message when the Passcode input dialog on the
+     * Commissioner has been shown to the user.
+     */
+    bool mCdUponPasscodeDialog = false;
+    /**
+     * Feature: Commissioner-Generated Passcode
+     * Flag to instruct the Commissioner to use the Commissioner-generated Passcode for commissioning.
+     */
+    bool mCommissionerPasscode = false;
+    /**
+     * Feature: Commissioner-Generated Passcode
+     * Flag to indicate whether or not the Commissionee has obtained the Commissioner Passcode from the user and is therefore ready
+     * for commissioning.
+     */
+    bool mCommissionerPasscodeReady = false;
+    /**
+     * Feature: Coordinate Passcode Dialogs
+     * Flag to indicate when the Commissionee user has decided to exit the commissioning process.
+     */
+    bool mCancelPasscode = false;
+
+    CHIP_ERROR addTargetAppInfo(const chip::Protocols::UserDirectedCommissioning::TargetAppInfo& targetAppInfo) {
+        if (mTargetAppInfos.size() >= kMaxTargetAppInfos)
+        {
+            ChipLogError(AppServer, "IdentificationDeclarationOptions::addTargetAppInfo() failed to add TargetAppInfo, max vector size is %zu", kMaxTargetAppInfos);
+            return CHIP_ERROR_NO_MEMORY;
+        }
+
+        mTargetAppInfos.push_back(targetAppInfo);
+        return CHIP_NO_ERROR;
+    }
+
+    std::vector<chip::Protocols::UserDirectedCommissioning::TargetAppInfo> getTargetAppInfoList() const { return mTargetAppInfos; }
+
+private:
+    // TVs can handle the memory impact of supporting a larger list. See examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
+    constexpr static size_t kMaxTargetAppInfos = 10;
+    /**
+     * Feature: Target Content Application
+     * The set of content app Vendor IDs (and optionally, Product IDs) that can be used for authentication.
+     * Also, if TargetAppInfo is passed in, VerifyOrEstablishConnection() will force User Directed Commissioning, in case the
+     * desired TargetApp is not found in the on-device CastingStore.
+     */
+    std::vector<chip::Protocols::UserDirectedCommissioning::TargetAppInfo> mTargetAppInfos;
+};
+
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
+++ b/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
@@ -61,10 +61,13 @@ public:
      */
     bool mCancelPasscode = false;
 
-    CHIP_ERROR addTargetAppInfo(const chip::Protocols::UserDirectedCommissioning::TargetAppInfo& targetAppInfo) {
+    CHIP_ERROR addTargetAppInfo(const chip::Protocols::UserDirectedCommissioning::TargetAppInfo & targetAppInfo)
+    {
         if (mTargetAppInfos.size() >= kMaxTargetAppInfos)
         {
-            ChipLogError(AppServer, "IdentificationDeclarationOptions::addTargetAppInfo() failed to add TargetAppInfo, max vector size is %zu", kMaxTargetAppInfos);
+            ChipLogError(AppServer,
+                         "IdentificationDeclarationOptions::addTargetAppInfo() failed to add TargetAppInfo, max vector size is %zu",
+                         kMaxTargetAppInfos);
             return CHIP_ERROR_NO_MEMORY;
         }
 

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -53,6 +53,10 @@
 
 #define CHIP_DEVICE_CONFIG_ENABLE_PAIRING_AUTOSTART 0
 
+// TVs can handle the memory impact of supporting a larger list of target apps. See
+// examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
+#define CHIP_DEVICE_CONFIG_UDC_MAX_TARGET_APPS 10
+
 // For casting, we need to allow more ACL entries, and more complex entries
 #define CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_TARGETS_PER_ENTRY 20
 #define CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_SUBJECTS_PER_ENTRY 20

--- a/examples/tv-casting-app/tv-casting-common/support/AppParameters.h
+++ b/examples/tv-casting-app/tv-casting-common/support/AppParameters.h
@@ -42,6 +42,7 @@ public:
                       chip::Credentials::DeviceAttestationCredentialsProvider * deviceAttestationCredentialsProvider,
                       chip::Credentials::DeviceAttestationVerifier * deviceAttestationVerifier,
                       ServerInitParamsProvider * serverInitParamsProvider)
+    // TODO: In the following PRs. Add CommissionerDeclarationHandler.
     {
         VerifyOrReturnError(commissionableDataProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(deviceAttestationCredentialsProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -621,7 +621,7 @@ void Server::Shutdown()
 CHIP_ERROR Server::SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress commissioner,
                                                         Protocols::UserDirectedCommissioning::IdentificationDeclaration & id)
 {
-    ChipLogDetail(AppServer, "SendUserDirectedCommissioningRequest2");
+    ChipLogDetail(AppServer, "Server::SendUserDirectedCommissioningRequest()");
 
     CHIP_ERROR err;
 

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -538,12 +538,6 @@ public:
         mCommissionerDeclarationHandler = commissionerDeclarationHandler;
     }
 
-    /**
-     * Remove the previously set Commissioner Declaration UDC request listener.
-     *
-     */
-    void RemoveCommissionerDeclarationHandler() { mCommissionerDeclarationHandler = nullptr; }
-
 private:
     void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle && msgBuf,
                            Transport::MessageTransportContext * ctxt = nullptr) override;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -538,6 +538,12 @@ public:
         mCommissionerDeclarationHandler = commissionerDeclarationHandler;
     }
 
+    /**
+     * Remove the previously set Commissioner Declaration UDC request listener.
+     *
+     */
+    void RemoveCommissionerDeclarationHandler() { mCommissionerDeclarationHandler = nullptr; }
+
 private:
     void OnMessageReceived(const Transport::PeerAddress & source, System::PacketBufferHandle && msgBuf,
                            Transport::MessageTransportContext * ctxt = nullptr) override;

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -367,6 +367,7 @@ CHIP_ERROR IdentificationDeclaration::ReadPayload(uint8_t * udcPayload, size_t p
                 {
                     ChipLogProgress(AppServer, "TLV end of array");
                     ReturnErrorOnFailure(reader.ExitContainer(listContainerType));
+                    err = CHIP_NO_ERROR;
                 }
             }
             break;


### PR DESCRIPTION
For the Linux tv-casting-app example app, implemented new Matter v1.3 IdentificationDeclaration message parameters. Modified the IdentificationDeclaration message parameters sent to the tv-app commissioner (CastingPlayer) during User Directed Commissioning (UDC).

**Change summary**

1. Defined a new IdentificationDeclarationOptions class in IdentificationDeclarationOptions.h.
2. In CastingPlayer.h/cpp Modified VerifyOrEstablishConnection() to accept an optional IdentificationDeclarationOptions parameter instead of the optional EndpointFilter parameter. Modified SendUserDirectedCommissioningRequest() to send the IdentificationDeclaration message with the new options.
3. Modified the Linux tv-casting-app connectedhomeip/examples/tv-casting-app/linux/simple-app-helper.cpp CommandHandler() call to VerifyOrEstablishConnection() to demo the new IdentificationDeclarationOptions parameter.
4. Per Chris DeCenzo modified /src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp ReadPayload() case kTargetAppListTag to remove misleading error message in the Tv-app logs. The inner loop which detects the end of the array of appids should be re-setting the err field like this:
5. Removed the EndpointFilter param in the call to VerifyOrEstablishConnection() in connectedhomeip/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm and connectedhomeip/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp to fix iOS and Android tv-casting-app  build issues resulting from the optional parameter being removed. 


**Testing**

Verified and tested locally with the Linux, Android and iOS tv-casting-app example mobile apps, and the Linux tv-app (CastingPlayer). With the Linux example app, when the discovered tv-app is selected (using “cast request x”), the tv-casting-app initiates User Directed Commissioning (UDC) by sending the first IdentificationDeclaration message to the tv-app with the CommissionerPasscode flag set to true. When the tv-app receives the IdentificationDeclaration message, it displays the Commissioner-Generated passcode field in the logs as expected.

