### PR TITLE
[Android][ICD]Implement Android ICD sending using buffer

### DIFF
--- a/kotlin-detect-config.yaml
+++ b/kotlin-detect-config.yaml
@@ -343,6 +343,7 @@ complexity:
             - "**/src/controller/java/tests/matter/tlv/TlvReaderTest.kt"
     LargeClass:
         excludes:
+            - "**/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt"
             - "**/src/controller/java/generated/java/**/*"
             - "**/src/controller/java/tests/matter/tlv/TlvReadWriteTest.kt"
             - "**/src/controller/java/tests/matter/jsontlv/JsonToTlvToJsonTest.kt"


### PR DESCRIPTION
Fix #31173 

Android chip-tool can buffer IM message when ICD device is not active.
In Wildcard Fragment, user can use this function.

1. Set Endpoint ID, Cluster ID, etc.
2. Add Attribute, Event
3. Push send Button
4. After receiving check in message, this message will send to ICD device.