### PR TITLE
Darwin: Address various MTRSetupPayload issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -242,7 +242,7 @@ jobs:
                   output.
               if: always()
               run: |
-                  git grep -I -n '0x%[0-9l.-]*[^0-9lxX".-]' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
+                  git grep -I -n '0x%[0-9l.*-]*[^xX"0-9l.*-]' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
 
             # git grep exits with 0 if it finds a match, but we want
             # to fail (exit nonzero) on match.  And we want to exclude this file,

--- a/src/darwin/Framework/CHIP/MTRDefines_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDefines_Internal.h
@@ -58,5 +58,9 @@
 typedef struct {} variable_hidden_by_mtr_hide;
 // clang-format on
 
+// mtr_[un]likely(expr): Evaluates a boolean expression and hints to the compiler that it is [un]likely to be true.
+#define mtr_likely(expr) __builtin_expect(!!(expr), 1)
+#define mtr_unlikely(expr) __builtin_expect(!!(expr), 0)
+
 // Default timed interaction timeout, in ms, if another one is not provided.
 #define MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS 10000

--- a/src/darwin/Framework/CHIP/MTRError.mm
+++ b/src/darwin/Framework/CHIP/MTRError.mm
@@ -19,6 +19,7 @@
 
 #import "MTRError.h"
 #import "MTRError_Internal.h"
+#import "MTRLogging_Internal.h"
 
 #import <app/MessageDef/StatusIB.h>
 #import <inet/InetError.h>
@@ -42,6 +43,11 @@ NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
 @end
 
 @implementation MTRError
+
++ (NSError *)errorWithCode:(MTRErrorCode)code
+{
+    return [NSError errorWithDomain:MTRErrorDomain code:code userInfo:nil];
+}
 
 + (NSError *)errorForCHIPErrorCode:(CHIP_ERROR)errorCode
 {
@@ -337,3 +343,9 @@ NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
 }
 
 @end
+
+void MTRThrowInvalidArgument(NSString * reason)
+{
+    MTR_LOG_ERROR("Invalid argument: %@", reason);
+    @throw [NSException exceptionWithName:NSInvalidArgumentException reason:reason userInfo:nil];
+}

--- a/src/darwin/Framework/CHIP/MTRError_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRError_Internal.h
@@ -16,8 +16,9 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <Matter/MTRDefines.h>
 #import <Matter/MTRError.h>
+
+#import "MTRDefines_Internal.h"
 
 #include <app/MessageDef/StatusIB.h>
 #include <lib/core/CHIPError.h>
@@ -25,12 +26,24 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+MTR_DIRECT_MEMBERS
 @interface MTRError : NSObject
++ (NSError *)errorWithCode:(MTRErrorCode)code;
 + (NSError * _Nullable)errorForCHIPErrorCode:(CHIP_ERROR)errorCode;
 + (NSError * _Nullable)errorForCHIPErrorCode:(CHIP_ERROR)errorCode logContext:(id _Nullable)contextToLog;
 + (NSError * _Nullable)errorForIMStatus:(const chip::app::StatusIB &)status;
 + (NSError * _Nullable)errorForIMStatusCode:(chip::Protocols::InteractionModel::Status)status;
 + (CHIP_ERROR)errorToCHIPErrorCode:(NSError * _Nullable)error;
 @end
