### PR TITLE
Linux: Guard mallinfo() use behind check for __GLIBC__

### DIFF
--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -225,9 +225,7 @@ DiagnosticDataProviderImpl & DiagnosticDataProviderImpl::GetDefaultInstance()
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapFree(uint64_t & currentHeapFree)
 {
-#ifndef __GLIBC__
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-#else
+#if defined(__GLIBC__)
     struct mallinfo mallocInfo = mallinfo();
 
     // Get the current amount of heap memory, in bytes, that are not being utilized
@@ -235,14 +233,14 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapFree(uint64_t & currentHeap
     currentHeapFree = mallocInfo.fordblks;
 
     return CHIP_NO_ERROR;
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapUsed(uint64_t & currentHeapUsed)
 {
-#ifndef __GLIBC__
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-#else
+#if defined(__GLIBC__)
     struct mallinfo mallocInfo = mallinfo();
 
     // Get the current amount of heap memory, in bytes, that are being used by
@@ -255,14 +253,14 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapUsed(uint64_t & currentHeap
         maxHeapHighWatermark = currentHeapUsed;
     }
     return CHIP_NO_ERROR;
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark)
 {
-#ifndef __GLIBC__
-    return CHIP_ERROR_NOT_IMPLEMENTED;
-#else
+#if defined(__GLIBC__)
     struct mallinfo mallocInfo = mallinfo();
 
     // The usecase of this function is embedded devices,on which we would need to intercept
@@ -281,6 +279,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
     currentHeapHighWatermark = maxHeapHighWatermark;
 
     return CHIP_NO_ERROR;
+#else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
 }
 

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -74,8 +74,10 @@ enum class WiFiStatsCountType
     kWiFiOverrunCount
 };
 
+#if defined(__GLIBC__)
 // Static variable to store the maximum heap size
 static size_t maxHeapHighWatermark = 0;
+#endif
 
 CHIP_ERROR GetEthernetStatsCount(EthernetStatsCountType type, uint64_t & count)
 {
@@ -287,10 +289,12 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
     // If implemented, the server SHALL set the value of the CurrentHeapHighWatermark attribute to the
     // value of the CurrentHeapUsed.
 
+#if defined(__GLIBC__)
     // Get the current amount of heap memory, in bytes, that are being used by
     // the current running program and reset the max heap high watermark to current heap amount.
     struct mallinfo mallocInfo = mallinfo();
     maxHeapHighWatermark       = mallocInfo.uordblks;
+#endif
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
Guard `mallinfo()` use behind check for `__GLIBC__`
Also use positive checks for `__GLIBC__` rather than `ifndef`