### PR TITLE
[Silbas] Remove AppConfig header from Silabs Platform

### DIFF
--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -28,7 +28,6 @@
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h>
 #endif
-#include "AppConfig.h"
 #include "FreeRTOS.h"
 #include "heap_4_silabs.h"
 #include <inet/InetInterface.h>

--- a/src/platform/silabs/PlatformManagerImpl.cpp
+++ b/src/platform/silabs/PlatformManagerImpl.cpp
@@ -39,8 +39,6 @@
 #include <lwip/tcpip.h>
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
-#include "AppConfig.h"
-
 using namespace chip::DeviceLayer::Internal;
 
 namespace chip {

--- a/src/platform/silabs/SiWx917/wifi/dhcp_client.cpp
+++ b/src/platform/silabs/SiWx917/wifi/dhcp_client.cpp
@@ -26,7 +26,6 @@
 #include "wfx_host_events.h"
 #include "wifi_config.h"
 
-#include "AppConfig.h"
 #include "FreeRTOS.h"
 #include "event_groups.h"
 

--- a/src/platform/silabs/SiWx917/wifi/dhcp_client.cpp
+++ b/src/platform/silabs/SiWx917/wifi/dhcp_client.cpp
@@ -29,6 +29,8 @@
 #include "FreeRTOS.h"
 #include "event_groups.h"
 
+#include <lib/support/logging/CHIPLogging.h>
+
 #define MAX_DHCP_TRIES (4)
 #define NETIF_IPV4_ADDRESS(X, Y) (((X) >> (8 * Y)) & 0xFF)
 
@@ -61,7 +63,7 @@ void dhcpclient_set_link_state(int link_up)
     if (link_up)
     {
         dhcp_state = DHCP_START;
-        SILABS_LOG("DHCP: Starting");
+        ChipLogProgress(DeviceLayer, "DHCP: Starting");
     }
     else
     {
@@ -87,7 +89,7 @@ uint8_t dhcpclient_poll(void * arg)
     switch (dhcp_state)
     {
     case DHCP_START:
-        SILABS_LOG("DHCP: Wait addr");
+        ChipLogProgress(DeviceLayer, "DHCP: Wait addr");
         ip_addr_set_zero_ip4(&netif->ip_addr);
         ip_addr_set_zero_ip4(&netif->netmask);
         ip_addr_set_zero_ip4(&netif->gw);
@@ -101,8 +103,8 @@ uint8_t dhcpclient_poll(void * arg)
             dhcp_state = DHCP_ADDRESS_ASSIGNED;
 
             uint64_t addr = netif->ip_addr.u_addr.ip4.addr;
-            SILABS_LOG("DHCP IP: %d.%d.%d.%d", NETIF_IPV4_ADDRESS(addr, 0), NETIF_IPV4_ADDRESS(addr, 1),
-                       NETIF_IPV4_ADDRESS(addr, 2), NETIF_IPV4_ADDRESS(addr, 3));
+            ChipLogProgress(DeviceLayer, "DHCP IP: %d.%d.%d.%d", NETIF_IPV4_ADDRESS(addr, 0), NETIF_IPV4_ADDRESS(addr, 1),
+                            NETIF_IPV4_ADDRESS(addr, 2), NETIF_IPV4_ADDRESS(addr, 3));
         }
         else
         {
@@ -113,7 +115,7 @@ uint8_t dhcpclient_poll(void * arg)
             {
                 dhcp_state = DHCP_TIMEOUT;
 
-                SILABS_LOG("*ERR*DHCP: Failed");
+                ChipLogProgress(DeviceLayer, "*ERR*DHCP: Failed");
                 /* Stop DHCP */
                 dhcp_stop(netif);
 
@@ -129,7 +131,7 @@ uint8_t dhcpclient_poll(void * arg)
 
     case DHCP_LINK_DOWN:
         /* Stop DHCP */
-        SILABS_LOG("*ERR*DHCP Link down");
+        ChipLogProgress(DeviceLayer, "*ERR*DHCP Link down");
         dhcp_stop(netif);
         dhcp_state = DHCP_OFF;
         break;

--- a/src/platform/silabs/SiWx917/wifi/lwip_netif.cpp
+++ b/src/platform/silabs/SiWx917/wifi/lwip_netif.cpp
@@ -22,7 +22,6 @@
 #include "wfx_host_events.h"
 #include "wifi_config.h"
 
-#include "AppConfig.h"
 #include "dhcp_client.h"
 #include "ethernetif.h"
 

--- a/src/platform/silabs/SiWx917/wifi/wfx_notify.cpp
+++ b/src/platform/silabs/SiWx917/wifi/wfx_notify.cpp
@@ -47,6 +47,8 @@ extern "C" {
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 
+#include <lib/support/logging/CHIPLogging.h>
+
 extern uint32_t retryInterval;
 /*
  * Notifications to the upper-layer
@@ -64,8 +66,6 @@ void wfx_started_notify()
 {
     sl_wfx_startup_ind_t evt;
     sl_wfx_mac_address_t mac;
-
-    SILABS_LOG("%s: started.", __func__);
 
     memset(&evt, 0, sizeof(evt));
     evt.header.id     = SL_WFX_STARTUP_IND_ID;
@@ -90,15 +90,13 @@ void wfx_connected_notify(int32_t status, sl_wfx_mac_address_t * ap)
 {
     sl_wfx_connect_ind_t evt;
 
-    SILABS_LOG("%s: started.", __func__);
-
     if (status != SUCCESS_STATUS)
     {
-        SILABS_LOG("%s: error: failed status: %d.", __func__, status);
+        ChipLogProgress(DeviceLayer, "%s: error: failed status: %ld.", __func__, status);
         return;
     }
 
-    SILABS_LOG("%s: connected.", __func__);
+    ChipLogProgress(DeviceLayer, "%s: connected.", __func__);
 
     memset(&evt, 0, sizeof(evt));
     evt.header.id     = SL_WFX_CONNECT_IND_ID;
@@ -123,8 +121,6 @@ void wfx_disconnected_notify(int32_t status)
 {
     sl_wfx_disconnect_ind_t evt;
 
-    SILABS_LOG("%s: started.", __func__);
-
     memset(&evt, 0, sizeof(evt));
     evt.header.id     = SL_WFX_DISCONNECT_IND_ID;
     evt.header.length = sizeof evt;
@@ -142,8 +138,6 @@ void wfx_disconnected_notify(int32_t status)
 void wfx_ipv6_notify(int got_ip)
 {
     sl_wfx_generic_message_t eventData;
-
-    SILABS_LOG("%s: started.", __func__);
 
     memset(&eventData, 0, sizeof(eventData));
     eventData.header.id     = got_ip ? IP_EVENT_GOT_IP6 : IP_EVENT_STA_LOST_IP;
@@ -171,8 +165,6 @@ void wfx_ipv6_notify(int got_ip)
 void wfx_ip_changed_notify(int got_ip)
 {
     sl_wfx_generic_message_t eventData;
-
-    SILABS_LOG("%s: started.", __func__);
 
     memset(&eventData, 0, sizeof(eventData));
     eventData.header.id     = got_ip ? IP_EVENT_STA_GOT_IP : IP_EVENT_STA_LOST_IP;
@@ -206,7 +198,8 @@ void wfx_retry_interval_handler(bool is_wifi_disconnection_event, uint16_t retry
          */
         if (retryJoin < MAX_JOIN_RETRIES_COUNT)
         {
-            SILABS_LOG("wfx_retry_interval_handler : Next attempt after %d Seconds", CONVERT_MS_TO_SEC(WLAN_RETRY_TIMER_MS));
+            ChipLogProgress(DeviceLayer, "wfx_retry_interval_handler : Next attempt after %d Seconds",
+                            CONVERT_MS_TO_SEC(WLAN_RETRY_TIMER_MS));
 #if SL_ICD_ENABLED
             // TODO: cleanup the retry logic MATTER-1921
             if (!chip::Server::GetInstance().GetCommissioningWindowManager().IsCommissioningWindowOpen())
@@ -218,7 +211,7 @@ void wfx_retry_interval_handler(bool is_wifi_disconnection_event, uint16_t retry
         }
         else
         {
-            SILABS_LOG("Connect failed after max %d tries", retryJoin);
+            ChipLogProgress(DeviceLayer, "Connect failed after max %d tries", retryJoin);
         }
     }
     else
@@ -232,7 +225,8 @@ void wfx_retry_interval_handler(bool is_wifi_disconnection_event, uint16_t retry
         {
             retryInterval = WLAN_MAX_RETRY_TIMER_MS;
         }
-        SILABS_LOG("wfx_retry_interval_handler : Next attempt after %d Seconds", CONVERT_MS_TO_SEC(retryInterval));
+        ChipLogProgress(DeviceLayer, "wfx_retry_interval_handler : Next attempt after %ld Seconds",
+                        CONVERT_MS_TO_SEC(retryInterval));
 #if SL_ICD_ENABLED
         wfx_rsi_power_save(RSI_SLEEP_MODE_8, STANDBY_POWER_SAVE_WITH_RAM_RETENTION);
 #endif // SL_ICD_ENABLED

--- a/src/platform/silabs/SiWx917/wifi/wfx_notify.cpp
+++ b/src/platform/silabs/SiWx917/wifi/wfx_notify.cpp
@@ -19,8 +19,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "AppConfig.h"
-
 #include "FreeRTOS.h"
 #include "event_groups.h"
 #include "silabs_utils.h"

--- a/src/platform/silabs/efr32/wifi/dhcp_client.cpp
+++ b/src/platform/silabs/efr32/wifi/dhcp_client.cpp
@@ -32,7 +32,6 @@
 #include "wfx_host_events.h"
 #include "wifi_config.h"
 
-#include "AppConfig.h"
 #include "FreeRTOS.h"
 #include "event_groups.h"
 

--- a/src/platform/silabs/efr32/wifi/dhcp_client.cpp
+++ b/src/platform/silabs/efr32/wifi/dhcp_client.cpp
@@ -35,6 +35,8 @@
 #include "FreeRTOS.h"
 #include "event_groups.h"
 
+#include <lib/support/logging/CHIPLogging.h>
+
 #define MAX_DHCP_TRIES 4
 #define NETIF_IPV4_ADDRESS(X, Y) (((X) >> (8 * Y)) & 0xFF)
 
@@ -67,7 +69,7 @@ void dhcpclient_set_link_state(int link_up)
     if (link_up)
     {
         dhcp_state = DHCP_START;
-        SILABS_LOG("DHCP: Starting");
+        ChipLogProgress(DeviceLayer, "DHCP: Starting");
     }
     else
     {
@@ -93,7 +95,7 @@ uint8_t dhcpclient_poll(void * arg)
     switch (dhcp_state)
     {
     case DHCP_START:
-        SILABS_LOG("DHCP: Wait addr");
+        ChipLogProgress(DeviceLayer, "DHCP: Wait addr");
         ip_addr_set_zero_ip4(&netif->ip_addr);
         ip_addr_set_zero_ip4(&netif->netmask);
         ip_addr_set_zero_ip4(&netif->gw);
@@ -107,8 +109,8 @@ uint8_t dhcpclient_poll(void * arg)
             dhcp_state = DHCP_ADDRESS_ASSIGNED;
 
             uint64_t addr = netif->ip_addr.u_addr.ip4.addr;
-            SILABS_LOG("DHCP IP: %d.%d.%d.%d", NETIF_IPV4_ADDRESS(addr, 0), NETIF_IPV4_ADDRESS(addr, 1),
-                       NETIF_IPV4_ADDRESS(addr, 2), NETIF_IPV4_ADDRESS(addr, 3));
+            ChipLogProgress(DeviceLayer, "DHCP IP: %d.%d.%d.%d", NETIF_IPV4_ADDRESS(addr, 0), NETIF_IPV4_ADDRESS(addr, 1),
+                            NETIF_IPV4_ADDRESS(addr, 2), NETIF_IPV4_ADDRESS(addr, 3));
         }
         else
         {
@@ -119,7 +121,7 @@ uint8_t dhcpclient_poll(void * arg)
             {
                 dhcp_state = DHCP_TIMEOUT;
 
-                SILABS_LOG("*ERR*DHCP: Failed");
+                ChipLogProgress(DeviceLayer, "*ERR*DHCP: Failed");
                 /* Stop DHCP */
                 dhcp_stop(netif);
 
@@ -135,7 +137,7 @@ uint8_t dhcpclient_poll(void * arg)
 
     case DHCP_LINK_DOWN:
         /* Stop DHCP */
-        SILABS_LOG("*ERR*DHCP Link down");
+        ChipLogProgress(DeviceLayer, "*ERR*DHCP Link down");
         dhcp_stop(netif);
         dhcp_state = DHCP_OFF;
         break;

--- a/src/platform/silabs/efr32/wifi/ethernetif.cpp
+++ b/src/platform/silabs/efr32/wifi/ethernetif.cpp
@@ -171,7 +171,7 @@ static void low_level_input(struct netif * netif, uint8_t * b, uint16_t len)
         }
 #ifdef WIFI_DEBUG_ENABLED
         ChipLogProgress(DeviceLayer,
-                        "%s: ACCEPT %d, [%02x:%02x:%02x:%02x:%02x:%02x]<-[%02x:%02x:%02x:%02x:%02x:%02x] type=%02x%02x", __func__,
+                        "%s: ACCEPT %ld, [%02x:%02x:%02x:%02x:%02x:%02x]<-[%02x:%02x:%02x:%02x:%02x:%02x] type=%02x%02x", __func__,
                         bufferoffset,
 
                         dst_mac[0], dst_mac[1], dst_mac[2], dst_mac[3], dst_mac[4], dst_mac[5],

--- a/src/platform/silabs/efr32/wifi/ethernetif.cpp
+++ b/src/platform/silabs/efr32/wifi/ethernetif.cpp
@@ -60,12 +60,7 @@ extern "C" {
 #include "lwip/timeouts.h"
 #include "netif/etharp.h"
 
-#ifndef SILABS_LOG
-extern "C" {
-void silabsLog(const char * aFormat, ...);
-#define SILABS_LOG(...) silabsLog(__VA_ARGS__);
-}
-#endif
+#include <lib/support/logging/CHIPLogging.h>
 
 StaticSemaphore_t xEthernetIfSemaBuffer;
 
@@ -152,13 +147,14 @@ static void low_level_input(struct netif * netif, uint8_t * b, uint16_t len)
         (memcmp(netif->hwaddr, dst_mac, netif->hwaddr_len) != 0))
     {
 #ifdef WIFI_DEBUG_ENABLED
-        SILABS_LOG("%s: DROP, [%02x:%02x:%02x:%02x:%02x:%02x]<-[%02x:%02x:%02x:%02x:%02x:%02x] type=%02x%02x", __func__,
+        ChipLogProgress(DeviceLayer, "%s: DROP, [%02x:%02x:%02x:%02x:%02x:%02x]<-[%02x:%02x:%02x:%02x:%02x:%02x] type=%02x%02x",
+                        __func__,
 
-                   dst_mac[0], dst_mac[1], dst_mac[2], dst_mac[3], dst_mac[4], dst_mac[5],
+                        dst_mac[0], dst_mac[1], dst_mac[2], dst_mac[3], dst_mac[4], dst_mac[5],
 
-                   src_mac[0], src_mac[1], src_mac[2], src_mac[3], src_mac[4], src_mac[5],
+                        src_mac[0], src_mac[1], src_mac[2], src_mac[3], src_mac[4], src_mac[5],
 
-                   b[12], b[13]);
+                        b[12], b[13]);
 #endif
         return;
     }
@@ -174,27 +170,28 @@ static void low_level_input(struct netif * netif, uint8_t * b, uint16_t len)
             bufferoffset += q->len;
         }
 #ifdef WIFI_DEBUG_ENABLED
-        SILABS_LOG("%s: ACCEPT %d, [%02x:%02x:%02x:%02x:%02x:%02x]<-[%02x:%02x:%02x:%02x:%02x:%02x] type=%02x%02x", __func__,
-                   bufferoffset,
+        ChipLogProgress(DeviceLayer,
+                        "%s: ACCEPT %d, [%02x:%02x:%02x:%02x:%02x:%02x]<-[%02x:%02x:%02x:%02x:%02x:%02x] type=%02x%02x", __func__,
+                        bufferoffset,
 
-                   dst_mac[0], dst_mac[1], dst_mac[2], dst_mac[3], dst_mac[4], dst_mac[5],
+                        dst_mac[0], dst_mac[1], dst_mac[2], dst_mac[3], dst_mac[4], dst_mac[5],
 
-                   src_mac[0], src_mac[1], src_mac[2], src_mac[3], src_mac[4], src_mac[5],
+                        src_mac[0], src_mac[1], src_mac[2], src_mac[3], src_mac[4], src_mac[5],
 
-                   b[12], b[13]);
+                        b[12], b[13]);
 #endif
 
         if (netif->input(p, netif) != ERR_OK)
         {
             gOverrunCount++;
-            SILABS_LOG("overrun count entering when fail to alloc value %d", gOverrunCount);
+            ChipLogProgress(DeviceLayer, "overrun count entering when fail to alloc value %ld", gOverrunCount);
             pbuf_free(p);
         }
     }
     else
     {
         gOverrunCount++;
-        SILABS_LOG("overrun count entering when fail to alloc value %d", gOverrunCount);
+        ChipLogProgress(DeviceLayer, "overrun count entering when fail to alloc value %ld", gOverrunCount);
     }
 }
 
@@ -241,9 +238,9 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
     // 12 is size of other data in buffer struct, user shouldn't have to care about this?
     if (sl_wfx_host_allocate_buffer((void **) &tx_buffer, SL_WFX_TX_FRAME_BUFFER, asize) != SL_STATUS_OK)
     {
-        SILABS_LOG("*ERR*EN-Out: No mem frame len=%d", framelength);
+        ChipLogProgress(DeviceLayer, "*ERR*EN-Out: No mem frame len=%ld", framelength);
         gOverrunCount++;
-        SILABS_LOG("overrun count exiting when faied to alloc value %d", gOverrunCount);
+        ChipLogProgress(DeviceLayer, "overrun count exiting when faied to alloc value %ld", gOverrunCount);
         return ERR_MEM;
     }
     buffer = tx_buffer->body.packet_data;
@@ -265,7 +262,7 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
     result = SL_STATUS_FAIL;
 
 #ifdef WIFI_DEBUG_ENABLED
-    SILABS_LOG("WF200: Out %d", (int) framelength);
+    ChipLogProgress(DeviceLayer, "WF200: Out %d", (int) framelength);
 #endif
 
     /* send the generated frame over Wifi network */
@@ -277,7 +274,7 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
 
     if (result != SL_STATUS_OK)
     {
-        SILABS_LOG("*ERR*Send enet %d", (int) framelength);
+        ChipLogProgress(DeviceLayer, "*ERR*Send enet %d", (int) framelength);
         return ERR_IF;
     }
     return ERR_OK;
@@ -312,7 +309,7 @@ void sl_wfx_host_received_frame_callback(sl_wfx_received_ind_t * rx_buffer)
             buffer = (uint8_t *) &(rx_buffer->body.frame[rx_buffer->body.frame_padding]);
 
 #ifdef WIFI_DEBUG_ENABLED
-            SILABS_LOG("WF200: In %d", (int) len);
+            ChipLogProgress(DeviceLayer, "WF200: In %d", (int) len);
 #endif
 
             low_level_input(netif, buffer, len);
@@ -320,14 +317,14 @@ void sl_wfx_host_received_frame_callback(sl_wfx_received_ind_t * rx_buffer)
         else
         {
 #ifdef WIFI_DEBUG_ENABLED
-            SILABS_LOG("WF200: NO-INTF");
+            ChipLogProgress(DeviceLayer, "WF200: NO-INTF");
 #endif
         }
     }
     else
     {
 #ifdef WIFI_DEBUG_ENABLED
-        SILABS_LOG("WF200: Invalid frame IN");
+        ChipLogProgress(DeviceLayer, "WF200: Invalid frame IN");
 #endif
     }
 }
@@ -360,7 +357,7 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
     uint16_t framelength = 0;
     uint16_t datalength  = 0;
 #ifdef WIFI_DEBUG_ENABLED
-    SILABS_LOG("LWIP : low_level_output");
+    ChipLogProgress(DeviceLayer, "LWIP : low_level_output");
 #endif
     if (xSemaphoreTake(ethout_sem, portMAX_DELAY) != pdTRUE)
     {
@@ -376,11 +373,11 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
         framelength = LWIP_FRAME_ALIGNMENT;
     }
 #ifdef WIFI_DEBUG_ENABLED
-    SILABS_LOG("EN-RSI: Output");
+    ChipLogProgress(DeviceLayer, "EN-RSI: Output");
 #endif
     if ((netif->flags & (NETIF_FLAG_LINK_UP | NETIF_FLAG_UP)) != (NETIF_FLAG_LINK_UP | NETIF_FLAG_UP))
     {
-        SILABS_LOG("EN-RSI:NOT UP");
+        ChipLogProgress(DeviceLayer, "EN-RSI:NOT UP");
         xSemaphoreGive(ethout_sem);
         return ERR_IF;
     }
@@ -395,7 +392,7 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
     if (!packet)
 #endif // SLI_SI91X_MCU_INTERFACE
     {
-        SILABS_LOG("EN-RSI:No buf");
+        ChipLogProgress(DeviceLayer, "EN-RSI:No buf");
         xSemaphoreGive(ethout_sem);
 #if (SLI_SI91X_MCU_INTERFACE | EXP_BOARD)
         return SL_STATUS_ALLOCATION_FAILED;
@@ -407,8 +404,8 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
 #endif // SLI_SI91X_MCU_INTERFACE
 #ifdef WIFI_DEBUG_ENABLED
     uint8_t * b = (uint8_t *) p->payload;
-    SILABS_LOG("EN-RSI: Out [%02x:%02x:%02x:%02x:%02x:%02x][%02x:%02x:%02x:%02x:%02x:%02x]type=%02x%02x", b[0], b[1], b[2], b[3],
-               b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13]);
+    ChipLogProgress(DeviceLayer, "EN-RSI: Out [%02x:%02x:%02x:%02x:%02x:%02x][%02x:%02x:%02x:%02x:%02x:%02x]type=%02x%02x", b[0],
+                    b[1], b[2], b[3], b[4], b[5], b[6], b[7], b[8], b[9], b[10], b[11], b[12], b[13]);
 #endif
     /* Generate the packet */
     for (q = p, datalength = 0; q != NULL; q = q->next)
@@ -422,7 +419,7 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
         wfx_rsi_pkt_add_data(packet, (uint8_t *) (p->payload), LWIP_FRAME_ALIGNMENT - datalength, datalength);
     }
 #ifdef WIFI_DEBUG_ENABLED
-    SILABS_LOG("EN-RSI: Sending %d", framelength);
+    ChipLogProgress(DeviceLayer, "EN-RSI: Sending %d", framelength);
 #endif
 
     /* forward the generated packet to RSI to
@@ -439,13 +436,13 @@ static err_t low_level_output(struct netif * netif, struct pbuf * p)
     if (wfx_rsi_send_data(packet, datalength))
 #endif
     {
-        SILABS_LOG("*ERR*EN-RSI:Send fail");
+        ChipLogProgress(DeviceLayer, "*ERR*EN-RSI:Send fail");
         xSemaphoreGive(ethout_sem);
         return ERR_IF;
     }
 
 #ifdef WIFI_DEBUG_ENABLED
-    SILABS_LOG("EN-RSI:Xmit %d", framelength);
+    ChipLogProgress(DeviceLayer, "EN-RSI:Xmit %d", framelength);
 #endif
     xSemaphoreGive(ethout_sem);
 

--- a/src/platform/silabs/efr32/wifi/lwip_netif.cpp
+++ b/src/platform/silabs/efr32/wifi/lwip_netif.cpp
@@ -28,7 +28,6 @@
 #include "wfx_host_events.h"
 #include "wifi_config.h"
 
-#include "AppConfig.h"
 #include "dhcp_client.h"
 #include "ethernetif.h"
 

--- a/src/platform/silabs/efr32/wifi/lwip_netif.cpp
+++ b/src/platform/silabs/efr32/wifi/lwip_netif.cpp
@@ -35,6 +35,7 @@
 #include "event_groups.h"
 #include "task.h"
 
+#include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;

--- a/src/platform/silabs/efr32/wifi/wfx_notify.cpp
+++ b/src/platform/silabs/efr32/wifi/wfx_notify.cpp
@@ -36,10 +36,10 @@
 #include "wfx_rsi.h"
 #endif
 
-#include <platform/CHIPDeviceLayer.h>
-// #include <app/server/Mdns.h>
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <platform/CHIPDeviceLayer.h>
 
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;
@@ -62,8 +62,6 @@ void wfx_started_notify()
 {
     sl_wfx_startup_ind_t evt;
     sl_wfx_mac_address_t mac;
-
-    SILABS_LOG("%s: started.", __func__);
 
     memset(&evt, 0, sizeof(evt));
     evt.header.id     = SL_WFX_STARTUP_IND_ID;
@@ -88,15 +86,13 @@ void wfx_connected_notify(int32_t status, sl_wfx_mac_address_t * ap)
 {
     sl_wfx_connect_ind_t evt;
 
-    SILABS_LOG("%s: started.", __func__);
-
     if (status != SUCCESS_STATUS)
     {
-        SILABS_LOG("%s: error: failed status: %d.", __func__, status);
+        ChipLogProgress(DeviceLayer, "%s: error: failed status: %ld.", __func__, status);
         return;
     }
 
-    SILABS_LOG("%s: connected.", __func__);
+    ChipLogProgress(DeviceLayer, "%s: connected.", __func__);
 
     memset(&evt, 0, sizeof(evt));
     evt.header.id     = SL_WFX_CONNECT_IND_ID;
@@ -121,8 +117,6 @@ void wfx_disconnected_notify(int32_t status)
 {
     sl_wfx_disconnect_ind_t evt;
 
-    SILABS_LOG("%s: started.", __func__);
-
     memset(&evt, 0, sizeof(evt));
     evt.header.id     = SL_WFX_DISCONNECT_IND_ID;
     evt.header.length = sizeof evt;
@@ -140,8 +134,6 @@ void wfx_disconnected_notify(int32_t status)
 void wfx_ipv6_notify(int got_ip)
 {
     sl_wfx_generic_message_t eventData;
-
-    SILABS_LOG("%s: started.", __func__);
 
     memset(&eventData, 0, sizeof(eventData));
     eventData.header.id     = got_ip ? IP_EVENT_GOT_IP6 : IP_EVENT_STA_LOST_IP;
@@ -169,8 +161,6 @@ void wfx_ipv6_notify(int got_ip)
 void wfx_ip_changed_notify(int got_ip)
 {
     sl_wfx_generic_message_t eventData;
-
-    SILABS_LOG("%s: started.", __func__);
 
     memset(&eventData, 0, sizeof(eventData));
     eventData.header.id     = got_ip ? IP_EVENT_STA_GOT_IP : IP_EVENT_STA_LOST_IP;
@@ -204,12 +194,12 @@ void wfx_retry_interval_handler(bool is_wifi_disconnection_event, uint16_t retry
          */
         if (retryJoin < MAX_JOIN_RETRIES_COUNT)
         {
-            SILABS_LOG("%s: Next attempt after %d Seconds", __func__, CONVERT_MS_TO_SEC(WLAN_RETRY_TIMER_MS));
+            ChipLogProgress(DeviceLayer, "%s: Next attempt after %d Seconds", __func__, CONVERT_MS_TO_SEC(WLAN_RETRY_TIMER_MS));
             vTaskDelay(pdMS_TO_TICKS(WLAN_RETRY_TIMER_MS));
         }
         else
         {
-            SILABS_LOG("Connect failed after max %d tries", retryJoin);
+            ChipLogProgress(DeviceLayer, "Connect failed after max %d tries", retryJoin);
         }
     }
     else
@@ -223,7 +213,7 @@ void wfx_retry_interval_handler(bool is_wifi_disconnection_event, uint16_t retry
         {
             retryInterval = WLAN_MAX_RETRY_TIMER_MS;
         }
-        SILABS_LOG("%s: Next attempt after %d Seconds", __func__, CONVERT_MS_TO_SEC(retryInterval));
+        ChipLogProgress(DeviceLayer, "%s: Next attempt after %ld Seconds", __func__, CONVERT_MS_TO_SEC(retryInterval));
         vTaskDelay(pdMS_TO_TICKS(retryInterval));
         retryInterval += retryInterval;
     }

--- a/src/platform/silabs/efr32/wifi/wfx_notify.cpp
+++ b/src/platform/silabs/efr32/wifi/wfx_notify.cpp
@@ -26,8 +26,6 @@
 #include "em_usart.h"
 #include "gpiointerrupt.h"
 
-#include "AppConfig.h"
-
 #include "FreeRTOS.h"
 #include "event_groups.h"
 #include "task.h"

--- a/src/platform/silabs/rs911x/wfx_sl_ble_init.c
+++ b/src/platform/silabs/rs911x/wfx_sl_ble_init.c
@@ -160,7 +160,6 @@ void rsi_ble_on_event_indication_confirmation(uint16_t resp_status, rsi_ble_set_
  */
 void rsi_ble_on_read_req_event(uint16_t event_id, rsi_ble_read_req_t * rsi_ble_read_req)
 {
-    SILABS_LOG("%s: starting", __func__);
     event_msg.event_id = event_id;
     memcpy(&event_msg.rsi_ble_read_req, rsi_ble_read_req, sizeof(rsi_ble_read_req_t));
     rsi_ble_app_set_event(RSI_BLE_EVENT_GATT_RD);


### PR DESCRIPTION
#### Description
Silabs Platform sources included the AppConfig header for no reason.
Remove the inclusion.

#### Tests
CI
