### PR TITLE
Add an explicit skip processing on error (do not attempt to use invalid data)

### DIFF
--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -458,6 +458,7 @@ void MinMdnsResolver::AdvancePendingResolverStates()
             if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(Discovery, "Failed to take discovery result: %" CHIP_ERROR_FORMAT, err.Format());
+                continue;
             }
 
             mActiveResolves.Complete(nodeData.operationalData.peerId);


### PR DESCRIPTION
This fixes a missing `continue` on error when parsing operational data.

I do not believe this error path of using invalid data can actually be reached since the only way the Take will fail is if `IsActiveOperationalBrowse` is false and this is exactly the top condition on that branch. However correctness-wise, if the Take can fail, we should propperly handle the failure.

This fixes #33287