### PR TITLE
[Darwin] MTRDeviceController to limit concurrent subscriptions to Thread-enabled devices

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -115,6 +115,11 @@ jobs:
                   echo "This is a simple log" > /tmp/darwin/framework-tests/end_user_support_log.txt
                   ../../../out/debug/chip-all-clusters-app --interface-id -1 --end_user_support_log /tmp/darwin/framework-tests/end_user_support_log.txt > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
                   ../../../out/debug/chip-all-clusters-app --interface-id -1 --dac_provider ../../../credentials/development/commissioner_dut/struct_cd_origin_pid_vid_correct/test_case_vector.json --product-id 32768 --discriminator 3839 --secured-device-port 5539 --KVS /tmp/chip-all-clusters-app-kvs2 > >(tee /tmp/darwin/framework-tests/all-cluster-app-origin-vid.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-origin-vid-err.log >&2) &
+                  ../../../out/debug/chip-all-clusters-app --interface-id -1 --discriminator 101 --passcode 1001 --KVS /tmp/chip-all-clusters-app-kvs101 --secured-device-port 5531 &
+                  ../../../out/debug/chip-all-clusters-app --interface-id -1 --discriminator 102 --passcode 1002 --KVS /tmp/chip-all-clusters-app-kvs102 --secured-device-port 5532 &
+                  ../../../out/debug/chip-all-clusters-app --interface-id -1 --discriminator 103 --passcode 1003 --KVS /tmp/chip-all-clusters-app-kvs103 --secured-device-port 5533 &
+                  ../../../out/debug/chip-all-clusters-app --interface-id -1 --discriminator 104 --passcode 1004 --KVS /tmp/chip-all-clusters-app-kvs104 --secured-device-port 5534 &
+                  ../../../out/debug/chip-all-clusters-app --interface-id -1 --discriminator 105 --passcode 1005 --KVS /tmp/chip-all-clusters-app-kvs105 --secured-device-port 5535 &
 
                   export TEST_RUNNER_ASAN_OPTIONS=__CURRENT_VALUE__:detect_stack_use_after_return=1
 

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -100,9 +100,6 @@ public:
         mClusterStateCache = std::move(aClusterStateCache);
     }
 
-    // Used to reset Resubscription backoff on events that indicate likely availability of device to come back online
-    void ResetResubscriptionBackoff() { mResubscriptionNumRetries = 0; }
-
 protected:
     // Report an error, which may be due to issues in our own internal state or
     // due to the OnError callback happening.
@@ -147,6 +144,10 @@ protected:
     NSMutableArray * _Nullable mAttributeReports = nil;
     NSMutableArray * _Nullable mEventReports = nil;
 
+    void CallResubscriptionScheduledHandler(NSError * error, NSNumber * resubscriptionDelay);
+    // Copied from ReadClient and customized for MTRDevice resubscription time reset
+    uint32_t ComputeTimeTillNextSubscription();
+
 private:
     DataReportCallback _Nullable mAttributeReportCallback = nil;
     DataReportCallback _Nullable mEventReportCallback = nil;
@@ -181,10 +182,6 @@ private:
     bool mHaveQueuedDeletion = false;
     OnDoneHandler _Nullable mOnDoneHandler = nil;
     dispatch_block_t mInterimReportBlock = nil;
-
-    // Copied from ReadClient and customized for
-    uint32_t ComputeTimeTillNextSubscription();
-    uint32_t mResubscriptionNumRetries = 0;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -145,8 +145,6 @@ protected:
     NSMutableArray * _Nullable mEventReports = nil;
 
     void CallResubscriptionScheduledHandler(NSError * error, NSNumber * resubscriptionDelay);
