### PR TITLE
Using strncmp instead of strcmp to make the function robust and safe from buffer overruns.

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -171,7 +171,7 @@ bool HandleNullableOptional(Argument & arg, char * argValue, std::function<bool(
     if (arg.isNullable())
     {
         auto * nullable = reinterpret_cast<chip::app::DataModel::Nullable<T> *>(arg.value);
-        if (strcmp(argValue, "null") == 0)
+        if (argValue != nullptr && strncmp(argValue, "null", 4) == 0)
         {
             nullable->SetNull();
             return true;


### PR DESCRIPTION
We use strncmp throughout examples/chip-tool/commands/common/Command.cpp for argument comparisons, but in one instance, we use strcmp(argValue, "null").

strncmp would only be necessary if argValue was not null-terminated and had a length of exactly 4, making strcmp unsafe. However, since argValue is always null-terminated in this context, it is safe to use either strncmp(argValue, "null", 4) or strcmp(argValue, "null").

This change is intended to standardize the method used for argument comparison in the code.

