### PR TITLE
Update network-commissioning to use `AddResponse` for responding to scan responses 

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -224,7 +224,8 @@ private:
     /// Fills up scanResponseArray with valid and de-duplicated thread responses from mNetworks.
     /// Handles sorting and keeping only larger rssi
     ///
-    /// Returns the valid list of scan responses into `validResponses`
+    /// Returns the valid list of scan responses into `validResponses`, which is only valid
+    /// as long as scanResponseArray is valid.
     CHIP_ERROR LoadResponses(Platform::ScopedMemoryBuffer<ThreadScanResponse> & scanResponseArray,
                              Span<ThreadScanResponse> & validResponses) const;
 };

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -215,8 +215,8 @@ private:
     CharSpan mDebugText;
     ThreadScanResponseIterator * mNetworks;
 
-    /// parses mNetworks into `buffer` and performs post-processing (sort and dedup)
-    /// on them.
+    /// Fills up scanResponseArray with valid and de-duplicated thread responses from mNetworks.
+    /// Handles sorting and keeping only largers rssi
     ///
     /// Returns the valid list of scan responses into `validResponses`
     CHIP_ERROR LoadResponses(Platform::ScopedMemoryBuffer<ThreadScanResponse> & scanResponseArray,
@@ -267,10 +267,9 @@ CHIP_ERROR ThreadScanResponseToTLV::LoadResponses(Platform::ScopedMemoryBuffer<T
             scanResponseArrayLength++;
         }
         scanResponseArray[scanResponseArrayLength - 1] = scanResponse;
+        Sorting::InsertionSort(scanResponseArray.Get(), scanResponseArrayLength,
+                               [](const ThreadScanResponse & a, const ThreadScanResponse & b) -> bool { return a.rssi > b.rssi; });
     }
-
-    Sorting::InsertionSort(scanResponseArray.Get(), scanResponseArrayLength,
-                           [](const ThreadScanResponse & a, const ThreadScanResponse & b) -> bool { return a.rssi > b.rssi; });
 
     validResponses = Span<ThreadScanResponse>(scanResponseArray.Get(), scanResponseArrayLength);
 

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -226,11 +226,11 @@ private:
     ///
     /// Returns the valid list of scan responses into `validResponses`
     CHIP_ERROR LoadResponses(Platform::ScopedMemoryBuffer<ThreadScanResponse> & scanResponseArray,
-                             Span<ThreadScanResponse> &validResponses) const;
+                             Span<ThreadScanResponse> & validResponses) const;
 };
 
 CHIP_ERROR ThreadScanResponseToTLV::LoadResponses(Platform::ScopedMemoryBuffer<ThreadScanResponse> & scanResponseArray,
-                                                  Span<ThreadScanResponse> &validResponses) const
+                                                  Span<ThreadScanResponse> & validResponses) const
 {
     VerifyOrReturnError(scanResponseArray.Alloc(chip::min(mNetworks->Count(), kMaxNetworksInScanResponse)), CHIP_ERROR_NO_MEMORY);
 

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -267,6 +267,9 @@ CHIP_ERROR ThreadScanResponseToTLV::LoadResponses(Platform::ScopedMemoryBuffer<T
             scanResponseArrayLength++;
         }
         scanResponseArray[scanResponseArrayLength - 1] = scanResponse;
+
+        // TODO: this is a sort (insertion sort even, so O(n^2)) in a O(n) loop,
+        ///      maybe we should find something better than a O(n^3) to preserve the highest rssi only
         Sorting::InsertionSort(scanResponseArray.Get(), scanResponseArrayLength,
                                [](const ThreadScanResponse & a, const ThreadScanResponse & b) -> bool { return a.rssi > b.rssi; });
     }

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -134,7 +134,7 @@ private:
     T * mValue;
 };
 
-/// convenience macor to auto-create a variable for you to release the given name at
+/// Convenience macro to auto-create a variable for you to release the given name at
 /// the exit of the current scope.
 #define DEFER_AUTO_RELEASE(name) AutoRelease autoRelease##__COUNTER__(name)
 
