### PR TITLE
ESP32: Lock Thread stack before calling GenericOpenThread::DoInit()

### DIFF
--- a/src/platform/ESP32/ThreadStackManagerImpl.cpp
+++ b/src/platform/ESP32/ThreadStackManagerImpl.cpp
@@ -52,8 +52,12 @@ ThreadStackManagerImpl ThreadStackManagerImpl::sInstance;
 
 CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 {
+    CHIP_ERROR err = CHIP_NO_ERROR;
     openthread_init_stack();
-    return GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(esp_openthread_get_instance());
+    _LockThreadStack();
+    err = GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(esp_openthread_get_instance());
+    _UnlockThreadStack();
+    return err;
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_StartThreadTask()


### PR DESCRIPTION
Lock Thread stack when calling `GenericThreadStackManagerImpl_OpenThread::DoInit()` for ESP32 platform.
