### PR TITLE
[Tizen] Gracefully terminate example apps

### DIFF
--- a/examples/platform/tizen/TizenServiceAppMain.cpp
+++ b/examples/platform/tizen/TizenServiceAppMain.cpp
@@ -18,7 +18,9 @@
 
 #include "TizenServiceAppMain.h"
 
+#include <app/server/Server.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/PlatformManager.h>
 
 #include <service_app.h>
 #include <tizen.h>
@@ -29,13 +31,13 @@ namespace {
 bool service_app_create(void * data)
 {
     auto app = reinterpret_cast<TizenServiceAppMain *>(data);
-    return app->AppCreated();
+    return app->AppCreate();
 }
 
 void service_app_terminate(void * data)
 {
     auto app = reinterpret_cast<TizenServiceAppMain *>(data);
-    app->AppTerminated();
+    app->AppTerminate();
 }
 
 void service_app_control(app_control_h app_control, void * data)
@@ -68,15 +70,17 @@ void TizenServiceAppMain::Exit()
     service_app_exit();
 }
 
-bool TizenServiceAppMain::AppCreated()
+bool TizenServiceAppMain::AppCreate()
 {
-    ChipLogProgress(NotSpecified, "Tizen app created");
+    ChipLogProgress(NotSpecified, "Tizen app create");
     return true;
 }
 
-void TizenServiceAppMain::AppTerminated()
+void TizenServiceAppMain::AppTerminate()
 {
-    ChipLogProgress(NotSpecified, "Tizen app terminated");
+    ChipLogProgress(NotSpecified, "Tizen app terminate");
+    chip::Server::GetInstance().GenerateShutDownEvent();
+    chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
 }
 
 static void TizenMainLoopWrapper()

--- a/examples/platform/tizen/TizenServiceAppMain.h
+++ b/examples/platform/tizen/TizenServiceAppMain.h
@@ -35,8 +35,8 @@ public:
     app_error_e RunMainLoop();
     void Exit();
 
-    virtual bool AppCreated();
-    virtual void AppTerminated();
+    virtual bool AppCreate();
+    virtual void AppTerminate();
     virtual void AppControl(app_control_h app_control);
 
 private:


### PR DESCRIPTION
### Problem

When Tizen example app terminates `Shutdown()` functions are not called (the app is forcefully terminated).


### Changes

- stop CHIP main event loop on termination

### Testing

Now, in logs one can see (previously last log was `-: Tizen app terminate`):
```
I/CHIP    ( 3126): -: Tizen app terminate
D/CHIP    ( 3126): ZCL: Emitting ShutDown event
D/CHIP    ( 3126): EVL: LogEvent event number: 0x0000000000000001 priority: 2, endpoint id:  0x0 cluster id: 0x0000_0028 event id: 0x1 Sys timestamp: 0x0000000000005154
D/CHIP    ( 3126): DMG: All ReadHandler-s are clean, clear GlobalDirtySet
D/CHIP    ( 3126): IN: SecureSession[0xb2002da8]: Released - Type:2 LSID:29722
D/CHIP    ( 3126): DMG: All ReadHandler-s are clean, clear GlobalDirtySet
D/CHIP    ( 3126): IN: SecureSession[0xb2001800]: Released - Type:1 LSID:29721
I/CHIP    ( 3126): DMG: AccessControl: finishing
I/CHIP    ( 3126): DMG: Examples::AccessControlDelegate::Finish
I/CHIP    ( 3126): DL: Inet Layer shutdown
I/CHIP    ( 3126): DL: BLE Layer shutdown
I/CHIP    ( 3126): DL: System Layer shutdown
```