### PR TITLE
OPCREDS: Remove all the PICS markers

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_2.yaml
@@ -177,7 +177,6 @@ tests:
       disabled: true
 
     - label: "Step 6: From TH1 read the CurrentFabricIndex"
-      PICS: OPCREDS.S.A0005
       verification: |
           ./chip-tool operationalcredentials read   current-fabric-index   1 0
 

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_4.yaml
@@ -74,7 +74,6 @@ tests:
           "Step 4: TH1 sends the UpdateNOC command to the Node Operational
           Credentials cluster with the following fields: NOCValue is set to
           noc_original ICACValue is to set icac_original"
-      PICS: OPCREDS.S.C07.Rsp
       verification: |
           Verify that the DUT responds with FAILSAFE_REQUIRED
 
@@ -135,7 +134,6 @@ tests:
           "Step 6: TH1 sends the UpdateNOC command to the Node Operational
           Credentials cluster with the following fields: NOCValue is set to
           noc_original ICACValue is to set icac_original"
-      PICS: OPCREDS.S.C07.Rsp
       verification: |
           Verify that the DUT responds with a NOCResponse with the StatusCode field set to MissingCsr that is status code 4
 
@@ -151,7 +149,6 @@ tests:
     - label:
           "Step 7: TH1 Sends CSRRequest command with the IsForUpdateNOC field
           set to false"
-      PICS: OPCREDS.S.C04.Rsp
       verification: |
           Verify that the DUT returns a CSRResponse and save as csr_not_update
 
@@ -182,7 +179,6 @@ tests:
           "Step 9: TH1 sends the UpdateNOC command to the Node Operational
           Credentials cluster with the following fields: NOCValue is set to
           noc_not_for_update ICACValue is to set icac_not_for_update"
-      PICS: OPCREDS.S.C07.Rsp
       verification: |
 
       disabled: true
@@ -190,7 +186,6 @@ tests:
     - label:
           "Step 10: TH1 Sends CSRRequest command with the IsForUpdateNOC field
           set to true"
-      PICS: OPCREDS.S.C04.Rsp
       verification: |
 
       disabled: true
@@ -199,7 +194,6 @@ tests:
           "Step 11: TH1 sends the UpdateNOC command to the Node Operational
           Credentials cluster with the following fields: NOCValue is set to
           noc_original ICACValue is to set icac_original"
-      PICS: OPCREDS.S.C07.Rsp
       verification: |
 
       disabled: true
@@ -225,7 +219,6 @@ tests:
           "Step 14: TH1 sends the UpdateNOC command to the Node Operational
           Credentials cluster with the following fields: NOCValue is set to
           noc_update_new_root ICACValue is to set icac_update_new_root"
-      PICS: OPCREDS.S.C07.Rsp
       verification: |
 
       disabled: true
@@ -247,7 +240,6 @@ tests:
           Credentials cluster with the following fields: NOCValue is set to
           noc_update_bad_fabric_on_noc ICACValue is to set
           icac_update_bad_fabric_on_noc"
-      PICS: OPCREDS.S.C07.Rsp
       verification: |
 
       disabled: true
@@ -269,7 +261,6 @@ tests:
           Credentials cluster with the following fields: NOCValue is set to
           noc_update_bad_fabric_on_icac ICACValue is to set
           icac_update_bad_fabric_on_icac"
-      PICS: OPCREDS.S.C07.Rsp
       verification: |
 
       disabled: true
@@ -277,7 +268,6 @@ tests:
     - label:
           "Step 19: TH1 sends AddTrustedRootCertificate command to DUT again
           with the RootCACertificate field set to new_root_cert"
-      PICS: OPCREDS.S.C0b.Rsp
       verification: |
 
       disabled: true
@@ -286,7 +276,6 @@ tests:
           "Step 20: TH1 sends the UpdateNOC command to the Node Operational
           Credentials cluster with the following fields: NOCValue is set to
           noc_update_new_root ICACValue is to set icac_update_new_root"
-      PICS: OPCREDS.S.C07.Rsp
       verification: |
 
       disabled: true
