### PR TITLE
[Python] Eliminate ZCLReadAttribute/ZCLSend

### DIFF
--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1097,20 +1097,24 @@ class BaseTestHelper:
         self.devCtrl.SetThreadOperationalDataset(bytes.fromhex(dataset))
         return True
 
-    def TestOnOffCluster(self, nodeid: int, endpoint: int, group: int):
+    async def TestOnOffCluster(self, nodeid: int, endpoint: int):
         self.logger.info(
             "Sending On/Off commands to device {} endpoint {}".format(nodeid, endpoint))
-        err, resp = self.devCtrl.ZCLSend("OnOff", "On", nodeid,
-                                         endpoint, group, {}, blocking=True)
-        if err != 0:
+
+        try:
+            await self.devCtrl.SendCommand(nodeid, endpoint,
+                                           Clusters.OnOff.Commands.On())
+        except IM.InteractionModelError as ex:
             self.logger.error(
-                "failed to send OnOff.On: error is {} with im response{}".format(err, resp))
+                "failed to send OnOff.On: error is {}".format(ex.status))
             return False
-        err, resp = self.devCtrl.ZCLSend("OnOff", "Off", nodeid,
-                                         endpoint, group, {}, blocking=True)
-        if err != 0:
+
+        try:
+            await self.devCtrl.SendCommand(nodeid, endpoint,
+                                           Clusters.OnOff.Commands.Off())
+        except IM.InteractionModelError as ex:
             self.logger.error(
-                "failed to send OnOff.Off: error is {} with im response {}".format(err, resp))
+                "failed to send OnOff.Off: error is {}".format(ex.status))
             return False
         return True
 

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -41,6 +41,7 @@ import chip.native
 from chip import ChipDeviceCtrl
 from chip.ChipStack import ChipStack
 from chip.crypto import p256keypair
+from chip.exceptions import ChipStackError
 from chip.utils import CommissioningBuildingBlocks
 from cirque_restart_remote_device import restartRemoteDevice
 from ecdsa import NIST256p
@@ -375,7 +376,7 @@ class BaseTestHelper:
             self.logger.error(
                 'Incorrectly succeeded in opening basic commissioning window')
             return False
-        except Exception:
+        except ChipStackError:
             pass
 
         # TODO:
@@ -403,7 +404,7 @@ class BaseTestHelper:
             self.logger.error(
                 'Incorrectly succeeded in opening enhanced commissioning window')
             return False
-        except Exception:
+        except ChipStackError:
             pass
 
         self.logger.info("Disarming failsafe on CASE connection")
@@ -1197,7 +1198,7 @@ class BaseTestHelper:
                     if req.expected_status != IM.Status.Success:
                         raise AssertionError(
                             f"Write attribute {req.attribute.__qualname__} expects failure but got success response")
-                except Exception as ex:
+                except ChipStackError as ex:
                     if req.expected_status != IM.Status.Success:
                         continue
                     else:

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1193,16 +1193,16 @@ class BaseTestHelper:
         failed_attribute_write = []
         for req in requests:
             try:
-                try:
-                    await self.devCtrl.WriteAttribute(nodeid, [(endpoint, req.attribute, 0)])
-                    if req.expected_status != IM.Status.Success:
-                        raise AssertionError(
-                            f"Write attribute {req.attribute.__qualname__} expects failure but got success response")
-                except ChipStackError as ex:
-                    if req.expected_status != IM.Status.Success:
-                        continue
-                    else:
-                        raise ex
+                # Errors tested here is in the per-attribute result list (type AttributeStatus)
+                write_res = await self.devCtrl.WriteAttribute(nodeid, [(endpoint, req.attribute(req.value))])
+                status = write_res[0].Status
+                if req.expected_status != status:
+                    raise AssertionError(
+                        f"Write attribute {req.attribute.__qualname__} expects {req.expected_status} but got {status}")
+
+                # Only execute read tests where write is successful.
+                if req.expected_status != IM.Status.Success:
+                    continue
 
                 res = await self.devCtrl.ReadAttribute(nodeid, [(endpoint, req.attribute)])
                 val = res[endpoint][req.cluster][req.attribute]

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1165,29 +1165,27 @@ class BaseTestHelper:
             self.logger.exception("Failed to resolve. {}".format(ex))
             return False
 