@@ -207,6 +207,7 @@ CHIP_ERROR WifiScanResponseToTLV::EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
+/// Handles encoding a ThreadScanResponseIterator into a TLV response structure.
 class ThreadScanResponseToTLV : public chip::app::DataModel::EncodableToTLV
 {
 public:

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -222,7 +222,7 @@ private:
     ThreadScanResponseIterator * mNetworks;
 
     /// Fills up scanResponseArray with valid and de-duplicated thread responses from mNetworks.
-    /// Handles sorting and keeping only largers rssi
+    /// Handles sorting and keeping only larger rssi
     ///
     /// Returns the valid list of scan responses into `validResponses`
     CHIP_ERROR LoadResponses(Platform::ScopedMemoryBuffer<ThreadScanResponse> & scanResponseArray,

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -138,7 +138,7 @@ private:
 /// the exit of the current scope.
 #define DEFER_AUTO_RELEASE(name) AutoRelease autoRelease##__COUNTER__(name)
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP || CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
 
 /// Handles encoding a WifiScanResponseIterator into a TLV response structure
 class WifiScanResponseToTLV : public chip::app::DataModel::EncodableToTLV
@@ -202,7 +202,7 @@ CHIP_ERROR WifiScanResponseToTLV::EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag
     return writer.EndContainer(outerType);
 }
 
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP || CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -138,6 +138,8 @@ private:
 /// the exit of the current scope.
 #define DEFER_AUTO_RELEASE(name) AutoRelease autoRelease##__COUNTER__(name)
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP || CHIP_DEVICE_CONFIG_ENABLE_THREAD
+
 /// Handles encoding a WifiScanResponseIterator into a TLV response structure
 class WifiScanResponseToTLV : public chip::app::DataModel::EncodableToTLV
 {
@@ -200,6 +202,10 @@ CHIP_ERROR WifiScanResponseToTLV::EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag
 
     return writer.EndContainer(outerType);
 }
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP || CHIP_DEVICE_CONFIG_ENABLE_THREAD
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
 class ThreadScanResponseToTLV : public chip::app::DataModel::EncodableToTLV
 {
@@ -324,6 +330,8 @@ CHIP_ERROR ThreadScanResponseToTLV::EncodeTo(TLV::TLVWriter & writer, TLV::Tag t
 
     return writer.EndContainer(outerType);
 }
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
 } // namespace
 

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -179,7 +179,6 @@ CHIP_ERROR WifiScanResponseToTLV::EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag
             size_t networksEncoded = 0;
             while (mNetworks->Next(scanResponse))
             {
-                // NOTE: it is assumed that scanResponse.ssid/bssid lifetime is larger than just within the `next` call
                 Structs::WiFiInterfaceScanResultStruct::Type result;
                 result.security = scanResponse.security;
                 result.ssid     = ByteSpan(scanResponse.ssid, scanResponse.ssidLen);

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -226,11 +226,11 @@ private:
     ///
     /// Returns the valid list of scan responses into `validResponses`
     CHIP_ERROR LoadResponses(Platform::ScopedMemoryBuffer<ThreadScanResponse> & scanResponseArray,
-                             Span<ThreadScanResponse> validResponses) const;
+                             Span<ThreadScanResponse> &validResponses) const;
 };
 
 CHIP_ERROR ThreadScanResponseToTLV::LoadResponses(Platform::ScopedMemoryBuffer<ThreadScanResponse> & scanResponseArray,
-                                                  Span<ThreadScanResponse> validResponses) const
+                                                  Span<ThreadScanResponse> &validResponses) const
 {
     VerifyOrReturnError(scanResponseArray.Alloc(chip::min(mNetworks->Count(), kMaxNetworksInScanResponse)), CHIP_ERROR_NO_MEMORY);
 

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -275,8 +275,8 @@ CHIP_ERROR ThreadScanResponseToTLV::LoadResponses(Platform::ScopedMemoryBuffer<T
         }
         scanResponseArray[scanResponseArrayLength - 1] = scanResponse;
 
-        // TODO: this is a sort (insertion sort even, so O(n^2)) in a O(n) loop,
-        ///      maybe we should find something better than a O(n^3) to preserve the highest rssi only
+        // TODO: this is a sort (insertion sort even, so O(n^2)) in a O(n) loop.
+        ///      There should be some better alternatives to not have some O(n^3) processing complexity.
         Sorting::InsertionSort(scanResponseArray.Get(), scanResponseArrayLength,
                                [](const ThreadScanResponse & a, const ThreadScanResponse & b) -> bool { return a.rssi > b.rssi; });
     }


### PR DESCRIPTION
This removes some usages of seemingly internal API for CommandHandler. This makes the logic more safe because it starts taking advantage of CommandHandler built-in behavior:

- Auto snapshot/rollback on failures and setting error codes on failures to write
- Simpler overall code

Also fixed oddities in the code:
- Release of iterators was inconsistent: thread was not checking for null, wifi was
- Release of iterators was not done on early exit or if internal defines were not set (but then maybe also those callbacks are never called, however unfortunately everything is common code)

### Tested:

- validated that I get Wifi results from a linux app and thread results from a nrfconnect board