### PR TITLE
Added endpoint id for Thread network commissioning instance

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -85,6 +85,9 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     # devices with multiple radios that have different sleep behavior for
     # different radios.
     chip_device_config_enable_dynamic_mrp_config = false
+
+    # Define the default endpoint id for the generic Thread network commissioning instance
+    chip_device_config_thread_network_endpoint_id = 0
   }
 
   if (chip_stack_lock_tracking == "auto") {
@@ -388,6 +391,11 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     }
 
     defines += [ "CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES=${chip_max_discovered_ip_addresses}" ]
+
+    if (chip_enable_openthread && chip_device_platform != "linux" &&
+        chip_device_platform != "tizen" && chip_device_platform != "webos") {
+      defines += [ "CHIP_DEVICE_CONFIG_THREAD_NETWORK_ENDPOINT_ID=${chip_device_config_thread_network_endpoint_id}" ]
+    }
 
     visibility = [
       ":platform_config_header",

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -76,7 +76,8 @@ static_assert(OPENTHREAD_API_VERSION >= 219, "OpenThread version too old");
 namespace {
 #ifndef _NO_NETWORK_COMMISSIONING_DRIVER_
 NetworkCommissioning::GenericThreadDriver sGenericThreadDriver;
-app::Clusters::NetworkCommissioning::Instance sThreadNetworkCommissioningInstance(0 /* Endpoint Id */, &sGenericThreadDriver);
+app::Clusters::NetworkCommissioning::Instance
+    sThreadNetworkCommissioningInstance(CHIP_DEVICE_CONFIG_THREAD_NETWORK_ENDPOINT_ID /* Endpoint Id */, &sGenericThreadDriver);
 #endif
 
 void initNetworkCommissioningThreadDriver(void)


### PR DESCRIPTION
Currently, the generic thread network commissioning instance can only be added at endpoint 0. To support multiple network interfaces, a configurable endpoint ID is necessary.
- Added a definition endpoint ID for Thread network commissioning instance.