### PR TITLE
Do not set up subscription when setting a delegate for a MTRDevice wi…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -690,7 +690,8 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     MTR_LOG_INFO("%@ setDelegate %@", self, delegate);
 
     // We should not set up a subscription for device controllers over XPC.
-    BOOL setUpSubscription = ![_deviceController isKindOfClass:MTRDeviceControllerOverXPC.class];;
+    BOOL setUpSubscription = ![_deviceController isKindOfClass:MTRDeviceControllerOverXPC.class];
+    ;
 
     // For unit testing only
 #ifdef DEBUG

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -689,7 +689,8 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 {
     MTR_LOG_INFO("%@ setDelegate %@", self, delegate);
 
-    BOOL setUpSubscription = YES;
+    // We should not set up a subscription for device controllers over XPC.
+    BOOL setUpSubscription = ![_deviceController isKindOfClass:MTRDeviceControllerOverXPC.class];;
 
     // For unit testing only
 #ifdef DEBUG
@@ -932,6 +933,14 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
         MTR_LOG_DEFAULT("%@ internal state change %lu => %lu", self, static_cast<unsigned long>(lastState), static_cast<unsigned long>(state));
     }
 }
+
+#ifdef DEBUG
+- (MTRInternalDeviceState)_getInternalState
+{
+    std::lock_guard lock(self->_lock);
+    return _internalDeviceState;
+}
+#endif
 
 // First Time Sync happens 2 minutes after reachability (this can be changed in the future)
 #define MTR_DEVICE_TIME_UPDATE_INITIAL_WAIT_TIME_SEC (60 * 2)

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -685,7 +685,8 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 #define MTR_DEVICE_SUBSCRIPTION_MAX_INTERVAL_MIN (10 * 60) // 10 minutes (for now)
 #define MTR_DEVICE_SUBSCRIPTION_MAX_INTERVAL_MAX (60 * 60) // 60 minutes
 
--(BOOL)_subscriptionsAllowed {
+- (BOOL)_subscriptionsAllowed
+{
     return ![_deviceController isKindOfClass:MTRDeviceControllerOverXPC.class];
 }
 
@@ -1693,8 +1694,7 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 {
     os_unfair_lock_assert_owner(&self->_lock);
 
-    if (![self _subscriptionsAllowed])
-    {
+    if (![self _subscriptionsAllowed]) {
         MTR_LOG("_setupSubscription: Subscriptions not allowed. Do not set up subscription");
         return;
     }

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -3618,6 +3618,37 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTAssertTrue(eventReportsReceived > 0);
 }
 
+- (void)test035_TestMTRDeviceSubscriptionNotEstablishedOverXPC
+{
+    static NSString * const MTRDeviceControllerId = @"MTRController";
+    __auto_type remoteController = [MTRDeviceController
+        sharedControllerWithID:MTRDeviceControllerId
+        xpcConnectBlock:^NSXPCConnection * _Nonnull {
+            return nil;
+        }];
+    
+    __auto_type * device = [MTRDevice deviceWithNodeID:kDeviceId deviceController:remoteController];
+    dispatch_queue_t queue = dispatch_get_main_queue();
+    
+    // We should not set up a subscription when creating a MTRDevice with a remote controller.
+    XCTestExpectation * subscriptionExpectation = [self expectationWithDescription:@"Subscription has been set up"];
+    subscriptionExpectation.inverted = YES;
+    
+    __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
+       
+    XCTAssertTrue([device _getInternalState] == MTRInternalDeviceStateUnsubscribed);
+    
+    delegate.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * attributeReport) {
+        [subscriptionExpectation fulfill];
+    };
+    
+    [device setDelegate:delegate queue:queue];
+    [self waitForExpectations:@[ subscriptionExpectation ] timeout:30];
+    
+    XCTAssertTrue([device _getInternalState] == MTRInternalDeviceStateUnsubscribed);
+}
+
+
 @end
 
 @interface MTRDeviceEncoderTests : XCTestCase

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -3620,7 +3620,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
 - (void)test035_TestMTRDeviceSubscriptionNotEstablishedOverXPC
 {
-    static NSString * const MTRDeviceControllerId = @"MTRController";
+   NSString * const MTRDeviceControllerId = @"MTRController";
     __auto_type remoteController = [MTRDeviceController
         sharedControllerWithID:MTRDeviceControllerId
                xpcConnectBlock:^NSXPCConnection * _Nonnull {

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -3626,25 +3626,25 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         xpcConnectBlock:^NSXPCConnection * _Nonnull {
             return nil;
         }];
-    
+
     __auto_type * device = [MTRDevice deviceWithNodeID:kDeviceId deviceController:remoteController];
     dispatch_queue_t queue = dispatch_get_main_queue();
-    
+
     // We should not set up a subscription when creating a MTRDevice with a remote controller.
     XCTestExpectation * subscriptionExpectation = [self expectationWithDescription:@"Subscription has been set up"];
     subscriptionExpectation.inverted = YES;
-    
+
     __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
-       
+
     XCTAssertTrue([device _getInternalState] == MTRInternalDeviceStateUnsubscribed);
-    
+
     delegate.onAttributeDataReceived = ^(NSArray<NSDictionary<NSString *, id> *> * attributeReport) {
         [subscriptionExpectation fulfill];
     };
-    
+
     [device setDelegate:delegate queue:queue];
     [self waitForExpectations:@[ subscriptionExpectation ] timeout:30];
-    
+
     XCTAssertTrue([device _getInternalState] == MTRInternalDeviceStateUnsubscribed);
 }
 

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -3623,9 +3623,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     static NSString * const MTRDeviceControllerId = @"MTRController";
     __auto_type remoteController = [MTRDeviceController
         sharedControllerWithID:MTRDeviceControllerId
-        xpcConnectBlock:^NSXPCConnection * _Nonnull {
-            return nil;
-        }];
+               xpcConnectBlock:^NSXPCConnection * _Nonnull {
+                   return nil;
+               }];
 
     __auto_type * device = [MTRDevice deviceWithNodeID:kDeviceId deviceController:remoteController];
     dispatch_queue_t queue = dispatch_get_main_queue();
@@ -3647,7 +3647,6 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     XCTAssertTrue([device _getInternalState] == MTRInternalDeviceStateUnsubscribed);
 }
