### PR TITLE
[Python] Add "automation" level to log defines

### DIFF
--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -36,6 +36,7 @@ from ctypes import CFUNCTYPE, Structure, c_bool, c_char_p, c_int64, c_uint8, c_u
 from threading import Condition, Event, Lock
 
 import chip.native
+from chip.logging import LOG_CATEGORY_AUTOMATION, LOG_CATEGORY_DETAIL, LOG_CATEGORY_ERROR, LOG_CATEGORY_PROGRESS
 from chip.native import PyChipError
 
 from .ChipUtility import ChipUtility
@@ -78,23 +79,14 @@ class DeviceStatusStruct(Structure):
 class LogCategory(object):
     """Debug logging categories used by chip."""
 
-    # NOTE: These values must correspond to those used in the chip C++ code.
-    Disabled = 0
-    Error = 1
-    Progress = 2
-    Detail = 3
-    Retain = 4
-
     @staticmethod
     def categoryToLogLevel(cat):
-        if cat == LogCategory.Error:
+        if cat == LOG_CATEGORY_ERROR:
             return logging.ERROR
-        elif cat == LogCategory.Progress:
+        elif cat == LOG_CATEGORY_PROGRESS:
             return logging.INFO
-        elif cat == LogCategory.Detail:
+        elif cat in (LOG_CATEGORY_DETAIL, LOG_CATEGORY_AUTOMATION):
             return logging.DEBUG
-        elif cat == LogCategory.Retain:
-            return logging.CRITICAL
         else:
             return logging.NOTSET
 

--- a/src/controller/python/chip/logging/__init__.py
+++ b/src/controller/python/chip/logging/__init__.py
@@ -19,11 +19,12 @@ import logging
 from chip.logging.library_handle import _GetLoggingLibraryHandle
 from chip.logging.types import LogRedirectCallback_t
 
-# Defines match support/logging/Constants.h (LogCategory enum)
-ERROR_CATEGORY_NONE = 0
-ERROR_CATEGORY_ERROR = 1
-ERROR_CATEGORY_PROGRESS = 2
-ERROR_CATEGORY_DETAIL = 3
+# Defines match src/lib/support/logging/Constants.h (LogCategory enum)
+LOG_CATEGORY_NONE = 0
+LOG_CATEGORY_ERROR = 1
+LOG_CATEGORY_PROGRESS = 2
+LOG_CATEGORY_DETAIL = 3
+LOG_CATEGORY_AUTOMATION = 4
 
 
 @LogRedirectCallback_t
@@ -34,11 +35,11 @@ def _RedirectToPythonLogging(category, module, message):
 
     logger = logging.getLogger('chip.native.%s' % module)
 
-    if category == ERROR_CATEGORY_ERROR:
+    if category == LOG_CATEGORY_ERROR:
         logger.error("%s", message)
-    elif category == ERROR_CATEGORY_PROGRESS:
+    elif category == LOG_CATEGORY_PROGRESS:
         logger.info("%s", message)
-    elif category == ERROR_CATEGORY_DETAIL:
+    elif category in (LOG_CATEGORY_DETAIL, LOG_CATEGORY_AUTOMATION):
         logger.debug("%s", message)
     else:
         # All logs are expected to have some reasonable category. This treats


### PR DESCRIPTION
So far the automation log level was missing. Add it to the log level defines in the logging module.

While at it, also rename to LOG_CATEGORY (instead of ERROR_CATEGORY) and remove duplicated log level definitions in ChipStack.