-    def TestReadBasicAttributes(self, nodeid: int, endpoint: int, group: int):
+    async def TestReadBasicAttributes(self, nodeid: int, endpoint: int):
+        attrs = Clusters.BasicInformation.Attributes
         basic_cluster_attrs = {
-            "VendorName": "TEST_VENDOR",
-            "VendorID": 0xFFF1,
-            "ProductName": "TEST_PRODUCT",
-            "ProductID": 0x8001,
-            "NodeLabel": "Test",
-            "Location": "XX",
-            "HardwareVersion": 0,
-            "HardwareVersionString": "TEST_VERSION",
-            "SoftwareVersion": 1,
-            "SoftwareVersionString": "1.0",
+            attrs.VendorName: "TEST_VENDOR",
+            attrs.VendorID: 0xFFF1,
+            attrs.ProductName: "TEST_PRODUCT",
+            attrs.ProductID: 0x8001,
+            attrs.NodeLabel: "Test",
+            attrs.Location: "XX",
+            attrs.HardwareVersion: 0,
+            attrs.HardwareVersionString: "TEST_VERSION",
+            attrs.SoftwareVersion: 1,
+            attrs.SoftwareVersionString: "1.0",
         }
         failed_zcl = {}
         for basic_attr, expected_value in basic_cluster_attrs.items():
             try:
-                res = self.devCtrl.ZCLReadAttribute(cluster="BasicInformation",
-                                                    attribute=basic_attr,
-                                                    nodeid=nodeid,
-                                                    endpoint=endpoint,
-                                                    groupid=group)
-                TestResult(f"Read attribute {basic_attr}", res).assertValueEqual(
-                    expected_value)
+                res = await self.devCtrl.ReadAttribute(nodeid, [(endpoint, basic_attr)])
+                readVal = res[endpoint][Clusters.BasicInformation][basic_attr]
+                if readVal != expected_value:
+                    raise Exception(f"Read attribute: expected value {expected_value}, got {readVal}")
             except Exception as ex:
                 failed_zcl[basic_attr] = str(ex)
         if failed_zcl:

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -376,7 +376,7 @@ class BaseTestHelper:
             self.logger.error(
                 'Incorrectly succeeded in opening basic commissioning window')
             return False
-        except ChipStackError:
+        except IM.InteractionModelError:
             pass
 
         # TODO:
@@ -404,7 +404,7 @@ class BaseTestHelper:
             self.logger.error(
                 'Incorrectly succeeded in opening enhanced commissioning window')
             return False
-        except ChipStackError:
+        except IM.InteractionModelError:
             pass
 
         self.logger.info("Disarming failsafe on CASE connection")

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -178,29 +178,6 @@ class TestTimeout(threading.Thread):
             TestFail("Timeout", doCrash=True)
 
 
-class TestResult:
-    def __init__(self, operationName, result):
-        self.operationName = operationName
-        self.result = result
-
-    def assertStatusEqual(self, expected):
-        if self.result is None:
-            raise Exception(f"{self.operationName}: no result got")
-        if self.result.status != expected:
-            raise Exception(
-                f"{self.operationName}: expected status {expected}, got {self.result.status}")
-        return self
-
-    def assertValueEqual(self, expected):
-        self.assertStatusEqual(0)
-        if self.result is None:
-            raise Exception(f"{self.operationName}: no result got")
-        if self.result.value != expected:
-            raise Exception(
-                f"{self.operationName}: expected value {expected}, got {self.result.value}")
-        return self
-
-
 class BaseTestHelper:
     def __init__(self, nodeid: int, paaTrustStorePath: str, testCommissioner: bool = False,
                  keypair: p256keypair.P256Keypair = None):

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -41,7 +41,6 @@ import chip.native
 from chip import ChipDeviceCtrl
 from chip.ChipStack import ChipStack
 from chip.crypto import p256keypair
