### PR TITLE
TC-SC-3.6: Add precondition to remove extra fabrics

### DIFF
--- a/src/python_testing/TC_SC_3_6.py
+++ b/src/python_testing/TC_SC_3_6.py
@@ -123,6 +123,24 @@ class TC_SC_3_6(MatterBaseTest):
         )
         asserts.assert_greater_equal(capability_minima.caseSessionsPerFabric, 3)
 
+        logging.info("Pre-condition: Remove all pre-existing fabrics on the device that do not belong to the TH")
+        commissioned_fabric_count: int = await self.read_single_attribute(
+            dev_ctrl, node_id=self.dut_node_id,
+            endpoint=0, attribute=Clusters.OperationalCredentials.Attributes.CommissionedFabrics)
+
+        if commissioned_fabric_count > 1:
+            fabrics: List[Clusters.OperationalCredentials.Structs.FabricDescriptorStruct] = await self.read_single_attribute(
+                dev_ctrl, node_id=self.dut_node_id, endpoint=0,
+                attribute=Clusters.OperationalCredentials.Attributes.Fabrics, fabricFiltered=False)
+            current_fabric_index = await self.read_single_attribute_check_success(cluster=Clusters.OperationalCredentials, attribute=Clusters.OperationalCredentials.Attributes.CurrentFabricIndex)
+            for fabric in fabrics:
+                if fabric.fabricIndex == current_fabric_index:
+                    continue
+                # This is not the test client's fabric, so remove it.
+                logging.info(f"Removing extra fabric at {fabric.fabricIndex} from device.")
+                await dev_ctrl.SendCommand(
+                    self.dut_node_id, 0, Clusters.OperationalCredentials.Commands.RemoveFabric(fabricIndex=fabric.fabricIndex))
+
         logging.info("Pre-conditions: use existing fabric to configure new fabrics so that total is %d fabrics" %
                      num_fabrics_to_commission)
 

--- a/src/python_testing/TC_SC_3_6.py
+++ b/src/python_testing/TC_SC_3_6.py
@@ -20,6 +20,7 @@ import logging
 import queue
 import time
 from threading import Event
+from typing import List
 
 import chip.clusters as Clusters
 from chip.clusters import ClusterObjects as ClustersObjects


### PR DESCRIPTION
Fix for CCB 4059

Before commissioning the other fabrics, remove pre-existing fabrics from the device because the TH does not have the ability to check for subscriptions from them.

Note that this change means that any pre-exisiting fabrics on the device WILL NOT BE THERE after this test. This is the same behaviour as in RR-1.1.

Test:
Tested against all-clusters app.
```
chip-tool pairing onnetwork-long 0x12344321 20202021 3840
chip-tool pairing open-commissioning-window 0x12344321 0 900 10000 3840
python src/python_testing/TC_SC_3_6.py --commissioning-method on-network --discriminator 3840 --passcode 20202021
```
Results (only relevant logs):
```
[MatterTest] 05-17 07:54:32.981 INFO Pre-condition: Remove all pre-existing fabrics on the device that do not belong to the TH 
...
[MatterTest] 05-17 07:54:32.994 INFO Removing extra fabric at 1 from device.
...
INFO:root:Final result: PASS !
```