### PR TITLE
Fix typo in kotlin-matter-controller README.md

### DIFF
--- a/examples/kotlin-matter-controller/README.md
+++ b/examples/kotlin-matter-controller/README.md
@@ -109,7 +109,7 @@ the top Matter directory:
 ```
 
 The Java executable file `kotlin-matter-controller` will be generated at
-`out/android-x86-kotlin-matter-controller/bin/`
+`out/linux-x64-kotlin-matter-controller/bin/`
 
 Run the kotlin-matter-controller
 


### PR DESCRIPTION
The location of the executable file mentioned in the "Building & Running the app" section is different from the actual location.
out/android-x86-kotlin-matter-controller/bin/ -> out/linux-x64-kotlin-matter-controller/bin/