-    // Copied from ReadClient and customized for MTRDevice resubscription time reset
-    uint32_t ComputeTimeTillNextSubscription();
 
 private:
     DataReportCallback _Nullable mAttributeReportCallback = nil;

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
@@ -125,57 +125,29 @@ void MTRBaseSubscriptionCallback::OnDeallocatePaths(ReadPrepareParams && aReadPr
 
 void MTRBaseSubscriptionCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId)
 {
-    // ReadClient resets it at ProcessSubscribeResponse after calling OnSubscriptionEstablished, so this is equivalent
-    mResubscriptionNumRetries = 0;
     if (mSubscriptionEstablishedHandler) {
         auto subscriptionEstablishedHandler = mSubscriptionEstablishedHandler;
         subscriptionEstablishedHandler();
     }
 }
 
-uint32_t MTRBaseSubscriptionCallback::ComputeTimeTillNextSubscription()
-{
-    uint32_t maxWaitTimeInMsec = 0;
-    uint32_t waitTimeInMsec = 0;
-    uint32_t minWaitTimeInMsec = 0;
-
-    if (mResubscriptionNumRetries <= CHIP_RESUBSCRIBE_MAX_FIBONACCI_STEP_INDEX) {
-        maxWaitTimeInMsec = GetFibonacciForIndex(mResubscriptionNumRetries) * CHIP_RESUBSCRIBE_WAIT_TIME_MULTIPLIER_MS;
-    } else {
-        maxWaitTimeInMsec = CHIP_RESUBSCRIBE_MAX_RETRY_WAIT_INTERVAL_MS;
-    }
-
-    if (maxWaitTimeInMsec != 0) {
-        minWaitTimeInMsec = (CHIP_RESUBSCRIBE_MIN_WAIT_TIME_INTERVAL_PERCENT_PER_STEP * maxWaitTimeInMsec) / 100;
-        waitTimeInMsec = minWaitTimeInMsec + (Crypto::GetRandU32() % (maxWaitTimeInMsec - minWaitTimeInMsec));
-    }
-
-    return waitTimeInMsec;
-}
-
 CHIP_ERROR MTRBaseSubscriptionCallback::OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause)
 {
-    // No need to check ReadClient internal state is Idle because ReadClient only calls OnResubscriptionNeeded after calling ClearActiveSubscriptionState(), which sets the state to Idle.
+    CHIP_ERROR err = ClusterStateCache::Callback::OnResubscriptionNeeded(apReadClient, aTerminationCause);
+    ReturnErrorOnFailure(err);
 
-    // This part is copied from ReadClient's DefaultResubscribePolicy:
-    auto timeTillNextResubscription = ComputeTimeTillNextSubscription();
-    ChipLogProgress(DataManagement,
-        "Will try to resubscribe to %02x:" ChipLogFormatX64 " at retry index %" PRIu32 " after %" PRIu32
-        "ms due to error %" CHIP_ERROR_FORMAT,
-        apReadClient->GetFabricIndex(), ChipLogValueX64(apReadClient->GetPeerNodeId()), mResubscriptionNumRetries, timeTillNextResubscription,
-        aTerminationCause.Format());
-    ReturnErrorOnFailure(apReadClient->ScheduleResubscription(timeTillNextResubscription, NullOptional, aTerminationCause == CHIP_ERROR_TIMEOUT));
+    auto error = [MTRError errorForCHIPErrorCode:aTerminationCause];
+    auto delayMs = @(apReadClient->ComputeTimeTillNextSubscription());
+    CallResubscriptionScheduledHandler(error, delayMs);
+    return CHIP_NO_ERROR;
+}
 
-    // Not as good a place to increment as when resubscription timer fires, but as is, this should be as good, because OnResubscriptionNeeded is only called from ReadClient's Close() while Idle, and nothing should cause this to happen
-    mResubscriptionNumRetries++;
-
+void MTRBaseSubscriptionCallback::CallResubscriptionScheduledHandler(NSError * error, NSNumber * resubscriptionDelay)
+{
     if (mResubscriptionCallback != nil) {
         auto callback = mResubscriptionCallback;
-        auto error = [MTRError errorForCHIPErrorCode:aTerminationCause];
-        auto delayMs = @(apReadClient->ComputeTimeTillNextSubscription());
-        callback(error, delayMs);
+        callback(error, resubscriptionDelay);
     }
-    return CHIP_NO_ERROR;
 }
 
 void MTRBaseSubscriptionCallback::OnUnsolicitedMessageFromPublisher(ReadClient *)

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -980,7 +980,7 @@ static NSString * const sAttributesKey = @"attributes";
     // Bit 2 Ethernet
     uint32_t networkCommissioningClusterFeatureMapValue = static_cast<uint32_t>(networkCommissioningClusterFeatureMapValueNumber.unsignedLongValue);
 