@@ -314,7 +303,6 @@ tests:
     - label:
           "Step 24: TH1 Sends CSRRequest command over PASE with the
           IsForUpdateNOC field set to true"
-      PICS: OPCREDS.S.C04.Rsp
       verification: |
 
       disabled: true
@@ -332,7 +320,6 @@ tests:
           "Step 26: TH1 sends the UpdateNOC command to the Node Operational
           Credentials cluster over PASE with the following fields: NOCValue is
           set to noc_pase ICACValue is to set icac_pase"
-      PICS: OPCREDS.S.C07.Rsp
       verification: |
 
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_5.yaml
@@ -84,7 +84,6 @@ tests:
     - label:
           "Step 5: TH1 Sends CSRRequest command with the IsForUpdateNOC field
           set to true"
-      PICS: OPCREDS.S.C04.Rsp
       verification: |
           To get csr nonce give below command 2 times in TH(chip-tool)
            echo hex:$(hexdump -vn32 -e'4/4 "%08X" ' /dev/urandom)
@@ -116,7 +115,6 @@ tests:
           "Step 7: TH1 sends the UpdateNOC command to the Node Operational
           Credentials cluster with the following fields: NOCValue is set to
           noc_update1 ICACValue is to set icac_update1"
-      PICS: OPCREDS.S.C07.Rsp
       verification: |
 
       disabled: true
@@ -152,7 +150,6 @@ tests:
     - label:
           "Step 12: TH1 Sends CSRRequest command with the IsForUpdateNOC field
           set to true"
-      PICS: OPCREDS.S.C04.Rsp
       verification: |
 
       disabled: true
@@ -174,7 +171,6 @@ tests:
           "Step 14: TH1 sends the UpdateNOC command to the Node Operational
           Credentials cluster with the following fields: NOCValue is set to
           noc_update2 ICACValue is to set icac_update2"
-      PICS: OPCREDS.S.C07.Rsp
       verification: |
 
       disabled: true

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_6.yaml
@@ -38,7 +38,6 @@ tests:
     - label:
           "Step 2: TH1 sends RemoveFabric command with Fabric Index as
           FabricIndex_TH1 to DUT"
-      PICS: OPCREDS.S.C0a.Rsp
       verification: |
           ./chip-tool operationalcredentials remove-fabric 1 1 0
 

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
@@ -39,7 +39,6 @@ tests:
     - label:
           "Step 1: Factory Reset DUT (to ensure NOC list is empty at the
           beginning of the following steps)"
-      PICS: OPCREDS.S.A0000
       # verification: ""
       # Disabling this step, because the test starts with a DUT device that has just been commissioned by the TH1 commissioner
       disabled: true
@@ -56,7 +55,6 @@ tests:
     - label:
           "Step 3.1: Save the FabricIndex for TH1 as TH1_Fabric_Index for future
           use."
-      PICS: OPCREDS.S.A0001
       identity: "alpha"
       command: "readAttribute"
       cluster: "Operational Credentials"
@@ -68,7 +66,6 @@ tests:
           "Step 3.2: TH1 does a non-fabric-filtered read of the Fabrics
           attribute from the Node Operational Credentials cluster. Save the
           FabricIndex for TH1 as TH1_Fabric_Index for future use."
-      PICS: OPCREDS.S.A0001
       identity: "alpha"
       command: "readAttribute"
       cluster: "Operational Credentials"
@@ -83,7 +80,6 @@ tests:
     - label:
           "Step 4: TH1 sends ArmFailSafe command to the DUT with the
           ExpiryLengthSeconds field set to 60 seconds"
-      PICS: CGEN.S.C00.Rsp && CGEN.S.C01.Tx
       identity: "alpha"
       cluster: "General Commissioning"
       command: "ArmFailSafe"
@@ -100,7 +96,6 @@ tests:
 
       # verification: "Verify that the DUT sends ArmFailSafeResponse command to TH1 with field ErrorCode as OK(0)"
     - label: "Step 5: TH1 Sends CSRRequest command with a random 32-byte nonce."
-      PICS: OPCREDS.S.C04.Rsp
       identity: "alpha"
       command: "CSRRequest"
       cluster: "Operational Credentials"
