### PR TITLE
Fix the icd registerClient

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -118,8 +118,9 @@ public:
 
         if (data != nullptr)
         {
+            chip::TLV::TLVReader counterTlvReader;
+            counterTlvReader.Init(*data);
             LogErrorOnFailure(RemoteDataModelLogger::LogCommandAsJSON(path, data));
-
             error = DataModelLogger::LogCommand(path, data);
             if (CHIP_NO_ERROR != error)
             {
@@ -128,10 +129,8 @@ public:
                 return;
             }
             if ((path.mEndpointId == chip::kRootEndpointId) && (path.mClusterId == chip::app::Clusters::IcdManagement::Id) &&
-                (path.mCommandId == chip::app::Clusters::IcdManagement::Commands::RegisterClient::Id))
+                (path.mCommandId == chip::app::Clusters::IcdManagement::Commands::RegisterClientResponse::Id))
             {
-                chip::TLV::TLVReader counterTlvReader;
-                counterTlvReader.Init(*data);
                 chip::app::Clusters::IcdManagement::Commands::RegisterClientResponse::DecodableType value;
                 CHIP_ERROR err = chip::app::DataModel::Decode(counterTlvReader, value);
                 if (CHIP_NO_ERROR != err)
@@ -139,7 +138,6 @@ public:
                     ChipLogError(chipTool, "Failed to decode ICD counter: %" CHIP_ERROR_FORMAT, err.Format());
                     return;
                 }
-
                 chip::app::ICDClientInfo clientInfo;
                 clientInfo.peer_node         = mScopedNodeId;
                 clientInfo.monitored_subject = mMonitoredSubject;

--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -118,11 +118,13 @@ public:
 
         if (data != nullptr)
         {
-            // log a snapshot to not advance the data reader.
-            chip::TLV::TLVReader counterTlvReader;
-            counterTlvReader.Init(*data);
-            LogErrorOnFailure(RemoteDataModelLogger::LogCommandAsJSON(path, data));
-            error = DataModelLogger::LogCommand(path, data);
+            {
+                // log a snapshot to not advance the data reader.
+                chip::TLV::TLVReader logTlvReader;
+                logTlvReader.Init(*data);
+                LogErrorOnFailure(RemoteDataModelLogger::LogCommandAsJSON(path, logTlvReader));
+                error = DataModelLogger::LogCommand(path, logTlvReader);
+            }
             if (CHIP_NO_ERROR != error)
             {
                 ChipLogError(chipTool, "Response Failure: Can not decode Data");
@@ -132,6 +134,9 @@ public:
             if ((path.mEndpointId == chip::kRootEndpointId) && (path.mClusterId == chip::app::Clusters::IcdManagement::Id) &&
                 (path.mCommandId == chip::app::Clusters::IcdManagement::Commands::RegisterClientResponse::Id))
             {
+                // log a snapshot to not advance the data reader.
+                chip::TLV::TLVReader counterTlvReader;
+                counterTlvReader.Init(*data);
                 chip::app::Clusters::IcdManagement::Commands::RegisterClientResponse::DecodableType value;
                 CHIP_ERROR err = chip::app::DataModel::Decode(counterTlvReader, value);
                 if (CHIP_NO_ERROR != err)

--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -118,6 +118,7 @@ public:
 
         if (data != nullptr)
         {
+            // log a snapshot to not advance the data reader.
             chip::TLV::TLVReader counterTlvReader;
             counterTlvReader.Init(*data);
             LogErrorOnFailure(RemoteDataModelLogger::LogCommandAsJSON(path, data));

--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -122,8 +122,8 @@ public:
                 // log a snapshot to not advance the data reader.
                 chip::TLV::TLVReader logTlvReader;
                 logTlvReader.Init(*data);
-                LogErrorOnFailure(RemoteDataModelLogger::LogCommandAsJSON(path, logTlvReader));
-                error = DataModelLogger::LogCommand(path, logTlvReader);
+                LogErrorOnFailure(RemoteDataModelLogger::LogCommandAsJSON(path, &logTlvReader));
+                error = DataModelLogger::LogCommand(path, &logTlvReader);
             }
             if (CHIP_NO_ERROR != error)
             {


### PR DESCRIPTION
In https://github.com/project-chip/connectedhomeip/pull/33690, I forgot to push the below fix
1. Fix the RegisterClientResponse name
2. tlv needs to be snapshotted before DataModelLogger::LogCommand for correct decoding since DataModelLogger::LogCommand has directly used the tlvreader, and advance inside

test: run multiple iterations for register/unregister
