### PR TITLE
Improve server logging on subscription failures.

### DIFF
--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -175,6 +175,16 @@ void ReadHandler::Close(CloseOptions options)
         }
     }
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
+
+#if CHIP_PROGRESS_LOGGING
+    if (IsType(InteractionType::Subscribe))
+    {
+        const ScopedNodeId & peer = mSessionHandle ? mSessionHandle->GetPeer() : ScopedNodeId();
+        ChipLogProgress(DataManagement, "Subscription id 0x%" PRIx32 " from node " ChipLogFormatScopedNodeId " torn down",
+                        mSubscriptionId, ChipLogValueScopedNodeId(peer));
+    }
+#endif // CHIP_PROGRESS_LOGGING
+
     MoveToState(HandlerState::AwaitingDestruction);
     mManagementCallback.OnDone(*this);
 }

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -106,8 +106,13 @@ ExchangeContext * ExchangeManager::NewContext(const SessionHandle & session, Exc
 {
     if (!session->IsActiveSession())
     {
+#if CHIP_ERROR_LOGGING
         // Disallow creating exchange on an inactive session
-        ChipLogError(ExchangeManager, "NewContext failed: session inactive");
+        const ScopedNodeId & peer = session->GetPeer();
+        ChipLogError(ExchangeManager, "NewContext failed: session %u to " ChipLogFormatScopedNodeId " is inactive",
+                     session->SessionIdForLogging(), ChipLogValueScopedNodeId(peer));
+#endif // CHIP_ERROR_LOGGING
+
         return nullptr;
     }
     return mContextPool.CreateObject(this, mNextExchangeId++, session, isInitiator, delegate);

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -107,12 +107,12 @@ ExchangeContext * ExchangeManager::NewContext(const SessionHandle & session, Exc
     if (!session->IsActiveSession())
     {
 #if CHIP_ERROR_LOGGING
-        // Disallow creating exchange on an inactive session
         const ScopedNodeId & peer = session->GetPeer();
         ChipLogError(ExchangeManager, "NewContext failed: session %u to " ChipLogFormatScopedNodeId " is inactive",
                      session->SessionIdForLogging(), ChipLogValueScopedNodeId(peer));
 #endif // CHIP_ERROR_LOGGING
 
+        // Disallow creating exchange on an inactive session
         return nullptr;
     }
     return mContextPool.CreateObject(this, mNextExchangeId++, session, isInitiator, delegate);


### PR DESCRIPTION
1) When logging "session inactive", log which session it is. 
2) When a subscription ReadHandler closes, log the relevant subscription ID and
   peer node.
