### PR TITLE
Operational Discovery with Continuous Query Support for Linux 

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -93,12 +93,11 @@ static void HandleNodeBrowse(void * context, DnssdService * services, size_t ser
         discoveryContext->Retain();
         // For some platforms browsed services are already resolved, so verify if resolve is really needed or call resolve callback
 
-        auto & ipAddress         = services[i].mAddress;
+        auto & ipAddress = services[i].mAddress;
 
         // mType(service name) exactly matches with operational service name
         bool isOperationalBrowse = (strncmp(services[i].mType, kOperationalServiceName, sizeof(services[i].mType)) == 0 &&
                                     strlen(services[i].mType) == strlen(kOperationalServiceName));
-
 
         // For operational browse result we currently don't need IP address hence skip resolution and handle differently.
         if (isOperationalBrowse)

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -96,15 +96,14 @@ static void HandleNodeBrowse(void * context, DnssdService * services, size_t ser
         auto & ipAddress = services[i].mAddress;
 
         // mType(service name) exactly matches with operational service name
-        bool isOperationalBrowse = (strncmp(services[i].mType, kOperationalServiceName, sizeof(services[i].mType)) == 0 &&
-                                    strlen(services[i].mType) == strlen(kOperationalServiceName));
+        bool isOperationalBrowse = strcmp(services[i].mType, kOperationalServiceName) == 0;
 
         // For operational browse result we currently don't need IP address hence skip resolution and handle differently.
         if (isOperationalBrowse)
         {
             HandleNodeOperationalBrowse(context, &services[i], error);
         }
-        // if SRV, TXT and AAAA records were received in DNS responses
+        // check whether SRV, TXT and AAAA records were received in DNS responses
         else if (strlen(services[i].mHostName) == 0 || services[i].mTextEntrySize == 0 || !ipAddress.has_value())
         {
             ChipDnssdResolve(&services[i], services[i].mInterface, HandleNodeResolve, context);

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -99,7 +99,7 @@ static void HandleNodeBrowse(void * context, DnssdService * services, size_t ser
         bool isOperationalBrowse = (strncmp(services[i].mType, kOperationalServiceName, sizeof(services[i].mType)) == 0 &&
                                     strlen(services[i].mType) == strlen(kOperationalServiceName));
 
-        
+
         // For operational browse result we currently don't need IP address hence skip resolution and handle differently.
         if (isOperationalBrowse)
         {

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -788,7 +788,7 @@ CHIP_ERROR DiscoveryImplPlatform::DiscoverOperational(DiscoveryFilter filter, Di
     ReturnErrorOnFailure(InitImpl());
     StopDiscovery(context);
 
-    char serviceName[kMaxCommissionerServiceNameSize];
+    char serviceName[kMaxOperationalServiceNameSize];
     ReturnErrorOnFailure(MakeServiceTypeName(serviceName, sizeof(serviceName), filter, DiscoveryType::kOperational));
 
     intptr_t browseIdentifier;

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -86,8 +86,8 @@ static void HandleNodeBrowse(void * context, DnssdService * services, size_t ser
         auto & ipAddress = services[i].mAddress;
 
         // Check that this is not operational browse result and if SRV, TXT and AAAA records were received in DNS responses
-        if (strncmp(services[i].mType, kOperationalServiceName, sizeof(kOperationalServiceName)) != 0
-            && (strlen(services[i].mHostName) == 0 || services[i].mTextEntrySize == 0 || !ipAddress.has_value()))
+        if (strncmp(services[i].mType, kOperationalServiceName, sizeof(kOperationalServiceName)) != 0 &&
+            (strlen(services[i].mHostName) == 0 || services[i].mTextEntrySize == 0 || !ipAddress.has_value()))
         {
             ChipDnssdResolve(&services[i], services[i].mInterface, HandleNodeResolve, context);
         }

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -94,12 +94,12 @@ static void HandleNodeBrowse(void * context, DnssdService * services, size_t ser
         // For some platforms browsed services are already resolved, so verify if resolve is really needed or call resolve callback
 
         auto & ipAddress = services[i].mAddress;
-        bool isOperationalBrowse = (strncmp(services[i].mType, kOperationalServiceName, sizeof(kOperationalServiceName)) == 0 
+        bool isOperationalBrowse = (strncmp(services[i].mType, kOperationalServiceName, sizeof(kOperationalServiceName)) == 0
                                         && strlen(services[i].mType) == strlen(kOperationalServiceName));
 
-        // if SRV, TXT and AAAA records were received in DNS responses, also for operational browse result we currently 
+        // if SRV, TXT and AAAA records were received in DNS responses, also for operational browse result we currently
         // don't need IP address hence skip resolution.
-        if ( !isOperationalBrowse && (strlen(services[i].mHostName) == 0 
+        if ( !isOperationalBrowse && (strlen(services[i].mHostName) == 0
                 || services[i].mTextEntrySize == 0 || !ipAddress.has_value()))
         {
             ChipDnssdResolve(&services[i], services[i].mInterface, HandleNodeResolve, context);

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -93,14 +93,14 @@ static void HandleNodeBrowse(void * context, DnssdService * services, size_t ser
         discoveryContext->Retain();
         // For some platforms browsed services are already resolved, so verify if resolve is really needed or call resolve callback
 
-        auto & ipAddress = services[i].mAddress;
-        bool isOperationalBrowse = (strncmp(services[i].mType, kOperationalServiceName, sizeof(kOperationalServiceName)) == 0
-                                        && strlen(services[i].mType) == strlen(kOperationalServiceName));
+        auto & ipAddress         = services[i].mAddress;
+        bool isOperationalBrowse = (strncmp(services[i].mType, kOperationalServiceName, sizeof(kOperationalServiceName)) == 0 &&
+                                    strlen(services[i].mType) == strlen(kOperationalServiceName));
 
         // if SRV, TXT and AAAA records were received in DNS responses, also for operational browse result we currently
         // don't need IP address hence skip resolution.
-        if ( !isOperationalBrowse && (strlen(services[i].mHostName) == 0
-                || services[i].mTextEntrySize == 0 || !ipAddress.has_value()))
+        if (!isOperationalBrowse &&
+            (strlen(services[i].mHostName) == 0 || services[i].mTextEntrySize == 0 || !ipAddress.has_value()))
         {
             ChipDnssdResolve(&services[i], services[i].mInterface, HandleNodeResolve, context);
         }

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -55,6 +55,7 @@ public:
     void NodeIdResolutionNoLongerNeeded(const PeerId & peerId) override;
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter, DiscoveryContext & context);
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter, DiscoveryContext & context);
+    CHIP_ERROR DiscoverOperational(DiscoveryFilter filter, DiscoveryContext & context);
     CHIP_ERROR StartDiscovery(DiscoveryType type, DiscoveryFilter filter, DiscoveryContext & context) override;
     CHIP_ERROR StopDiscovery(DiscoveryContext & context) override;
     CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override;

--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -162,6 +162,10 @@ CHIP_ERROR MakeServiceTypeName(char * buffer, size_t bufferLen, DiscoveryFilter 
         {
             requiredSize = snprintf(buffer, bufferLen, kCommissionerServiceName);
         }
+        else if (type == DiscoveryType::kOperational)
+        {
+            requiredSize = snprintf(buffer, bufferLen, kOperationalServiceName);
+        }
         else
         {
             return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/lib/dnssd/platform/Dnssd.h
+++ b/src/lib/dnssd/platform/Dnssd.h
@@ -81,7 +81,8 @@ struct DnssdService
     // Time to live in seconds. Per rfc6762 section 10, because we have a hostname, our default TTL is 120 seconds
     uint32_t mTtlSeconds = 120;
 
-    void ToDiscoveredNodeData(const Span<Inet::IPAddress> & addresses, DiscoveredNodeData & nodeData);
+    void ToDiscoveredCommissionNodeData(const Span<Inet::IPAddress> & addresses, DiscoveredNodeData & nodeData);
+    void ToDiscoveredOperationalNodeBrowseData(DiscoveredNodeData & nodeData);
 };
 
 /**

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -277,7 +277,7 @@ void RegisterDnsCommands()
           "Browse Matter commissionables. Usage: dns browse commissionable [subtype]" },
         { &BrowseCommissionerHandler, "commissioner", "Browse Matter commissioners. Usage: dns browse commissioner [subtype]" },
         { &BrowseOperationalHandler, "operational", "Browse Matter operational nodes. Usage: dns browse operational" },
-        { &BrowseStopHandler, "stop", "Stop ongoing browse. USage: dns browse stop"},
+        { &BrowseStopHandler, "stop", "Stop ongoing browse. Usage: dns browse stop"},
 
     };
 

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -261,6 +261,13 @@ CHIP_ERROR BrowseOperationalHandler(int argc, char ** argv)
     return sResolverProxy.DiscoverOperationalNodes(filter);
 }
 
+CHIP_ERROR BrowseStopHandler(int argc, char ** argv)
+{
+    streamer_printf(streamer_get(), "Stopping browse...\r\n");
+
+    return sResolverProxy.StopDiscovery();
+}
+
 } // namespace
 
 void RegisterDnsCommands()
@@ -270,18 +277,14 @@ void RegisterDnsCommands()
           "Browse Matter commissionables. Usage: dns browse commissionable [subtype]" },
         { &BrowseCommissionerHandler, "commissioner", "Browse Matter commissioners. Usage: dns browse commissioner [subtype]" },
         { &BrowseOperationalHandler, "operational", "Browse Matter operational nodes. Usage: dns browse operational" },
+        { &BrowseStopHandler, "stop", "Stop ongoing browse. USage: dns browse stop"},
+
     };
 
     static constexpr Command subCommands[] = {
         { &ResolveHandler, "resolve",
           "Resolve Matter operational service. Usage: dns resolve fabricid nodeid (e.g. dns resolve 5544332211 1)" },
         { &SubShellCommand<ArraySize(browseSubCommands), browseSubCommands>, "browse", "Browse Matter DNS services" },
-    };
 
     static constexpr Command dnsCommand = { &SubShellCommand<ArraySize(subCommands), subCommands>, "dns", "DNS client commands" };
-
-    Engine::Root().RegisterCommands(&dnsCommand, 1);
-}
-
-} // namespace Shell
 } // namespace chip

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -285,6 +285,12 @@ void RegisterDnsCommands()
         { &ResolveHandler, "resolve",
           "Resolve Matter operational service. Usage: dns resolve fabricid nodeid (e.g. dns resolve 5544332211 1)" },
         { &SubShellCommand<ArraySize(browseSubCommands), browseSubCommands>, "browse", "Browse Matter DNS services" },
+    };
 
     static constexpr Command dnsCommand = { &SubShellCommand<ArraySize(subCommands), subCommands>, "dns", "DNS client commands" };
+
+    Engine::Root().RegisterCommands(&dnsCommand, 1);
+}
+
+} // namespace Shell
 } // namespace chip

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -277,7 +277,7 @@ void RegisterDnsCommands()
           "Browse Matter commissionables. Usage: dns browse commissionable [subtype]" },
         { &BrowseCommissionerHandler, "commissioner", "Browse Matter commissioners. Usage: dns browse commissioner [subtype]" },
         { &BrowseOperationalHandler, "operational", "Browse Matter operational nodes. Usage: dns browse operational" },
-        { &BrowseStopHandler, "stop", "Stop ongoing browse. Usage: dns browse stop"},
+        { &BrowseStopHandler, "stop", "Stop ongoing browse. Usage: dns browse stop" },
 
     };
 

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -610,7 +610,7 @@ bool ResolveContext::TryReportingResultsForInterfaceIndex(uint32_t interfaceInde
 
         // mType(service name) exactly matches with operational service name
         if (strncmp(services[i].mType, kOperationalServiceName, sizeof(services[i].mType)) == 0 &&
-                                        strlen(services[i].mType) == strlen(kOperationalServiceName))
+            strlen(services[i].mType) == strlen(kOperationalServiceName))
         {
             service.ToDiscoveredOperationalNodeBrowseData(nodeData);
         }

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -609,8 +609,7 @@ bool ResolveContext::TryReportingResultsForInterfaceIndex(uint32_t interfaceInde
         DiscoveredNodeData nodeData;
 
         // mType(service name) exactly matches with operational service name
-        if (strncmp(services[i].mType, kOperationalServiceName, sizeof(services[i].mType)) == 0 &&
-            strlen(services[i].mType) == strlen(kOperationalServiceName))
+        if (strncmp(service[i].mType, kOperationalServiceName) == 0)
         {
             service.ToDiscoveredOperationalNodeBrowseData(nodeData);
         }

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -607,7 +607,7 @@ bool ResolveContext::TryReportingResultsForInterfaceIndex(uint32_t interfaceInde
     {
         auto delegate = static_cast<DiscoverNodeDelegate *>(context);
         DiscoveredNodeData nodeData;
-        service.ToDiscoveredNodeData(addresses, nodeData);
+        service.ToDiscoveredCommissionNodeData(addresses, nodeData);
         delegate->OnNodeDiscovered(nodeData);
     }
     else

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -617,7 +617,7 @@ bool ResolveContext::TryReportingResultsForInterfaceIndex(uint32_t interfaceInde
         else
         {
             service.ToDiscoveredCommissionNodeData(addresses, nodeData);
-        }        
+        }
         delegate->OnNodeDiscovered(nodeData);
     }
     else

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -608,8 +608,8 @@ bool ResolveContext::TryReportingResultsForInterfaceIndex(uint32_t interfaceInde
         auto delegate = static_cast<DiscoverNodeDelegate *>(context);
         DiscoveredNodeData nodeData;
 
-        // mType(service name) exactly matches with operational service name
-        if (strncmp(service[i].mType, kOperationalServiceName) == 0)
+        // check whether mType(service name) exactly matches with operational service name
+        if (strcmp(service.mType, kOperationalServiceName) == 0)
         {
             service.ToDiscoveredOperationalNodeBrowseData(nodeData);
         }

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -608,7 +608,7 @@ bool ResolveContext::TryReportingResultsForInterfaceIndex(uint32_t interfaceInde
         auto delegate = static_cast<DiscoverNodeDelegate *>(context);
         DiscoveredNodeData nodeData;
 
-        // check whether mType(service name) exactly matches with operational service name
+        // Check whether mType (service name) exactly matches with operational service name
         if (strcmp(service.mType, kOperationalServiceName) == 0)
         {
             service.ToDiscoveredOperationalNodeBrowseData(nodeData);

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -607,7 +607,17 @@ bool ResolveContext::TryReportingResultsForInterfaceIndex(uint32_t interfaceInde
     {
         auto delegate = static_cast<DiscoverNodeDelegate *>(context);
         DiscoveredNodeData nodeData;
-        service.ToDiscoveredCommissionNodeData(addresses, nodeData);
+
+        // mType(service name) exactly matches with operational service name
+        if (strncmp(services[i].mType, kOperationalServiceName, sizeof(services[i].mType)) == 0 &&
+                                        strlen(services[i].mType) == strlen(kOperationalServiceName))
+        {
+            service.ToDiscoveredOperationalNodeBrowseData(nodeData);
+        }
+        else
+        {
+            service.ToDiscoveredCommissionNodeData(addresses, nodeData);
+        }        
         delegate->OnNodeDiscovered(nodeData);
     }
     else

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -809,7 +809,6 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
             {
                 service.mInterface = static_cast<chip::Inet::InterfaceId>(interface);
             }
-            service.mType[kDnssdTypeMaxSize] = 0;
             service.mTtlSeconds              = 0;
             context->mCallback(context->mContext, &service, 1, false, CHIP_NO_ERROR);
         }

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -611,8 +611,8 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
     {
         avahiInterface = AVAHI_IF_UNSPEC;
     }
-    browseContext->mInterface     = avahiInterface;
-    browseContext->mProtocol      = GetFullType(type, protocol);
+    browseContext->mInterface         = avahiInterface;
+    browseContext->mProtocol          = GetFullType(type, protocol);
     browseContext->mReceivedAllCached = false;
     browseContext->mStopped.store(false);
 
@@ -688,12 +688,11 @@ void CopyTypeWithoutProtocol(char (&dest)[N], const char * typeAndProtocol)
 
 void MdnsAvahi::InvokeDelegateOrCleanUp(BrowseContext * context, AvahiServiceBrowser * browser)
 {
-     // If we were already asked to stop, no need to send a callback - no one is listening.
+    // If we were already asked to stop, no need to send a callback - no one is listening.
     if (!context->mStopped.load())
     {
         // since this is continuous browse, finalBrowse will always be false.
-        context->mCallback(context->mContext, context->mServices.data(), context->mServices.size(), false,
-                            CHIP_NO_ERROR);
+        context->mCallback(context->mContext, context->mServices.data(), context->mServices.size(), false, CHIP_NO_ERROR);
 
         // Clearing records/services already passed to application through delegate. Keeping it may cause
         // duplicates in next query / retry attempt as currently found will also come again from cache.
@@ -765,8 +764,8 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
             // don't attempt to erase if vector has been cleared
             if (context->mServices.size())
             {
-                context->mServices.erase(
-                    std::remove_if(context->mServices.begin(), context->mServices.end(), [name, type](const DnssdService & service) {
+                context->mServices.erase(std::remove_if(
+                    context->mServices.begin(), context->mServices.end(), [name, type](const DnssdService & service) {
                         return strcmp(name, service.mName) == 0 && type == GetFullType(service.mType, service.mProtocol);
                     }));
             }
@@ -783,7 +782,7 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
             {
                 service.mInterface = static_cast<chip::Inet::InterfaceId>(interface);
             }
-            service.mTtlSeconds              = 0;
+            service.mTtlSeconds = 0;
             if (context->mReceivedAllCached)
             {
                 context->mServices.push_back(service);

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -770,21 +770,22 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
                     }));
             }
 
-            DnssdService service = {};
-
-            Platform::CopyString(service.mName, name);
-            CopyTypeWithoutProtocol(service.mType, type);
-            service.mProtocol      = GetProtocolInType(type);
-            service.mAddressType   = context->mAddressType;
-            service.mTransportType = ToAddressType(protocol);
-            service.mInterface     = Inet::InterfaceId::Null();
-            if (interface != AVAHI_IF_UNSPEC)
-            {
-                service.mInterface = static_cast<chip::Inet::InterfaceId>(interface);
-            }
-            service.mTtlSeconds = 0;
             if (context->mReceivedAllCached)
             {
+                DnssdService service = {};
+
+                Platform::CopyString(service.mName, name);
+                CopyTypeWithoutProtocol(service.mType, type);
+                service.mProtocol      = GetProtocolInType(type);
+                service.mAddressType   = context->mAddressType;
+                service.mTransportType = ToAddressType(protocol);
+                service.mInterface     = Inet::InterfaceId::Null();
+                if (interface != AVAHI_IF_UNSPEC)
+                {
+                    service.mInterface = static_cast<chip::Inet::InterfaceId>(interface);
+                }
+                service.mTtlSeconds = 0;
+
                 context->mServices.push_back(service);
                 InvokeDelegateOrCleanUp(context, browser);
             }

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -775,7 +775,7 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
 
             // Clear retry info and services.
             context->mNextRetryDelay = chip::System::Clock::Seconds16(1);
-            context->mBrowseRetries = 0;
+            context->mBrowseRetries  = 0;
             context->mServices.clear();
             // Hand the ownership of the context over to the timer. It will either schedule a new browse on the context,
             // triggering this function, or it will delete and not reschedule (if stopped).
@@ -810,7 +810,7 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
                 service.mInterface = static_cast<chip::Inet::InterfaceId>(interface);
             }
             service.mType[kDnssdTypeMaxSize] = 0;
-            service.mTtlSeconds = 0;
+            service.mTtlSeconds              = 0;
             context->mCallback(context->mContext, &service, 1, false, CHIP_NO_ERROR);
         }
 

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -613,7 +613,7 @@ CHIP_ERROR MdnsAvahi::Browse(const char * type, DnssdServiceProtocol protocol, c
     }
     browseContext->mInterface     = avahiInterface;
     browseContext->mProtocol      = GetFullType(type, protocol);
-    browseContext->mBrowseRetries = 0;
+    browseContext->mReceivedAllCached = false;
     browseContext->mStopped.store(false);
 
     browser = avahi_service_browser_new(mClient, avahiInterface, AVAHI_PROTO_UNSPEC, browseContext->mProtocol.c_str(), nullptr,
@@ -686,28 +686,23 @@ void CopyTypeWithoutProtocol(char (&dest)[N], const char * typeAndProtocol)
     }
 }
 
-void MdnsAvahi::BrowseRetryCallback(chip::System::Layer * aLayer, void * appState)
+void MdnsAvahi::InvokeDelegateOrCleanUp(BrowseContext * context, AvahiServiceBrowser * browser)
 {
-    BrowseContext * context = static_cast<BrowseContext *>(appState);
-
-    // free existing browser handle
-    avahi_service_browser_free(context->mBrowser);
-    context->mBrowser = nullptr;
-
-    // Don't schedule anything new if we've stopped.
-    if (context->mStopped.load())
+     // If we were already asked to stop, no need to send a callback - no one is listening.
+    if (!context->mStopped.load())
     {
-        chip::Platform::Delete(context);
-        return;
+        // since this is continuous browse, finalBrowse will always be false.
+        context->mCallback(context->mContext, context->mServices.data(), context->mServices.size(), false,
+                            CHIP_NO_ERROR);
+
+        // Clearing records/services already passed to application through delegate. Keeping it may cause
+        // duplicates in next query / retry attempt as currently found will also come again from cache.
+        context->mServices.clear();
     }
-    AvahiServiceBrowser * newBrowser =
-        avahi_service_browser_new(context->mInstance->mClient, context->mInterface, AVAHI_PROTO_UNSPEC, context->mProtocol.c_str(),
-                                  nullptr, static_cast<AvahiLookupFlags>(0), HandleBrowse, context);
-    if (newBrowser == nullptr)
+    else
     {
-        // If we failed to create the browser, this browse context is effectively done. We need to call the final callback and
-        // delete the context.
-        context->mCallback(context->mContext, context->mServices.data(), context->mServices.size(), true, CHIP_NO_ERROR);
+        // browse is stopped, so free browse handle and context
+        avahi_service_browser_free(browser);
         chip::Platform::Delete(context);
     }
 }
@@ -727,6 +722,13 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
         break;
     case AVAHI_BROWSER_NEW:
         ChipLogProgress(DeviceLayer, "Avahi browse: cache new");
+        if (context->mStopped.load())
+        {
+            // browse is stopped, so free browse handle and context
+            avahi_service_browser_free(browser);
+            chip::Platform::Delete(context);
+            break;
+        }
         if (strcmp("local", domain) == 0)
         {
             DnssdService service = {};
@@ -743,59 +745,31 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
             }
             service.mType[kDnssdTypeMaxSize] = 0;
             context->mServices.push_back(service);
+            if (context->mReceivedAllCached)
+            {
+                InvokeDelegateOrCleanUp(context, browser);
+            }
         }
         break;
     case AVAHI_BROWSER_ALL_FOR_NOW: {
         ChipLogProgress(DeviceLayer, "Avahi browse: all for now");
-        bool needRetries = context->mBrowseRetries++ < kMaxBrowseRetries && !context->mStopped.load();
+        context->mReceivedAllCached = true;
 
-        // If we were already asked to stop, no need to send a callback - no one is listening.
-        if (!context->mStopped.load())
-        {
-            context->mCallback(context->mContext, context->mServices.data(), context->mServices.size(), !needRetries,
-                               CHIP_NO_ERROR);
-
-            // Clearing records/services already passed to application through delegate. Keeping it may cause
-            // duplicates in next query / retry attempt as currently found will also come again from cache.
-            context->mServices.clear();
-        }
-        // hold on to browser handle so we don't lose out any message, this will be freed just before next query
-        context->mBrowser = browser;
-
-        if (needRetries)
-        {
-            context->mNextRetryDelay *= 2;
-            // Hand the ownership of the context over to the timer. It will either schedule a new browse on the context,
-            // triggering this function, or it will delete and not reschedule (if stopped).
-            DeviceLayer::SystemLayer().StartTimer(context->mNextRetryDelay / 2, BrowseRetryCallback, context);
-        }
-        else if (!context->mStopped.load())
-        {
-            // Re-trigger query until StopBrowse() is called
-
-            // Clear retry info and services.
-            context->mNextRetryDelay = chip::System::Clock::Seconds16(1);
-            context->mBrowseRetries  = 0;
-            context->mServices.clear();
-            // Hand the ownership of the context over to the timer. It will either schedule a new browse on the context,
-            // triggering this function, or it will delete and not reschedule (if stopped).
-            DeviceLayer::SystemLayer().StartTimer(context->mNextQueryDelay, BrowseRetryCallback, context);
-        }
-        else
-        {
-            // We didn't schedule a timer, so we're responsible for deleting the context
-            chip::Platform::Delete(context);
-        }
+        InvokeDelegateOrCleanUp(context, browser);
         break;
     }
     case AVAHI_BROWSER_REMOVE:
         ChipLogProgress(DeviceLayer, "Avahi browse: remove");
         if (strcmp("local", domain) == 0)
         {
-            context->mServices.erase(
-                std::remove_if(context->mServices.begin(), context->mServices.end(), [name, type](const DnssdService & service) {
-                    return strcmp(name, service.mName) == 0 && type == GetFullType(service.mType, service.mProtocol);
-                }));
+            // don't attempt to erase if vector has been cleared
+            if (context->mServices.size())
+            {
+                context->mServices.erase(
+                    std::remove_if(context->mServices.begin(), context->mServices.end(), [name, type](const DnssdService & service) {
+                        return strcmp(name, service.mName) == 0 && type == GetFullType(service.mType, service.mProtocol);
+                    }));
+            }
 
             DnssdService service = {};
 
@@ -810,7 +784,11 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
                 service.mInterface = static_cast<chip::Inet::InterfaceId>(interface);
             }
             service.mTtlSeconds              = 0;
-            context->mCallback(context->mContext, &service, 1, false, CHIP_NO_ERROR);
+            if (context->mReceivedAllCached)
+            {
+                context->mServices.push_back(service);
+                InvokeDelegateOrCleanUp(context, browser);
+            }
         }
 
         break;

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -754,12 +754,12 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
         {
             context->mCallback(context->mContext, context->mServices.data(), context->mServices.size(), !needRetries,
                                CHIP_NO_ERROR);
-            
-            // Clearing records/services already passed to application through delegate. Keeping it may cause 
-            // duplicates in next query / retry attempt as currently found will also come again from cache. 
-            context->mServices.clear();            
+
+            // Clearing records/services already passed to application through delegate. Keeping it may cause
+            // duplicates in next query / retry attempt as currently found will also come again from cache.
+            context->mServices.clear();
         }
-        // hold on to browser handle so we don't lose out any message, this will be freed just before next query 
+        // hold on to browser handle so we don't lose out any message, this will be freed just before next query
         context->mBrowser = browser;
 
         if (needRetries)

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -137,7 +137,7 @@ private:
         chip::System::Clock::Timeout mNextRetryDelay = chip::System::Clock::Seconds16(1);
         chip::System::Clock::Timeout mNextQueryDelay = chip::System::Clock::Seconds16(60);
         std::atomic_bool mStopped{ false };
-        AvahiServiceBrowser *mBrowser;
+        AvahiServiceBrowser * mBrowser;
     };
 
     struct ResolveContext

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -131,11 +131,9 @@ private:
         void * mContext;
         Inet::IPAddressType mAddressType;
         std::vector<DnssdService> mServices;
-        size_t mBrowseRetries;
+        bool mReceivedAllCached;
         AvahiIfIndex mInterface;
         std::string mProtocol;
-        chip::System::Clock::Timeout mNextRetryDelay = chip::System::Clock::Seconds16(1);
-        chip::System::Clock::Timeout mNextQueryDelay = chip::System::Clock::Seconds16(60);
         std::atomic_bool mStopped{ false };
         AvahiServiceBrowser * mBrowser;
     };
@@ -183,7 +181,7 @@ private:
     static void HandleBrowse(AvahiServiceBrowser * broswer, AvahiIfIndex interface, AvahiProtocol protocol, AvahiBrowserEvent event,
                              const char * name, const char * type, const char * domain, AvahiLookupResultFlags flags,
                              void * userdata);
-    static void BrowseRetryCallback(chip::System::Layer * aLayer, void * appState);
+    static void InvokeDelegateOrCleanUp(BrowseContext * context, AvahiServiceBrowser * browser);
     static void HandleResolve(AvahiServiceResolver * resolver, AvahiIfIndex interface, AvahiProtocol protocol,
                               AvahiResolverEvent event, const char * name, const char * type, const char * domain,
                               const char * host_name, const AvahiAddress * address, uint16_t port, AvahiStringList * txt,

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -135,7 +135,9 @@ private:
         AvahiIfIndex mInterface;
         std::string mProtocol;
         chip::System::Clock::Timeout mNextRetryDelay = chip::System::Clock::Seconds16(1);
+        chip::System::Clock::Timeout mNextQueryDelay = chip::System::Clock::Seconds16(60);
         std::atomic_bool mStopped{ false };
+        AvahiServiceBrowser *mBrowser;
     };
 
     struct ResolveContext


### PR DESCRIPTION
Added operational node discovery/browse support to linux platform mdns implementation. Also, enhanced browse implementation in linux mdns to support continuous query browse instead single shot query.

This is a follow up from #32750 for linux platform.