### PR TITLE
[Android] Fix QR Code parsing about vendor info

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceDetailsFragment.kt
@@ -61,7 +61,6 @@ class CHIPDeviceDetailsFragment : Fragment() {
     binding.discriminatorEd.setText(deviceInfo.discriminator.toString())
     binding.serialNumberEd.setText(deviceInfo.serialNumber)
     binding.discoveryCapabilitiesTv.text = "${deviceInfo.discoveryCapabilities}"
-
     if (deviceInfo.optionalQrCodeInfoMap.isEmpty()) {
       binding.vendorTagsLabelTv.visibility = View.GONE
       binding.vendorTagsContainer.visibility = View.GONE

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceInfo.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/setuppayloadscanner/CHIPDeviceInfo.kt
@@ -86,10 +86,9 @@ data class CHIPDeviceInfo(
         setupPayload.getLongDiscriminatorValue(),
         setupPayload.setupPinCode,
         setupPayload.commissioningFlow,
-        setupPayload
-          .getAllOptionalVendorData().associate { info ->
-            info.tag to QrCodeInfo(info.tag, info.type, info.data, info.int32)
-          },
+        setupPayload.getAllOptionalVendorData().associate { info ->
+          info.tag to QrCodeInfo(info.tag, info.type, info.data, info.int32)
+        },
         setupPayload.discoveryCapabilities,
         setupPayload.hasShortDiscriminator,
         serialNumber

--- a/examples/android/CHIPTool/app/src/main/res/layout/chip_device_info_fragment.xml
+++ b/examples/android/CHIPTool/app/src/main/res/layout/chip_device_info_fragment.xml
@@ -151,7 +151,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
-            android:layout_below="@id/vendorTagsLabelTv"
+            android:layout_below="@id/vendorTagsContainer"
             android:layout_alignParentStart="true"
             android:textSize="20sp"/>
         <EditText
@@ -159,7 +159,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
-            android:layout_below="@id/vendorTagsLabelTv"
+            android:layout_below="@id/vendorTagsContainer"
             android:layout_toEndOf="@id/discoveryCapabilitiesLabelTv"
             android:layout_alignParentEnd="true"
             android:textSize="11sp"
@@ -260,6 +260,6 @@
             android:layout_below="@id/showQRCodeUriBtn"
             android:layout_alignParentBottom="true"
             android:layout_alignParentStart="true"
-            android:textSize="20sp"/>
+            android:textSize="12sp"/>
     </RelativeLayout>
 </ScrollView>

--- a/src/controller/java/src/matter/onboardingpayload/QRCodeBasicOnboardingPayloadGenerator.kt
+++ b/src/controller/java/src/matter/onboardingpayload/QRCodeBasicOnboardingPayloadGenerator.kt
@@ -178,6 +178,6 @@ private fun populateTLVBits(
 
   for (i in 0 until tlvBufSizeInBytes) {
     val value = tlvBuf[i]
-    populateBits(bits, offset, value.toLong(), 8, totalPayloadDataSizeInBits)
+    populateBits(bits, offset, value.toUByte().toLong(), 8, totalPayloadDataSizeInBits)
   }
 }


### PR DESCRIPTION
Fix to parse Vendor optional Data in QR Code.
Android Chiptool UI can show vendor optional Data.

