### PR TITLE
Feat: possibility to get node id of the unsolicited message sender

### DIFF
--- a/src/messaging/ExchangeDelegate.h
+++ b/src/messaging/ExchangeDelegate.h
@@ -140,7 +140,7 @@ public:
 /**
  * @brief
  *   This class handles unsolicited messages. The implementation can select an exchange delegate to use based on the payload header
- * of the incoming message.
+ * of the incoming message or its session.
  */
 class DLL_EXPORT UnsolicitedMessageHandler
 {
@@ -158,9 +158,19 @@ public:
      *
      *  @param[in]  payloadHeader A reference to the PayloadHeader object for the unsolicited message.  The protocol and message
      *                            type of this header match the UnsolicitedMessageHandler.
+     *  @param[in]  session       A reference to the session where unsolicited message was received.
      *  @param[out] newDelegate   A new exchange delegate to be used by the new exchange created to handle the message.
      */
-    virtual CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) = 0;
+    virtual CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, const SessionHandle & session,
+                                                    ExchangeDelegate *& newDelegate)
+    {
+        return OnUnsolicitedMessageReceived(payloadHeader, newDelegate);
+    }
+
+    virtual CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate)
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
 
     /**
      * @brief

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -320,7 +320,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
         ExchangeDelegate * delegate = nullptr;
 
         // Fetch delegate from the handler
-        CHIP_ERROR err = matchingUMH->Handler->OnUnsolicitedMessageReceived(payloadHeader, delegate);
+        CHIP_ERROR err = matchingUMH->Handler->OnUnsolicitedMessageReceived(payloadHeader, session, delegate);
         if (err != CHIP_NO_ERROR)
         {
             // Using same error message for all errors to reduce code size.


### PR DESCRIPTION
Add ability to get peer node id in the in the `UnsolicitedMessageHandler` implementation.
Usecase: parallel OTA sessions. We need to know node id of the bdx unsolicited message sender.

Current change is backwards compatible.

