### PR TITLE
Darwin: add helpers for essential attributes for logging; log unexpected C-quality attributes

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -3653,7 +3653,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
 #pragma mark Log Help
 
-- (NSNumber *)_informationalNumberAtAttributePath:(MTRAttributePath *)attributePath
+- (nullable NSNumber *)_informationalNumberAtAttributePath:(MTRAttributePath *)attributePath
 {
     auto * cachedData = [self _cachedAttributeValueForPath:attributePath];
 
@@ -3662,12 +3662,11 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
         MTRDataKey : cachedData,
     }
                                                                     error:nil];
-    // REVIEWERS:  is it worth logging the `error` above?
 
     return attrReport.value;
 }
 
-- (NSNumber *)_informationalVendorID
+- (nullable NSNumber *)_informationalVendorID
 {
     auto * vendorIDPath = [MTRAttributePath attributePathWithEndpointID:@(kRootEndpointId)
                                                               clusterID:@(MTRClusterIDTypeBasicInformationID)
@@ -3676,7 +3675,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     return [self _informationalNumberAtAttributePath:vendorIDPath];
 }
 
-- (NSNumber *)_informationalProductID
+- (nullable NSNumber *)_informationalProductID
 {
     auto * productIDPath = [MTRAttributePath attributePathWithEndpointID:@(kRootEndpointId)
                                                                clusterID:@(MTRClusterIDTypeBasicInformationID)

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -93,17 +93,17 @@ NSString * const MTRDataVersionKey = @"dataVersion";
 }
 @end
 
-// Stores essential-for-logging attributes immutably for use in logs
-@interface MTRDeviceEssentialAttributes : NSObject
+// convenience object for commonly-logged device attributes
+@interface MTRDeviceInformationalAttributes : NSObject
 @property (readonly) UInt16 vendorID;
 @property (readonly) UInt16 productID;
 @property (readonly) BOOL usesThread;
 
-- (void)addEssentialAttributesToCurrentMetricScope;
+- (void)addInformationalAttributesToCurrentMetricScope;
 
 @end
 
-@implementation MTRDeviceEssentialAttributes
+@implementation MTRDeviceInformationalAttributes
 
 - (instancetype)initWithVendorID:(UInt16)vendorID productID:(UInt16)productID usesThread:(BOOL)usesThread {
     self = [super init];
@@ -117,7 +117,7 @@ NSString * const MTRDataVersionKey = @"dataVersion";
     return self;
 }
 
-- (void)addEssentialAttributesToCurrentMetricScope {
+- (void)addInformationalAttributesToCurrentMetricScope {
     using namespace chip::Tracing::DarwinFramework;
     MATTER_LOG_METRIC(kMetricDeviceVendorID, _vendorID);
     MATTER_LOG_METRIC(kMetricDeviceProductID, _productID);
@@ -1926,11 +1926,11 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
         // (removals are OK)
         
         // log when a device violates expectations for Changes Omitted Quality attributes.
-        MTRDeviceEssentialAttributes * attributes = [self _essentialAttributesForCurrentState];
+        MTRDeviceInformationalAttributes * attributes = [self _informationalAttributesForCurrentState];
         
         using namespace chip::Tracing::DarwinFramework;
         MATTER_LOG_METRIC_BEGIN(kMetricUnexpectedCQualityUpdate);
-        [attributes addEssentialAttributesToCurrentMetricScope];
+        [attributes addInformationalAttributesToCurrentMetricScope];
         MATTER_LOG_METRIC_END(kMetricUnexpectedCQualityUpdate);
         
         return;
@@ -3688,7 +3688,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
 #pragma mark Log Help
 
-- (MTRDeviceEssentialAttributes *)_essentialAttributesForCurrentState {
+- (MTRDeviceInformationalAttributes *)_informationalAttributesForCurrentState {
     MTRClusterPath * basicInfoClusterPath = [MTRClusterPath clusterPathWithEndpointID:@(kRootEndpointId) clusterID:@(MTRClusterIDTypeBasicInformationID)];
     MTRDeviceClusterData * basicInfoClusterData = [self _clusterDataForPath:basicInfoClusterPath];
     
@@ -3699,7 +3699,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     
     BOOL usesThread = [self _deviceUsesThread];
     
-    return [[MTRDeviceEssentialAttributes alloc] initWithVendorID:vendorID productID:productID usesThread:usesThread];
+    return [[MTRDeviceInformationalAttributes alloc] initWithVendorID:vendorID productID:productID usesThread:usesThread];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -3653,35 +3653,40 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
 #pragma mark Log Help
 
-- (NSNumber *)_informationalNumberAtAttributePath:(MTRAttributePath *)attributePath {
+- (NSNumber *)_informationalNumberAtAttributePath:(MTRAttributePath *)attributePath
+{
     auto * cachedData = [self _cachedAttributeValueForPath:attributePath];
 
     auto * attrReport = [[MTRAttributeReport alloc] initWithResponseValue:@{
         MTRAttributePathKey : attributePath,
         MTRDataKey : cachedData,
-    } error:nil];
+    }
+                                                                    error:nil];
     // REVIEWERS:  is it worth logging the `error` above?
 
     return attrReport.value;
 }
 
-- (NSNumber *)_informationalVendorID {
+- (NSNumber *)_informationalVendorID
+{
     auto * vendorIDPath = [MTRAttributePath attributePathWithEndpointID:@(kRootEndpointId)
-                                                                          clusterID:@(MTRClusterIDTypeBasicInformationID)
-                                                                        attributeID:@(MTRClusterBasicAttributeVendorIDID)];
+                                                              clusterID:@(MTRClusterIDTypeBasicInformationID)
+                                                            attributeID:@(MTRClusterBasicAttributeVendorIDID)];
 
     return [self _informationalNumberAtAttributePath:vendorIDPath];
 }
 
-- (NSNumber *)_informationalProductID {
+- (NSNumber *)_informationalProductID
+{
     auto * productIDPath = [MTRAttributePath attributePathWithEndpointID:@(kRootEndpointId)
-                                                                          clusterID:@(MTRClusterIDTypeBasicInformationID)
-                                                                        attributeID:@(MTRClusterBasicAttributeProductIDID)];
+                                                               clusterID:@(MTRClusterIDTypeBasicInformationID)
+                                                             attributeID:@(MTRClusterBasicAttributeProductIDID)];
 
     return [self _informationalNumberAtAttributePath:productIDPath];
 }
 
-- (void)_addInformationalAttributesToCurrentMetricScope {
+- (void)_addInformationalAttributesToCurrentMetricScope
+{
     using namespace chip::Tracing::DarwinFramework;
     MATTER_LOG_METRIC(kMetricDeviceVendorID, [self _informationalVendorID].unsignedShortValue);
     MATTER_LOG_METRIC(kMetricDeviceProductID, [self _informationalProductID].unsignedShortValue);

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -359,10 +359,6 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 
 @property (nonatomic) MTRInternalDeviceState internalDeviceState;
 
-// TODO:  cache this once I understand the point in the MTRDevice lifecycle that the relevant attributes will be present.
-// kmo 22 may 2024 14h55
-// @property (nonatomic) MTRDeviceEssentialAttributes * essentialAttributes;
-
 #define MTRDEVICE_SUBSCRIPTION_ATTEMPT_MIN_WAIT_SECONDS (1)
 #define MTRDEVICE_SUBSCRIPTION_ATTEMPT_MAX_WAIT_SECONDS (3600)
 @property (nonatomic) uint32_t lastSubscriptionAttemptWait;
@@ -1754,8 +1750,6 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
         BOOL isStartUpEvent = (eventPath.cluster.unsignedLongValue == MTRClusterIDTypeBasicInformationID)
             && (eventPath.event.unsignedLongValue == MTREventIDTypeClusterBasicInformationEventStartUpID);
         if (isStartUpEvent) {
-            // REVIEWERS:  this seems like a good place to set up / cache
-            // the essential device attributes - is it?
             if (_estimatedStartTimeFromGeneralDiagnosticsUpTime) {
                 // If UpTime was received, make use of it as mark of system start time
                 MTR_LOG("%@ StartUp event: set estimated start time forward to %@", self,

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1891,13 +1891,13 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
         // Do not persist new values for Changes Omitted Quality (aka C Quality)
         // attributes unless they're part of a Priming Report or from a read response.
         // (removals are OK)
-        
+
         // log when a device violates expectations for Changes Omitted Quality attributes.
         using namespace chip::Tracing::DarwinFramework;
         MATTER_LOG_METRIC_BEGIN(kMetricUnexpectedCQualityUpdate);
         [self _addInformationalAttributesToCurrentMetricScope];
         MATTER_LOG_METRIC_END(kMetricUnexpectedCQualityUpdate);
-        
+
         return;
     }
 
@@ -3655,13 +3655,13 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
 - (NSNumber *)_informationalNumberAtAttributePath:(MTRAttributePath *)attributePath {
     auto * cachedData = [self _cachedAttributeValueForPath:attributePath];
-    
+
     auto * attrReport = [[MTRAttributeReport alloc] initWithResponseValue:@{
         MTRAttributePathKey : attributePath,
         MTRDataKey : cachedData,
     } error:nil];
     // REVIEWERS:  is it worth logging the `error` above?
-    
+
     return attrReport.value;
 }
 
@@ -3669,7 +3669,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     auto * vendorIDPath = [MTRAttributePath attributePathWithEndpointID:@(kRootEndpointId)
                                                                           clusterID:@(MTRClusterIDTypeBasicInformationID)
                                                                         attributeID:@(MTRClusterBasicAttributeVendorIDID)];
-    
+
     return [self _informationalNumberAtAttributePath:vendorIDPath];
 }
 
@@ -3677,7 +3677,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     auto * productIDPath = [MTRAttributePath attributePathWithEndpointID:@(kRootEndpointId)
                                                                           clusterID:@(MTRClusterIDTypeBasicInformationID)
                                                                         attributeID:@(MTRClusterBasicAttributeProductIDID)];
-    
+
     return [self _informationalNumberAtAttributePath:productIDPath];
 }
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1883,7 +1883,7 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     }
 
     [clusterData storeValue:value forAttribute:path.attribute];
-    
+
     if (value != nil
         && isFromSubscription
         && !_receivingPrimingReport

--- a/src/darwin/Framework/CHIP/MTRMetricKeys.h
+++ b/src/darwin/Framework/CHIP/MTRMetricKeys.h
@@ -69,6 +69,9 @@ constexpr Tracing::MetricKey kMetricDeviceVendorID = "dwnfw_device_vendor_id";
 // Device Product ID
 constexpr Tracing::MetricKey kMetricDeviceProductID = "dwnfw_device_product_id";
 
+// Device Uses Thread
+constexpr Tracing::MetricKey kMetricDeviceUsesThread = "dwnfw_device_uses_thread_bool";
+
 // Counter of number of devices discovered on the network during setup
 constexpr Tracing::MetricKey kMetricOnNetworkDevicesAdded = "dwnfw_onnet_devices_added";
 
@@ -80,6 +83,9 @@ constexpr Tracing::MetricKey kMetricBLEDevicesAdded = "dwnfw_ble_devices_added";
 
 // Counter of number of BLE devices removed during setup
 constexpr Tracing::MetricKey kMetricBLEDevicesRemoved = "dwnfw_ble_devices_removed";
+
+// Unexpected C quality attribute update outside of priming
+constexpr Tracing::MetricKey kMetricUnexpectedCQualityUpdate = "dwnpm_bad_c_attr_update";
 
 } // namespace DarwinFramework
 } // namespace Tracing


### PR DESCRIPTION
 Log a metric event when we see an unexpected update of a C-quality attribute

future work:
add these attributes to other Darwin-side logs? (later PR)
