### PR TITLE
Make generate.py a bit smarter about determining the ZCL definition file.

### DIFF
--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -90,20 +90,21 @@ def detectZclFile(zapFile):
     prefix_chip_root_dir = True
     path = 'src/app/zap-templates/zcl/zcl.json'
 
-    data = json.load(open(zapFile))
-    for package in data["package"]:
-        if package["type"] != "zcl-properties":
-            continue
+    if zapFile:
+        data = json.load(open(zapFile))
+        for package in data["package"]:
+            if package["type"] != "zcl-properties":
+                continue
 
-        prefix_chip_root_dir = (package["pathRelativity"] != "resolveEnvVars")
-        # found the right path, try to figure out the actual path
-        if package["pathRelativity"] == "relativeToZap":
-            path = os.path.abspath(os.path.join(
-                os.path.dirname(zapFile), package["path"]))
-        elif package["pathRelativity"] == "resolveEnvVars":
-            path = os.path.expandvars(package["path"])
-        else:
-            path = package["path"]
+            prefix_chip_root_dir = (package["pathRelativity"] != "resolveEnvVars")
+            # found the right path, try to figure out the actual path
+            if package["pathRelativity"] == "relativeToZap":
+                path = os.path.abspath(os.path.join(
+                    os.path.dirname(zapFile), package["path"]))
+            elif package["pathRelativity"] == "resolveEnvVars":
+                path = os.path.expandvars(package["path"])
+            else:
+                path = package["path"]
 
     return getFilePath(path, prefix_chip_root_dir)
 


### PR DESCRIPTION
If the ZCL definition file is not specified, it tries to look in the ZAP file provided, but falls back to our in-tree zcl.json if the ZAP file has nothing specified.

This change just uses the fallback if neither the ZCL definition file _nor_ the ZAP file are specified, which allows simpler codegen command lines for client-side things that don't have a specific ZAP file attached to them.
