### PR TITLE
Worked on issue 243; replaced input with self.wait_for_user_input; other changes

### DIFF
--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -122,7 +122,7 @@ class TC_OPSTATE_BASE():
             self.write_to_app_pipe(command)
             time.sleep(0.1)
         else:
-            input("Press Enter when done.\n")
+            self.wait_for_user_input(prompt_msg="Press Enter when ready.\n")
 
     def send_manual_or_pipe_command(self, device: str, name: str, operation: str, param: Any = None):
         command = {
@@ -1113,7 +1113,7 @@ class TC_OPSTATE_BASE():
             # In CI environment, the STOP coommand (step 8) already resets the variables. Only ask for
             # reboot outside CI environment.
             if not self.is_ci:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(prompt_msg="Press Enter when ready.\n")
 
             # STEP 12: TH waits for {PIXIT.WAITTIME.REBOOT}
             self.step(12)

--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -1113,7 +1113,7 @@ class TC_OPSTATE_BASE():
             # In CI environment, the STOP coommand (step 8) already resets the variables. Only ask for
             # reboot outside CI environment.
             if not self.is_ci:
-                self.wait_for_user_input(prompt_msg="Press Enter when ready.\n")
+                self.wait_for_user_input(prompt_msg="Restart DUT. Press Enter when ready.\n")
 
             # STEP 12: TH waits for {PIXIT.WAITTIME.REBOOT}
             self.step(12)

--- a/src/python_testing/TC_RVCCLEANM_2_1.py
+++ b/src/python_testing/TC_RVCCLEANM_2_1.py
@@ -138,7 +138,8 @@ class TC_RVCCLEANM_2_1(MatterBaseTest):
                 print("Changing mode to Cleaning")
                 await self.send_run_change_to_mode_cmd(1)
             else:
-                self.wait_for_user_input(prompt_msg="Manually put the device in a state from which it will FAIL to transition to mode %d, and press Enter when done" % (self.mode_fail))
+                self.wait_for_user_input(
+                    prompt_msg="Manually put the device in a state from which it will FAIL to transition to mode %d, and press Enter when done" % (self.mode_fail))
 
             self.print_step(6, "Read CurrentMode attribute")
             old_current_mode = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.CurrentMode)
@@ -169,7 +170,8 @@ class TC_RVCCLEANM_2_1(MatterBaseTest):
             print("Changing mode to Idle")
             await self.send_run_change_to_mode_cmd(0)
         else:
-            self.wait_for_user_input(prompt_msg="Manually put the device in a state from which it will SUCCESSFULLY transition to mode %d, and press Enter when done" % (self.mode_ok))
+            self.wait_for_user_input(
+                prompt_msg="Manually put the device in a state from which it will SUCCESSFULLY transition to mode %d, and press Enter when done" % (self.mode_ok))
 
         self.print_step(10, "Read CurrentMode attribute")
         old_current_mode = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.CurrentMode)

--- a/src/python_testing/TC_RVCCLEANM_2_1.py
+++ b/src/python_testing/TC_RVCCLEANM_2_1.py
@@ -138,7 +138,7 @@ class TC_RVCCLEANM_2_1(MatterBaseTest):
                 print("Changing mode to Cleaning")
                 await self.send_run_change_to_mode_cmd(1)
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(prompt_msg="Manually put the device in a state from which it will FAIL to transition to mode %d, and press Enter when done" % (self.mode_fail))
 
             self.print_step(6, "Read CurrentMode attribute")
             old_current_mode = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.CurrentMode)
@@ -169,7 +169,7 @@ class TC_RVCCLEANM_2_1(MatterBaseTest):
             print("Changing mode to Idle")
             await self.send_run_change_to_mode_cmd(0)
         else:
-            input("Press Enter when done.\n")
+            self.wait_for_user_input(prompt_msg="Manually put the device in a state from which it will SUCCESSFULLY transition to mode %d, and press Enter when done" % (self.mode_ok))
 
         self.print_step(10, "Read CurrentMode attribute")
         old_current_mode = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.CurrentMode)

--- a/src/python_testing/TC_RVCCLEANM_2_2.py
+++ b/src/python_testing/TC_RVCCLEANM_2_2.py
@@ -101,7 +101,8 @@ class TC_RVCCLEANM_2_2(MatterBaseTest):
         if self.is_ci:
             await self.send_run_change_to_mode_cmd(1)
         else:
