### PR TITLE
[v1.3branch] [ESP32] Change MRP config depends for esp platform

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -1232,7 +1232,7 @@ menu "CHIP Device Layer"
     menu "Message Reliable Protocol Options"
         config MRP_LOCAL_ACTIVE_RETRY_INTERVAL_FOR_THREAD
             int "MRP local active retry interval for Thread network in milliseconds"
-            depends on OPENTHREAD_ENABLED
+            depends on ENABLE_MATTER_OVER_THREAD
             range 0 3600000
             default 800
             help
@@ -1240,7 +1240,7 @@ menu "CHIP Device Layer"
 
         config MRP_LOCAL_ACTIVE_RETRY_INTERVAL_FOR_WIFI_ETHERNET
             int "MRP local active retry interval for WIFI or ETHERNET network in milliseconds"
-            depends on !OPENTHREAD_ENABLED
+            depends on !ENABLE_MATTER_OVER_THREAD
             range 0 3600000
             default 300
             help
@@ -1248,7 +1248,7 @@ menu "CHIP Device Layer"
 
         config MRP_LOCAL_IDLE_RETRY_INTERVAL_FOR_THREAD
             int "MRP local idle retry interval for Thread network in milliseconds"
-            depends on OPENTHREAD_ENABLED
+            depends on ENABLE_MATTER_OVER_THREAD
             range 0 3600000
             default 800
             help
@@ -1256,7 +1256,7 @@ menu "CHIP Device Layer"
 
         config MRP_LOCAL_IDLE_RETRY_INTERVAL_FOR_WIFI_ETHERNET
             int "MRP local idle retry interval for WIFI or ETHERNET network in milliseconds"
-            depends on !OPENTHREAD_ENABLED
+            depends on !ENABLE_MATTER_OVER_THREAD
             range 0 3600000
             default 500
             help
@@ -1264,7 +1264,7 @@ menu "CHIP Device Layer"
 
         config MRP_RETRY_INTERVAL_SENDER_BOOST_FOR_THREAD
             int "MRP retransmission delta timeout for Thread network in milliseconds"
-            depends on OPENTHREAD_ENABLED
+            depends on ENABLE_MATTER_OVER_THREAD
             range 0 3600000
             default 500
             help
@@ -1272,7 +1272,7 @@ menu "CHIP Device Layer"
 
         config MRP_RETRY_INTERVAL_SENDER_BOOST_FOR_WIFI_ETHERNET
             int "MRP retransmission delta timeout for WIFI or ETHERNET network in milliseconds"
-            depends on !OPENTHREAD_ENABLED
+            depends on !ENABLE_MATTER_OVER_THREAD
             range 0 3600000
             default 0
             help


### PR DESCRIPTION
Change MRP config depends for esp platform.

`OPENTHREAD_ENABLED` doesn't work for the case that Matter over Wi-Fi and Thread BR are both enabled on a device.

