### PR TITLE
Remove extra logging in minmdns resolver.

### DIFF
--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -363,7 +363,6 @@ void MinMdnsResolver::AdvancePendingResolverStates()
     {
         if (!resolver->IsActive())
         {
-            ChipLogError(Discovery, "resolver inactive, continue to next");
             continue;
         }
 


### PR DESCRIPTION
Resolver list is a fixed size always, so a message of "inactive" tagged as an error seems to just fill up logs (especially seen in python repl)
