### PR TITLE
Fix template-id-cdtor error in static_support_smart_ptr.h

### DIFF
--- a/src/lib/support/static_support_smart_ptr.h
+++ b/src/lib/support/static_support_smart_ptr.h
@@ -54,7 +54,7 @@ template <class T>
 class CheckedGlobalInstanceReference
 {
 public:
-    CheckedGlobalInstanceReference<T>() = default;
+    CheckedGlobalInstanceReference() = default;
     CheckedGlobalInstanceReference(T * e) { VerifyOrDie(e == GlobalInstanceProvider<T>::InstancePointer()); }
     CheckedGlobalInstanceReference & operator=(T * value)
     {
@@ -89,7 +89,7 @@ template <class T>
 class SimpleInstanceReference
 {
 public:
-    SimpleInstanceReference<T>() = default;
+    SimpleInstanceReference() = default;
     SimpleInstanceReference(T * e) : mValue(e) {}
     SimpleInstanceReference & operator=(T * value)
     {


### PR DESCRIPTION
With PR https://github.com/project-chip/connectedhomeip/pull/33426, master failed to build with std=c++20 with error template-id-cdtor.

This PR is to fix is. Manually tested by setting the parameter to std=c++20, std=c++17, std=gnu++20 and std=gnu++17

Fixes: #33493

