### PR TITLE
[Tizen] Allow to pass CHIP error to device event

### DIFF
--- a/src/ble/BleUUID.h
+++ b/src/ble/BleUUID.h
@@ -101,7 +101,6 @@ constexpr std::pair<bool, ChipBleUUID> StringToUUID(const char (&str)[N])
 //       BlueZ API https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/org.bluez.Device.rst
 //       describes ServiceData as "Keys are the UUIDs in string format" however no description
 //       on actual case required
-inline constexpr char CHIP_BLE_DESC_SHORT_UUID_STR[]    = "2902";
 inline constexpr char CHIP_BLE_SERVICE_SHORT_UUID_STR[] = "fff6";
 inline constexpr char CHIP_BLE_SERVICE_LONG_UUID_STR[]  = "0000fff6-0000-1000-8000-00805f9b34fb";
 inline constexpr char CHIP_BLE_CHAR_1_UUID_STR[]        = "18ee2ef5-263d-4559-959f-4f9c429f9d11";

--- a/src/platform/Linux/CHIPDevicePlatformEvent.h
+++ b/src/platform/Linux/CHIPDevicePlatformEvent.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <lib/core/CHIPError.h>
 #include <platform/CHIPDeviceEvent.h>
 #include <system/SystemPacketBuffer.h>
 

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -271,7 +271,7 @@ void BLEManagerImpl::NotificationStateChangedCb(bool notify, bt_gatt_server_h se
 
     ChipLogProgress(DeviceLayer, "Notification State Changed %d on %s: %s", notify, __ConvertAttTypeToStr(type),
                     StringOrNullMarker(uuid.get()));
-    NotifyBLESubscribed(notify ? true : false, conn);
+    NotifyBLESubscribed(conn, notify ? true : false);
 }
 
 void BLEManagerImpl::WriteCompletedCb(int result, bt_gatt_h gattHandle, void * userData)
@@ -347,83 +347,70 @@ void BLEManagerImpl::AdvertisingStateChangedCb(int result, bt_advertiser_h adver
 
 void BLEManagerImpl::NotifyBLEPeripheralGATTServerRegisterComplete(CHIP_ERROR error)
 {
-    ChipDeviceEvent event;
-    event.Type = DeviceEventType::kPlatformTizenBLEPeripheralGATTServerRegisterComplete;
-    event.Platform.BLEPeripheralGATTServerRegisterComplete.mError = error;
+    ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformTizenBLEPeripheralGATTServerRegisterComplete,
+                           .Platform = { .BLEPeripheralGATTServerRegisterComplete = { .mError = error } } };
     PlatformMgr().PostEventOrDie(&event);
 }
 
 void BLEManagerImpl::NotifyBLEPeripheralAdvConfiguredComplete(CHIP_ERROR error)
 {
-    ChipDeviceEvent event;
-    event.Type                                               = DeviceEventType::kPlatformTizenBLEPeripheralAdvConfiguredComplete;
-    event.Platform.BLEPeripheralAdvConfiguredComplete.mError = error;
+    ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformTizenBLEPeripheralAdvConfiguredComplete,
+                           .Platform = { .BLEPeripheralAdvConfiguredComplete = { .mError = error } } };
     PlatformMgr().PostEventOrDie(&event);
 }
 
 void BLEManagerImpl::NotifyBLEPeripheralAdvStartComplete(CHIP_ERROR error)
 {
-    ChipDeviceEvent event;
-    event.Type                                          = DeviceEventType::kPlatformTizenBLEPeripheralAdvStartComplete;
-    event.Platform.BLEPeripheralAdvStartComplete.mError = error;
+    ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformTizenBLEPeripheralAdvStartComplete,
+                           .Platform = { .BLEPeripheralAdvStartComplete = { .mError = error } } };
     PlatformMgr().PostEventOrDie(&event);
 }
 
 void BLEManagerImpl::NotifyBLEPeripheralAdvStopComplete(CHIP_ERROR error)
 {
-    ChipDeviceEvent event;
-    event.Type                                         = DeviceEventType::kPlatformTizenBLEPeripheralAdvStopComplete;
-    event.Platform.BLEPeripheralAdvStopComplete.mError = error;
+    ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformTizenBLEPeripheralAdvStopComplete,
+                           .Platform = { .BLEPeripheralAdvStopComplete = { .mError = error } } };
     PlatformMgr().PostEventOrDie(&event);
 }
 