-from chip.exceptions import ChipStackError
 from chip.utils import CommissioningBuildingBlocks
 from cirque_restart_remote_device import restartRemoteDevice
 from ecdsa import NIST256p

--- a/src/controller/python/test/test_scripts/commissioning_failure_test.py
+++ b/src/controller/python/test/test_scripts/commissioning_failure_test.py
@@ -19,6 +19,7 @@
 
 # Commissioning test.
 
+import asyncio
 import os
 import sys
 from optparse import OptionParser
@@ -121,9 +122,8 @@ def main():
     FailIfNot(test.TestCommissionFailure(1, 0), "Failed to commission device")
 
     logger.info("Testing on off cluster")
-    FailIfNot(test.TestOnOffCluster(nodeid=1,
-                                    endpoint=LIGHTING_ENDPOINT_ID,
-                                    group=GROUP_ID), "Failed to test on off cluster")
+    FailIfNot(asyncio.run(test.TestOnOffCluster(nodeid=1,
+                                                endpoint=LIGHTING_ENDPOINT_ID)), "Failed to test on off cluster")
 
     timeoutTicker.stop()
 

--- a/src/controller/python/test/test_scripts/commissioning_test.py
+++ b/src/controller/python/test/test_scripts/commissioning_test.py
@@ -19,6 +19,7 @@
 
 # Commissioning test.
 
+import asyncio
 import os
 import sys
 from optparse import OptionParser
@@ -146,9 +147,8 @@ def main():
         TestFail("Must provide device address or setup payload to commissioning the device")
 
     logger.info("Testing on off cluster")
-    FailIfNot(test.TestOnOffCluster(nodeid=options.nodeid,
-                                    endpoint=LIGHTING_ENDPOINT_ID,
-                                    group=GROUP_ID), "Failed to test on off cluster")
+    FailIfNot(asyncio.run(test.TestOnOffCluster(nodeid=options.nodeid,
+                                                endpoint=LIGHTING_ENDPOINT_ID)), "Failed to test on off cluster")
 
     FailIfNot(test.TestUsedTestCommissioner(),
               "Test commissioner check failed")

--- a/src/controller/python/test/test_scripts/failsafe_tests.py
+++ b/src/controller/python/test/test_scripts/failsafe_tests.py
@@ -19,6 +19,7 @@
 
 # Commissioning test.
 
+import asyncio
 import os
 import sys
 from optparse import OptionParser
@@ -99,7 +100,7 @@ def main():
                                      nodeid=1),
               "Failed to finish key exchange")
 
-    FailIfNot(test.TestFailsafe(nodeid=1), "Failed failsafe test")
+    FailIfNot(asyncio.run(test.TestFailsafe(nodeid=1)), "Failed failsafe test")
 
     timeoutTicker.stop()
 

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -122,9 +122,8 @@ def TestDatamodel(test: BaseTestHelper, device_nodeid: int):
               "Failed when testing Python Cluster Object APIs")
 
     logger.info("Testing attribute reading")
-    FailIfNot(test.TestReadBasicAttributes(nodeid=device_nodeid,
-                                           endpoint=ENDPOINT_ID,
-                                           group=GROUP_ID),
+    FailIfNot(asyncio.run(test.TestReadBasicAttributes(nodeid=device_nodeid,
+                                                       endpoint=ENDPOINT_ID)),
               "Failed to test Read Basic Attributes")
 
     logger.info("Testing attribute writing")
@@ -133,9 +132,8 @@ def TestDatamodel(test: BaseTestHelper, device_nodeid: int):
               "Failed to test Write Basic Attributes")
 
     logger.info("Testing attribute reading basic again")
