### PR TITLE
Linux tv-casting-app v1.3 Commissioner-Generated passcode flow

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -101,6 +101,8 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
                             "MatterCastingPlayer-JNI::verifyOrEstablishConnection() ConnectCallback() Connected to Casting Player "
                             "with device ID: %s",
                             playerPtr->GetId());
+            // The Java jSuccessCallback is expecting a Void v callback parameter which translates to a nullptr. When calling the
+            // Java method from C++ via JNI, passing nullptr is equivalent to passing a Void object in Java.
             MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.Handle(nullptr);
         }
         else
@@ -118,6 +120,7 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
     matter::casting::core::ConnectionCallbacks connectionCallbacks;
     connectionCallbacks.mOnConnectionComplete = connectCallback;
 
+    // TODO: Verify why commissioningWindowTimeoutSec is a "unsigned long long int" type. Seems too big.
     castingPlayer->VerifyOrEstablishConnection(connectionCallbacks,
                                                static_cast<unsigned long long int>(commissioningWindowTimeoutSec), idOptions);
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -24,6 +24,7 @@
 #include "core/CastingApp.h"             // from tv-casting-common
 #include "core/CastingPlayer.h"          // from tv-casting-common
 #include "core/CastingPlayerDiscovery.h" // from tv-casting-common
+#include "core/ConnectionCallbacks.h"    // from tv-casting-common
 
 #include <app/clusters/bindings/BindingManager.h>
 #include <app/server/Server.h>
@@ -92,24 +93,33 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
     MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.SetUp(env, jSuccessCallback);
     MatterCastingPlayerJNIMgr().mConnectionFailureHandler.SetUp(env, jFailureCallback);
 
-    // TODO: In the following PRs. Add optional CommissionerDeclarationHandler callback parameter.
-    castingPlayer->VerifyOrEstablishConnection(
-        [](CHIP_ERROR err, CastingPlayer * playerPtr) {
-            ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::verifyOrEstablishConnection() ConnectCallback called");
-            if (err == CHIP_NO_ERROR)
-            {
-                ChipLogProgress(AppServer, "MatterCastingPlayer-JNI:: Connected to Casting Player with device ID: %s",
-                                playerPtr->GetId());
-                MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.Handle(nullptr);
-            }
-            else
-            {
-                ChipLogError(AppServer, "MatterCastingPlayer-JNI:: ConnectCallback, connection error: %" CHIP_ERROR_FORMAT,
-                             err.Format());
-                MatterCastingPlayerJNIMgr().mConnectionFailureHandler.Handle(err);
-            }
-        },
-        static_cast<unsigned long long int>(commissioningWindowTimeoutSec), idOptions);
+    auto connectCallback = [](CHIP_ERROR err, CastingPlayer * playerPtr) {
+        ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::verifyOrEstablishConnection() ConnectCallback()");
+        if (err == CHIP_NO_ERROR)
+        {
+            ChipLogProgress(AppServer,
+                            "MatterCastingPlayer-JNI::verifyOrEstablishConnection() ConnectCallback() Connected to Casting Player "
+                            "with device ID: %s",
+                            playerPtr->GetId());
+            MatterCastingPlayerJNIMgr().mConnectionSuccessHandler.Handle(nullptr);
+        }
+        else
+        {
+            ChipLogError(
+                AppServer,
+                "MatterCastingPlayer-JNI::verifyOrEstablishConnection() ConnectCallback() Connection error: %" CHIP_ERROR_FORMAT,
+                err.Format());
+            MatterCastingPlayerJNIMgr().mConnectionFailureHandler.Handle(err);
+        }
+    };
+
+    // TODO: In the following PRs. Add optional CommissionerDeclarationHandler callback parameter for the Commissioner-Generated
+    // passcode commissioning flow.
+    matter::casting::core::ConnectionCallbacks connectionCallbacks;
+    connectionCallbacks.mOnConnectionComplete = connectCallback;
+
+    castingPlayer->VerifyOrEstablishConnection(connectionCallbacks,
+                                               static_cast<unsigned long long int>(commissioningWindowTimeoutSec), idOptions);
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }
 

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -35,7 +35,7 @@
 const uint16_t kDesiredEndpointVendorId = 65521;
 
 DiscoveryDelegateImpl * DiscoveryDelegateImpl::_discoveryDelegateImpl = nullptr;
-bool gAwaitingCommissionerPasscodeInput                                = false;
+bool gAwaitingCommissionerPasscodeInput                               = false;
 std::shared_ptr<matter::casting::core::CastingPlayer> targetCastingPlayer;
 
 DiscoveryDelegateImpl * DiscoveryDelegateImpl::GetInstance()

--- a/examples/tv-casting-app/linux/simple-app-helper.h
+++ b/examples/tv-casting-app/linux/simple-app-helper.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2023-2024 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,8 @@
 #include "core/CastingPlayerDiscovery.h"
 #include "core/IdentificationDeclarationOptions.h"
 #include "core/Types.h"
+#include <LinuxCommissionableDataProvider.h>
+#include <Options.h>
 #include <platform/CHIPDeviceLayer.h>
 
 /**
@@ -67,6 +69,12 @@ public:
      */
     void HandleOnUpdated(matter::casting::memory::Strong<matter::casting::core::CastingPlayer> player) override;
 };
