### PR TITLE
[thread] fix the crash issue when the SRP server discovery failure

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1353,7 +1353,7 @@ template <class ImplClass>
 void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnSrpClientStateChange(const otSockAddr * aServerSockAddr,
                                                                                  void * aContext)
 {
-    if (aServerSockAddr)
+    if (aServerSockAddr != nullptr)
     {
         ChipLogProgress(DeviceLayer, "SRP Client was started, detected server: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x",
                         Encoding::BigEndian::HostSwap16(aServerSockAddr->mAddress.mFields.m16[0]),


### PR DESCRIPTION
When the SRP server rejects the end device's mDNS request, the end device cannot discover the SRP server's address. In this case, the value of the parameter `aServerSockAddr`is `nullptr`, and printing it will cause a system crash


