### PR TITLE
Remove provisional from evse, evse mode, epm, eem, power topology

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -3876,7 +3876,7 @@ cluster ValveConfigurationAndControl = 129 {
 }
 
 /** This cluster provides a mechanism for querying data about electrical power as measured by the server. */
-provisional cluster ElectricalPowerMeasurement = 144 {
+cluster ElectricalPowerMeasurement = 144 {
   revision 1;
 
   enum MeasurementTypeEnum : enum16 {
@@ -3981,7 +3981,7 @@ provisional cluster ElectricalPowerMeasurement = 144 {
 }
 
 /** This cluster provides a mechanism for querying data about the electrical energy imported or provided by the server. */
-provisional cluster ElectricalEnergyMeasurement = 145 {
+cluster ElectricalEnergyMeasurement = 145 {
   revision 1;
 
   enum MeasurementTypeEnum : enum16 {
@@ -4278,7 +4278,7 @@ provisional cluster DeviceEnergyManagement = 152 {
 }
 
 /** Electric Vehicle Supply Equipment (EVSE) is equipment used to charge an Electric Vehicle (EV) or Plug-In Hybrid Electric Vehicle. This cluster provides an interface to the functionality of Electric Vehicle Supply Equipment (EVSE) management. */
-provisional cluster EnergyEvse = 153 {
+cluster EnergyEvse = 153 {
   revision 2;
 
   enum EnergyTransferStoppedReasonEnum : enum8 {
@@ -4490,7 +4490,7 @@ provisional cluster EnergyPreference = 155 {
 }
 
 /** The Power Topology Cluster provides a mechanism for expressing how power is flowing between endpoints. */
-provisional cluster PowerTopology = 156 {
+cluster PowerTopology = 156 {
   revision 1;
 
   bitmap Feature : bitmap32 {
@@ -4511,7 +4511,7 @@ provisional cluster PowerTopology = 156 {
 }
 
 /** Attributes and commands for selecting a mode from a list of supported options. */
-provisional cluster EnergyEvseMode = 157 {
+cluster EnergyEvseMode = 157 {
   revision 1;
 
   enum ModeTag : enum16 {

--- a/examples/energy-management-app/energy-management-common/energy-management-app.matter
+++ b/examples/energy-management-app/energy-management-common/energy-management-app.matter
@@ -1237,7 +1237,7 @@ cluster GroupKeyManagement = 63 {
 }
 
 /** This cluster provides a mechanism for querying data about electrical power as measured by the server. */
-provisional cluster ElectricalPowerMeasurement = 144 {
+cluster ElectricalPowerMeasurement = 144 {
   revision 1;
 
   enum MeasurementTypeEnum : enum16 {
@@ -1342,7 +1342,7 @@ provisional cluster ElectricalPowerMeasurement = 144 {
 }
 
 /** This cluster provides a mechanism for querying data about the electrical energy imported or provided by the server. */
-provisional cluster ElectricalEnergyMeasurement = 145 {
+cluster ElectricalEnergyMeasurement = 145 {
   revision 1;
 
   enum MeasurementTypeEnum : enum16 {
@@ -1639,7 +1639,7 @@ provisional cluster DeviceEnergyManagement = 152 {
 }
 
 /** Electric Vehicle Supply Equipment (EVSE) is equipment used to charge an Electric Vehicle (EV) or Plug-In Hybrid Electric Vehicle. This cluster provides an interface to the functionality of Electric Vehicle Supply Equipment (EVSE) management. */
-provisional cluster EnergyEvse = 153 {
+cluster EnergyEvse = 153 {
   revision 2;
 
   enum EnergyTransferStoppedReasonEnum : enum8 {
@@ -1817,7 +1817,7 @@ provisional cluster EnergyEvse = 153 {
 }
 
 /** The Power Topology Cluster provides a mechanism for expressing how power is flowing between endpoints. */
-provisional cluster PowerTopology = 156 {
+cluster PowerTopology = 156 {
   revision 1;
 
   bitmap Feature : bitmap32 {
@@ -1838,7 +1838,7 @@ provisional cluster PowerTopology = 156 {
 }
 
 /** Attributes and commands for selecting a mode from a list of supported options. */
-provisional cluster EnergyEvseMode = 157 {
+cluster EnergyEvseMode = 157 {
   revision 1;
 
   enum ModeTag : enum16 {

--- a/src/app/zap-templates/zcl/data-model/chip/electrical-energy-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/electrical-energy-measurement-cluster.xml
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 <configurator>
   <domain name="CHIP"/>
-  <cluster apiMaturity="provisional">
+  <cluster>
     <name>Electrical Energy Measurement</name>
     <domain>Measurement &amp; Sensing</domain>
     <code>0x0091</code>
@@ -52,25 +52,25 @@ limitations under the License.
     <attribute code="0x0004" side="server" define="PERIODIC_ENERGY_EXPORTED" type="EnergyMeasurementStruct" isNullable="true" optional="true">PeriodicEnergyExported</attribute>
     <attribute code="0x0005" side="server" define="CUMULATIVE_ENERGY_RESET" type="CumulativeEnergyResetStruct" isNullable="true" optional="true">CumulativeEnergyReset</attribute>
     <!--Conformance feature EXPE & PERE - for now optional-->
-    <event code="0x00" side="server" name="CumulativeEnergyMeasured" priority="info" apiMaturity="provisional" optional="true">
+    <event code="0x00" side="server" name="CumulativeEnergyMeasured" priority="info" optional="true">
       <description>CumulativeEnergyMeasured</description>
       <field id="0" name="EnergyImported" type="EnergyMeasurementStruct" optional="true"/>
       <field id="1" name="EnergyExported" type="EnergyMeasurementStruct" optional="true"/>
     </event>
-    <event code="0x01" side="server" name="PeriodicEnergyMeasured" priority="info" apiMaturity="provisional" optional="true">
+    <event code="0x01" side="server" name="PeriodicEnergyMeasured" priority="info" optional="true">
       <description>PeriodicEnergyMeasured</description>
       <field id="0" name="EnergyImported" type="EnergyMeasurementStruct" optional="true"/>
       <field id="1" name="EnergyExported" type="EnergyMeasurementStruct" optional="true"/>
     </event>
   </cluster>
-  <struct name="CumulativeEnergyResetStruct" apiMaturity="provisional">
+  <struct name="CumulativeEnergyResetStruct">
     <cluster code="0x0091"/>
     <item fieldId="0" name="ImportedResetTimestamp" type="epoch_s" isNullable="true" optional="true"/>
     <item fieldId="1" name="ExportedResetTimestamp" type="epoch_s" isNullable="true" optional="true"/>
     <item fieldId="2" name="ImportedResetSystime" type="systime_ms" isNullable="true" optional="true"/>
     <item fieldId="3" name="ExportedResetSystime" type="systime_ms" isNullable="true" optional="true"/>
   </struct>
-  <struct name="EnergyMeasurementStruct" apiMaturity="provisional">
+  <struct name="EnergyMeasurementStruct">
     <cluster code="0x0091"/>
     <item fieldId="0" name="Energy" type="energy_mwh" min="0" max="4611686018427387904"/>
     <item fieldId="1" name="StartTimestamp" type="epoch_s" optional="true"/>

--- a/src/app/zap-templates/zcl/data-model/chip/electrical-power-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/electrical-power-measurement-cluster.xml
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 <configurator>
   <domain name="CHIP"/>
-  <cluster apiMaturity="provisional">
+  <cluster>
     <name>Electrical Power Measurement</name>
     <domain>Measurement &amp; Sensing</domain>
     <code>0x0090</code>
@@ -82,18 +82,18 @@ limitations under the License.
     <!--Conformance feature [POLY] - for now optional-->
     <attribute code="0x0011" side="server" define="POWER_FACTOR" type="int64s" isNullable="true" min="-10000" max="10000" optional="true">PowerFactor</attribute>
     <attribute code="0x0012" side="server" type="amperage_ma" define="NEUTRAL_CURRENT" isNullable="true" min="-4611686018427387904" max="4611686018427387904" optional="true">NeutralCurrent</attribute>
-    <event code="0x00" side="server" name="MeasurementPeriodRanges" priority="info" apiMaturity="provisional" optional="true">
+    <event code="0x00" side="server" name="MeasurementPeriodRanges" priority="info" optional="true">
       <description>MeasurementPeriodRanges</description>
       <field id="0" name="Ranges" array="true" type="MeasurementRangeStruct"/>
     </event>
   </cluster>
-  <enum name="PowerModeEnum" type="enum8" apiMaturity="provisional">
+  <enum name="PowerModeEnum" type="enum8">
     <cluster code="0x0090"/>
     <item name="Unknown" value="0x00"/>
     <item name="DC" value="0x01"/>
     <item name="AC" value="0x02"/>
   </enum>
-  <struct name="MeasurementRangeStruct" apiMaturity="provisional">
+  <struct name="MeasurementRangeStruct">
     <cluster code="0x0090"/>
     <item fieldId="0" name="MeasurementType" type="MeasurementTypeEnum" min="0x0000" max="0x000E"/>
     <item fieldId="1" name="Min" type="int64s" min="-4611686018427387904" max="4611686018427387904"/>
@@ -107,7 +107,7 @@ limitations under the License.
     <item fieldId="9" name="MinSystime" type="systime_ms" optional="true"/>
     <item fieldId="10" name="MaxSystime" type="systime_ms" optional="true"/>
   </struct>
-  <struct name="HarmonicMeasurementStruct" apiMaturity="provisional">
+  <struct name="HarmonicMeasurementStruct">
     <cluster code="0x0090"/>
     <item fieldId="0" name="Order" type="int8u" min="1" default="1"/>
     <item fieldId="1" name="Measurement" type="int64s" min="-4611686018427387904" max="4611686018427387904" isNullable="true"/>

--- a/src/app/zap-templates/zcl/data-model/chip/energy-evse-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-evse-cluster.xml
@@ -14,7 +14,7 @@ limitations under the License.
 <configurator>
   <domain name="Energy Management"/>
 
-  <enum name="StateEnum" type="enum8" apiMaturity="provisional">
+  <enum name="StateEnum" type="enum8">
     <cluster code="0x0099"/>
     <item name="NotPluggedIn" value="0x00"/>
     <item name="PluggedInNoDemand" value="0x01"/>
@@ -25,7 +25,7 @@ limitations under the License.
     <item name="Fault" value="0x06"/>
   </enum>
 
-  <enum name="SupplyStateEnum" type="enum8" apiMaturity="provisional">
+  <enum name="SupplyStateEnum" type="enum8">
     <cluster code="0x0099"/>
     <item name="Disabled" value="0x00"/>
     <item name="ChargingEnabled" value="0x01"/>
@@ -34,7 +34,7 @@ limitations under the License.
     <item name="DisabledDiagnostics" value="0x04"/>
   </enum>
 
-  <enum name="FaultStateEnum" type="enum8" apiMaturity="provisional">
+  <enum name="FaultStateEnum" type="enum8">
     <cluster code="0x0099"/>
     <item name="NoError" value="0x00"/>
     <item name="MeterFailure" value="0x01"/>
@@ -55,7 +55,7 @@ limitations under the License.
     <item name="Other" value="0xFF"/>
   </enum>
 
-  <enum name="EnergyTransferStoppedReasonEnum" type="enum8" apiMaturity="provisional">
+  <enum name="EnergyTransferStoppedReasonEnum" type="enum8">
     <cluster code="0x0099"/>
     <item name="EVStopped" value="0x00"/>
     <item name="EVSEStopped" value="0x01"/>
@@ -86,7 +86,7 @@ limitations under the License.
     <item fieldId="1" name="ChargingTargets" array="true" type="ChargingTargetStruct" length="10"/>
   </struct>
 
-  <cluster apiMaturity="provisional">
+  <cluster>
     <name>Energy EVSE</name>
     <domain>Energy Management</domain>
     <code>0x0099</code>
@@ -177,7 +177,7 @@ limitations under the License.
     <command source="client" code="0x01" name="Disable" optional="false" mustUseTimedInvoke="true" apiMaturity="provisional">
       <description>Allows a client to disable the EVSE from charging and discharging.</description>
     </command>
-    <command source="client" code="0x02" name="EnableCharging" optional="false" mustUseTimedInvoke="true" apiMaturity="provisional">
+    <command source="client" code="0x02" name="EnableCharging" optional="false" mustUseTimedInvoke="true">
       <arg name="ChargingEnabledUntil" type="epoch_s" isNullable="true"/>
       <arg name="MinimumChargeCurrent" type="amperage_ma" min="0" max="80000"/>
       <arg name="MaximumChargeCurrent" type="amperage_ma" min="0" max="80000"/>
@@ -188,7 +188,7 @@ limitations under the License.
       <arg name="MaximumDischargeCurrent" type="amperage_ma" min="0" max="80000"/>
       <description>Allows a client to enable the EVSE to discharge an EV.</description>
     </command>
-    <command source="client" code="0x04" name="StartDiagnostics" optional="true" mustUseTimedInvoke="true" apiMaturity="provisional">
+    <command source="client" code="0x04" name="StartDiagnostics" optional="true" mustUseTimedInvoke="true">
       <description>Allows a client to put the EVSE into a self-diagnostics mode.</description>
     </command>
     <command source="client" code="0x05" name="SetTargets" optional="true" mustUseTimedInvoke="true" apiMaturity="provisional">
@@ -205,41 +205,41 @@ limitations under the License.
       <arg name="ChargingTargetSchedules" type="ChargingTargetScheduleStruct" array="true" length="7"/>
       <description>The GetTargetsResponse is sent in response to the GetTargets Command.</description>
     </command>
-    <event side="server" code="0x00" name="EVConnected" priority="info" apiMaturity="provisional">
+    <event side="server" code="0x00" name="EVConnected" priority="info">
       <description>EVConnected</description>
-      <field id="0" name="SessionID" type="int32u" apiMaturity="provisional"/>
+      <field id="0" name="SessionID" type="int32u"/>
     </event>
-    <event side="server" code="0x01" name="EVNotDetected" priority="info" apiMaturity="provisional">
+    <event side="server" code="0x01" name="EVNotDetected" priority="info">
       <description>EVNotDetected</description>
-      <field id="0" name="SessionID" type="int32u" apiMaturity="provisional"/>
-      <field id="1" name="State" type="StateEnum" apiMaturity="provisional" min="0x00" max="0x06"/>
-      <field id="2" name="SessionDuration" type="elapsed_s" apiMaturity="provisional"/>
-      <field id="3" name="SessionEnergyCharged" type="energy_mwh" min="0" apiMaturity="provisional"/>
+      <field id="0" name="SessionID" type="int32u"/>
+      <field id="1" name="State" type="StateEnum" min="0x00" max="0x06"/>
+      <field id="2" name="SessionDuration" type="elapsed_s" apiMaturit/>
+      <field id="3" name="SessionEnergyCharged" type="energy_mwh" min="0"/>
       <field id="4" name="SessionEnergyDischarged" type="energy_mwh" min="0" optional="true" apiMaturity="provisional"/>
     </event>
-    <event side="server" code="0x02" name="EnergyTransferStarted" priority="info" apiMaturity="provisional">
+    <event side="server" code="0x02" name="EnergyTransferStarted" priority="info">
       <description>EnergyTransferStarted</description>
-      <field id="0" name="SessionID" type="int32u" apiMaturity="provisional"/>
-      <field id="1" name="State" type="StateEnum" apiMaturity="provisional" min="0x00" max="0x06"/>
-      <field id="2" name="MaximumCurrent" type="amperage_ma" min="0" max="80000" apiMaturity="provisional"/>
+      <field id="0" name="SessionID" type="int32u"/>
+      <field id="1" name="State" type="StateEnum" min="0x00" max="0x06"/>
+      <field id="2" name="MaximumCurrent" type="amperage_ma" min="0" max="80000"/>
     </event>
-    <event side="server" code="0x03" name="EnergyTransferStopped" priority="info" apiMaturity="provisional">
+    <event side="server" code="0x03" name="EnergyTransferStopped" priority="info">
       <description>EnergyTransferStopped</description>
-      <field id="0" name="SessionID" type="int32u" apiMaturity="provisional"/>
-      <field id="1" name="State" type="StateEnum" apiMaturity="provisional" min="0x00" max="0x06"/>
-      <field id="2" name="Reason" type="EnergyTransferStoppedReasonEnum" apiMaturity="provisional" min="0x00" max="0x02"/>
-      <field id="4" name="EnergyTransferred" type="energy_mwh" min="0" apiMaturity="provisional"/>
+      <field id="0" name="SessionID" type="int32u"/>
+      <field id="1" name="State" type="StateEnum" min="0x00" max="0x06"/>
+      <field id="2" name="Reason" type="EnergyTransferStoppedReasonEnum" min="0x00" max="0x02"/>
+      <field id="4" name="EnergyTransferred" type="energy_mwh" min="0"/>
     </event>
-    <event side="server" code="0x04" name="Fault" priority="critical" apiMaturity="provisional">
+    <event side="server" code="0x04" name="Fault" priority="critical">
       <description>Fault</description>
-      <field id="0" name="SessionID" type="int32u" isNullable="true" apiMaturity="provisional"/>
-      <field id="1" name="State" type="StateEnum" apiMaturity="provisional" min="0x00" max="0x06"/>
-      <field id="2" name="FaultStatePreviousState" type="FaultStateEnum" apiMaturity="provisional" min="0x00" max="0xFF"/>
-      <field id="4" name="FaultStateCurrentState" type="FaultStateEnum" apiMaturity="provisional" min="0x00" max="0xFF"/>
+      <field id="0" name="SessionID" type="int32u" isNullable="true"/>
+      <field id="1" name="State" type="StateEnum" min="0x00" max="0x06"/>
+      <field id="2" name="FaultStatePreviousState" type="FaultStateEnum" min="0x00" max="0xFF"/>
+      <field id="4" name="FaultStateCurrentState" type="FaultStateEnum" min="0x00" max="0xFF"/>
     </event>
-    <event side="server" code="0x05" name="RFID" priority="info" apiMaturity="provisional" optional="true">
+    <event side="server" code="0x05" name="RFID" priority="info" optional="true">
       <description>RFID</description>
-      <field id="0" name="UID" type="octet_string" length="10" apiMaturity="provisional"/>
+      <field id="0" name="UID" type="octet_string" length="10"/>
     </event>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/energy-evse-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-evse-cluster.xml
@@ -213,7 +213,7 @@ limitations under the License.
       <description>EVNotDetected</description>
       <field id="0" name="SessionID" type="int32u"/>
       <field id="1" name="State" type="StateEnum" min="0x00" max="0x06"/>
-      <field id="2" name="SessionDuration" type="elapsed_s" apiMaturit/>
+      <field id="2" name="SessionDuration" type="elapsed_s"/>
       <field id="3" name="SessionEnergyCharged" type="energy_mwh" min="0"/>
       <field id="4" name="SessionEnergyDischarged" type="energy_mwh" min="0" optional="true" apiMaturity="provisional"/>
     </event>

--- a/src/app/zap-templates/zcl/data-model/chip/energy-evse-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-evse-mode-cluster.xml
@@ -24,7 +24,7 @@ limitations under the License.
     <item value="0x4002" name="SolarCharging"/>
   </enum>
 
-  <cluster apiMaturity="provisional">
+  <cluster>
     <domain>General</domain>
     <name>Energy EVSE Mode</name>
     <code>0x009D</code>

--- a/src/app/zap-templates/zcl/data-model/chip/power-topology-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/power-topology-cluster.xml
@@ -17,7 +17,7 @@ limitations under the License.
 <configurator>
   <domain name="Measurement &amp; Sensing"/>
 
-  <cluster code="0x009C" apiMaturity="provisional">
+  <cluster code="0x009C">
     <domain>Measurement &amp; Sensing</domain>
     <name>Power Topology</name>
     <code>0x009C</code>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -4112,7 +4112,7 @@ cluster ValveConfigurationAndControl = 129 {
 }
 
 /** This cluster provides a mechanism for querying data about electrical power as measured by the server. */
-provisional cluster ElectricalPowerMeasurement = 144 {
+cluster ElectricalPowerMeasurement = 144 {
   revision 1;
 
   enum MeasurementTypeEnum : enum16 {
@@ -4217,7 +4217,7 @@ provisional cluster ElectricalPowerMeasurement = 144 {
 }
 
 /** This cluster provides a mechanism for querying data about the electrical energy imported or provided by the server. */
-provisional cluster ElectricalEnergyMeasurement = 145 {
+cluster ElectricalEnergyMeasurement = 145 {
   revision 1;
 
   enum MeasurementTypeEnum : enum16 {
@@ -4803,7 +4803,7 @@ provisional cluster DeviceEnergyManagement = 152 {
 }
 
 /** Electric Vehicle Supply Equipment (EVSE) is equipment used to charge an Electric Vehicle (EV) or Plug-In Hybrid Electric Vehicle. This cluster provides an interface to the functionality of Electric Vehicle Supply Equipment (EVSE) management. */
-provisional cluster EnergyEvse = 153 {
+cluster EnergyEvse = 153 {
   revision 2;
 
   enum EnergyTransferStoppedReasonEnum : enum8 {
@@ -5015,7 +5015,7 @@ provisional cluster EnergyPreference = 155 {
 }
 
 /** The Power Topology Cluster provides a mechanism for expressing how power is flowing between endpoints. */
-provisional cluster PowerTopology = 156 {
+cluster PowerTopology = 156 {
   revision 1;
 
   bitmap Feature : bitmap32 {
@@ -5036,7 +5036,7 @@ provisional cluster PowerTopology = 156 {
 }
 
 /** Attributes and commands for selecting a mode from a list of supported options. */
-provisional cluster EnergyEvseMode = 157 {
+cluster EnergyEvseMode = 157 {
   revision 1;
 
   enum ModeTag : enum16 {


### PR DESCRIPTION
Per slack discussion - several cluster in 1.3 are no longer provisional. This PR changes:

- src/app/zap-templates/zcl/data-model/chip/electrical-energy-measurement-cluster.xml
- src/app/zap-templates/zcl/data-model/chip/electrical-power-measurement-cluster.xml
- src/app/zap-templates/zcl/data-model/chip/energy-evse-cluster.xml
- src/app/zap-templates/zcl/data-model/chip/energy-evse-mode-cluster.xml
- src/app/zap-templates/zcl/data-model/chip/power-topology-cluster.xml

Note in EEVSE - there are still some aspects (features) which are provisional and these have been left as such.