### PR TITLE
[NXP] Add crc to requirements

### DIFF
--- a/scripts/setup/requirements.nxp.txt
+++ b/scripts/setup/requirements.nxp.txt
@@ -1,3 +1,4 @@
+crc>=7.0.0
 jsonschema>=4.17.0
 pycrypto>=2.6.1
 pycryptodome>=3.20.0


### PR DESCRIPTION
Add `crc` module to the NXP python requirements file.