### PR TITLE
Streamline bloat reports, part 2 of 2

### DIFF
--- a/scripts/tools/memory/gh_report.py
+++ b/scripts/tools/memory/gh_report.py
@@ -276,6 +276,10 @@ class SizeContext:
                 continue
 
             df = pd.DataFrame(changes.rows, columns=changes.columns)
+
+            # Filter down to region reports only.
+            df = df[df['kind'] == 'region'].drop('kind', axis=1)
+
             df.attrs = {
                 'name': f'{pr},{parent},{commit}',
                 'title': (f'PR #{pr}: ' if pr else '') +

--- a/scripts/tools/memory/gh_sizes.py
+++ b/scripts/tools/memory/gh_sizes.py
@@ -77,8 +77,7 @@ import memdf.collect
 import memdf.report
 import memdf.select
 import memdf.util
-import numpy as np  # type: ignore
-from memdf import Config, ConfigDescription, DFs, SectionDF, SegmentDF
+from memdf import Config, ConfigDescription, DFs, SectionDF
 
 PLATFORM_CONFIG_DIR = pathlib.Path('scripts/tools/memory/platform')
 

--- a/scripts/tools/memory/memdf/sizedb.py
+++ b/scripts/tools/memory/memdf/sizedb.py
@@ -109,13 +109,6 @@ class SizeDatabase(memdf.util.sqlite.Database):
                     'size': i['size'],
                     'kind': frame
                 })
-        # Add segment sizes.
-        for i in r['frames'].get('wr', []):
-            r['sizes'].append({
-                'name': ('(read only)', '(read/write)')[int(i['wr'])],
-                'size': i['size'],
-                'kind': 'wr'
-            })
         self.add_sizes(**r)
 
     def add_sizes_from_zipfile(self, f: Union[IO, Path], origin: Dict):

--- a/scripts/tools/memory/memdf/sizedb.py
+++ b/scripts/tools/memory/memdf/sizedb.py
@@ -175,6 +175,7 @@ class SizeDatabase(memdf.util.sqlite.Database):
             pb.id AS parent_build,
             cb.id AS commit_build,
             t.platform, t.config, t.target,
+            cs.kind AS kind,
             cs.name AS name,
             ps.size AS parent_size,
             cs.size AS commit_size,
@@ -189,7 +190,7 @@ class SizeDatabase(memdf.util.sqlite.Database):
                      cs.name, cb.time DESC, pb.time DESC
         ''', (commit, parent))
 
-        keep = ('platform', 'target', 'config', 'name', 'parent_size',
+        keep = ('platform', 'target', 'config', 'kind', 'name', 'parent_size',
                 'commit_size')
         things: set[int] = set()
         artifacts: set[int] = set()
@@ -222,7 +223,7 @@ class SizeDatabase(memdf.util.sqlite.Database):
                 artifacts.add(row['artifact'])
                 builds.add(row['commit_build'])
 
-        return ChangeInfo(('platform', 'target', 'config', 'section',
+        return ChangeInfo(('platform', 'target', 'config', 'kind', 'section',
                            parent[:8], commit[:8], 'change', '% change'), rows,
                           things, builds, stale_builds, artifacts,
                           stale_artifacts)


### PR DESCRIPTION
Remove the early attempt to aggregate FLASH vs RAM based on whether ELF segments are writable or not, which turned out not to be useful because several platforms mark flash segments as writable. Now that explicit section groups are in use (#33642), there is no additional value to segment aggregation even on platforms that mark them accurately.


