### PR TITLE
Use AddResponse instead of AddResponseData when no error checking is performed (ContentAppCommandDelegate.cpp)

### DIFF
--- a/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
@@ -197,7 +197,7 @@ void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::Hand
         }
         else
         {
-            handlerContext.mCommandHandler.AddResponseData(handlerContext.mRequestPath, launchResponse);
+            handlerContext.mCommandHandler.AddResponse(handlerContext.mRequestPath, launchResponse);
         }
         break;
     }
@@ -211,7 +211,7 @@ void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::Hand
         }
         else
         {
-            handlerContext.mCommandHandler.AddResponseData(handlerContext.mRequestPath, navigateTargetResponse);
+            handlerContext.mCommandHandler.AddResponse(handlerContext.mRequestPath, navigateTargetResponse);
         }
         break;
     }
@@ -225,7 +225,7 @@ void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::Hand
         }
         else
         {
-            handlerContext.mCommandHandler.AddResponseData(handlerContext.mRequestPath, playbackResponse);
+            handlerContext.mCommandHandler.AddResponse(handlerContext.mRequestPath, playbackResponse);
         }
         break;
     }
@@ -244,7 +244,7 @@ void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::Hand
         }
         else
         {
-            handlerContext.mCommandHandler.AddResponseData(handlerContext.mRequestPath, getSetupPINresponse);
+            handlerContext.mCommandHandler.AddResponse(handlerContext.mRequestPath, getSetupPINresponse);
         }
         break;
     }


### PR DESCRIPTION
`AddResponseData` returns a CHIP_ERROR that should be handled. 

Since this code did not check the return code, use `AddResponse` that sets the return error code on failure (e.g. failing to encode data). Most code seems to use AddResponse and never AddResponseData.