### PR TITLE
[v1.3][OpenThread] Disable IPv6 interface during erasing persistent info. 

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1220,6 +1220,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ErasePersistentInfo(v
     ChipLogProgress(DeviceLayer, "Erasing Thread persistent info...");
     Impl()->LockThreadStack();
     otThreadSetEnabled(mOTInst, false);
+    otIp6SetEnabled(mOTInst, false);
     otInstanceErasePersistentInfo(mOTInst);
     Impl()->UnlockThreadStack();
 }


### PR DESCRIPTION
Apart from disabling Thread, and erasing Persistent Info, we should disable the IPv6 interface as well and block receiving further packets.
Otherwise, if we don't reboot the device after erasing Thread persistent data, we can get a packet and as a result, it causes an assert during processing AES_ECB
(because crypto keys have been removed).

Cherry-picked from Master branch: https://github.com/project-chip/connectedhomeip/commit/416f6a315f286a242e78048039b6525cafaabd74

