### PR TITLE
Fix issue related to teardown of some App Tests

### DIFF
--- a/src/app/tests/AppTestContext.cpp
+++ b/src/app/tests/AppTestContext.cpp
@@ -49,6 +49,12 @@ void AppContext::SetUpTestSuite()
 
 void AppContext::TearDownTestSuite()
 {
+    // Adding a DrainAndServiceIO call fixes the teardown for some tests (TestAclAttribute and TestReportScheduler); these were
+    // triggering failures in tests that follow them when running on nRF CI (Zephyr native_posix where all Unit Tests are compiled
+    // into a single file)
+    // TODO: understand this more and solve underlying issue
+    LoopbackMessagingContext::DrainAndServiceIO();
+
     chip::DeviceLayer::PlatformMgr().Shutdown();
     LoopbackMessagingContext::TearDownTestSuite();
 }

--- a/src/app/tests/AppTestContext.cpp
+++ b/src/app/tests/AppTestContext.cpp
@@ -49,10 +49,16 @@ void AppContext::SetUpTestSuite()
 
 void AppContext::TearDownTestSuite()
 {
-    // Adding a DrainAndServiceIO call fixes the teardown for some tests (TestAclAttribute and TestReportScheduler); these were
-    // triggering failures in tests that follow them when running on nRF CI (Zephyr native_posix where all Unit Tests are compiled
-    // into a single file)
-    // TODO: understand this more and solve underlying issue
+    // Some test suites finish with unprocessed work left in the platform manager event queue.
+    // This can particularly be a problem when this unprocessed work involves reporting engine runs,
+    // since those can take a while and cause later tests to not reach their queued work before
+    // their timeouts hit.  This is only an issue in setups where all unit tests are compiled into
+    // a single file (e.g. nRF CI (Zephyr native_posix)).
+    //
+    // Work around this issue by doing a DrainAndServiceIO() here to attempt to flush out any queued-up work.
+    //
+    // TODO: Solve the underlying issue where test suites leave unprocessed work.  Or is this actually
+    // the right solution?
     LoopbackMessagingContext::DrainAndServiceIO();
 
     chip::DeviceLayer::PlatformMgr().Shutdown();

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -123,6 +123,7 @@ chip_test_suite_using_nltest("tests") {
   output_name = "libAppTests"
 
   test_sources = [
+    "TestAclAttribute.cpp",
     "TestAclEvent.cpp",
     "TestAttributeAccessInterfaceCache.cpp",
     "TestAttributePathExpandIterator.cpp",
@@ -151,6 +152,7 @@ chip_test_suite_using_nltest("tests") {
     "TestPendingResponseTrackerImpl.cpp",
     "TestPowerSourceCluster.cpp",
     "TestReadInteraction.cpp",
+    "TestReportScheduler.cpp",
     "TestReportingEngine.cpp",
     "TestStatusIB.cpp",
     "TestStatusResponseMessage.cpp",
@@ -163,8 +165,6 @@ chip_test_suite_using_nltest("tests") {
   if (!chip_fake_platform) {
     test_sources += [ "TestFailSafeContext.cpp" ]
   }
-
-  test_sources += [ "TestAclAttribute.cpp" ]
 
   # DefaultICDClientStorage assumes that raw AES key is used by the application
   if (chip_crypto != "psa") {
@@ -187,16 +187,6 @@ chip_test_suite_using_nltest("tests") {
   if (chip_device_platform != "nrfconnect" &&
       chip_device_platform != "openiotsdk" && chip_device_platform != "fake") {
     test_sources += [ "TestEventLogging.cpp" ]
-  }
-
-  # The platform manager is not properly clearing queues in test teardown, which results in
-  # DrainIO calls not being able to run in expected time (5seconds) if unprocessed reported engine
-  # runs are remaining, causing tests to crash in Open IoT SDK and Zephyr tests since they are
-  # running all tests in one file. We need to figure out how to properly clean the event queues
-  # before enabling this test for these platforms.
-  if (chip_device_platform != "nrfconnect" &&
-      chip_device_platform != "openiotsdk") {
-    test_sources += [ "TestReportScheduler.cpp" ]
   }
 
   cflags = [ "-Wconversion" ]


### PR DESCRIPTION
              Is this required as part of this change?  Seems like an unrelated fix that could use very careful review not in the context of a mass-change....

_Originally posted by @bzbarsky-apple in https://github.com/project-chip/connectedhomeip/pull/33638#discussion_r1617960964_
            
## Context

- `TestAclAttribute.cpp` and `TestReportScheduler.cpp` are triggering failures in (some) tests that follow them when being run on Nordic CI (on the Zephyr Native POSIX target, which compiles all unit tests into a single binary).
- At the moment, `TestReportScheduler.cpp` is not being run for Nordic, and `TestAclAttribute.cpp` is being configured to run last, right after all the tests that it triggers failures.
- That tests on which the failures happen are `TestAclEvent` and `TestReadInteraction`: it seems that the problem is related to `Report Data` that comes after a Read Request --> the Callback that will call `BuildAndSendSingleReportData` is not being called.
- A solution (workaround?) which solves this problem, however, is to just call `DrainAndServiceIO()` right in the teardown of these Tests (`TestAclAttribute.cpp` and `TestReportScheduler.cpp` ) --> However, I thought I might just put it in the teardown of AppTestContext incase we add more tests in the future that might trigger the same problem


UPDATE: There was already an issue for this here:  [#27976](https://github.com/project-chip/connectedhomeip/issues/27976)