-void BLEManagerImpl::NotifyBLEWriteReceived(System::PacketBufferHandle & buf, BLE_CONNECTION_OBJECT conId)
+void BLEManagerImpl::NotifyBLEWriteReceived(BLE_CONNECTION_OBJECT conId, System::PacketBufferHandle & buf)
 {
-    ChipDeviceEvent event;
-    event.Type                        = DeviceEventType::kCHIPoBLEWriteReceived;
-    event.CHIPoBLEWriteReceived.ConId = conId;
-    event.CHIPoBLEWriteReceived.Data  = std::move(buf).UnsafeRelease();
+    ChipDeviceEvent event{ .Type                  = DeviceEventType::kCHIPoBLEWriteReceived,
+                           .CHIPoBLEWriteReceived = { .ConId = conId, .Data = std::move(buf).UnsafeRelease() } };
     PlatformMgr().PostEventOrDie(&event);
 }
 
-void BLEManagerImpl::NotifyBLENotificationReceived(System::PacketBufferHandle & buf, BLE_CONNECTION_OBJECT conId)
+void BLEManagerImpl::NotifyBLENotificationReceived(BLE_CONNECTION_OBJECT conId, System::PacketBufferHandle & buf)
 {
-    ChipDeviceEvent event;
-    event.Type                                       = DeviceEventType::kPlatformTizenBLEIndicationReceived;
-    event.Platform.BLEIndicationReceived.mConnection = conId;
-    event.Platform.BLEIndicationReceived.mData       = std::move(buf).UnsafeRelease();
+    ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformTizenBLEIndicationReceived,
+                           .Platform = {
+                               .BLEIndicationReceived = { .mConnection = conId, .mData = std::move(buf).UnsafeRelease() } } };
     PlatformMgr().PostEventOrDie(&event);
 }
 
-void BLEManagerImpl::NotifyBLESubscribed(bool indicationsEnabled, BLE_CONNECTION_OBJECT conId)
+void BLEManagerImpl::NotifyBLESubscribed(BLE_CONNECTION_OBJECT conId, bool indicationsEnabled)
 {
-    ChipDeviceEvent event;
-    event.Type = (indicationsEnabled) ? DeviceEventType::kCHIPoBLESubscribe : DeviceEventType::kCHIPoBLEUnsubscribe;
-    event.CHIPoBLESubscribe.ConId = conId;
+    ChipDeviceEvent event{ .Type = indicationsEnabled ? DeviceEventType::kCHIPoBLESubscribe : DeviceEventType::kCHIPoBLEUnsubscribe,
+                           .CHIPoBLESubscribe = { .ConId = conId } };
     PlatformMgr().PostEventOrDie(&event);
 }
 
 void BLEManagerImpl::NotifyBLEIndicationConfirmation(BLE_CONNECTION_OBJECT conId)
 {
-    ChipDeviceEvent event;
-    event.Type                          = DeviceEventType::kCHIPoBLEIndicateConfirm;
-    event.CHIPoBLEIndicateConfirm.ConId = conId;
+    ChipDeviceEvent event{ .Type = DeviceEventType::kCHIPoBLEIndicateConfirm, .CHIPoBLEIndicateConfirm = { .ConId = conId } };
     PlatformMgr().PostEventOrDie(&event);
 }
 
 void BLEManagerImpl::NotifyBLEConnectionEstablished(BLE_CONNECTION_OBJECT conId, CHIP_ERROR error)
 {
-    ChipDeviceEvent event;
-    event.Type = DeviceEventType::kCHIPoBLEConnectionEstablished;
+    ChipDeviceEvent event{ .Type = DeviceEventType::kCHIPoBLEConnectionEstablished };
     PlatformMgr().PostEventOrDie(&event);
 }
 
 void BLEManagerImpl::NotifyBLEDisconnection(BLE_CONNECTION_OBJECT conId, CHIP_ERROR error)
 {
-    ChipDeviceEvent event;
-    event.Type                           = DeviceEventType::kCHIPoBLEConnectionError;
-    event.CHIPoBLEConnectionError.ConId  = conId;
-    event.CHIPoBLEConnectionError.Reason = error;
+    ChipDeviceEvent event{ .Type                    = DeviceEventType::kCHIPoBLEConnectionError,
+                           .CHIPoBLEConnectionError = { .ConId = conId, .Reason = error } };
     PlatformMgr().PostEventOrDie(&event);
 }
 
