### PR TITLE
Post-merge updates for IM/DM separation

### DIFF
--- a/src/app/interaction-model/ActionContext.h
+++ b/src/app/interaction-model/ActionContext.h
@@ -22,13 +22,13 @@ namespace chip {
 namespace app {
 namespace InteractionModel {
 
-// Context for a currently executing request
-class RequestContext
+// Context for a currently executing action
+class ActionContext
 {
 public:
-    virtual ~RequestContext() = default;
+    virtual ~ActionContext() = default;
 
-    /// Valid ONLY during synchronous handling of a Read/Write/Invoke
+    /// Valid ONLY during synchronous handling of an action.
     ///
     /// Used sparingly, however some operations will require these. An example
     /// usage is "Operational Credentials aborting communications on removed fabrics"

--- a/src/app/interaction-model/Actions.h
+++ b/src/app/interaction-model/Actions.h
@@ -18,7 +18,7 @@
 
 #include <app/interaction-model/Events.h>
 #include <app/interaction-model/Paths.h>
-#include <app/interaction-model/RequestContext.h>
+#include <app/interaction-model/ActionContext.h>
 
 namespace chip {
 namespace app {
@@ -29,7 +29,7 @@ struct InteractionModelActions
 {
     Events * events;
     Paths * paths;
-    RequestContext * requestContext;
+    ActionContext * requestContext;
 };
 
 } // namespace InteractionModel

--- a/src/app/interaction-model/Actions.h
+++ b/src/app/interaction-model/Actions.h
@@ -16,9 +16,9 @@
  */
 #pragma once
 
+#include <app/interaction-model/ActionContext.h>
 #include <app/interaction-model/Events.h>
 #include <app/interaction-model/Paths.h>
-#include <app/interaction-model/ActionContext.h>
 
 namespace chip {
 namespace app {

--- a/src/app/interaction-model/BUILD.gn
+++ b/src/app/interaction-model/BUILD.gn
@@ -15,8 +15,8 @@ import("//build_overrides/chip.gni")
 
 source_set("interaction-model") {
   sources = [
-    "Actions.h",
     "ActionContex.h",
+    "Actions.h",
     "Events.h",
     "InvokeResponder.h",
     "IterationTypes.h",

--- a/src/app/interaction-model/BUILD.gn
+++ b/src/app/interaction-model/BUILD.gn
@@ -16,13 +16,13 @@ import("//build_overrides/chip.gni")
 source_set("interaction-model") {
   sources = [
     "Actions.h",
+    "ActionContex.h",
     "Events.h",
     "InvokeResponder.h",
     "IterationTypes.h",
     "Model.h",
     "OperationTypes.h",
     "Paths.h",
-    "RequestContext.h",
   ]
 
   public_deps = [

--- a/src/app/interaction-model/BUILD.gn
+++ b/src/app/interaction-model/BUILD.gn
@@ -15,7 +15,7 @@ import("//build_overrides/chip.gni")
 
 source_set("interaction-model") {
   sources = [
-    "ActionContex.h",
+    "ActionContext.h",
     "Context.h",
     "Events.h",
     "InvokeResponder.h",

--- a/src/app/interaction-model/BUILD.gn
+++ b/src/app/interaction-model/BUILD.gn
@@ -16,7 +16,7 @@ import("//build_overrides/chip.gni")
 source_set("interaction-model") {
   sources = [
     "ActionContex.h",
-    "Actions.h",
+    "Context.h",
     "Events.h",
     "InvokeResponder.h",
     "IterationTypes.h",

--- a/src/app/interaction-model/Context.h
+++ b/src/app/interaction-model/Context.h
@@ -25,11 +25,15 @@ namespace app {
 namespace InteractionModel {
 
 /// Data provided to data models in order to interface with the interaction model environment.
-struct InteractionModelActions
+///
+/// Provides callback-style functionality to notify the interaction model of changes
+/// (e.g. using paths to notify of attribute data changes or events to generate events)
+/// as well as fetching current state (via actionContext)
+struct InteractionModelContext
 {
     Events * events;
     Paths * paths;
-    ActionContext * requestContext;
+    ActionContext * actionContext;
 };
 
 } // namespace InteractionModel

--- a/src/app/interaction-model/Events.h
+++ b/src/app/interaction-model/Events.h
@@ -107,7 +107,7 @@ std::optional<EventNumber> GenerateEvent(G & generator, const T & aEventData, En
 /// Exposes event access capabilities.
 ///
 /// Allows callers to "generate events" which effectively notifies of an event having
-/// ocurred. 
+/// ocurred.
 class Events
 {
 public:

--- a/src/app/interaction-model/Events.h
+++ b/src/app/interaction-model/Events.h
@@ -33,10 +33,10 @@ namespace InteractionModel {
 
 namespace internal {
 template <typename T>
-class SimpleEventLoggingDelegate : public EventLoggingDelegate
+class SimpleEventPayloadWriter : public EventLoggingDelegate
 {
 public:
-    SimpleEventLoggingDelegate(const T & aEventData) : mEventData(aEventData){};
+    SimpleEventPayloadWriter(const T & aEventData) : mEventData(aEventData){};
     CHIP_ERROR WriteEvent(chip::TLV::TLVWriter & aWriter) final override
     {
         return DataModel::Encode(aWriter, TLV::ContextTag(EventDataIB::Tag::kData), mEventData);
@@ -49,7 +49,7 @@ private:
 template <typename G, typename T, std::enable_if_t<DataModel::IsFabricScoped<T>::value, bool> = true>
 std::optional<EventNumber> GenerateEvent(G & generator, const T & aEventData, EndpointId aEndpoint)
 {
-    internal::SimpleEventLoggingDelegate<T> eventPayloadWriter(aEventData);
+    internal::SimpleEventPayloadWriter<T> eventPayloadWriter(aEventData);
     ConcreteEventPath path(aEndpoint, aEventData.GetClusterId(), aEventData.GetEventId());
     EventOptions eventOptions;
     eventOptions.mPath        = path;
@@ -86,7 +86,7 @@ std::optional<EventNumber> GenerateEvent(G & generator, const T & aEventData, En
 template <typename G, typename T, std::enable_if_t<!DataModel::IsFabricScoped<T>::value, bool> = true>
 std::optional<EventNumber> GenerateEvent(G & generator, const T & aEventData, EndpointId endpointId)
 {
-    internal::SimpleEventLoggingDelegate<T> eventPayloadWriter(aEventData);
+    internal::SimpleEventPayloadWriter<T> eventPayloadWriter(aEventData);
     ConcreteEventPath path(endpointId, aEventData.GetClusterId(), aEventData.GetEventId());
     EventOptions eventOptions;
     eventOptions.mPath     = path;

--- a/src/app/interaction-model/Events.h
+++ b/src/app/interaction-model/Events.h
@@ -56,7 +56,7 @@ std::optional<EventNumber> GenerateEvent(G & generator, const T & aEventData, En
     eventOptions.mPriority    = aEventData.GetPriorityLevel();
     eventOptions.mFabricIndex = aEventData.GetFabricIndex();
 
-    // this skips generating the event if it is fabric-scoped however the event does not seem
+    // this skips generating the event if it is fabric-scoped but the provided event data is not
     // associated with any fabric.
     if (eventOptions.mFabricIndex == kUndefinedFabricIndex)
     {

--- a/src/app/interaction-model/Events.h
+++ b/src/app/interaction-model/Events.h
@@ -56,7 +56,8 @@ std::optional<EventNumber> GenerateEvent(G & generator, const T & aEventData, En
     eventOptions.mPriority    = aEventData.GetPriorityLevel();
     eventOptions.mFabricIndex = aEventData.GetFabricIndex();
 
-    // this skips generating the event if it's fabric-scoped but no fabric association exists yet.
+    // this skips generating the event if it is fabric-scoped however the event does not seem
+    // associated with any fabric.
     if (eventOptions.mFabricIndex == kUndefinedFabricIndex)
     {
         ChipLogError(EventLogging, "Event encode failure: no fabric index for fabric scoped event");

--- a/src/app/interaction-model/Events.h
+++ b/src/app/interaction-model/Events.h
@@ -104,6 +104,10 @@ std::optional<EventNumber> GenerateEvent(G & generator, const T & aEventData, En
 
 } // namespace internal
 
+/// Exposes event access capabilities.
+///
+/// Allows callers to "generate events" which effectively notifies of an event having
+/// ocurred. 
 class Events
 {
 public:

--- a/src/app/interaction-model/InvokeResponder.h
+++ b/src/app/interaction-model/InvokeResponder.h
@@ -26,7 +26,7 @@ namespace InteractionModel {
 
 /// Handles encoding of an invoke response for a specific invoke request.
 ///
-/// This class handles a single response (i.e. a CommandDataIB within the
+/// This class handles a single request (i.e. a CommandDataIB within the
 /// matter protocol) and is responsible for constructing its corresponding
 /// response (i.e. a InvokeResponseIB within the matter protocol)
 ///

--- a/src/app/interaction-model/IterationTypes.h
+++ b/src/app/interaction-model/IterationTypes.h
@@ -72,7 +72,7 @@ struct AttributeEntry
 ///   - Any internal iteration errors are just logged (callers do not handle iteration CHIP_ERROR)
 ///   - Iteration order is NOT guaranteed globally. Only the following is guaranteed:
 ///     - when iterating over an endpoint, ALL clusters of that endpoint will be iterated first, before
-///       switching the endpoint (order of clusters ids themselves not guaranteed)
+///       switching the endpoint (order of clusters themselves not guaranteed)
 ///     - when iterating over a cluster, ALL attributes of that cluster will be iterated first, before
 ///       switching to a new cluster
 ///     - uniqueness and completeness (iterate over all possible distinct values as long as no

--- a/src/app/interaction-model/IterationTypes.h
+++ b/src/app/interaction-model/IterationTypes.h
@@ -70,8 +70,13 @@ struct AttributeEntry
 /// Iteration rules:
 ///   - kInvalidEndpointId will be returned when iteration ends (or generally kInvalid* for paths)
 ///   - Any internal iteration errors are just logged (callers do not handle iteration CHIP_ERROR)
-///   - Iteration order is NOT guaranteed, however uniqueness and completeness is (must iterate
-///     over all possible distinct values as long as no internal structural changes occur)
+///   - Iteration order is NOT guaranteed globally. Only the following is guaranteed:
+///     - when iterating over an endpoint, ALL clusters of that endpoint will be iterated first, before
+///       switching the endpoint (order of clusters ids themselves not guaranteed)
+///     - when iterating over a cluster, ALL attributes of that cluster will be iterated first, before
+///       switching to a new cluster
+///     - uniqueness and completeness (iterate over all possible distinct values as long as no
+///       internal structural changes occur)
 class AttributeTreeIterator
 {
 public:

--- a/src/app/interaction-model/Model.h
+++ b/src/app/interaction-model/Model.h
@@ -53,7 +53,7 @@ public:
 
     // During the transition phase, we expect a large subset of code to require access to
     // event emitting, path marking and other operations
-    virtual InteractionModelActions CurrentActions() { return mActions; }
+    virtual InteractionModelActions CurrentActions() const { return mActions; }
 
     /// List reading has specific handling logic:
     ///   `state` contains in/out data about the current list reading. MUST start with kInvalidListIndex on first call
@@ -94,14 +94,14 @@ public:
     ///         - `NeedsTimedInteraction` for writes that are not timed however are required to be so
     virtual CHIP_ERROR WriteAttribute(const WriteAttributeRequest & request, AttributeValueDecoder & decoder) = 0;
 
-    /// `responder` is used to send back the reply.
+    /// `reply` is used to send back the reply.
     ///    - calling Reply() or ReplyAsync() will let the application control the reply
     ///    - returning a CHIP_NO_ERROR without reply/reply_async implies a Status::Success reply without data
-    ///    - returning a CHIP_*_ERROR implies an error reply (error and data are mutually exclusive)
+    ///    - returning a value other than CHIP_NO_ERROR implies an error reply (error and data are mutually exclusive)
     ///
     /// See InvokeReply/AutoCompleteInvokeResponder for details on how to send back replies and expected
-    /// error handling. If you require knowledge if a response was successfully sent, use the underlying
-    /// `reply` object instead of returning an error codes from Invoke.
+    /// error handling. If you need to know weather a response was successfully sent, use the underlying
+    /// `reply` object instead of returning an error code from Invoke.
     ///
     /// Return codes
     ///   CHIP_IM_GLOBAL_STATUS(code):

--- a/src/app/interaction-model/Model.h
+++ b/src/app/interaction-model/Model.h
@@ -22,7 +22,7 @@
 #include <app/AttributeValueDecoder.h>
 #include <app/AttributeValueEncoder.h>
 
-#include <app/interaction-model/Actions.h>
+#include <app/interaction-model/Context.h>
 #include <app/interaction-model/InvokeResponder.h>
 #include <app/interaction-model/IterationTypes.h>
 #include <app/interaction-model/OperationTypes.h>
@@ -44,16 +44,16 @@ public:
     virtual ~Model() = default;
 
     // `actions` pointers  will be guaranteed valid until Shutdown is called()
-    virtual CHIP_ERROR Startup(InteractionModelActions actions)
+    virtual CHIP_ERROR Startup(InteractionModelContext actions)
     {
-        mActions = actions;
+        mContext = actions;
         return CHIP_NO_ERROR;
     }
     virtual CHIP_ERROR Shutdown() = 0;
 
     // During the transition phase, we expect a large subset of code to require access to
     // event emitting, path marking and other operations
-    virtual InteractionModelActions CurrentActions() const { return mActions; }
+    virtual InteractionModelContext CurrentActions() const { return mContext; }
 
     /// List reading has specific handling logic:
     ///   `state` contains in/out data about the current list reading. MUST start with kInvalidListIndex on first call
@@ -115,7 +115,7 @@ public:
     virtual CHIP_ERROR Invoke(const InvokeRequest & request, chip::TLV::TLVReader & input_arguments, InvokeReply & reply) = 0;
 
 private:
-    InteractionModelActions mActions = { nullptr };
+    InteractionModelContext mContext = { nullptr };
 };
 
 } // namespace InteractionModel

--- a/src/app/interaction-model/Model.h
+++ b/src/app/interaction-model/Model.h
@@ -43,17 +43,17 @@ class Model : public AttributeTreeIterator
 public:
     virtual ~Model() = default;
 
-    // `actions` pointers  will be guaranteed valid until Shutdown is called()
-    virtual CHIP_ERROR Startup(InteractionModelContext actions)
+    // `context` pointers  will be guaranteed valid until Shutdown is called()
+    virtual CHIP_ERROR Startup(InteractionModelContext context)
     {
-        mContext = actions;
+        mContext = context;
         return CHIP_NO_ERROR;
     }
     virtual CHIP_ERROR Shutdown() = 0;
 
     // During the transition phase, we expect a large subset of code to require access to
     // event emitting, path marking and other operations
-    virtual InteractionModelContext CurrentActions() const { return mContext; }
+    virtual InteractionModelContext CurrentContext() const { return mContext; }
 
     /// List reading has specific handling logic:
     ///   `state` contains in/out data about the current list reading. MUST start with kInvalidListIndex on first call

--- a/src/app/interaction-model/OperationTypes.h
+++ b/src/app/interaction-model/OperationTypes.h
@@ -67,7 +67,7 @@ struct ReadState
 enum class WriteFlags : uint32_t
 {
     kTimed     = 0x0001, // Received as a 2nd command after a timed invoke
-    kListBegin = 0x0002, // This is the FIRST list data element in a series of data
+    kListBegin = 0x0002, // This is the FIRST list of data elements
     kListEnd   = 0x0004, // This is the LAST list element to write
 };
 
@@ -79,7 +79,7 @@ struct WriteAttributeRequest : OperationRequest
 
 enum class InvokeFlags : uint32_t
 {
-    kTimed = 0x0001, // Received as a 2nd command after a timed invoke
+    kTimed = 0x0001, // Command received as part of a timed invoke interaction.
 };
 
 struct InvokeRequest : OperationRequest

--- a/src/app/interaction-model/OperationTypes.h
+++ b/src/app/interaction-model/OperationTypes.h
@@ -66,7 +66,7 @@ struct ReadState
 
 enum class WriteFlags : uint32_t
 {
-    kTimed     = 0x0001, // Received as a 2nd command after a timed invoke
+    kTimed     = 0x0001, // Write is a timed write (i.e. a Timed Request Action preceeded it)
     kListBegin = 0x0002, // This is the FIRST list of data elements
     kListEnd   = 0x0004, // This is the LAST list element to write
 };

--- a/src/app/interaction-model/Paths.h
+++ b/src/app/interaction-model/Paths.h
@@ -22,23 +22,21 @@ namespace chip {
 namespace app {
 namespace InteractionModel {
 
-/// Handles path attributes for interaction models.
+/// Notification listener for attribute changes.
 ///
-/// It allows a user of the class to mark specific paths
-/// as having changed. The intended use is for some listener to
-/// perform operations as a result of something having changed,
-/// usually by forwarding updates (e.g. in case of subscriptions
-/// that cover that path).
+/// Used to notify that a specific attribute path (or several attributes
+/// via wildcards) have changed their underlying content. 
 ///
-/// Methods on this class MUCH be called from within the matter
+/// Methods on this class MUST be called from within the matter
 /// main loop as they will likely trigger interaction model
-/// internal updates and subscription event updates.
+/// internal updates and subscription data reporting.
 class Paths
 {
 public:
     virtual ~Paths() = 0;
 
-    /// Mark some specific attributes dirty.
+    /// Mark some specific attribute dirty (or several of attributes when using wildcards).
+    ///
     /// Wildcards are supported.
     virtual void MarkDirty(const AttributePathParams & path) = 0;
 };

--- a/src/app/interaction-model/Paths.h
+++ b/src/app/interaction-model/Paths.h
@@ -35,7 +35,7 @@ class Paths
 public:
     virtual ~Paths() = 0;
 
-    /// Mark some specific attribute dirty (or several of attributes when using wildcards).
+    /// Mark all attributes matching the given path (which may be a wildcard) dirty.
     ///
     /// Wildcards are supported.
     virtual void MarkDirty(const AttributePathParams & path) = 0;

--- a/src/app/interaction-model/Paths.h
+++ b/src/app/interaction-model/Paths.h
@@ -25,7 +25,7 @@ namespace InteractionModel {
 /// Notification listener for attribute changes.
 ///
 /// Used to notify that a specific attribute path (or several attributes
-/// via wildcards) have changed their underlying content. 
+/// via wildcards) have changed their underlying content.
 ///
 /// Methods on this class MUST be called from within the matter
 /// main loop as they will likely trigger interaction model

--- a/src/app/interaction-model/tests/TestEventEmitting.cpp
+++ b/src/app/interaction-model/tests/TestEventEmitting.cpp
@@ -102,8 +102,7 @@ TEST(TestInteractionModelEventEmitting, TestBasicType)
 
     std::optional<EventNumber> n1 = events->GenerateEvent(event, 0 /* EndpointId */);
 
-    ASSERT_TRUE(n1.has_value());
-    ASSERT_EQ(*n1, logOnlyEvents.CurrentEventNumber()); // NOLINT(bugprone-unchecked-optional-access)
+    ASSERT_EQ(n1, logOnlyEvents.CurrentEventNumber());
     ASSERT_EQ(logOnlyEvents.LastOptions().mPath,
               ConcreteEventPath(0 /* endpointId */, StartUpEventType::GetClusterId(), StartUpEventType::GetEventId()));
 
@@ -118,9 +117,7 @@ TEST(TestInteractionModelEventEmitting, TestBasicType)
     ASSERT_EQ(decoded_event.softwareVersion, kFakeSoftwareVersion);
 
     std::optional<EventNumber> n2 = events->GenerateEvent(event, /* endpointId = */ 1);
-    ASSERT_TRUE(n2.has_value());
-    ASSERT_EQ(*n2, logOnlyEvents.CurrentEventNumber()); // NOLINT(bugprone-unchecked-optional-access)
-    ASSERT_NE(n1, logOnlyEvents.CurrentEventNumber());
+    ASSERT_EQ(n2, logOnlyEvents.CurrentEventNumber());
 
     ASSERT_EQ(logOnlyEvents.LastOptions().mPath,
               ConcreteEventPath(1 /* endpointId */, StartUpEventType::GetClusterId(), StartUpEventType::GetEventId()));
@@ -147,8 +144,7 @@ TEST(TestInteractionModelEventEmitting, TestFabricScoped)
     event.fabricIndex = kTestFabricIndex;
     n1                = events->GenerateEvent(event, /* endpointId = */ 0);
 
-    ASSERT_TRUE(n1.has_value());
-    ASSERT_EQ(*n1, logOnlyEvents.CurrentEventNumber()); // NOLINT(bugprone-unchecked-optional-access)
+    ASSERT_EQ(n1, logOnlyEvents.CurrentEventNumber());
     ASSERT_EQ(logOnlyEvents.LastOptions().mPath,
               ConcreteEventPath(0 /* endpointId */, AccessControlEntryChangedType::GetClusterId(),
                                 AccessControlEntryChangedType::GetEventId()));

--- a/src/app/interaction-model/tests/TestEventEmitting.cpp
+++ b/src/app/interaction-model/tests/TestEventEmitting.cpp
@@ -100,8 +100,10 @@ TEST(TestInteractionModelEventEmitting, TestBasicType)
 
     StartUpEventType event{ kFakeSoftwareVersion };
 
-    EventNumber n1 = events->GenerateEvent(event, 0 /* EndpointId */);
-    ASSERT_EQ(n1, logOnlyEvents.CurrentEventNumber());
+    std::optional<EventNumber> n1 = events->GenerateEvent(event, 0 /* EndpointId */);
+
+    ASSERT_TRUE(n1.has_value());
+    ASSERT_EQ(*n1, logOnlyEvents.CurrentEventNumber());
     ASSERT_EQ(logOnlyEvents.LastOptions().mPath,
               ConcreteEventPath(0 /* endpointId */, StartUpEventType::GetClusterId(), StartUpEventType::GetEventId()));
 
@@ -115,8 +117,9 @@ TEST(TestInteractionModelEventEmitting, TestBasicType)
     ASSERT_EQ(err, CHIP_NO_ERROR);
     ASSERT_EQ(decoded_event.softwareVersion, kFakeSoftwareVersion);
 
-    EventNumber n2 = events->GenerateEvent(event, /* endpointId = */ 1);
-    ASSERT_EQ(n2, logOnlyEvents.CurrentEventNumber());
+    std::optional<EventNumber> n2 = events->GenerateEvent(event, /* endpointId = */ 1);
+    ASSERT_TRUE(n2.has_value());
+    ASSERT_EQ(*n2, logOnlyEvents.CurrentEventNumber());
     ASSERT_NE(n1, logOnlyEvents.CurrentEventNumber());
 
     ASSERT_EQ(logOnlyEvents.LastOptions().mPath,
@@ -137,14 +140,14 @@ TEST(TestInteractionModelEventEmitting, TestFabricScoped)
     event.adminNodeID     = chip::app::DataModel::MakeNullable(kTestNodeId);
     event.adminPasscodeID = chip::app::DataModel::MakeNullable(kTestPasscode);
 
-    EventNumber n1 = events->GenerateEvent(event, 0 /* EndpointId */);
+    std::optional<EventNumber> n1 = events->GenerateEvent(event, 0 /* EndpointId */);
     // encoding without a fabric ID MUST fail for fabric events
-    ASSERT_EQ(n1, kInvalidEventId);
+    ASSERT_FALSE(n1.has_value());
 
     event.fabricIndex = kTestFabricIndex;
     n1                = events->GenerateEvent(event, /* endpointId = */ 0);
 
-    ASSERT_NE(n1, kInvalidEventId);
+    ASSERT_TRUE(n1.has_value());
     ASSERT_EQ(n1, logOnlyEvents.CurrentEventNumber());
     ASSERT_EQ(logOnlyEvents.LastOptions().mPath,
               ConcreteEventPath(0 /* endpointId */, AccessControlEntryChangedType::GetClusterId(),

--- a/src/app/interaction-model/tests/TestEventEmitting.cpp
+++ b/src/app/interaction-model/tests/TestEventEmitting.cpp
@@ -103,7 +103,7 @@ TEST(TestInteractionModelEventEmitting, TestBasicType)
     std::optional<EventNumber> n1 = events->GenerateEvent(event, 0 /* EndpointId */);
 
     ASSERT_TRUE(n1.has_value());
-    ASSERT_EQ(*n1, logOnlyEvents.CurrentEventNumber());
+    ASSERT_EQ(*n1, logOnlyEvents.CurrentEventNumber()); // NOLINT(bugprone-unchecked-optional-access)
     ASSERT_EQ(logOnlyEvents.LastOptions().mPath,
               ConcreteEventPath(0 /* endpointId */, StartUpEventType::GetClusterId(), StartUpEventType::GetEventId()));
 
@@ -119,7 +119,7 @@ TEST(TestInteractionModelEventEmitting, TestBasicType)
 
     std::optional<EventNumber> n2 = events->GenerateEvent(event, /* endpointId = */ 1);
     ASSERT_TRUE(n2.has_value());
-    ASSERT_EQ(*n2, logOnlyEvents.CurrentEventNumber());
+    ASSERT_EQ(*n2, logOnlyEvents.CurrentEventNumber()); // NOLINT(bugprone-unchecked-optional-access)
     ASSERT_NE(n1, logOnlyEvents.CurrentEventNumber());
 
     ASSERT_EQ(logOnlyEvents.LastOptions().mPath,
@@ -148,7 +148,7 @@ TEST(TestInteractionModelEventEmitting, TestFabricScoped)
     n1                = events->GenerateEvent(event, /* endpointId = */ 0);
 
     ASSERT_TRUE(n1.has_value());
-    ASSERT_EQ(n1, logOnlyEvents.CurrentEventNumber());
+    ASSERT_EQ(*n1, logOnlyEvents.CurrentEventNumber()); // NOLINT(bugprone-unchecked-optional-access)
     ASSERT_EQ(logOnlyEvents.LastOptions().mPath,
               ConcreteEventPath(0 /* endpointId */, AccessControlEntryChangedType::GetClusterId(),
                                 AccessControlEntryChangedType::GetEventId()));


### PR DESCRIPTION
Going through review comments post-submit in #32914

### Changes:
- several renames and comment updates


Not addressed:
  - renaming "interactionModel" to "dataModel" (larger change, should probably be stand-alone)
  - InvokeRequest not touched as I am moving towards using CommandHandler, in which case all this code is obsolete