### PR TITLE
Streamline bloat reports, part 1

### DIFF
--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -316,9 +316,6 @@ class V1Comment:
             threshold_df = df[df['% change'] > threshold]
             if threshold_df.empty:
                 threshold_df = None
-        decrease_df = df[df['change'] < 0]
-        if decrease_df.empty:
-            decrease_df = None
 
         with io.StringIO() as md:
             md.write(df.attrs['title'])
@@ -328,22 +325,6 @@ class V1Comment:
                 md.write(f'**Increases above {threshold:.2g}%:**\n\n')
                 md.write('<!--ghr-report:threshold-->\n\n')
                 V1Comment.write_df(config, threshold_df, md)
-
-            if increase_df is not None:
-                summary = V1Comment.summary(increase_df)
-                md.write('<details>\n')
-                md.write(f'<summary>Increases ({summary})</summary>\n')
-                md.write('<!--ghr-report:increases-->\n\n')
-                V1Comment.write_df(config, increase_df, md)
-                md.write('</details>\n\n')
-
-            if decrease_df is not None:
-                summary = V1Comment.summary(decrease_df)
-                md.write('<details>\n')
-                md.write(f'<summary>Decreases ({summary})</summary>\n')
-                md.write('<!--ghr-report:decreases-->\n\n')
-                V1Comment.write_df(config, decrease_df, md)
-                md.write('</details>\n\n')
 
             summary = V1Comment.summary(df)
             md.write('<details>\n')

--- a/scripts/tools/memory/memdf/sizedb.py
+++ b/scripts/tools/memory/memdf/sizedb.py
@@ -105,10 +105,10 @@ class SizeDatabase(memdf.util.sqlite.Database):
         for frame in ['section', 'region']:
             for i in r['frames'].get(frame, []):
                 r['sizes'].append({
-                'name': i[frame],
-                'size': i['size'],
-                'kind': frame
-            })
+                    'name': i[frame],
+                    'size': i['size'],
+                    'kind': frame
+                })
         # Add segment sizes.
         for i in r['frames'].get('wr', []):
             r['sizes'].append({

--- a/scripts/tools/memory/platform/bl602.cfg
+++ b/scripts/tools/memory/platform/bl602.cfg
@@ -30,11 +30,17 @@
     #         'end': [],
     #     }
     # },
-    # 'region': {
-    #     # Regions are sets of sections that can be used for aggregate reports.
-    #     'sections': {
-    #         'FLASH': [],
-    #         'RAM': []
-    #     }
-    # },
+    'region': {
+        # Regions are sets of sections that can be used for aggregate reports.
+        'sections': {
+            'FLASH': [
+                '.text',
+                '.rodata',
+            ],
+            'RAM': [
+                '.bss',
+                '.data',
+            ],
+        }
+    },
 }

--- a/scripts/tools/memory/platform/mbed.cfg
+++ b/scripts/tools/memory/platform/mbed.cfg
@@ -30,13 +30,17 @@
 #           'end': [],
 #       }
 #   },
-#   'region': {
-#       # Regions are sets of sections that can be used for aggregate reports.
-#       'sections': {
-#           'FLASH': [
-#           ],
-#           'RAM': [
-#           ]
-#       }
-#   },
+    'region': {
+        # Regions are sets of sections that can be used for aggregate reports.
+        'sections': {
+            'FLASH': [
+                '.text',
+                '.rodata',
+            ],
+            'RAM': [
+                '.bss',
+                '.data',
+            ],
+        }
+    },
 }

--- a/scripts/tools/memory/platform/openiotsdk.cfg
+++ b/scripts/tools/memory/platform/openiotsdk.cfg
@@ -20,4 +20,17 @@
         # when operating by sections.
         'default': ['.text', '.data', '.bss', '.stack', '.heap'],
     },
+    'region': {
+        # Regions are sets of sections that can be used for aggregate reports.
+        'sections': {
+            'FLASH': [
+                '.text',
+                '.rodata',
+            ],
+            'RAM': [
+                '.bss',
+                '.data',
+            ],
+        }
+    },
 }

--- a/scripts/tools/memory/platform/p6.cfg
+++ b/scripts/tools/memory/platform/p6.cfg
@@ -30,13 +30,17 @@
 #           'end': [],
 #       }
 #   },
-#   'region': {
-#       # Regions are sets of sections that can be used for aggregate reports.
-#       'sections': {
-#           'FLASH': [
-#           ],
-#           'RAM': [
-#           ]
-#       }
-#   },
+    'region': {
+        # Regions are sets of sections that can be used for aggregate reports.
+        'sections': {
+            'FLASH': [
+                '.text',
+                '.rodata',
+            ],
+            'RAM': [
+                '.bss',
+                '.data',
+            ],
+        }
+    },
 }

--- a/scripts/tools/memory/platform/telink.cfg
+++ b/scripts/tools/memory/platform/telink.cfg
@@ -30,13 +30,19 @@
 #           'end': [],
 #       }
 #   },
-#   'region': {
-#       # Regions are sets of sections that can be used for aggregate reports.
-#       'sections': {
-#           'FLASH': [
-#           ],
-#           'RAM': [
-#           ]
-#       }
-#   },
+    'region': {
+        # Regions are sets of sections that can be used for aggregate reports.
+        'sections': {
+            'FLASH': [
+                'text',
+                'rodata',
+            ],
+            'RAM': [
+                'bss',
+                'data',
+                'noinit',
+                'ram_code',
+            ],
+        }
+    },
 }


### PR DESCRIPTION
- Remove ‘Increases’ and ‘Decreases’ tables from the GitHub comment reports, leaving only the full table and the large-increase highlights.

- Add region groups to platform configurations. Reports will switch to summary flash and RAM totals rather than reporting each section. Some platform report configurations did not already indicate which section(s) belong in which reportable region.

- Add region sizes to size report artifacts.

- Record area type (section, region, read/write) in the size database.

A followup will remove sizes other than regions from the GitHub comment reports.
