### PR TITLE
Add a pigweed-string-format adapter for CHIP_ERROR since that makes unit test debugability a LOT better

### DIFF
--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -15,6 +15,7 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 import("//build_overrides/nlio.gni")
+import("//build_overrides/pigweed.gni")
 
 import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/build/chip/tests.gni")
@@ -103,6 +104,15 @@ source_set("error") {
     ":chip_config_header",
     "${chip_root}/src/lib/support:attributes",
     "${chip_root}/src/lib/support:type-traits",
+  ]
+}
+
+source_set("string-builder-adapters") {
+  sources = [ "StringBuilderAdapters.h" ]
+
+  public_deps = [
+    ":error",
+    "$dir_pw_string",
   ]
 }
 

--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -108,7 +108,10 @@ source_set("error") {
 }
 
 source_set("string-builder-adapters") {
-  sources = [ "StringBuilderAdapters.h" ]
+  sources = [
+    "StringBuilderAdapters.cpp",
+    "StringBuilderAdapters.h",
+  ]
 
   public_deps = [
     ":error",

--- a/src/lib/core/StringBuilderAdapters.cpp
+++ b/src/lib/core/StringBuilderAdapters.cpp
@@ -1,0 +1,31 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <lib/core/StringBuilderAdapters.h>
+
+namespace pw {
+
+template <>
+StatusWithSize ToString<CHIP_ERROR>(const CHIP_ERROR & err, pw::span<char> buffer)
+{
+    if (CHIP_ERROR::IsSuccess(err))
+    {
+        // source location probably does not matter
+        return pw::string::Format(buffer, "CHIP_NO_ERROR");
+    }
+    return pw::string::Format(buffer, "CHIP_ERROR:<%" CHIP_ERROR_FORMAT ">", err.Format());
+}
+
+} // namespace pw

--- a/src/lib/core/StringBuilderAdapters.h
+++ b/src/lib/core/StringBuilderAdapters.h
@@ -32,6 +32,14 @@
 ///
 /// On failure without adapters, the objects are reported as "24-byte object at 0x....."
 /// which is not as helpful as a full CHIP_ERROR formatted output.
+///
+/// Example output WITHOUT the adapters
+///    Expected: .... == CHIP_ERROR(0, "src/setup_payload/tests/TestAdditionalDataPayload.cpp", 234)
+///    Actual: <24-byte object at 0x7ffe39510b80> == <24-byte object at 0x7ffe39510ba0>
+///
+/// Example output WITH the adapters:
+///    Expected: .... == CHIP_ERROR(0, "src/setup_payload/tests/TestAdditionalDataPayload.cpp", 234)
+///    Actual: CHIP_ERROR:<src/lib/core/TLVReader.cpp:889: Error 0x00000022> == CHIP_NO_ERROR
 
 #include <pw_string/string_builder.h>
 

--- a/src/lib/core/StringBuilderAdapters.h
+++ b/src/lib/core/StringBuilderAdapters.h
@@ -1,0 +1,54 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+/// This header includes pigweed stringbuilder adaptations for various chip types.
+/// You can see https://pigweed.dev/pw_string/guide.html as a reference.
+///
+/// In particular, pigweed code generally looks like:
+///
+///    pw::StringBuffer<42> sb;
+///    sb << "Here is a value: ";
+///    sb << value;
+///
+/// Where specific formatters exist for "value". In particular these are used when
+/// reporting unit test assertions such as ASSERT_EQ/EXPECT_EQ so if you write code
+/// like:
+///
+///    ASSERT_EQ(SomeCall(), CHIP_NO_ERROR);
+///
+/// On failure without adapters, the objects are reported as "24-byte object at 0x....."
+/// which is not as helpful as a full CHIP_ERROR formatted output.
+
+#include <pw_string/string_builder.h>
+
+#include <lib/core/CHIPError.h>
+
+namespace pw {
+
+template <>
+
+StatusWithSize ToString<CHIP_ERROR>(const CHIP_ERROR & err, pw::span<char> buffer)
+{
+    if (CHIP_ERROR::IsSuccess(err))
+    {
+        // source location probably does not matter
+        return pw::string::Format(buffer, "CHIP_NO_ERROR");
+    }
+    return pw::string::Format(buffer, "CHIP_ERROR:<%" CHIP_ERROR_FORMAT ">", err.Format());
+}
+
+} // namespace pw

--- a/src/lib/core/StringBuilderAdapters.h
+++ b/src/lib/core/StringBuilderAdapters.h
@@ -48,15 +48,6 @@
 namespace pw {
 
 template <>
-
-StatusWithSize ToString<CHIP_ERROR>(const CHIP_ERROR & err, pw::span<char> buffer)
-{
-    if (CHIP_ERROR::IsSuccess(err))
-    {
-        // source location probably does not matter
-        return pw::string::Format(buffer, "CHIP_NO_ERROR");
-    }
-    return pw::string::Format(buffer, "CHIP_ERROR:<%" CHIP_ERROR_FORMAT ">", err.Format());
-}
+StatusWithSize ToString<CHIP_ERROR>(const CHIP_ERROR & err, pw::span<char> buffer);
 
 } // namespace pw

--- a/src/setup_payload/tests/BUILD.gn
+++ b/src/setup_payload/tests/BUILD.gn
@@ -36,5 +36,6 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/platform",
     "${chip_root}/src/setup_payload",
+    "${chip_root}/src/lib/core:string-builder-adapters",
   ]
 }

--- a/src/setup_payload/tests/BUILD.gn
+++ b/src/setup_payload/tests/BUILD.gn
@@ -34,8 +34,8 @@ chip_test_suite("tests") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/platform",
     "${chip_root}/src/setup_payload",
-    "${chip_root}/src/lib/core:string-builder-adapters",
   ]
 }

--- a/src/setup_payload/tests/TestAdditionalDataPayload.cpp
+++ b/src/setup_payload/tests/TestAdditionalDataPayload.cpp
@@ -28,6 +28,7 @@
 
 #include <gtest/gtest.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPMemString.h>

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -22,14 +22,14 @@
  *
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 #include <stdio.h>
 
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/verhoeff/Verhoeff.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
 #include <setup_payload/ManualSetupPayloadParser.h>
 #include <setup_payload/SetupPayload.h>
-
-#include <lib/support/verhoeff/Verhoeff.h>
 
 #include <algorithm>
 #include <math.h>

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -26,7 +26,9 @@
 
 #include <nlbyteorder.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/Span.h>
 
 using namespace chip;

--- a/src/setup_payload/tests/TestQRCodeTLV.cpp
+++ b/src/setup_payload/tests/TestQRCodeTLV.cpp
@@ -16,9 +16,11 @@
  */
 #include "TestHelpers.h"
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
 #include <nlbyteorder.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/ScopedBuffer.h>
 
 using namespace chip;


### PR DESCRIPTION
Without this, we have:

```
Actual: <24-byte object at 0x7ffe39510b80> == <24-byte object at 0x7ffe39510ba0> 
```

and with this we have:

```
Actual: CHIP_ERROR:<src/lib/core/TLVReader.cpp:889: Error 0x00000022> == CHIP_NO_ERROR
```

Started using this in one example unit test, however did not update all of them as that seems quite a bit of work. We can update as a followup or add these when we find errors or for new tests.