### PR TITLE
Use data() instead of begin() in Protocols.cpp

### DIFF
--- a/src/protocols/Protocols.cpp
+++ b/src/protocols/Protocols.cpp
@@ -86,27 +86,27 @@ const char * GetMessageTypeName(Id protocolId, uint8_t msgType)
     switch (protocolId.GetProtocolId())
     {
     case InteractionModel::Id.GetProtocolId():
-        lookupTable     = MessageTypeTraits<InteractionModel::MsgType>::GetTypeToNameTable()->begin();
+        lookupTable     = MessageTypeTraits<InteractionModel::MsgType>::GetTypeToNameTable()->data();
         lookupTableSize = MessageTypeTraits<InteractionModel::MsgType>::GetTypeToNameTable()->size();
         break;
 
     case SecureChannel::Id.GetProtocolId():
-        lookupTable     = MessageTypeTraits<SecureChannel::MsgType>::GetTypeToNameTable()->begin();
+        lookupTable     = MessageTypeTraits<SecureChannel::MsgType>::GetTypeToNameTable()->data();
         lookupTableSize = MessageTypeTraits<SecureChannel::MsgType>::GetTypeToNameTable()->size();
         break;
 
     case BDX::Id.GetProtocolId():
-        lookupTable     = MessageTypeTraits<bdx::MessageType>::GetTypeToNameTable()->begin();
+        lookupTable     = MessageTypeTraits<bdx::MessageType>::GetTypeToNameTable()->data();
         lookupTableSize = MessageTypeTraits<bdx::MessageType>::GetTypeToNameTable()->size();
         break;
 
     case Echo::Id.GetProtocolId():
-        lookupTable     = MessageTypeTraits<Echo::MsgType>::GetTypeToNameTable()->begin();
+        lookupTable     = MessageTypeTraits<Echo::MsgType>::GetTypeToNameTable()->data();
         lookupTableSize = MessageTypeTraits<Echo::MsgType>::GetTypeToNameTable()->size();
         break;
 
     case UserDirectedCommissioning::Id.GetProtocolId():
-        lookupTable     = MessageTypeTraits<UserDirectedCommissioning::MsgType>::GetTypeToNameTable()->begin();
+        lookupTable     = MessageTypeTraits<UserDirectedCommissioning::MsgType>::GetTypeToNameTable()->data();
         lookupTableSize = MessageTypeTraits<UserDirectedCommissioning::MsgType>::GetTypeToNameTable()->size();
         break;
 
@@ -123,3 +123,4 @@ const char * GetMessageTypeName(Id protocolId, uint8_t msgType)
 
 } // namespace Protocols
 } // namespace chip
+                   

--- a/src/protocols/Protocols.cpp
+++ b/src/protocols/Protocols.cpp
@@ -123,4 +123,3 @@ const char * GetMessageTypeName(Id protocolId, uint8_t msgType)
 
 } // namespace Protocols
 } // namespace chip
-                   


### PR DESCRIPTION
The GetProtocolName() function tries to store the result of std::array<T>::begin() in a raw pointer type, but this no longer works on some newer versions of clang, since clang now returns an iterator object. This change fixes this by switching to std::array<T>::data() instead, which always returns a raw pointer.
