### PR TITLE
[cloudbuild] Switch unit test to a larger EFR32 part as otherwise we run out of flash

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -77,7 +77,7 @@ steps:
               --target efr32-brd4161a-light-rpc
               --target efr32-brd4161a-lock-openthread-mtd
               --target efr32-brd4161a-lock-rpc-openthread-mtd
-              --target efr32-brd4161a-unit-test
+              --target efr32-brd4187c-unit-test
               build
               --create-archives /workspace/artifacts/
       waitFor:


### PR DESCRIPTION
Builds were failing with

```
2024-05-07 20:06:45 INFO    FAILED: matter-silabs-device_tests.out matter-silabs-device_tests.out.map
2024-05-07 20:06:45 INFO    arm-none-eabi-g++ -T../../src/test_driver/efr32/third_party/connectedhomeip/examples/platform/silabs/ldscripts/efr32mg12.ld -Wl,--no-warn-rwx-segment -march=armv7e-m -mcpu=cortex-m4 -mabi=aapcs -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb -Os --specs=nosys.specs --specs=nano.specs -Werror -Wl,--fatal-warnings -fdiagnostics-color -Wl,--gc-sections -Wl,--wrap=malloc -Wl,--wrap=free -Wl,--wrap=realloc -Wl,--wrap=calloc -Wl,--wrap=MemoryAlloc -Wl,--wrap=_malloc_r -Wl,--wrap=_realloc_r -Wl,--wrap=_free_r -Wl,--wrap=_calloc_r -Wl,-Map,./matter-silabs-device_tests.out.map -Wl,--cref @./matter-silabs-device_tests.out.rsp -o ./matter-silabs-device_tests.out
2024-05-07 20:06:45 INFO    /home/vscode/pigweed/env/cipd/packages/arm/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld: ./matter-silabs-device_tests.out section `.text' will not fit in region `FLASH'
2024-05-07 20:06:45 INFO    /home/vscode/pigweed/env/cipd/packages/arm/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld: FLASH memory overflowed !
2024-05-07 20:06:45 INFO    /home/vscode/pigweed/env/cipd/packages/arm/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld: FLASH memory overlapped with NVM section.
2024-05-07 20:06:45 INFO    /home/vscode/pigweed/env/cipd/packages/arm/bin/../lib/gcc/arm-none-eabi/12.2.1/../../../../arm-none-eabi/bin/ld: region `FLASH' overflowed by 120032 bytes
2024-05-07 20:06:45 INFO    collect2: error: ld returned 1 exit status
2024-05-07 20:06:45 INFO    ninja: build stopped: subcommand failed
```

when switching to other part we seem ok.