### PR TITLE
remove provisional from boolean state configuration and valve config clusters

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -3752,7 +3752,7 @@ cluster ActivatedCarbonFilterMonitoring = 114 {
 }
 
 /** This cluster is used to configure a boolean sensor. */
-provisional cluster BooleanStateConfiguration = 128 {
+cluster BooleanStateConfiguration = 128 {
   revision 1;
 
   bitmap AlarmModeBitmap : bitmap8 {
@@ -3810,7 +3810,7 @@ provisional cluster BooleanStateConfiguration = 128 {
 }
 
 /** This cluster is used to configure a valve. */
-provisional cluster ValveConfigurationAndControl = 129 {
+cluster ValveConfigurationAndControl = 129 {
   revision 1;
 
   enum StatusCodeEnum : enum8 {

--- a/src/app/zap-templates/zcl/data-model/chip/boolean-state-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/boolean-state-configuration-cluster.xml
@@ -28,7 +28,7 @@ limitations under the License.
     <field name="GeneralFault" mask="0x1"/>
   </bitmap>
 
-  <cluster apiMaturity="provisional">
+  <cluster>
     <domain>General</domain>
     <name>Boolean State Configuration</name>
     <code>0x0080</code>

--- a/src/app/zap-templates/zcl/data-model/chip/valve-configuration-and-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/valve-configuration-and-control-cluster.xml
@@ -40,7 +40,7 @@ limitations under the License.
      <item name="FailureDueToFault" value="0x02"/>
   </enum>
 
-  <cluster apiMaturity="provisional">
+  <cluster>
     <domain>HVAC</domain>
     <name>Valve Configuration and Control</name>
     <code>0x0081</code>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -3988,7 +3988,7 @@ cluster ActivatedCarbonFilterMonitoring = 114 {
 }
 
 /** This cluster is used to configure a boolean sensor. */
-provisional cluster BooleanStateConfiguration = 128 {
+cluster BooleanStateConfiguration = 128 {
   revision 1;
 
   bitmap AlarmModeBitmap : bitmap8 {
@@ -4046,7 +4046,7 @@ provisional cluster BooleanStateConfiguration = 128 {
 }
 
 /** This cluster is used to configure a valve. */
-provisional cluster ValveConfigurationAndControl = 129 {
+cluster ValveConfigurationAndControl = 129 {
   revision 1;
 
   enum StatusCodeEnum : enum8 {


### PR DESCRIPTION
PR removes provisional tags from boolean state configuration and valve config and control clusters