### PR TITLE
Setup bloat reports for Tizen CI builds

### DIFF
--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -71,12 +71,12 @@ jobs:
             - name: Bloat report - chip-tool
               run: |
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    linux arm chip-tool-ubsan out/tizen-arm-chip-tool-ubsan/chip-tool \
+                    tizen arm chip-tool-ubsan out/tizen-arm-chip-tool-ubsan/chip-tool \
                     /tmp/bloat_reports/
             - name: Bloat report - all-clusters-app
               run: |
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    linux arm all-clusters-app out/tizen-arm-all-clusters/chip-all-clusters-app \
+                    tizen arm all-clusters-app out/tizen-arm-all-clusters/chip-all-clusters-app \
                     /tmp/bloat_reports/
 
             - name: Uploading Size Reports

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -50,6 +50,12 @@ jobs:
               with:
                 platform: tizen
 
+            - name: Set up environment for size reports
+              uses: ./.github/actions/setup-size-reports
+              if: ${{ !env.ACT }}
+              with:
+                gh-context: ${{ toJson(github) }}
+
             - name: Build Tizen examples
               run: |
                   ./scripts/run_in_build_env.sh \
@@ -61,3 +67,20 @@ jobs:
                           build \
                           --copy-artifacts-to out/artifacts \
                       "
+
+            - name: Bloat report - chip-tool
+              run: |
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    linux arm chip-tool-ubsan out/tizen-arm-chip-tool-ubsan/chip-tool \
+                    /tmp/bloat_reports/
+            - name: Bloat report - all-clusters-app
+              run: |
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    linux arm all-clusters-app out/tizen-arm-all-clusters/chip-all-clusters-app \
+                    /tmp/bloat_reports/
+
+            - name: Uploading Size Reports
+              uses: ./.github/actions/upload-size-reports
+              if: ${{ !env.ACT }}
+              with:
+                platform-name: Tizen

--- a/scripts/tools/memory/platform/tizen.cfg
+++ b/scripts/tools/memory/platform/tizen.cfg
@@ -1,0 +1,67 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Memory tools default configuation for Tizen.
+
+{
+    'section': {
+        # By default, only these sections will be included
+        # when operating by sections.
+        'default': [
+            '.text', '.data', '.data.rel.ro', '.bss', '.dynamic', '.got',
+            '.init', '.init_array', '.rodata'
+        ]
+    },
+    'region': {
+        # Regions are sets of sections that can be used for aggregate reports.
+        'sections': {
+            'FLASH': [
+                ".dynstr",
+                ".dynsym",
+                ".eh_frame_hdr",
+                ".eh_frame",
+                ".fini",
+                ".gcc_except_table",
+                ".gnu.version_d",
+                ".gnu.version_r",
+                ".gnu.version",
+                ".hash",
+                ".init",
+                ".interp",
+                ".note.ABI-tag",
+                ".rodata1",
+                ".rodata",
+                ".strtab",
+                ".symtab",
+                ".text",
+            ],
+            'RAM': [
+                ".bss",
+                ".ctors",
+                ".data1",
+                ".data.rel.ro",
+                ".data",
+                ".dtors",
+                ".dynamic",
+                ".fini_array",
+                ".got.plt",
+                ".init_array",
+                ".jcr",
+                ".preinit_array",
+                ".tbss",
+                ".tdata",
+            ]
+        }
+    },
+}


### PR DESCRIPTION
This PR adds blot reports for Tizen examples built in CI on GitHub Actions. Since Tizen is very similar to Linux, no Tizen-specific configuration was created, instead, bloat report uses Linux configuration.