### PR TITLE
[Linux] Add test logic to verify commissioning between Linux tv-casting-app and Linux tv-app.

### DIFF
--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -31,7 +31,7 @@ logging.basicConfig(level=logging.INFO, format='%(levelname)s - %(message)s')
 TV_APP_MAX_START_WAIT_SEC = 2
 
 # The maximum amount of time to commission the Linux tv-casting-app and the tv-app before timeout.
-COMMISSIONING_STAGE_MAX_WAIT_SEC =3
+COMMISSIONING_STAGE_MAX_WAIT_SEC = 3
 
 # File names of logs for the Linux tv-casting-app and the Linux tv-app.
 LINUX_TV_APP_LOGS = 'Linux-tv-app-logs.txt'
@@ -277,7 +277,8 @@ def validate_commissioning_success(tv_casting_app_info: Tuple[subprocess.Popen, 
     while True:
         # Check if we exceeded the maximum wait time for validating commissioning success between the Linux tv-casting-app and the Linux tv-app.
         if time.time() - start_wait_time > COMMISSIONING_STAGE_MAX_WAIT_SEC:
-            logging.error('The commissioning between the Linux tv-casting-app process and the Linux tv-app process did not complete successfully within the timeout.')
+            logging.error(
+                'The commissioning between the Linux tv-casting-app process and the Linux tv-app process did not complete successfully within the timeout.')
             return False
 
         tv_casting_line = tv_casting_app_process.stdout.readline()
@@ -416,7 +417,7 @@ def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path):
                     # Example string: \x1b[0;32m[1714582264602] [77989:2286038] [SVR] Discovered Commissioner #0\x1b[0m
                     #                 The value '0' will be extracted from the string.
                     valid_discovered_commissioner_number = valid_discovered_commissioner.split('#')[-1].replace('\x1b[0m', '')
-                
+
                     test_commissioning_fn(valid_discovered_commissioner_number, tv_casting_app_info, tv_app_info, log_paths)
 
 

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -291,7 +291,6 @@ def validate_commissioning_success(tv_casting_app_info: Tuple[subprocess.Popen, 
             if 'Commissioning completed successfully' in tv_casting_line:
                 logging.info('Commissioning success noted on the Linux tv-casting-app output:')
                 logging.info(tv_casting_line.rstrip('\n'))
-                continue_reading_tv_casting_app_output = False
             elif 'Commissioning failed' in tv_casting_line:
                 logging.error('Commissioning failed noted on the Linux tv-casting-app output:')
                 logging.error(tv_casting_line.rstrip('\n'))


### PR DESCRIPTION
Fixes #33300 

**Problem**
There is no CI check to test that the commissioning between the Linux tv-casting-app and the Linux tv-app continues to work whenever a PR is created.

**Solution Overview**
Add testing logic to the `run_tv_casting_test.py` script to verify that commissioning continues to work between the tv-casting-app and the tv-app.

The output of the tv-casting-app and the tv-app will be parsed for strings of interest as they are received and the output will also be written to their corresponding log files.

The following has been added to the test script:
- The user (in this case the test script) will pass in `cast request {valid_discovered_commissioner_number}` to the tv-casting-app subprocess once we find the `cast request 0` string in the tv-casting-app output. This is the indication from the tv-casting-app to the user that it is ready for the cast request to be initiated.
- After the cast request is initiated by the user (in this case the test script), we will verify that the `device Name`, `vendor id`, and `product id` noted under the `Identification Declaration` block in the tv-casting-app output matches the corresponding values on the tv-app side.
- Once the device information is confirmed, we will parse the tv-app output for the `Via Shell Enter: controller ux ok|cancel` string. This will indicate that the user can approve the cast request by sending `controller ux ok` to the tv-app subprocess.
- Lastly, we will parse the output of both the tv-casting-app and the tv-app for messages indicating that commissioning was successful. These messages are `Commissioning completed successfully` and `PROMPT USER: commissioning success` respectively.
- If we're not able to find the strings of interest within the timeout that was set for each of the stages above or if we see `Commissioning failed` in the tv-casting-app output, we will print an error message, dump the logs to console, and exit on error.

**Testing**
Tested the script locally by running `python3 ./scripts/tests/run_tv_casting_test.py` and observing the output. Also verified that the updated test script works as expected in the CI check.
