### PR TITLE
Fix crash in android tv-app when handling level commands

### DIFF
--- a/examples/tv-app/android/java/LevelManager.cpp
+++ b/examples/tv-app/android/java/LevelManager.cpp
@@ -83,6 +83,7 @@ void LevelManager::PostLevelChanged(chip::EndpointId endpoint, uint8_t value)
 
 jboolean LevelManager::SetLevel(jint endpoint, jint value)
 {
+    chip::DeviceLayer::StackLock stack;
     chip::Protocols::InteractionModel::Status status = app::Clusters::LevelControl::Attributes::CurrentLevel::Set(
         static_cast<chip::EndpointId>(endpoint), static_cast<uint8_t>(value));
     return status == chip::Protocols::InteractionModel::Status::Success;


### PR DESCRIPTION
a small PR, same as [issue ](https://github.com/project-chip/connectedhomeip/issues/21708)

