### PR TITLE
[Bridge-App] Fix TempSensor2 is not reachable in bridge

### DIFF
--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -899,13 +899,11 @@ void ApplicationInit()
     // Setup Mock Devices
     Light1.SetReachable(true);
     Light2.SetReachable(true);
-
     Light1.SetChangeCallback(&HandleDeviceOnOffStatusChanged);
     Light2.SetChangeCallback(&HandleDeviceOnOffStatusChanged);
 
     TempSensor1.SetReachable(true);
-    TempSensor1.SetReachable(true);
-
+    TempSensor2.SetReachable(true);
     TempSensor1.SetChangeCallback(&HandleDeviceTempSensorStatusChanged);
     TempSensor2.SetChangeCallback(&HandleDeviceTempSensorStatusChanged);
 
@@ -914,7 +912,6 @@ void ApplicationInit()
     ActionLight2.SetReachable(true);
     ActionLight3.SetReachable(true);
     ActionLight4.SetReachable(true);
-
     ActionLight1.SetChangeCallback(&HandleDeviceOnOffStatusChanged);
     ActionLight2.SetChangeCallback(&HandleDeviceOnOffStatusChanged);
     ActionLight3.SetChangeCallback(&HandleDeviceOnOffStatusChanged);
@@ -929,7 +926,6 @@ void ApplicationInit()
     ComposedTempSensor2.SetReachable(true);
     ComposedPowerSource.SetReachable(true);
     ComposedPowerSource.SetBatChargeLevel(58);
-
     ComposedTempSensor1.SetChangeCallback(&HandleDeviceTempSensorStatusChanged);
     ComposedTempSensor2.SetChangeCallback(&HandleDeviceTempSensorStatusChanged);
     ComposedPowerSource.SetChangeCallback(&HandleDevicePowerSourceStatusChanged);


### PR DESCRIPTION
There is an init typo for TempSensor2

TempSensor1.SetReachable(true);
TempSensor1.SetReachable(true);
   ->
TempSensor1.SetReachable(true);
TempSensor2.SetReachable(true);