### PR TITLE
[ESP32] Remove the Lambda function from ConnectivityManager implementation.

### DIFF
--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -780,7 +780,7 @@ void ConnectivityManagerImpl::ChangeWiFiStationState(WiFiStationState newState)
         ChipLogProgress(DeviceLayer, "WiFi station state change: %s -> %s", WiFiStationStateToStr(mWiFiStationState),
                         WiFiStationStateToStr(newState));
         mWiFiStationState = newState;
-        SystemLayer().ScheduleLambda([]() { NetworkCommissioning::ESPWiFiDriver::GetInstance().OnNetworkStatusChange(); });
+        NetworkCommissioning::ESPWiFiDriver::GetInstance().OnNetworkStatusChange();
     }
 }
 


### PR DESCRIPTION
**Change Overview:**
- Removed  ScheduleLambda function  in ESP32 ConnectivityManager to decrease the size of event queue on the platform.
- Both the ScheduleLambda and OnNetworkStatusChange run in the CHIP context  irrespective of the lambda function.

**Testing**
- Tested the lighting-app esp32 and commissioned and controlled the device successfully.
- Tested for the functionality for OnNetworkStatusChange with and without scheduling the lamda. 


