### PR TITLE
[ESP32] Backport the unregistering wifi and IP event handler change in factory reset flow to v1.3-branch.

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -29,6 +29,7 @@
 #include <lib/support/CodeUtils.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/ESP32/ESP32Config.h>
+#include <platform/ESP32/ESP32Utils.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
@@ -403,6 +404,22 @@ void ConfigurationManagerImpl::RunConfigUnitTest(void)
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;
+
+    // Unregistering the wifi and IP event handlers from the esp_default_event_loop()
+    err = ESP32Utils::MapError(esp_event_handler_unregister(IP_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to unregister IP event handler");
+    }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    err =
+        ESP32Utils::MapError(esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent));
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to unregister wifi event handler");
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 


### PR DESCRIPTION
**Change Overview:**
-  Backport the change in #33684 to v1.3-branch.