+
+// Similar to VerifyOrDie, but throws an NSInvalidArgumentException
+#define MTRVerifyArgumentOrDie(cond, reason) \
+    do {                                     \
+        if (mtr_unlikely(!(cond))) {         \
+            MTRThrowInvalidArgument(reason); \
+        }                                    \
+    } while (0)
+
+MTR_EXTERN _Noreturn void MTRThrowInvalidArgument(NSString * reason);
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.h
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-MTR_DEPRECATED("Please use [MTRSetupPayload setupPayloadWithOnboardingPayload:error:]", ios(16.1, 16.4), macos(13.0, 13.3),
+MTR_DEPRECATED("Please use -[MTRSetupPayload initWithManualPairingCode:]", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRManualSetupPayloadParser : NSObject
 - (instancetype)initWithDecimalStringRepresentation:(NSString *)decimalStringRepresentation;

--- a/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.h
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-MTR_DEPRECATED("Please use -[MTRSetupPayload initWithManualPairingCode:]", ios(16.1, 16.4), macos(13.0, 13.3),
+MTR_DEPRECATED("Please use -[MTRSetupPayload initWithPayload:]", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRManualSetupPayloadParser : NSObject
 - (instancetype)initWithDecimalStringRepresentation:(NSString *)decimalStringRepresentation;

--- a/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.mm
@@ -18,7 +18,7 @@
 #import "MTRManualSetupPayloadParser.h"
 
 #import "MTRError_Internal.h"
-#import "MTRSetupPayload.h"
+#import "MTRSetupPayload_Internal.h"
 
 @implementation MTRManualSetupPayloadParser {
     NSString * _decimalStringRepresentation;

--- a/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.mm
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2024 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -14,56 +14,30 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 #import "MTRManualSetupPayloadParser.h"
 
 #import "MTRError_Internal.h"
-#import "MTRFramework.h"
-#import "MTRLogging_Internal.h"
-#import "MTRSetupPayload_Internal.h"
-
-#import <setup_payload/ManualSetupPayloadParser.h>
-#import <setup_payload/SetupPayload.h>
-
-#include <string>
+#import "MTRSetupPayload.h"
 
 @implementation MTRManualSetupPayloadParser {
     NSString * _decimalStringRepresentation;
-    chip::ManualSetupPayloadParser * _chipManualSetupPayloadParser;
-}
-
-+ (void)initialize
-{
-    MTRFrameworkInit();
 }
 
 - (id)initWithDecimalStringRepresentation:(NSString *)decimalStringRepresentation
 {
-    if (self = [super init]) {
-        _decimalStringRepresentation = decimalStringRepresentation;
-        _chipManualSetupPayloadParser = new chip::ManualSetupPayloadParser(std::string([decimalStringRepresentation UTF8String]));
-    }
+    self = [super init];
+    _decimalStringRepresentation = decimalStringRepresentation;
     return self;
 }
 
 - (MTRSetupPayload *)populatePayload:(NSError * __autoreleasing *)error
 {
-    chip::SetupPayload cPlusPluspayload;
-    MTRSetupPayload * payload;
-
-    CHIP_ERROR chipError = _chipManualSetupPayloadParser->populatePayload(cPlusPluspayload);
-    if (chipError == CHIP_NO_ERROR) {
-        payload = [[MTRSetupPayload alloc] initWithSetupPayload:cPlusPluspayload];
-    } else if (error) {
-        *error = [MTRError errorForCHIPErrorCode:chipError];
+    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithManualPairingCode:_decimalStringRepresentation];
+    if (!payload && error) {
+        *error = [MTRError errorWithCode:MTRErrorCodeInvalidArgument];
     }
-
     return payload;
-}
-
-- (void)dealloc
-{
-    delete _chipManualSetupPayloadParser;
-    _chipManualSetupPayloadParser = nullptr;
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.h
@@ -28,7 +28,7 @@ typedef NS_ENUM(NSUInteger, MTROnboardingPayloadType) {
     MTROnboardingPayloadTypeNFC
 } MTR_DEPRECATED("MTROnboardingPayloadType is unused", ios(16.1, 17.0), macos(13.0, 14.0), watchos(9.1, 10.0), tvos(16.1, 17.0));
 
-MTR_DEPRECATED("Please use [MTRSetupPayload setupPayloadWithOnboardingPayload:error:]", ios(16.1, 17.0), macos(13.0, 14.0),
+MTR_DEPRECATED("Please use [MTRSetupPayload initWithPayload:]", ios(16.1, 17.0), macos(13.0, 14.0),
     watchos(9.1, 10.0), tvos(16.1, 17.0))
 @interface MTROnboardingPayloadParser : NSObject
 

--- a/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.mm
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2024 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,50 +16,15 @@
  */
 
 #import "MTROnboardingPayloadParser.h"
-#import "MTRManualSetupPayloadParser.h"
-#import "MTRQRCodeSetupPayloadParser.h"
+
 #import "MTRSetupPayload.h"
 
 @implementation MTROnboardingPayloadParser
 
-+ (bool)isQRCode:(NSString *)codeString
-{
-    return [codeString hasPrefix:@"MT:"];
-}
-
 + (MTRSetupPayload * _Nullable)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
                                                           error:(NSError * __autoreleasing *)error
 {
-    MTRSetupPayload * payload;
-    // MTROnboardingPayloadTypeNFC is of type QR code and handled same as QR code
-    MTROnboardingPayloadType type =
-        [self isQRCode:onboardingPayload] ? MTROnboardingPayloadTypeQRCode : MTROnboardingPayloadTypeManualCode;
-    switch (type) {
-    case MTROnboardingPayloadTypeManualCode:
-        payload = [self setupPayloadForManualCodeOnboardingPayload:onboardingPayload error:error];
-        break;
-    case MTROnboardingPayloadTypeQRCode:
-        payload = [self setupPayloadForQRCodeOnboardingPayload:onboardingPayload error:error];
-        break;
-    default:
-        break;
-    }
-    return payload;
+    return [MTRSetupPayload setupPayloadWithOnboardingPayload:onboardingPayload error:error];
 }
 
-+ (MTRSetupPayload * _Nullable)setupPayloadForQRCodeOnboardingPayload:(NSString *)onboardingPayload
-                                                                error:(NSError * __autoreleasing *)error
-{
-    MTRQRCodeSetupPayloadParser * qrCodeParser =
-        [[MTRQRCodeSetupPayloadParser alloc] initWithBase38Representation:onboardingPayload];
-    return [qrCodeParser populatePayload:error];
-}
-
-+ (MTRSetupPayload * _Nullable)setupPayloadForManualCodeOnboardingPayload:(NSString *)onboardingPayload
-                                                                    error:(NSError * __autoreleasing *)error
-{
-    MTRManualSetupPayloadParser * manualParser =
-        [[MTRManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:onboardingPayload];
-    return [manualParser populatePayload:error];
-}
 @end

--- a/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.h
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-MTR_DEPRECATED("Please use [MTRSetupPayload -initWithQRCode:]", ios(16.1, 16.4), macos(13.0, 13.3),
+MTR_DEPRECATED("Please use [MTRSetupPayload -initWithPayload:]", ios(16.1, 16.4), macos(13.0, 13.3),
     watchos(9.1, 9.4), tvos(16.1, 16.4))
 @interface MTRQRCodeSetupPayloadParser : NSObject
 - (instancetype)initWithBase38Representation:(NSString *)base38Representation;

--- a/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.mm
@@ -18,7 +18,7 @@
 #import "MTRQRCodeSetupPayloadParser.h"
 
 #import "MTRError_Internal.h"
-#import "MTRSetupPayload.h"
+#import "MTRSetupPayload_Internal.h"
 
 @implementation MTRQRCodeSetupPayloadParser {
     NSString * _base38Representation;

--- a/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.mm
+++ b/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.mm
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2024 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,54 +16,28 @@
  */
 
 #import "MTRQRCodeSetupPayloadParser.h"
+
 #import "MTRError_Internal.h"
-#import "MTRFramework.h"
-#import "MTRLogging_Internal.h"
-#import "MTRSetupPayload_Internal.h"
-
-#import <setup_payload/QRCodeSetupPayloadParser.h>
-#import <setup_payload/SetupPayload.h>
-
-#include <string>
+#import "MTRSetupPayload.h"
 
 @implementation MTRQRCodeSetupPayloadParser {
     NSString * _base38Representation;
-    chip::QRCodeSetupPayloadParser * _chipQRCodeSetupPayloadParser;
-}
-
-+ (void)initialize
-{
-    MTRFrameworkInit();
 }
 
 - (id)initWithBase38Representation:(NSString *)base38Representation
 {
-    if (self = [super init]) {
-        _base38Representation = base38Representation;
-        _chipQRCodeSetupPayloadParser = new chip::QRCodeSetupPayloadParser(std::string([base38Representation UTF8String]));
-    }
+    self = [super init];
+    _base38Representation = base38Representation;
     return self;
 }
 
 - (MTRSetupPayload *)populatePayload:(NSError * __autoreleasing *)error
 {
-    chip::SetupPayload cPlusPluspayload;
-    MTRSetupPayload * payload;
-
-    CHIP_ERROR chipError = _chipQRCodeSetupPayloadParser->populatePayload(cPlusPluspayload);
-    if (chipError == CHIP_NO_ERROR) {
-        payload = [[MTRSetupPayload alloc] initWithSetupPayload:cPlusPluspayload];
-    } else if (error) {
-        *error = [MTRError errorForCHIPErrorCode:chipError];
+    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithQRCode:_base38Representation];
+    if (!payload && error) {
+        *error = [MTRError errorWithCode:MTRErrorCodeInvalidArgument];
     }
-
     return payload;
-}
-
-- (void)dealloc
-{
-    delete _chipQRCodeSetupPayloadParser;
-    _chipQRCodeSetupPayloadParser = nullptr;
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -109,7 +109,7 @@ MTR_NEWLY_AVAILABLE
  * will not work, because some required information will be missing.
  *
  * This class can also be used to create an onboarding payload directly
- * from the underlying values
+ * from the underlying values (passcode, discriminator, etc).
  */
 MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @interface MTRSetupPayload : NSObject <NSSecureCoding> /* also <NSCopying> (see below) */

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -61,18 +61,26 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
 MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @interface MTROptionalQRCodeInfo : NSObject /* <NSCopying> (see below) */
 
-- (instancetype)initWithTag:(uint8_t)tag stringValue:(NSString *)value MTR_NEWLY_AVAILABLE;
-- (instancetype)initWithTag:(uint8_t)tag int32Value:(int32_t)value MTR_NEWLY_AVAILABLE;
+/**
+ * Initializes the object with a tag and string value.
+ * The tag must be in the range 0x80 - 0xFF.
+ */
+- (instancetype)initWithTag:(NSNumber *)tag stringValue:(NSString *)value MTR_NEWLY_AVAILABLE;
+
+/**
+ * Initializes the object with a tag and int32 value.
+ * The tag must be in the range 0x80 - 0xFF.
+ */
+- (instancetype)initWithTag:(NSNumber *)tag int32Value:(int32_t)value MTR_NEWLY_AVAILABLE;
 
 @property (nonatomic, readonly, assign) MTROptionalQRCodeInfoType type MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 
 /**
- * The TLV tag number for this information item.
+ * The vendor-specific TLV tag number for this information item.
  *
- * Tags in the range 0x00 - 0x7F are reserved for Matter-defined elements.
- * Vendor-specific elements must have tags in the range 0x80 - 0xFF.
+ * Vendor-specific elements have tags in the range 0x80 - 0xFF.
  */
-@property (nonatomic, readonly, assign) uint8_t tagNumber MTR_NEWLY_AVAILABLE;
+@property (nonatomic, readonly, copy) NSNumber * tag;
 
 /**
  * The value held in this extension element,
@@ -160,18 +168,19 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @property (nonatomic, readonly, copy) NSArray<MTROptionalQRCodeInfo *> * vendorElements MTR_NEWLY_AVAILABLE;
 
 /**
- Returns the Manufacturer-specific extension element with the specified tag, if any.
+ * Returns the Manufacturer-specific extension element with the specified tag, if any.
+ * The tag must be in the range 0x80 - 0xFF.
  */
-- (nullable MTROptionalQRCodeInfo *)vendorElementWithTag:(uint8_t)tag MTR_NEWLY_AVAILABLE;
+- (nullable MTROptionalQRCodeInfo *)vendorElementWithTag:(NSNumber *)tag MTR_NEWLY_AVAILABLE;
 
 /**
  * Removes the extension element with the specified tag, if any.
+ * The tag must be in the range 0x80 - 0xFF.
  */
-- (void)removeVendorElementWithTag:(uint8_t)tag MTR_NEWLY_AVAILABLE;
+- (void)removeVendorElementWithTag:(NSNumber *)tag MTR_NEWLY_AVAILABLE;
 
 /**
  * Adds or replaces a Manufacturer-specific extension element.
- * The element must have a tag in the vendor-specific range (0x80 - 0xFF).
  */
 - (void)addOrReplaceVendorElement:(MTROptionalQRCodeInfo *)element MTR_NEWLY_AVAILABLE;
 
@@ -229,8 +238,6 @@ MTR_NEWLY_AVAILABLE
 
 @property (nonatomic, copy) NSNumber * infoType
     MTR_DEPRECATED("Please use type", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
-
-@property (nonatomic, copy) NSNumber * tag MTR_NEWLY_DEPRECATED("Please use tagNumber");
 
 - (void)setType:(MTROptionalQRCodeInfoType)type MTR_NEWLY_DEPRECATED("MTROptionalQRCodeInfo is immutable");
 - (void)setTag:(NSNumber *)tag MTR_NEWLY_DEPRECATED("MTROptionalQRCodeInfo is immutable");

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
  * setters has no effect.
  */
 MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
-@interface MTROptionalQRCodeInfo : NSObject <NSCopying>
+@interface MTROptionalQRCodeInfo : NSObject /* <NSCopying> (see below) */
 
 - (instancetype)initWithTag:(uint8_t)tag stringValue:(NSString *)value MTR_NEWLY_AVAILABLE;
 - (instancetype)initWithTag:(uint8_t)tag int32Value:(int32_t)value MTR_NEWLY_AVAILABLE;
@@ -72,7 +72,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * Tags in the range 0x00 - 0x7F are reserved for Matter-defined elements.
  * Vendor-specific elements must have tags in the range 0x80 - 0xFF.
  */
-@property (nonatomic, readonly, assign) uint8_t tagNumber;
+@property (nonatomic, readonly, assign) uint8_t tagNumber MTR_NEWLY_AVAILABLE;
 
 /**
  * The value held in this extension element,
@@ -88,6 +88,10 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 
 @end
 
+MTR_NEWLY_AVAILABLE
+@interface MTROptionalQRCodeInfo () <NSCopying>
+@end
+
 /**
  * A Matter Onboarding Payload.
  *
@@ -100,7 +104,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * from the underlying values
  */
 MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
-@interface MTRSetupPayload : NSObject <NSCopying, NSSecureCoding>
+@interface MTRSetupPayload : NSObject <NSSecureCoding> /* also <NSCopying> (see below) */
 
 /**
  * Initializes the payload object from the provide QR Code or Manual Pairing Code string.
@@ -153,23 +157,23 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 /**
  * The list of Manufacturer-specific extension elements contained in the setup code. May be empty.
  */
-@property (nonatomic, readonly, copy) NSArray<MTROptionalQRCodeInfo *> * vendorElements;
+@property (nonatomic, readonly, copy) NSArray<MTROptionalQRCodeInfo *> * vendorElements MTR_NEWLY_AVAILABLE;
 
 /**
  Returns the Manufacturer-specific extension element with the specified tag, if any.
  */
-- (nullable MTROptionalQRCodeInfo *)vendorElementWithTag:(uint8_t)tag;
+- (nullable MTROptionalQRCodeInfo *)vendorElementWithTag:(uint8_t)tag MTR_NEWLY_AVAILABLE;
 
 /**
  * Removes the extension element with the specified tag, if any.
  */
-- (void)removeVendorElementWithTag:(uint8_t)tag;
+- (void)removeVendorElementWithTag:(uint8_t)tag MTR_NEWLY_AVAILABLE;
 
 /**
  * Adds or replaces a Manufacturer-specific extension element.
  * The element must have a tag in the vendor-specific range (0x80 - 0xFF).
  */
-- (void)addOrReplaceVendorElement:(MTROptionalQRCodeInfo *)element;
+- (void)addOrReplaceVendorElement:(MTROptionalQRCodeInfo *)element MTR_NEWLY_AVAILABLE;
 
 /**
  * Generate a random Matter-valid setup PIN.
@@ -213,6 +217,10 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  */
 - (NSString * _Nullable)qrCodeString MTR_NEWLY_AVAILABLE;
 
+@end
+
+MTR_NEWLY_AVAILABLE
+@interface MTRSetupPayload () <NSCopying>
 @end
 
 @interface MTROptionalQRCodeInfo (Deprecated)

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020-2023 Project CHIP Authors
+ *    Copyright (c) 2020-2024 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef NS_OPTIONS(NSUInteger, MTRDiscoveryCapabilities) {
-    MTRDiscoveryCapabilitiesUnknown = 0, // Device capabilities are not known (e.g. all we have is a numeric code).
+    MTRDiscoveryCapabilitiesUnknown = 0, // Device capabilities are not known (e.g. we parsed a Manual Pairing Code).
     MTRDiscoveryCapabilitiesNone MTR_DEPRECATED_WITH_REPLACEMENT(
         "MTRDiscoveryCapabilitiesUnknown", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4))
     = 0,
@@ -28,7 +28,7 @@ typedef NS_OPTIONS(NSUInteger, MTRDiscoveryCapabilities) {
     MTRDiscoveryCapabilitiesBLE = 1 << 1, // Device supports BLE
     MTRDiscoveryCapabilitiesOnNetwork = 1 << 2, // Device supports On Network setup
 
-    // If new values are added here, update the "description" method to include them.
+    // Note: New values added here need to be included in MTRDiscoveryCapabilitiesAsString()
 
     MTRDiscoveryCapabilitiesAllMask
     = MTRDiscoveryCapabilitiesSoftAP | MTRDiscoveryCapabilitiesBLE | MTRDiscoveryCapabilitiesOnNetwork,
@@ -38,7 +38,7 @@ typedef NS_ENUM(NSUInteger, MTRCommissioningFlow) {
     MTRCommissioningFlowStandard = 0, // Device automatically enters commissioning mode upon power-up
     MTRCommissioningFlowUserActionRequired = 1, // Device requires a user interaction to enter commissioning mode
     MTRCommissioningFlowCustom = 2, // Commissioning steps should be retrieved from the distributed compliance ledger
-    MTRCommissioningFlowInvalid = 3,
+    MTRCommissioningFlowInvalid MTR_NEWLY_DEPRECATED("Not a valid MTRCommissioningFlow value") = 3,
 };
 
 typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
@@ -49,36 +49,76 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
 };
 
 /**
- * An optional information item present in the QR code the setup payload was
- * initialized from.
+ * An optional information item present in the setup payload.
+ *
+ * Note that while the Matter specification allows elements containing
+ * arbitrary TLV data types, this implementation currently only supports
+ * String and Int32 values.
+ *
+ * Objects of this type are immutable; calling any deprecated property
+ * setters has no effect.
  */
 MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
-@interface MTROptionalQRCodeInfo : NSObject
+@interface MTROptionalQRCodeInfo : NSObject <NSCopying>
 
-@property (nonatomic, assign) MTROptionalQRCodeInfoType type MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+- (instancetype)initWithTag:(uint8_t)tag stringValue:(NSString *)value MTR_NEWLY_AVAILABLE;
+- (instancetype)initWithTag:(uint8_t)tag int32Value:(int32_t)value MTR_NEWLY_AVAILABLE;
 
-/**
- * The numeric value of the TLV tag for this information item.
- */
-@property (nonatomic, copy) NSNumber * tag;
+@property (nonatomic, readonly, assign) MTROptionalQRCodeInfoType type MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 
 /**
- * Exactly one of integerValue and stringValue will be non-nil, depending on the
- * the value of "type".
+ * The TLV tag number for this information item.
+ *
+ * Tags in the range 0x00 - 0x7F are reserved for Matter-defined elements.
+ * Vendor-specific elements must have tags in the range 0x80 - 0xFF.
  */
-@property (nonatomic, copy, nullable) NSNumber * integerValue;
-@property (nonatomic, copy, nullable) NSString * stringValue;
+@property (nonatomic, readonly, assign) uint8_t tagNumber;
+
+/**
+ * The value held in this extension element,
+ * if `type` is an integer type, or nil otherwise.
+ */
+@property (nonatomic, readonly, copy, nullable) NSNumber * integerValue;
+
+/**
+ * The value held in this extension element,
+ * if `type` is `MTROptionalQRCodeInfoTypeString`, or nil otherwise.
+ */
+@property (nonatomic, readonly, copy, nullable) NSString * stringValue;
 
 @end
 
 /**
- * A setup payload that can be created from a numeric code or QR code and
- * serialized to a numeric code or QR code, though serializing to QR code after
- * creating from numeric code will not work, because some required information
- * will be missing.
+ * A Matter Onboarding Payload.
+ *
+ * It can be represented as a numeric Manual Pairing Code or as QR Code.
+ * The QR Code format contains more information though, so creating a
+ * QR Code from a payload that was initialized from a Manual Pairing Code
+ * will not work, because some required information will be missing.
+ *
+ * This class can also be used to create an onboarding payload directly
+ * from the underlying values
  */
 MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
-@interface MTRSetupPayload : NSObject <NSSecureCoding>
+@interface MTRSetupPayload : NSObject <NSCopying, NSSecureCoding>
+
+/**
+ * Initializes the payload object from the provide QR Code or Manual Pairing Code string.
+ * Returns nil if the payload is not valid.
+ */
+- (nullable instancetype)initWithPayload:(NSString *)payload MTR_NEWLY_AVAILABLE;
+
+/**
+ * Initializes the payload object from a QR Code string.
+ * Returns nil if the QR Code string is invalid.
+ */
+- (nullable instancetype)initWithQRCode:(NSString *)qrCodePayload MTR_NEWLY_AVAILABLE;
+
+/**
+ * Initializes the payload object from a Manual Pairing Code string.
+ * Returns nil if the pairing code is not valid.
+ */
+- (nullable instancetype)initWithManualPairingCode:(NSString *)manualCode MTR_NEWLY_AVAILABLE;
 
 @property (nonatomic, copy) NSNumber * version;
 @property (nonatomic, copy) NSNumber * vendorID;
@@ -92,19 +132,44 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  */
 @property (nonatomic, assign)
     MTRDiscoveryCapabilities discoveryCapabilities MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+
 @property (nonatomic, copy) NSNumber * discriminator;
 
 /**
  * If hasShortDiscriminator is true, the discriminator value contains just the
  * high 4 bits of the full discriminator.  For example, if
  * hasShortDiscriminator is true and discriminator is 0xA, then the full
- * discriminator can be anything in the range 0xA00 t0 0xAFF.
+ * discriminator can be anything in the range 0xA00 to 0xAFF.
  */
 @property (nonatomic, assign) BOOL hasShortDiscriminator;
+
 @property (nonatomic, copy) NSNumber * setupPasscode MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
 
+/**
+ * The value of the Serial Number extension element, if any.
+ */
 @property (nonatomic, copy, nullable) NSString * serialNumber;
-- (NSArray<MTROptionalQRCodeInfo *> * _Nullable)getAllOptionalVendorData:(NSError * __autoreleasing *)error;
+
+/**
+ * The list of Manufacturer-specific extension elements contained in the setup code. May be empty.
+ */
+@property (nonatomic, readonly, copy) NSArray<MTROptionalQRCodeInfo *> * vendorElements;
+
+/**
+ Returns the Manufacturer-specific extension element with the specified tag, if any.
+ */
+- (nullable MTROptionalQRCodeInfo *)vendorElementWithTag:(uint8_t)tag;
+
+/**
+ * Removes the extension element with the specified tag, if any.
+ */
+- (void)removeVendorElementWithTag:(uint8_t)tag;
+
+/**
+ * Adds or replaces a Manufacturer-specific extension element.
+ * The element must have a tag in the vendor-specific range (0x80 - 0xFF).
+ */
+- (void)addOrReplaceVendorElement:(MTROptionalQRCodeInfo *)element;
 
 /**
  * Generate a random Matter-valid setup PIN.
@@ -117,53 +182,79 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 + (NSNumber *)generateRandomSetupPasscode MTR_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
 
 /**
- * Create an MTRSetupPayload with the given onboarding payload.
- *
- * Will return nil on errors (e.g. if the onboarding payload cannot be parsed).
- */
-+ (MTRSetupPayload * _Nullable)setupPayloadWithOnboardingPayload:(NSString *)onboardingPayload
-                                                           error:(NSError * __autoreleasing *)error
-    MTR_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
-
-/**
  * Initialize an MTRSetupPayload with the given passcode and discriminator.
  * This will pre-set version, product id, and vendor id to 0.
  */
 - (instancetype)initWithSetupPasscode:(NSNumber *)setupPasscode
                         discriminator:(NSNumber *)discriminator MTR_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
 
-/** Get 11 digit manual entry code from the setup payload. */
-- (NSString * _Nullable)manualEntryCode;
+/**
+ * Creates a Manual Pairing Code from this setup payload.
+ * Returns nil if this payload cannot be represented as a valid Manual Pairing Code.
+ *
+ * The following properties must be populated for a valid Manual Pairing Code:
+ *  - setupPasscode
+ *  - discriminator (short or long)
+ *
+ * In most cases the pairing code will be 11 digits long. If the payload indicates
+ * a `commissioningFlow` other than `MTRCommissioningFlowStandard`, a 21 digit code
+ * will be produced that includes the vendorID and productID values.
+ */
+- (nullable NSString *)manualEntryCode;
 
 /**
- * Get a QR code from the setup payload.
+ * Creates a QR Code payload from this setup payload.
+ * Returns nil if this payload cannot be represented as a valid QR Code.
  *
- * Returns nil on failure (e.g. if the setup payload does not have all the
- * information a QR code needs).
+ * The following properties must be populated for a valid QR Code:
+ * - setupPasscode
+ * - discriminator (must be long)
+ * - discoveryCapabilities (not MTRDiscoveryCapabilitiesUnknown)
  */
-- (NSString * _Nullable)qrCodeString:(NSError * __autoreleasing *)error
-    MTR_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
+- (NSString * _Nullable)qrCodeString MTR_NEWLY_AVAILABLE;
 
 @end
 
 @interface MTROptionalQRCodeInfo (Deprecated)
 
-@property (nonatomic, copy)
-    NSNumber * infoType MTR_DEPRECATED("Please use type", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+- (instancetype)init MTR_NEWLY_DEPRECATED("Please use -initWithTag:...value:");
 
+@property (nonatomic, copy) NSNumber * infoType
+    MTR_DEPRECATED("Please use type", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+
+@property (nonatomic, copy) NSNumber * tag MTR_NEWLY_DEPRECATED("Please use tagNumber");
+
+- (void)setType:(MTROptionalQRCodeInfoType)type MTR_NEWLY_DEPRECATED("MTROptionalQRCodeInfo is immutable");
+- (void)setTag:(NSNumber *)tag MTR_NEWLY_DEPRECATED("MTROptionalQRCodeInfo is immutable");
+- (void)setIntegerValue:(NSNumber *)integerValue MTR_NEWLY_DEPRECATED("MTROptionalQRCodeInfo is immutable");
+- (void)setStringValue:(NSString *)stringValue MTR_NEWLY_DEPRECATED("MTROptionalQRCodeInfo is immutable");
 @end
 
 @interface MTRSetupPayload (Deprecated)
 
 @property (nonatomic, copy, nullable) NSNumber * rendezvousInformation MTR_DEPRECATED(
     "Please use discoveryCapabilities", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+
 @property (nonatomic, copy) NSNumber * setUpPINCode MTR_DEPRECATED(
     "Please use setupPasscode", ios(16.1, 16.4), macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
 
-- (instancetype)init MTR_DEPRECATED("Please use initWithSetupPasscode or setupPayloadWithOnboardingPayload", ios(16.1, 16.4),
+- (instancetype)init MTR_DEPRECATED("Please use -initWithSetupPasscode:discriminator: or -initWithPayload:", ios(16.1, 16.4),
     macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
-+ (instancetype)new MTR_DEPRECATED("Please use initWithSetupPasscode or setupPayloadWithOnboardingPayload", ios(16.1, 16.4),
+
++ (instancetype)new MTR_DEPRECATED("Please use -initWithSetupPasscode:discriminator: or -initWithPayload:", ios(16.1, 16.4),
     macos(13.0, 13.3), watchos(9.1, 9.4), tvos(16.1, 16.4));
+
++ (MTRSetupPayload * _Nullable)setupPayloadWithOnboardingPayload:(NSString *)onboardingPayload
+                                                           error:(NSError * __autoreleasing *)error
+    MTR_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
+        MTR_NEWLY_DEPRECATED("Please use -initWithPayload:");
+
+- (NSString * _Nullable)qrCodeString:(NSError * __autoreleasing *)error
+    MTR_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
+        MTR_NEWLY_DEPRECATED("Please use -qrCodeString");
+
+- (NSArray<MTROptionalQRCodeInfo *> * _Nullable)getAllOptionalVendorData:(NSError * __autoreleasing *)error
+    MTR_NEWLY_DEPRECATED("Please use -vendorElements");
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -120,18 +120,6 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  */
 - (nullable instancetype)initWithPayload:(NSString *)payload MTR_NEWLY_AVAILABLE;
 
-/**
- * Initializes the payload object from a QR Code string.
- * Returns nil if the QR Code string is invalid.
- */
-- (nullable instancetype)initWithQRCode:(NSString *)qrCodePayload MTR_NEWLY_AVAILABLE;
-
-/**
- * Initializes the payload object from a Manual Pairing Code string.
- * Returns nil if the pairing code is not valid.
- */
-- (nullable instancetype)initWithManualPairingCode:(NSString *)manualCode MTR_NEWLY_AVAILABLE;
-
 @property (nonatomic, copy) NSNumber * version;
 @property (nonatomic, copy) NSNumber * vendorID;
 @property (nonatomic, copy) NSNumber * productID;

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -19,251 +19,503 @@
 
 #import "MTRError_Internal.h"
 #import "MTRFramework.h"
-#import "MTROnboardingPayloadParser.h"
+#import "MTRLogging_Internal.h"
+#import "MTRUtilities.h"
 
 #include <setup_payload/ManualSetupPayloadGenerator.h>
+#include <setup_payload/ManualSetupPayloadParser.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <setup_payload/QRCodeSetupPayloadParser.h>
 #include <setup_payload/SetupPayload.h>
 #include <string>
 
-@implementation MTROptionalQRCodeInfo
+MTR_DIRECT_MEMBERS
+@implementation MTROptionalQRCodeInfo {
+    chip::OptionalQRCodeInfo _info;
+}
+
+- (instancetype)initWithTag:(uint8_t)tag int32Value:(int32_t)value
+{
+    self = [super init];
+    _info.type = chip::optionalQRCodeInfoTypeInt32;
+    _info.tag = tag;
+    _info.int32 = value;
+    return self;
+}
+
+- (instancetype)initWithTag:(uint8_t)tag stringValue:(NSString *)value
+{
+    self = [super init];
+    _info.type = chip::optionalQRCodeInfoTypeString;
+    _info.tag = tag;
+    _info.data = value.UTF8String;
+    return self;
+}
+
+- (nullable instancetype)initWithQRCodeInfo:(chip::OptionalQRCodeInfo const &)info
+{
+    self = [super init];
+    _info = info;
+    // Don't expose objects with an invalid type.
+    VerifyOrReturnValue(self.type != MTROptionalQRCodeInfoTypeUnknown, nil);
+    return self;
+}
+
+- (CHIP_ERROR)addAsVendorElementTo:(chip::SetupPayload &)payload
+{
+    switch (_info.type) {
+    case chip::optionalQRCodeInfoTypeString:
+        return payload.addOptionalVendorData(_info.tag, _info.data);
+    case chip::optionalQRCodeInfoTypeInt32:
+        return payload.addOptionalVendorData(_info.tag, _info.int32);
+    default:
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+}
+
+- (MTROptionalQRCodeInfoType)type
+{
+    // The way OptionalQRCodeInfo uses what are effectively C type identifiers (uint32 etc)
+    // rather than TLV types is not ideal. If we add support for additional integer types
+    // we should consider replacing MTROptionalQRCodeInfoTypeInt32 with
+    // MTROptionalQRCodeInfoTypeInteger and hiding the low-level C representation.
+    switch (_info.type) {
+    case chip::optionalQRCodeInfoTypeString:
+        return MTROptionalQRCodeInfoTypeString;
+    case chip::optionalQRCodeInfoTypeInt32:
+        return MTROptionalQRCodeInfoTypeInt32;
+    // No 'default:' so we get a warning if new types are added.
+    // OptionalQRCodeInfo does not support these types
+    case chip::optionalQRCodeInfoTypeInt64:
+    case chip::optionalQRCodeInfoTypeUInt32:
+    case chip::optionalQRCodeInfoTypeUInt64:
+    // We should never see the unknown type
+    case chip::optionalQRCodeInfoTypeUnknown:
+        /* fall through */;
+    }
+    return MTROptionalQRCodeInfoTypeUnknown;
+}
+
+- (uint8_t)tagNumber
+{
+    return _info.tag;
+}
+
+- (NSNumber *)integerValue
+{
+    VerifyOrReturnValue(_info.type == chip::optionalQRCodeInfoTypeInt32, nil);
+    return @(_info.int32);
+}
+
+- (NSString *)stringValue
+{
+    VerifyOrReturnValue(_info.type == chip::optionalQRCodeInfoTypeString, nil);
+    return [NSString stringWithUTF8String:_info.data.c_str()];
+}
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    return self; // immutable
+}
+
+- (NSUInteger)hash
+{
+    return _info.type << 8 | _info.tag;
+}
+
+- (BOOL)isEqual:(id)object
+{
+    VerifyOrReturnValue([object class] == [self class], NO);
+    MTROptionalQRCodeInfo * other = object;
+    VerifyOrReturnValue(_info.tag == other->_info.tag, NO);
+    VerifyOrReturnValue(_info.type == other->_info.type, NO);
+    VerifyOrReturnValue(_info.int32 == other->_info.int32, NO);
+    VerifyOrReturnValue(_info.data == other->_info.data, NO);
+    return YES;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"0x%02x=%@", self.tagNumber, self.integerValue ?: self.stringValue];
+}
+
 @end
+
+static constexpr uint8_t kShortDiscriminatorMask = (1 << chip::SetupDiscriminator::kShortBits) - 1;
+static constexpr uint16_t kLongDiscriminatorMask = (1 << chip::SetupDiscriminator::kLongBits) - 1;
+
+static MTRDiscoveryCapabilities KnownDiscoveryCapabilities(NSUInteger value)
+{
+    // A known but 0 value cannot be represented by MTRDiscoveryCapabilities
+    // since MTRDiscoveryCapabilitiesUnknown represents an absent value.
+    // However such a 0 value is not logically valid, because OnNetwork must
+    // always be supported. So just return that if we get a value of 0.
+    return (value != MTRDiscoveryCapabilitiesUnknown ? value : MTRDiscoveryCapabilitiesOnNetwork);
+}
+
+static NSString * MTRDiscoveryCapabilitiesAsString(MTRDiscoveryCapabilities value)
+{
+    VerifyOrReturnValue(value != MTRDiscoveryCapabilitiesUnknown, @"Unknown");
+    NSMutableString * capabilities = [NSMutableString string];
+    if (value & MTRDiscoveryCapabilitiesSoftAP) {
+        [capabilities appendString:@"|SoftAP"];
+        value &= ~MTRDiscoveryCapabilitiesSoftAP;
+    }
+    if (value & MTRDiscoveryCapabilitiesBLE) {
+        [capabilities appendString:@"|BLE"];
+        value &= ~MTRDiscoveryCapabilitiesBLE;
+    }
+    if (value & MTRDiscoveryCapabilitiesOnNetwork) {
+        [capabilities appendString:@"|OnNetwork"];
+        value &= ~MTRDiscoveryCapabilitiesOnNetwork;
+    }
+    if (value != 0) {
+        [capabilities appendFormat:@"|0x%llx", (unsigned long long) value];
+    }
+    return [capabilities substringFromIndex:1];
+}
 
 MTR_DIRECT_MEMBERS
 @implementation MTRSetupPayload {
-    chip::SetupPayload _chipSetupPayload;
+    // Apart from the additional logic to handle discriminators detailed below,
+    // this class is simply a wrapper around this underlying SetupPayload.
+    chip::SetupPayload _payload;
+
+    // SetupPayload deals with the discriminator value and its shortness as a composite
+    // SetupDiscriminator value, which is arguably a tidier API than letting clients
+    // set a value first and only later tell us whether it's long or short. But that is
+    // what our API does, so we need to continue to support it. To make this work, we
+    // keep track of the potentially-long value that was set by the client.
+    NSNumber * _Nullable _shadowDiscriminator;
 }
 
 + (void)initialize
 {
-    // Need to make sure we set up Platform memory stuff before we start
-    // serializing payloads.
+    // Some aspects of working with chip::SetupPayload use Platform memory primitives.
     MTRFrameworkInit();
 }
 
-- (MTRDiscoveryCapabilities)convertRendezvousFlags:(const chip::Optional<chip::RendezvousInformationFlags> &)value
+- (nullable instancetype)initWithPayload:(NSString *)payload
 {
-    if (!value.HasValue()) {
-        return MTRDiscoveryCapabilitiesUnknown;
-    }
-
-    NSUInteger flags = 0;
-    if (value.Value().Has(chip::RendezvousInformationFlag::kBLE)) {
-        flags |= MTRDiscoveryCapabilitiesBLE;
-    }
-    if (value.Value().Has(chip::RendezvousInformationFlag::kSoftAP)) {
-        flags |= MTRDiscoveryCapabilitiesSoftAP;
-    }
-    if (value.Value().Has(chip::RendezvousInformationFlag::kOnNetwork)) {
-        flags |= MTRDiscoveryCapabilitiesOnNetwork;
-    }
-    if (flags == MTRDiscoveryCapabilitiesUnknown) {
-        // OnNetwork has to be supported!
-        flags = MTRDiscoveryCapabilitiesOnNetwork;
-    }
-    return flags;
+    return ([payload hasPrefix:@"MT:"]) ? [self initWithQRCode:payload] : [self initWithManualPairingCode:payload];
 }
 
-+ (chip::Optional<chip::RendezvousInformationFlags>)convertDiscoveryCapabilities:(MTRDiscoveryCapabilities)value
+- (CHIP_ERROR)initializeFromQRCode:(NSString *)qrCode
 {
-    if (value == MTRDiscoveryCapabilitiesUnknown) {
-        return chip::NullOptional;
-    }
-
-    chip::RendezvousInformationFlags flags;
-    if (value & MTRDiscoveryCapabilitiesBLE) {
-        flags.Set(chip::RendezvousInformationFlag::kBLE);
-    }
-    if (value & MTRDiscoveryCapabilitiesSoftAP) {
-        flags.Set(chip::RendezvousInformationFlag::kSoftAP);
-    }
-    if (value & MTRDiscoveryCapabilitiesOnNetwork) {
-        flags.Set(chip::RendezvousInformationFlag::kOnNetwork);
-    }
-    return chip::MakeOptional(flags);
+    std::string string([(qrCode ?: @"") UTF8String]); // handle nil gracefully
+    chip::QRCodeSetupPayloadParser parser(string);
+    return parser.populatePayload(_payload);
 }
 
-- (MTRCommissioningFlow)convertCommissioningFlow:(chip::CommissioningFlow)value
+- (nullable instancetype)initWithQRCode:(NSString *)qrCodePayload
 {
-    if (value == chip::CommissioningFlow::kStandard) {
-        return MTRCommissioningFlowStandard;
+    self = [super init];
+    CHIP_ERROR err = [self initializeFromQRCode:qrCodePayload];
+    if (err != CHIP_NO_ERROR) {
+        MTR_LOG_ERROR("Failed to parse QR Code payload: %" CHIP_ERROR_FORMAT, err.Format());
+        return nil;
     }
-    if (value == chip::CommissioningFlow::kUserActionRequired) {
-        return MTRCommissioningFlowUserActionRequired;
+    if (!_payload.isValidQRCodePayload(chip::PayloadContents::ValidationMode::kConsume)) {
+        MTR_LOG_ERROR("Invalid QR Code payload");
+        return nil;
     }
-    if (value == chip::CommissioningFlow::kCustom) {
-        return MTRCommissioningFlowCustom;
-    }
-    return MTRCommissioningFlowInvalid;
+
+    return self;
 }
 
-+ (chip::CommissioningFlow)unconvertCommissioningFlow:(MTRCommissioningFlow)value
+- (nullable instancetype)initWithManualPairingCode:(NSString *)manualCode
 {
-    if (value == MTRCommissioningFlowStandard) {
-        return chip::CommissioningFlow::kStandard;
-    }
-    if (value == MTRCommissioningFlowUserActionRequired) {
-        return chip::CommissioningFlow::kUserActionRequired;
-    }
-    if (value == MTRCommissioningFlowCustom) {
-        return chip::CommissioningFlow::kCustom;
-    }
-    // It's MTRCommissioningFlowInvalid ... now what?  But in practice
-    // this is not called when we have MTRCommissioningFlowInvalid.
-    return chip::CommissioningFlow::kStandard;
-}
+    self = [super init];
 
-- (instancetype)initWithSetupPayload:(chip::SetupPayload)setupPayload
-{
-    if (self = [super init]) {
-        _chipSetupPayload = setupPayload;
-        _version = [NSNumber numberWithUnsignedChar:setupPayload.version];
-        _vendorID = [NSNumber numberWithUnsignedShort:setupPayload.vendorID];
-        _productID = [NSNumber numberWithUnsignedShort:setupPayload.productID];
-        _commissioningFlow = [self convertCommissioningFlow:setupPayload.commissioningFlow];
-        _discoveryCapabilities = [self convertRendezvousFlags:setupPayload.rendezvousInformation];
-        _hasShortDiscriminator = setupPayload.discriminator.IsShortDiscriminator();
-        if (_hasShortDiscriminator) {
-            _discriminator = [NSNumber numberWithUnsignedShort:setupPayload.discriminator.GetShortValue()];
-        } else {
-            _discriminator = [NSNumber numberWithUnsignedShort:setupPayload.discriminator.GetLongValue()];
-        }
-        _setupPasscode = [NSNumber numberWithUnsignedInt:setupPayload.setUpPINCode];
-
-        [self getSerialNumber:setupPayload];
+    std::string string([(manualCode ?: @"") UTF8String]); // handle nil gracefully
+    chip::ManualSetupPayloadParser parser(string);
+    CHIP_ERROR err = parser.populatePayload(_payload);
+    if (err != CHIP_NO_ERROR) {
+        MTR_LOG_ERROR("Failed to parse Manual Pairing Code: %" CHIP_ERROR_FORMAT, err.Format());
+        return nil;
     }
+    if (!_payload.isValidManualCode(chip::PayloadContents::ValidationMode::kConsume)) {
+        MTR_LOG_ERROR("Invalid Manual Pairing Code");
+        return nil;
+    }
+
     return self;
 }
 
 - (instancetype)initWithSetupPasscode:(NSNumber *)setupPasscode discriminator:(NSNumber *)discriminator
 {
-    if (self = [super init]) {
-        _version = @(0); // Only supported Matter version so far.
-        _vendorID = @(0); // Not available.
-        _productID = @(0); // Not available.
-        _commissioningFlow = MTRCommissioningFlowStandard;
-        // We are using a long discriminator, so have to have a known
-        // discoveryCapabilities to be a valid payload.  Just default to "try
-        // all discovery methods".
-        _discoveryCapabilities = MTRDiscoveryCapabilitiesAllMask;
-        _hasShortDiscriminator = NO;
-        _discriminator = discriminator;
-        _setupPasscode = setupPasscode;
-        _serialNumber = nil;
-    }
+    self = [super init];
+
+    // A default-constructed SetupPayload already has most of the expected
+    // default values. Set discoveryCapabilities to "all known methods" so
+    // we're representing a valid QR Code payload.
+    self.setupPasscode = setupPasscode;
+    self.discriminator = discriminator;
+    self.discoveryCapabilities = MTRDiscoveryCapabilitiesAllMask;
+
     return self;
 }
 
-- (void)getSerialNumber:(chip::SetupPayload)setupPayload
+- (instancetype)initWithSetupPayload:(chip::SetupPayload)setupPayload
 {
-    std::string serialNumberC;
-    CHIP_ERROR err = setupPayload.getSerialNumber(serialNumberC);
-    if (err == CHIP_NO_ERROR) {
-        _serialNumber = [NSString stringWithUTF8String:serialNumberC.c_str()];
-    }
+    self = [super init];
+    _payload = setupPayload;
+    return self;
 }
 
-- (NSArray<MTROptionalQRCodeInfo *> *)getAllOptionalVendorData:(NSError * __autoreleasing *)error
+#pragma mark - Mutable properties
+
+- (NSNumber *)version
 {
-    NSMutableArray<MTROptionalQRCodeInfo *> * allOptionalData = [NSMutableArray new];
-    std::vector<chip::OptionalQRCodeInfo> chipOptionalData = _chipSetupPayload.getAllOptionalVendorData();
-    for (chip::OptionalQRCodeInfo chipInfo : chipOptionalData) {
-        MTROptionalQRCodeInfo * info = [MTROptionalQRCodeInfo new];
-        info.tag = [NSNumber numberWithUnsignedChar:chipInfo.tag];
-        switch (chipInfo.type) {
-        case chip::optionalQRCodeInfoTypeString:
-            info.type = MTROptionalQRCodeInfoTypeString;
-            info.stringValue = [NSString stringWithUTF8String:chipInfo.data.c_str()];
-            break;
-        case chip::optionalQRCodeInfoTypeInt32:
-            info.type = MTROptionalQRCodeInfoTypeInt32;
-            info.integerValue = [NSNumber numberWithInt:chipInfo.int32];
-            break;
-        default:
-            if (error) {
-                *error = [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidArgument userInfo:nil];
-            }
-            return nil;
-        }
-        [allOptionalData addObject:info];
-    }
-    return allOptionalData;
+    return @(_payload.version);
 }
 
-+ (NSUInteger)generateRandomPIN
+- (void)setVersion:(NSNumber *)version
 {
-    return [[MTRSetupPayload generateRandomSetupPasscode] unsignedIntValue];
+    _payload.version = static_cast<decltype(_payload.version)>(version.unsignedIntegerValue);
 }
 
-+ (NSNumber *)generateRandomSetupPasscode
+- (NSNumber *)vendorID
 {
-    do {
-        // Make sure the thing we generate is in the right range.
-        uint32_t setupPIN = arc4random_uniform(chip::kSetupPINCodeMaximumValue) + 1;
-        if (chip::SetupPayload::IsValidSetupPIN(setupPIN)) {
-            return @(setupPIN);
-        }
-
-        // We got pretty unlikely with our random number generation.  Just try
-        // again.  The chance that this loop does not terminate in a reasonable
-        // amount of time is astronomically low, assuming arc4random_uniform is not
-        // broken.
-    } while (true);
-
-    // Not reached.
-    return @(chip::kSetupPINCodeUndefinedValue);
+    return @(_payload.vendorID);
 }
 
-+ (bool)isQRCode:(NSString *)onboardingPayload
+- (void)setVendorID:(NSNumber *)vendorID
 {
-    return [onboardingPayload hasPrefix:@"MT:"];
+    _payload.vendorID = static_cast<decltype(_payload.vendorID)>(vendorID.unsignedIntegerValue);
 }
 
-+ (MTRSetupPayload * _Nullable)setupPayloadWithOnboardingPayload:(NSString *)onboardingPayload
-                                                           error:(NSError * __autoreleasing *)error
+- (NSNumber *)productID
 {
-    // TODO: Do we actually need the MTROnboardingPayloadParser abstraction?
-    MTRSetupPayload * payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:onboardingPayload error:error];
-    if (payload == nil) {
-        return nil;
-    }
+    return @(_payload.productID);
+}
 
-    bool isQRCode = [MTRSetupPayload isQRCode:onboardingPayload];
-    bool validPayload;
-    if (isQRCode) {
-        validPayload = payload->_chipSetupPayload.isValidQRCodePayload();
+- (void)setProductID:(NSNumber *)productID
+{
+    _payload.productID = static_cast<decltype(_payload.productID)>(productID.unsignedIntegerValue);
+}
+
+- (MTRCommissioningFlow)commissioningFlow
+{
+    // To avoid ending up with special logic to handle MTRCommissioningFlowInvalid,
+    // we simply cast between MTRCommissioningFlow and chip::CommissioningFlow.
+    // Both types represent the same set of values defined in the Matter spec.
+    using chip::CommissioningFlow;
+    static_assert(static_cast<CommissioningFlow>(MTRCommissioningFlowStandard) == CommissioningFlow::kStandard);
+    static_assert(static_cast<CommissioningFlow>(MTRCommissioningFlowUserActionRequired) == CommissioningFlow::kUserActionRequired);
+    static_assert(static_cast<CommissioningFlow>(MTRCommissioningFlowCustom) == CommissioningFlow::kCustom);
+    return static_cast<MTRCommissioningFlow>(_payload.commissioningFlow);
+}
+
+- (void)setCommissioningFlow:(MTRCommissioningFlow)commissioningFlow
+{
+    _payload.commissioningFlow = static_cast<chip::CommissioningFlow>(commissioningFlow);
+}
+
+- (MTRDiscoveryCapabilities)discoveryCapabilities
+{
+    VerifyOrReturnValue(_payload.rendezvousInformation.HasValue(), MTRDiscoveryCapabilitiesUnknown);
+
+    // MTRDiscoveryCapabilities and chip::RendezvousInformationFlag represent
+    // the same set of bit flags from the Matter spec, so we can simply cast.
+    using RendezvousFlag = chip::RendezvousInformationFlag;
+    static_assert(static_cast<RendezvousFlag>(MTRDiscoveryCapabilitiesSoftAP) == RendezvousFlag::kSoftAP);
+    static_assert(static_cast<RendezvousFlag>(MTRDiscoveryCapabilitiesBLE) == RendezvousFlag::kBLE);
+    static_assert(static_cast<RendezvousFlag>(MTRDiscoveryCapabilitiesOnNetwork) == RendezvousFlag::kOnNetwork);
+    auto value = static_cast<MTRDiscoveryCapabilities>(_payload.rendezvousInformation.Value().Raw());
+
+    // Ensure a known (HasValue()) but 0 value does not map to MTRDiscoveryCapabilitiesUnknown.
+    return KnownDiscoveryCapabilities(value);
+}
+
+- (void)setDiscoveryCapabilities:(MTRDiscoveryCapabilities)discoveryCapabilities
+{
+    if (discoveryCapabilities == MTRDiscoveryCapabilitiesUnknown) {
+        _payload.rendezvousInformation.ClearValue();
     } else {
-        validPayload = payload->_chipSetupPayload.isValidManualCode();
+        auto flags = static_cast<chip::RendezvousInformationFlags::IntegerType>(discoveryCapabilities);
+        _payload.rendezvousInformation.SetValue(chip::RendezvousInformationFlags(flags));
     }
+}
 
-    if (!validPayload) {
-        if (error) {
-            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_ARGUMENT logContext:onboardingPayload];
+- (NSNumber *)discriminator
+{
+    VerifyOrReturnValue(_shadowDiscriminator == nil, _shadowDiscriminator);
+    auto & pd = _payload.discriminator;
+    return @(pd.IsShortDiscriminator() ? pd.GetShortValue() : pd.GetLongValue());
+}
+
+- (void)setDiscriminator:(uint16_t)discriminator isShort:(BOOL)isShort
+{
+    if (isShort) {
+        _payload.discriminator.SetShortValue(discriminator & kShortDiscriminatorMask);
+        _shadowDiscriminator = @(discriminator); // keep as a shadow value
+    } else {
+        _payload.discriminator.SetLongValue(discriminator);
+        _shadowDiscriminator = nil; // no need to keep a shadow copy
+    }
+}
+
+- (void)setDiscriminator:(NSNumber *)discriminator
+{
+    // Truncate down to the range of a long discriminator. Then update
+    // our SetupPayload with the value, but keep the current shortness.
+    uint16_t value = discriminator.unsignedIntegerValue & kLongDiscriminatorMask;
+    [self setDiscriminator:value isShort:self.hasShortDiscriminator];
+}
+
+- (BOOL)hasShortDiscriminator
+{
+    return _payload.discriminator.IsShortDiscriminator();
+}
+
+- (void)setHasShortDiscriminator:(BOOL)hasShortDiscriminator
+{
+    VerifyOrReturn(hasShortDiscriminator != self.hasShortDiscriminator);
+    [self setDiscriminator:self.discriminator.unsignedShortValue isShort:hasShortDiscriminator];
+}
+
+- (NSNumber *)setupPasscode
+{
+    return @(_payload.setUpPINCode);
+}
+
+- (void)setSetupPasscode:(NSNumber *)setupPasscode
+{
+    _payload.setUpPINCode = static_cast<decltype(_payload.setUpPINCode)>(setupPasscode.unsignedIntegerValue);
+}
+
+- (nullable NSString *)serialNumber
+{
+    std::string value;
+    VerifyOrReturnValue(_payload.getSerialNumber(value) == CHIP_NO_ERROR, nil);
+    return [NSString stringWithUTF8String:value.c_str()];
+}
+
+- (void)setSerialNumber:(nullable NSString *)serialNumber
+{
+    if (serialNumber) {
+        NSString * existing = self.serialNumber;
+        if (existing) {
+            // The underlying TLV tag can be encoded as either a string or an integer,
+            // avoid changing it if the represented serial number is not changing.
+            VerifyOrReturn(![existing isEqualToString:serialNumber]);
+            _payload.removeSerialNumber();
         }
-        return nil;
+        CHIP_ERROR err = _payload.addSerialNumber(serialNumber.UTF8String);
+        if (err != CHIP_NO_ERROR) {
+            MTR_LOG_ERROR("Ignoring unexpected error in SetupPayload::addSerialNumber: %" CHIP_ERROR_FORMAT, err.Format());
+        }
+    } else {
+        _payload.removeSerialNumber();
     }
+}
 
-    return payload;
+- (NSArray<MTROptionalQRCodeInfo *> *)vendorElements
+{
+    std::vector<chip::OptionalQRCodeInfo> elements = _payload.getAllOptionalVendorData();
+    VerifyOrReturnValue(!elements.empty(), @[]);
+    NSMutableArray<MTROptionalQRCodeInfo *> * infos = [[NSMutableArray alloc] initWithCapacity:elements.size()];
+    for (auto const & element : elements) {
+        MTROptionalQRCodeInfo * info = [[MTROptionalQRCodeInfo alloc] initWithQRCodeInfo:element];
+        if (info != nil) { // ignore invalid elements (there shouldn't be any)
+            [infos addObject:info];
+        }
+    }
+    return infos;
+}
+
+- (MTROptionalQRCodeInfo *)vendorElementWithTag:(uint8_t)tag
+{
+    chip::OptionalQRCodeInfo element;
+    VerifyOrReturnValue(_payload.getOptionalVendorData(tag, element) == CHIP_NO_ERROR, nil);
+    return [[MTROptionalQRCodeInfo alloc] initWithQRCodeInfo:element];
+}
+
+- (void)removeVendorElementWithTag:(uint8_t)tag
+{
+    _payload.removeOptionalVendorData(tag);
+}
+
+- (void)addOrReplaceVendorElement:(MTROptionalQRCodeInfo *)element
+{
+    MTRVerifyArgumentOrDie(chip::SetupPayload::IsVendorTag(element.tagNumber), @"element.tagNumber");
+    CHIP_ERROR err = [element addAsVendorElementTo:_payload];
+    VerifyOrDieWithMsg(err == CHIP_NO_ERROR, NotSpecified, "Internal error: %" CHIP_ERROR_FORMAT, err.Format());
+}
+
+#pragma mark - Export methods
+
+- (nullable NSString *)manualEntryCode
+{
+    chip::ManualSetupPayloadGenerator generator(_payload);
+    std::string result;
+    VerifyOrReturnValue(generator.payloadDecimalStringRepresentation(result) == CHIP_NO_ERROR, nil);
+    return [NSString stringWithUTF8String:result.c_str()];
+}
+
+- (nullable NSString *)qrCodeString
+{
+    return [self qrCodeStringSkippingValidation:NO];
+}
+
+- (nullable NSString *)qrCodeStringSkippingValidation:(BOOL)allowInvalid
+{
+    chip::QRCodeSetupPayloadGenerator generator(_payload);
+    generator.SetAllowInvalidPayload(allowInvalid);
+    std::string result;
+    CHIP_ERROR err = generator.payloadBase38RepresentationWithAutoTLVBuffer(result);
+    if (allowInvalid) {
+        // Encoding should always work if invalid payloads are allowed
+        VerifyOrDieWithMsg(err == CHIP_NO_ERROR, NotSpecified, "Internal error: %" CHIP_ERROR_FORMAT, err.Format());
+    } else {
+        VerifyOrReturnValue(err == CHIP_NO_ERROR, nil);
+    }
+    return [NSString stringWithUTF8String:result.c_str()];
+}
+
+#pragma mark - Miscellaneous
+
+- (id)copyWithZone:(NSZone *)zone
+{
+    MTRSetupPayload * copy = [[MTRSetupPayload alloc] initWithSetupPayload:_payload];
+    copy->_shadowDiscriminator = _shadowDiscriminator;
+    return copy;
+}
+
+- (NSUInteger)hash
+{
+    return self.discriminator.unsignedIntegerValue;
+}
+
+- (BOOL)isEqual:(id)object
+{
+    VerifyOrReturnValue([object class] == [self class], NO);
+    MTRSetupPayload * other = object;
+    VerifyOrReturnValue(_payload == other->_payload, NO);
+    VerifyOrReturnValue(MTREqualObjects(_shadowDiscriminator, other->_shadowDiscriminator), NO);
+    return YES;
 }
 
 - (NSString *)description
 {
-    NSMutableArray<NSString *> * capabilities = [NSMutableArray array];
-    if (self.discoveryCapabilities & MTRDiscoveryCapabilitiesSoftAP) {
-        [capabilities addObject:@"SoftAP"];
-    }
-    if (self.discoveryCapabilities & MTRDiscoveryCapabilitiesBLE) {
-        [capabilities addObject:@"BLE"];
-    }
-    if (self.discoveryCapabilities & MTRDiscoveryCapabilitiesOnNetwork) {
-        [capabilities addObject:@"OnNetwork"];
-    }
-    if (capabilities.count == 0) {
-        [capabilities addObject:@"Unknown"];
+    // Note: The description does not include the passcode for security reasons!
+
+    NSMutableString * result = [NSMutableString stringWithFormat:@"<MTRSetupPayload: discriminator=0x%0*x",
+                                                (self.hasShortDiscriminator ? 1 : 3), self.discriminator.unsignedIntValue];
+
+    auto capabilities = self.discoveryCapabilities;
+    if (capabilities != MTRDiscoveryCapabilitiesUnknown) {
+        [result appendFormat:@" discoveryCapabilities=%@", MTRDiscoveryCapabilitiesAsString(capabilities)];
     }
 
-    return [NSString stringWithFormat:@"<MTRSetupPayload: discriminator=0x%x hasShortDiscriminator=%@ discoveryCapabilities=%@>",
-                     self.discriminator.unsignedIntValue, self.hasShortDiscriminator ? @"YES" : @"NO", [capabilities componentsJoinedByString:@"|"]];
+    auto flow = self.commissioningFlow;
+    if (flow != MTRCommissioningFlowStandard) {
+        [result appendFormat:@" commissioningFlow=0x%llx", (unsigned long long) flow];
+    }
+
+    [result appendString:@">"];
+    return result;
 }
 
 #pragma mark - NSSecureCoding
@@ -272,11 +524,12 @@ static NSString * const MTRSetupPayloadCodingKeyVersion = @"MTRSP.ck.version";
 static NSString * const MTRSetupPayloadCodingKeyVendorID = @"MTRSP.ck.vendorID";
 static NSString * const MTRSetupPayloadCodingKeyProductID = @"MTRSP.ck.productID";
 static NSString * const MTRSetupPayloadCodingKeyCommissioningFlow = @"MTRSP.ck.commissioningFlow";
-static NSString * const MTRSetupPayloadCodingKeyDiscoveryCapabilities = @"MTRSP.ck.rendezvousFlags";
+static NSString * const MTRSetupPayloadCodingKeyRendevouzInformation = @"MTRSP.ck.rendezvousFlags";
 static NSString * const MTRSetupPayloadCodingKeyHasShortDiscriminator = @"MTRSP.ck.hasShortDiscriminator";
 static NSString * const MTRSetupPayloadCodingKeyDiscriminator = @"MTRSP.ck.discriminator";
 static NSString * const MTRSetupPayloadCodingKeySetupPasscode = @"MTRSP.ck.setupPINCode";
 static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serialNumber";
+static NSString * const MTRSetupPayloadCodingKeyQRCode = @"qr";
 
 + (BOOL)supportsSecureCoding
 {
@@ -285,162 +538,94 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
+    [coder encodeObject:[self qrCodeStringSkippingValidation:YES] forKey:MTRSetupPayloadCodingKeyQRCode];
     [coder encodeObject:self.version forKey:MTRSetupPayloadCodingKeyVersion];
     [coder encodeObject:self.vendorID forKey:MTRSetupPayloadCodingKeyVendorID];
     [coder encodeObject:self.productID forKey:MTRSetupPayloadCodingKeyProductID];
-    // Casts are safe because commissioning flow, discoveryCapabilities, and
-    // hasShortDiscriminator values are all pretty small and non-negative.
-    [coder encodeInteger:static_cast<NSInteger>(self.commissioningFlow) forKey:MTRSetupPayloadCodingKeyCommissioningFlow];
-    // We used to encode the discovery capabilities as an NSNumber object, with
-    // nil representing "unknown".  Keep doing that, for backwards compat.
-    [coder encodeObject:[MTRSetupPayload _boxDiscoveryCapabilities:self.discoveryCapabilities]
-                 forKey:MTRSetupPayloadCodingKeyDiscoveryCapabilities];
-    [coder encodeInteger:static_cast<NSInteger>(self.hasShortDiscriminator) forKey:MTRSetupPayloadCodingKeyHasShortDiscriminator];
+    [coder encodeInteger:self.commissioningFlow forKey:MTRSetupPayloadCodingKeyCommissioningFlow];
+    // For compatibility reasons, keep encoding rendevouzInformation instead of discoveryCapabilities
+    [coder encodeObject:self.rendezvousInformation forKey:MTRSetupPayloadCodingKeyRendevouzInformation];
+    [coder encodeInteger:(self.hasShortDiscriminator ? 1 : 0) forKey:MTRSetupPayloadCodingKeyHasShortDiscriminator];
     [coder encodeObject:self.discriminator forKey:MTRSetupPayloadCodingKeyDiscriminator];
     [coder encodeObject:self.setupPasscode forKey:MTRSetupPayloadCodingKeySetupPasscode];
     [coder encodeObject:self.serialNumber forKey:MTRSetupPayloadCodingKeySerialNumber];
 }
 
-- (instancetype _Nullable)initWithCoder:(NSCoder *)decoder
+- (instancetype)initWithCoder:(NSCoder *)coder
 {
-    NSNumber * version = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeyVersion];
-    NSNumber * vendorID = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeyVendorID];
-    NSNumber * productID = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeyProductID];
-    NSInteger commissioningFlow = [decoder decodeIntegerForKey:MTRSetupPayloadCodingKeyCommissioningFlow];
-    MTRDiscoveryCapabilities discoveryCapabilities =
-        [MTRSetupPayload _unboxDiscoveryCapabilities:[decoder decodeObjectOfClass:[NSNumber class]
-                                                                           forKey:MTRSetupPayloadCodingKeyDiscoveryCapabilities]];
-    NSInteger hasShortDiscriminator = [decoder decodeIntegerForKey:MTRSetupPayloadCodingKeyHasShortDiscriminator];
-    NSNumber * discriminator = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeyDiscriminator];
-    NSNumber * setupPasscode = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeySetupPasscode];
-    NSString * serialNumber = [decoder decodeObjectOfClass:[NSString class] forKey:MTRSetupPayloadCodingKeySerialNumber];
+    self = [super init];
 
-    MTRSetupPayload * payload = [[MTRSetupPayload alloc] init];
-    payload.version = version;
-    payload.vendorID = vendorID;
-    payload.productID = productID;
-    payload.commissioningFlow = static_cast<MTRCommissioningFlow>(commissioningFlow);
-    payload.discoveryCapabilities = discoveryCapabilities;
-    payload.hasShortDiscriminator = static_cast<BOOL>(hasShortDiscriminator);
-    payload.discriminator = discriminator;
-    payload.setupPasscode = setupPasscode;
-    payload.serialNumber = serialNumber;
-
-    return payload;
-}
-
-- (NSString * _Nullable)manualEntryCode
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    std::string outDecimalString;
-    chip::SetupPayload payload;
-
-    /// The 11 digit manual pairing code only requires the version, VID_PID present flag,
-    /// discriminator, and the setup pincode.
-    payload.version = [self.version unsignedCharValue];
-    if (self.hasShortDiscriminator) {
-        payload.discriminator.SetShortValue([self.discriminator unsignedCharValue]);
+    // We can't rely on the QR code to be present because older versions of this class
+    // did not encode it. When present, it carries almost the entire state of the object.
+    NSString * qrCode = [coder decodeObjectOfClass:NSString.class forKey:MTRSetupPayloadCodingKeyQRCode];
+    if (qrCode != nil) {
+        [self initializeFromQRCode:qrCode];
     } else {
-        payload.discriminator.SetLongValue([self.discriminator unsignedShortValue]);
-    }
-    payload.setUpPINCode = [self.setupPasscode unsignedIntValue];
-
-    err = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(outDecimalString);
-
-    if (err != CHIP_NO_ERROR) {
-        return nil;
+        self.version = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyVersion];
+        self.vendorID = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyVendorID];
+        self.productID = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyProductID];
+        self.commissioningFlow = static_cast<MTRCommissioningFlow>([coder decodeIntegerForKey:MTRSetupPayloadCodingKeyCommissioningFlow]);
+        self.setupPasscode = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeySetupPasscode];
+        self.serialNumber = [coder decodeObjectOfClass:NSString.class forKey:MTRSetupPayloadCodingKeySerialNumber];
     }
 
-    return [NSString stringWithUTF8String:outDecimalString.c_str()];
+    // The QR code cannot represent short discriminators or the absence of rendevouz
+    //  information, so always decode the state of those properties separately.
+    self.hasShortDiscriminator = ([coder decodeIntegerForKey:MTRSetupPayloadCodingKeyHasShortDiscriminator] != 0);
+    self.discriminator = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyDiscriminator];
+    // For compatibility reasons, keep decoding rendevouzInformation instead of discoveryCapabilities
+    self.rendezvousInformation = [coder decodeObjectOfClass:NSNumber.class forKey:MTRSetupPayloadCodingKeyRendevouzInformation];
+
+    return self;
 }
 
-- (NSString * _Nullable)qrCodeString:(NSError * __autoreleasing *)error
+#pragma mark - Utility class methods
+
++ (NSUInteger)generateRandomPIN
 {
-    if (self.commissioningFlow == MTRCommissioningFlowInvalid) {
-        // No idea how to map this to the standard codes.
-        if (error != nil) {
-            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE logContext:@"invalid flow"];
+    do {
+        // Make sure the thing we generate is in the right range.
+        uint32_t setupPIN = arc4random_uniform(chip::kSetupPINCodeMaximumValue) + 1;
+        if (chip::SetupPayload::IsValidSetupPIN(setupPIN)) {
+            return setupPIN;
         }
-        return nil;
-    }
 
-    if (self.hasShortDiscriminator) {
-        // Can't create a QR code with a short discriminator.
-        if (error != nil) {
-            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE logContext:@"cannot create a QR code with a short descrimintor"];
-        }
-        return nil;
-    }
-
-    if (self.discoveryCapabilities == MTRDiscoveryCapabilitiesUnknown) {
-        // Can't create a QR code if we don't know the discovery capabilities.
-        if (error != nil) {
-            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE logContext:@"cannot create a QR code with unknown discovery capabilities"];
-        }
-        return nil;
-    }
-
-    chip::SetupPayload payload;
-
-    payload.version = [self.version unsignedCharValue];
-    payload.vendorID = [self.vendorID unsignedShortValue];
-    payload.productID = [self.productID unsignedShortValue];
-    payload.commissioningFlow = [MTRSetupPayload unconvertCommissioningFlow:self.commissioningFlow];
-    payload.rendezvousInformation = [MTRSetupPayload convertDiscoveryCapabilities:self.discoveryCapabilities];
-    payload.discriminator.SetLongValue([self.discriminator unsignedShortValue]);
-    payload.setUpPINCode = [self.setupPasscode unsignedIntValue];
-    if (self.serialNumber != nil) {
-        CHIP_ERROR err = payload.addSerialNumber(self.serialNumber.UTF8String);
-        if (err != CHIP_NO_ERROR) {
-            if (error != nil) {
-                *error = [MTRError errorForCHIPErrorCode:err];
-            }
-            return nil;
-        }
-    }
-
-    std::string outQRCodeString;
-    CHIP_ERROR err = chip::QRCodeSetupPayloadGenerator(payload).payloadBase38RepresentationWithAutoTLVBuffer(outQRCodeString);
-
-    if (err != CHIP_NO_ERROR) {
-        if (error != nil) {
-            *error = [MTRError errorForCHIPErrorCode:err];
-        }
-        return nil;
-    }
-
-    return [NSString stringWithUTF8String:outQRCodeString.c_str()];
+        // We got pretty unlikely with our random number generation.  Just try
+        // again.  The chance that this loop does not terminate in a reasonable
+        // amount of time is astronomically low, assuming arc4random_uniform is not
+        // broken.
+    } while (true);
 }
 
-+ (nullable NSNumber *)_boxDiscoveryCapabilities:(MTRDiscoveryCapabilities)discoveryCapabilities
++ (NSNumber *)generateRandomSetupPasscode
 {
-    if (discoveryCapabilities == MTRDiscoveryCapabilitiesUnknown) {
-        return nil;
-    }
-
-    return @(discoveryCapabilities);
-}
-
-+ (MTRDiscoveryCapabilities)_unboxDiscoveryCapabilities:(nullable NSNumber *)boxedDiscoveryCapabilities
-{
-    if (boxedDiscoveryCapabilities == nil) {
-        return MTRDiscoveryCapabilitiesUnknown;
-    }
-
-    NSUInteger value = [boxedDiscoveryCapabilities unsignedIntegerValue];
-    if (value == MTRDiscoveryCapabilitiesUnknown) {
-        // The discovery capabilities were actually known
-        // (rendezvousInformation is not nil), and must support on-network.
-        return MTRDiscoveryCapabilitiesOnNetwork;
-    }
-
-    return static_cast<MTRDiscoveryCapabilities>(value);
+    return @([self generateRandomPIN]);
 }
 
 @end
 
 MTR_DIRECT_MEMBERS
 @implementation MTROptionalQRCodeInfo (Deprecated)
+
+- (instancetype)init
+{
+    return [self initWithTag:0xff stringValue:@""];
+}
+
+- (void)setType:(MTROptionalQRCodeInfoType)type
+{
+    /* ignored */
+}
+
+- (NSNumber *)tag
+{
+    return @(self.tagNumber);
+}
+
+- (void)setTag:(NSNumber *)tag
+{
+    /* ignored */
+}
 
 - (NSNumber *)infoType
 {
@@ -449,7 +634,17 @@ MTR_DIRECT_MEMBERS
 
 - (void)setInfoType:(NSNumber *)infoType
 {
-    self.type = static_cast<MTROptionalQRCodeInfoType>([infoType unsignedIntegerValue]);
+    /* ignored */
+}
+
+- (void)setIntegerValue:(NSNumber *)integerValue
+{
+    /* ignored */
+}
+
+- (void)setStringValue:(NSString *)stringValue
+{
+    /* ignored */
 }
 
 @end
@@ -457,14 +652,39 @@ MTR_DIRECT_MEMBERS
 MTR_DIRECT_MEMBERS
 @implementation MTRSetupPayload (Deprecated)
 
+- (instancetype)init
+{
+    return [super init]; // a default-constructed SetupPayload is fine here
+}
+
++ (instancetype)new
+{
+    return [super new];
+}
+
++ (MTRSetupPayload * _Nullable)setupPayloadWithOnboardingPayload:(NSString *)onboardingPayload
+                                                           error:(NSError * __autoreleasing *)error
+{
+    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithPayload:onboardingPayload];
+    if (!payload && error) {
+        *error = [MTRError errorWithCode:MTRErrorCodeInvalidArgument];
+    }
+    return payload;
+}
+
 - (nullable NSNumber *)rendezvousInformation
 {
-    return [MTRSetupPayload _boxDiscoveryCapabilities:self.discoveryCapabilities];
+    auto value = self.discoveryCapabilities;
+    return (value != MTRDiscoveryCapabilitiesUnknown) ? @(value) : nil;
 }
 
 - (void)setRendezvousInformation:(nullable NSNumber *)rendezvousInformation
 {
-    self.discoveryCapabilities = [MTRSetupPayload _unboxDiscoveryCapabilities:rendezvousInformation];
+    if (rendezvousInformation != nil) {
+        self.discoveryCapabilities = KnownDiscoveryCapabilities(rendezvousInformation.unsignedIntegerValue);
+    } else {
+        self.discoveryCapabilities = MTRDiscoveryCapabilitiesUnknown;
+    }
 }
 
 - (NSNumber *)setUpPINCode
@@ -477,26 +697,18 @@ MTR_DIRECT_MEMBERS
     self.setupPasscode = setUpPINCode;
 }
 
-- (instancetype)init
+- (nullable NSString *)qrCodeString:(NSError * __autoreleasing _Nullable *)error
 {
-    if (self = [super init]) {
-        _version = @(0); // Only supported Matter version so far.
-        _vendorID = @(0); // Not available.
-        _productID = @(0); // Not available.
-        _commissioningFlow = MTRCommissioningFlowStandard;
-        _discoveryCapabilities = MTRDiscoveryCapabilitiesUnknown;
-        _hasShortDiscriminator = NO;
-        _discriminator = @(0);
-        _setupPasscode = @(11111111); // Invalid passcode
-        _serialNumber = nil;
+    NSString * result = [self qrCodeString];
+    if (!result && error) {
+        *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
     }
-
-    return self;
+    return result;
 }
 
-+ (instancetype)new
+- (NSArray<MTROptionalQRCodeInfo *> *)getAllOptionalVendorData:(NSError * __autoreleasing *)error
 {
-    return [[self alloc] init];
+    return self.vendorElements; // never actually fails
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -85,6 +85,7 @@ MTR_DIRECT_MEMBERS
     case chip::optionalQRCodeInfoTypeInt32:
         return MTROptionalQRCodeInfoTypeInt32;
     // No 'default:' so we get a warning if new types are added.
+    // Note: isEqual: also switches over these types.
     // OptionalQRCodeInfo does not support these types
     case chip::optionalQRCodeInfoTypeInt64:
     case chip::optionalQRCodeInfoTypeUInt32:
@@ -129,9 +130,14 @@ MTR_DIRECT_MEMBERS
     MTROptionalQRCodeInfo * other = object;
     VerifyOrReturnValue(_info.tag == other->_info.tag, NO);
     VerifyOrReturnValue(_info.type == other->_info.type, NO);
-    VerifyOrReturnValue(_info.int32 == other->_info.int32, NO);
-    VerifyOrReturnValue(_info.data == other->_info.data, NO);
-    return YES;
+    switch (_info.type) {
+    case chip::optionalQRCodeInfoTypeString:
+        return _info.data == other->_info.data;
+    case chip::optionalQRCodeInfoTypeInt32:
+        return _info.int32 == other->_info.int32;
+    default:
+        return NO; // unreachable, type is checked in init
+    }
 }
 
 - (NSString *)description

--- a/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
@@ -21,9 +21,15 @@
 
 #import <setup_payload/SetupPayload.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 MTR_DIRECT_MEMBERS
 @interface MTRSetupPayload ()
 
 - (instancetype)initWithSetupPayload:(chip::SetupPayload)setupPayload;
+- (nullable instancetype)initWithQRCode:(NSString *)qrCodePayload;
+- (nullable instancetype)initWithManualPairingCode:(NSString *)manualCode;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
@@ -19,16 +19,11 @@
 
 #import "MTRDefines_Internal.h"
 
-#ifdef __cplusplus
-#import <lib/core/Optional.h>
 #import <setup_payload/SetupPayload.h>
-#endif
 
 MTR_DIRECT_MEMBERS
 @interface MTRSetupPayload ()
 
-#ifdef __cplusplus
 - (instancetype)initWithSetupPayload:(chip::SetupPayload)setupPayload;
-#endif
 
 @end

--- a/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
@@ -29,8 +29,6 @@ MTR_DIRECT_MEMBERS
 
 #ifdef __cplusplus
 - (instancetype)initWithSetupPayload:(chip::SetupPayload)setupPayload;
-- (MTRDiscoveryCapabilities)convertRendezvousFlags:(const chip::Optional<chip::RendezvousInformationFlags> &)value;
-- (MTRCommissioningFlow)convertCommissioningFlow:(chip::CommissioningFlow)value;
 #endif
 
 @end

--- a/src/darwin/Framework/CHIP/MTRUtilities.h
+++ b/src/darwin/Framework/CHIP/MTRUtilities.h
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2024 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,15 +17,11 @@
 
 #import <Matter/MTRDefines.h>
 
-@class MTRSetupPayload;
-
 NS_ASSUME_NONNULL_BEGIN
 
-MTR_DEPRECATED("Please use [MTRSetupPayload -initWithQRCode:]", ios(16.1, 16.4), macos(13.0, 13.3),
-    watchos(9.1, 9.4), tvos(16.1, 16.4))
-@interface MTRQRCodeSetupPayloadParser : NSObject
-- (instancetype)initWithBase38Representation:(NSString *)base38Representation;
-- (MTRSetupPayload * _Nullable)populatePayload:(NSError * __autoreleasing *)error;
-@end
+/**
+ * Calls `-[NSObject isEqual:]` but returns YES when comparing nil to nil.
+ */
+MTR_EXTERN BOOL MTREqualObjects(id<NSObject> _Nullable a, id<NSObject> _Nullable b);
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRUtilities.mm
+++ b/src/darwin/Framework/CHIP/MTRUtilities.mm
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2024 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,17 +15,9 @@
  *    limitations under the License.
  */
 
-#import <Matter/MTRDefines.h>
+#import "MTRUtilities.h"
 
-@class MTRSetupPayload;
-
-NS_ASSUME_NONNULL_BEGIN
-
-MTR_DEPRECATED("Please use [MTRSetupPayload -initWithQRCode:]", ios(16.1, 16.4), macos(13.0, 13.3),
-    watchos(9.1, 9.4), tvos(16.1, 16.4))
-@interface MTRQRCodeSetupPayloadParser : NSObject
-- (instancetype)initWithBase38Representation:(NSString *)base38Representation;
-- (MTRSetupPayload * _Nullable)populatePayload:(NSError * __autoreleasing *)error;
-@end
-
-NS_ASSUME_NONNULL_END
+BOOL MTREqualObjects(id<NSObject> _Nullable a, id<NSObject> _Nullable b)
+{
+    return (a == nil) ? (b == nil) : [a isEqual:b];
+}

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
@@ -212,27 +212,27 @@
     }
 
     // Test access by tag
-    XCTAssertEqualObjects([payload vendorElementWithTag:130].stringValue, @"myData");
-    XCTAssertEqualObjects([payload vendorElementWithTag:131].integerValue, @12);
+    XCTAssertEqualObjects([payload vendorElementWithTag:@130].stringValue, @"myData");
+    XCTAssertEqualObjects([payload vendorElementWithTag:@131].integerValue, @12);
 }
 
 - (void)testAddVendorElement
 {
     MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithSetupPasscode:@314159 discriminator:@555];
     XCTAssertEqual(payload.vendorElements.count, 0);
-    [payload addOrReplaceVendorElement:[[MTROptionalQRCodeInfo alloc] initWithTag:0xff int32Value:42]];
+    [payload addOrReplaceVendorElement:[[MTROptionalQRCodeInfo alloc] initWithTag:@0xff int32Value:42]];
     XCTAssertEqual(payload.vendorElements.count, 1);
     XCTAssertEqualObjects(payload.vendorElements.firstObject.integerValue, @42);
-    XCTAssertEqualObjects([payload vendorElementWithTag:0xff].integerValue, @42);
+    XCTAssertEqualObjects([payload vendorElementWithTag:@0xff].integerValue, @42);
 }
 
 - (void)testVendorElementsEncodedToQRCode
 {
     MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithSetupPasscode:@314159 discriminator:@555];
-    [payload addOrReplaceVendorElement:[[MTROptionalQRCodeInfo alloc] initWithTag:0x80 stringValue:@"Hello"]];
+    [payload addOrReplaceVendorElement:[[MTROptionalQRCodeInfo alloc] initWithTag:@0x80 stringValue:@"Hello"]];
     MTRSetupPayload * decoded = [[MTRSetupPayload alloc] initWithPayload:payload.qrCodeString];
     XCTAssertNotNil(decoded);
-    XCTAssertEqualObjects([decoded vendorElementWithTag:0x80].stringValue, @"Hello");
+    XCTAssertEqualObjects([decoded vendorElementWithTag:@0x80].stringValue, @"Hello");
 }
 
 - (void)testRemoveVendorElements
@@ -240,21 +240,21 @@
     MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithPayload:@"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"];
     XCTAssertNotNil(payload);
     XCTAssertEqual(payload.vendorElements.count, 2);
-    [payload removeVendorElementWithTag:0]; // no change, no vendor element present with this tag
+    [payload removeVendorElementWithTag:@128]; // no change, no vendor element present with this tag
     XCTAssertEqual(payload.vendorElements.count, 2);
-    [payload removeVendorElementWithTag:130];
+    [payload removeVendorElementWithTag:@130];
     XCTAssertEqual(payload.vendorElements.count, 1);
-    [payload removeVendorElementWithTag:131];
+    [payload removeVendorElementWithTag:@131];
     XCTAssertEqual(payload.vendorElements.count, 0);
 }
 
 - (void)testQrCodeInfoCopyAndEquality
 {
-    MTROptionalQRCodeInfo * a = [[MTROptionalQRCodeInfo alloc] initWithTag:1 stringValue:@"hello"];
-    MTROptionalQRCodeInfo * b = [[MTROptionalQRCodeInfo alloc] initWithTag:1 stringValue:@"hello"];
-    MTROptionalQRCodeInfo * c = [[MTROptionalQRCodeInfo alloc] initWithTag:0xff stringValue:@"hello"];
-    MTROptionalQRCodeInfo * d = [[MTROptionalQRCodeInfo alloc] initWithTag:1 int32Value:42];
-    MTROptionalQRCodeInfo * e = [[MTROptionalQRCodeInfo alloc] initWithTag:1 int32Value:0xbad];
+    MTROptionalQRCodeInfo * a = [[MTROptionalQRCodeInfo alloc] initWithTag:@0x88 stringValue:@"hello"];
+    MTROptionalQRCodeInfo * b = [[MTROptionalQRCodeInfo alloc] initWithTag:@0x88 stringValue:@"hello"];
+    MTROptionalQRCodeInfo * c = [[MTROptionalQRCodeInfo alloc] initWithTag:@0xff stringValue:@"hello"];
+    MTROptionalQRCodeInfo * d = [[MTROptionalQRCodeInfo alloc] initWithTag:@0x88 int32Value:42];
+    MTROptionalQRCodeInfo * e = [[MTROptionalQRCodeInfo alloc] initWithTag:@0x88 int32Value:0xbad];
     XCTAssertTrue([a isEqual:a]);
     XCTAssertTrue([a isEqual:[a copy]]);
     XCTAssertTrue([a isEqual:b]);
@@ -458,7 +458,7 @@
     XCTAssertTrue([copy isEqual:payload]);
     XCTAssertEqual(payload.hash, copy.hash);
 
-    MTROptionalQRCodeInfo * element = [[MTROptionalQRCodeInfo alloc] initWithTag:0x80 stringValue:@"To infinity and beyond!"];
+    MTROptionalQRCodeInfo * element = [[MTROptionalQRCodeInfo alloc] initWithTag:@0x80 stringValue:@"To infinity and beyond!"];
     [copy addOrReplaceVendorElement:element];
     XCTAssertFalse([copy isEqual:payload]);
     [payload addOrReplaceVendorElement:element];
@@ -477,6 +477,14 @@
     // We must be able to process QR codes that include discovery methods we don't understand yet
     XCTAssertEqual([[MTRSetupPayload alloc] initWithPayload:@"MT:000002VDK3VHMR49000"].discoveryCapabilities, 0x84);
     XCTAssertEqual([[MTRSetupPayload alloc] initWithPayload:@"MT:-24J0Q.C.0KA0648G00"].discoveryCapabilities, 0xfa);
+}
+
+- (void)testDescriptionShowsUnknownDiscoveryMethods
+{
+    MTRSetupPayload * a = [[MTRSetupPayload alloc] initWithSetupPasscode:@888 discriminator:@555];
+    MTRSetupPayload * b = [a copy];
+    b.discoveryCapabilities |= 0x80;
+    XCTAssertNotEqualObjects(a.description, b.description);
 }
 
 @end

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
@@ -44,30 +44,6 @@
     XCTAssertEqualObjects(payload.manualEntryCode, @"641286075300001000016");
 }
 
-- (void)testInitWithManualCode
-{
-    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithManualPairingCode:@"641286075300001000016"];
-    XCTAssertNotNil(payload);
-    XCTAssertTrue(payload.hasShortDiscriminator);
-    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 10);
-    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 12345670);
-    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
-    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
-    XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowCustom);
-    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
-    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesUnknown);
-}
-
-- (void)testInitWithManualCode_Empty
-{
-    XCTAssertNil([[MTRSetupPayload alloc] initWithManualPairingCode:@""]);
-}
-
-- (void)testInitWithManualCode_QRCode
-{
-    XCTAssertNil([[MTRSetupPayload alloc] initWithManualPairingCode:@"MT:M5L90MP500K64J00000"]); // a valid QR code
-}
-
 - (void)testOnboardingPayloadParser_QRCode_NoError
 {
     NSError * error;
@@ -84,30 +60,6 @@
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
     XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
-}
-
-- (void)testInitWithQRCode
-{
-    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithQRCode:@"MT:M5L90MP500K64J00000"];
-    XCTAssertNotNil(payload);
-    XCTAssertFalse(payload.hasShortDiscriminator);
-    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
-    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
-    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
-    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
-    XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
-    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
-    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
-}
-
-- (void)testInitWithQRCode_WrongPrefix
-{
-    XCTAssertNil([[MTRSetupPayload alloc] initWithQRCode:@"XX:M5L90MP500K64J00000"]);
-}
-
-- (void)testInitWithQRCode_ManualCode
-{
-    XCTAssertNil([[MTRSetupPayload alloc] initWithQRCode:@"641286075300001000016"]); // a valid manual pairing code
 }
 
 - (void)testOnboardingPayloadParser_QRCode_WrongVersion
