### PR TITLE
Updated chip-cert-bins Dockerfile

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -89,7 +89,6 @@ RUN set -x \
     wget \
     git-lfs \
     zlib1g-dev \
-    && rm -rf /var/lib/apt/lists/ \
     && git lfs install \
     && : # last line
 
@@ -119,13 +118,12 @@ RUN case ${TARGETPLATFORM} in \
 
 # Python 3 and PIP
 RUN set -x \
-    && DEBIAN_FRONTEND=noninteractive  apt-get update \
-    && DEBIAN_FRONTEND=noninteractive  apt-get install -y libgirepository1.0-dev \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common \
+    && DEBIAN_FRONTEND=noninteractive  apt-get install -y \
+    libgirepository1.0-dev \
+    software-properties-common \
     && add-apt-repository universe \
     && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && python3 get-pip.py \
-    && rm -rf /var/lib/apt/lists/ \
     && : # last line
 
 RUN set -x \
@@ -148,9 +146,9 @@ RUN set -x \
     && git clone https://github.com/google/bloaty.git \
     && mkdir -p bloaty/build \
     && cd bloaty/build \
-    && cmake ../ \
-    && make -j8 \
-    && make install \
+    && cmake -G Ninja ../ \
+    && ninja \
+    && ninja install \
     && cd ../.. \
     && rm -rf bloaty \
     && : # last line
@@ -194,7 +192,6 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-lit-icd-ipv6only \
     --target linux-x64-energy-management-ipv6only \
     --target linux-x64-microwave-oven-ipv6only \
-    --target linux-x64-rvc-ipv6only \
     build \
     && mv out/linux-x64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
     && mv out/linux-x64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
@@ -214,7 +211,6 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-x64-lit-icd-ipv6only/lit-icd-app out/lit-icd-app \
     && mv out/linux-x64-energy-management-ipv6only/chip-energy-management-app out/chip-energy-management-app \
     && mv out/linux-x64-microwave-oven-ipv6only/chip-microwave-oven-app out/chip-microwave-oven-app \
-    && mv out/linux-x64-rvc-ipv6only/chip-rvc-app out/chip-rvc-app \
     ;; \
     "linux/arm64")\
     set -x \
@@ -257,7 +253,6 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-arm64-lit-icd-ipv6only/lit-icd-app out/lit-icd-app \
     && mv out/linux-arm64-energy-management-ipv6only/chip-energy-management-app out/chip-energy-management-app \
     && mv out/linux-arm64-microwave-oven-ipv6only/chip-microwave-oven-app out/chip-microwave-oven-app \
-    && mv out/linux-arm64-rvc-ipv6only/chip-rvc-app out/chip-rvc-app \
     ;; \
     *) ;; \
     esac
@@ -290,18 +285,19 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-app1 chip-app1
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/lit-icd-app lit-icd-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-energy-management-app chip-energy-management-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-microwave-oven-app chip-microwave-oven-app
-COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-rvc-app chip-rvc-app
 
 # Stage 3.1: Setup the Matter Python environment
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/python_lib python_lib
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/python_env python_env
-COPY --from=chip-build-cert-bins /root/connectedhomeip/src/python_testing python_testing/scripts/sdk
-COPY --from=chip-build-cert-bins /root/connectedhomeip/data_model python_testing/data_model
+COPY --from=chip-build-cert-bins /root/connectedhomeip/src/python_testing python_testing
 
 COPY --from=chip-build-cert-bins /root/connectedhomeip/scripts/tests/requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 COPY --from=chip-build-cert-bins /root/connectedhomeip/src/python_testing/requirements.txt /tmp/requirements.txt
 RUN pip install -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+# PIP requires MASON package compilation, which seems to require a JDK
+RUN set -x && DEBIAN_FRONTEND=noninteractive apt-get install -fy openjdk-8-jdk
 
 RUN pip install --no-cache-dir python_lib/controller/python/chip*.whl


### PR DESCRIPTION
This PR was copied from https://github.com/project-chip/connectedhomeip/pull/33015, since it was not merged into master branch.

Fixes https://github.com/project-chip/connectedhomeip/issues/32989

### Changes

- Do not needlesly clear apt update results, as it is reused and a build image will not copy over their contents anyway

- Update compile of bloaty to use ninja, so we do not hardcode -j8

- Install openjdk8 before installing chip whl, since apparently we depend on mason which depends on the jdk