### PR TITLE
Conformance: add start of arithmetic conformance

### DIFF
--- a/src/python_testing/conformance_support.py
+++ b/src/python_testing/conformance_support.py
@@ -131,7 +131,7 @@ class literal:
 
     def __call__(self):
         # This should never be called
-        raise ConformanceException(f'Literal conformance function should not be called - this is simply a value holder')
+        raise ConformanceException('Literal conformance function should not be called - this is simply a value holder')
 
     def __str__(self):
         return str(self.value)


### PR DESCRIPTION
https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/7808 represents the first arithmetic conformance operation. Adding a new conformance class to match this. Currently this just returns optional to match the current behaviour, but this will be changed in an upcoming PR (see
https://github.com/project-chip/connectedhomeip/issues/33422)

However, that change requires that we assess the conformance based on the attribute values, which we do pass in right now. This therefore requires a bit of an API change on the conformance classes and I've opted to address this in a separate PR to keep the changes compact.

