### PR TITLE
Decouple `CommandHandler.h/cpp` from the BUILD.gn build rules of app/interaction-model

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -98,7 +98,6 @@ jobs:
                      --known-failure controller/ExamplePersistentStorage.cpp \
                      --known-failure controller/ExamplePersistentStorage.h \
                      --known-failure app/AttributeAccessToken.h \
-                     --known-failure app/CommandHandler.h \
                      --known-failure app/CommandHandlerInterface.h \
                      --known-failure app/CommandResponseSender.h \
                      --known-failure app/CommandSenderLegacyCallback.h \

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -299,10 +299,12 @@ static_library("attribute-access") {
 
 source_set("required-privileges") {
   sources = [ "RequiredPrivilege.h" ]
+
   public_deps = [
     ":paths",
     "${chip_root}/src/access:types",
   ]
+
   if (chip_build_controller_dynamic_server) {
     sources += [
       "util/privilege-storage.cpp",
@@ -315,7 +317,7 @@ source_set("required-privileges") {
       "${chip_root}/src/app/dynamic_server:mock-codegen-includes",
     ]
 
-    public_configs += [ ":config-controller-dynamic-server" ]
+    public_configs = [ ":config-controller-dynamic-server" ]
   }
 }
 

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -246,8 +246,6 @@ static_library("interaction-model") {
       "dynamic_server/AccessControl.cpp",
       "dynamic_server/AccessControl.h",
       "dynamic_server/DynamicDispatcher.cpp",
-      "util/privilege-storage.cpp",
-      "util/privilege-storage.h",
     ]
 
     public_deps += [
@@ -305,6 +303,12 @@ source_set("required-privileges") {
     ":paths",
     "${chip_root}/src/access:types",
   ]
+  if (chip_build_controller_dynamic_server) {
+    sources += [
+      "util/privilege-storage.cpp",
+      "util/privilege-storage.h",
+    ]
+  }
 }
 
 source_set("status-response") {

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -308,6 +308,14 @@ source_set("required-privileges") {
       "util/privilege-storage.cpp",
       "util/privilege-storage.h",
     ]
+
+    public_deps += [
+      ":global-attributes",
+      "${chip_root}/src/access",
+      "${chip_root}/src/app/dynamic_server:mock-codegen-includes",
+    ]
+
+    public_configs += [ ":config-controller-dynamic-server" ]
   }
 }
 

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -179,9 +179,6 @@ static_library("interaction-model") {
     "ReadClient.h",  # TODO: cpp is only included conditionally. Needs logic
                      # fixing
     "ReadPrepareParams.h",
-    "RequiredPrivilege.h",
-    "StatusResponse.cpp",
-    "StatusResponse.h",
     "SubscriptionResumptionStorage.h",
     "TimedHandler.cpp",
     "TimedHandler.h",
@@ -210,6 +207,7 @@ static_library("interaction-model") {
 
   public_deps = [
     ":app_config",
+    ":command-handler",
     ":constants",
     ":paths",
     ":subscription-info-provider",
@@ -301,6 +299,46 @@ static_library("attribute-access") {
   ]
 }
 
+source_set("required-privileges") {
+  sources = [ "RequiredPrivilege.h" ]
+  public_deps = [
+    ":paths",
+    "${chip_root}/src/access:types",
+  ]
+}
+
+source_set("status-response") {
+  sources = [
+    "StatusResponse.cpp",
+    "StatusResponse.h",
+  ]
+  public_deps = [
+    ":constants",
+    "${chip_root}/src/app/MessageDef",
+    "${chip_root}/src/messaging",
+  ]
+}
+
+source_set("command-handler") {
+  sources = [
+    "CommandHandler.cpp",
+    "CommandHandler.h",
+    "CommandHandlerExchangeInterface.h",
+  ]
+
+  public_deps = [
+    ":paths",
+    ":required-privileges",
+    ":status-response",
+    "${chip_root}/src/access:types",
+    "${chip_root}/src/app/MessageDef",
+    "${chip_root}/src/app/data-model",
+    "${chip_root}/src/app/util:callbacks",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/messaging",
+  ]
+}
+
 # Note to developpers, instead of continuously adding files in the app librabry, it is recommand to create smaller source_sets that app can depend on.
 # This way, we can have a better understanding of dependencies and other componenets can depend on the different source_sets without needing to depend on the entire app library.
 static_library("app") {
@@ -312,8 +350,6 @@ static_library("app") {
     "AttributePersistenceProvider.h",
     "ChunkedWriteCallback.cpp",
     "ChunkedWriteCallback.h",
-    "CommandHandler.cpp",
-    "CommandHandlerExchangeInterface.h",
     "CommandResponseHelper.h",
     "CommandResponseSender.cpp",
     "DefaultAttributePersistenceProvider.cpp",
@@ -338,7 +374,6 @@ static_library("app") {
     #       (app depending on im and im including these headers):
     #       Name with _ so that linter does not recognize it
     # "CommandResponseSender._h"
-    # "CommandHandler._h"
     # "ReadHandler._h",
     # "WriteHandler._h"
   ]

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -15,28 +15,20 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-/**
- *    @file
- *      This file defines object for a CHIP IM Invoke Command Handler
- *
- */
-
-#include "CommandHandler.h"
-#include "InteractionModelEngine.h"
-#include "RequiredPrivilege.h"
-#include "messaging/ExchangeContext.h"
+#include <app/CommandHandler.h>
 
 #include <access/AccessControl.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/RequiredPrivilege.h>
 #include <app/util/MatterCallbacks.h>
+#include <app/StatusResponse.h>
 #include <credentials/GroupDataProvider.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/TLVData.h>
 #include <lib/core/TLVUtilities.h>
 #include <lib/support/IntrusiveList.h>
 #include <lib/support/TypeTraits.h>
+#include <messaging/ExchangeContext.h>
 #include <platform/LockTracker.h>
 #include <protocols/secure_channel/Constants.h>
 

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -20,8 +20,8 @@
 #include <access/AccessControl.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/RequiredPrivilege.h>
-#include <app/util/MatterCallbacks.h>
 #include <app/StatusResponse.h>
+#include <app/util/MatterCallbacks.h>
 #include <credentials/GroupDataProvider.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/TLVData.h>

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -30,9 +30,8 @@
 
 #pragma once
 
-#include "CommandPathRegistry.h"
-
 #include <app/CommandHandlerExchangeInterface.h>
+#include <app/CommandPathRegistry.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/Encode.h>
 #include <lib/core/CHIPCore.h>


### PR DESCRIPTION
This makes CommandHandler reasonably stand-alone to be referenced without pulling in a dependency on the entire interactionmodelengine. Given that includes are not circular anymore.


### Changes

- Remove a include for "InteractionModelEngine" (that was used for the sideffect of pulling in StatusResponse constants) to make CommandHandler fully decoupled
- Create several separate source sets in `app/BUILD.gn` such that things can be compiled/included independently. Final end result is that `:command-handler` is its own stand-alone item that does not depend on app or im. Had to pull out "status-response" as well as "required-privileges", did not try to group these further
- Removed the "known error" in the linter checks since this is not an error anymore now after the decoupling.