### PR TITLE
Fixing usage of NSUserDefaults

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -145,9 +145,6 @@ using namespace chip::Tracing::DarwinFramework;
     return [MTRDeviceControllerFactory.sharedInstance initializeController:self withParameters:controllerParameters error:error];
 }
 
-static NSString * const kLocalTestUserDefaultDomain = @"org.csa-iot.matter.darwintest";
-static NSString * const kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey = @"subscriptionPoolSizeOverride";
-
 - (instancetype)initWithFactory:(MTRDeviceControllerFactory *)factory
                              queue:(dispatch_queue_t)queue
                    storageDelegate:(id<MTRDeviceControllerStorageDelegate> _Nullable)storageDelegate
@@ -256,9 +253,9 @@ static NSString * const kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey = @
         }
 
         // Provide a way to test different subscription pool sizes without code change
-        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
-        if ([defaults objectForKey:kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey]) {
-            NSInteger subscriptionPoolSizeOverride = [defaults integerForKey:kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey];
+        NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
+        if ([defaults objectForKey:kDefaultSubscriptionPoolSizeOverrideKey]) {
+            NSInteger subscriptionPoolSizeOverride = [defaults integerForKey:kDefaultSubscriptionPoolSizeOverrideKey];
             if (subscriptionPoolSizeOverride < 1) {
                 concurrentSubscriptionPoolSize = 1;
             } else {
@@ -934,8 +931,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
 - (MTRBaseDevice *)deviceBeingCommissionedWithNodeID:(NSNumber *)nodeID error:(NSError * __autoreleasing *)error
 {
-    auto block = ^MTRBaseDevice *
-    {
+    auto block = ^MTRBaseDevice * {
         chip::CommissioneeDeviceProxy * deviceProxy;
 
         auto errorCode = self->_cppCommissioner->GetDeviceBeingCommissioned(nodeID.unsignedLongLongValue, &deviceProxy);
@@ -1092,8 +1088,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
 - (NSData * _Nullable)attestationChallengeForDeviceID:(NSNumber *)deviceID
 {
-    auto block = ^NSData *
-    {
+    auto block = ^NSData * {
         chip::CommissioneeDeviceProxy * deviceProxy;
 
         auto errorCode = CHIP_NO_ERROR;
@@ -1891,8 +1886,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         return nil;
     }
 
-    auto block = ^NSString *
-    {
+    auto block = ^NSString * {
         chip::SetupPayload setupPayload;
         errorCode = chip::Controller::AutoCommissioningWindowOpener::OpenCommissioningWindow(self->_cppCommissioner, deviceID,
             chip::System::Clock::Seconds16(static_cast<uint16_t>(duration)), chip::Crypto::kSpake2p_Min_PBKDF_Iterations,

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -931,7 +931,8 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
 - (MTRBaseDevice *)deviceBeingCommissionedWithNodeID:(NSNumber *)nodeID error:(NSError * __autoreleasing *)error
 {
-    auto block = ^MTRBaseDevice * {
+    auto block = ^MTRBaseDevice *
+    {
         chip::CommissioneeDeviceProxy * deviceProxy;
 
         auto errorCode = self->_cppCommissioner->GetDeviceBeingCommissioned(nodeID.unsignedLongLongValue, &deviceProxy);
@@ -1088,7 +1089,8 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
 - (NSData * _Nullable)attestationChallengeForDeviceID:(NSNumber *)deviceID
 {
-    auto block = ^NSData * {
+    auto block = ^NSData *
+    {
         chip::CommissioneeDeviceProxy * deviceProxy;
 
         auto errorCode = CHIP_NO_ERROR;
@@ -1886,7 +1888,8 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         return nil;
     }
 
-    auto block = ^NSString * {
+    auto block = ^NSString *
+    {
         chip::SetupPayload setupPayload;
         errorCode = chip::Controller::AutoCommissioningWindowOpener::OpenCommissioningWindow(self->_cppCommissioner, deviceID,
             chip::System::Clock::Seconds16(static_cast<uint16_t>(duration)), chip::Crypto::kSpake2p_Min_PBKDF_Iterations,

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
@@ -16,6 +16,7 @@
  */
 
 #import "MTRDeviceControllerLocalTestStorage.h"
+#import "MTRDevice_Internal.h"
 #import "MTRLogging_Internal.h"
 
 @implementation MTRDeviceControllerLocalTestStorage {

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
@@ -18,22 +18,19 @@
 #import "MTRDeviceControllerLocalTestStorage.h"
 #import "MTRLogging_Internal.h"
 
-static NSString * const kLocalTestUserDefaultDomain = @"org.csa-iot.matter.darwintest";
-static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
-
 @implementation MTRDeviceControllerLocalTestStorage {
     id<MTRDeviceControllerStorageDelegate> _passThroughStorage;
 }
 
 + (BOOL)localTestStorageEnabled
 {
-    NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+    NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
     return [defaults boolForKey:kLocalTestUserDefaultEnabledKey];
 }
 
 + (void)setLocalTestStorageEnabled:(BOOL)localTestStorageEnabled
 {
-    NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+    NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
     [defaults setBool:localTestStorageEnabled forKey:kLocalTestUserDefaultEnabledKey];
     MTR_LOG("MTRDeviceControllerLocalTestStorage setLocalTestStorageEnabled %d", localTestStorageEnabled);
     BOOL storedLocalTestStorageEnabled = [defaults boolForKey:kLocalTestUserDefaultEnabledKey];
@@ -58,7 +55,7 @@ static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
                               sharingType:(MTRStorageSharingType)sharingType
 {
     if (sharingType == MTRStorageSharingTypeNotShared) {
-        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+        NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
         NSData * storedData = [defaults dataForKey:key];
         NSError * error;
         id value = [NSKeyedUnarchiver unarchivedObjectOfClasses:MTRDeviceControllerStorageClasses() fromData:storedData error:&error];
@@ -86,7 +83,7 @@ static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
             MTR_LOG_ERROR("MTRDeviceControllerLocalTestStorage storeValue: failed to convert value object to data %@", error);
             return NO;
         }
-        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+        NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
         [defaults setObject:data forKey:key];
         return YES;
     } else {
@@ -105,7 +102,7 @@ static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
           sharingType:(MTRStorageSharingType)sharingType
 {
     if (sharingType == MTRStorageSharingTypeNotShared) {
-        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+        NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
         [defaults removeObjectForKey:key];
         return YES;
     } else {
@@ -121,7 +118,7 @@ static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
 - (NSDictionary<NSString *, id<NSSecureCoding>> *)valuesForController:(MTRDeviceController *)controller securityLevel:(MTRStorageSecurityLevel)securityLevel sharingType:(MTRStorageSharingType)sharingType
 {
     if (sharingType == MTRStorageSharingTypeNotShared) {
-        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+        NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
         return [defaults dictionaryRepresentation];
     } else {
         if (_passThroughStorage && [_passThroughStorage respondsToSelector:@selector(valuesForController:securityLevel:sharingType:)]) {
@@ -136,7 +133,7 @@ static NSString * const kLocalTestUserDefaultEnabledKey = @"enableTestStorage";
 - (BOOL)controller:(MTRDeviceController *)controller storeValues:(NSDictionary<NSString *, id<NSSecureCoding>> *)values securityLevel:(MTRStorageSecurityLevel)securityLevel sharingType:(MTRStorageSharingType)sharingType
 {
     if (sharingType == MTRStorageSharingTypeNotShared) {
-        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
+        NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
         BOOL success = YES;
         for (NSString * key in values) {
             NSError * error = nil;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
@@ -25,15 +25,15 @@
 + (BOOL)localTestStorageEnabled
 {
     NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
-    return [defaults boolForKey:kTestUserDefaultEnabledKey];
+    return [defaults boolForKey:kTestStorageUserDefaultEnabledKey];
 }
 
 + (void)setLocalTestStorageEnabled:(BOOL)localTestStorageEnabled
 {
     NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setBool:localTestStorageEnabled forKey:kTestUserDefaultEnabledKey];
+    [defaults setBool:localTestStorageEnabled forKey:kTestStorageUserDefaultEnabledKey];
     MTR_LOG("MTRDeviceControllerLocalTestStorage setLocalTestStorageEnabled %d", localTestStorageEnabled);
-    BOOL storedLocalTestStorageEnabled = [defaults boolForKey:kTestUserDefaultEnabledKey];
+    BOOL storedLocalTestStorageEnabled = [defaults boolForKey:kTestStorageUserDefaultEnabledKey];
     if (storedLocalTestStorageEnabled != localTestStorageEnabled) {
         MTR_LOG_ERROR("MTRDeviceControllerLocalTestStorage setLocalTestStorageEnabled %d failed", localTestStorageEnabled);
     }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerLocalTestStorage.mm
@@ -25,15 +25,15 @@
 + (BOOL)localTestStorageEnabled
 {
     NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
-    return [defaults boolForKey:kLocalTestUserDefaultEnabledKey];
+    return [defaults boolForKey:kTestUserDefaultEnabledKey];
 }
 
 + (void)setLocalTestStorageEnabled:(BOOL)localTestStorageEnabled
 {
     NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setBool:localTestStorageEnabled forKey:kLocalTestUserDefaultEnabledKey];
+    [defaults setBool:localTestStorageEnabled forKey:kTestUserDefaultEnabledKey];
     MTR_LOG("MTRDeviceControllerLocalTestStorage setLocalTestStorageEnabled %d", localTestStorageEnabled);
-    BOOL storedLocalTestStorageEnabled = [defaults boolForKey:kLocalTestUserDefaultEnabledKey];
+    BOOL storedLocalTestStorageEnabled = [defaults boolForKey:kTestUserDefaultEnabledKey];
     if (storedLocalTestStorageEnabled != localTestStorageEnabled) {
         MTR_LOG_ERROR("MTRDeviceControllerLocalTestStorage setLocalTestStorageEnabled %d failed", localTestStorageEnabled);
     }

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -103,7 +103,6 @@ NSNumber * MTRClampedNumber(NSNumber * aNumber, NSNumber * min, NSNumber * max);
 #pragma mark - Constants
 
 static NSString * const kDefaultSubscriptionPoolSizeOverrideKey = @"subscriptionPoolSizeOverride";
-static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOverride";
 static NSString * const kTestStorageUserDefaultEnabledKey = @"enableTestStorage";
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -104,5 +104,6 @@ NSNumber * MTRClampedNumber(NSNumber * aNumber, NSNumber * min, NSNumber * max);
 
 static NSString * const kDefaultSubscriptionPoolSizeOverrideKey = @"subscriptionPoolSizeOverride";
 static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOverride";
+static NSString * const kTestUserDefaultEnabledKey = @"enableTestStorage";
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -100,4 +100,9 @@ MTR_TESTABLE
 // Returns min or max, if it is below or above, respectively.
 NSNumber * MTRClampedNumber(NSNumber * aNumber, NSNumber * min, NSNumber * max);
 
+#pragma mark - Constants
+
+static NSString * const kDefaultSubscriptionPoolSizeOverrideKey = @"subscriptionPoolSizeOverride";
+static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOverride";
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -105,4 +105,7 @@ NSNumber * MTRClampedNumber(NSNumber * aNumber, NSNumber * min, NSNumber * max);
 static NSString * const kDefaultSubscriptionPoolSizeOverrideKey = @"subscriptionPoolSizeOverride";
 static NSString * const kTestStorageUserDefaultEnabledKey = @"enableTestStorage";
 
+// Declared inside platform, but noting here for reference
+// static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOverride";
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -104,6 +104,6 @@ NSNumber * MTRClampedNumber(NSNumber * aNumber, NSNumber * min, NSNumber * max);
 
 static NSString * const kDefaultSubscriptionPoolSizeOverrideKey = @"subscriptionPoolSizeOverride";
 static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOverride";
-static NSString * const kTestUserDefaultEnabledKey = @"enableTestStorage";
+static NSString * const kTestStorageUserDefaultEnabledKey = @"enableTestStorage";
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2051,9 +2051,6 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 10;
     [controller shutdown];
 }
 
-static NSString * const kLocalTestUserDefaultDomain = @"org.csa-iot.matter.darwintest";
-static NSString * const kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey = @"subscriptionPoolSizeOverride";
-
 // TODO: This might also want to go in a separate test file, with some shared setup for commissioning devices per test
 - (void)doTestSubscriptionPoolWithSize:(NSInteger)subscriptionPoolSize
 {
@@ -2075,11 +2072,11 @@ static NSString * const kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey = @
 
     NSError * error;
 
-    NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kLocalTestUserDefaultDomain];
-    NSNumber * subscriptionPoolSizeOverrideOriginalValue = [defaults objectForKey:kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey];
+    NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
+    NSNumber * subscriptionPoolSizeOverrideOriginalValue = [defaults objectForKey:kDefaultSubscriptionPoolSizeOverrideKey];
 
     // Test DeviceController with a Subscription pool
-    [defaults setInteger:subscriptionPoolSize forKey:kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey];
+    [defaults setInteger:subscriptionPoolSize forKey:kDefaultSubscriptionPoolSizeOverrideKey];
 
     MTRPerControllerStorageTestsCertificateIssuer * certificateIssuer;
     MTRDeviceController * controller = [self startControllerWithRootKeys:rootKeys
@@ -2182,9 +2179,9 @@ static NSString * const kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey = @
     XCTAssertFalse([controller isRunning]);
 
     if (subscriptionPoolSizeOverrideOriginalValue) {
-        [defaults setInteger:subscriptionPoolSizeOverrideOriginalValue.integerValue forKey:kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey];
+        [defaults setInteger:subscriptionPoolSizeOverrideOriginalValue.integerValue forKey:kDefaultSubscriptionPoolSizeOverrideKey];
     } else {
-        [defaults removeObjectForKey:kLocalTestUserDefaultSubscriptionPoolSizeOverrideKey];
+        [defaults removeObjectForKey:kDefaultSubscriptionPoolSizeOverrideKey];
     }
 }
 

--- a/src/platform/Darwin/UserDefaults.mm
+++ b/src/platform/Darwin/UserDefaults.mm
@@ -21,6 +21,8 @@
 
 #import <Foundation/Foundation.h>
 
+static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOverride";
+
 namespace chip {
 namespace Platform {
 

--- a/src/platform/Darwin/UserDefaults.mm
+++ b/src/platform/Darwin/UserDefaults.mm
@@ -21,15 +21,12 @@
 
 #import <Foundation/Foundation.h>
 
-static NSString * const kUserDefaultDomain = @"org.csa-iot.matter.darwin";
-static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOverride";
-
 namespace chip {
 namespace Platform {
 
     std::optional<uint16_t> GetUserDefaultDnssdSRPTimeoutInMSecs()
     {
-        NSUserDefaults * defaults = [[NSUserDefaults alloc] initWithSuiteName:kUserDefaultDomain];
+        NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
         NSInteger srpTimeoutValue = [defaults integerForKey:kSRPTimeoutInMsecsUserDefaultKey];
         if (CanCastTo<uint16_t>(srpTimeoutValue)) {
             uint16_t timeoutinMsecs = static_cast<uint16_t>(srpTimeoutValue);


### PR DESCRIPTION
We were reading from a particular domain, we should be reading from the standard one so it works with sandboxes, and the global domain.