### PR TITLE
Darwin: remove `_handleAttributeReport` convenience method

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1367,11 +1367,6 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     [self _reportAttributes:[self _getAttributesToReportWithReportedValues:attributeReport fromSubscription:isFromSubscription]];
 }
 
-- (void)_handleAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport
-{
-    [self _handleAttributeReport:attributeReport fromSubscription:NO];
-}
-
 #ifdef DEBUG
 - (void)unitTestInjectEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport
 {
@@ -1384,7 +1379,7 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 {
     dispatch_async(self.queue, ^{
         [self _handleReportBegin];
-        [self _handleAttributeReport:attributeReport];
+        [self _handleAttributeReport:attributeReport fromSubscription:NO];
         [self _handleReportEnd];
     });
 }
@@ -2168,7 +2163,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                                 // Since the format is the same data-value dictionary, this looks like an
                                 // attribute report
                                 MTR_LOG_INFO("Read attribute work item [%llu] result: %@  [0x%016llX:%@:0x%llX:0x%llX]", workItemID, values, nodeID.unsignedLongLongValue, endpointID, clusterID.unsignedLongLongValue, attributeID.unsignedLongLongValue);
-                                [self _handleAttributeReport:values];
+                                [self _handleAttributeReport:values fromSubscription:NO];
                             }
 
                             // TODO: better retry logic

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1375,11 +1375,11 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     });
 }
 
-- (void)unitTestInjectAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport
+- (void)unitTestInjectAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport fromSubscription:(BOOL)isFromSubscription
 {
     dispatch_async(self.queue, ^{
         [self _handleReportBegin];
-        [self _handleAttributeReport:attributeReport fromSubscription:NO];
+        [self _handleAttributeReport:attributeReport fromSubscription:isFromSubscription];
         [self _handleReportEnd];
     });
 }

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -3202,7 +3202,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         wasOnDeviceConfigurationChangedCallbackCalled = YES;
     };
 
-    [device unitTestInjectAttributeReport:attributeReport];
+    [device unitTestInjectAttributeReport:attributeReport fromSubscription:YES];
 
     [testcase waitForExpectations:@[ gotAttributeReportExpectation, gotAttributeReportEndExpectation, deviceConfigurationChangedExpectation ] timeout:kTimeoutInSeconds];
     if (!expectConfigurationChanged) {
@@ -3530,7 +3530,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         [deviceConfigurationChangedExpectationForAttributeReportWithMultipleAttributes fulfill];
     };
 
-    [device unitTestInjectAttributeReport:attributeReport];
+    [device unitTestInjectAttributeReport:attributeReport fromSubscription:YES];
     [self waitForExpectations:@[ gotAttributeReportWithMultipleAttributesExpectation, gotAttributeReportWithMultipleAttributesEndExpectation, deviceConfigurationChangedExpectationForAttributeReportWithMultipleAttributes ] timeout:kTimeoutInSeconds];
 }
 

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDevice (TestDebug)
 - (void)unitTestInjectEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport;
-- (void)unitTestInjectAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport;
+- (void)unitTestInjectAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport fromSubscription:(BOOL)isFromSubscription;
 - (NSUInteger)unitTestAttributesReportedSinceLastCheck;
 - (void)unitTestClearClusterData;
 @end


### PR DESCRIPTION
Per previous PR discussion, force callers to explicitly declare whether or not the report is from a subscription.
