### PR TITLE
Fix typo in java-matter-controller README.md

### DIFF
--- a/examples/java-matter-controller/README.md
+++ b/examples/java-matter-controller/README.md
@@ -120,7 +120,7 @@ the top Matter directory:
 ```
 
 The Java executable file `java-matter-controller` will be generated at
-`out/android-x86-java-matter-controller/bin/`
+`out/linux-x64-java-matter-controller/bin/`
 
 Run the java-matter-controller
 


### PR DESCRIPTION
The location of the executable file mentioned in the "Building & Running the app" section is different from the actual location.
out/android-x86-java-matter-controller/bin/ -> out/linux-x64-java-matter-controller/bin/

