### PR TITLE
Have nicer command lines for zap_regen_all invoking zap_generate.

### DIFF
--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -30,6 +30,9 @@ from typing import Optional
 
 from zap_execution import ZapTool
 
+# TODO: Can we share this constant definition with zap_regen_all.py?
+DEFAULT_DATA_MODEL_DESCRIPTION_FILE = 'src/app/zap-templates/zcl/zcl.json'
+
 
 @dataclass
 class CmdLineArgs:
@@ -88,7 +91,7 @@ def detectZclFile(zapFile):
     print(f"Searching for zcl file from {zapFile}")
 
     prefix_chip_root_dir = True
-    path = 'src/app/zap-templates/zcl/zcl.json'
+    path = DEFAULT_DATA_MODEL_DESCRIPTION_FILE
 
     if zapFile:
         data = json.load(open(zapFile))

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -35,6 +35,9 @@ from typing import List
 CHIP_ROOT_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), '../..'))
 
+# TODO: Can we share this constant definition with generate.py?
+DEFAULT_DATA_MODEL_DESCRIPTION_FILE = 'src/app/zap-templates/zcl/zcl.json'
+
 
 class TargetType(Flag):
     """Type of targets that can be re-generated"""
@@ -108,6 +111,12 @@ class ZapInput:
         """What command to execute for this zap input. """
         if self.zap_file:
             return [script, self.zap_file]
+        if self.properties_json == DEFAULT_DATA_MODEL_DESCRIPTION_FILE:
+            # Omit the -z bits because that's the default generate.py
+            # will use anyway, and this leads to nicer-looking command
+            # lines if people need to run the regen manually and get
+            # their command line from our --dry-run.
+            return [script]
         return [script, '-z', self.properties_json]
 
 
@@ -382,7 +391,7 @@ def getGlobalTemplatesTargets():
 
         targets.append(ZAPGenerateTarget.MatterIdlTarget(ZapInput.FromZap(filepath)))
 
-    targets.append(ZAPGenerateTarget.MatterIdlTarget(ZapInput.FromPropertiesJson('src/app/zap-templates/zcl/zcl.json'),
+    targets.append(ZAPGenerateTarget.MatterIdlTarget(ZapInput.FromPropertiesJson(DEFAULT_DATA_MODEL_DESCRIPTION_FILE),
                    client_side=True, matter_file_name="src/controller/data_model/controller-clusters.matter"))
 
     return targets
@@ -414,7 +423,7 @@ def getGoldenTestImageTargets():
 
 
 def getSpecificTemplatesTargets():
-    zap_input = ZapInput.FromPropertiesJson('src/app/zap-templates/zcl/zcl.json')
+    zap_input = ZapInput.FromPropertiesJson(DEFAULT_DATA_MODEL_DESCRIPTION_FILE)
 
     # Mapping of required template and output directory
     templates = {


### PR DESCRIPTION
Both places are hardcoding the same zcl.json file path, but at least we should not include it in the command line if it's not needed....
