### PR TITLE
[crypto] Log PSA crypto error codes in more places

### DIFF
--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -48,14 +48,6 @@ namespace Crypto {
 
 namespace {
 
-void logPsaError(psa_status_t status)
-{
-    if (status != 0)
-    {
-        ChipLogError(Crypto, "PSA error: %d", static_cast<int>(status));
-    }
-}
-
 bool isBufferNonEmpty(const uint8_t * data, size_t data_length)
 {
     return data != nullptr && data_length > 0;
@@ -281,6 +273,7 @@ CHIP_ERROR PsaKdf::Init(const ByteSpan & secret, const ByteSpan & salt, const By
     psa_set_key_usage_flags(&attrs, PSA_KEY_USAGE_DERIVE);
 
     status = psa_import_key(&attrs, secret.data(), secret.size(), &mSecretKeyId);
+    LogPsaError(status);
     psa_reset_key_attributes(&attrs);
     VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
 
@@ -312,9 +305,18 @@ CHIP_ERROR PsaKdf::InitOperation(psa_key_id_t hkdfKey, const ByteSpan & salt, co
     return CHIP_NO_ERROR;
 }
 
+void LogPsaError(psa_status_t status)
+{
+    if (status != PSA_SUCCESS)
+    {
+        ChipLogError(Crypto, "PSA error: %d", static_cast<int>(status));
+    }
+}
+
 CHIP_ERROR PsaKdf::DeriveBytes(const MutableByteSpan & output)
 {
     psa_status_t status = psa_key_derivation_output_bytes(&mOperation, output.data(), output.size());
+    LogPsaError(status);
     VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
 
     return CHIP_NO_ERROR;
@@ -323,6 +325,7 @@ CHIP_ERROR PsaKdf::DeriveBytes(const MutableByteSpan & output)
 CHIP_ERROR PsaKdf::DeriveKey(const psa_key_attributes_t & attributes, psa_key_id_t & keyId)
 {
     psa_status_t status = psa_key_derivation_output_key(&attributes, &mOperation, &keyId);
+    LogPsaError(status);
     VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
 
     return CHIP_NO_ERROR;
@@ -367,6 +370,7 @@ CHIP_ERROR HMAC_sha::HMAC_SHA256(const uint8_t * key, size_t key_length, const u
     VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
 exit:
+    LogPsaError(status);
     psa_destroy_key(keyId);
     psa_reset_key_attributes(&attrs);
 
@@ -476,6 +480,7 @@ exit:
     }
 
 exit:
+    LogPsaError(status);
     psa_destroy_key(keyId);
     psa_reset_key_attributes(&attrs);
 
@@ -519,7 +524,7 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_len
     error = out_signature.SetLength(outputLen);
 
 exit:
-    logPsaError(status);
+    LogPsaError(status);
     return error;
 }
 
@@ -544,7 +549,7 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, cons
     VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INVALID_SIGNATURE);
 
 exit:
-    logPsaError(status);
+    LogPsaError(status);
     psa_destroy_key(keyId);
     psa_reset_key_attributes(&attributes);
 
@@ -573,7 +578,7 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_hash_signature(const uint8_t * hash, co
     VerifyOrExit(status == PSA_SUCCESS, error = CHIP_ERROR_INVALID_SIGNATURE);
 
 exit:
-    logPsaError(status);
+    LogPsaError(status);
     psa_destroy_key(keyId);
     psa_reset_key_attributes(&attributes);
 
@@ -596,7 +601,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     SuccessOrExit(error = out_secret.SetLength(outputLength));
 
 exit:
-    logPsaError(status);
+    LogPsaError(status);
 
     return error;
 }
@@ -671,7 +676,7 @@ CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
     mInitialized = true;
 
 exit:
-    logPsaError(status);
+    LogPsaError(status);
     psa_reset_key_attributes(&attributes);
 
     return error;
@@ -697,7 +702,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
     error = output.SetLength(bbuf.Needed());
 
 exit:
-    logPsaError(status);
+    LogPsaError(status);
 
     return error;
 }
@@ -728,7 +733,7 @@ CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
     mInitialized = true;
 
 exit:
-    logPsaError(status);
+    LogPsaError(status);
 
     return error;
 }

--- a/src/crypto/CHIPCryptoPALPSA.h
+++ b/src/crypto/CHIPCryptoPALPSA.h
@@ -150,5 +150,10 @@ private:
     psa_key_derivation_operation_t mOperation = PSA_KEY_DERIVATION_OPERATION_INIT;
 };
 
+/**
+ * @brief Log PSA status code if it indicates an error.
+ */
+void LogPsaError(psa_status_t status);
+
 } // namespace Crypto
 } // namespace chip

--- a/src/crypto/PSAOperationalKeystore.cpp
+++ b/src/crypto/PSAOperationalKeystore.cpp
@@ -160,6 +160,7 @@ CHIP_ERROR PSAOperationalKeystore::PersistentP256Keypair::Deserialize(P256Serial
     memcpy(mPublicKey.Bytes(), input.ConstBytes(), mPublicKey.Length());
 
 exit:
+    LogPsaError(status);
     psa_reset_key_attributes(&attributes);
 
     return error;

--- a/src/crypto/PSASessionKeystore.cpp
+++ b/src/crypto/PSASessionKeystore.cpp
@@ -92,6 +92,7 @@ CHIP_ERROR PSASessionKeystore::CreateKey(const Symmetric128BitsKeyByteArray & ke
     AesKeyAttributes attrs;
     psa_status_t status =
         psa_import_key(&attrs.Get(), keyMaterial, sizeof(Symmetric128BitsKeyByteArray), &key.AsMutable<psa_key_id_t>());
+    LogPsaError(status);
     VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
 
     return CHIP_NO_ERROR;
@@ -105,7 +106,7 @@ CHIP_ERROR PSASessionKeystore::CreateKey(const Symmetric128BitsKeyByteArray & ke
     HmacKeyAttributes attrs;
     psa_status_t status =
         psa_import_key(&attrs.Get(), keyMaterial, sizeof(Symmetric128BitsKeyByteArray), &key.AsMutable<psa_key_id_t>());
-
+    LogPsaError(status);
     VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
 
     return CHIP_NO_ERROR;
@@ -118,7 +119,7 @@ CHIP_ERROR PSASessionKeystore::CreateKey(const ByteSpan & keyMaterial, HkdfKeyHa
 
     HkdfKeyAttributes attrs;
     psa_status_t status = psa_import_key(&attrs.Get(), keyMaterial.data(), keyMaterial.size(), &key.AsMutable<psa_key_id_t>());
-
+    LogPsaError(status);
     VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
Log PSA crypto error codes in more places to make it easier to catch and analyze crypto misconfiguration, such as too low number of available key slots.
