### PR TITLE
Make TC_IDM_4_2.py a bit more resistent to timing issues in Step 8

### DIFF
--- a/src/python_testing/TC_IDM_4_2.py
+++ b/src/python_testing/TC_IDM_4_2.py
@@ -408,8 +408,8 @@ class TC_IDM_4_2(MatterBaseTest):
             [(0, node_label_attr(value=new_node_label_write))]
         )
 
-        # Wait MinIntervalFloor seconds before reading updated attribute value
-        time.sleep(same_min_max_interval_sec)
+        # Wait MinIntervalFloor seconds (plus a bit longer for timing reasons) before reading updated attribute value
+        time.sleep(same_min_max_interval_sec + 0.1)
         new_node_label_read = sub_cr1_update_value.GetAttribute(node_label_attr_typed_path)
 
         # Verify new attribute value after MinIntervalFloor time


### PR DESCRIPTION
fixes #33515

PS: yes i know that this is a bit "hacky" because the additional waiting time is not accurately determined, but I would not know how. So in my eyes this is a pragmatic "better then the former too exact approach" solution :-)

I know that this test was removed from test plans ifor Matter 1.3, but for me it still has it's value to verify matter.js in CI, so it would be cool to get this small optimization in here. Alternatively I can wait until https://github.com/project-chip/connectedhomeip/pull/33299 lands and you can close the issue and the PR.
