### PR TITLE
Linux: link with libatomic

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -356,6 +356,7 @@ config("runtime_default") {
   }
   if (current_os == "linux" || current_os == "tizen" || current_os == "webos") {
     libs = [
+      "atomic",
       "dl",
       "pthread",
       "rt",


### PR DESCRIPTION
Use of atomic builtins (`__atomic_*`) can require `-latomic` depending on what gets inlined (or not) on a particular platform.

For example

```
/bin/ld: lib/libCHIP.a(libSystemLayer.SystemClock.cpp.o): undefined reference to symbol '__atomic_store_8@@LIBATOMIC_1.0'
/home/karsten/workspace/openwrt/staging_dir/toolchain-mipsel_24kc_gcc-12.3.0_musl/lib/gcc/mipsel-openwrt-linux-musl/12.3.0/../../../../mipsel-openwrt-linux-musl/bin/ld: /home/karsten/workspace/openwrt/staging_dir/toolchain-mipsel_24kc_gcc-12.3.0_musl/mipsel-openwrt-linux-musl/bin/../../../toolchain-mipsel_24kc_gcc-12.3.0_musl/lib/libatomic.so.1: error adding symbols: DSO missing from command line
```