### PR TITLE
[Silabs]Make changes to the window manager class so its static constructor do…

### DIFF
--- a/examples/window-app/silabs/include/WindowManager.h
+++ b/examples/window-app/silabs/include/WindowManager.h
@@ -155,7 +155,7 @@ private:
 
     LEDWidget mActionLED;
 #ifdef DISPLAY_ENABLED
-    Timer mIconTimer;
+    Timer * mIconTimer = nullptr;
     LcdIcon mIcon = LcdIcon::None;
 #endif
 };

--- a/examples/window-app/silabs/include/WindowManager.h
+++ b/examples/window-app/silabs/include/WindowManager.h
@@ -156,6 +156,6 @@ private:
     LEDWidget mActionLED;
 #ifdef DISPLAY_ENABLED
     Timer * mIconTimer = nullptr;
-    LcdIcon mIcon = LcdIcon::None;
+    LcdIcon mIcon      = LcdIcon::None;
 #endif
 };

--- a/examples/window-app/silabs/include/WindowManager.h
+++ b/examples/window-app/silabs/include/WindowManager.h
@@ -40,6 +40,7 @@ public:
         typedef void (*Callback)(Timer & timer);
 
         Timer(uint32_t timeoutInMs, Callback callback, void * context);
+        ~Timer();
 
         void Start();
         void Stop();

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -538,11 +538,7 @@ WindowManager & WindowManager::Instance()
     return WindowManager::sWindow;
 }
 
-#ifdef DISPLAY_ENABLED
-WindowManager::WindowManager() : mIconTimer(LCD_ICON_TIMEOUT, OnIconTimeout, this) {}
-#else
 WindowManager::WindowManager() {}
-#endif
 
 void WindowManager::OnIconTimeout(WindowManager::Timer & timer)
 {
@@ -556,6 +552,9 @@ CHIP_ERROR WindowManager::Init()
 {
     chip::DeviceLayer::PlatformMgr().LockChipStack();
 
+#ifdef DISPLAY_ENABLED
+    mIconTimer = new Timer(LCD_ICON_TIMEOUT, OnIconTimeout, this);
+#endif
     // Timers
     mLongPressTimer = new Timer(LONG_PRESS_TIMEOUT, OnLongPressTimeout, this);
 
@@ -768,13 +767,13 @@ void WindowManager::GeneralEventHandler(AppEvent * aEvent)
         window->UpdateLCD();
         break;
     case AppEvent::kEventType_CoverChange:
-        window->mIconTimer.Start();
+        if (window->mIconTimer != nullptr) { window->mIconTimer->Start(); }
         window->mIcon = (window->GetCover().mEndpoint == 1) ? LcdIcon::One : LcdIcon::Two;
         window->UpdateLCD();
         break;
     case AppEvent::kEventType_TiltModeChange:
         ChipLogDetail(AppServer, "App control mode changed to %s", window->mTiltMode ? "Tilt" : "Lift");
-        window->mIconTimer.Start();
+        if (window->mIconTimer != nullptr) { window->mIconTimer->Start(); }
         window->mIcon = window->mTiltMode ? LcdIcon::Tilt : LcdIcon::Lift;
         window->UpdateLCD();
         break;

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -514,6 +514,15 @@ WindowManager::Timer::Timer(uint32_t timeoutInMs, Callback callback, void * cont
     }
 }
 
+WindowManager::Timer::~Timer()
+{
+    if (mHandler)
+    {
+        osTimerDelete(mHandler);
+        mHandler = nullptr;
+    }
+}
+
 void WindowManager::Timer::Stop()
 {
     mIsActive = false;

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -767,13 +767,19 @@ void WindowManager::GeneralEventHandler(AppEvent * aEvent)
         window->UpdateLCD();
         break;
     case AppEvent::kEventType_CoverChange:
-        if (window->mIconTimer != nullptr) { window->mIconTimer->Start(); }
+        if (window->mIconTimer != nullptr)
+        {
+            window->mIconTimer->Start();
+        }
         window->mIcon = (window->GetCover().mEndpoint == 1) ? LcdIcon::One : LcdIcon::Two;
         window->UpdateLCD();
         break;
     case AppEvent::kEventType_TiltModeChange:
         ChipLogDetail(AppServer, "App control mode changed to %s", window->mTiltMode ? "Tilt" : "Lift");
-        if (window->mIconTimer != nullptr) { window->mIconTimer->Start(); }
+        if (window->mIconTimer != nullptr)
+        {
+            window->mIconTimer->Start();
+        }
         window->mIcon = window->mTiltMode ? LcdIcon::Tilt : LcdIcon::Lift;
         window->UpdateLCD();
         break;


### PR DESCRIPTION
… not call a dynamic allocation before code entry.

The Timer object constructor dynamically creates a new cmsis os timer. 
Change the object mIconTimer from the window manager class to a pointer and have the timer object dynamically allocated at init time. 