### PR TITLE
Fix advertised device type for all-clusters-app to match data model.

### DIFF
--- a/examples/all-clusters-app/linux/include/CHIPProjectAppConfig.h
+++ b/examples/all-clusters-app/linux/include/CHIPProjectAppConfig.h
@@ -47,3 +47,7 @@
 #define CHIP_CONFIG_MAX_PATHS_PER_INVOKE 5
 
 #define CHIP_CONFIG_ENABLE_BDX_LOG_TRANSFER 1
+
+// Claim a device type while advertising that matches the device type on our
+// endpoint 1.
+#define CHIP_DEVICE_CONFIG_DEVICE_TYPE 0x0101

--- a/examples/all-clusters-app/linux/include/CHIPProjectAppConfig.h
+++ b/examples/all-clusters-app/linux/include/CHIPProjectAppConfig.h
@@ -49,5 +49,5 @@
 #define CHIP_CONFIG_ENABLE_BDX_LOG_TRANSFER 1
 
 // Claim a device type while advertising that matches the device type on our
-// endpoint 1.
+// endpoint 1.  0x0101 is the "Dimmable Light" device type.
 #define CHIP_DEVICE_CONFIG_DEVICE_TYPE 0x0101

--- a/examples/all-clusters-app/tizen/include/CHIPProjectAppConfig.h
+++ b/examples/all-clusters-app/tizen/include/CHIPProjectAppConfig.h
@@ -33,3 +33,7 @@
 // All clusters app has 3 group endpoints. This needs to defined here so that
 // CHIP_CONFIG_MAX_GROUPS_PER_FABRIC is properly configured.
 #define CHIP_CONFIG_MAX_GROUP_ENDPOINTS_PER_FABRIC 3
+
+// Claim a device type while advertising that matches the device type on our
+// endpoint 1.
+#define CHIP_DEVICE_CONFIG_DEVICE_TYPE 0x0101

--- a/examples/all-clusters-app/tizen/include/CHIPProjectAppConfig.h
+++ b/examples/all-clusters-app/tizen/include/CHIPProjectAppConfig.h
@@ -35,5 +35,5 @@
 #define CHIP_CONFIG_MAX_GROUP_ENDPOINTS_PER_FABRIC 3
 
 // Claim a device type while advertising that matches the device type on our
-// endpoint 1.
+// endpoint 1.  0x0101 is the "Dimmable Light" device type.
 #define CHIP_DEVICE_CONFIG_DEVICE_TYPE 0x0101

--- a/src/app/tests/suites/TestDiscovery.yaml
+++ b/src/app/tests/suites/TestDiscovery.yaml
@@ -17,6 +17,9 @@ name: Test Discovery
 config:
     nodeId: 0x12344321
     endpoint: 0
+    # These defaults correspond to the behavior of all-clusters-app, and
+    # different values should be passed on the command line when testing
+    # against any other server.
     discriminator:
         type: int16u
         defaultValue: 3840
@@ -31,7 +34,7 @@ config:
         defaultValue: 32769
     deviceType:
         type: int16u
-        defaultValue: 65535
+        defaultValue: 0x0101
 
 tests:
     - label: "Stop target device"


### PR DESCRIPTION
We were claiming a device type of 0x0101 in the Descriptor DeviceTypeList on endpoint 1, but claiming a device type of 0xFFFF (not even a valid value) via DNS-SD advertising.  Align our advertising behavior with the data model values.

Fixes https://github.com/project-chip/connectedhomeip/issues/33697
