### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-49 : [Silabs] Update SDKs to new versions
+50 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -12,7 +12,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=047fe473eb7e407d9905c7f1f24533e12f534280
+ARG ZEPHYR_REVISION=68deadeb5c20b82d68700e720d4580e8003bf1d8
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- west.yml: Modify BLE driver for B95
- drivers: ieee802154: telink: Optimize RF initialization process
- drivers: dts: config: Add flash driver and blocking module for W91
- drivers: dts: config: use mtimer for blocking timeout and add dlm section
- soc: riscv: telink_w91: ipc: Kconfig.ipc: Increase bind timeout
- soc: riscv: telink_w91: Fix mcuboot
- riscv: telink_w91: Clean configs
- samples: boards: tlsr9x: Add IPC speed test application
- samples: boards: tlsr9x: Add simple socket application
- drivers: wifi: telink: Dummy L2 implementation
- drivers: wifi: telink: IPC L2 implementation
- drivers: pwm: add W91 pwm drivers

Testing
Tested manually.

**Steps:**

- Build image
- Run docker
- Check if Telink examples able to be built successfully