@@ -441,7 +393,7 @@
 
 - (void)testCopyingAndEquality
 {
-    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithQRCode:@"MT:M5L9000000K64J00000"];
+    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithPayload:@"MT:M5L9000000K64J00000"];
     XCTAssertFalse(payload.hasShortDiscriminator); // came from a QR code
     XCTAssert(payload.discriminator.integerValue > 0xf); // can't "accidentally" round-trip through a short discriminator
 

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadTests.m
@@ -1,6 +1,6 @@
 /**
  *
- *    Copyright (c) 2020 Project CHIP Authors
+ *    Copyright (c) 2020-2024 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -40,6 +40,32 @@
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowCustom);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
     XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesUnknown);
+
+    XCTAssertEqualObjects(payload.manualEntryCode, @"641286075300001000016");
+}
+
+- (void)testInitWithManualCode
+{
+    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithManualPairingCode:@"641286075300001000016"];
+    XCTAssertNotNil(payload);
+    XCTAssertTrue(payload.hasShortDiscriminator);
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 10);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 12345670);
+    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
+    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
+    XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowCustom);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesUnknown);
+}
+
+- (void)testInitWithManualCode_Empty
+{
+    XCTAssertNil([[MTRSetupPayload alloc] initWithManualPairingCode:@""]);
+}
+
+- (void)testInitWithManualCode_QRCode
+{
+    XCTAssertNil([[MTRSetupPayload alloc] initWithManualPairingCode:@"MT:M5L90MP500K64J00000"]); // a valid QR code
 }
 
 - (void)testOnboardingPayloadParser_QRCode_NoError
@@ -58,6 +84,30 @@
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
     XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
+}
+
+- (void)testInitWithQRCode
+{
+    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithQRCode:@"MT:M5L90MP500K64J00000"];
+    XCTAssertNotNil(payload);
+    XCTAssertFalse(payload.hasShortDiscriminator);
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
+    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
+    XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
+}
+
+- (void)testInitWithQRCode_WrongPrefix
+{
+    XCTAssertNil([[MTRSetupPayload alloc] initWithQRCode:@"XX:M5L90MP500K64J00000"]);
+}
+
+- (void)testInitWithQRCode_ManualCode
+{
+    XCTAssertNil([[MTRSetupPayload alloc] initWithQRCode:@"641286075300001000016"]); // a valid manual pairing code
 }
 
 - (void)testOnboardingPayloadParser_QRCode_WrongVersion
@@ -90,31 +140,13 @@
     XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
 }
 
-- (void)testManualParser
-{
-    NSError * error;
-    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"641286075300001000016" error:&error];
-
-    XCTAssertNotNil(payload);
-    XCTAssertNil(error);
-
-    XCTAssertTrue(payload.hasShortDiscriminator);
-    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 10);
-    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 12345670);
-    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
-    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
-    XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowCustom);
-    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
-    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesUnknown);
-}
-
 - (void)testManualParser_Error
 {
     NSError * error;
     MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"" error:&error];
 
     XCTAssertNil(payload);
-    XCTAssertEqual(error.code, MTRErrorCodeInvalidStringLength);
+    XCTAssertNotNil(error);
 }
 
 - (void)testQRCodeParser_Error
@@ -123,7 +155,7 @@
     MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L90MP500K64J0000." error:&error];
 
     XCTAssertNil(payload);
-    XCTAssertEqual(error.code, MTRErrorCodeInvalidArgument);
+    XCTAssertNotNil(error);
 }
 
 - (void)testQRCodeParser
@@ -178,6 +210,62 @@
             XCTAssertEqual(info.integerValue.intValue, 12);
         }
     }
+
+    // Test access by tag
+    XCTAssertEqualObjects([payload vendorElementWithTag:130].stringValue, @"myData");
+    XCTAssertEqualObjects([payload vendorElementWithTag:131].integerValue, @12);
+}
+
+- (void)testAddVendorElement
+{
+    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithSetupPasscode:@314159 discriminator:@555];
+    XCTAssertEqual(payload.vendorElements.count, 0);
+    [payload addOrReplaceVendorElement:[[MTROptionalQRCodeInfo alloc] initWithTag:0xff int32Value:42]];
+    XCTAssertEqual(payload.vendorElements.count, 1);
+    XCTAssertEqualObjects(payload.vendorElements.firstObject.integerValue, @42);
+    XCTAssertEqualObjects([payload vendorElementWithTag:0xff].integerValue, @42);
+}
+
+- (void)testVendorElementsEncodedToQRCode
+{
+    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithSetupPasscode:@314159 discriminator:@555];
+    [payload addOrReplaceVendorElement:[[MTROptionalQRCodeInfo alloc] initWithTag:0x80 stringValue:@"Hello"]];
+    MTRSetupPayload * decoded = [[MTRSetupPayload alloc] initWithPayload:payload.qrCodeString];
+    XCTAssertNotNil(decoded);
+    XCTAssertEqualObjects([decoded vendorElementWithTag:0x80].stringValue, @"Hello");
+}
+
+- (void)testRemoveVendorElements
+{
+    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithPayload:@"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"];
+    XCTAssertNotNil(payload);
+    XCTAssertEqual(payload.vendorElements.count, 2);
+    [payload removeVendorElementWithTag:0]; // no change, no vendor element present with this tag
+    XCTAssertEqual(payload.vendorElements.count, 2);
+    [payload removeVendorElementWithTag:130];
+    XCTAssertEqual(payload.vendorElements.count, 1);
+    [payload removeVendorElementWithTag:131];
+    XCTAssertEqual(payload.vendorElements.count, 0);
+}
+
+- (void)testQrCodeInfoCopyAndEquality
+{
+    MTROptionalQRCodeInfo * a = [[MTROptionalQRCodeInfo alloc] initWithTag:1 stringValue:@"hello"];
+    MTROptionalQRCodeInfo * b = [[MTROptionalQRCodeInfo alloc] initWithTag:1 stringValue:@"hello"];
+    MTROptionalQRCodeInfo * c = [[MTROptionalQRCodeInfo alloc] initWithTag:0xff stringValue:@"hello"];
+    MTROptionalQRCodeInfo * d = [[MTROptionalQRCodeInfo alloc] initWithTag:1 int32Value:42];
+    MTROptionalQRCodeInfo * e = [[MTROptionalQRCodeInfo alloc] initWithTag:1 int32Value:0xbad];
+    XCTAssertTrue([a isEqual:a]);
+    XCTAssertTrue([a isEqual:[a copy]]);
+    XCTAssertTrue([a isEqual:b]);
+    XCTAssertTrue([a isEqual:[b copy]]);
+    XCTAssertEqual(a.hash, b.hash);
+    XCTAssertEqual(a.hash, [[a copy] hash]);
+    XCTAssertFalse([a isEqual:nil]);
+    XCTAssertFalse([a isEqual:c]);
+    XCTAssertFalse([a isEqual:d]);
+    XCTAssertFalse([a isEqual:e]);
+    XCTAssertFalse([d isEqual:e]);
 }
 
 - (void)testQRCodeWithNoCapabilities
@@ -198,7 +286,7 @@
     XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesOnNetwork);
 }
 
-- (void)testQRCodePropertyAliases
+- (void)testDeprecatedPropertyAliases
 {
     NSError * error;
     MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L9000000K64J00000" error:&error];
@@ -294,6 +382,9 @@
          ]) {
         MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:string error:&error];
         XCTAssertNotNil(payload, @"Error: %@", error);
+        // Ensure our test data has discriminator values that make for the most meaningful round-trip tests.
+        XCTAssert(payload.discriminator.integerValue != 0);
+        XCTAssert(payload.hasShortDiscriminator || payload.discriminator.integerValue > 0xf);
         [payloads addObject:payload];
     }
 
@@ -301,7 +392,14 @@
     [payloads addObject:[[MTRSetupPayload alloc] init]];
     [payloads addObject:[[MTRSetupPayload alloc] initWithSetupPasscode:@22222222 discriminator:@42]];
 
+    MTRSetupPayload * futureValues = [[MTRSetupPayload alloc] initWithSetupPasscode:@314159 discriminator:@555];
+    futureValues.commissioningFlow = 3; // reserved in the spec
+    futureValues.discoveryCapabilities = 0x84; // bits 3-7 reserved in the spec
+    [payloads addObject:futureValues];
+
     for (MTRSetupPayload * payload in payloads) {
+        NSLog(@"Payload: %@", payload);
+
         NSData * data = [NSKeyedArchiver archivedDataWithRootObject:payload requiringSecureCoding:YES error:&error];
         XCTAssertNotNil(data, @"Error: %@", error);
         MTRSetupPayload * decoded = [NSKeyedUnarchiver unarchivedObjectOfClass:MTRSetupPayload.class fromData:data error:&error];
@@ -322,18 +420,16 @@
         NSArray<MTROptionalQRCodeInfo *> * decodedVDs = [decoded getAllOptionalVendorData:&error];
         XCTAssertNotNil(decodedVDs, @"Error: %@", error);
 
-#if 0 // TODO: Encode / decode optional vendor data
-      // MTROptionalQRCodeInfo does not implement isEqual (yet)
         XCTAssertEqual(decodedVDs.count, payloadVDs.count);
-        for (int i = 0; i < decodedVDs.count; i++){
+        for (int i = 0; i < decodedVDs.count; i++) {
             MTROptionalQRCodeInfo * decodedVD = decodedVDs[i];
             MTROptionalQRCodeInfo * payloadVD = payloadVDs[i];
             XCTAssertEqual(decodedVD.type, payloadVD.type);
             XCTAssertEqualObjects(decodedVD.tag, payloadVD.tag);
             XCTAssertEqualObjects(decodedVD.integerValue, payloadVD.integerValue);
             XCTAssertEqualObjects(decodedVD.stringValue, payloadVD.stringValue);
+            XCTAssertEqualObjects(decodedVD, payloadVD); // also check with isEqual:
         }
-#endif
 
         // Note that we can't necessarily expect the manualEntryCode and qrCode strings
         // we generate here to match the original string, but we should get the same
@@ -341,6 +437,46 @@
         XCTAssertEqualObjects([decoded qrCodeString:NULL], [payload qrCodeString:NULL]);
         XCTAssertEqualObjects(decoded.manualEntryCode, payload.manualEntryCode);
     }
+}
+
+- (void)testCopyingAndEquality
+{
+    MTRSetupPayload * payload = [[MTRSetupPayload alloc] initWithQRCode:@"MT:M5L9000000K64J00000"];
+    XCTAssertFalse(payload.hasShortDiscriminator); // came from a QR code
+    XCTAssert(payload.discriminator.integerValue > 0xf); // can't "accidentally" round-trip through a short discriminator
+
+    MTRSetupPayload * copy = [payload copy];
+    XCTAssertNotIdentical(payload, copy); // MTRSetupPayload is mutable, must be a new object
+
+    XCTAssertTrue([payload isEqual:copy]);
+    XCTAssertTrue([copy isEqual:payload]);
+    XCTAssertEqual(payload.hash, copy.hash);
+
+    copy.hasShortDiscriminator = YES;
+    XCTAssertFalse([copy isEqual:payload]);
+    copy.hasShortDiscriminator = NO;
+    XCTAssertTrue([copy isEqual:payload]);
+    XCTAssertEqual(payload.hash, copy.hash);
+
+    MTROptionalQRCodeInfo * element = [[MTROptionalQRCodeInfo alloc] initWithTag:0x80 stringValue:@"To infinity and beyond!"];
+    [copy addOrReplaceVendorElement:element];
+    XCTAssertFalse([copy isEqual:payload]);
+    [payload addOrReplaceVendorElement:element];
+    XCTAssertTrue([copy isEqual:payload]);
+    XCTAssertEqual(payload.hash, copy.hash);
+
+    copy.serialNumber = @"555-123";
+    XCTAssertFalse([copy isEqual:payload]);
+    payload.serialNumber = @"555-123";
+    XCTAssertTrue([copy isEqual:payload]);
+    XCTAssertEqual(payload.hash, copy.hash);
+}
+
+- (void)testCanParseFutureDiscoveryMethod
+{
+    // We must be able to process QR codes that include discovery methods we don't understand yet
+    XCTAssertEqual([[MTRSetupPayload alloc] initWithPayload:@"MT:000002VDK3VHMR49000"].discoveryCapabilities, 0x84);
+    XCTAssertEqual([[MTRSetupPayload alloc] initWithPayload:@"MT:-24J0Q.C.0KA0648G00"].discoveryCapabilities, 0xfa);
 }
 
 @end

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -109,6 +109,8 @@
 		3D0C484B29DA4FA0006D811F /* MTRErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D0C484A29DA4FA0006D811F /* MTRErrorTests.m */; };
 		3D3928D72BBCEA3D00CDEBB2 /* MTRAvailabilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D3928D62BBCEA3D00CDEBB2 /* MTRAvailabilityTests.m */; settings = {COMPILER_FLAGS = "-UMTR_NO_AVAILABILITY -Wno-unguarded-availability-new"; }; };
 		3D4733AF2BDF1B80003DC19B /* MTRSetupPayloadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D4733AE2BDF1B80003DC19B /* MTRSetupPayloadTests.m */; };
