### PR TITLE
[Tizen] Add libatomic.so to QEMU Docker image

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-52 : [NXP] Update K32W0 SDK to 2.6.14
+53 : [Tizen] Add libatomic.so to QEMU Docker image

--- a/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
@@ -84,6 +84,7 @@ RUN set -x \
     # Add extra libraries to the root image
     && guestfish --rw -a $TIZEN_IOT_IMAGE_ROOT -m /dev/sda copy-in \
     $TIZEN_SDK_TOOLCHAIN/arm-tizen-linux-gnueabi/lib/libasan.so.* \
+    $TIZEN_SDK_TOOLCHAIN/arm-tizen-linux-gnueabi/lib/libatomic.so.* \
     $TIZEN_SDK_TOOLCHAIN/arm-tizen-linux-gnueabi/lib/libubsan.so.* \
     $TIZEN_SDK_SYSROOT/usr/lib/libbluetooth-api.so.* \
     $TIZEN_SDK_SYSROOT/usr/lib/libcapi-network-bluetooth.so.* \


### PR DESCRIPTION
### Problem

Tizen CI in PR https://github.com/project-chip/connectedhomeip/pull/33628 fails because Tizen application can be linked with `libatomic.so`, however, such library is not available on QEMU image used by CI.

### Changes

Add `libatomic.so` to QEMU image

### Testing

Tested locally, that with this new Docker image, one can successfully run `./scripts/build/build_examples.py --target tizen-arm-tests-no-ble-no-thread build` with PR https://github.com/project-chip/connectedhomeip/pull/33628