### PR TITLE
Add withSourceLocation param to ErrorStr

### DIFF
--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -35,9 +35,9 @@
 #include <limits>
 #include <type_traits>
 
-#if __cplusplus >= 202002L
+#if CHIP_CONFIG_ERROR_SOURCE && __cplusplus >= 202002L
 #include <source_location>
-#endif // __cplusplus >= 202002L
+#endif // CHIP_CONFIG_ERROR_SOURCE && __cplusplus >= 202002L
 
 namespace chip {
 
@@ -157,8 +157,7 @@ public:
     {}
 #else
     constexpr ChipError(SdkPart part, uint8_t code, const char * file, unsigned int line) :
-        mError(MakeInteger(part, code)) CHIP_INITIALIZE_ERROR_SOURCE(file, line, /*loc=*/nullptr)
-    {}
+        mError(MakeInteger(part, code)) CHIP_INITIALIZE_ERROR_SOURCE(file, line, /*loc=*/nullptr){}
 #endif // __cplusplus >= 202002L
 
     /**
@@ -239,10 +238,10 @@ public:
      * @note
      *  Normally, prefer to use Format()
      */
-    const char * AsString() const
+    const char * AsString(bool withSourceLocation = true) const
     {
-        extern const char * ErrorStr(ChipError);
-        return ErrorStr(*this);
+        extern const char * ErrorStr(ChipError, bool);
+        return ErrorStr(*this, withSourceLocation);
     }
 
     /**

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -157,7 +157,8 @@ public:
     {}
 #else
     constexpr ChipError(SdkPart part, uint8_t code, const char * file, unsigned int line) :
-        mError(MakeInteger(part, code)) CHIP_INITIALIZE_ERROR_SOURCE(file, line, /*loc=*/nullptr){}
+        mError(MakeInteger(part, code)) CHIP_INITIALIZE_ERROR_SOURCE(file, line, /*loc=*/nullptr)
+    {}
 #endif // __cplusplus >= 202002L
 
     /**

--- a/src/lib/core/ErrorStr.cpp
+++ b/src/lib/core/ErrorStr.cpp
@@ -41,19 +41,21 @@ static ErrorFormatter * sErrorFormatterList = nullptr;
  * describing the provided error.
  *
  * @param[in] err                      The error for format and describe.
+ * @param[in] withSourceLocation       Whether or not to include the source
+ * location in the output string. Only used if CHIP_CONFIG_ERROR_SOURCE &&
+ * !CHIP_CONFIG_SHORT_ERROR_STR. Defaults to true.
  *
  * @return A pointer to a NULL-terminated C string describing the
  *         provided error.
  */
-DLL_EXPORT const char * ErrorStr(CHIP_ERROR err)
+DLL_EXPORT const char * ErrorStr(CHIP_ERROR err, bool withSourceLocation)
 {
     char * formattedError   = sErrorStr;
     uint16_t formattedSpace = sizeof(sErrorStr);
 
 #if CHIP_CONFIG_ERROR_SOURCE && !CHIP_CONFIG_SHORT_ERROR_STR
 
-    const char * const file = err.GetFile();
-    if (file != nullptr)
+    if (const char * const file = err.GetFile(); withSourceLocation && file != nullptr)
     {
         int n = snprintf(formattedError, formattedSpace, "%s:%u: ", file, err.GetLine());
         if (n > formattedSpace)

--- a/src/lib/core/ErrorStr.h
+++ b/src/lib/core/ErrorStr.h
@@ -48,7 +48,7 @@ struct ErrorFormatter
     ErrorFormatter * Next;
 };
 
-extern const char * ErrorStr(CHIP_ERROR err);
+extern const char * ErrorStr(CHIP_ERROR err, bool withSourceLocation = true);
 extern void RegisterErrorFormatter(ErrorFormatter * errFormatter);
 extern void DeregisterErrorFormatter(ErrorFormatter * errFormatter);
 extern void FormatError(char * buf, uint16_t bufSize, const char * subsys, CHIP_ERROR err, const char * desc);
@@ -56,3 +56,4 @@ extern void FormatError(char * buf, uint16_t bufSize, const char * subsys, CHIP_
 extern const char * StatusReportStr(uint32_t profileId, uint16_t statusCode);
 
 } // namespace chip
+                   

--- a/src/lib/core/ErrorStr.h
+++ b/src/lib/core/ErrorStr.h
@@ -56,4 +56,3 @@ extern void FormatError(char * buf, uint16_t bufSize, const char * subsys, CHIP_
 extern const char * StatusReportStr(uint32_t profileId, uint16_t statusCode);
 
 } // namespace chip
-                   

--- a/src/lib/core/tests/TestCHIPErrorStr.cpp
+++ b/src/lib/core/tests/TestCHIPErrorStr.cpp
@@ -232,4 +232,3 @@ TEST(TestCHIPErrorStr, CheckCoreErrorStrWithoutSourceLocation)
 #endif // CHIP_CONFIG_ERROR_SOURCE
     }
 }
- 

--- a/src/lib/core/tests/TestCHIPErrorStr.cpp
+++ b/src/lib/core/tests/TestCHIPErrorStr.cpp
@@ -231,4 +231,3 @@ TEST(TestCHIPErrorStr, CheckCoreErrorStrWithoutSourceLocation)
 #endif // CHIP_CONFIG_ERROR_SOURCE
     }
 }
- 

--- a/src/lib/core/tests/TestCHIPErrorStr.cpp
+++ b/src/lib/core/tests/TestCHIPErrorStr.cpp
@@ -25,7 +25,6 @@
  */
 
 #include <inttypes.h>
-#include <iostream>
 #include <stdint.h>
 #include <string.h>
 
@@ -232,3 +231,4 @@ TEST(TestCHIPErrorStr, CheckCoreErrorStrWithoutSourceLocation)
 #endif // CHIP_CONFIG_ERROR_SOURCE
     }
 }
+ 


### PR DESCRIPTION
This allows callers to choose at runtime whether or not to include source locations in error strings.

