### PR TITLE
Add ability to add pending fabric at a chosen fabric index

### DIFF
--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -2124,4 +2124,16 @@ CHIP_ERROR FabricTable::PeekFabricIndexForNextAddition(FabricIndex & outIndex)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR FabricTable::SetFabricIndexForNextAddition(FabricIndex fabricIndex)
+{
+    VerifyOrReturnError(!mStateFlags.Has(StateFlags::kIsPendingFabricDataPresent), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(IsValidFabricIndex(fabricIndex), CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    const FabricInfo * fabricInfo = FindFabricWithIndex(fabricIndex);
+    VerifyOrReturnError(fabricInfo == nullptr, CHIP_ERROR_FABRIC_EXISTS);
+
+    mNextAvailableFabricIndex.SetValue(fabricIndex);
+    return CHIP_NO_ERROR;
+}
+
 } // namespace chip

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -1003,6 +1003,13 @@ public:
      */
     CHIP_ERROR PeekFabricIndexForNextAddition(FabricIndex & outIndex);
 
+    /**
+     * Set the fabric index that will be used fo the next fabric added.
+     *
+     * Returns an error if the |fabricIndex| is already in use.
+     */
+    CHIP_ERROR SetFabricIndexForNextAddition(FabricIndex fabricIndex);
+
 private:
     enum class StateFlags : uint16_t
     {

--- a/src/credentials/tests/CHIPCert_test_vectors.h
+++ b/src/credentials/tests/CHIPCert_test_vectors.h
@@ -140,6 +140,8 @@ extern const ByteSpan sTestCert_Node01_01_PublicKey;
 extern const ByteSpan sTestCert_Node01_01_PrivateKey;
 extern const ByteSpan sTestCert_Node01_01_SubjectKeyId;
 extern const ByteSpan sTestCert_Node01_01_AuthorityKeyId;
+inline constexpr NodeId kTestCert_Node01_01_NodeId     = 0xDEDEDEDE00010001;
+inline constexpr FabricId kTestCert_Node01_01_FabricId = 0xFAB000000000001D;
 
 extern const ByteSpan sTestCert_Node01_01_Err01_Chip;
 
@@ -149,6 +151,8 @@ extern const ByteSpan sTestCert_Node01_02_PublicKey;
 extern const ByteSpan sTestCert_Node01_02_PrivateKey;
 extern const ByteSpan sTestCert_Node01_02_SubjectKeyId;
 extern const ByteSpan sTestCert_Node01_02_AuthorityKeyId;
+inline constexpr NodeId kTestCert_Node01_02_NodeId     = 0xDEDEDEDE00010002;
+inline constexpr FabricId kTestCert_Node01_02_FabricId = 0xFAB000000000001D;
 
 extern const ByteSpan sTestCert_Node02_01_Chip;
 extern const ByteSpan sTestCert_Node02_01_DER;
@@ -156,6 +160,8 @@ extern const ByteSpan sTestCert_Node02_01_PublicKey;
 extern const ByteSpan sTestCert_Node02_01_PrivateKey;
 extern const ByteSpan sTestCert_Node02_01_SubjectKeyId;
 extern const ByteSpan sTestCert_Node02_01_AuthorityKeyId;
+inline constexpr NodeId kTestCert_Node02_01_NodeId     = 0xDEDEDEDE00020001;
+inline constexpr FabricId kTestCert_Node02_01_FabricId = 0xFAB000000000001D;
 
 extern const ByteSpan sTestCert_Node02_02_Chip;
 extern const ByteSpan sTestCert_Node02_02_DER;
@@ -163,6 +169,8 @@ extern const ByteSpan sTestCert_Node02_02_PublicKey;
 extern const ByteSpan sTestCert_Node02_02_PrivateKey;
 extern const ByteSpan sTestCert_Node02_02_SubjectKeyId;
 extern const ByteSpan sTestCert_Node02_02_AuthorityKeyId;
+inline constexpr NodeId kTestCert_Node02_02_NodeId     = 0xDEDEDEDE00020002;
+inline constexpr FabricId kTestCert_Node02_02_FabricId = 0xFAB000000000001D;
 
 extern const ByteSpan sTestCert_Node02_03_Chip;
 extern const ByteSpan sTestCert_Node02_03_DER;
@@ -170,6 +178,8 @@ extern const ByteSpan sTestCert_Node02_03_PublicKey;
 extern const ByteSpan sTestCert_Node02_03_PrivateKey;
 extern const ByteSpan sTestCert_Node02_03_SubjectKeyId;
 extern const ByteSpan sTestCert_Node02_03_AuthorityKeyId;
+inline constexpr NodeId kTestCert_Node02_03_NodeId     = 0xDEDEDEDE00020003;
+inline constexpr FabricId kTestCert_Node02_03_FabricId = 0xFAB000000000001D;
 
 extern const ByteSpan sTestCert_Node02_04_Chip;
 extern const ByteSpan sTestCert_Node02_04_DER;
@@ -177,6 +187,8 @@ extern const ByteSpan sTestCert_Node02_04_PublicKey;
 extern const ByteSpan sTestCert_Node02_04_PrivateKey;
 extern const ByteSpan sTestCert_Node02_04_SubjectKeyId;
 extern const ByteSpan sTestCert_Node02_04_AuthorityKeyId;
+inline constexpr NodeId kTestCert_Node02_04_NodeId     = 0xDEDEDEDE00020004;
+inline constexpr FabricId kTestCert_Node02_04_FabricId = 0xFAB000000000001D;
 
 extern const ByteSpan sTestCert_Node02_05_Chip;
 extern const ByteSpan sTestCert_Node02_05_DER;
@@ -184,6 +196,8 @@ extern const ByteSpan sTestCert_Node02_05_PublicKey;
 extern const ByteSpan sTestCert_Node02_05_PrivateKey;
 extern const ByteSpan sTestCert_Node02_05_SubjectKeyId;
 extern const ByteSpan sTestCert_Node02_05_AuthorityKeyId;
+inline constexpr NodeId kTestCert_Node02_05_NodeId     = 0xDEDEDEDE00020005;
+inline constexpr FabricId kTestCert_Node02_05_FabricId = 0xFAB000000000001D;
 
 extern const ByteSpan sTestCert_Node02_06_Chip;
 extern const ByteSpan sTestCert_Node02_06_DER;
@@ -191,6 +205,8 @@ extern const ByteSpan sTestCert_Node02_06_PublicKey;
 extern const ByteSpan sTestCert_Node02_06_PrivateKey;
 extern const ByteSpan sTestCert_Node02_06_SubjectKeyId;
 extern const ByteSpan sTestCert_Node02_06_AuthorityKeyId;
+inline constexpr NodeId kTestCert_Node02_06_NodeId     = 0xDEDEDEDE00020006;
+inline constexpr FabricId kTestCert_Node02_06_FabricId = 0xFAB000000000001D;
 
 extern const ByteSpan sTestCert_Node02_07_Chip;
 extern const ByteSpan sTestCert_Node02_07_DER;
@@ -198,6 +214,8 @@ extern const ByteSpan sTestCert_Node02_07_PublicKey;
 extern const ByteSpan sTestCert_Node02_07_PrivateKey;
 extern const ByteSpan sTestCert_Node02_07_SubjectKeyId;
 extern const ByteSpan sTestCert_Node02_07_AuthorityKeyId;
+inline constexpr NodeId kTestCert_Node02_07_NodeId     = 0xDEDEDEDE00020007;
+inline constexpr FabricId kTestCert_Node02_07_FabricId = 0xFAB000000000001D;
 
 extern const ByteSpan sTestCert_Node02_08_Chip;
 extern const ByteSpan sTestCert_Node02_08_DER;
@@ -205,6 +223,8 @@ extern const ByteSpan sTestCert_Node02_08_PublicKey;
 extern const ByteSpan sTestCert_Node02_08_PrivateKey;
 extern const ByteSpan sTestCert_Node02_08_SubjectKeyId;
 extern const ByteSpan sTestCert_Node02_08_AuthorityKeyId;
+inline constexpr NodeId kTestCert_Node02_08_NodeId     = 0xDEDEDEDE00020008;
+inline constexpr FabricId kTestCert_Node02_08_FabricId = 0xFAB000000000001D;
 
 extern const ByteSpan sTestCert_PDCID01_Chip;
 extern const ByteSpan sTestCert_PDCID01_ChipCompact;


### PR DESCRIPTION
Currently it's only possible to allocate fabric indexes sequentially starting from 1.

Sparse fabric tables could be produced by adding & removing fabrics, but not directly.

This allow the application to control the assignment of fabric ids directly by providing a function that overrides the next index to use.

eg If an application has 3 fabrics, it can recreate the fabric table from scratch while keeping consistent indexes.