### PR TITLE
[Python] Eliminate ZCLSubscribeAttribute

### DIFF
--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1425,25 +1425,26 @@ class BaseTestHelper:
     controller 1 in container 1 while the Step2 is executed in controller 2 in container 2
     '''
 
-    def TestSubscriptionResumptionCapacityStep1(self, nodeid: int, endpoint: int, passcode: int, subscription_capacity: int):
+    async def TestSubscriptionResumptionCapacityStep1(self, nodeid: int, endpoint: int, passcode: int, subscription_capacity: int):
         try:
             # BasicInformation Cluster, NodeLabel Attribute
             for i in range(subscription_capacity):
-                self.devCtrl.ZCLSubscribeAttribute(
-                    "BasicInformation", "NodeLabel", nodeid, endpoint, 1, 50, keepSubscriptions=True, autoResubscribe=False)
+                await self.devCtrl.ReadAttribute(nodeid, [(endpoint, Clusters.BasicInformation.Attributes.NodeLabel)], None,
+                                                 False, reportInterval=(1, 50),
+                                                 keepSubscriptions=True, autoResubscribe=False)
 
             logger.info("Send OpenCommissioningWindow command on fist controller")
             discriminator = 3840
             salt = secrets.token_bytes(16)
             iterations = 2000
             verifier = GenerateVerifier(passcode, salt, iterations)
-            asyncio.run(self.devCtrl.SendCommand(
+            await self.devCtrl.SendCommand(
                 nodeid, 0, Clusters.AdministratorCommissioning.Commands.OpenCommissioningWindow(
                     commissioningTimeout=180,
                     PAKEPasscodeVerifier=verifier,
                     discriminator=discriminator,
                     iterations=iterations,
-                    salt=salt), timedRequestTimeoutMs=10000))
+                    salt=salt), timedRequestTimeoutMs=10000)
             return True
 
         except Exception as ex:

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1453,8 +1453,8 @@ class BaseTestHelper:
 
         return True
 
-    def TestSubscriptionResumptionCapacityStep2(self, nodeid: int, endpoint: int, remote_ip: str, ssh_port: int,
-                                                remote_server_app: str, subscription_capacity: int):
+    async def TestSubscriptionResumptionCapacityStep2(self, nodeid: int, endpoint: int, remote_ip: str, ssh_port: int,
+                                                      remote_server_app: str, subscription_capacity: int):
         try:
             self.logger.info("Restart remote deivce")
             extra_agrs = f"--thread --discriminator 3840 --subscription-capacity {subscription_capacity}"
@@ -1468,8 +1468,9 @@ class BaseTestHelper:
             self.logger.info("Send a new subscription request from the second controller")
             # Close previous session so that the second controller will res-establish the session with the remote device
             self.devCtrl.CloseSession(nodeid)
-            self.devCtrl.ZCLSubscribeAttribute(
-                "BasicInformation", "NodeLabel", nodeid, endpoint, 1, 50, keepSubscriptions=True, autoResubscribe=False)
+            await self.devCtrl.ReadAttribute(nodeid, [(endpoint, Clusters.BasicInformation.Attributes.NodeLabel)], None,
+                                             False, reportInterval=(1, 50),
+                                             keepSubscriptions=True, autoResubscribe=False)
 
             if restartRemoteThread.is_alive():
                 # Thread join timed out

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -720,7 +720,7 @@ class BaseTestHelper:
         # was received.
         #
         await self.devCtrl2.WriteAttribute(nodeid, [(1, Clusters.UnitTesting.Attributes.Int8u(4))])
-        time.sleep(2)
+        await asyncio.sleep(2)
 
         sub.Shutdown()
 
@@ -752,7 +752,7 @@ class BaseTestHelper:
         # was received.  Use a different value from before, so there is an actual change.
         #
         await self.devCtrl2.WriteAttribute(nodeid, [(1, Clusters.UnitTesting.Attributes.Int8u(5))])
-        time.sleep(2)
+        await asyncio.sleep(2)
 
         sub.Shutdown()
 
@@ -775,7 +775,7 @@ class BaseTestHelper:
             await self.devCtrl.ReadAttribute(nodeid, [(Clusters.BasicInformation.Attributes.ClusterRevision)])
 
         await self.devCtrl.WriteAttribute(nodeid, [(1, Clusters.UnitTesting.Attributes.Int8u(6))])
-        time.sleep(2)
+        await asyncio.sleep(2)
 
         sub.Shutdown()
 

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -129,9 +129,8 @@ def TestDatamodel(test: BaseTestHelper, device_nodeid: int):
               "Failed to test Read Basic Attributes")
 
     logger.info("Testing attribute writing")
-    FailIfNot(test.TestWriteBasicAttributes(nodeid=device_nodeid,
-                                            endpoint=ENDPOINT_ID,
-                                            group=GROUP_ID),
+    FailIfNot(asyncio.run(test.TestWriteBasicAttributes(nodeid=device_nodeid,
+                                                        endpoint=ENDPOINT_ID)),
               "Failed to test Write Basic Attributes")
 
     logger.info("Testing attribute reading basic again")

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -141,11 +141,11 @@ def TestDatamodel(test: BaseTestHelper, device_nodeid: int):
               "Failed to test Read Basic Attributes")
 
     logger.info("Testing subscription")
-    FailIfNot(test.TestSubscription(nodeid=device_nodeid, endpoint=LIGHTING_ENDPOINT_ID),
+    FailIfNot(asyncio.run(test.TestSubscription(nodeid=device_nodeid, endpoint=LIGHTING_ENDPOINT_ID)),
               "Failed to subscribe attributes.")
 
     logger.info("Testing another subscription that kills previous subscriptions")
-    FailIfNot(test.TestSubscription(nodeid=device_nodeid, endpoint=LIGHTING_ENDPOINT_ID),
+    FailIfNot(asyncio.run(test.TestSubscription(nodeid=device_nodeid, endpoint=LIGHTING_ENDPOINT_ID)),
               "Failed to subscribe attributes.")
 
     logger.info("Testing re-subscription")

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
@@ -19,6 +19,7 @@
 
 # Commissioning test.
 
+import asyncio
 import os
 import sys
 from optparse import OptionParser
@@ -113,8 +114,8 @@ def main():
         "Failed on on-network commissioing")
 
     FailIfNot(
-        test.TestSubscriptionResumptionCapacityStep1(
-            options.nodeid, TEST_ENDPOINT_ID, options.setuppin, options.subscriptionCapacity),
+        asyncio.run(test.TestSubscriptionResumptionCapacityStep1(
+            options.nodeid, TEST_ENDPOINT_ID, options.setuppin, options.subscriptionCapacity)),
         "Failed on step 1 of testing subscription resumption capacity")
 
     timeoutTicker.stop()

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
@@ -19,6 +19,7 @@
 
 # Commissioning test.
 
+import asyncio
 import os
 import sys
 from optparse import OptionParser
@@ -125,8 +126,9 @@ def main():
         "Failed on on-network commissioing")
 
     FailIfNot(
-        test.TestSubscriptionResumptionCapacityStep2(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
-                                                     TEST_SSH_PORT, options.remoteServerApp, options.subscriptionCapacity),
+        asyncio.run(
+            test.TestSubscriptionResumptionCapacityStep2(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
+                                                         TEST_SSH_PORT, options.remoteServerApp, options.subscriptionCapacity)),
         "Failed on testing subscription resumption capacity")
 
     timeoutTicker.stop()

--- a/src/controller/python/test/test_scripts/subscription_resumption_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_test.py
@@ -19,6 +19,7 @@
 
 # Commissioning test.
 
+import asyncio
 import os
 import sys
 from optparse import OptionParser
@@ -115,8 +116,8 @@ def main():
         "Failed on on-network commissioing")
 
     FailIfNot(
-        test.TestSubscriptionResumption(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
-                                        TEST_SSH_PORT, options.remoteServerApp), "Failed to resume subscription")
+        asyncio.run(test.TestSubscriptionResumption(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
+                                                    TEST_SSH_PORT, options.remoteServerApp)), "Failed to resume subscription")
 
     timeoutTicker.stop()
 

--- a/src/controller/python/test/test_scripts/subscription_resumption_timeout_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_timeout_test.py
@@ -19,11 +19,13 @@
 
 # Commissioning test.
 
+import asyncio
 import os
 import sys
 from optparse import OptionParser
 
 from base import BaseTestHelper, FailIfNot, TestFail, TestTimeout, logger
+from chip import clusters as Clusters
 
 TEST_DISCRIMINATOR = 3840
 TEST_SETUPPIN = 20202021
@@ -101,10 +103,12 @@ def main():
 
     FailIfNot(
         test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
-        "Failed on on-network commissioing")
+        "Failed on on-network commissioning")
+
     try:
-        test.devCtrl.ZCLSubscribeAttribute("BasicInformation", "NodeLabel", options.nodeid, TEST_ENDPOINT_ID, 1, 2,
-                                           keepSubscriptions=True, autoResubscribe=False)
+        asyncio.run(test.devCtrl.ReadAttribute(options.nodeid,
+                                               [(TEST_ENDPOINT_ID, Clusters.BasicInformation.Attributes.NodeLabel)],
+                                               None, False, reportInterval=(1, 2), keepSubscriptions=True, autoResubscribe=False))
     except Exception as ex:
         TestFail(f"Failed to subscribe attribute: {ex}")
 


### PR DESCRIPTION
This eliminates use of ZCLSubscribeAttribute and improves some tests using asyncio.
