### PR TITLE
Revert using strncmp instead of strcmp to make the function robust and safe from buffer overruns. #33449

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -171,7 +171,7 @@ bool HandleNullableOptional(Argument & arg, char * argValue, std::function<bool(
     if (arg.isNullable())
     {
         auto * nullable = reinterpret_cast<chip::app::DataModel::Nullable<T> *>(arg.value);
-        if (argValue != nullptr && strncmp(argValue, "null", 4) == 0)
+        if (strcmp(argValue, "null") == 0)
         {
             nullable->SetNull();
             return true;

--- a/examples/fabric-admin/commands/common/Command.cpp
+++ b/examples/fabric-admin/commands/common/Command.cpp
@@ -171,7 +171,7 @@ bool HandleNullableOptional(Argument & arg, char * argValue, std::function<bool(
     if (arg.isNullable())
     {
         auto * nullable = reinterpret_cast<chip::app::DataModel::Nullable<T> *>(arg.value);
-        if (argValue != nullptr && strncmp(argValue, "null", 4) == 0)
+        if (strcmp(argValue, "null") == 0)
         {
             nullable->SetNull();
             return true;

--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -707,6 +707,20 @@ tests:
       response:
           value: 0
 
+    # Tests for Nullable String attribute
+
+    - label: "Write attribute NULLABLE_CHAR_STRING - Value starting with null"
+      command: "writeAttribute"
+      attribute: "nullable_char_string"
+      arguments:
+          value: "nulla"
+
+    - label: "Read attribute NULLABLE_CHAR_STRING"
+      command: "readAttribute"
+      attribute: "nullable_char_string"
+      response:
+          value: "nulla"
+
     # Tests for Octet String attribute
 
     - label: "Read attribute OCTET_STRING Default Value"

--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -707,20 +707,6 @@ tests:
       response:
           value: 0
 
-    # Tests for Nullable String attribute
-
-    - label: "Write attribute NULLABLE_CHAR_STRING - Value starting with null"
-      command: "writeAttribute"
-      attribute: "nullable_char_string"
-      arguments:
-          value: "nulla"
-
-    - label: "Read attribute NULLABLE_CHAR_STRING"
-      command: "readAttribute"
-      attribute: "nullable_char_string"
-      response:
-          value: "nulla"
-
     # Tests for Octet String attribute
 
     - label: "Read attribute OCTET_STRING Default Value"
@@ -2910,7 +2896,7 @@ tests:
           constraints:
               notValue: nullableOctetStrTestValue
 
-    # Tests for Char String attribute
+    # Tests for Nullable Char String attribute
 
     - label: "Read attribute NULLABLE_CHAR_STRING Default Value"
       command: "readAttribute"
@@ -2981,6 +2967,18 @@ tests:
       attribute: "list_int8u"
       response:
           error: UNSUPPORTED_CLUSTER
+
+    - label: "Write attribute NULLABLE_CHAR_STRING - Value starting with null"
+      command: "writeAttribute"
+      attribute: "nullable_char_string"
+      arguments:
+          value: "nulla"
+
+    - label: "Read attribute NULLABLE_CHAR_STRING"
+      command: "readAttribute"
+      attribute: "nullable_char_string"
+      response:
+          value: "nulla"
 
     # Tests for command with optional arguments
     - label:


### PR DESCRIPTION
The previous fix in [PR #33449](https://github.com/project-chip/connectedhomeip/pull/33449) used strncmp instead of strcmp for equality checks. After further offline discussions, we concluded that this change was not well-considered and could introduce additional thread safety issues.

This PR reverts the previous fix and adds tests for the Nullable String attribute to ensure proper handling and validation.