-    return (networkCommissioningClusterFeatureMapValue & (1 << 1));
+    return (networkCommissioningClusterFeatureMapValue & (1 << 1)) ? YES : NO;
 }
 
 - (void)_clearSubscriptionPoolWork

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -940,7 +940,7 @@ static NSString * const sAttributesKey = @"attributes";
 
 // This method is used for signaling whether to use the subscription pool. This functions as
 // a heuristic for whether to throttle subscriptions to the device via a pool of subscriptions.
-// If products appear that have both Thread and Wifi enabled but is primarily on wifi, this
+// If products appear that have both Thread and Wifi enabled but are primarily on wifi, this
 // method will need to be updated to reflect that.
 - (BOOL)_deviceUsesThread
 {

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -979,9 +979,6 @@ static NSString * const sAttributesKey = @"attributes";
         return NO;
     }
 
-    // Bit 0 WiFi
-    // Bit 1 Thread
-    // Bit 2 Ethernet
     uint32_t networkCommissioningClusterFeatureMapValue = static_cast<uint32_t>(networkCommissioningClusterFeatureMapValueNumber.unsignedLongValue);
 
     return (networkCommissioningClusterFeatureMapValue & MTRNetworkCommissioningFeatureThreadNetworkInterface) != 0 ? YES : NO;

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -393,7 +393,7 @@ static NSString * const sAttributesKey = @"attributes";
     // If this is true when the report ends, we notify the delegate.
     BOOL _deviceConfigurationChanged;
 
-    // The completion block is set when the subscription / resubscription work is enqueued, and called / cleared when:
+    // The completion block is set when the subscription / resubscription work is enqueued, and called / cleared when any of the following happen:
     //   1. Subscription establishes
     //   2. When OnResubscriptionNeeded is called
     //   3. On subscription reset (including when getSessionForNode fails)

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -971,6 +971,9 @@ static NSString * const sAttributesKey = @"attributes";
     MTRClusterPath * networkCommissioningClusterPath = [MTRClusterPath clusterPathWithEndpointID:@(kRootEndpointId) clusterID:@(MTRClusterIDTypeNetworkCommissioningID)];
     MTRDeviceClusterData * networkCommissioningClusterData = [self _clusterDataForPath:networkCommissioningClusterPath];
     NSNumber * networkCommissioningClusterFeatureMapValueNumber = networkCommissioningClusterData.attributes[@(MTRClusterGlobalAttributeFeatureMapID)][MTRValueKey];
+    
+    if ( networkCommissioningClusterFeatureMapValueNumber == nil )
+        return NO;
     if (![networkCommissioningClusterFeatureMapValueNumber isKindOfClass:[NSNumber class]]) {
         MTR_LOG_ERROR("%@ Unexpected NetworkCommissioning FeatureMap value %@", self, networkCommissioningClusterFeatureMapValueNumber);
         return NO;

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -967,7 +967,7 @@ static NSString * const sAttributesKey = @"attributes";
     }
 #endif
 
