### PR TITLE
Use a valid command id in TC_IDM_1_4.py

### DIFF
--- a/src/python_testing/TC_IDM_1_4.py
+++ b/src/python_testing/TC_IDM_1_4.py
@@ -74,7 +74,11 @@ class TC_IDM_1_4(MatterBaseTest):
         cap_for_batch_commands = 100
         number_of_commands_to_send = min(max_paths_per_invoke + 1, cap_for_batch_commands)
 
+        # Use a valid (according to MEI definition) command-id (in this case belonging to Test Vendor MC with prefix 0xfff4)
+        # which should never be existing on a prodiction device. We use this decodable id to prevent hitting issues with the
+        # specification being not clearly defined in respect to decoding vs processing the invoke requests.
         invalid_command_id = 0xfff4_00ff
+
         list_of_commands_to_send = []
         for endpoint_index in range(number_of_commands_to_send):
             # Using Toggle command to form the base as it is a command that doesn't take

--- a/src/python_testing/TC_IDM_1_4.py
+++ b/src/python_testing/TC_IDM_1_4.py
@@ -74,7 +74,7 @@ class TC_IDM_1_4(MatterBaseTest):
         cap_for_batch_commands = 100
         number_of_commands_to_send = min(max_paths_per_invoke + 1, cap_for_batch_commands)
 
-        invalid_command_id = 0xffff_ffff
+        invalid_command_id = 0xfff4_00ff
         list_of_commands_to_send = []
         for endpoint_index in range(number_of_commands_to_send):
             # Using Toggle command to form the base as it is a command that doesn't take


### PR DESCRIPTION
The test TC_IDM_1_4.py used 0xffff_ffff as test command id. In fact this is not valid MEI according to specification.

While chip seems to validate this fact later the test works.

In matter.js such datatype validations are handled earlier and thats why we throw an constraint error because the value is wrong data type wise. 

I did not found any place in the specification where it is defined when such "semantic" data value checks should be done (unless some very specific error cases in some adapters).

I think this is a theoretical topic in this case because it will hopefully never happen in real live devices 8and when it does the exact error should be irrelevant) for this test it matters because the test fails.

With the change of the command ID to be a still unknown, but valid, value the issue is gone. I also think that tests should still use basically "correct" values. ;-)

Thank you for considering this change.
