### PR TITLE
[ICD] Reset mNeedIcdRegistration to false when starting the commision flow

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -125,6 +125,8 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
 
     mParams = params;
 
+    mNeedIcdRegistration = false;
+
     if (haveMaybeDanglingBufferPointers)
     {
         mParams.ClearExternalBufferDependentValues();
@@ -760,7 +762,6 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
                 }
             }
 
-            mNeedIcdRegistration = false;
             if (mParams.GetICDRegistrationStrategy() != ICDRegistrationStrategy::kIgnore)
             {
                 if (mDeviceCommissioningInfo.icd.isLIT && mDeviceCommissioningInfo.icd.checkInProtocolSupport)

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -760,6 +760,7 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
                 }
             }
 
+            mNeedIcdRegistration = false;
             if (mParams.GetICDRegistrationStrategy() != ICDRegistrationStrategy::kIgnore)
             {
                 if (mDeviceCommissioningInfo.icd.isLIT && mDeviceCommissioningInfo.icd.checkInProtocolSupport)


### PR DESCRIPTION
When commissioning a LIT device,  mNeedIcdRegistration will be set to true. Following a non-LIT device, mNeedIcdRegistration is still true, then commissioner will continue with LIT registration.
We should reset the mNeedIcdRegistration to false before check whether the device is LIT or not.