### PR TITLE
pkg-config.py: fix IndexError when --variable=prefix is empty

### DIFF
--- a/build/config/linux/pkg-config.py
+++ b/build/config/linux/pkg-config.py
@@ -99,7 +99,7 @@ def GetPkgConfigPrefixToStrip(options, args):
     # from pkg-config's |prefix| variable.
     prefix = subprocess.check_output([options.pkg_config,
                                       "--variable=prefix"] + args, env=os.environ).decode('utf-8')
-    if prefix[-4] == '/usr':
+    if prefix[:4] == '/usr':
         return prefix[4:]
     return prefix
 


### PR DESCRIPTION
sometimes (e.g. with openssl-3.3.0) the pkg-config returns just new-line and prefix[-4] then fails with IndexError.

Fixes:

```
Command: python3 build/config/linux/pkg-config.py -s recipe-sysroot --system_libdir lib openssl Returned 1.
stderr:

Traceback (most recent call last):
  File "build/config/linux/pkg-config.py", line 259, in <module>
    sys.exit(main())
             ^^^^^^
  File "build/config/linux/pkg-config.py", line 156, in main
    prefix = GetPkgConfigPrefixToStrip(options, args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "build/config/linux/pkg-config.py", line 102, in GetPkgConfigPrefixToStrip
    if prefix[-4] == '/usr':
       ~~~~~~^^^^
IndexError: string index out of range
```