### PR TITLE
Fix test by making darwin-framework-tool use the same command timeout as chip-tool.

### DIFF
--- a/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.h
@@ -38,7 +38,7 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(10); }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(20); }
 
     virtual CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endPointId) = 0;
 


### PR DESCRIPTION
The commands now take a bit longer to time out on the exchange level, so we were hitting the test timeout.
