### PR TITLE
Remove final keyword from the class contains virtual functions

### DIFF
--- a/examples/common/pigweed/rpc_services/BooleanState.h
+++ b/examples/common/pigweed/rpc_services/BooleanState.h
@@ -28,7 +28,7 @@
 namespace chip {
 namespace rpc {
 
-class BooleanState final : public pw_rpc::nanopb::BooleanState::Service<BooleanState>
+class BooleanState : public pw_rpc::nanopb::BooleanState::Service<BooleanState>
 {
 public:
     virtual ~BooleanState() = default;

--- a/examples/common/pigweed/rpc_services/Locking.h
+++ b/examples/common/pigweed/rpc_services/Locking.h
@@ -27,7 +27,7 @@
 namespace chip {
 namespace rpc {
 
-class Locking final : public pw_rpc::nanopb::Locking::Service<Locking>
+class Locking : public pw_rpc::nanopb::Locking::Service<Locking>
 {
 public:
     virtual ~Locking() = default;


### PR DESCRIPTION
 If the class is declared as final, it cannot be inherited from. Therefore, the virtual member functions are unnecessary. 
 
 We should either remove the final keyword from class declaration or the virtual keyword from the member functions of the final class.
 
I choose to remove the final keyword from the class declaration to  align with other RPC service interfaces  