### PR TITLE
Compilation error fix source location in CHIPError

### DIFF
--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -132,7 +132,7 @@ public:
      *  The result is valid only if CanEncapsulate() is true.
      */
     constexpr ChipError(Range range, ValueType value) : ChipError(range, value, /*file=*/nullptr, /*line=*/0) {}
-#if __cplusplus >= 202002L
+#if CHIP_CONFIG_ERROR_SOURCE && __cplusplus >= 202002L
     constexpr ChipError(Range range, ValueType value, const char * file, unsigned int line,
                         std::source_location location = std::source_location::current()) :
         mError(MakeInteger(range, (value & MakeMask(0, kValueLength)))) CHIP_INITIALIZE_ERROR_SOURCE(file, line, location)
@@ -141,7 +141,7 @@ public:
     constexpr ChipError(Range range, ValueType value, const char * file, unsigned int line) :
         mError(MakeInteger(range, (value & MakeMask(0, kValueLength)))) CHIP_INITIALIZE_ERROR_SOURCE(file, line, /*loc=*/nullptr)
     {}
-#endif // __cplusplus >= 202002L
+#endif // CHIP_CONFIG_ERROR_SOURCE && __cplusplus >= 202002L
 
     /**
      * Construct a CHIP_ERROR for SdkPart @a part with @a code.
@@ -150,7 +150,7 @@ public:
      *  The macro version CHIP_SDK_ERROR checks that the numeric value is constant and well-formed.
      */
     constexpr ChipError(SdkPart part, uint8_t code) : ChipError(part, code, /*file=*/nullptr, /*line=*/0) {}
-#if __cplusplus >= 202002L
+#if CHIP_CONFIG_ERROR_SOURCE && __cplusplus >= 202002L
     constexpr ChipError(SdkPart part, uint8_t code, const char * file, unsigned int line,
                         std::source_location location = std::source_location::current()) :
         mError(MakeInteger(part, code)) CHIP_INITIALIZE_ERROR_SOURCE(file, line, location)
@@ -159,7 +159,7 @@ public:
     constexpr ChipError(SdkPart part, uint8_t code, const char * file, unsigned int line) :
         mError(MakeInteger(part, code)) CHIP_INITIALIZE_ERROR_SOURCE(file, line, /*loc=*/nullptr)
     {}
-#endif // __cplusplus >= 202002L
+#endif // CHIP_CONFIG_ERROR_SOURCE && __cplusplus >= 202002L
 
     /**
      * Construct a CHIP_ERROR constant for SdkPart @a part with @a code at the current source line.
@@ -180,7 +180,7 @@ public:
      *  This is intended to be used only in foreign function interfaces.
      */
     explicit constexpr ChipError(StorageType error) : ChipError(error, /*file=*/nullptr, /*line=*/0) {}
-#if __cplusplus >= 202002L
+#if CHIP_CONFIG_ERROR_SOURCE && __cplusplus >= 202002L
     explicit constexpr ChipError(StorageType error, const char * file, unsigned int line,
                                  std::source_location location = std::source_location::current()) :
         mError(error) CHIP_INITIALIZE_ERROR_SOURCE(file, line, location)
@@ -189,7 +189,7 @@ public:
     explicit constexpr ChipError(StorageType error, const char * file, unsigned int line) :
         mError(error) CHIP_INITIALIZE_ERROR_SOURCE(file, line, /*loc=*/nullptr)
     {}
-#endif // __cplusplus >= 202002L
+#endif // CHIP_CONFIG_ERROR_SOURCE && __cplusplus >= 202002L
 
 #undef CHIP_INITIALIZE_ERROR_SOURCE
 


### PR DESCRIPTION
Problem:

Compilation issue when cpp standard is greater than 20 and CHIP_CONFIG_ERROR_SOURCE is undefined  

![image](https://github.com/project-chip/connectedhomeip/assets/40396600/68eb762b-d181-4c3e-966b-8a74397c64a4)

Fix: Correct constuctor defines similar to import