### PR TITLE
[Linux] Add mechanism to redirect CHIP log other than stdout

### DIFF
--- a/src/platform/logging/LogV.h
+++ b/src/platform/logging/LogV.h
@@ -30,6 +30,25 @@ namespace Platform {
  */
 void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v);
 
+/**
+ * Open a log file for appending log messages. This function opens
+ * the specified file and ensures that subsequent logs are written to
+ * this file. It should be called at the start of the application
+ * before any logging is done.
+ *
+ * @param[in] filePath  The path to the log file. If the file does not
+ *                      exist, it will be created. If it exists, log
+ *                      messages will be appended to it.
+ */
+void OpenLogFile(const char * filePath);
+
+/**
+ * Close the log file if it is open. This function should be called
+ * at the end of the application to ensure that all log messages are
+ * flushed to disk and the file is properly closed.
+ */
+void CloseLogFile();
+
 } // namespace Platform
 } // namespace Logging
 } // namespace chip


### PR DESCRIPTION
Currently, both shell command and CHIP logs are printed out to the same console on Linux, make it very difficult to interact with the example app via shell CLI.

```
[1714771193.157408][264120:264121] CHIP:DL: Got IP address on interface: wlp3s0 IP: 192.168.86.250
[1714771193.157474][264120:264122] CHIP:DL: HandlePlatformSpecificBLEEvent 32770
[1714771194.179146][264120:264121] CHIP:DL: Got IP address on interface: wlp3s0 IP: 192.168.86.250
[1714771194.179241][264120:264122] CHIP:DL: HandlePlatformSpecificBLEEvent 32770 (edited) 
```

Event though I can turn off those logs, but it is better to have a way to redirect logging to another place so that I can only see CLI message in console and check CHIP log in another place 