### PR TITLE
Add a timeout argument to darwin-framework-tool data model commands.

### DIFF
--- a/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.h
@@ -21,6 +21,10 @@
 #include "../common/CHIPCommandBridge.h"
 #include <lib/core/CHIPEncoding.h>
 
+#define DFT_MODEL_COMMAND_DEFAULT_TIMEOUT 20
+#define DFT_STRINGIFY_HELPER(arg) #arg
+#define DFT_STRINGIFY(arg) DFT_STRINGIFY_HELPER(arg)
+
 class ModelCommand : public CHIPCommandBridge
 {
 public:
@@ -30,6 +34,10 @@ public:
     {
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
         AddArgument("endpoint-id", 0, UINT16_MAX, &mEndPointId);
+        AddArgument(
+            "timeout", 0, UINT16_MAX, &mTimeout,
+            "Amount of time to allow the command to run for before considering it to have timed out.  Defaults to " DFT_STRINGIFY(
+                DFT_MODEL_COMMAND_DEFAULT_TIMEOUT) " seconds.");
     }
 
     void Shutdown() override;
@@ -38,11 +46,19 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(20); }
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mTimeout.ValueOr(DFT_MODEL_COMMAND_DEFAULT_TIMEOUT));
+    }
 
     virtual CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endPointId) = 0;
 
 private:
     chip::NodeId mNodeId;
     chip::EndpointId mEndPointId;
+    chip::Optional<uint16_t> mTimeout;
 };
+
+#undef DFT_STRINGIFY
+#undef DFT_STRINGIFY_HELPER
+#undef DFT_MODEL_COMMAND_DEFAULT_TIMEOUT


### PR DESCRIPTION
chip-tool has one, and this will make it easier to use in YAMLs that run in both.

