### PR TITLE
Darwin: Keep MTRCommissionableBrowser around until OnBleScanStopped

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
@@ -84,7 +84,7 @@ public:
         mBleScannerDelegateOwner = owner; // retain the owner until OnBleScanStopped is called
         ReturnErrorOnFailure(PlatformMgrImpl().StartBleScan(this));
 #else
-        (void)owner;
+        (void) owner;
 #endif // CONFIG_NETWORK_LAYER_BLE
 
         ReturnErrorOnFailure(Resolver::Instance().Init(chip::DeviceLayer::UDPEndPointManager()));

--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
@@ -114,11 +114,7 @@ public:
 
 #if CONFIG_NETWORK_LAYER_BLE
         mBleScannerDelegateOwner = owner; // retain the owner until OnBleScanStopped is called
-        CHIP_ERROR err = PlatformMgrImpl().StopBleScan();
-        if (err != CHIP_NO_ERROR) {
-            mBleScannerDelegateOwner = nil;
-            return err;
-        }
+        PlatformMgrImpl().StopBleScan(); // doesn't actually fail, and if it did we'd want to carry on regardless
 #else
         (void) owner;
 #endif // CONFIG_NETWORK_LAYER_BLE


### PR DESCRIPTION
Because the BLE platform implementation uses a separate dispatch queue, StopBleScan() does not synchrnously stop any further use of the current BleScannerDelegate. Keep the MTRCommissionableBrowser that contains the delegate alive until OnBleScanStopped to avoid a UAF.