+
+/**
+ * @brief Initializes a LinuxCommissionableDataProvider using configuration options provided via a LinuxDeviceOptions. It first
+ * checks if a setup PIN code is specified; if not, it attempts to use a temporary default passcode.
+ */
+CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & provider, LinuxDeviceOptions & options);
 
 /**
  * @brief Linux tv-casting-app's onCompleted handler for CastingPlayer.VerifyOrEstablishConnection API

--- a/examples/tv-casting-app/linux/simple-app.cpp
+++ b/examples/tv-casting-app/linux/simple-app.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2023-2024 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,47 +44,6 @@ using namespace matter::casting::support;
 
 // To hold SPAKE2+ verifier, discriminator, passcode
 LinuxCommissionableDataProvider gCommissionableDataProvider;
-
-CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & provider, LinuxDeviceOptions & options)
-{
-    chip::Optional<uint32_t> setupPasscode;
-
-    if (options.payload.setUpPINCode != 0)
-    {
-        setupPasscode.SetValue(options.payload.setUpPINCode);
-    }
-    else if (!options.spake2pVerifier.HasValue())
-    {
-        uint32_t defaultTestPasscode = 0;
-        chip::DeviceLayer::TestOnlyCommissionableDataProvider TestOnlyCommissionableDataProvider;
-        VerifyOrDie(TestOnlyCommissionableDataProvider.GetSetupPasscode(defaultTestPasscode) == CHIP_NO_ERROR);
-
-        ChipLogError(Support,
-                     "*** WARNING: Using temporary passcode %u due to no neither --passcode or --spake2p-verifier-base64 "
-                     "given on command line. This is temporary and will be deprecated. Please update your scripts "
-                     "to explicitly configure onboarding credentials. ***",
-                     static_cast<unsigned>(defaultTestPasscode));
-        setupPasscode.SetValue(defaultTestPasscode);
-        options.payload.setUpPINCode = defaultTestPasscode;
-    }
-    else
-    {
-        // Passcode is 0, so will be ignored, and verifier will take over. Onboarding payload
-        // printed for debug will be invalid, but if the onboarding payload had been given
-        // properly to the commissioner later, PASE will succeed.
-    }
-
-    // Default to minimum PBKDF iterations
-    uint32_t spake2pIterationCount = chip::Crypto::kSpake2p_Min_PBKDF_Iterations;
-    if (options.spake2pIterations != 0)
-    {
-        spake2pIterationCount = options.spake2pIterations;
-    }
-    ChipLogError(Support, "PASE PBKDF iterations set to %u", static_cast<unsigned>(spake2pIterationCount));
-
-    return provider.Init(options.spake2pVerifier, options.spake2pSalt, spake2pIterationCount, setupPasscode,
-                         options.payload.discriminator.GetLongValue());
-}
 
 /**
  * @brief Provides the unique ID that is used by the SDK to generate the Rotating Device ID.

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -107,6 +107,8 @@ chip_data_model("tv-casting-common") {
     "core/CastingPlayerDiscovery.h",
     "core/Command.h",
     "core/CommissionerDeclarationHandler.cpp",
+    "core/CommissionerDeclarationHandler.h",
+    "core/ConnectionCallbacks.h",
     "core/Endpoint.cpp",
     "core/Endpoint.h",
     "core/Types.h",

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp
@@ -90,9 +90,7 @@ CHIP_ERROR CastingApp::UpdateCommissionableDataProvider(chip::DeviceLayer::Commi
 {
     ChipLogProgress(Discovery, "CastingApp::UpdateCommissionableDataProvider()");
     chip::DeviceLayer::SetCommissionableDataProvider(commissionableDataProvider);
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    err            = mAppParameters->SetCommissionableDataProvider(commissionableDataProvider);
-    return err;
+    return mAppParameters->SetCommissionableDataProvider(commissionableDataProvider);
 }
 
 void ReconnectHandler(CHIP_ERROR err, matter::casting::core::CastingPlayer * castingPlayer)

--- a/examples/tv-casting-app/tv-casting-common/core/CastingApp.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingApp.h
@@ -53,6 +53,14 @@ public:
     CHIP_ERROR Initialize(const matter::casting::support::AppParameters & appParameters);
 
     /**
+     * @brief Update the CommissionableDataProvider stored in this CastingApp's AppParameters and the CommissionableDataProvider to
+     * be used for the commissioning session.
+     * @param commissionableDataProvider the new CommissionableDataProvider to be used for the next commissioning session.
+     *
+     */
+    CHIP_ERROR UpdateCommissionableDataProvider(chip::DeviceLayer::CommissionableDataProvider * commissionableDataProvider);
+
+    /**
      * @brief Starts the Matter server that the CastingApp runs on and registers all the necessary delegates
      * CastingApp.
      * If the CastingApp was previously connected to a CastingPlayer and then Stopped by calling the Stop()

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -29,7 +29,8 @@ namespace core {
 
 CastingPlayer * CastingPlayer::mTargetCastingPlayer = nullptr;
 
-void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, unsigned long long int commissioningWindowTimeoutSec,
+void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCallbacks,
+                                                unsigned long long int commissioningWindowTimeoutSec,
                                                 IdentificationDeclarationOptions idOptions)
 {
     ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() called");
@@ -46,11 +47,29 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, uns
         ChipLogError(
             AppServer,
             "CastingPlayer::VerifyOrEstablishConnection() called while already connecting/connected to this CastingPlayer"));
+    VerifyOrExit(
+        connectionCallbacks.mOnConnectionComplete != nullptr,
+        ChipLogError(AppServer,
+                     "CastingPlayer::VerifyOrEstablishConnection() ConnectionCallbacks.mOnConnectionComplete was not provided"));
     mConnectionState               = CASTING_PLAYER_CONNECTING;
-    mOnCompleted                   = onCompleted;
+    mOnCompleted                   = connectionCallbacks.mOnConnectionComplete;
     mCommissioningWindowTimeoutSec = commissioningWindowTimeoutSec;
     mTargetCastingPlayer           = this;
     mIdOptions                     = idOptions;
+
+    // Register the handler for Commissioner's CommissionerDeclaration messages. The CommissionerDeclaration messages provide
+    // information indicating the Commissioner's pre-commissioning state.
+    if (connectionCallbacks.mCommissionerDeclarationCallback != nullptr)
+    {
+        matter::casting::core::CommissionerDeclarationHandler::GetInstance()->SetCommissionerDeclarationCallback(
+            connectionCallbacks.mCommissionerDeclarationCallback);
+    }
+    else
+    {
+        ChipLogProgress(
+            AppServer,
+            "CastingPlayer::VerifyOrEstablishConnection() CommissionerDeclarationCallback not provided in ConnectionCallbacks");
+    }
 
     // If *this* CastingPlayer was previously connected to, its nodeId, fabricIndex and other attributes should be present
     // in the CastingStore cache. If that is the case, AND, the cached data contains the endpoint desired by the client, if any,
@@ -72,7 +91,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, uns
                     "CastingPlayer::VerifyOrEstablishConnection() calling FindOrEstablishSession on cached CastingPlayer");
                 *this                          = cachedCastingPlayers[index];
                 mConnectionState               = CASTING_PLAYER_CONNECTING;
-                mOnCompleted                   = onCompleted;
+                mOnCompleted                   = connectionCallbacks.mOnConnectionComplete;
                 mCommissioningWindowTimeoutSec = commissioningWindowTimeoutSec;
 
                 FindOrEstablishSession(
@@ -118,9 +137,33 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectCallback onCompleted, uns
     }
     else
     {
+        ChipLogProgress(AppServer,
+                        "CastingPlayer::VerifyOrEstablishConnection() verifying User Directed Commissioning (UDC) state");
+        mIdOptions.LogDetail();
+        SuccessOrExit(err = support::ChipDeviceEventHandler::SetUdcStatus(true));
+
+        if (!GetSupportsCommissionerGeneratedPasscode() && mIdOptions.mCommissionerPasscode)
+        {
+            ChipLogError(
+                AppServer,
+                "CastingPlayer::VerifyOrEstablishConnection() the target CastingPlayer doesn't support Commissioner-Generated "
+                "passcode yet IdentificationDeclarationOptions.mCommissionerPasscode is set to true");
+            SuccessOrExit(err = CHIP_ERROR_INVALID_ARGUMENT);
+        }
+        if (!matter::casting::core::CommissionerDeclarationHandler::GetInstance()->HasCommissionerDeclarationCallback() &&
+            mIdOptions.mCommissionerPasscode)
+        {
+            ChipLogError(AppServer,
+                         "CastingPlayer::VerifyOrEstablishConnection() the CommissionerDeclaration message callback has not been "
+                         "set yet IdentificationDeclarationOptions.mCommissionerPasscode is set to true");
+            SuccessOrExit(err = CHIP_ERROR_INVALID_ARGUMENT);
+        }
+
+        ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() calling OpenBasicCommissioningWindow()");
         SuccessOrExit(err = chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(
                           chip::System::Clock::Seconds16(mCommissioningWindowTimeoutSec)));
 
+        ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() calling SendUserDirectedCommissioningRequest()");
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
         SuccessOrExit(err = SendUserDirectedCommissioningRequest());
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
@@ -130,13 +173,64 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection() failed with %" CHIP_ERROR_FORMAT, err.Format());
-        support::ChipDeviceEventHandler::SetUdcStatus(false);
-        mConnectionState               = CASTING_PLAYER_NOT_CONNECTED;
-        mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
-        mTargetCastingPlayer           = nullptr;
-        mOnCompleted(err, nullptr);
-        mOnCompleted = nullptr;
+        resetState(err);
     }
+}
+
+void CastingPlayer::ContinueConnecting(ConnectionCallbacks connectionCallbacks,
+                                       unsigned long long int commissioningWindowTimeoutSec)
+{
+    ChipLogProgress(AppServer, "CastingPlayer::ContinueConnecting()");
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    SuccessOrExit(err = support::ChipDeviceEventHandler::SetUdcStatus(true));
+    VerifyOrExit(
+        connectionCallbacks.mOnConnectionComplete != nullptr,
+        ChipLogError(AppServer, "CastingPlayer::ContinueConnecting() ConnectionCallbacks.mOnConnectionComplete was not provided"));
+    mConnectionState               = CASTING_PLAYER_CONNECTING;
+    mOnCompleted                   = connectionCallbacks.mOnConnectionComplete;
+    mCommissioningWindowTimeoutSec = commissioningWindowTimeoutSec;
+    mTargetCastingPlayer           = this;
+
+    // Register the handler for Commissioner's CommissionerDeclaration messages. The CommissionerDeclaration messages provide
+    // information indicating the Commissioner's pre-commissioning state.
+    if (connectionCallbacks.mCommissionerDeclarationCallback != nullptr)
+    {
+        matter::casting::core::CommissionerDeclarationHandler::GetInstance()->SetCommissionerDeclarationCallback(
+            connectionCallbacks.mCommissionerDeclarationCallback);
+    }
+    else
+    {
+        ChipLogProgress(
+            AppServer,
+            "CastingPlayer::VerifyOrEstablishConnection() CommissionerDeclarationCallback not provided in ConnectionCallbacks");
+    }
+
+    ChipLogProgress(AppServer, "CastingPlayer::ContinueConnecting() calling OpenBasicCommissioningWindow()");
+    SuccessOrExit(err = chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(
+                      chip::System::Clock::Seconds16(mCommissioningWindowTimeoutSec)));
+
+    mIdOptions.mCommissionerPasscodeReady = true;
+    ChipLogProgress(AppServer, "CastingPlayer::ContinueConnecting() calling SendUserDirectedCommissioningRequest()");
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
+    SuccessOrExit(err = SendUserDirectedCommissioningRequest());
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "CastingPlayer::ContinueConnecting() failed with %" CHIP_ERROR_FORMAT, err.Format());
+        resetState(err);
+    }
+}
+
+void CastingPlayer::resetState(CHIP_ERROR err)
+{
+    support::ChipDeviceEventHandler::SetUdcStatus(false);
+    mConnectionState               = CASTING_PLAYER_NOT_CONNECTED;
+    mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
+    mTargetCastingPlayer           = nullptr;
+    mOnCompleted(err, nullptr);
+    mOnCompleted = nullptr;
 }
 
 void CastingPlayer::Disconnect()
@@ -170,8 +264,6 @@ CHIP_ERROR CastingPlayer::SendUserDirectedCommissioningRequest()
     chip::Inet::IPAddress * ipAddressToUse = GetIpAddressForUDCRequest();
     VerifyOrReturnValue(ipAddressToUse != nullptr, CHIP_ERROR_INCORRECT_STATE,
                         ChipLogError(AppServer, "No IP Address found to send UDC request to"));
-
-    ReturnErrorOnFailure(support::ChipDeviceEventHandler::SetUdcStatus(true));
 
     chip::Protocols::UserDirectedCommissioning::IdentificationDeclaration id = mIdOptions.buildIdentificationDeclarationMessage();
 
@@ -246,7 +338,7 @@ bool CastingPlayer::ContainsDesiredTargetApp(
 
 void CastingPlayer::LogDetail() const
 {
-    ChipLogProgress(AppServer, "CastingPlayer::LogDetail() called");
+    ChipLogProgress(AppServer, "CastingPlayer::LogDetail()");
     if (strlen(mAttributes.id) != 0)
     {
         ChipLogDetail(AppServer, "\tID: %s", mAttributes.id);
@@ -308,6 +400,7 @@ ConnectionContext::ConnectionContext(void * clientContext, core::CastingPlayer *
                                      chip::OnDeviceConnected onDeviceConnectedFn,
                                      chip::OnDeviceConnectionFailure onDeviceConnectionFailureFn)
 {
+    ChipLogProgress(AppServer, "CastingPlayer::ConnectionContext()");
     mClientContext               = clientContext;
     mTargetCastingPlayer         = targetCastingPlayer;
     mOnDeviceConnectedFn         = onDeviceConnectedFn;

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -29,6 +29,7 @@ namespace core {
 
 CastingPlayer * CastingPlayer::mTargetCastingPlayer = nullptr;
 
+// TODO: Verify why commissioningWindowTimeoutSec is a "unsigned long long int" type. Seems too big.
 void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCallbacks,
                                                 unsigned long long int commissioningWindowTimeoutSec,
                                                 IdentificationDeclarationOptions idOptions)
@@ -225,12 +226,16 @@ exit:
 
 void CastingPlayer::resetState(CHIP_ERROR err)
 {
+    ChipLogProgress(AppServer, "CastingPlayer::resetState()");
     support::ChipDeviceEventHandler::SetUdcStatus(false);
     mConnectionState               = CASTING_PLAYER_NOT_CONNECTED;
     mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
     mTargetCastingPlayer           = nullptr;
-    mOnCompleted(err, nullptr);
-    mOnCompleted = nullptr;
+    if (mOnCompleted)
+    {
+        mOnCompleted(err, nullptr);
+        mOnCompleted = nullptr;
+    }
 }
 
 void CastingPlayer::Disconnect()

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -224,7 +224,8 @@ private:
     ConnectCallback mOnCompleted                          = {};
 
     /**
-     * @brief resets this CastingPlayer's state and calls mOnCompleted with the CHIP_ERROR.
+     * @brief resets this CastingPlayer's state and calls mOnCompleted with the CHIP_ERROR. Also, after calling mOnCompleted, it
+     * clears mOnCompleted by setting it to a nullptr.
      */
     void resetState(CHIP_ERROR err);
 

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
@@ -68,6 +68,6 @@ void CommissionerDeclarationHandler::SetCommissionerDeclarationCallback(
     mCmmissionerDeclarationCallback_ = std::move(callback);
 }
 