-    FailIfNot(test.TestReadBasicAttributes(nodeid=1,
-                                           endpoint=ENDPOINT_ID,
-                                           group=GROUP_ID),
+    FailIfNot(asyncio.run(test.TestReadBasicAttributes(nodeid=1,
+                                                       endpoint=ENDPOINT_ID)),
               "Failed to test Read Basic Attributes")
 
     logger.info("Testing subscription")

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -102,9 +102,8 @@ def TestDatamodel(test: BaseTestHelper, device_nodeid: int):
     logger.info("Testing datamodel functions")
 
     logger.info("Testing on off cluster")
-    FailIfNot(test.TestOnOffCluster(nodeid=device_nodeid,
-                                    endpoint=LIGHTING_ENDPOINT_ID,
-                                    group=GROUP_ID), "Failed to test on off cluster")
+    FailIfNot(asyncio.run(test.TestOnOffCluster(nodeid=device_nodeid,
+                                                endpoint=LIGHTING_ENDPOINT_ID)), "Failed to test on off cluster")
 
     logger.info("Testing level control cluster")
     FailIfNot(asyncio.run(test.TestLevelControlCluster(nodeid=device_nodeid,
@@ -112,9 +111,8 @@ def TestDatamodel(test: BaseTestHelper, device_nodeid: int):
               "Failed to test level control cluster")
 
     logger.info("Testing sending commands to non exist endpoint")
-    FailIfNot(not test.TestOnOffCluster(nodeid=device_nodeid,
-                                        endpoint=233,
-                                        group=GROUP_ID), "Failed to test on off cluster on non-exist endpoint")
+    FailIfNot(not asyncio.run(test.TestOnOffCluster(nodeid=device_nodeid,
+                                                    endpoint=233)), "Failed to test on off cluster on non-exist endpoint")
 
     # Test experimental Python cluster objects API
     logger.info("Testing cluster objects API")
@@ -149,9 +147,8 @@ def TestDatamodel(test: BaseTestHelper, device_nodeid: int):
               "Failed to validated re-subscription")
 
     logger.info("Testing on off cluster over resolved connection")
-    FailIfNot(test.TestOnOffCluster(nodeid=device_nodeid,
-                                    endpoint=LIGHTING_ENDPOINT_ID,
-                                    group=GROUP_ID), "Failed to test on off cluster")
+    FailIfNot(asyncio.run(test.TestOnOffCluster(nodeid=device_nodeid,
+                                                endpoint=LIGHTING_ENDPOINT_ID)), "Failed to test on off cluster")
 
     logger.info("Testing writing/reading fabric sensitive data")
     asyncio.run(test.TestFabricSensitive(nodeid=device_nodeid))

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -107,9 +107,8 @@ def TestDatamodel(test: BaseTestHelper, device_nodeid: int):
                                     group=GROUP_ID), "Failed to test on off cluster")
 
     logger.info("Testing level control cluster")
-    FailIfNot(test.TestLevelControlCluster(nodeid=device_nodeid,
-                                           endpoint=LIGHTING_ENDPOINT_ID,
-                                           group=GROUP_ID),
+    FailIfNot(asyncio.run(test.TestLevelControlCluster(nodeid=device_nodeid,
+                                                       endpoint=LIGHTING_ENDPOINT_ID)),
               "Failed to test level control cluster")
 
     logger.info("Testing sending commands to non exist endpoint")

--- a/src/controller/python/test/test_scripts/split_commissioning_test.py
+++ b/src/controller/python/test/test_scripts/split_commissioning_test.py
@@ -19,6 +19,7 @@
 
 # Commissioning test.
 
+import asyncio
 import os
 import sys
 from optparse import OptionParser
@@ -118,14 +119,12 @@ def main():
               "Failed to commission device 2")
 
     logger.info("Testing on off cluster on device 1")
