### PR TITLE
Increase dnssd kHostNameMaxLength to 40 bytes

### DIFF
--- a/src/lib/dnssd/Constants.h
+++ b/src/lib/dnssd/Constants.h
@@ -29,7 +29,12 @@ namespace Dnssd {
  * Matter DNS host settings
  */
 
-inline constexpr size_t kHostNameMaxLength = 16; // MAC or 802.15.4 Extended Address in hex
+// Matter spec expects hostname to be MAC or 802.15.4 Extended Address in hex.
+// But in latest android nsdManager, it would set hostname with 40 bytes with prefix as android_,
+// and there is no existing API to update the hostname, therefore we put temporary workaround with 40 bytes.
+// Follow-up with ticket issue https://github.com/project-chip/connectedhomeip/issues/33474
+inline constexpr size_t kHostNameMaxLength = 40;
+//
 
 /*
  * Matter DNS service subtypes


### PR DESCRIPTION
In pixel 7, we see nsdManager is advertising host name with 40bytes, in android nsdManager, there is no API to set this hostname.
The below is avahi-browse -r _matter._tcp
=  wlan0 IPv6 B6071280809E4E17-000000000001B669             _matter._tcp         local
   hostname = [Android_25101c8afe6a479387b1d63318378d56.local]
   address = [192.168.0.102]
   port = [58586]

During ICD check-in test, we see the mdns advertisment from android cannot be resolved in lit icd board because of the the above length issue so that lit cannot send the check-in message,
In order to resolve this issue, we expand the kHostNameMaxLength to 40 in dnssd.