+		3D4733B32BE2D1DA003DC19B /* MTRUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D4733B22BE2D1CF003DC19B /* MTRUtilities.h */; };
+		3D4733B52BE2D3D7003DC19B /* MTRUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3D4733B42BE2D3D1003DC19B /* MTRUtilities.mm */; };
 		3D69868529383096007314E7 /* com.csa.matter.plist in Copy Logging Preferences */ = {isa = PBXBuildFile; fileRef = 3D69868029382EF4007314E7 /* com.csa.matter.plist */; };
 		3D843711294977000070D20A /* NSStringSpanConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D84370E294977000070D20A /* NSStringSpanConversion.h */; };
 		3D843712294977000070D20A /* MTRCallbackBridgeBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D84370F294977000070D20A /* MTRCallbackBridgeBase.h */; };
@@ -500,6 +502,8 @@
 		3D0C484A29DA4FA0006D811F /* MTRErrorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRErrorTests.m; sourceTree = "<group>"; };
 		3D3928D62BBCEA3D00CDEBB2 /* MTRAvailabilityTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRAvailabilityTests.m; sourceTree = "<group>"; };
 		3D4733AE2BDF1B80003DC19B /* MTRSetupPayloadTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRSetupPayloadTests.m; sourceTree = "<group>"; };
+		3D4733B22BE2D1CF003DC19B /* MTRUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRUtilities.h; sourceTree = "<group>"; };
+		3D4733B42BE2D3D1003DC19B /* MTRUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRUtilities.mm; sourceTree = "<group>"; };
 		3D69868029382EF4007314E7 /* com.csa.matter.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = com.csa.matter.plist; sourceTree = "<group>"; };
 		3D84370E294977000070D20A /* NSStringSpanConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSStringSpanConversion.h; sourceTree = "<group>"; };
 		3D84370F294977000070D20A /* MTRCallbackBridgeBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCallbackBridgeBase.h; sourceTree = "<group>"; };
@@ -1355,6 +1359,8 @@
 				997DED152695343400975E97 /* MTRThreadOperationalDataset.mm */,
 				51C659D72BA3787500C54922 /* MTRTimeUtils.h */,
 				51C659D82BA3787500C54922 /* MTRTimeUtils.mm */,