-
 
 @end
 

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -3620,7 +3620,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
 - (void)test035_TestMTRDeviceSubscriptionNotEstablishedOverXPC
 {
-   NSString * const MTRDeviceControllerId = @"MTRController";
+    NSString * const MTRDeviceControllerId = @"MTRController";
     __auto_type remoteController = [MTRDeviceController
         sharedControllerWithID:MTRDeviceControllerId
                xpcConnectBlock:^NSXPCConnection * _Nonnull {

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -59,10 +59,31 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface MTRDevice (TestDebug)
+typedef NS_ENUM(NSUInteger, MTRInternalDeviceState) {
+    // Unsubscribed means we do not have a subscription and are not trying to set one up.
+    MTRInternalDeviceStateUnsubscribed = 0,
+    // Subscribing means we are actively trying to establish our initial subscription (e.g. doing
+    // DNS-SD discovery, trying to establish CASE to the peer, getting priming reports, etc).
+    MTRInternalDeviceStateSubscribing = 1,
+    // InitialSubscriptionEstablished means we have at some point finished setting up a
+    // subscription.  That subscription may have dropped since then, but if so it's the ReadClient's
+    // responsibility to re-establish it.
+    MTRInternalDeviceStateInitialSubscriptionEstablished = 2,
+    // Resubscribing means we had established a subscription, but then
+    // detected a subscription drop due to not receiving a report on time. This
+    // covers all the actions that happen when re-subscribing (discovery, CASE,
+    // getting priming reports, etc).
+    MTRInternalDeviceStateResubscribing = 3,
+    // LaterSubscriptionEstablished meant that we had a subscription drop and
+    // then re-created a subscription.
+    MTRInternalDeviceStateLaterSubscriptionEstablished = 4,
+};
+
 - (void)unitTestInjectEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport;
 - (void)unitTestInjectAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport fromSubscription:(BOOL)isFromSubscription;
 - (NSUInteger)unitTestAttributesReportedSinceLastCheck;
 - (void)unitTestClearClusterData;
+- (MTRInternalDeviceState)_getInternalState;
 @end
 #endif
 


### PR DESCRIPTION
…th a remote controller over XPC

- Add tests for testing the behavior when a MTRDevice is created with an XPC controller

Fixes: #33557 

