### PR TITLE
Linux tv-casting-app v1.3 Commissioner-Generated passcode follow up

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -120,9 +120,8 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
     matter::casting::core::ConnectionCallbacks connectionCallbacks;
     connectionCallbacks.mOnConnectionComplete = connectCallback;
 
-    // TODO: Verify why commissioningWindowTimeoutSec is a "unsigned long long int" type. Seems too big.
-    castingPlayer->VerifyOrEstablishConnection(connectionCallbacks,
-                                               static_cast<unsigned long long int>(commissioningWindowTimeoutSec), idOptions);
+    castingPlayer->VerifyOrEstablishConnection(connectionCallbacks, static_cast<uint64_t>(commissioningWindowTimeoutSec),
+                                               idOptions);
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -120,7 +120,7 @@ JNI_METHOD(jobject, verifyOrEstablishConnection)
     matter::casting::core::ConnectionCallbacks connectionCallbacks;
     connectionCallbacks.mOnConnectionComplete = connectCallback;
 
-    castingPlayer->VerifyOrEstablishConnection(connectionCallbacks, static_cast<uint64_t>(commissioningWindowTimeoutSec),
+    castingPlayer->VerifyOrEstablishConnection(connectionCallbacks, static_cast<uint16_t>(commissioningWindowTimeoutSec),
                                                idOptions);
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -33,6 +33,9 @@
 
 // VendorId of the Endpoint on the CastingPlayer that the CastingApp desires to interact with after connection
 const uint16_t kDesiredEndpointVendorId = 65521;
+// EndpointId of the Endpoint on the CastingPlayer that the CastingApp desires to interact with after connection using the
+// Commissioner-Generated passcode commissioning flow
+const uint8_t kDesiredEndpointId = 1;
 // Indicates that the Commissioner-Generated passcode commissioning flow is in progress.
 bool gCommissionerGeneratedPasscodeFlowRunning = false;
 
@@ -294,12 +297,14 @@ void ConnectionHandler(CHIP_ERROR err, matter::casting::core::CastingPlayer * ca
                            [](const matter::casting::memory::Strong<matter::casting::core::Endpoint> & endpoint) {
                                if (gCommissionerGeneratedPasscodeFlowRunning)
                                {
-                                   // Since the tv-app with Vendor ID 1111 does not implement the endpoint with Vendor ID 65521 we
-                                   // will (temporarily) use the endpoint with ID == 1 for demo interactions. See
+                                   // For the example Commissioner-Generated passcode commissioning flow, run demo interactions with
+                                   // the Endpoint with ID 1. For this flow, we commissioned with the Target Content Application
+                                   // with Vendor ID 1111. Since this target content application does not report its Endpoint's
+                                   // Vendor IDs, we find the desired endpoint based on the Endpoint ID. See
                                    // connectedhomeip/examples/tv-app/tv-common/include/AppTv.h.
-                                   return endpoint->GetId() == 1;
+                                   return endpoint->GetId() == kDesiredEndpointId;
                                }
-                               return endpoint->GetVendorId() == kDesiredEndpointVendorId; // 65521
+                               return endpoint->GetVendorId() == kDesiredEndpointVendorId;
                            });
     if (it != endpoints.end())
     {
@@ -408,10 +413,11 @@ CHIP_ERROR CommandHandler(int argc, char ** argv)
                                     index);
                     idOptions.mCommissionerPasscode = true;
 
-                    // Override the default target Vendor ID for this example (Commissioner-Generated passcode commissioning flow).
-                    // This tv-app target Vendor ID (1111), does not implement the AccountLogin cluster, which would otherwise auto
-                    // commission using the Commissionee-Generated passcode upon recieving the IdentificationDeclaration Message.
-                    // See connectedhomeip/examples/tv-app/tv-common/include/AppTv.h.
+                    // For the example Commissioner-Generated passcode commissioning flow, override the default Target Content
+                    // Application Vendor ID, which is configured on the tv-app. This Target Content Application Vendor ID (1111),
+                    // does not implement the AccountLogin cluster, which would otherwise auto commission using the
+                    // Commissionee-Generated passcode upon recieving the IdentificationDeclaration Message. See
+                    // connectedhomeip/examples/tv-app/tv-common/include/AppTv.h.
                     targetAppInfo.vendorId                    = 1111;
                     gCommissionerGeneratedPasscodeFlowRunning = true;
                 }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -29,7 +29,7 @@ namespace core {
 
 CastingPlayer * CastingPlayer::mTargetCastingPlayer = nullptr;
 
-void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCallbacks, uint64_t commissioningWindowTimeoutSec,
+void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCallbacks, uint16_t commissioningWindowTimeoutSec,
                                                 IdentificationDeclarationOptions idOptions)
 {
     ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() called");
@@ -387,6 +387,26 @@ void CastingPlayer::LogDetail() const
     {
         ChipLogDetail(AppServer, "\tFabric Index: %u", mAttributes.fabricIndex);
     }
+}
+
+CastingPlayer::CastingPlayer(const CastingPlayer & other) :
+    mEndpoints(other.mEndpoints), mConnectionState(other.mConnectionState), mAttributes(other.mAttributes),
+    mIdOptions(other.mIdOptions), mCommissioningWindowTimeoutSec(other.mCommissioningWindowTimeoutSec),
+    mOnCompleted(other.mOnCompleted)
+{}
+
+CastingPlayer & CastingPlayer::operator=(const CastingPlayer & other)
+{
+    if (this != &other)
+    {
+        mAttributes                    = other.mAttributes;
+        mEndpoints                     = other.mEndpoints;
+        mConnectionState               = other.mConnectionState;
+        mIdOptions                     = other.mIdOptions;
+        mCommissioningWindowTimeoutSec = other.mCommissioningWindowTimeoutSec;
+        mOnCompleted                   = other.mOnCompleted;
+    }
+    return *this;
 }
 
 ConnectionContext::ConnectionContext(void * clientContext, core::CastingPlayer * targetCastingPlayer,

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -29,9 +29,7 @@ namespace core {
 
 CastingPlayer * CastingPlayer::mTargetCastingPlayer = nullptr;
 
-// TODO: Verify why commissioningWindowTimeoutSec is a "unsigned long long int" type. Seems too big.
-void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCallbacks,
-                                                unsigned long long int commissioningWindowTimeoutSec,
+void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCallbacks, uint64_t commissioningWindowTimeoutSec,
                                                 IdentificationDeclarationOptions idOptions)
 {
     ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() called");
@@ -70,6 +68,25 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
         ChipLogProgress(
             AppServer,
             "CastingPlayer::VerifyOrEstablishConnection() CommissionerDeclarationCallback not provided in ConnectionCallbacks");
+    }
+
+    ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() verifying User Directed Commissioning (UDC) state");
+    mIdOptions.LogDetail();
+    if (!GetSupportsCommissionerGeneratedPasscode() && mIdOptions.mCommissionerPasscode)
+    {
+        ChipLogError(AppServer,
+                     "CastingPlayer::VerifyOrEstablishConnection() the target CastingPlayer doesn't support Commissioner-Generated "
+                     "passcode yet IdentificationDeclarationOptions.mCommissionerPasscode is set to true");
+        SuccessOrExit(err = CHIP_ERROR_INVALID_ARGUMENT);
+    }
+    if (!matter::casting::core::CommissionerDeclarationHandler::GetInstance()->HasCommissionerDeclarationCallback() &&
+        mIdOptions.mCommissionerPasscode)
+    {
+        ChipLogError(
+            AppServer,
+            "CastingPlayer::VerifyOrEstablishConnection() the CommissionerDeclarationHandler CommissionerDeclaration message "
+            "callback has not been set, yet IdentificationDeclarationOptions.mCommissionerPasscode is set to true");
+        SuccessOrExit(err = CHIP_ERROR_INVALID_ARGUMENT);
     }
 
     // If *this* CastingPlayer was previously connected to, its nodeId, fabricIndex and other attributes should be present
@@ -138,28 +155,11 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
     }
     else
     {
-        ChipLogProgress(AppServer,
-                        "CastingPlayer::VerifyOrEstablishConnection() verifying User Directed Commissioning (UDC) state");
-        mIdOptions.LogDetail();
-        SuccessOrExit(err = support::ChipDeviceEventHandler::SetUdcStatus(true));
-
-        if (!GetSupportsCommissionerGeneratedPasscode() && mIdOptions.mCommissionerPasscode)
-        {
-            ChipLogError(
-                AppServer,
-                "CastingPlayer::VerifyOrEstablishConnection() the target CastingPlayer doesn't support Commissioner-Generated "
-                "passcode yet IdentificationDeclarationOptions.mCommissionerPasscode is set to true");
-            SuccessOrExit(err = CHIP_ERROR_INVALID_ARGUMENT);
-        }
-        if (!matter::casting::core::CommissionerDeclarationHandler::GetInstance()->HasCommissionerDeclarationCallback() &&
-            mIdOptions.mCommissionerPasscode)
-        {
-            ChipLogError(AppServer,
-                         "CastingPlayer::VerifyOrEstablishConnection() the CommissionerDeclaration message callback has not been "
-                         "set yet IdentificationDeclarationOptions.mCommissionerPasscode is set to true");
-            SuccessOrExit(err = CHIP_ERROR_INVALID_ARGUMENT);
-        }
-
+        // We need to call OpenBasicCommissioningWindow() for both Commissionee-Generated passcode commissioning flow and
+        // Commissioner-Generated passcode commissioning flow. Per the Matter spec (UserDirectedCommissioning), even if the
+        // Commissionee sends an IdentificationDeclaration with CommissionerPasscode set to true, the Commissioner will first
+        // attempt to use AccountLogin in order to obtain Passcode using rotatingID. If no Passcode is obtained, Commissioner
+        // displays a Passcode.
         ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() calling OpenBasicCommissioningWindow()");
         SuccessOrExit(err = chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(
                           chip::System::Clock::Seconds16(mCommissioningWindowTimeoutSec)));
@@ -178,33 +178,19 @@ exit:
     }
 }
 
