### PR TITLE
Use EncodableToTLV in TestCommandInteraction

### DIFF
--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -88,7 +88,7 @@ constexpr CommandId kTestNonExistCommandId                = 0;
 
 const app::CommandSender::TestOnlyMarker kCommandSenderTestOnlyMarker;
 
-class SimpleTLVPayload : public chip::app::DataModel::EncodableToTLV
+class SimpleTLVPayload : public app::DataModel::EncodableToTLV
 {
 public:
     CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag) const override

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -399,8 +399,7 @@ private:
     {
     public:
         CommandHandlerWithUnrespondedCommand(CommandHandler::Callback * apCallback, const ConcreteCommandPath & aRequestCommandPath,
-                                             const Optional<uint16_t> & aRef) :
-            CommandHandler(apCallback)
+                                             const Optional<uint16_t> & aRef) : CommandHandler(apCallback)
         {
             GetCommandPathRegistry().Add(aRequestCommandPath, aRef.std_optional());
             SetExchangeInterface(&mMockCommandResponder);
@@ -615,8 +614,22 @@ void TestCommandInteraction::AddInvokeResponseData(nlTestSuite * apSuite, void *
     }
     else
     {
+#if 1
         SimpleTLVPayload payloadWriter;
         CHIP_ERROR err = apCommandHandler->TryAddResponseData(requestCommandPath, aResponseCommandId, payloadWriter);
+#else
+        const CommandHandler::InvokeResponseParameters prepareParams(requestCommandPath);
+        ConcreteCommandPath responseCommandPath = { kTestEndpointId, kTestClusterId, aResponseCommandId };
+        CHIP_ERROR err = apCommandHandler->PrepareInvokeResponseCommand(responseCommandPath, prepareParams);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        chip::TLV::TLVWriter * writer = apCommandHandler->GetCommandDataIBTLVWriter();
+
+        err = writer->PutBoolean(chip::TLV::ContextTag(1), true);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        err = apCommandHandler->FinishCommand();
+#endif
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     }
 }

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -399,7 +399,8 @@ private:
     {
     public:
         CommandHandlerWithUnrespondedCommand(CommandHandler::Callback * apCallback, const ConcreteCommandPath & aRequestCommandPath,
-                                             const Optional<uint16_t> & aRef) : CommandHandler(apCallback)
+                                             const Optional<uint16_t> & aRef) :
+            CommandHandler(apCallback)
         {
             GetCommandPathRegistry().Add(aRequestCommandPath, aRef.std_optional());
             SetExchangeInterface(&mMockCommandResponder);

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -614,22 +614,8 @@ void TestCommandInteraction::AddInvokeResponseData(nlTestSuite * apSuite, void *
     }
     else
     {
-#if 1
         SimpleTLVPayload payloadWriter;
-        CHIP_ERROR err = apCommandHandler->TryAddResponseData(requestCommandPath, aResponseCommandId, payloadWriter);
-#else
-        const CommandHandler::InvokeResponseParameters prepareParams(requestCommandPath);
-        ConcreteCommandPath responseCommandPath = { kTestEndpointId, kTestClusterId, aResponseCommandId };
-        CHIP_ERROR err = apCommandHandler->PrepareInvokeResponseCommand(responseCommandPath, prepareParams);
-        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-        chip::TLV::TLVWriter * writer = apCommandHandler->GetCommandDataIBTLVWriter();
-
-        err = writer->PutBoolean(chip::TLV::ContextTag(1), true);
-        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-        err = apCommandHandler->FinishCommand();
-#endif
+        CHIP_ERROR err = apCommandHandler->AddResponseData(requestCommandPath, aResponseCommandId, payloadWriter);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
     }
 }


### PR DESCRIPTION
This replaces some usages of direct prepare/GetIBTLVWriter/FinishCommand on CommandHandler.

I only kept a single instance of this where the direct API is being tested without it being invoked through a CommandHandler dispatch.


Intent is to treat these functions as more internal API as using AddStatus/AddResponse (and equivalent) seem to be the public API that we want everyone to use since those include snapsho/rollback/retry capability.