### PR TITLE
[Tizen] Fix Matter devices BLE scan after changes in 92f8cd0

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -1404,7 +1404,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
     }
 
     /* Send StartChipScan Request to Scanner Class */
-    strcpy(data.service_uuid, Ble::CHIP_BLE_DESC_SHORT_UUID_STR);
+    strcpy(data.service_uuid, Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR);
     err = mDeviceScanner->StartChipScan(kNewConnectionScanTimeout, ScanFilterType::kServiceData, data);
     VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Failed to start BLE scan"));
 

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <strings.h>
 #include <utility>
 
 #include <bluetooth.h>
@@ -55,31 +56,16 @@ std::unique_ptr<ChipDeviceScanner> ChipDeviceScanner::Create(ChipDeviceScannerDe
     return std::make_unique<ChipDeviceScanner>(delegate);
 }
 
-static void __CleanupServiceData(bt_adapter_le_service_data_s * dataList, size_t count)
+static void __PrintLEScanData(const bt_adapter_le_service_data_s & data)
 {
-    VerifyOrReturn(dataList != nullptr);
-    VerifyOrReturn(count != 0);
-
-    for (size_t i = 0; i < count; i++)
-    {
-        g_free(dataList[i].service_uuid);
-        g_free(dataList[i].service_data);
-    }
-    g_free(dataList);
-}
-
-static void __PrintLEScanData(bt_adapter_le_service_data_s * dataList, size_t idx)
-{
-    VerifyOrReturn(dataList != nullptr);
-
     // Print Service UUID in the Service Data
     ChipLogDetail(DeviceLayer, "======Service UUID========");
-    ChipLogDetail(DeviceLayer, "Service UUID::[%s]", dataList[idx].service_uuid);
+    ChipLogDetail(DeviceLayer, "Service UUID::[%s]", data.service_uuid);
 
     // Print Service Data
     ChipLogDetail(DeviceLayer, "======Service Data========");
-    ChipLogDetail(DeviceLayer, "Service Data Length::[%d]", dataList[idx].service_data_len);
-    ChipLogByteSpan(DeviceLayer, ByteSpan(reinterpret_cast<uint8_t *>(dataList[idx].service_data), dataList[idx].service_data_len));
+    ChipLogDetail(DeviceLayer, "Service Data Length::[%d]", data.service_data_len);
+    ChipLogByteSpan(DeviceLayer, ByteSpan(reinterpret_cast<uint8_t *>(data.service_data), data.service_data_len));
 }
 
 static bool __IsChipThingDevice(bt_adapter_le_device_scan_result_info_s * info,
@@ -91,25 +77,22 @@ static bool __IsChipThingDevice(bt_adapter_le_device_scan_result_info_s * info,
     bt_adapter_le_service_data_s * dataList = nullptr;
     bool isChipDevice                       = false;
 
-    ChipLogProgress(DeviceLayer, "Is [%s] ChipThingDevice ?: Check now", info->remote_address);
-
     if (bt_adapter_le_get_scan_result_service_data_list(info, BT_ADAPTER_LE_PACKET_ADVERTISING, &dataList, &count) == BT_ERROR_NONE)
     {
         for (int i = 0; i < count; i++)
         {
-            if (g_strcmp0(dataList[i].service_uuid, chip::Ble::CHIP_BLE_CHAR_1_UUID_STR) == 0 ||
-                g_strcmp0(dataList[i].service_uuid, chip::Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR) == 0)
+            if (strcasecmp(dataList[i].service_uuid, chip::Ble::CHIP_BLE_SERVICE_LONG_UUID_STR) == 0 ||
+                strcasecmp(dataList[i].service_uuid, chip::Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR) == 0)
             {
-                ChipLogProgress(DeviceLayer, "CHIP Thing Device Found! [Service Data UUID] = %s", dataList[i].service_uuid);
-                // Print full Service Data
-                __PrintLEScanData(dataList, i);
+                __PrintLEScanData(dataList[i]);
                 memcpy(&aDeviceInfo, dataList[i].service_data, dataList[i].service_data_len);
                 isChipDevice = true;
                 break;
             }
         }
     }
-    __CleanupServiceData(dataList, count);
+
+    bt_adapter_le_free_service_data_list(dataList, count);
     return isChipDevice;
 }
 
@@ -120,17 +103,12 @@ void ChipDeviceScanner::LeScanResultCb(int result, bt_adapter_le_device_scan_res
     auto self = reinterpret_cast<ChipDeviceScanner *>(userData);
     chip::Ble::ChipBLEDeviceIdentificationInfo deviceInfo;
 
-    ChipLogProgress(DeviceLayer, "LE Device Reported!! remote addr [%s]", info->remote_address);
+    ChipLogProgress(DeviceLayer, "LE device reported: %s", info->remote_address);
+    VerifyOrReturn(__IsChipThingDevice(info, deviceInfo),
+                   ChipLogDetail(Ble, "Device %s does not look like a CHIP device", info->remote_address));
 
-    if (__IsChipThingDevice(info, deviceInfo))
-    {
-        // Looks like a CHIP Thing Device: Service UUID matched
-        ChipLogProgress(DeviceLayer, "Looks Like Got a CHIP Thing Device: Process further");
-        // Report probable CHIP Thing Device to BLEMgrImp class
-        self->mDelegate->OnChipDeviceScanned(info, deviceInfo);
-    }
-    else
-        ChipLogProgress(DeviceLayer, "Does not Look like a CHIP Device, Skip.....");
+    // Report probable CHIP device to BLEMgrImp class
+    self->mDelegate->OnChipDeviceScanned(info, deviceInfo);
 }
 
 gboolean ChipDeviceScanner::TimerExpiredCb(gpointer userData)


### PR DESCRIPTION
### Problem

In 92f8cd0 there were typos which changed `chip_ble_service_uuid_short` to `CHIP_BLE_DESC_SHORT_UUID_STR` and `0000FFF6-0000-1000-8000-00805F9B34FB` to `CHIP_BLE_CHAR_1_UUID_STR`.


### Changes

- fix introduced typos
- account for changes in #33692 (case insensitive UUID comparison)

### Testing

Manually checked that Tizen controller can scan and connect to Matter BLE devices.