### PR TITLE
Darwin Tests: Add missing os/lock.h import

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRAsyncWorkQueueTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRAsyncWorkQueueTests.m
@@ -16,6 +16,7 @@
 
 #import <Matter/Matter.h>
 #import <XCTest/XCTest.h>
+#import <os/lock.h>
 
 #import "MTRAsyncWorkQueue.h"
 


### PR DESCRIPTION
Depending on target platform relying on an implicit import from some other header does not work (and is bad style in either case).