-}; // namespace core
-}; // namespace casting
-}; // namespace matter
+} // namespace core
+} // namespace casting
+} // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
@@ -64,6 +64,6 @@ private:
     ~CommissionerDeclarationHandler() {}
 };
 
-}; // namespace core
-}; // namespace casting
-}; // namespace matter
+} // namespace core
+} // namespace casting
+} // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "ConnectionCallbacks.h"
 #include "Types.h"
 
 namespace matter {
@@ -25,7 +26,8 @@ namespace casting {
 namespace core {
 
 /**
- * @brief React to the Commissioner's CommissionerDeclaration messages with this singleton.
+ * @brief React to the Commissioner's CommissionerDeclaration messages with this singleton. This is an implementation of the
+ * CommissionerDeclarationHandler from connectedhomeip/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h.
  */
 class CommissionerDeclarationHandler : public chip::Protocols::UserDirectedCommissioning::CommissionerDeclarationHandler
 {
@@ -35,11 +37,29 @@ public:
 
     static CommissionerDeclarationHandler * GetInstance();
 
+    /**
+     * @brief Called when a Commissioner Declaration UDC message has been received.
+     * @param[in] source The source of the Commissioner Declaration message.
+     * @param[in] cd The Commissioner Declaration message.
+     */
     void OnCommissionerDeclarationMessage(const chip::Transport::PeerAddress & source,
                                           chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd) override;
 
+    /**
+     * @brief OnCommissionerDeclarationMessage() will call the CommissionerDeclarationCallback set by this function.
+     */
+    void SetCommissionerDeclarationCallback(CommissionerDeclarationCallback callback);
+
+    /**
+     * @brief returns true if the CommissionerDeclarationHandler sigleton has a CommissionerDeclarationCallback set, false
+     * otherwise.
+     */
+    bool HasCommissionerDeclarationCallback() { return static_cast<bool>(mCmmissionerDeclarationCallback_); };
+
 private:
     static CommissionerDeclarationHandler * sCommissionerDeclarationHandler_;
+    CommissionerDeclarationCallback mCmmissionerDeclarationCallback_;
+
     CommissionerDeclarationHandler() {}
     ~CommissionerDeclarationHandler() {}
 };

--- a/examples/tv-casting-app/tv-casting-common/core/ConnectionCallbacks.h
+++ b/examples/tv-casting-app/tv-casting-common/core/ConnectionCallbacks.h
@@ -30,30 +30,31 @@ class CastingPlayer;
  * @brief Called when the User Directed Commissioning (UDC) process succeeds or fails.
  * @param[in] err For success, called back with CHIP_NO_ERROR. For failure, called back with an error.
  * @param[in] castingPlayer For success, called back with a CastingPlayer *. For failure, called back with a nullptr.
-*/
+ */
 using ConnectCallback = std::function<void(CHIP_ERROR err, CastingPlayer * castingPlayer)>;
 
 /**
-* @brief Called when a Commissioner Declaration UDC message has been received.
-* @param[in] source The source of the Commissioner Declaration message.
-* @param[in] cd The Commissioner Declaration message.
-*/
-using CommissionerDeclarationCallback = std::function<void(const chip::Transport::PeerAddress & source, chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)>;
+ * @brief Called when a Commissioner Declaration UDC message has been received.
+ * @param[in] source The source of the Commissioner Declaration message.
+ * @param[in] cd The Commissioner Declaration message.
+ */
+using CommissionerDeclarationCallback = std::function<void(const chip::Transport::PeerAddress & source,
+                                                           chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)>;
 
 /**
  * @brief A container class for User Directed Commissioning (UDC) callbacks.
  */
 class ConnectionCallbacks
 {
-    public:
-        /**
-         * The callback called when the connection process has ended, regardless of whether it was successful or not.
-         */
-        ConnectCallback mOnConnectionComplete = nullptr;
-        /**
-         * The callback called when the Commissionee receives a CommissionerDeclaration message from the Commissioner.
-         */
-        CommissionerDeclarationCallback mCommissionerDeclarationCallback = nullptr;
+public:
+    /**
+     * The callback called when the connection process has ended, regardless of whether it was successful or not.
+     */
+    ConnectCallback mOnConnectionComplete = nullptr;
+    /**
+     * The callback called when the Commissionee receives a CommissionerDeclaration message from the Commissioner.
+     */
+    CommissionerDeclarationCallback mCommissionerDeclarationCallback = nullptr;
 };
 
 }; // namespace core

--- a/examples/tv-casting-app/tv-casting-common/core/ConnectionCallbacks.h
+++ b/examples/tv-casting-app/tv-casting-common/core/ConnectionCallbacks.h
@@ -1,0 +1,61 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "Types.h"
+
+namespace matter {
+namespace casting {
+namespace core {
+
+class CastingPlayer;
+
+/**
+ * @brief Called when the User Directed Commissioning (UDC) process succeeds or fails.
+ * @param[in] err For success, called back with CHIP_NO_ERROR. For failure, called back with an error.
+ * @param[in] castingPlayer For success, called back with a CastingPlayer *. For failure, called back with a nullptr.
+*/
+using ConnectCallback = std::function<void(CHIP_ERROR err, CastingPlayer * castingPlayer)>;
+
+/**
+* @brief Called when a Commissioner Declaration UDC message has been received.
+* @param[in] source The source of the Commissioner Declaration message.
+* @param[in] cd The Commissioner Declaration message.
+*/
+using CommissionerDeclarationCallback = std::function<void(const chip::Transport::PeerAddress & source, chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)>;
+
+/**
+ * @brief A container class for User Directed Commissioning (UDC) callbacks.
+ */
+class ConnectionCallbacks
+{
+    public:
+        /**
+         * The callback called when the connection process has ended, regardless of whether it was successful or not.
+         */
+        ConnectCallback mOnConnectionComplete = nullptr;
+        /**
+         * The callback called when the Commissionee receives a CommissionerDeclaration message from the Commissioner.
+         */
+        CommissionerDeclarationCallback mCommissionerDeclarationCallback = nullptr;
+};
+
+}; // namespace core
+}; // namespace casting
+}; // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/ConnectionCallbacks.h
+++ b/examples/tv-casting-app/tv-casting-common/core/ConnectionCallbacks.h
@@ -38,13 +38,13 @@ using ConnectCallback = std::function<void(CHIP_ERROR err, CastingPlayer * casti
  * @param[in] source The source of the Commissioner Declaration message.
  * @param[in] cd The Commissioner Declaration message.
  */
-using CommissionerDeclarationCallback = std::function<void(const chip::Transport::PeerAddress & source,
-                                                           chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)>;
+using CommissionerDeclarationCallback = std::function<void(
+    const chip::Transport::PeerAddress & source, const chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)>;
 
 /**
- * @brief A container class for User Directed Commissioning (UDC) callbacks.
+ * @brief A container struct for User Directed Commissioning (UDC) callbacks.
  */
-class ConnectionCallbacks
+struct ConnectionCallbacks
 {
 public:
     /**
@@ -57,6 +57,6 @@ public:
     CommissionerDeclarationCallback mCommissionerDeclarationCallback = nullptr;
 };
 
-}; // namespace core
-}; // namespace casting
-}; // namespace matter
+} // namespace core
+} // namespace casting
+} // namespace matter

--- a/examples/tv-casting-app/tv-casting-common/core/ConnectionCallbacks.h
+++ b/examples/tv-casting-app/tv-casting-common/core/ConnectionCallbacks.h
@@ -46,7 +46,6 @@ using CommissionerDeclarationCallback = std::function<void(
  */
 struct ConnectionCallbacks
 {
-public:
     /**
      * The callback called when the connection process has ended, regardless of whether it was successful or not.
      */

--- a/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
+++ b/examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "Types.h"
+#include <app/server/Dnssd.h>
 #include <vector>
 
 namespace matter {
@@ -61,8 +62,15 @@ public:
      */
     bool mCancelPasscode = false;
 
+    /**
+     * Commissionee's (random) DNS-SD instance name. This field is mandatory and will be auto generated if not provided by the
+     * client.
+     */
+    char mCommissioneeInstanceName[chip::Dnssd::Commission::kInstanceNameMaxLength + 1] = "";
+
     CHIP_ERROR addTargetAppInfo(const chip::Protocols::UserDirectedCommissioning::TargetAppInfo & targetAppInfo)
     {
+        ChipLogProgress(AppServer, "IdentificationDeclarationOptions::addTargetAppInfo()");
         if (mTargetAppInfos.size() >= CHIP_DEVICE_CONFIG_UDC_MAX_TARGET_APPS)
         {
             ChipLogError(AppServer,
@@ -94,21 +102,52 @@ public:
         id.SetNoPasscode(mNoPasscode);
         id.SetCdUponPasscodeDialog(mCdUponPasscodeDialog);
         id.SetCancelPasscode(mCancelPasscode);
-
-        ChipLogProgress(AppServer,
-                        "IdentificationDeclarationOptions::buildIdentificationDeclarationMessage() mCommissionerPasscode: %s",
-                        mCommissionerPasscode ? "true" : "false");
         id.SetCommissionerPasscode(mCommissionerPasscode);
-
-        ChipLogProgress(AppServer,
-                        "IdentificationDeclarationOptions::buildIdentificationDeclarationMessage() mCommissionerPasscodeReady: %s",
-                        mCommissionerPasscodeReady ? "true" : "false");
         if (mCommissionerPasscodeReady)
         {
             id.SetCommissionerPasscodeReady(true);
+            id.SetInstanceName(mCommissioneeInstanceName);
             mCommissionerPasscodeReady = false;
         }
+        else
+        {
+            ChipLogProgress(AppServer,
+                            "IdentificationDeclarationOptions::buildIdentificationDeclarationMessage() generating InstanceName");
+            CHIP_ERROR err = chip::app::DnssdServer::Instance().GetCommissionableInstanceName(mCommissioneeInstanceName,
+                                                                                              sizeof(mCommissioneeInstanceName));
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(AppServer,
+                             "IdentificationDeclarationOptions::buildIdentificationDeclarationMessage() Failed to get mdns "
+                             "instance name error: %" CHIP_ERROR_FORMAT,
+                             err.Format());
+            }
+            else
+            {
+                id.SetInstanceName(mCommissioneeInstanceName);
+                ChipLogProgress(AppServer,
+                                "IdentificationDeclarationOptions::buildIdentificationDeclarationMessage() InstanceName set to: %s",
+                                mCommissioneeInstanceName);
+            }
+        }
+        LogDetail();
         return id;
+    }
+
+    void LogDetail()
+    {
+        ChipLogDetail(AppServer, "IdentificationDeclarationOptions::LogDetail()");
+        ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mNoPasscode:                %s",
+                      mNoPasscode ? "true" : "false");
+        ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mCdUponPasscodeDialog:      %s",
+                      mCdUponPasscodeDialog ? "true" : "false");
+        ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mCommissionerPasscode:      %s",
+                      mCommissionerPasscode ? "true" : "false");
+        ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mCommissionerPasscodeReady: %s",
+                      mCommissionerPasscodeReady ? "true" : "false");
+        ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mCancelPasscode:            %s",
+                      mCancelPasscode ? "true" : "false");
+        ChipLogDetail(AppServer, "IdentificationDeclarationOptions::mCommissioneeInstanceName:  %s", mCommissioneeInstanceName);
     }
 
 private:

--- a/examples/tv-casting-app/tv-casting-common/support/AppParameters.h
+++ b/examples/tv-casting-app/tv-casting-common/support/AppParameters.h
@@ -42,7 +42,6 @@ public:
                       chip::Credentials::DeviceAttestationCredentialsProvider * deviceAttestationCredentialsProvider,
                       chip::Credentials::DeviceAttestationVerifier * deviceAttestationVerifier,
                       ServerInitParamsProvider * serverInitParamsProvider)
-    // TODO: In the following PRs. Add CommissionerDeclarationHandler.
     {
         VerifyOrReturnError(commissionableDataProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(deviceAttestationCredentialsProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -61,6 +60,14 @@ public:
     MutableByteSpanDataProvider * GetRotatingDeviceIdUniqueIdProvider() const { return mRotatingDeviceIdUniqueIdProvider; }
 
     chip::DeviceLayer::CommissionableDataProvider * GetCommissionableDataProvider() const { return mCommissionableDataProvider; }
+
+    CHIP_ERROR SetCommissionableDataProvider(chip::DeviceLayer::CommissionableDataProvider * commissionableDataProvider) const
+    {
+        ChipLogProgress(AppServer, "AppParameters::SetCommissionableDataProvider()");
+        VerifyOrReturnError(commissionableDataProvider != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        mCommissionableDataProvider = commissionableDataProvider;
+        return CHIP_NO_ERROR;
+    }
 
     chip::Credentials::DeviceAttestationCredentialsProvider * GetDeviceAttestationCredentialsProvider() const
     {
@@ -82,7 +89,7 @@ private:
      * @brief Provides CommissionableData (such as setupPasscode, discriminator, etc) used to get the CastingApp commissioned
      *
      */
-    chip::DeviceLayer::CommissionableDataProvider * mCommissionableDataProvider;
+    mutable chip::DeviceLayer::CommissionableDataProvider * mCommissionableDataProvider;
 
     /**
      * @brief Provides DeviceAttestationCredentials of the CastingApp during commissioning

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -94,7 +94,7 @@ void ChipDeviceEventHandler::HandleFailSafeTimerExpired()
     // if UDC was in progress (when the Fail-Safe timer expired), reset TargetCastingPlayer commissioning state and return early
     if (sUdcInProgress)
     {
-        ChipLogProgress(AppServer, "ChipDeviceEventHandler::HandleFailSafeTimerExpired when sUdcInProgress: %d, returning early",
+        ChipLogProgress(AppServer, "ChipDeviceEventHandler::HandleFailSafeTimerExpired() when sUdcInProgress: %d, returning early",
                         sUdcInProgress);
         sUdcInProgress                                            = false;
         CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
@@ -105,17 +105,19 @@ void ChipDeviceEventHandler::HandleFailSafeTimerExpired()
     }
 
     // if UDC was NOT in progress (when the Fail-Safe timer expired), start UDC
-    ChipLogProgress(AppServer, "ChipDeviceEventHandler::HandleFailSafeTimerExpired when sUdcInProgress: %d, starting UDC",
+    ChipLogProgress(AppServer, "ChipDeviceEventHandler::HandleFailSafeTimerExpired() when sUdcInProgress: %d, starting UDC",
                     sUdcInProgress);
     chip::DeviceLayer::SystemLayer().StartTimer(
         chip::System::Clock::Milliseconds32(1),
         [](chip::System::Layer * aSystemLayer, void * aAppState) {
-            ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle running OpenBasicCommissioningWindow");
+            ChipLogProgress(AppServer, "ChipDeviceEventHandler::HandleFailSafeTimerExpired() running OpenBasicCommissioningWindow");
             CHIP_ERROR err = chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(
                 chip::System::Clock::Seconds16(CastingPlayer::GetTargetCastingPlayer()->mCommissioningWindowTimeoutSec));
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(AppServer, "ChipDeviceEventHandler::Handle Failed to OpenBasicCommissioningWindow %" CHIP_ERROR_FORMAT,
+                ChipLogError(AppServer,
+                             "ChipDeviceEventHandler::HandleFailSafeTimerExpired() Failed to OpenBasicCommissioningWindow "
+                             "%" CHIP_ERROR_FORMAT,
                              err.Format());
                 CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(err, nullptr);
                 return;
@@ -126,7 +128,8 @@ void ChipDeviceEventHandler::HandleFailSafeTimerExpired()
             if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(AppServer,
-                             "ChipDeviceEventHandler::Handle Failed to SendUserDirectedCommissioningRequest %" CHIP_ERROR_FORMAT,
+                             "ChipDeviceEventHandler::HandleFailSafeTimerExpired() Failed to SendUserDirectedCommissioningRequest "
+                             "%" CHIP_ERROR_FORMAT,
                              err.Format());
                 CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(err, nullptr);
                 return;
@@ -209,10 +212,10 @@ void ChipDeviceEventHandler::HandleCommissioningComplete(const chip::DeviceLayer
 
 CHIP_ERROR ChipDeviceEventHandler::SetUdcStatus(bool udcInProgress)
 {
-    ChipLogProgress(AppServer, "ChipDeviceEventHandler::SetUdcStatus called with udcInProgress: %d", udcInProgress);
+    ChipLogProgress(AppServer, "ChipDeviceEventHandler::SetUdcStatus() called with udcInProgress: %d", udcInProgress);
     if (sUdcInProgress == udcInProgress)
     {
-        ChipLogError(AppServer, "UDC in progress state is already %d", sUdcInProgress);
+        ChipLogError(AppServer, "ChipDeviceEventHandler::SetUdcStatus() UDC in progress state is already %d", sUdcInProgress);
         return CHIP_ERROR_INCORRECT_STATE;
     }
     sUdcInProgress = udcInProgress;

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -628,23 +628,27 @@ CHIP_ERROR Server::SendUserDirectedCommissioningRequest(chip::Transport::PeerAdd
     // only populate fields left blank by the client
     if (strlen(id.GetInstanceName()) == 0)
     {
+        ChipLogDetail(AppServer, "Server::SendUserDirectedCommissioningRequest() Instance Name not known");
         char nameBuffer[chip::Dnssd::Commission::kInstanceNameMaxLength + 1];
         err = app::DnssdServer::Instance().GetCommissionableInstanceName(nameBuffer, sizeof(nameBuffer));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(AppServer, "Failed to get mdns instance name error: %" CHIP_ERROR_FORMAT, err.Format());
+            ChipLogError(
+                AppServer,
+                "Server::SendUserDirectedCommissioningRequest() Failed to get mdns instance name error: %" CHIP_ERROR_FORMAT,
+                err.Format());
             return err;
         }
         id.SetInstanceName(nameBuffer);
+        ChipLogDetail(AppServer, "Server::SendUserDirectedCommissioningRequest() Instance Name set to %s", nameBuffer);
     }
-    ChipLogDetail(AppServer, "instanceName=%s", id.GetInstanceName());
 
     if (id.GetVendorId() == 0)
     {
         uint16_t vendorId = 0;
         if (DeviceLayer::GetDeviceInstanceInfoProvider()->GetVendorId(vendorId) != CHIP_NO_ERROR)
         {
-            ChipLogDetail(Discovery, "Vendor ID not known");
+            ChipLogDetail(AppServer, "Server::SendUserDirectedCommissioningRequest() Vendor ID not known");
         }
         else
         {
@@ -657,7 +661,7 @@ CHIP_ERROR Server::SendUserDirectedCommissioningRequest(chip::Transport::PeerAdd
         uint16_t productId = 0;
         if (DeviceLayer::GetDeviceInstanceInfoProvider()->GetProductId(productId) != CHIP_NO_ERROR)
         {
-            ChipLogDetail(Discovery, "Product ID not known");
+            ChipLogDetail(AppServer, "Server::SendUserDirectedCommissioningRequest() Product ID not known");
         }
         else
         {
@@ -671,7 +675,7 @@ CHIP_ERROR Server::SendUserDirectedCommissioningRequest(chip::Transport::PeerAdd
         if (!chip::DeviceLayer::ConfigurationMgr().IsCommissionableDeviceNameEnabled() ||
             chip::DeviceLayer::ConfigurationMgr().GetCommissionableDeviceName(deviceName, sizeof(deviceName)) != CHIP_NO_ERROR)
         {
-            ChipLogDetail(Discovery, "Device Name not known");
+            ChipLogDetail(AppServer, "Server::SendUserDirectedCommissioningRequest() Device Name not known");
         }
         else
         {
@@ -710,11 +714,12 @@ CHIP_ERROR Server::SendUserDirectedCommissioningRequest(chip::Transport::PeerAdd
 
     if (err == CHIP_NO_ERROR)
     {
-        ChipLogDetail(AppServer, "Send UDC request success");
+        ChipLogDetail(AppServer, "Server::SendUserDirectedCommissioningRequest() Send UDC request success");
     }
     else
     {
-        ChipLogError(AppServer, "Send UDC request failed, err: %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogError(AppServer, "Server::SendUserDirectedCommissioningRequest() Send UDC request failed, err: %" CHIP_ERROR_FORMAT,
+                     err.Format());
     }
     return err;
 }


### PR DESCRIPTION
Linux tv-casting-app example app, implemented new Matter v1.3 Matter Casting User Directed Commissioning (UDC) feature commissioner-generated passcode flow.

**Change summary**

1.	Added UpdateCommissionableDataProvider() function to connectedhomeip/examples/tv-casting-app/tv-casting-common/core/CastingApp.cpp/h which updates the Provided in the DeviceLayer. Also updated the VerifyOrEstablishConnection() function call with the new connectionCallbacks parameter.
2.	Added a SetCommissionableDataProvider() function to  connectedhomeip/examples/tv-casting-app/tv-casting-common/support/AppParameters.h
3.	Created connectedhomeip/examples/tv-casting-app/tv-casting-common/core/ConnectionCallbacks.h to hold the two UDC callbacks which are now passed to VerifyOrEstablishConnection() function
4.	Updated /examples/tv-casting-app/tv-casting-common/core/IdentificationDeclarationOptions.h to set the CommissioneeInstanceName when building an IdentificationDeclaration message.
5.	Updated connectedhomeip/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h with SetCommissionerDeclarationCallback() to set the client defined callback. Also updated OnCommissionerDeclarationMessage() to close the commissioning window when a CommissionerDeclaration message is received. This allows us to regenerate the PAKE verifier before opening the next commissioning window and sending the next IdentificationDeclaration message to the commissioner. 
6.	Updated connectedhomeip/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp VerifyOrEstablishConnection() with the new ConnectionCallbacks parameter. VerifyOrEstablishConnection() now sets the CommissionerDeclarationCallback passed in ConnectionCallbacks by the client. Added error checking to confirm the UDC status. 
7.	Updated connectedhomeip/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp with ContinueConnecting() function to send a second IdentificationDeclaration to the commissioner once the user has entered the commissioner-generated passcode in the tv-casting-app UX.
8.	Updated connectedhomeip/examples/tv-casting-app/linux/simple-app-helper.cpp/h with CommissionerDeclarationCallback() to handle the commissioners messages. Added the “setcommissionerpasscode <passcode>” command which allows the user to enter the commissioner-generated passcode. This command also calls InitCommissionableDataProvider() and UpdateCommissionableDataProvider() to update the commissioning session’s PAKE verifier and then calls ContinueConnecting().
9.	Updated VerifyOrEstablishConnection() function with the new param in MatterCastingPlayer-JNI.cpp and MatterTvCastingBridge/MCCastingPlayer.mm
10.	Moved InitCommissionableDataProvider() from connectedhomeip/examples/tv-casting-app/linux/simple-app.cpp to simple-app-helper.cpp/h so that it can be reused.

**Testing**

Verified and tested locally with the Linux, Android and iOS tv-casting-app example mobile apps, and the Linux tv-app (CastingPlayer). With the Linux example tv-casting-app app, we are able to successfully commission using the commissioner generated passcode flow as follows:

**Usage**

1.	Start tv-app:                connectedhomeip % ./out/tv-app/chip-tv-app
2.	Start tv-casting-app:   connectedhomeip % ./out/tv-casting-app/chip-tv-casting-app
3.	In tv-casting-app:       > cast request 0 commissioner-generated-passcode
4.	In tv-app:                    > controller ux ok
5.	Tv-app displays the commissioner-generated-passcode in hex: Casting passcode: [0x00BC_614E] or 12345678 in decimal.
6.	In tv-casting-app:       > cast setcommissionerpasscode 12345678
7.	The logs display “simple-app-helper.cpp::ConnectionHandler(): Successfully connected to CastingPlayer (ID: 88665A3712045650)”
