### PR TITLE
[Linux] Add test logic to verify the subscription state in the Linux tv-casting-app.

### DIFF
--- a/.github/workflows/examples-linux-tv-casting-app.yaml
+++ b/.github/workflows/examples-linux-tv-casting-app.yaml
@@ -67,7 +67,7 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                     "python3 ./scripts/tests/run_tv_casting_test.py"
-              timeout-minutes: 1
+              timeout-minutes: 2 # Comment this out to debug if GitHub Action times out.
 
             - name: Uploading Size Reports
               uses: ./.github/actions/upload-size-reports

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -122,7 +122,7 @@ def handle_casting_failure(casting_state: str, log_file_paths: List[str]):
 def extract_value_from_string(line: str, value_name: str, casting_state: str, log_paths) -> str:
     """Extract and return value from given input string.
 
-    Some input string examples as they are received from the Linux tv-casting-app and tv-app output:
+    Some string examples as they are received from the Linux tv-casting-app and/or tv-app output:
     1. On 'darwin' machines:
         \x1b[0;34m[1715206773402] [20056:2842184] [DMG]  Cluster = 0x506,\x1b[0m
         The substring to be extracted here is '0x506'.

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -122,21 +122,35 @@ def handle_casting_failure(casting_state: str, log_file_paths: List[str]):
 def extract_value_from_string(line: str, value_name: str, casting_state: str, log_paths) -> str:
     """Extract and return value from given input string.
 
-    The string is expected to be in the following format as it is received
-    from the Linux tv-casting-app output:
-    \x1b[0;34m[1715206773402] [20056:2842184] [DMG]  Cluster = 0x506,\x1b[0m
-    The substring to be extracted here is '0x506'.
-    Or:
-    \x1b[0;32m[1714582264602] [77989:2286038] [SVR] Discovered Commissioner #0\x1b[0m
-    The integer value to be extracted here is '0'.
-    Or:
-    \x1b[0;34m[1713741926895] [7276:9521344] [DIS] Vendor ID: 65521\x1b[0m
-    The integer value to be extracted here is '65521'.
-    Or:
-    \x1b[0;34m[1714583616179] [7029:2386956] [SVR] 	device Name: Test TV casting app\x1b[0m
-    The substring to be extracted here is 'Test TV casting app'.
+    Some input string examples as they are received from the Linux tv-casting-app and tv-app output:
+    1. On 'darwin' machines:
+        \x1b[0;34m[1715206773402] [20056:2842184] [DMG]  Cluster = 0x506,\x1b[0m
+        The substring to be extracted here is '0x506'.
+
+        Or:
+        \x1b[0;32m[1714582264602] [77989:2286038] [SVR] Discovered Commissioner #0\x1b[0m
+        The integer value to be extracted here is '0'.
+
+        Or:
+        \x1b[0;34m[1713741926895] [7276:9521344] [DIS] Vendor ID: 65521\x1b[0m
+        The integer value to be extracted here is '65521'.
+
+        Or:
+        \x1b[0;34m[1714583616179] [7029:2386956] [SVR] 	device Name: Test TV casting app\x1b[0m
+        The substring to be extracted here is 'Test TV casting app'.
+
+    2. On 'linux' machines:
+        [1716224960.316809][6906:6906] CHIP:DMG: \t\t\t\t\tCluster = 0x506,\n
+        [1716224958.576320][6906:6906] CHIP:SVR: Discovered Commissioner #0
+        [1716224958.576407][6906:6906] CHIP:DIS: \tVendor ID: 65521\n
+        [1716224959.580746][6906:6906] CHIP:SVR: \tdevice Name: Test TV casting app\n
     """
-    log_line_pattern = r'\x1b\[0;\d+m\[\d+\] \[\d+:\d+\] \[[A-Z]{1,3}\] (.+?)\x1b\[0m'
+    log_line_pattern = ''
+    if sys.platform == 'darwin':
+        log_line_pattern = r'\x1b\[0;\d+m\[\d+\] \[\d+:\d+\] \[[A-Z]{1,3}\] (.+)\x1b\[0m'
+    elif sys.platform == 'linux':
+        log_line_pattern = r'\[\d+\.\d+\]\[\d+:\d+\] [A-Z]{1,4}:[A-Z]{1,3}: (.+)'
+
     log_line_match = re.search(log_line_pattern, line)
 
     if log_line_match:


### PR DESCRIPTION
Fixes #33397 

**Problem**
There is currently no CI check to verify that the Linux tv-casting-app is still subscribed to the `MediaPlayback` cluster and the `CurrentState` (playback state) attribute whenever a PR is created.

**Solution Overview**
Add test logic to the `run_tv_casting_test.py` file to verify the subscription state of the Linux tv-casting-app. The output will be written to the tv-casting-app log file.

The following has been added to the test script:
- Parse the Linux tv-casting-app output for `ReportDataMessage` and validate the `Cluster` and `Attribute` values against the `MediaPlayback` cluster and `CurrentState` attribute. The cluster and attribute values are `0x506` and `0x0000_0000` respectively. For reference, these values are set [here](https://github.com/project-chip/connectedhomeip/blob/550b1c13608c2bbcbaca6e4375b19997cec4418b/examples/tv-app/tv-common/tv-app.zap#L5190-L5193) for the cluster value and [here](https://github.com/project-chip/connectedhomeip/blob/master/examples/tv-app/tv-common/tv-app.zap#L5320-L5321) for the attribute value.
- Log the first instance of the `ReportDataMessage` with valid cluster and attribute values to console.
- If we are not able to find a `ReportDataMessage` with valid cluster and attribute values within the timeout, then we print an error message, dump the logs to console, and exit on error.
- Also cleaned up logging messages to improve readability and maintain uniformity.

**Testing**
Tested the script locally by running `python3 ./scripts/tests/run_tv_casting_test.py` and observing the output. Also verified that the CI check works as expected.