-void CastingPlayer::ContinueConnecting(ConnectionCallbacks connectionCallbacks,
-                                       unsigned long long int commissioningWindowTimeoutSec)
+void CastingPlayer::ContinueConnecting()
 {
     ChipLogProgress(AppServer, "CastingPlayer::ContinueConnecting()");
     CHIP_ERROR err = CHIP_NO_ERROR;
-    SuccessOrExit(err = support::ChipDeviceEventHandler::SetUdcStatus(true));
-    VerifyOrExit(
-        connectionCallbacks.mOnConnectionComplete != nullptr,
-        ChipLogError(AppServer, "CastingPlayer::ContinueConnecting() ConnectionCallbacks.mOnConnectionComplete was not provided"));
-    mConnectionState               = CASTING_PLAYER_CONNECTING;
-    mOnCompleted                   = connectionCallbacks.mOnConnectionComplete;
-    mCommissioningWindowTimeoutSec = commissioningWindowTimeoutSec;
-    mTargetCastingPlayer           = this;
-
-    // Register the handler for Commissioner's CommissionerDeclaration messages. The CommissionerDeclaration messages provide
-    // information indicating the Commissioner's pre-commissioning state.
-    if (connectionCallbacks.mCommissionerDeclarationCallback != nullptr)
+    // Verify that mOnCompleted is not nullptr.
+    VerifyOrExit(mOnCompleted != nullptr, ChipLogError(AppServer, "CastingPlayer::ContinueConnecting() mOnCompleted == nullptr"));
+    if (!matter::casting::core::CommissionerDeclarationHandler::GetInstance()->HasCommissionerDeclarationCallback())
     {
-        matter::casting::core::CommissionerDeclarationHandler::GetInstance()->SetCommissionerDeclarationCallback(
-            connectionCallbacks.mCommissionerDeclarationCallback);
+        ChipLogProgress(AppServer,
+                        "CastingPlayer::ContinueConnecting() CommissionerDeclaration message callback has not been set.");
     }
-    else
-    {
-        ChipLogProgress(
-            AppServer,
-            "CastingPlayer::VerifyOrEstablishConnection() CommissionerDeclarationCallback not provided in ConnectionCallbacks");
-    }
+    mConnectionState     = CASTING_PLAYER_CONNECTING;
+    mTargetCastingPlayer = this;
 
     ChipLogProgress(AppServer, "CastingPlayer::ContinueConnecting() calling OpenBasicCommissioningWindow()");
     SuccessOrExit(err = chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(
@@ -271,6 +257,8 @@ CHIP_ERROR CastingPlayer::SendUserDirectedCommissioningRequest()
                         ChipLogError(AppServer, "No IP Address found to send UDC request to"));
 
     chip::Protocols::UserDirectedCommissioning::IdentificationDeclaration id = mIdOptions.buildIdentificationDeclarationMessage();
+
+    ReturnErrorOnFailure(support::ChipDeviceEventHandler::SetUdcStatus(true));
 
     ReturnErrorOnFailure(chip::Server::GetInstance().SendUserDirectedCommissioningRequest(
         chip::Transport::PeerAddress::UDP(*ipAddressToUse, mAttributes.port, mAttributes.interfaceId), id));

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -390,9 +390,9 @@ void CastingPlayer::LogDetail() const
 }
 
 CastingPlayer::CastingPlayer(const CastingPlayer & other) :
-    mEndpoints(other.mEndpoints), mConnectionState(other.mConnectionState), mAttributes(other.mAttributes),
-    mIdOptions(other.mIdOptions), mCommissioningWindowTimeoutSec(other.mCommissioningWindowTimeoutSec),
-    mOnCompleted(other.mOnCompleted)
+    std::enable_shared_from_this<CastingPlayer>(other), mEndpoints(other.mEndpoints), mConnectionState(other.mConnectionState),
+    mAttributes(other.mAttributes), mIdOptions(other.mIdOptions),
+    mCommissioningWindowTimeoutSec(other.mCommissioningWindowTimeoutSec), mOnCompleted(other.mOnCompleted)
 {}
 
 CastingPlayer & CastingPlayer::operator=(const CastingPlayer & other)

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -38,8 +38,8 @@ namespace core {
 
 const int kPortMaxLength = 5; // port is uint16_t
 // +1 for the : between the hostname and the port.
-const int kIdMaxLength                                      = chip::Dnssd::kHostNameMaxLength + kPortMaxLength + 1;
-const unsigned long long int kCommissioningWindowTimeoutSec = 3 * 60; // 3 minutes
+const int kIdMaxLength                        = chip::Dnssd::kHostNameMaxLength + kPortMaxLength + 1;
+const uint64_t kCommissioningWindowTimeoutSec = 3 * 60; // 3 minutes
 
 /**
  * @brief Describes an Endpoint that the client wants to connect to
@@ -131,8 +131,8 @@ public:
      * TargetApp is not found in the on-device CastingStore.
      */
     void VerifyOrEstablishConnection(ConnectionCallbacks connectionCallbacks,
-                                     unsigned long long int commissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec,
-                                     IdentificationDeclarationOptions idOptions           = IdentificationDeclarationOptions());
+                                     uint64_t commissioningWindowTimeoutSec     = kCommissioningWindowTimeoutSec,
+                                     IdentificationDeclarationOptions idOptions = IdentificationDeclarationOptions());
 
     /**
      * @brief Continues the UDC process during the Commissioner-Generated passcode commissioning flow by sending a second
@@ -145,12 +145,10 @@ public:
      * CommissionableDataProvider
      * (matter::casting::core::CastingApp::GetInstance()->UpdateCommissionableDataProvider(CommissionableDataProvider)).
      *
-     * @param connectionCallbacks contains the ConnectCallback and CommissionerDeclarationCallback (Optional).
-     * @param commissioningWindowTimeoutSec (Optional) time (in sec) to keep the commissioning window open, if commissioning is
-     * required. Needs to be >= kCommissioningWindowTimeoutSec.
+     * The same connectionCallbacks and commissioningWindowTimeoutSec parameters passed in to VerifyOrEstablishConnection() will be
+     * used.
      */
-    void ContinueConnecting(ConnectionCallbacks connectionCallbacks,
-                            unsigned long long int commissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec);
+    void ContinueConnecting();
 
     /**
      * @brief Sets the internal connection state of this CastingPlayer to "disconnected"
@@ -220,8 +218,8 @@ private:
     CastingPlayerAttributes mAttributes;
     IdentificationDeclarationOptions mIdOptions;
     static CastingPlayer * mTargetCastingPlayer;
-    unsigned long long int mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
-    ConnectCallback mOnCompleted                          = {};
+    uint64_t mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
+    ConnectCallback mOnCompleted            = {};
 
     /**
      * @brief resets this CastingPlayer's state and calls mOnCompleted with the CHIP_ERROR. Also, after calling mOnCompleted, it

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
@@ -38,7 +38,7 @@ CommissionerDeclarationHandler * CommissionerDeclarationHandler::GetInstance()
 }
 
 // TODO: In the following PRs. Implement setHandler() for CommissionerDeclaration messages and expose messages to higher layers for
-// Linux(DONE), Android(pending) and iOS(pending).
+// Linux, Android and iOS.
 void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(
     const chip::Transport::PeerAddress & source, chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)
 {

--- a/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
@@ -145,6 +145,12 @@ public:
         }
         return nullptr;
     }
+
+    void LogDetail() const
+    {
+        ChipLogProgress(AppServer, "Endpoint::LogDetail() Endpoint ID: %d, Vendor ID: %d, Product ID: %d", mAttributes.mId,
+                        mAttributes.mVendorId, mAttributes.mProductId);
+    }
 };
 
 }; // namespace core


### PR DESCRIPTION
Linux tv-casting-app example app, addressed post merge comments on PR 33479 and changed the CastingPlayer endpoint for demo interactions.

**Change summary**

1.	In CastingPlayer.h, changed “const unsigned long long int kCommissioningWindowTimeoutSec” to “const uint16_t kCommissioningWindowTimeoutSec” per andy31415 from Google.
2.	In CastingPlayer.h, removed the parameters from ContinueConnecting() since we can use the parameters that were passed to VerifyOrEstablishConnection().
3.	Moved some error checking, verifying the IdentificationDeclarationOptions, in CastingPlayer.cpp which needs to be verified prior to the IsFailSafeArmed() check.
4.	In simple-app-helper.cpp added a gCommissionerGeneratedPasscodeFlow Boolean to control which Endpoint we perform demo interactions on. 
5.	Also, in simple-app-helper.cpp changed the connectedhomeip/examples/tv-app target app Vendor ID for the Commissioner Generated Passcode flow to (1111). The default target app Vendor ID previously used (65521) has Account Login implemented and would commission with that by default without displaying the Commissioner Generated Passcode.
6.     Added a copy constructor and assignment operator to CastingPlayer.h per sharadb-amazon request.

**Testing**

Verified and tested locally with the Linux, Android and iOS tv-casting-app example mobile apps, and the Linux tv-app (CastingPlayer). With the Linux example tv-casting-app app, we are able to successfully commission using the commissioner generated passcode flow as follows:

1.	Start tv-app:                connectedhomeip % ./out/tv-app/chip-tv-app
2.	Start tv-casting-app:   connectedhomeip % ./out/tv-casting-app/chip-tv-casting-app
3.	In tv-casting-app:       > cast request 0 commissioner-generated-passcode
4.	In tv-app:                    > controller ux ok
5.	Tv-app displays the commissioner-generated-passcode in hex: Casting passcode: [0x00BC_614E] or 12345678 in decimal.
7.	In tv-casting-app:       > cast setcommissionerpasscode 12345678
8.	The logs display “simple-app-helper.cpp::ConnectionHandler(): Successfully connected to CastingPlayer (ID: 88665A3712045650) using Commissioner-Generated passcode

