### PR TITLE
[1.3 cherry-pick] [mrp] Make sure not all packet buffers are used for retransmissions

### DIFF
--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -130,7 +130,10 @@ namespace chip {
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if !LWIP_PBUF_FROM_CUSTOM_POOLS && PBUF_POOL_SIZE != 0
-#define CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE std::min(PBUF_POOL_SIZE, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS)
+// Configure the table size to be less than the number of packet buffers to make sure
+// that not all buffers are held by the retransmission entries, in which case the device
+// is unable to receive an ACK and hence becomes unavailable until a message times out.
+#define CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE std::min(PBUF_POOL_SIZE - 1, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS)
 #else
 #define CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS
 #endif // !LWIP_PBUF_FROM_CUSTOM_POOLS && PBUF_POOL_SIZE != 0
@@ -138,7 +141,11 @@ namespace chip {
 #else // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 #if CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE != 0
-#define CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE std::min(CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS)
+// Configure the table size to be less than the number of packet buffers to make sure
+// that not all buffers are held by the retransmission entries, in which case the device
+// is unable to receive an ACK and hence becomes unavailable until a message times out.
+#define CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE                                                                                         \
+    std::min(CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE - 1, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS)
 #else
 #define CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS
 #endif // CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE != 0


### PR DESCRIPTION
Cherry-pick of #33334.

On constrained devices, the number of available packet buffers can be very low. During stress testing a device that has 8 buffers available, which is the default on many platforms, it was observed that the device would receive a lot of parallel read requests and then it would use all its buffers for responses. The responses would then be stored in the retransmission table,
awaiting an ACK, but the ACK would never arrive because of lack of available buffers.

Configure the retransmission table size to be less than the number of packet buffers to make sure that not all buffers are held by the retransmission entries, in which case the device is unable to receive an ACK and hence it becomes unavailable until any message times out.