### PR TITLE
[Silabs] Added [[maybe_unused]] to remove errors from NDEBUG builds

### DIFF
--- a/examples/light-switch-app/silabs/src/ZclCallbacks.cpp
+++ b/examples/light-switch-app/silabs/src/ZclCallbacks.cpp
@@ -30,12 +30,11 @@
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
 
-#ifndef NDEBUG
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
-    ClusterId clusterId     = attributePath.mClusterId;
-    AttributeId attributeId = attributePath.mAttributeId;
+    ClusterId clusterId                      = attributePath.mClusterId;
+    [[maybe_unused]] AttributeId attributeId = attributePath.mAttributeId;
     ChipLogProgress(Zcl, "Cluster callback: " ChipLogFormatMEI, ChipLogValueMEI(clusterId));
 
     if (clusterId == OnOffSwitchConfiguration::Id)
@@ -51,7 +50,6 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
                         ChipLogValueMEI(attributeId), type, *value, size);
     }
 }
-#endif
 
 /** @brief OnOff Cluster Init
  *

--- a/examples/light-switch-app/silabs/src/ZclCallbacks.cpp
+++ b/examples/light-switch-app/silabs/src/ZclCallbacks.cpp
@@ -30,7 +30,7 @@
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
 
-#ifndef NDEBUG 
+#ifndef NDEBUG
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
@@ -51,7 +51,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
                         ChipLogValueMEI(attributeId), type, *value, size);
     }
 }
-#ifndef NDEBUG 
+#ifndef NDEBUG
 
 
 /** @brief OnOff Cluster Init

--- a/examples/light-switch-app/silabs/src/ZclCallbacks.cpp
+++ b/examples/light-switch-app/silabs/src/ZclCallbacks.cpp
@@ -53,7 +53,6 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 }
 #ifndef NDEBUG
 
-
 /** @brief OnOff Cluster Init
  *
  * This function is called when a specific cluster is initialized. It gives the

--- a/examples/light-switch-app/silabs/src/ZclCallbacks.cpp
+++ b/examples/light-switch-app/silabs/src/ZclCallbacks.cpp
@@ -51,7 +51,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
                         ChipLogValueMEI(attributeId), type, *value, size);
     }
 }
-#ifndef NDEBUG
+#endif
 
 /** @brief OnOff Cluster Init
  *

--- a/examples/light-switch-app/silabs/src/ZclCallbacks.cpp
+++ b/examples/light-switch-app/silabs/src/ZclCallbacks.cpp
@@ -30,6 +30,7 @@
 using namespace ::chip;
 using namespace ::chip::app::Clusters;
 
+#ifndef NDEBUG 
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
@@ -50,6 +51,8 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
                         ChipLogValueMEI(attributeId), type, *value, size);
     }
 }
+#ifndef NDEBUG 
+
 
 /** @brief OnOff Cluster Init
  *

--- a/examples/lock-app/silabs/src/ZclCallbacks.cpp
+++ b/examples/lock-app/silabs/src/ZclCallbacks.cpp
@@ -39,6 +39,7 @@ using namespace ::chip::app::Clusters;
 using namespace ::chip::DeviceLayer::Internal;
 using ::chip::app::DataModel::Nullable;
 
+#ifndef NDEBUG 
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
@@ -56,6 +57,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 #endif // DIC_ENABLE
     }
 }
+#endif // NDEBUG
 
 /** @brief DoorLock Cluster Init
  *

--- a/examples/lock-app/silabs/src/ZclCallbacks.cpp
+++ b/examples/lock-app/silabs/src/ZclCallbacks.cpp
@@ -39,7 +39,6 @@ using namespace ::chip::app::Clusters;
 using namespace ::chip::DeviceLayer::Internal;
 using ::chip::app::DataModel::Nullable;
 
-#ifndef NDEBUG
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
@@ -49,7 +48,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 
     if (clusterId == DoorLock::Id && attributeId == DoorLock::Attributes::LockState::Id)
     {
-        DoorLock::DlLockState lockState = *(reinterpret_cast<DoorLock::DlLockState *>(value));
+        [[maybe_unused]] DoorLock::DlLockState lockState = *(reinterpret_cast<DoorLock::DlLockState *>(value));
         ChipLogProgress(Zcl, "Door lock cluster: " ChipLogFormatMEI " state %d", ChipLogValueMEI(clusterId),
                         to_underlying(lockState));
 #ifdef DIC_ENABLE
@@ -57,7 +56,6 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 #endif // DIC_ENABLE
     }
 }
-#endif // NDEBUG
 
 /** @brief DoorLock Cluster Init
  *

--- a/examples/lock-app/silabs/src/ZclCallbacks.cpp
+++ b/examples/lock-app/silabs/src/ZclCallbacks.cpp
@@ -39,7 +39,7 @@ using namespace ::chip::app::Clusters;
 using namespace ::chip::DeviceLayer::Internal;
 using ::chip::app::DataModel::Nullable;
 
-#ifndef NDEBUG 
+#ifndef NDEBUG
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {


### PR DESCRIPTION
Description of Problem/Feature: 
Unused variable errors within these methods when adding the NDEBUG define. Changes affect lock/light-switch.

Description of Fix/Solution:
Added [[maybe_unused]] before variable declarations.
