### PR TITLE
Python wheels: move template into its own gni

### DIFF
--- a/build/chip/python_wheel.gni
+++ b/build/chip/python_wheel.gni
@@ -1,0 +1,88 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+
+import("$dir_pw_build/python.gni")
+import("${chip_root}/src/system/system.gni")
+
+declare_args() {
+  chip_python_version = "0.0"
+  chip_python_package_prefix = "chip"
+  chip_python_supports_stack_locking = chip_system_config_locking != "none"
+}
+
+template("chip_python_wheel_action") {
+  _dist_dir = "${root_out_dir}/controller/python"
+
+  _py_manifest_file = "${target_gen_dir}/${target_name}.py_manifest.json"
+
+  pw_python_action(target_name) {
+    script = "build-chip-wheel.py"
+    forward_variables_from(invoker, "*")
+
+    _py_manifest_files_rebased = []
+    foreach(_manifest_entry, py_manifest_files) {
+      inputs += _manifest_entry.sources
+      _py_manifest_files_rebased += [
+        {
+          src_dir = rebase_path(_manifest_entry.src_dir,
+                                get_path_info(_py_manifest_file, "dir"))
+          sources =
+              rebase_path(_manifest_entry.sources, _manifest_entry.src_dir)
+        },
+      ]
+    }
+
+    if (defined(invoker.py_scripts)) {
+      _py_scripts = invoker.py_scripts
+    } else {
+      _py_scripts = []
+    }
+
+    _py_manifest = {
+      files = _py_manifest_files_rebased
+      packages = py_packages
+      scripts = _py_scripts
+      package_reqs = py_package_reqs
+    }
+
+    write_file(_py_manifest_file, _py_manifest, "json")
+
+    args = [
+      "--package_name",
+      py_package_name,
+      "--build_number",
+      chip_python_version,
+      "--build_dir",
+      rebase_path("${target_gen_dir}/${target_name}.py_build", root_build_dir),
+      "--dist_dir",
+      rebase_path(_dist_dir, root_build_dir),
+      "--manifest",
+      rebase_path(_py_manifest_file, root_build_dir),
+      "--plat-name",
+      py_platform_tag,
+    ]
+
+    if (defined(invoker.lib_name)) {
+      args += [
+        "--lib-name",
+        lib_name,
+      ]
+    }
+
+    outputs = [ "${_dist_dir}/$output_name" ]
+  }
+}

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -18,6 +18,7 @@ import("//build_overrides/pigweed.gni")
 
 import("$dir_pw_build/python.gni")
 
+import("${chip_root}/build/chip/python_wheel.gni")
 import("${chip_root}/build/chip/tools.gni")
 import("${chip_root}/src/platform/python.gni")
 import("${chip_root}/src/system/system.gni")
@@ -29,12 +30,6 @@ if (current_os == "mac") {
 
 config("controller_wno_deprecate") {
   cflags = [ "-Wno-deprecated-declarations" ]
-}
-
-declare_args() {
-  chip_python_version = "0.0"
-  chip_python_package_prefix = "chip"
-  chip_python_supports_stack_locking = chip_system_config_locking != "none"
 }
 
 shared_library("ChipDeviceCtrl") {
@@ -152,69 +147,6 @@ shared_library("ChipDeviceCtrl") {
   }
 
   configs += [ ":controller_wno_deprecate" ]
-}
-
-template("chip_python_wheel_action") {
-  _dist_dir = "${root_out_dir}/controller/python"
-
-  _py_manifest_file = "${target_gen_dir}/${target_name}.py_manifest.json"
-
-  pw_python_action(target_name) {
-    script = "build-chip-wheel.py"
-    forward_variables_from(invoker, "*")
-
-    _py_manifest_files_rebased = []
-    foreach(_manifest_entry, py_manifest_files) {
-      inputs += _manifest_entry.sources
-      _py_manifest_files_rebased += [
-        {
-          src_dir = rebase_path(_manifest_entry.src_dir,
-                                get_path_info(_py_manifest_file, "dir"))
-          sources =
-              rebase_path(_manifest_entry.sources, _manifest_entry.src_dir)
-        },
-      ]
-    }
-
-    if (defined(invoker.py_scripts)) {
-      _py_scripts = invoker.py_scripts
-    } else {
-      _py_scripts = []
-    }
-
-    _py_manifest = {
-      files = _py_manifest_files_rebased
-      packages = py_packages
-      scripts = _py_scripts
-      package_reqs = py_package_reqs
-    }
-
-    write_file(_py_manifest_file, _py_manifest, "json")
-
-    args = [
-      "--package_name",
-      py_package_name,
-      "--build_number",
-      chip_python_version,
-      "--build_dir",
-      rebase_path("${target_gen_dir}/${target_name}.py_build", root_build_dir),
-      "--dist_dir",
-      rebase_path(_dist_dir, root_build_dir),
-      "--manifest",
-      rebase_path(_py_manifest_file, root_build_dir),
-      "--plat-name",
-      py_platform_tag,
-    ]
-
-    if (defined(invoker.lib_name)) {
-      args += [
-        "--lib-name",
-        lib_name,
-      ]
-    }
-
-    outputs = [ "${_dist_dir}/$output_name" ]
-  }
 }
 
 chip_python_wheel_action("chip-core") {


### PR DESCRIPTION
This will let us re-use the template later for wheels not in src/controller/python.

Nothing within the template has been changed - this is just a move.

Test: ran build_python.sh, it's fine still.