-    FailIfNot(test.TestOnOffCluster(nodeid=1,
-                                    endpoint=LIGHTING_ENDPOINT_ID,
-                                    group=GROUP_ID), "Failed to test on off cluster on device 1")
+    FailIfNot(asyncio.run(test.TestOnOffCluster(nodeid=1,
+                                                endpoint=LIGHTING_ENDPOINT_ID)), "Failed to test on off cluster on device 1")
 
     logger.info("Testing on off cluster on device 2")
-    FailIfNot(test.TestOnOffCluster(nodeid=2,
-                                    endpoint=LIGHTING_ENDPOINT_ID,
-                                    group=GROUP_ID), "Failed to test on off cluster on device 2")
+    FailIfNot(asyncio.run(test.TestOnOffCluster(nodeid=2,
+                                                endpoint=LIGHTING_ENDPOINT_ID)), "Failed to test on off cluster on device 2")
 
     timeoutTicker.stop()
 

--- a/src/test_driver/mbed/integration_tests/common/utils.py
+++ b/src/test_driver/mbed/integration_tests/common/utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 
+import asyncio
 import logging
 import platform
 import random
@@ -114,21 +115,33 @@ def send_zcl_command(devCtrl, line):
         if len(args) < 5:
             raise exceptions.InvalidArgumentCount(5, len(args))
 
-        if args[0] not in all_commands:
-            raise exceptions.UnknownCluster(args[0])
-        command = all_commands.get(args[0]).get(args[1], None)
+        cluster = args[0]
+        command = args[1]
+        if cluster not in all_commands:
+            raise exceptions.UnknownCluster(cluster)
+        commandObj = all_commands.get(cluster).get(command, None)
         # When command takes no arguments, (not command) is True
-        if command is None:
-            raise exceptions.UnknownCommand(args[0], args[1])
-        err, res = devCtrl.ZCLSend(args[0], args[1], int(
-            args[2]), int(args[3]), int(args[4]), FormatZCLArguments(args[5:], command), blocking=True)
-        if err != 0:
-            log.error("Failed to send ZCL command [{}] {}.".format(err, res))
-        elif res is not None:
-            log.info("Success, received command response:")
-            log.info(res)
-        else:
-            log.info("Success, no command response.")
+        if commandObj is None:
+            raise exceptions.UnknownCommand(cluster, command)
+
+        try:
+            req = commandObj(**FormatZCLArguments(args[5:], command))
+        except BaseException:
+            raise exceptions.UnknownCommand(cluster, command)
+
+        nodeid = int(args[2])
+        endpoint = int(args[3])
+        try:
+            res = asyncio.run(devCtrl.SendCommand(nodeid, endpoint, req))
+            logging.debug(f"CommandResponse {res}")
+            if res is not None:
+                log.info("Success, received command response:")
+                log.info(res)
+            else:
+                log.info("Success, no command response.")
+        except exceptions.InteractionModelError as ex:
+            return (int(ex.status), None)
+            log.error("Failed to send ZCL command [{}] {}.".format(int(ex.status), None))
     except exceptions.ChipStackException as ex:
         log.error("An exception occurred during processing ZCL command:")
         log.error(str(ex))

--- a/src/test_driver/mbed/integration_tests/common/utils.py
+++ b/src/test_driver/mbed/integration_tests/common/utils.py
@@ -125,7 +125,7 @@ def send_zcl_command(devCtrl, line):
             raise exceptions.UnknownCommand(cluster, command)
 
         try:
-            req = commandObj(**FormatZCLArguments(args[5:], command))
+            req = commandObj(**FormatZCLArguments(args[5:], commandObj))
         except BaseException:
             raise exceptions.UnknownCommand(cluster, command)
 


### PR DESCRIPTION
This eliminates use of ZCLReadAttribute and ZCLSend and improves some tests using asyncio.
