### PR TITLE
[Darwin] Fix MTRDeviceConnectivityMonitor DNSServiceRefDeallocate call on the correct queue

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.mm
@@ -264,8 +264,11 @@ static void ResolveCallback(
 
 - (void)stopMonitoring
 {
-    MTR_LOG_INFO("%@ stop connectivity monitoring for %@", self, _instanceName);
-    std::lock_guard lock(sConnectivityMonitorLock);
-    [self _stopMonitoring];
+    // DNSServiceRefDeallocate must be called on the same queue set on the shared connection.
+    dispatch_async(sSharedResolverQueue, ^{
+        MTR_LOG_INFO("%@ stop connectivity monitoring for %@", self, self->_instanceName);
+        std::lock_guard lock(sConnectivityMonitorLock);
+        [self _stopMonitoring];
+    });
 }
 @end


### PR DESCRIPTION
This is a race caused by not calling `DNSServiceRefDeallocate` on the right queue, which means if there's a resolve callback happening at the same time the monitor object calls that and goes away, then this crash can happen with the void pointer left holding dealloc'ed memory.

The fix here is to async the method that calls `DNSServiceRefDeallocate` onto the right queue.