-            self.wait_for_user_input(prompt_msg="Manually put the device in a state in which the RVC Run Mode cluster’s CurrentMode attribute is set to a mode without the Idle mode tag, and press Enter when done.")
+            self.wait_for_user_input(
+                prompt_msg="Manually put the device in a state in which the RVC Run Mode cluster’s CurrentMode attribute is set to a mode without the Idle mode tag, and press Enter when done.")
 
         self.print_step(3, "Read the RvcRunMode SupportedModes attribute")
         supported_run_modes = await self.read_run_supported_modes()

--- a/src/python_testing/TC_RVCCLEANM_2_2.py
+++ b/src/python_testing/TC_RVCCLEANM_2_2.py
@@ -63,7 +63,7 @@ class TC_RVCCLEANM_2_2(MatterBaseTest):
     # Prints the instruction and waits for a user input to continue
     def print_instruction(self, step_number, instruction):
         self.print_step(step_number, instruction)
-        input("Press Enter when done.\n")
+        self.wait_for_user_input(prompt_msg=f"{instruction}, and press Enter when ready.")
 
     def pics_TC_RVCCLEANM_2_2(self) -> list[str]:
         return ["RVCCLEANM.S"]
@@ -101,7 +101,7 @@ class TC_RVCCLEANM_2_2(MatterBaseTest):
         if self.is_ci:
             await self.send_run_change_to_mode_cmd(1)
         else:
-            input("Press Enter when done.\n")
+            self.wait_for_user_input(prompt_msg="Manually put the device in a state in which the RVC Run Mode cluster’s CurrentMode attribute is set to a mode without the Idle mode tag, and press Enter when done.")
 
         self.print_step(3, "Read the RvcRunMode SupportedModes attribute")
         supported_run_modes = await self.read_run_supported_modes()

--- a/src/python_testing/TC_RVCOPSTATE_2_1.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_1.py
@@ -158,53 +158,60 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
             asserts.assert_true(operational_state in defined_states or in_range, "OperationalState has an invalid ID value!")
 
             if self.check_pics("RVCOPSTATE.S.M.ST_STOPPED"):
-                self.print_step("6a", "Manually put the device in the stopped state")
+                test_step = "Manually put the device in the stopped state"
+                self.print_step("6a", test_step)
                 if not self.is_ci:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_opstate(step="6b", expected_state=Clusters.OperationalState.Enums.OperationalStateEnum.kStopped)
             if self.check_pics("RVCOPSTATE.S.M.ST_RUNNING"):
-                self.print_step("6c", "Manually put the device in the running state")
+                test_step = "Manually put the device in the running state"
+                self.print_step("6c", test_step)
                 if self.is_ci:
                     await self.send_run_change_to_mode_cmd(1)
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_opstate(step="6d", expected_state=Clusters.OperationalState.Enums.OperationalStateEnum.kRunning)
             if self.check_pics("RVCOPSTATE.S.M.ST_PAUSED"):
-                self.print_step("6e", "Manually put the device in the paused state")
+                test_step = "Manually put the device in the paused state"
+                self.print_step("6e", test_step)
                 if self.is_ci:
                     await self.send_pause_cmd()
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_opstate(step="6f", expected_state=Clusters.OperationalState.Enums.OperationalStateEnum.kPaused)
             if self.check_pics("RVCOPSTATE.S.M.ST_ERROR"):
