### PR TITLE
[Silabs ] Bugfix re-enable ICD in lock-app

### DIFF
--- a/examples/lock-app/silabs/openthread.gni
+++ b/examples/lock-app/silabs/openthread.gni
@@ -28,7 +28,7 @@ openthread_external_platform =
 sl_enable_test_event_trigger = true
 
 # ICD Default configurations
-chip_enable_icd_server = false
+chip_enable_icd_server = true
 chip_subscription_timeout_resumption = false
 sl_use_subscription_syncing = true
 


### PR DESCRIPTION
Re-enable ICD in lock-app openthread.gni