### PR TITLE
[Darwin] Disable metric collector debug logging

### DIFF
--- a/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
+++ b/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
@@ -25,6 +25,11 @@
 #include <tracing/metric_event.h>
 #include <tracing/registry.h>
 
+/*
+ * Set this to MTR_LOG_DEBUG(__VA_ARGS__) to enable logging noisy debug logging for metrics events processing
+ */
+#define MTR_METRICS_LOG_DEBUG(...)
+
 using MetricEvent = chip::Tracing::MetricEvent;
 
 @implementation MTRMetricData {
@@ -74,7 +79,8 @@ using MetricEvent = chip::Tracing::MetricEvent;
     case ValueType::kUndefined:
         break;
     }
-    MTR_LOG_DEBUG("Initializing metric event data %s, type: %d, with time point %llu", event.key(), _type, _timePoint.count());
+
+    MTR_METRICS_LOG_DEBUG("Initializing metric event data %s, type: %d, with time point %llu", event.key(), _type, _timePoint.count());
     return self;
 }
 
@@ -83,7 +89,7 @@ using MetricEvent = chip::Tracing::MetricEvent;
     auto duration = _timePoint - fromData->_timePoint;
     _duration = [NSNumber numberWithDouble:double(duration.count()) / USEC_PER_SEC];
 
-    MTR_LOG_DEBUG("Calculating duration for Matter metric with type %d, from type %d, (%llu - %llu) = %llu us (%llu s)",
+    MTR_METRICS_LOG_DEBUG("Calculating duration for Matter metric with type %d, from type %d, (%llu - %llu) = %llu us (%llu s)",
         _type, fromData->_type, _timePoint.count(), fromData->_timePoint.count(), duration.count(), [_duration unsignedLongLongValue]);
 }
 
@@ -201,19 +207,19 @@ static inline NSString * suffixNameForMetric(const MetricEvent & event)
     using ValueType = MetricEvent::Value::Type;
     switch (event.ValueType()) {
     case ValueType::kInt32:
-        MTR_LOG_DEBUG("Received metric event, key: %s, type: %d, value: %d", event.key(), static_cast<int>(event.type()), event.ValueInt32());
+        MTR_METRICS_LOG_DEBUG("Received metric event, key: %s, type: %d, value: %d", event.key(), static_cast<int>(event.type()), event.ValueInt32());
         break;
     case ValueType::kUInt32:
-        MTR_LOG_DEBUG("Received metric event, key: %s, type: %d, value: %u", event.key(), static_cast<int>(event.type()), event.ValueUInt32());
+        MTR_METRICS_LOG_DEBUG("Received metric event, key: %s, type: %d, value: %u", event.key(), static_cast<int>(event.type()), event.ValueUInt32());
         break;
     case ValueType::kChipErrorCode:
-        MTR_LOG_DEBUG("Received metric event, key: %s, type: %d, error value: %u", event.key(), static_cast<int>(event.type()), event.ValueErrorCode());
+        MTR_METRICS_LOG_DEBUG("Received metric event, key: %s, type: %d, error value: %u", event.key(), static_cast<int>(event.type()), event.ValueErrorCode());
         break;
     case ValueType::kUndefined:
-        MTR_LOG_DEBUG("Received metric event, key: %s, type: %d, value: nil", event.key(), static_cast<int>(event.type()));
+        MTR_METRICS_LOG_DEBUG("Received metric event, key: %s, type: %d, value: nil", event.key(), static_cast<int>(event.type()));
         break;
     default:
-        MTR_LOG_DEBUG("Received metric event, key: %s, type: %d, unknown value", event.key(), static_cast<int>(event.type()));
+        MTR_METRICS_LOG_DEBUG("Received metric event, key: %s, type: %d, unknown value", event.key(), static_cast<int>(event.type()));
         return;
     }
 


### PR DESCRIPTION
- The debug logging in metrics collector is very noisy and debug is enabled by default.
- Disabling the metrics debug logging since it is not really useful except for developer development mode debugging, which is recompile and test.

