### PR TITLE
[ESP32] Unregistering wifi and IP event handlers before factory reset to avoid random crashes due to PostEventQueue failure.

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -29,6 +29,7 @@
 #include <lib/support/CodeUtils.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/ESP32/ESP32Config.h>
+#include <platform/ESP32/ESP32Utils.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
@@ -403,6 +404,19 @@ void ConfigurationManagerImpl::RunConfigUnitTest(void)
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;
+
+    // Unregistering the wifi and IP event handlers from the esp_default_event_loop()
+    err = ESP32Utils::MapError(esp_event_handler_unregister(IP_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to unregister IP event handler");
+    }
+
+    err = ESP32Utils::MapError(esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to unregister wifi event handler");
+    }
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -412,7 +412,8 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
         ChipLogError(DeviceLayer, "Failed to unregister IP event handler");
     }
 
-    err = ESP32Utils::MapError(esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent));
+    err =
+        ESP32Utils::MapError(esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Failed to unregister wifi event handler");

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -412,12 +412,14 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
         ChipLogError(DeviceLayer, "Failed to unregister IP event handler");
     }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     err =
         ESP32Utils::MapError(esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent));
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(DeviceLayer, "Failed to unregister wifi event handler");
     }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 


### PR DESCRIPTION
**Problem**
- Some random crashes are observed in case the event queue is full and some events like WIFI_EVENT_STA_DISCONNECT gets posted to the platform queue at the time of factory reset.
- This leads to crash due to `PostEventOrDie` on failure to post the `wifi event.`

**Change Overview**
- Unregistered the `wifi and IP `event handlers just before the factory reset flow in `DoFactoryReset` to avoid posting esp events to the esp default event loop.

**Testing**
- Tested the changes in the factory reset flow by adding some debug prints.
- Tested the behaviour for esp32 lighting-app with these changes.