### PR TITLE
Use EncodableToTLV in im_responder

### DIFF
--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -52,7 +52,7 @@ namespace app {
 
 namespace {
 
-class TestTLVDataEncoder : public chip::app::DataModel::EncodableToTLV
+class TestTLVDataEncoder : public DataModel::EncodableToTLV
 {
 public:
     CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag) const override

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -50,6 +50,25 @@
 namespace chip {
 namespace app {
 
+namespace {
+
+class TestTLVDataEncoder : public chip::app::DataModel::EncodableToTLV
+{
+public:
+    CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag) const override
+    {
+        TLV::TLVType outerType;
+        ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outerType));
+
+        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTestFieldId1), kTestFieldValue1));
+        ReturnErrorOnFailure(writer.Put(chip::TLV::ContextTag(kTestFieldId2), kTestFieldValue2));
+
+        return writer.EndContainer(outerType);
+    }
+};
+
+} // namespace
+
 Protocols::InteractionModel::Status ServerClusterCommandExists(const ConcreteCommandPath & aCommandPath)
 {
     // The Mock cluster catalog -- only have one command on one cluster on one endpoint.
@@ -104,17 +123,8 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aRequestCommandPat
     {
         printf("responder constructing command data in command");
 
-        chip::TLV::TLVWriter * writer;
-
-        const CommandHandler::InvokeResponseParameters prepareParams(aRequestCommandPath);
-        ReturnOnFailure(apCommandObj->PrepareInvokeResponseCommand(path, prepareParams));
-
-        writer = apCommandObj->GetCommandDataIBTLVWriter();
-        ReturnOnFailure(writer->Put(chip::TLV::ContextTag(kTestFieldId1), kTestFieldValue1));
-
-        ReturnOnFailure(writer->Put(chip::TLV::ContextTag(kTestFieldId2), kTestFieldValue2));
-
-        ReturnOnFailure(apCommandObj->FinishCommand());
+        TestTLVDataEncoder testData;
+        apCommandObj->AddResponse(path, kTestCommandId, testData);
     }
     statusCodeFlipper = !statusCodeFlipper;
 }


### PR DESCRIPTION
This makes the API cleaner and safer (have snapshot & rollback capabilities, less use of prepare/finish).

Goal is to start treating PrepareCommand/GetCommandDataIBTLVWriter/FinishCommand as private APIs.