@@ -432,9 +419,8 @@ void BLEManagerImpl::NotifyHandleConnectFailed(CHIP_ERROR error)
     ChipLogProgress(DeviceLayer, "Connection failed: %" CHIP_ERROR_FORMAT, error.Format());
     if (mIsCentral)
     {
-        ChipDeviceEvent event;
-        event.Type                                    = DeviceEventType::kPlatformTizenBLECentralConnectFailed;
-        event.Platform.BLECentralConnectFailed.mError = error;
+        ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformTizenBLECentralConnectFailed,
+                               .Platform = { .BLECentralConnectFailed = { .mError = error } } };
         PlatformMgr().PostEventOrDie(&event);
     }
 }
@@ -443,27 +429,23 @@ void BLEManagerImpl::NotifyHandleNewConnection(BLE_CONNECTION_OBJECT conId)
 {
     if (mIsCentral)
     {
-        ChipDeviceEvent event;
-        event.Type                                     = DeviceEventType::kPlatformTizenBLECentralConnected;
-        event.Platform.BLECentralConnected.mConnection = conId;
+        ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformTizenBLECentralConnected,
+                               .Platform = { .BLECentralConnected = { .mConnection = conId } } };
         PlatformMgr().PostEventOrDie(&event);
     }
 }
 
 void BLEManagerImpl::NotifyHandleWriteComplete(BLE_CONNECTION_OBJECT conId)
 {
-    ChipDeviceEvent event;
-    event.Type                                  = DeviceEventType::kPlatformTizenBLEWriteComplete;
-    event.Platform.BLEWriteComplete.mConnection = conId;
+    ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformTizenBLEWriteComplete,
+                           .Platform = { .BLEWriteComplete = { .mConnection = conId } } };
     PlatformMgr().PostEventOrDie(&event);
 }
 
 void BLEManagerImpl::NotifySubscribeOpComplete(BLE_CONNECTION_OBJECT conId, bool isSubscribed)
 {
-    ChipDeviceEvent event;
-    event.Type                                          = DeviceEventType::kPlatformTizenBLESubscribeOpComplete;
-    event.Platform.BLESubscribeOpComplete.mConnection   = conId;
-    event.Platform.BLESubscribeOpComplete.mIsSubscribed = isSubscribed;
+    ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformTizenBLESubscribeOpComplete,
+                           .Platform = { .BLESubscribeOpComplete = { .mConnection = conId, .mIsSubscribed = isSubscribed } } };
     PlatformMgr().PostEventOrDie(&event);
 }
 