@@ -119,7 +114,6 @@ tests:
     - label:
           "Step 6.1: Read the commissioner root certificate from TH2's fabric.
           Save RCAC as Root_CA_Certificate_TH2"
-      # PICS:
       identity: "beta"
       cluster: "CommissionerCommands"
       command: "GetCommissionerRootCertificate"
@@ -135,7 +129,6 @@ tests:
           TH2. Save ICAC as Intermediate_Certificate_TH2. Save NOC as
           Node_Operational_Certificate_TH2. Save IPK as IPK_TH2. Extract the
           RCAC public key and save as Root_Public_Key_TH2."
-      # PICS:
       identity: "beta"
       cluster: "CommissionerCommands"
       command: "IssueNocChain"
@@ -156,7 +149,6 @@ tests:
 
       # verification: ""
     - label: "Step 7.1: Read the commissioner node ID from TH2"
-      # PICS:
       identity: "beta"
       cluster: "CommissionerCommands"
       command: "GetCommissionerNodeId"
@@ -169,7 +161,6 @@ tests:
     - label:
           "Step 7.2: TH1 sends AddTrustedRootCertificate command to DUT with
           RootCACertificate set to Root_CA_Certificate_TH2"
-      PICS: OPCREDS.S.C0b.Rsp
       identity: "alpha"
       command: "AddTrustedRootCertificate"
       cluster: "Operational Credentials"
@@ -184,7 +175,6 @@ tests:
           fields: NOCValue as Node_Operational_Certificate_TH2. ICACValue as
           Intermediate_Certificate_TH2. IpkValue as IPK_TH2. CaseAdminSubject as
           the NodeID of TH2. AdminVendorId as the Vendor ID of TH2."
-      PICS: OPCREDS.S.C06.Rsp && OPCREDS.S.C08.Tx
       identity: "alpha"
       command: "AddNOC"
       cluster: "Operational Credentials"
@@ -207,14 +197,12 @@ tests:
 
       # verification: "Verify that DUT responds with NOCResponse with status code OK"
     - label: "Step 9: TH2 starts discovery of DUT using Operational Discovery"
-      # PICS: ""
       # verification: ""
       # Disabling this step as this occurs from the AddNOC command being run
       disabled: true
 
     - label:
           "Step 10: TH2 opens a CASE session with DUT over operational network."
-      # PICS: ""
       identity: "beta"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
@@ -225,7 +213,6 @@ tests:
 
       # verification: "DUT is able to open the CASE session with TH2"
     - label: "Step 11: TH2 sends CommissioningComplete command"
-      PICS: CGEN.S.C05.Tx
       nodeId: 0x43211234
       identity: "beta"
       cluster: "General Commissioning"
@@ -240,7 +227,6 @@ tests:
           "Step 12: TH2 reads the Current Fabric Index attribute from the Node
           Operational Credentials cluster. Save the FabricIndex for TH2 as
           TH2_Fabric_Index."
-      PICS: OPCREDS.S.A0001
       identity: "beta"
       nodeId: 0x43211234
       command: "readAttribute"
@@ -253,7 +239,6 @@ tests:
     - label:
           "Step 13: TH2 does a non-fabric-filtered read of the Fabrics attribute
           from the Node Operational Credentials cluster"
-      PICS: OPCREDS.S.A0001
       identity: "beta"
       nodeId: 0x43211234
       command: "readAttribute"
@@ -273,7 +258,6 @@ tests:
     - label:
           "Step 14: TH1 sends RemoveFabric command to DUT with the FabricIndex
           field set to TH2_Fabric_Index."
-      PICS: OPCREDS.S.C0a.Rsp
       identity: "alpha"
       command: "RemoveFabric"
       cluster: "Operational Credentials"


### PR DESCRIPTION
Everything in this cluster is mandatory, these steps do not need to be gated on the presence of a PICS, and if the PICS are set incorrectly, these tests will fail in unexpected and hard to debug ways.

https://github.com/CHIP-Specifications/chip-test-plans/pull/4146 for test plans

