### PR TITLE
Remove AppConfig dependency for the platform_base

### DIFF
--- a/src/controller/tests/TestEventCaching.cpp
+++ b/src/controller/tests/TestEventCaching.cpp
@@ -22,7 +22,6 @@
 #include "app/ConcreteAttributePath.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app/AppConfig.h>
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/EventLogging.h>

--- a/src/controller/tests/TestEventNumberCaching.cpp
+++ b/src/controller/tests/TestEventNumberCaching.cpp
@@ -19,7 +19,6 @@
 #include "app-common/zap-generated/ids/Clusters.h"
 #include "app/ClusterStateCache.h"
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app/AppConfig.h>
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/EventLogging.h>

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -26,7 +26,6 @@
 #include "app-common/zap-generated/ids/Clusters.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app/AppConfig.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/InteractionModelEngine.h>
 #include <app/tests/AppTestContext.h>

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -21,7 +21,6 @@
 #include "app/ConcreteAttributePath.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
-#include <app/AppConfig.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandlerInterface.h>

--- a/src/messaging/ReliableMessageContext.cpp
+++ b/src/messaging/ReliableMessageContext.cpp
@@ -23,16 +23,14 @@
 
 #include <inttypes.h>
 
-#include <messaging/ExchangeContext.h>
-#include <messaging/ExchangeMgr.h>
-#include <messaging/ReliableMessageContext.h>
-
-#include <app/AppConfig.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Defer.h>
 #include <messaging/ErrorCategory.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
+#include <messaging/ReliableMessageContext.h>
 #include <messaging/ReliableMessageMgr.h>
 #include <platform/PlatformManager.h>
 #include <protocols/Protocols.h>

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -509,7 +509,6 @@ if (chip_device_platform != "none") {
 
     public_deps = [
       ":platform_base",
-      "${chip_root}/src/app:app_config",  # TODO: Move into platforms using it
       "${chip_root}/src/app/common:cluster-objects",
       "${chip_root}/src/crypto",
       "${chip_root}/src/lib/support",


### PR DESCRIPTION
#### Description
After #33324, `app_config` did not seem to be necessary in the platform_base dependecies. Removing it since it shouldn't affect any builds.

- Remove `app_config` from the platform_base
- Remove the `AppConfig.h` include from files that don't use any of the defines in the config

####
CI to validate nothing breaks