@@ -899,7 +881,7 @@ void BLEManagerImpl::HandleC1CharWriteEvent(BLE_CONNECTION_OBJECT conId, const u
     // Copy the data to a packet buffer.
     buf = System::PacketBufferHandle::NewWithData(value, len);
     VerifyOrExit(!buf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
-    NotifyBLEWriteReceived(buf, conId);
+    NotifyBLEWriteReceived(conId, buf);
     return;
 exit:
     if (err != CHIP_NO_ERROR)
@@ -918,7 +900,7 @@ void BLEManagerImpl::HandleRXCharChanged(BLE_CONNECTION_OBJECT conId, const uint
     // Copy the data to a packet buffer.
     buf = System::PacketBufferHandle::NewWithData(value, len);
     VerifyOrExit(!buf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
-    NotifyBLENotificationReceived(buf, conId);
+    NotifyBLENotificationReceived(conId, buf);
     return;
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -74,6 +74,9 @@ namespace Internal {
 
 namespace {
 
+// Bluetooth SIG defined UUID for Client Characteristic Configuration Descriptor
+constexpr const char * kClientCharacteristicConfigurationUUID = "2902";
+
 constexpr System::Clock::Timeout kNewConnectionScanTimeout = System::Clock::Seconds16(20);
 constexpr System::Clock::Timeout kConnectTimeout           = System::Clock::Seconds16(20);
 constexpr System::Clock::Timeout kFastAdvertiseTimeout =
@@ -631,10 +634,10 @@ CHIP_ERROR BLEManagerImpl::RegisterGATTServer()
                  ChipLogError(DeviceLayer, "bt_gatt_server_set_characteristic_notification_state_change_cb() failed: %s",
                               get_error_message(ret)));
 
-    // Create CCC Descriptor for 2nd Characteristic
-    ret = bt_gatt_descriptor_create(Ble::CHIP_BLE_DESC_SHORT_UUID_STR, BT_GATT_PERMISSION_READ | BT_GATT_PERMISSION_WRITE,
+    ret = bt_gatt_descriptor_create(kClientCharacteristicConfigurationUUID, BT_GATT_PERMISSION_READ | BT_GATT_PERMISSION_WRITE,
                                     desc_value, sizeof(desc_value), &desc);
     VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_descriptor_create() failed: %s", get_error_message(ret)));
+
     ret = bt_gatt_characteristic_add_descriptor(char2, desc);
     VerifyOrExit(ret == BT_ERROR_NONE,
                  ChipLogError(DeviceLayer, "bt_gatt_characteristic_add_descriptor() failed: %s", get_error_message(ret)));

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -574,7 +574,7 @@ CHIP_ERROR BLEManagerImpl::RegisterGATTServer()
     VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_create() failed: %s", get_error_message(ret)));
 
     // Create Service (BTP Service)
-    ret = bt_gatt_service_create(Ble::CHIP_BLE_SERVICE_LONG_UUID_STR, BT_GATT_SERVICE_TYPE_PRIMARY, &service);
+    ret = bt_gatt_service_create(Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR, BT_GATT_SERVICE_TYPE_PRIMARY, &service);
     VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_service_create() failed: %s", get_error_message(ret)));
 
     // Create 1st Characteristic (Client TX Buffer)

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -133,7 +133,7 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
+    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
     CHIP_ERROR CancelConnection() override;
 
     //  ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -200,9 +200,9 @@ private:
     void NotifyBLEPeripheralAdvConfiguredComplete(CHIP_ERROR error);
     void NotifyBLEPeripheralAdvStartComplete(CHIP_ERROR error);
     void NotifyBLEPeripheralAdvStopComplete(CHIP_ERROR error);
-    void NotifyBLESubscribed(bool indicationsEnabled, BLE_CONNECTION_OBJECT conId);
+    void NotifyBLESubscribed(BLE_CONNECTION_OBJECT conId, bool indicationsEnabled);
     void NotifyBLEIndicationConfirmation(BLE_CONNECTION_OBJECT conId);
-    void NotifyBLEWriteReceived(System::PacketBufferHandle & buf, BLE_CONNECTION_OBJECT conId);
+    void NotifyBLEWriteReceived(BLE_CONNECTION_OBJECT conId, System::PacketBufferHandle & buf);
     static void HandleAdvertisingTimeout(chip::System::Layer *, void * appState);
     AdvertisingIntervals GetAdvertisingIntervals() const;
 
@@ -214,7 +214,7 @@ private:
     void NotifyHandleConnectFailed(CHIP_ERROR error);
     void NotifyHandleWriteComplete(BLE_CONNECTION_OBJECT conId);
     void NotifySubscribeOpComplete(BLE_CONNECTION_OBJECT conId, bool isSubscribed);
-    void NotifyBLENotificationReceived(System::PacketBufferHandle & buf, BLE_CONNECTION_OBJECT conId);
+    void NotifyBLENotificationReceived(BLE_CONNECTION_OBJECT conId, System::PacketBufferHandle & buf);
 
     CHIP_ERROR RegisterGATTServer();
     CHIP_ERROR StartBLEAdvertising();

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -133,7 +133,7 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
+    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
     CHIP_ERROR CancelConnection() override;
 
     //  ===== Members that implement virtual methods on ChipDeviceScannerDelegate
@@ -196,10 +196,10 @@ private:
     bool IsDeviceChipPeripheral(BLE_CONNECTION_OBJECT conId);
 
     // ==== BLE Adv & GATT Server.
-    void NotifyBLEPeripheralGATTServerRegisterComplete(bool aIsSuccess, void * apAppstate);
-    void NotifyBLEPeripheralAdvConfiguredComplete(bool aIsSuccess, void * apAppstate);
-    void NotifyBLEPeripheralAdvStartComplete(bool aIsSuccess, void * apAppstate);
-    void NotifyBLEPeripheralAdvStopComplete(bool aIsSuccess, void * apAppstate);
+    void NotifyBLEPeripheralGATTServerRegisterComplete(CHIP_ERROR error);
+    void NotifyBLEPeripheralAdvConfiguredComplete(CHIP_ERROR error);
+    void NotifyBLEPeripheralAdvStartComplete(CHIP_ERROR error);
+    void NotifyBLEPeripheralAdvStopComplete(CHIP_ERROR error);
     void NotifyBLESubscribed(bool indicationsEnabled, BLE_CONNECTION_OBJECT conId);
     void NotifyBLEIndicationConfirmation(BLE_CONNECTION_OBJECT conId);
     void NotifyBLEWriteReceived(System::PacketBufferHandle & buf, BLE_CONNECTION_OBJECT conId);

--- a/src/platform/Tizen/CHIPDevicePlatformEvent.h
+++ b/src/platform/Tizen/CHIPDevicePlatformEvent.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <lib/core/CHIPError.h>
 #include <platform/CHIPDeviceEvent.h>
 #include <system/SystemPacketBuffer.h>
 
@@ -67,23 +68,19 @@ struct ChipDevicePlatformEvent
     {
         struct
         {
-            bool mIsSuccess;
-            void * mpAppstate;
+            CHIP_ERROR mError;
         } BLEPeripheralGATTServerRegisterComplete;
         struct
         {
-            bool mIsSuccess;
-            void * mpAppstate;
+            CHIP_ERROR mError;
         } BLEPeripheralAdvConfiguredComplete;
         struct
         {
-            bool mIsSuccess;
-            void * mpAppstate;
+            CHIP_ERROR mError;
         } BLEPeripheralAdvStartComplete;
         struct
         {
-            bool mIsSuccess;
-            void * mpAppstate;
+            CHIP_ERROR mError;
         } BLEPeripheralAdvStopComplete;
         struct
         {


### PR DESCRIPTION
### Problem

When reporting error from async operation it's not possible to pass error value.

### Changes

- store CHIP_ERROR instead of "bool isSuccess" in the event
- do not initialize characteristics with dummy values
- do not keep non-Matter UUIDs in BleUUID.h (Client Characteristic Configuration)
- create GATT service with short Bluetooth SIG UUID

### Testing

CI will verify potential build brakes.