### PR TITLE
Remove Interaction Model Engine dependency in WriteHandler

### DIFF
--- a/src/app/InteractionModelDelegatePointers.cpp
+++ b/src/app/InteractionModelDelegatePointers.cpp
@@ -31,6 +31,12 @@ app::TimedHandlerDelegate * GlobalInstanceProvider<app::TimedHandlerDelegate>::I
     return app::InteractionModelEngine::GetInstance();
 }
 
+template <>
+app::WriteHandlerDelegate * GlobalInstanceProvider<app::WriteHandlerDelegate>::InstancePointer()
+{
+    return app::InteractionModelEngine::GetInstance();
+}
+
 } // namespace chip
 
 #endif

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -869,7 +869,7 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnWriteRequest(Messa
     {
         if (writeHandler.IsFree())
         {
-            VerifyOrReturnError(writeHandler.Init() == CHIP_NO_ERROR, Status::Busy);
+            VerifyOrReturnError(writeHandler.Init(this) == CHIP_NO_ERROR, Status::Busy);
             return writeHandler.OnWriteRequest(apExchangeContext, std::move(aPayload), aIsTimedWrite);
         }
     }

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -91,7 +91,8 @@ class InteractionModelEngine : public Messaging::UnsolicitedMessageHandler,
                                public ReadHandler::ManagementCallback,
                                public FabricTable::Delegate,
                                public SubscriptionsInfoProvider,
-                               public TimedHandlerDelegate
+                               public TimedHandlerDelegate,
+                               public WriteHandlerDelegate
 {
 public:
     /**
@@ -235,6 +236,9 @@ public:
     void OnTimedWrite(TimedHandler * apTimedHandler, Messaging::ExchangeContext * apExchangeContext,
                       const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload) override;
 
+    // WriteHandlerDelegate implementation
+    bool HasConflictWriteRequests(const WriteHandler * apWriteHandler, const ConcreteAttributePath & apath) override;
+
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
     /**
      *  Activate the idle subscriptions.
@@ -278,12 +282,6 @@ public:
      * Returns the number of dirty subscriptions. Including the subscriptions that are generating reports.
      */
     size_t GetNumDirtySubscriptions() const;
-
-    /**
-     * Returns whether the write operation to the given path is conflict with another write operations. (i.e. another write
-     * transaction is in the middle of processing the chunked value of the given path.)
-     */
-    bool HasConflictWriteRequests(const WriteHandler * apWriteHandler, const ConcreteAttributePath & aPath);
 
     /**
      * Select the oldest (and the one that exceeds the per subscription resource minimum if there are any) read handler on the

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -194,7 +194,7 @@ private:
     bool mAttributeWriteSuccessful                = false;
     Optional<AttributeAccessToken> mACLCheckCache = NullOptional;
 
-    // This may be "fake" pointer or a real delegate pointer, depending
+    // This may be a "fake" pointer or a real delegate pointer, depending
     // on CHIP_CONFIG_STATIC_GLOBAL_INTERACTION_MODEL_ENGINE setting.
     //
     // When this is not a real pointer, it checks that the value is always

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -64,8 +64,8 @@ public:
      *  of this instance, this method is invoked once after object
      *  construction until a call to Close is made to terminate the
      *  instance.
-     * 
-     *  @param[in] apWriteHandlerDelegate  A Valid pointer to the WriteHandlerDelegate. 
+     *
+     *  @param[in] apWriteHandlerDelegate  A Valid pointer to the WriteHandlerDelegate.
      *
      *  @retval #CHIP_ERROR_INCORRECT_STATE If the state is not equal to
      *          kState_NotInitialized.

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -41,7 +41,7 @@ class WriteHandler;
 
 class WriteHandlerDelegate
 {
- public:
+public:
     virtual ~WriteHandlerDelegate() = default;
 
     /**

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -45,7 +45,7 @@ public:
     virtual ~WriteHandlerDelegate() = default;
 
     /**
-     * Returns whether the write operation to the given path is conflict with another write operations.
+     * Returns whether the write operation to the given path is in conflict with another write operation.
      * (i.e. another write transaction is in the middle of processing the chunked value of the given path.)
      */
     virtual bool HasConflictWriteRequests(const WriteHandler * apWriteHandler, const ConcreteAttributePath & aPath) = 0;

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -46,7 +46,7 @@ public:
 
     /**
      * Returns whether the write operation to the given path is in conflict with another write operation.
-     * (i.e. another write transaction is in the middle of processing the chunked value of the given path.)
+     * (i.e. another write transaction is in the middle of processing a chunked write to the given path.)
      */
     virtual bool HasConflictWriteRequests(const WriteHandler * apWriteHandler, const ConcreteAttributePath & aPath) = 0;
 };

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -19,6 +19,7 @@
 #pragma once
 #include <app/AttributeAccessToken.h>
 #include <app/AttributePathParams.h>
+#include <app/InteractionModelDelegatePointers.h>
 #include <app/MessageDef/WriteResponseMessage.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLVDebug.h>
@@ -35,6 +36,21 @@
 
 namespace chip {
 namespace app {
+
+class WriteHandler;
+
+class WriteHandlerDelegate
+{
+ public:
+    virtual ~WriteHandlerDelegate() = default;
+
+    /**
+     * Returns whether the write operation to the given path is conflict with another write operations.
+     * (i.e. another write transaction is in the middle of processing the chunked value of the given path.)
+     */
+    virtual bool HasConflictWriteRequests(const WriteHandler * apWriteHandler, const ConcreteAttributePath & aPath) = 0;
+};
+
 /**
  *  @brief The write handler is responsible for processing a write request and sending a write reply.
  */
@@ -48,12 +64,14 @@ public:
      *  of this instance, this method is invoked once after object
      *  construction until a call to Close is made to terminate the
      *  instance.
+     * 
+     *  @param[in] apWriteHandlerDelegate  A Valid pointer to the WriteHandlerDelegate. 
      *
      *  @retval #CHIP_ERROR_INCORRECT_STATE If the state is not equal to
      *          kState_NotInitialized.
      *  @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR Init(WriteHandlerDelegate * apWriteHandlerDelegate);
 
     /**
      *  Process a write request.  Parts of the processing may end up being asynchronous, but the WriteHandler
@@ -175,6 +193,14 @@ private:
     //  Where (1)-(3) will be consistent among the whole list write request, while (4) and (5) are not appliable to group writes.
     bool mAttributeWriteSuccessful                = false;
     Optional<AttributeAccessToken> mACLCheckCache = NullOptional;
+
+    // This may be "fake" pointer or a real delegate pointer, depending
+    // on CHIP_CONFIG_STATIC_GLOBAL_INTERACTION_MODEL_ENGINE setting.
+    //
+    // When this is not a real pointer, it checks that the value is always
+    // set to the global InteractionModelEngine and the size of this
+    // member is 1 byte.
+    InteractionModelDelegatePointer<WriteHandlerDelegate> mDelegate;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -338,7 +338,7 @@ void TestWriteInteraction::TestWriteHandler(nlTestSuite * apSuite, void * apCont
             app::WriteHandler writeHandler;
 
             System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-            err                            = writeHandler.Init();
+            err                            = writeHandler.Init(chip::app::InteractionModelEngine::GetInstance());
 
             GenerateWriteRequest(apSuite, apContext, messageIsTimed, buf);
 

--- a/src/lib/support/static_support_smart_ptr.h
+++ b/src/lib/support/static_support_smart_ptr.h
@@ -54,6 +54,7 @@ template <class T>
 class CheckedGlobalInstanceReference
 {
 public:
+    CheckedGlobalInstanceReference<T>() = default;
     CheckedGlobalInstanceReference(T * e) { VerifyOrDie(e == GlobalInstanceProvider<T>::InstancePointer()); }
     CheckedGlobalInstanceReference & operator=(T * value)
     {
@@ -63,6 +64,7 @@ public:
 
     inline T * operator->() { return GlobalInstanceProvider<T>::InstancePointer(); }
     inline const T * operator->() const { return GlobalInstanceProvider<T>::InstancePointer(); }
+    inline operator bool() const { return true; }
 };
 
 /// A class that acts as a wrapper to a pointer and provides
@@ -87,6 +89,7 @@ template <class T>
 class SimpleInstanceReference
 {
 public:
+    SimpleInstanceReference<T>() = default;
     SimpleInstanceReference(T * e) : mValue(e) {}
     SimpleInstanceReference & operator=(T * value)
     {
@@ -96,9 +99,10 @@ public:
 
     T * operator->() { return mValue; }
     const T * operator->() const { return mValue; }
+    inline operator bool() const { return mValue != nullptr; }
 
 private:
-    T * mValue;
+    T * mValue = nullptr;
 };
 
 } // namespace chip

--- a/src/lib/support/tests/TestStaticSupportSmartPtr.cpp
+++ b/src/lib/support/tests/TestStaticSupportSmartPtr.cpp
@@ -56,6 +56,7 @@ TEST(TestStaticSupportSmartPtr, TestCheckedGlobalInstanceReference)
     // We expect that sizes of global references is minimal
     EXPECT_EQ(sizeof(ref), 1u);
 
+    ASSERT_TRUE(ref);
     EXPECT_EQ(ref->num, 123);
     EXPECT_STREQ(ref->str, "abc");
 
@@ -69,6 +70,7 @@ TEST(TestStaticSupportSmartPtr, TestCheckedGlobalInstanceReference)
 
     CheckedGlobalInstanceReference<TestClass> ref2(&gTestClass);
 
+    ASSERT_TRUE(ref2);
     EXPECT_EQ(ref->num, ref2->num);
     EXPECT_STREQ(ref->str, ref2->str);
 
@@ -95,6 +97,9 @@ TEST(TestStaticSupportSmartPtr, TestSimpleInstanceReference)
     // overhead of simple references should be a simple pointer
     EXPECT_LE(sizeof(ref_a), sizeof(void *));
 
+    ASSERT_TRUE(ref_a);
+    ASSERT_TRUE(ref_b);
+
     EXPECT_EQ(ref_a->num, 123);
     EXPECT_EQ(ref_b->num, 100);
 
@@ -103,6 +108,10 @@ TEST(TestStaticSupportSmartPtr, TestSimpleInstanceReference)
 
     EXPECT_EQ(a.num, 99);
     EXPECT_EQ(ref_b->num, 30);
+
+    // Check default constructed SimpleInstanceReference
+    SimpleInstanceReference<TestClass> ref_default;
+    ASSERT_FALSE(ref_default);
 }
 
 } // namespace

--- a/src/lib/support/tests/TestStaticSupportSmartPtr.cpp
+++ b/src/lib/support/tests/TestStaticSupportSmartPtr.cpp
@@ -84,6 +84,10 @@ TEST(TestStaticSupportSmartPtr, TestCheckedGlobalInstanceReference)
         EXPECT_EQ(ref2->num, 321);
         EXPECT_STREQ(ref2->str, "test");
     }
+
+    // Check default constructed CheckedGlobalInstanceReference
+    CheckedGlobalInstanceReference<TestClass> ref_default;
+    ASSERT_TRUE(ref_default);
 }
 
 TEST(TestStaticSupportSmartPtr, TestSimpleInstanceReference)


### PR DESCRIPTION
Remove direct usage of InteractionModelEngine::GetInstance()->HasConflictWriteRequest. Instead, add a write handler delegate to WriteHandlers.

Also, like TimedHandle, uses InteractionModelDelegatePointer to minimize memory impact.

This is beneficial and allow us to have in-process testing (e.g. one client and one server running in parallel as different IM engines). 

