### PR TITLE
Make sure to include ember defines for door lock.

### DIFF
--- a/examples/chef/common/clusters/door-lock/chef-doorlock-stubs.cpp
+++ b/examples/chef/common/clusters/door-lock/chef-doorlock-stubs.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app/data-model/Nullable.h>
+#include <app/util/config.h>
 #include <lib/core/DataModelTypes.h>
 
 #ifdef MATTER_DM_PLUGIN_DOOR_LOCK_SERVER

--- a/examples/chef/common/clusters/door-lock/chef-lock-endpoint.cpp
+++ b/examples/chef/common/clusters/door-lock/chef-lock-endpoint.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/util/config.h>
 #include <cstring>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>

--- a/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
+++ b/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 #include <lib/support/logging/CHIPLogging.h>
+#include <app/util/config.h>
 
 #ifdef MATTER_DM_PLUGIN_DOOR_LOCK_SERVER
 #include "chef-lock-manager.h"

--- a/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
+++ b/examples/chef/common/clusters/door-lock/chef-lock-manager.cpp
@@ -15,8 +15,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <lib/support/logging/CHIPLogging.h>
 #include <app/util/config.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 #ifdef MATTER_DM_PLUGIN_DOOR_LOCK_SERVER
 #include "chef-lock-manager.h"


### PR DESCRIPTION
Chef was using MATTER_DM_PLUGIN_DOOR_LOCK_SERVER without including relevant headers (and assuming that data model would transitively define them)

This does not work anymore after #32776 , so include app config instead.