-                self.print_step("6g", "Manually put the device in the error state")
+                test_step = "Manually put the device in the error state"
+                self.print_step("6g", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "UnableToStartOrResume"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_opstate(step="6h", expected_state=Clusters.OperationalState.Enums.OperationalStateEnum.kError)
             if self.check_pics("RVCOPSTATE.S.M.ST_SEEKING_CHARGER"):
-                self.print_step("6i", "Manually put the device in the seeking charger state")
+                test_step = "Manually put the device in the seeking charger state"
+                self.print_step("6i", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "Reset"}')
                     await self.send_run_change_to_mode_cmd(1)
                     await self.send_run_change_to_mode_cmd(0)
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_opstate(step="6j", expected_state=Clusters.RvcOperationalState.Enums.OperationalStateEnum.kSeekingCharger)
             if self.check_pics("RVCOPSTATE.S.M.ST_CHARGING"):
-                self.print_step("6k", "Manually put the device in the charging state")
+                test_step = "Manually put the device in the charging state"
+                self.print_step("6k", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ChargerFound"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_opstate(step="6l", expected_state=Clusters.RvcOperationalState.Enums.OperationalStateEnum.kCharging)
             if self.check_pics("RVCOPSTATE.S.M.ST_DOCKED"):
-                self.print_step("6m", "Manually put the device in the docked state")
+                test_step = "Manually put the device in the docked state"
+                self.print_step("6m", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "Charged"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_opstate(step="6n", expected_state=Clusters.RvcOperationalState.Enums.OperationalStateEnum.kDocked)
 
         if self.check_pics("RVCOPSTATE.S.A0005"):
@@ -226,86 +233,98 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
                 asserts.assert_true(operational_error.errorStateLabel is not None, "ErrorStateLabel should be populated")
 
             if self.check_pics("RVCOPSTATE.S.M.ERR_NO_ERROR"):
-                self.print_step("7a", "Manually put the device in the no error state")
+                test_step = "Manually put the device in the no error state"
+                self.print_step("7a", test_step)
                 if not self.is_ci:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7b", expected_error=Clusters.OperationalState.Enums.ErrorStateEnum.kNoError)
             if self.check_pics("RVCOPSTATE.S.M.ERR_UNABLE_TO_START_OR_RESUME"):
-                self.print_step("7c", "Manually put the device in the unable to start or resume error state")
+                test_step = "Manually put the device in the unable to start or resume error state"
+                self.print_step("7c", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "UnableToStartOrResume"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7d", expected_error=Clusters.OperationalState.Enums.ErrorStateEnum.kUnableToStartOrResume)
             if self.check_pics("RVCOPSTATE.S.M.ERR_UNABLE_TO_COMPLETE_OPERATION"):
-                self.print_step("7e", "Manually put the device in the unable to complete operation error state")
+                test_step = "Manually put the device in the unable to complete operation error state"
+                self.print_step("7e", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "UnableToCompleteOperation"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7f", expected_error=Clusters.OperationalState.Enums.ErrorStateEnum.kUnableToCompleteOperation)
             if self.check_pics("RVCOPSTATE.S.M.ERR_COMMAND_INVALID_IN_STATE"):
-                self.print_step("7g", "Manually put the device in the command invalid error state")
+                test_step = "Manually put the device in the command invalid error state"
+                self.print_step("7g", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "CommandInvalidInState"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7h", expected_error=Clusters.OperationalState.Enums.ErrorStateEnum.kCommandInvalidInState)
             if self.check_pics("RVCOPSTATE.S.M.ERR_FAILED_TO_FIND_CHARGING_DOCK"):
-                self.print_step("7i", "Manually put the device in the failed to find dock error state")
+                test_step = "Manually put the device in the failed to find dock error state"
+                self.print_step("7i", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "FailedToFindChargingDock"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7j", expected_error=Clusters.RvcOperationalState.Enums.ErrorStateEnum.kFailedToFindChargingDock)
             if self.check_pics("RVCOPSTATE.S.M.ERR_STUCK"):
-                self.print_step("7k", "Manually put the device in the stuck error state")
+                test_step = "Manually put the device in the stuck error state"
+                self.print_step("7k", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "Stuck"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7l", expected_error=Clusters.RvcOperationalState.Enums.ErrorStateEnum.kStuck)
             if self.check_pics("RVCOPSTATE.S.M.ERR_DUST_BIN_MISSING"):
-                self.print_step("7m", "Manually put the device in the dust bin missing error state")
+                test_step = "Manually put the device in the dust bin missing error state"
+                self.print_step("7m", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "DustBinMissing"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7n", expected_error=Clusters.RvcOperationalState.Enums.ErrorStateEnum.kDustBinMissing)
             if self.check_pics("RVCOPSTATE.S.M.ERR_DUST_BIN_FULL"):
-                self.print_step("7o", "Manually put the device in the dust bin full error state")
+                test_step = "Manually put the device in the dust bin full error state"
+                self.print_step("7o", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "DustBinFull"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7p", expected_error=Clusters.RvcOperationalState.Enums.ErrorStateEnum.kDustBinFull)
             if self.check_pics("RVCOPSTATE.S.M.ERR_WATER_TANK_EMPTY"):
-                self.print_step("7q", "Manually put the device in the water tank empty error state")
+                test_step = "Manually put the device in the water tank empty error state"
+                self.print_step("7q", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "WaterTankEmpty"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7r", expected_error=Clusters.RvcOperationalState.Enums.ErrorStateEnum.kWaterTankEmpty)
             if self.check_pics("RVCOPSTATE.S.M.ERR_WATER_TANK_MISSING"):
-                self.print_step("7s", "Manually put the device in the water tank missing error state")
+                test_step = "Manually put the device in the water tank missing error state"
+                self.print_step("7s", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "WaterTankMissing"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7t", expected_error=Clusters.RvcOperationalState.Enums.ErrorStateEnum.kWaterTankMissing)
             if self.check_pics("RVCOPSTATE.S.M.ERR_WATER_TANK_LID_OPEN"):
-                self.print_step("7u", "Manually put the device in the water tank lid open error state")
+                test_step = "Manually put the device in the water tank lid open error state"
+                self.print_step("7u", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "WaterTankLidOpen"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7v", expected_error=Clusters.RvcOperationalState.Enums.ErrorStateEnum.kWaterTankLidOpen)
             if self.check_pics("RVCOPSTATE.S.M.ERR_MOP_CLEANING_PAD_MISSING"):
-                self.print_step("7w", "Manually put the device in the mop cleaning pad missing error state")
+                test_step = "Manually put the device in the mop cleaning pad missing error state"
+                self.print_step("7w", test_step)
                 if self.is_ci:
                     self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "MopCleaningPadMissing"}')
                 else:
-                    input("Press Enter when done.\n")
+                    self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_operror(step="7x", expected_error=Clusters.RvcOperationalState.Enums.ErrorStateEnum.kMopCleaningPadMissing)
 
 

--- a/src/python_testing/TC_RVCOPSTATE_2_3.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_3.py
@@ -137,7 +137,7 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
     # Prints the instruction and waits for a user input to continue
     def print_instruction(self, step_number, instruction):
         self.print_step(step_number, instruction)
-        input("Press Enter when done.\n")
+        self.wait_for_user_input(prompt_msg=f"{instruction}, and press Enter when done.")
 
     def pics_TC_RVCOPSTATE_2_3(self) -> list[str]:
         return ["RVCOPSTATE.S"]
@@ -172,11 +172,12 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
         if self.is_ci:
             self.write_to_app_pipe('{"Name": "Reset"}')
 
-        self.print_step(2, "Manually put the device in a state where it can receive a Pause command")
+        test_step = "Manually put the device in a state where it can receive a Pause command"
+        self.print_step(2, test_step)
         if self.is_ci:
             await self.send_run_change_to_mode_cmd(1)
         else:
-            input("Press Enter when done.\n")
+            self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
 
         self.print_step(3, "Read OperationalStateList attribute")
         op_state_list = await self.read_mod_attribute_expect_success(endpoint=self.endpoint,
@@ -253,11 +254,12 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
             await self.read_operational_state_with_check(23, op_states.kRunning)
 
         if self.check_pics("RVCOPSTATE.S.M.ST_STOPPED"):
-            self.print_step(24, "Manually put the device in the Stopped(0x00) operational state")
+            test_step = "Manually put the device in the Stopped(0x00) operational state"
+            self.print_step(24, test_step)
             if self.is_ci:
                 self.write_to_app_pipe('{"Name": "Reset"}')
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
 
             await self.read_operational_state_with_check(25, op_states.kStopped)
 
@@ -266,11 +268,12 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
             await self.send_resume_cmd_with_check(27, op_errors.kCommandInvalidInState)
 
         if self.check_pics("RVCOPSTATE.S.M.ST_ERROR"):
-            self.print_step(28, "Manually put the device in the Error(0x03) operational state")
+            test_step = "Manually put the device in the Error(0x03) operational state"
+            self.print_step(28, test_step)
             if self.is_ci:
                 self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "Stuck"}')
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
 
             await self.read_operational_state_with_check(29, op_states.kError)
 
@@ -279,53 +282,55 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
             await self.send_resume_cmd_with_check(31, op_errors.kCommandInvalidInState)
 
         if self.check_pics("RVCOPSTATE.S.M.ST_CHARGING"):
-            self.print_step(32, "Manually put the device in the Charging(0x41) operational state")
+            test_step = "Manually put the device in the Charging(0x41) operational state"
+            self.print_step(32, test_step)
             if self.is_ci:
                 self.write_to_app_pipe('{"Name": "Reset"}')
                 await self.send_run_change_to_mode_cmd(1)
                 await self.send_run_change_to_mode_cmd(0)
                 self.write_to_app_pipe('{"Name": "ChargerFound"}')
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
 
             await self.read_operational_state_with_check(33, rvc_op_states.kCharging)
 
             await self.send_pause_cmd_with_check(34, op_errors.kCommandInvalidInState)
-
-            self.print_step(
-                35, "Manually put the device in the Charging(0x41) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag")
+            test_step = "Manually put the device in the Charging(0x41) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag"
+            self.print_step(35, test_step)
             if not self.is_ci:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
 
             await self.read_operational_state_with_check(36, rvc_op_states.kCharging)
 
             await self.send_resume_cmd_with_check(37, op_errors.kCommandInvalidInState)
 
         if self.check_pics("RVCOPSTATE.S.M.ST_DOCKED"):
-            self.print_step(38, "Manually put the device in the Docked(0x42) operational state")
+            test_step = "Manually put the device in the Docked(0x42) operational state"
+            self.print_step(38, test_step)
             if self.is_ci:
                 self.write_to_app_pipe('{"Name": "Charged"}')
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
 
             await self.read_operational_state_with_check(39, rvc_op_states.kDocked)
 
             await self.send_pause_cmd_with_check(40, op_errors.kCommandInvalidInState)
 
-            self.print_step(
-                41, "Manually put the device in the Docked(0x42) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag")
+            test_step = "Manually put the device in the Docked(0x42) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag"
+            self.print_step(41, test_step)
             if not self.is_ci:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
 
             await self.send_resume_cmd_with_check(42, op_errors.kCommandInvalidInState)
 
         if self.check_pics("RVCOPSTATE.S.M.ST_SEEKING_CHARGER"):
-            self.print_step(43, "Manually put the device in the SeekingCharger(0x40) operational state")
+            test_step = "Manually put the device in the SeekingCharger(0x40) operational state"
+            self.print_step(43, test_step)
             if self.is_ci:
                 await self.send_run_change_to_mode_cmd(1)
                 await self.send_run_change_to_mode_cmd(0)
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
 
             await self.read_operational_state_with_check(44, rvc_op_states.kSeekingCharger)
 

--- a/src/python_testing/TC_RVCOPSTATE_2_4.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_4.py
@@ -124,7 +124,7 @@ class TC_RVCOPSTATE_2_4(MatterBaseTest):
             if self.is_ci:
                 self.write_to_app_pipe('{"Name": "ErrorEvent", "Error": "UnableToStartOrResume"}')
             else:
-                self.wait_for_user_input(step_name)
+                self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
 
             await self.read_operational_state_with_check(3, op_states.kError)
 
@@ -138,7 +138,7 @@ class TC_RVCOPSTATE_2_4(MatterBaseTest):
                 self.write_to_app_pipe('{"Name": "Docked"}')
                 self.write_to_app_pipe('{"Name": "Charging"}')
             else:
-                self.wait_for_user_input(step_name)
+                self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
 
             await self.read_operational_state_with_check(6, rvc_op_states.kCharging)
 
@@ -150,7 +150,7 @@ class TC_RVCOPSTATE_2_4(MatterBaseTest):
             if self.is_ci:
                 self.write_to_app_pipe('{"Name": "Charged"}')
             else:
-                self.wait_for_user_input(step_name)
+                self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
 
             await self.read_operational_state_with_check(9, rvc_op_states.kDocked)
 
@@ -163,7 +163,7 @@ class TC_RVCOPSTATE_2_4(MatterBaseTest):
                 await self.send_run_change_to_mode_cmd(rvc_app_run_mode_cleaning)
                 await self.send_run_change_to_mode_cmd(rvc_app_run_mode_idle)
             else:
-                self.wait_for_user_input(step_name)
+                self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
 
             await self.read_operational_state_with_check(9, rvc_op_states.kSeekingCharger)
 

--- a/src/python_testing/TC_RVCRUNM_2_1.py
+++ b/src/python_testing/TC_RVCRUNM_2_1.py
@@ -133,7 +133,7 @@ class TC_RVCRUNM_2_1(MatterBaseTest):
                 print("Change to RVC Run mode Cleaning")
                 await self.send_change_to_mode_cmd(newMode=1)
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(prompt_msg="Manually put the device in a state from which it will FAIL to transition to mode %d, and press Enter when ready." % (self.mode_fail))
 
             self.print_step(6, "Read CurrentMode attribute")
             old_current_mode = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.CurrentMode)
@@ -163,7 +163,7 @@ class TC_RVCRUNM_2_1(MatterBaseTest):
         if self.is_ci:
             print("Continuing...")
         else:
-            input("Press Enter when done.\n")
+            self.wait_for_user_input(prompt_msg="Manually put the device in a state from which it will SUCCESSFULLY transition to mode %d, and press Enter when ready." % (self.mode_ok))
 
         self.print_step(10, "Read CurrentMode attribute")
         old_current_mode = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.CurrentMode)

--- a/src/python_testing/TC_RVCRUNM_2_1.py
+++ b/src/python_testing/TC_RVCRUNM_2_1.py
@@ -133,7 +133,8 @@ class TC_RVCRUNM_2_1(MatterBaseTest):
                 print("Change to RVC Run mode Cleaning")
                 await self.send_change_to_mode_cmd(newMode=1)
             else:
-                self.wait_for_user_input(prompt_msg="Manually put the device in a state from which it will FAIL to transition to mode %d, and press Enter when ready." % (self.mode_fail))
+                self.wait_for_user_input(
+                    prompt_msg="Manually put the device in a state from which it will FAIL to transition to mode %d, and press Enter when ready." % (self.mode_fail))
 
             self.print_step(6, "Read CurrentMode attribute")
             old_current_mode = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.CurrentMode)
@@ -163,7 +164,8 @@ class TC_RVCRUNM_2_1(MatterBaseTest):
         if self.is_ci:
             print("Continuing...")
         else:
-            self.wait_for_user_input(prompt_msg="Manually put the device in a state from which it will SUCCESSFULLY transition to mode %d, and press Enter when ready." % (self.mode_ok))
+            self.wait_for_user_input(
+                prompt_msg="Manually put the device in a state from which it will SUCCESSFULLY transition to mode %d, and press Enter when ready." % (self.mode_ok))
 
         self.print_step(10, "Read CurrentMode attribute")
         old_current_mode = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.CurrentMode)

--- a/src/python_testing/TC_RVCRUNM_2_2.py
+++ b/src/python_testing/TC_RVCRUNM_2_2.py
@@ -135,12 +135,12 @@ class TC_RVCRUNM_2_2(MatterBaseTest):
         # Ensure that the device is in the correct state
         if self.is_ci:
             self.write_to_app_pipe('{"Name": "Reset"}')
-
-        self.print_step(2, "Manually put the device in a RVC Run Mode cluster mode with "
+        test_step = ("Manually put the device in a RVC Run Mode cluster mode with "
                            "the Idle(0x4000) mode tag and in a device state that allows changing to either "
                            "of these modes: %i, %i" % (self.mode_a, self.mode_b))
+        self.print_step(2, test_step)
         if not self.is_ci:
-            input("Press Enter when done.\n")
+            self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when ready.")
 
         self.print_step(3, "Read the RvcRunMode SupportedModes attribute")
         supported_run_modes = await self.read_run_supported_modes()
@@ -206,11 +206,10 @@ class TC_RVCRUNM_2_2(MatterBaseTest):
             if self.is_ci:
                 self.write_to_app_pipe('{"Name": "ChargerFound"}')
             else:
-                input("Press Enter when done.\n")
+                self.wait_for_user_input(prompt_msg="Manually put the device in one of Stopped(0x00), Paused(0x02), Charging(0x41) or Docked(0x42), and press Enter when ready.\n")
 
             self.print_step(10, "Read RVCOPSTATE's OperationalState attribute")
             op_state = await self.read_op_state_operational_state()
-
             asserts.assert_true(op_state in valid_op_states,
                                 "Expected RVCOPSTATE's OperationalState attribute to be one of Stopped(0x00), Paused(0x02), Charging(0x41) or Docked(0x42)")
 

--- a/src/python_testing/TC_RVCRUNM_2_2.py
+++ b/src/python_testing/TC_RVCRUNM_2_2.py
@@ -136,8 +136,8 @@ class TC_RVCRUNM_2_2(MatterBaseTest):
         if self.is_ci:
             self.write_to_app_pipe('{"Name": "Reset"}')
         test_step = ("Manually put the device in a RVC Run Mode cluster mode with "
-                           "the Idle(0x4000) mode tag and in a device state that allows changing to either "
-                           "of these modes: %i, %i" % (self.mode_a, self.mode_b))
+                     "the Idle(0x4000) mode tag and in a device state that allows changing to either "
+                     "of these modes: %i, %i" % (self.mode_a, self.mode_b))
         self.print_step(2, test_step)
         if not self.is_ci:
             self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when ready.")
@@ -206,7 +206,8 @@ class TC_RVCRUNM_2_2(MatterBaseTest):
             if self.is_ci:
                 self.write_to_app_pipe('{"Name": "ChargerFound"}')
             else:
-                self.wait_for_user_input(prompt_msg="Manually put the device in one of Stopped(0x00), Paused(0x02), Charging(0x41) or Docked(0x42), and press Enter when ready.\n")
+                self.wait_for_user_input(
+                    prompt_msg="Manually put the device in one of Stopped(0x00), Paused(0x02), Charging(0x41) or Docked(0x42), and press Enter when ready.\n")
 
             self.print_step(10, "Read RVCOPSTATE's OperationalState attribute")
             op_state = await self.read_op_state_operational_state()

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -1105,15 +1105,13 @@ class MatterBaseTest(base_test.BaseTestClass):
 
     def wait_for_user_input(self,
                             prompt_msg: str,
-                            input_msg: str = "Press Enter when done.\n",
                             prompt_msg_placeholder: str = "Submit anything to continue",
                             default_value: str = "y") -> str:
         """Ask for user input and wait for it.
 
         Args:
-            prompt_msg (str): Message for TH UI prompt. Indicates what is expected from the user.
-            input_msg (str, optional): Prompt for input function, used when running tests manually. Defaults to "Press Enter when done.\n".
-            prompt_msg_placeholder (str, optional): TH UI prompt input placeholder. Defaults to "Submit anything to continue".
+            prompt_msg (str): Message for TH UI prompt and input function. Indicates what is expected from the user.
+            prompt_msg_placeholder (str, optional): TH UI prompt input placeholder (where the user types). Defaults to "Submit anything to continue".
             default_value (str, optional): TH UI prompt default value. Defaults to "y".
 
         Returns:
@@ -1123,7 +1121,7 @@ class MatterBaseTest(base_test.BaseTestClass):
             self.runner_hook.show_prompt(msg=prompt_msg,
                                          placeholder=prompt_msg_placeholder,
                                          default_value=default_value)
-        return input(input_msg)
+        return input(f'{prompt_msg.removesuffix(chr(10))}\n')
 
 
 def generate_mobly_test_config(matter_test_config: MatterTestConfig):


### PR DESCRIPTION
Worked on issue #243 that was assigned to me.

This includes the following:

- Replaced input with self.wait_for_user_input in the following Python scripts:
  - TC_OpstateCommon.py
  - TC_RVCCLEANM_2_1.py
  - TC_RVCCLEANM_2_2.py
  - TC_RVCOPSTATE_2_1.py
  - TC_RVCOPSTATE_2_3.py
  - TC_RVCOPSTATE_2_4.py
  - TC_RVCRUNM_2_1.py
  - TC_RVCRUNM_2_2.py
  - matter_testing_support.py
- Removed input_msg argument from wait_for_user_input
- Accordingly, passed test steps into prompt_msg, and appended "Press Enter when ready".
- Adjusted the return value accordingly, taking into account that it needs to end with an \n for the text to print properly in the test framework.