### PR TITLE
CASESessionManager should shut down AddressResolve::Resolver

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -29,6 +29,11 @@ CHIP_ERROR CASESessionManager::Init(chip::System::Layer * systemLayer, const CAS
     return AddressResolve::Resolver::Instance().Init(systemLayer);
 }
 
+void CASESessionManager::Shutdown()
+{
+    AddressResolve::Resolver::Instance().Shutdown();
+}
+
 void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
                                                 Callback::Callback<OnDeviceConnectionFailure> * onFailure,
 #if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -59,7 +59,7 @@ public:
     }
 
     CHIP_ERROR Init(chip::System::Layer * systemLayer, const CASESessionManagerConfig & params);
-    void Shutdown() {}
+    void Shutdown();
 
     /**
      * Find an existing session for the given node ID, or trigger a new session


### PR DESCRIPTION
CASESessionManager initializes the address resolver in its Init method, so it should also shut it down in Shutdown.
