### PR TITLE
[Android] ICD checkin message can't receive in some Android device

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -238,6 +238,16 @@ class CHIPToolActivity :
     }
   }
 
+  override fun onResume() {
+    super.onResume()
+    ChipClient.startDnssd(this)
+  }
+
+  override fun onPause() {
+    ChipClient.stopDnssd(this)
+    super.onPause()
+  }
+
   companion object {
     private const val TAG = "CHIPToolActivity"
     private const val ADDRESS_COMMISSIONING_FRAGMENT_TAG = "address_commissioning_fragment"

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/ChipClient.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/ChipClient.kt
@@ -114,6 +114,21 @@ object ChipClient {
     icdCheckInCallback = callback
   }
 
+  fun startDnssd(context: Context) {
+    if (!this::chipDeviceController.isInitialized) {
+      getDeviceController(context)
+    } else {
+      chipDeviceController.startDnssd()
+    }
+  }
+
+  fun stopDnssd(context: Context) {
+    if (!this::chipDeviceController.isInitialized) {
+      getDeviceController(context)
+    }
+    chipDeviceController.stopDnssd()
+  }
+
   /**
    * Wrapper around [ChipDeviceController.getConnectedDevicePointer] to return the value directly.
    */

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/AddressUpdateFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/AddressUpdateFragment.kt
@@ -230,6 +230,10 @@ class AddressUpdateFragment : ICDCheckInCallback, Fragment() {
     val runnable =
       object : Runnable {
         override fun run() {
+          if (!isAdded) {
+            Log.d(TAG, "Fragment is not attached")
+            return
+          }
           if (icdTotalRemainStayActiveTimeMs >= ICD_PROGRESS_STEP) {
             icdDeviceRemainStayActiveTimeMs -= ICD_PROGRESS_STEP
             icdTotalRemainStayActiveTimeMs -= ICD_PROGRESS_STEP

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -1088,12 +1088,14 @@ CHIP_ERROR AndroidDeviceControllerWrapper::SyncDeleteKeyValue(const char * key)
     return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
 }
 
-void AndroidDeviceControllerWrapper::StartDnssd() {
+void AndroidDeviceControllerWrapper::StartDnssd()
+{
     FabricTable * fabricTable = DeviceControllerFactory::GetInstance().GetSystemState()->Fabrics();
     chip::app::DnssdServer::Instance().SetFabricTable(fabricTable);
     chip::app::DnssdServer::Instance().StartServer();
 }
 
-void AndroidDeviceControllerWrapper::StopDnssd() {
+void AndroidDeviceControllerWrapper::StopDnssd()
+{
     chip::app::DnssdServer::Instance().StopServer();
 }

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -25,6 +25,8 @@
 
 #include <string.h>
 
+#include <app/server/Dnssd.h>
+
 #include <lib/support/CodeUtils.h>
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
@@ -1084,4 +1086,14 @@ CHIP_ERROR AndroidDeviceControllerWrapper::SyncDeleteKeyValue(const char * key)
 {
     ChipLogProgress(chipTool, "KVS: Deleting key %s", StringOrNullMarker(key));
     return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
+}
+
+void AndroidDeviceControllerWrapper::StartDnssd() {
+    FabricTable * fabricTable = DeviceControllerFactory::GetInstance().GetSystemState()->Fabrics();
+    chip::app::DnssdServer::Instance().SetFabricTable(fabricTable);
+    chip::app::DnssdServer::Instance().StartServer();
+}
+
+void AndroidDeviceControllerWrapper::StopDnssd() {
+    chip::app::DnssdServer::Instance().StopServer();
 }

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -1091,7 +1091,7 @@ CHIP_ERROR AndroidDeviceControllerWrapper::SyncDeleteKeyValue(const char * key)
 void AndroidDeviceControllerWrapper::StartDnssd()
 {
     FabricTable * fabricTable = DeviceControllerFactory::GetInstance().GetSystemState()->Fabrics();
-    VerifyOrReturn(fabricTable != nullptr, ChipLogError(controller, "Fail to get fabricTable in StartDnssd"));
+    VerifyOrReturn(fabricTable != nullptr, ChipLogError(Controller, "Fail to get fabricTable in StartDnssd"));
     chip::app::DnssdServer::Instance().SetFabricTable(fabricTable);
     chip::app::DnssdServer::Instance().StartServer();
 }

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -1065,7 +1065,7 @@ void AndroidDeviceControllerWrapper::OnICDRegistrationComplete(chip::NodeId icdN
 
 CHIP_ERROR AndroidDeviceControllerWrapper::SyncGetKeyValue(const char * key, void * value, uint16_t & size)
 {
-    ChipLogProgress(chipTool, "KVS: Getting key %s", StringOrNullMarker(key));
+    ChipLogProgress(Controller, "KVS: Getting key %s", StringOrNullMarker(key));
 
     size_t read_size = 0;
 
@@ -1078,19 +1078,20 @@ CHIP_ERROR AndroidDeviceControllerWrapper::SyncGetKeyValue(const char * key, voi
 
 CHIP_ERROR AndroidDeviceControllerWrapper::SyncSetKeyValue(const char * key, const void * value, uint16_t size)
 {
-    ChipLogProgress(chipTool, "KVS: Setting key %s", StringOrNullMarker(key));
+    ChipLogProgress(Controller, "KVS: Setting key %s", StringOrNullMarker(key));
     return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Put(key, value, size);
 }
 
 CHIP_ERROR AndroidDeviceControllerWrapper::SyncDeleteKeyValue(const char * key)
 {
-    ChipLogProgress(chipTool, "KVS: Deleting key %s", StringOrNullMarker(key));
+    ChipLogProgress(Controller, "KVS: Deleting key %s", StringOrNullMarker(key));
     return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(key);
 }
 
 void AndroidDeviceControllerWrapper::StartDnssd()
 {
     FabricTable * fabricTable = DeviceControllerFactory::GetInstance().GetSystemState()->Fabrics();
+    VerifyOrReturn(fabricTable != nullptr, ChipLogError(controller, "Fail to get fabricTable in StartDnssd"));
     chip::app::DnssdServer::Instance().SetFabricTable(fabricTable);
     chip::app::DnssdServer::Instance().StartServer();
 }

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -214,6 +214,10 @@ public:
 
     CHIP_ERROR SetICDCheckInDelegate(jobject checkInDelegate);
 
+    void StartDnssd();
+
+    void StopDnssd();
+
 private:
     using ChipDeviceControllerPtr = std::unique_ptr<chip::Controller::DeviceCommissioner>;
 

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -2154,6 +2154,26 @@ JNI_METHOD(jbyteArray, validateAndExtractCSR)(JNIEnv * env, jclass clazz, jbyteA
     return javaCsr;
 }
 
+JNI_METHOD(void, startDnssd)(JNIEnv * env, jobject self, jlong handle)
+{
+    ChipLogProgress(Controller, "startDnssd() called");
+    chip::DeviceLayer::StackLock lock;
+
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+
+    wrapper->StartDnssd();
+}
+
+JNI_METHOD(void, stopDnssd)(JNIEnv * env, jobject self, jlong handle)
+{
+    ChipLogProgress(Controller, "stopDnssd() called");
+    chip::DeviceLayer::StackLock lock;
+
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+
+    wrapper->StopDnssd();
+}
+
 void * IOThreadMain(void * arg)
 {
     JNIEnv * env;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -2160,7 +2160,8 @@ JNI_METHOD(void, startDnssd)(JNIEnv * env, jobject self, jlong handle)
     chip::DeviceLayer::StackLock lock;
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    VerifyOrReturn(wrapper != nullptr, ChipLogError(Controller, "AndroidDeviceControllerWrapper::FromJNIHandle in startDnssd fails!"));
+    VerifyOrReturn(wrapper != nullptr,
+                   ChipLogError(Controller, "AndroidDeviceControllerWrapper::FromJNIHandle in startDnssd fails!"));
     wrapper->StartDnssd();
 }
 
@@ -2170,7 +2171,8 @@ JNI_METHOD(void, stopDnssd)(JNIEnv * env, jobject self, jlong handle)
     chip::DeviceLayer::StackLock lock;
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    VerifyOrReturn(wrapper != nullptr, ChipLogError(Controller, "AndroidDeviceControllerWrapper::FromJNIHandle in stopDnssd fails!"));
+    VerifyOrReturn(wrapper != nullptr,
+                   ChipLogError(Controller, "AndroidDeviceControllerWrapper::FromJNIHandle in stopDnssd fails!"));
     wrapper->StopDnssd();
 }
 

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -2160,7 +2160,7 @@ JNI_METHOD(void, startDnssd)(JNIEnv * env, jobject self, jlong handle)
     chip::DeviceLayer::StackLock lock;
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-
+    VerifyOrReturn(wrapper != nullptr, ChipLogError(Controller, "AndroidDeviceControllerWrapper::FromJNIHandle in startDnssd fails!"));
     wrapper->StartDnssd();
 }
 
@@ -2170,7 +2170,7 @@ JNI_METHOD(void, stopDnssd)(JNIEnv * env, jobject self, jlong handle)
     chip::DeviceLayer::StackLock lock;
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-
+    VerifyOrReturn(wrapper != nullptr, ChipLogError(Controller, "AndroidDeviceControllerWrapper::FromJNIHandle in stopDnssd fails!"));
     wrapper->StopDnssd();
 }
 

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -803,6 +803,14 @@ public class ChipDeviceController {
     return getAttestationChallenge(deviceControllerPtr, devicePtr);
   }
 
+  public void startDnssd() {
+    startDnssd(deviceControllerPtr);
+  }
+
+  public void stopDnssd() {
+    stopDnssd(deviceControllerPtr);
+  }
+
   /**
    * @brief Auto-Resubscribe to the given attribute path with keepSubscriptions and isFabricFiltered
    * @param SubscriptionEstablishedCallback Callback when a subscribe response has been received and
@@ -1586,6 +1594,10 @@ public class ChipDeviceController {
   private native int getFabricIndex(long deviceControllerPtr);
 
   private native void shutdownCommissioning(long deviceControllerPtr);
+
+  private native void startDnssd(long deviceControllerPtr);
+
+  private native void stopDnssd(long deviceControllerPtr);
 
   static {
     System.loadLibrary("CHIPController");


### PR DESCRIPTION
In some Android devices, there is an issue where a Check in message is not received when commissioning an ICD Device. To improve this, Dnssd Start/Stop is controlled when the app starts/stops to receive a Check in Message.

