### PR TITLE
Fix GCC compilation with -finstrument-functions

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -944,7 +944,8 @@ CHIP_ERROR TestOnlyExtractCommandPathFromNextInvokeRequest(TLV::TLVReader & invo
     case CommandHandler::NlFaultInjectionType::SkipSecondResponse:
         return "Single InvokeResponseMessages. Dropping response to second request";
     }
-    VerifyOrDieWithMsg(false, DataManagement, "TH Failure: Unexpected fault type");
+    ChipLogError(DataManagement, "TH Failure: Unexpected fault type");
+    chipAbort();
 }
 
 } // anonymous namespace


### PR DESCRIPTION
### Problem

When compiling with `-finstrument-functions` gcc reports error:
```
../../src/app/CommandHandler.cpp: In function ‘const char* chip::app::{anonymous}::GetFaultInjectionTypeStr(chip::app::CommandHandler::NlFaultInjectionType)’:
../../src/app/CommandHandler.cpp:948:1: error: control reaches end of non-void function [-Werror=return-type]
  948 | }
      | ^
```

### Changes

Abort at the end of the function unconditionally.