### PR TITLE
Move config header dependencies from platform to platform_base

### DIFF
--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -220,5 +220,6 @@ find_in_ancestors() {
     # generate and build
     set -x
     gn --root="$CHIP_ROOT" gen --check out --args="${args[*]}"
-    exec ninja -v -C out
+    ninja -C out -v
+    ninja -C out -t missingdeps
 }

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -418,7 +418,9 @@ if (chip_device_platform != "none") {
   source_set("platform_base") {
     public_deps = [
       ":platform_config_header",
+      "${chip_root}/src/app/icd/server:icd-server-config",
       "${chip_root}/src/ble",
+      "${chip_root}/src/credentials:build_time_header",
       "${chip_root}/src/inet",
       "${chip_root}/src/lib/core",
       "${chip_root}/src/lib/support",
@@ -507,10 +509,8 @@ if (chip_device_platform != "none") {
 
     public_deps = [
       ":platform_base",
-      "${chip_root}/src/app:app_config",
+      "${chip_root}/src/app:app_config",  # TODO: Move into platforms using it
       "${chip_root}/src/app/common:cluster-objects",
-      "${chip_root}/src/app/icd/server:icd-server-config",
-      "${chip_root}/src/credentials:build_time_header",
       "${chip_root}/src/crypto",
       "${chip_root}/src/lib/support",
     ]


### PR DESCRIPTION
Conceptually the generic headers in include/platform/ belong to platform_base, and some of them include these generated headers. Specifically
- GenericConfigurationManagerImpl.ipp includes FirmwareBuildTime.h
- ConnectivityManager.h includes ICDServerConfig.h

Also enforce we don't have missing deps when building the Darwin framework.
