### PR TITLE
Error failed: Success (!) in logs

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -478,7 +478,7 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
     {
         CHIP_ERROR err = mTransportMgr->SendMessage(*destination, std::move(msgBuf));
 #if CHIP_ERROR_LOGGING
-        if (!IsSuccess(err))
+        if (!chip::ChipError::IsSuccess(err))
         {
             char addressStr[Transport::PeerAddress::kMaxToStringSize] = { 0 };
             destination->ToString(addressStr);

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -478,7 +478,7 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
     {
         CHIP_ERROR err = mTransportMgr->SendMessage(*destination, std::move(msgBuf));
 #if CHIP_ERROR_LOGGING
-        if (err != CHIP_NO_ERROR)
+        if (!IsSuccess(err))
         {
             char addressStr[Transport::PeerAddress::kMaxToStringSize] = { 0 };
             destination->ToString(addressStr);


### PR DESCRIPTION
Logs show this constantly, which makes it hard to parse for just errors:

* Error                  | 2024-04-19 07:18:15.028262-0700 | com.csa.matter                 | Inet                           | SendMessage() to UDP:[fd55:7e52:e56f:1:97a5:a2d0:34fb:8f1b]:5540 failed: src/inet/UDPEndPoint.cpp:121: Success
* Error                  | 2024-04-19 07:18:15.449594-0700 | com.csa.matter                 | Inet                           | SendMessage() to UDP:[fd55:7e52:e56f:1:86a1:4c3f:e4cf:4332]:5540 failed: src/inet/UDPEndPoint.cpp:121: Success
* Error                  | 2024-04-19 07:18:16.003170-0700 | com.csa.matter                 | Inet                           | SendMessage() to UDP:[fd55:7e52:e56f:1:97a5:a2d0:34fb:8f1b]:5540 failed: src/inet/UDPEndPoint.cpp:121: Success

