### PR TITLE
Fix for test hanging when no ProductID/VendorID is present

### DIFF
--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -2804,8 +2804,8 @@ TEST_F(TestChipCryptoPAL, TestVIDPID_x509Extraction)
         AttestationCertVidPid vidpid;
         CHIP_ERROR result = ExtractVIDPIDFromX509Cert(testCase.cert, vidpid);
         EXPECT_EQ(result, testCase.expectedResult);
-        EXPECT_EQ(vidpid.mVendorId.HasValue(), testCase.expectedVidPresent);
-        EXPECT_EQ(vidpid.mProductId.HasValue(), testCase.expectedPidPresent);
+        ASSERT_EQ(vidpid.mVendorId.HasValue(), testCase.expectedVidPresent);
+        ASSERT_EQ(vidpid.mProductId.HasValue(), testCase.expectedPidPresent);
 
         // If present, make sure the VID matches expectation.
         if (testCase.expectedVidPresent)


### PR DESCRIPTION
TestChipCryptoPAL is hanging when no Product ID or Vendor ID is present during TestVIDPID_x509Extraction. Wrong value is checked
