### PR TITLE
[NXP] Update K32W0 SDK to 2.6.14

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-51 : [NuttX] Update Docker image to support compile with external source
+52 : [NXP] Update K32W0 SDK to 2.6.14

--- a/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /opt/sdk
 
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir west==1.0.0 \
-    && west init -m https://github.com/nxp-mcuxpresso/mcux-sdk --mr "MCUX_2.6.13_K32W0" \
+    && west init -m https://github.com/nxp-mcuxpresso/mcux-sdk --mr "MCUX_2.6.14_K32W0" \
     && west update \
     && chmod +x core/tools/imagetool/sign_images.sh \
     && ln -sf ../rtos core \


### PR DESCRIPTION
K32W0 docker image now points to latest SDK release: 2.6.14.