+				3D4733B22BE2D1CF003DC19B /* MTRUtilities.h */,
+				3D4733B42BE2D3D1003DC19B /* MTRUtilities.mm */,
 				3D843710294977000070D20A /* NSDataSpanConversion.h */,
 				3D84370E294977000070D20A /* NSStringSpanConversion.h */,
 				5117DD3729A931AE00FFA1AA /* MTROperationalBrowser.h */,
@@ -1643,6 +1649,7 @@
 				514C7A022B64223400DD6D7B /* MTRServerEndpoint_Internal.h in Headers */,
 				511913FC28C100EF009235E9 /* MTRBaseSubscriptionCallback.h in Headers */,
 				51565CB12A7AD77600469F18 /* MTRDeviceControllerDataStore.h in Headers */,
+				3D4733B32BE2D1DA003DC19B /* MTRUtilities.h in Headers */,
 				3D843713294977000070D20A /* NSDataSpanConversion.h in Headers */,
 				991DC08B247704DC00C13860 /* MTRLogging_Internal.h in Headers */,
 				51FE723F2ACDEF3E00437032 /* MTRCommandPayloadExtensions_Internal.h in Headers */,
@@ -1893,6 +1900,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3D4733B52BE2D3D7003DC19B /* MTRUtilities.mm in Sources */,
 				2C8C8FC2253E0C2100797F05 /* MTRPersistentStorageDelegateBridge.mm in Sources */,
 				99AECC802798A57F00B6355B /* MTRCommissioningParameters.mm in Sources */,
 				2CB7163C252E8A7C0026E2BB /* MTRDeviceControllerDelegateBridge.mm in Sources */,