-    MTRClusterPath * networkCommissioningClusterPath = [MTRClusterPath clusterPathWithEndpointID:@(0) clusterID:@(MTRClusterIDTypeNetworkCommissioningID)];
+    MTRClusterPath * networkCommissioningClusterPath = [MTRClusterPath clusterPathWithEndpointID:@(kRootEndpointId) clusterID:@(MTRClusterIDTypeNetworkCommissioningID)];
     MTRDeviceClusterData * networkCommissioningClusterData = [self _clusterDataForPath:networkCommissioningClusterPath];
     NSNumber * networkCommissioningClusterFeatureMapValueNumber = networkCommissioningClusterData.attributes[@(MTRClusterGlobalAttributeFeatureMapID)][MTRValueKey];
     if (![networkCommissioningClusterFeatureMapValueNumber isKindOfClass:[NSNumber class]]) {

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -959,6 +959,7 @@ static NSString * const sAttributesKey = @"attributes";
 #ifdef DEBUG
     id testDelegate = _weakDelegate.strongObject;
     if (testDelegate) {
+        // Note: This is a hack to allow our unit tests to test the subscription pooling behavior we have implemented for thread, so we mock devices to be a thread device
         if ([testDelegate respondsToSelector:@selector(unitTestPretendThreadEnabled:)]) {
             if ([testDelegate unitTestPretendThreadEnabled:self]) {
                 return YES;

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -948,7 +948,7 @@ static NSString * const sAttributesKey = @"attributes";
 
     // Device is thread-enabled if there is a Thread Network Diagnostics cluster on endpoint 0
     for (MTRClusterPath * path in [self _knownClusters]) {
-        if (path.endpoint.unsignedShortValue != 0) {
+        if (path.endpoint.unsignedShortValue != kRootEndpointId) {
             continue;
         }
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -981,7 +981,7 @@ static NSString * const sAttributesKey = @"attributes";
     // Bit 2 Ethernet
     uint32_t networkCommissioningClusterFeatureMapValue = static_cast<uint32_t>(networkCommissioningClusterFeatureMapValueNumber.unsignedLongValue);
 
-    return (networkCommissioningClusterFeatureMapValue & (1 << 1)) ? YES : NO;
+    return (networkCommissioningClusterFeatureMapValue & MTRNetworkCommissioningFeatureThreadNetworkInterface) != 0 ? YES : NO;
 }
 
 - (void)_clearSubscriptionPoolWork

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -971,7 +971,7 @@ static NSString * const sAttributesKey = @"attributes";
     MTRClusterPath * networkCommissioningClusterPath = [MTRClusterPath clusterPathWithEndpointID:@(kRootEndpointId) clusterID:@(MTRClusterIDTypeNetworkCommissioningID)];
     MTRDeviceClusterData * networkCommissioningClusterData = [self _clusterDataForPath:networkCommissioningClusterPath];
     NSNumber * networkCommissioningClusterFeatureMapValueNumber = networkCommissioningClusterData.attributes[@(MTRClusterGlobalAttributeFeatureMapID)][MTRValueKey];
-    
+
     if ( networkCommissioningClusterFeatureMapValueNumber == nil )
         return NO;
     if (![networkCommissioningClusterFeatureMapValueNumber isKindOfClass:[NSNumber class]]) {

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -972,7 +972,7 @@ static NSString * const sAttributesKey = @"attributes";
     MTRDeviceClusterData * networkCommissioningClusterData = [self _clusterDataForPath:networkCommissioningClusterPath];
     NSNumber * networkCommissioningClusterFeatureMapValueNumber = networkCommissioningClusterData.attributes[@(MTRClusterGlobalAttributeFeatureMapID)][MTRValueKey];
 
-    if ( networkCommissioningClusterFeatureMapValueNumber == nil )
+    if (networkCommissioningClusterFeatureMapValueNumber == nil)
         return NO;
     if (![networkCommissioningClusterFeatureMapValueNumber isKindOfClass:[NSNumber class]]) {
         MTR_LOG_ERROR("%@ Unexpected NetworkCommissioning FeatureMap value %@", self, networkCommissioningClusterFeatureMapValueNumber);

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -395,8 +395,8 @@ static NSString * const sAttributesKey = @"attributes";
 
     // The completion block is set when the subscription / resubscription work is enqueued, and called / cleared when any of the following happen:
     //   1. Subscription establishes
-    //   2. When OnResubscriptionNeeded is called
-    //   3. On subscription reset (including when getSessionForNode fails)
+    //   2. OnResubscriptionNeeded is called
+    //   3. Subscription reset (including when getSessionForNode fails)
     MTRAsyncWorkCompletionBlock _subscriptionPoolWorkCompletionBlock;
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -472,6 +472,7 @@ MTR_DIRECT_MEMBERS
     NSUUID * uniqueIdentifier;
     id<MTROTAProviderDelegate> _Nullable otaProviderDelegate;
     dispatch_queue_t _Nullable otaProviderDelegateQueue;
+    NSUInteger concurrentSubscriptionPoolSize = 0;
     if ([startupParams isKindOfClass:[MTRDeviceControllerParameters class]]) {
         MTRDeviceControllerParameters * params = startupParams;
         storageDelegate = params.storageDelegate;
@@ -479,6 +480,7 @@ MTR_DIRECT_MEMBERS
         uniqueIdentifier = params.uniqueIdentifier;
         otaProviderDelegate = params.otaProviderDelegate;
         otaProviderDelegateQueue = params.otaProviderDelegateQueue;
+        concurrentSubscriptionPoolSize = params.concurrentSubscriptionsAllowedOnThread;
     } else if ([startupParams isKindOfClass:[MTRDeviceControllerStartupParams class]]) {
         MTRDeviceControllerStartupParams * params = startupParams;
         storageDelegate = nil;
@@ -539,7 +541,8 @@ MTR_DIRECT_MEMBERS
                         storageDelegateQueue:storageDelegateQueue
                          otaProviderDelegate:otaProviderDelegate
                     otaProviderDelegateQueue:otaProviderDelegateQueue
-                            uniqueIdentifier:uniqueIdentifier];
+                            uniqueIdentifier:uniqueIdentifier
+              concurrentSubscriptionPoolSize:concurrentSubscriptionPoolSize];
     if (controller == nil) {
         if (error != nil) {
             *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_ARGUMENT];

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -480,7 +480,7 @@ MTR_DIRECT_MEMBERS
         uniqueIdentifier = params.uniqueIdentifier;
         otaProviderDelegate = params.otaProviderDelegate;
         otaProviderDelegateQueue = params.otaProviderDelegateQueue;
-        concurrentSubscriptionPoolSize = params.concurrentSubscriptionsAllowedOnThread;
+        concurrentSubscriptionPoolSize = params.concurrentSubscriptionEstablishmentsAllowedOnThread;
     } else if ([startupParams isKindOfClass:[MTRDeviceControllerStartupParams class]]) {
         MTRDeviceControllerStartupParams * params = startupParams;
         storageDelegate = nil;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
@@ -80,7 +80,7 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
 /**
  * Sets the maximum subscriptions allowed for devices on Thread. This defaults to 3.
  */
-@property (nonatomic, assign) NSUInteger concurrentSubscriptionsAllowedOnThread;
+@property (nonatomic, assign) NSUInteger concurrentSubscriptionsAllowedOnThread MTR_NEWLY_AVAILABLE;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
@@ -80,7 +80,7 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
 /**
  * Sets the maximum subscriptions allowed for devices on Thread. This defaults to 3.
  *
- * If this value is 0, the maximum subscriptinos allowed will be set to 1.
+ * If this value is 0, the maximum subscriptions allowed will be set to 1.
  */
 @property (nonatomic, assign) NSUInteger concurrentSubscriptionsAllowedOnThread MTR_NEWLY_AVAILABLE;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
@@ -78,7 +78,7 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
 - (void)setOTAProviderDelegate:(id<MTROTAProviderDelegate>)otaProviderDelegate queue:(dispatch_queue_t)queue;
 
 /**
- * Sets the maximum subscriptions allowed for devices on Thread. This defaults to 3.
+ * Sets the maximum simultaneous subscriptions allowed to be established at one time for devices on Thread. This defaults to a large number.
  *
  * If this value is 0, the maximum subscriptions allowed will be set to 1.
  */

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
@@ -79,6 +79,8 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
 
 /**
  * Sets the maximum subscriptions allowed for devices on Thread. This defaults to 3.
+ *
+ * If this value is 0, the maximum subscriptinos allowed will be set to 1.
  */
 @property (nonatomic, assign) NSUInteger concurrentSubscriptionsAllowedOnThread MTR_NEWLY_AVAILABLE;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
@@ -77,6 +77,11 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
  */
 - (void)setOTAProviderDelegate:(id<MTROTAProviderDelegate>)otaProviderDelegate queue:(dispatch_queue_t)queue;
 
+/**
+ * Sets the maximum subscriptions allowed for devices on Thread. This defaults to 3.
+ */
+@property (nonatomic, assign) NSUInteger concurrentSubscriptionsAllowedOnThread;
+
 @end
 
 MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
@@ -78,7 +78,8 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
 - (void)setOTAProviderDelegate:(id<MTROTAProviderDelegate>)otaProviderDelegate queue:(dispatch_queue_t)queue;
 
 /**
- * Sets the maximum simultaneous subscriptions allowed to be established at one time for devices on Thread. This defaults to a large number.
+ * Sets the maximum simultaneous subscription establishments that can be happening
+ * at one time for devices on Thread. This defaults to a large number.
  *
  * If this value is 0, the maximum subscription establishments allowed at a time will be set to 1.
  */

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
@@ -83,7 +83,7 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
  *
  * If this value is 0, the maximum subscription establishments allowed at a time will be set to 1.
  */
-@property (nonatomic, assign) NSUInteger concurrentSubscriptionsAllowedOnThread MTR_NEWLY_AVAILABLE;
+@property (nonatomic, assign) NSUInteger concurrentSubscriptionEstablishmentsAllowedOnThread MTR_NEWLY_AVAILABLE;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
@@ -80,7 +80,7 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
 /**
  * Sets the maximum simultaneous subscriptions allowed to be established at one time for devices on Thread. This defaults to a large number.
  *
- * If this value is 0, the maximum subscriptions allowed will be set to 1.
+ * If this value is 0, the maximum subscription establishments allowed at a time will be set to 1.
  */
 @property (nonatomic, assign) NSUInteger concurrentSubscriptionsAllowedOnThread MTR_NEWLY_AVAILABLE;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -288,7 +288,7 @@ constexpr NSUInteger kDefaultConcurrentSubscriptionPoolSize = 300;
     _storageDelegateQueue = storageDelegateQueue;
     _uniqueIdentifier = uniqueIdentifier;
 
-    _concurrentSubscriptionsAllowedOnThread = kDefaultConcurrentSubscriptionPoolSize;
+    _concurrentSubscriptionEstablishmentsAllowedOnThread = kDefaultConcurrentSubscriptionPoolSize;
 
     return self;
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -254,6 +254,8 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
 }
 @end
 
+constexpr NSUInteger kDefaultConcurrentSubscriptionPoolSize = 3;
+
 @implementation MTRDeviceControllerParameters
 - (instancetype)initWithStorageDelegate:(id<MTRDeviceControllerStorageDelegate>)storageDelegate
                    storageDelegateQueue:(dispatch_queue_t)storageDelegateQueue
@@ -285,6 +287,8 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
     _storageDelegate = storageDelegate;
     _storageDelegateQueue = storageDelegateQueue;
     _uniqueIdentifier = uniqueIdentifier;
+
+    _concurrentSubscriptionsAllowedOnThread = kDefaultConcurrentSubscriptionPoolSize;
 
     return self;
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -254,7 +254,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
 }
 @end
 
-constexpr NSUInteger kDefaultConcurrentSubscriptionPoolSize = 3;
+constexpr NSUInteger kDefaultConcurrentSubscriptionPoolSize = 300;
 
 @implementation MTRDeviceControllerParameters
 - (instancetype)initWithStorageDelegate:(id<MTRDeviceControllerStorageDelegate>)storageDelegate

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -42,6 +42,7 @@
 @class MTRDeviceControllerStartupParamsInternal;
 @class MTRDeviceControllerFactory;
 @class MTRDevice;
+@class MTRAsyncWorkQueue;
 
 namespace chip {
 class FabricTable;
@@ -95,17 +96,24 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) dispatch_queue_t otaProviderDelegateQueue;
 
 /**
+ * A queue with a fixed width that allows a number of MTRDevice objects to perform
+ * subscription at the same time.
+ */
+@property (nonatomic, readonly) MTRAsyncWorkQueue<MTRDeviceController *> * concurrentSubscriptionPool;
+
+/**
  * Init a newly created controller.
  *
  * Only MTRDeviceControllerFactory should be calling this.
  */
 - (instancetype)initWithFactory:(MTRDeviceControllerFactory *)factory
-                          queue:(dispatch_queue_t)queue
-                storageDelegate:(id<MTRDeviceControllerStorageDelegate> _Nullable)storageDelegate
-           storageDelegateQueue:(dispatch_queue_t _Nullable)storageDelegateQueue
-            otaProviderDelegate:(id<MTROTAProviderDelegate> _Nullable)otaProviderDelegate
-       otaProviderDelegateQueue:(dispatch_queue_t _Nullable)otaProviderDelegateQueue
-               uniqueIdentifier:(NSUUID *)uniqueIdentifier;
+                             queue:(dispatch_queue_t)queue
+                   storageDelegate:(id<MTRDeviceControllerStorageDelegate> _Nullable)storageDelegate
+              storageDelegateQueue:(dispatch_queue_t _Nullable)storageDelegateQueue
+               otaProviderDelegate:(id<MTROTAProviderDelegate> _Nullable)otaProviderDelegate
+          otaProviderDelegateQueue:(dispatch_queue_t _Nullable)otaProviderDelegateQueue
+                  uniqueIdentifier:(NSUUID *)uniqueIdentifier
+    concurrentSubscriptionPoolSize:(NSUInteger)concurrentSubscriptionPoolSize;
 
 /**
  * Check whether this controller is running on the given fabric, as represented

--- a/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
@@ -34,6 +34,11 @@ static const uint16_t kTestProductId1 = 0x8000u;
 static const uint16_t kTestProductId2 = 0x8001u;
 static const uint16_t kTestDiscriminator1 = 3840u;
 static const uint16_t kTestDiscriminator2 = 3839u;
+static const uint16_t kTestDiscriminator3 = 101u;
+static const uint16_t kTestDiscriminator4 = 102u;
+static const uint16_t kTestDiscriminator5 = 103u;
+static const uint16_t kTestDiscriminator6 = 104u;
+static const uint16_t kTestDiscriminator7 = 105u;
 static const uint16_t kDiscoverDeviceTimeoutInSeconds = 10;
 static const uint16_t kExpectedDiscoveredDevicesCount = 2;
 
@@ -97,7 +102,7 @@ static MTRDeviceController * sController = nil;
     XCTAssertEqual(instanceName.length, 16); // The  instance name is random, so just ensure the len is right.
     XCTAssertEqualObjects(vendorId, @(kTestVendorId));
     XCTAssertTrue([productId isEqual:@(kTestProductId1)] || [productId isEqual:@(kTestProductId2)]);
-    XCTAssertTrue([discriminator isEqual:@(kTestDiscriminator1)] || [discriminator isEqual:@(kTestDiscriminator2)]);
+    XCTAssertTrue([discriminator isEqual:@(kTestDiscriminator1)] || [discriminator isEqual:@(kTestDiscriminator2)] || [discriminator isEqual:@(kTestDiscriminator3)] || [discriminator isEqual:@(kTestDiscriminator4)] || [discriminator isEqual:@(kTestDiscriminator5)] || [discriminator isEqual:@(kTestDiscriminator6)] || [discriminator isEqual:@(kTestDiscriminator7)]);
     XCTAssertEqual(commissioningMode, YES);
 
     NSLog(@"Found Device (%@) with discriminator: %@ (vendor: %@, product: %@)", instanceName, discriminator, vendorId, productId);

--- a/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
@@ -40,7 +40,7 @@ static const uint16_t kTestDiscriminator5 = 103u;
 static const uint16_t kTestDiscriminator6 = 104u;
 static const uint16_t kTestDiscriminator7 = 105u;
 static const uint16_t kDiscoverDeviceTimeoutInSeconds = 10;
-static const uint16_t kExpectedDiscoveredDevicesCount = 2;
+static const uint16_t kExpectedDiscoveredDevicesCount = 7;
 
 // Singleton controller we use.
 static MTRDeviceController * sController = nil;

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2131,7 +2131,7 @@ static NSString * const kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey = @
 
     XCTAssertEqual(subscriptionDequeueCount, orderedDeviceIDs.count);
 
-    // Reset our commissionee.
+    // Reset our commissionees.
     for (NSNumber * deviceID in deviceOnboardingPayloads) {
         __auto_type * baseDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];
         ResetCommissionee(baseDevice, queue, self, kTimeoutInSeconds);

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2132,7 +2132,7 @@ static NSString * const kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey = @
     XCTAssertEqual(subscriptionDequeueCount, orderedDeviceIDs.count);
 
     // Reset our commissionees.
-    for (NSNumber * deviceID in deviceOnboardingPayloads) {
+    for (NSNumber * deviceID in orderedDeviceIDs) {
         __auto_type * baseDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];
         ResetCommissionee(baseDevice, queue, self, kTimeoutInSeconds);
     }

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2037,7 +2037,7 @@ static NSString * const kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey = @
     NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
     NSNumber * subscriptionPoolSizeOverrideOriginalValue = [defaults objectForKey:kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey];
 
-    // Test DeviceController with a Subscription pool of 2
+    // Test DeviceController with a Subscription pool
     [defaults setInteger:subscriptionPoolSize forKey:kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey];
 
     MTRPerControllerStorageTestsCertificateIssuer * certificateIssuer;

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
@@ -31,6 +31,9 @@ typedef void (^MTRDeviceTestDelegateDataHandler)(NSArray<NSDictionary<NSString *
 @property (nonatomic) BOOL skipExpectedValuesForWrite;
 @property (nonatomic) BOOL forceAttributeReportsIfMatchingCache;
 @property (nonatomic, nullable) dispatch_block_t onDeviceConfigurationChanged;
+@property (nonatomic) BOOL pretendThreadEnabled;
+@property (nonatomic, nullable) dispatch_block_t onSubscriptionPoolDequeue;
+@property (nonatomic, nullable) dispatch_block_t onSubscriptionPoolWorkComplete;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.m
@@ -77,4 +77,23 @@
     }
 }
 
+- (BOOL)unitTestPretendThreadEnabled:(MTRDevice *)device
+{
+    return self.pretendThreadEnabled;
+}
+
+- (void)unitTestSubscriptionPoolDequeue:(MTRDevice *)device
+{
+    if (self.onSubscriptionPoolDequeue != nil) {
+        self.onSubscriptionPoolDequeue();
+    }
+}
+
+- (void)unitTestSubscriptionPoolWorkComplete:(MTRDevice *)device
+{
+    if (self.onSubscriptionPoolWorkComplete != nil) {
+        self.onSubscriptionPoolWorkComplete();
+    }
+}
+
 @end


### PR DESCRIPTION
This patch adds the ability to throttle concurrent subscriptions to Thread-enabled devices, to avoid flooding the Thread network.

Specific changes:
* Added MTRDeviceControllerParameters property to specify the number of concurrent subscriptions allowed to Thread devices (defaults to 3 per controller)
* Moved the `OnResubscriptionNeeded` retry count etc., from `MTRBaseSubscriptionCallback` to the local `SubscriptionCallback` in `MTRDevice.m`.
* Added logic in MTRDevice to enqueue the subscription work into the concurrent subscriptions pool.

Currently working on unit tests.