--- a/src/darwin/Framework/Matter.xcodeproj/xcshareddata/xcschemes/darwin-framework-tool.xcscheme
+++ b/src/darwin/Framework/Matter.xcodeproj/xcshareddata/xcschemes/darwin-framework-tool.xcscheme
@@ -38,6 +38,7 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       viewDebuggingEnabled = "No">
       <BuildableProductRunnable

--- a/src/darwin/Framework/Matter.xcodeproj/xcshareddata/xcschemes/darwin-framework-tool.xcscheme
+++ b/src/darwin/Framework/Matter.xcodeproj/xcshareddata/xcschemes/darwin-framework-tool.xcscheme
@@ -38,7 +38,6 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       viewDebuggingEnabled = "No">
       <BuildableProductRunnable


### PR DESCRIPTION
API:
- Conform to NSCopying and implement isEqual / hash
- Simplify a number of methods to not return NSError
- Add initWithPayload: as a replacement for setupPayloadWithOnboardingPayload:error:
- Add initWithQRCode: and initWithManualPairingCode: for cases where payload type is known.
- Add vendorElements as a replacement for getAllOptionalVendorData:
- Add vendorElementWithTag:
- Add removeVendorElementWithTag:
- Add addOrReplaceVendorElement:

Behaviour fixes:
- Allow QRCodes with unknown discovery methods to be parsed
- Include vendor elements in qrCodeString
- Preserve vendor elements encodeWithCoder / initWithCoder

Also simplify the implementation by acting as a direct wrapper of chip::SetupPayload.

Implement parsing in MTRSetupPayload directly and implement the deprecated
`MTR*PayloadParser` classes in terms of it, instead of the other way around.
