### PR TITLE
Modified wifi network diagnostics cluster name, WiFi to Wi-Fi

### DIFF
--- a/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.zap
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.zap
@@ -2742,7 +2742,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -4340,7 +4340,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.zap
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.zap
@@ -3002,7 +3002,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/bridge-app/bridge-common/bridge-app.zap
+++ b/examples/bridge-app/bridge-common/bridge-app.zap
@@ -3249,7 +3249,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.zap
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.zap
@@ -2714,7 +2714,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/chef/devices/rootnode_dishwasher_cc105034fe.zap
+++ b/examples/chef/devices/rootnode_dishwasher_cc105034fe.zap
@@ -2094,7 +2094,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.zap
+++ b/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.zap
@@ -2094,7 +2094,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/chef/devices/rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680.zap
+++ b/examples/chef/devices/rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680.zap
@@ -2094,7 +2094,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/chef/sample_app_util/test_files/sample_zap_file.zap
+++ b/examples/chef/sample_app_util/test_files/sample_zap_file.zap
@@ -3024,7 +3024,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.zap
+++ b/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.zap
@@ -3098,7 +3098,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/dishwasher-app/dishwasher-common/dishwasher-app.zap
+++ b/examples/dishwasher-app/dishwasher-common/dishwasher-app.zap
@@ -2234,7 +2234,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/fabric-bridge-app/fabric-bridge-common/fabric-bridge-app.zap
+++ b/examples/fabric-bridge-app/fabric-bridge-common/fabric-bridge-app.zap
@@ -2884,7 +2884,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/laundry-washer-app/nxp/zap/laundry-washer-app.zap
+++ b/examples/laundry-washer-app/nxp/zap/laundry-washer-app.zap
@@ -2240,7 +2240,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/light-switch-app/light-switch-common/light-switch-app.zap
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.zap
@@ -3024,7 +3024,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.zap
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.zap
@@ -1903,7 +1903,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/lighting-app/lighting-common/lighting-app.zap
+++ b/examples/lighting-app/lighting-common/lighting-app.zap
@@ -2979,7 +2979,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.zap
@@ -1877,7 +1877,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.zap
+++ b/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.zap
@@ -2217,7 +2217,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/lock-app/lock-common/lock-app.zap
+++ b/examples/lock-app/lock-common/lock-app.zap
@@ -3654,7 +3654,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/microwave-oven-app/microwave-oven-common/microwave-oven-app.zap
+++ b/examples/microwave-oven-app/microwave-oven-common/microwave-oven-app.zap
@@ -1790,7 +1790,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/network-manager-app/network-manager-common/network-manager-app.zap
+++ b/examples/network-manager-app/network-manager-common/network-manager-app.zap
@@ -2033,7 +2033,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/placeholder/linux/apps/app1/config.zap
+++ b/examples/placeholder/linux/apps/app1/config.zap
@@ -4056,7 +4056,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/placeholder/linux/apps/app2/config.zap
+++ b/examples/placeholder/linux/apps/app2/config.zap
@@ -4072,7 +4072,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/refrigerator-app/refrigerator-common/refrigerator-app.zap
+++ b/examples/refrigerator-app/refrigerator-common/refrigerator-app.zap
@@ -2002,7 +2002,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/temperature-measurement-app/temperature-measurement-common/temperature-measurement.zap
+++ b/examples/temperature-measurement-app/temperature-measurement-common/temperature-measurement.zap
@@ -1962,7 +1962,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/thermostat/nxp/zap/thermostat_matter_wifi.zap
+++ b/examples/thermostat/nxp/zap/thermostat_matter_wifi.zap
@@ -2248,7 +2248,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/thermostat/thermostat-common/thermostat.zap
+++ b/examples/thermostat/thermostat-common/thermostat.zap
@@ -3156,7 +3156,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/tv-app/tv-common/tv-app.zap
+++ b/examples/tv-app/tv-common/tv-app.zap
@@ -3174,7 +3174,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
@@ -1745,7 +1745,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/virtual-device-app/virtual-device-common/virtual-device-app.zap
+++ b/examples/virtual-device-app/virtual-device-common/virtual-device-app.zap
@@ -2972,7 +2972,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/examples/window-app/common/window-app.zap
+++ b/examples/window-app/common/window-app.zap
@@ -3782,7 +3782,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/scripts/tools/zap/tests/inputs/all-clusters-app.zap
+++ b/scripts/tools/zap/tests/inputs/all-clusters-app.zap
@@ -4082,7 +4082,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/scripts/tools/zap/tests/inputs/lighting-app.zap
+++ b/scripts/tools/zap/tests/inputs/lighting-app.zap
@@ -3087,7 +3087,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
@@ -637,7 +637,7 @@
             { ZAP_SIMPLE_DEFAULT(0x000F), 0x0000FFFC, 4, ZAP_TYPE(BITMAP32), 0 }, /* FeatureMap */                                 \
             { ZAP_SIMPLE_DEFAULT(2), 0x0000FFFD, 2, ZAP_TYPE(INT16U), 0 },        /* ClusterRevision */                            \
                                                                                                                                    \
-            /* Endpoint: 0, Cluster: WiFi Network Diagnostics (server) */                                                          \
+            /* Endpoint: 0, Cluster: Wi-Fi Network Diagnostics (server) */                                                         \
             { ZAP_EMPTY_DEFAULT(), 0x00000000, 7, ZAP_TYPE(OCTET_STRING),                                                          \
               ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(NULLABLE) }, /* BSSID */                                   \
             { ZAP_EMPTY_DEFAULT(), 0x00000001, 1, ZAP_TYPE(ENUM8),                                                                 \
@@ -1502,7 +1502,7 @@
   /* Endpoint: 0, Cluster: Software Diagnostics (server) */ \
   /* EventList (index=12) */ \
   0x00000000, /* SoftwareFault */ \
-  /* Endpoint: 0, Cluster: WiFi Network Diagnostics (server) */ \
+  /* Endpoint: 0, Cluster: Wi-Fi Network Diagnostics (server) */ \
   /* EventList (index=13) */ \
   0x00000000, /* Disconnection */ \
   0x00000001, /* AssociationFailure */ \
@@ -1662,7 +1662,7 @@
   /*   AcceptedCommandList (index=44) */ \
   0x00000000 /* ResetCounts */, \
   chip::kInvalidCommandId /* end of list */, \
-  /* Endpoint: 0, Cluster: WiFi Network Diagnostics (server) */\
+  /* Endpoint: 0, Cluster: Wi-Fi Network Diagnostics (server) */\
   /*   AcceptedCommandList (index=46) */ \
   0x00000000 /* ResetCounts */, \
   chip::kInvalidCommandId /* end of list */, \
@@ -2197,7 +2197,7 @@
       .eventCount = 0, \
     },\
   { \
-      /* Endpoint: 0, Cluster: WiFi Network Diagnostics (server) */ \
+      /* Endpoint: 0, Cluster: Wi-Fi Network Diagnostics (server) */ \
       .clusterId = 0x00000036, \
       .attributes = ZAP_ATTRIBUTE_INDEX(173), \
       .attributeCount = 15, \

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/gen_config.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/gen_config.h
@@ -205,7 +205,7 @@
 #define MATTER_DM_PLUGIN_THREAD_NETWORK_DIAGNOSTICS_SERVER
 #define MATTER_DM_PLUGIN_THREAD_NETWORK_DIAGNOSTICS
 
-// Use this macro to check if the server side of the WiFi Network Diagnostics cluster is included
+// Use this macro to check if the server side of the Wi-Fi Network Diagnostics cluster is included
 #define ZCL_USING_WIFI_NETWORK_DIAGNOSTICS_CLUSTER_SERVER
 #define MATTER_DM_PLUGIN_WI_FI_NETWORK_DIAGNOSTICS_SERVER
 #define MATTER_DM_PLUGIN_WI_FI_NETWORK_DIAGNOSTICS

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/endpoint_config.h
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/endpoint_config.h
@@ -336,7 +336,7 @@
             { ZAP_SIMPLE_DEFAULT(0x000F), 0x0000FFFC, 4, ZAP_TYPE(BITMAP32), 0 }, /* FeatureMap */                                 \
             { ZAP_SIMPLE_DEFAULT(2), 0x0000FFFD, 2, ZAP_TYPE(INT16U), 0 },        /* ClusterRevision */                            \
                                                                                                                                    \
-            /* Endpoint: 0, Cluster: WiFi Network Diagnostics (server) */                                                          \
+            /* Endpoint: 0, Cluster: Wi-Fi Network Diagnostics (server) */                                                         \
             { ZAP_EMPTY_DEFAULT(), 0x00000000, 7, ZAP_TYPE(OCTET_STRING),                                                          \
               ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE) | ZAP_ATTRIBUTE_MASK(NULLABLE) }, /* BSSID */                                   \
             { ZAP_EMPTY_DEFAULT(), 0x00000001, 1, ZAP_TYPE(ENUM8),                                                                 \
@@ -545,7 +545,7 @@
   0x00000001, /* RadioFaultChange */ \
   0x00000002, /* NetworkFaultChange */ \
   0x00000003, /* BootReason */ \
-  /* Endpoint: 0, Cluster: WiFi Network Diagnostics (server) */ \
+  /* Endpoint: 0, Cluster: Wi-Fi Network Diagnostics (server) */ \
   /* EventList (index=12) */ \
   0x00000000, /* Disconnection */ \
   0x00000001, /* AssociationFailure */ \
@@ -652,7 +652,7 @@
   /*   AcceptedCommandList (index=41) */ \
   0x00000000 /* ResetCounts */, \
   chip::kInvalidCommandId /* end of list */, \
-  /* Endpoint: 0, Cluster: WiFi Network Diagnostics (server) */\
+  /* Endpoint: 0, Cluster: Wi-Fi Network Diagnostics (server) */\
   /*   AcceptedCommandList (index=43) */ \
   0x00000000 /* ResetCounts */, \
   chip::kInvalidCommandId /* end of list */, \
@@ -947,7 +947,7 @@
       .eventCount = 0, \
     },\
   { \
-      /* Endpoint: 0, Cluster: WiFi Network Diagnostics (server) */ \
+      /* Endpoint: 0, Cluster: Wi-Fi Network Diagnostics (server) */ \
       .clusterId = 0x00000036, \
       .attributes = ZAP_ATTRIBUTE_INDEX(154), \
       .attributeCount = 15, \

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/gen_config.h
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/gen_config.h
@@ -139,7 +139,7 @@
 #define MATTER_DM_PLUGIN_THREAD_NETWORK_DIAGNOSTICS_SERVER
 #define MATTER_DM_PLUGIN_THREAD_NETWORK_DIAGNOSTICS
 
-// Use this macro to check if the server side of the WiFi Network Diagnostics cluster is included
+// Use this macro to check if the server side of the Wi-Fi Network Diagnostics cluster is included
 #define ZCL_USING_WIFI_NETWORK_DIAGNOSTICS_CLUSTER_SERVER
 #define MATTER_DM_PLUGIN_WI_FI_NETWORK_DIAGNOSTICS_SERVER
 #define MATTER_DM_PLUGIN_WI_FI_NETWORK_DIAGNOSTICS

--- a/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
@@ -250,7 +250,7 @@ class WiFiDiagnosticsDelegate : public DeviceLayer::WiFiDiagnosticsDelegate
 
         for (auto endpoint : EnabledEndpointsWithServerCluster(WiFiNetworkDiagnostics::Id))
         {
-            // If WiFi Network Diagnostics cluster is implemented on this endpoint
+            // If Wi-Fi Network Diagnostics cluster is implemented on this endpoint
             Events::Disconnection::Type event{ reasonCode };
             EventNumber eventNumber;
 
@@ -271,7 +271,7 @@ class WiFiDiagnosticsDelegate : public DeviceLayer::WiFiDiagnosticsDelegate
 
         for (auto endpoint : EnabledEndpointsWithServerCluster(WiFiNetworkDiagnostics::Id))
         {
-            // If WiFi Network Diagnostics cluster is implemented on this endpoint
+            // If Wi-Fi Network Diagnostics cluster is implemented on this endpoint
             EventNumber eventNumber;
 
             if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
@@ -290,7 +290,7 @@ class WiFiDiagnosticsDelegate : public DeviceLayer::WiFiDiagnosticsDelegate
         Events::ConnectionStatus::Type event{ static_cast<ConnectionStatusEnum>(connectionStatus) };
         for (auto endpoint : EnabledEndpointsWithServerCluster(WiFiNetworkDiagnostics::Id))
         {
-            // If WiFi Network Diagnostics cluster is implemented on this endpoint
+            // If Wi-Fi Network Diagnostics cluster is implemented on this endpoint
             EventNumber eventNumber;
 
             if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))

--- a/src/app/tests/suites/TestDescriptorCluster.yaml
+++ b/src/app/tests/suites/TestDescriptorCluster.yaml
@@ -58,7 +58,7 @@ tests:
                   0x0033, # General Diagnostics
                   0x0034, # Software Diagnostics
                   0x0035, # Thread Network Diagnostiscs
-                  0x0036, # WiFi Network Diagnostics
+                  0x0036, # Wi-Fi Network Diagnostics
                   0x0037, # Ethernet Network Diagnostics
                   0x0038, # Time Synchronization
                   0x003C, # Administrator Commissioning

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -84,7 +84,7 @@ limitations under the License.
             <include cluster="Diagnostic Logs" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Software Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="WiFi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Wi-Fi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="ICD Management" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
@@ -2606,7 +2606,7 @@ limitations under the License.
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
             <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="WiFi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Wi-Fi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
         </clusters>
     </deviceType>

--- a/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wifi-network-diagnostics-cluster.xml
@@ -50,7 +50,7 @@ limitations under the License.
 
   <cluster>
     <domain>General</domain>
-    <name>WiFi Network Diagnostics</name>
+    <name>Wi-Fi Network Diagnostics</name>
     <code>0x0036</code>
     <define>WIFI_NETWORK_DIAGNOSTICS_CLUSTER</define>
     <description>The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.</description>

--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -353,7 +353,7 @@
             "ChannelPage0Mask",
             "OperationalDatasetComponents"
         ],
-        "WiFi Network Diagnostics": [
+        "Wi-Fi Network Diagnostics": [
             "BSSID",
             "SecurityType",
             "WiFiVersion",

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -351,7 +351,7 @@
             "ChannelPage0Mask",
             "OperationalDatasetComponents"
         ],
-        "WiFi Network Diagnostics": [
+        "Wi-Fi Network Diagnostics": [
             "BSSID",
             "SecurityType",
             "WiFiVersion",

--- a/src/controller/data_model/controller-clusters.zap
+++ b/src/controller/data_model/controller-clusters.zap
@@ -1233,7 +1233,7 @@
           ]
         },
         {
-          "name": "WiFi Network Diagnostics",
+          "name": "Wi-Fi Network Diagnostics",
           "code": 54,
           "mfgCode": null,
           "define": "WIFI_NETWORK_DIAGNOSTICS_CLUSTER",

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -3218,7 +3218,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @end
 
 /**
- * Cluster WiFi Network Diagnostics
+ * Cluster Wi-Fi Network Diagnostics
  *
  * The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.
  */

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -1498,7 +1498,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @end
 
 /**
- * Cluster WiFi Network Diagnostics
+ * Cluster Wi-Fi Network Diagnostics
  *    The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.
  */
 MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -234,7 +234,7 @@ public:
     virtual CHIP_ERROR ResetEthNetworkDiagnosticsCounts();
 
     /**
-     * WiFi network diagnostics methods
+     * Wi-Fi network diagnostics methods
      */
 
     /**

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -1599,7 +1599,7 @@ chip::Protocols::InteractionModel::Status MatterThreadNetworkDiagnosticsClusterS
 void emberAfThreadNetworkDiagnosticsClusterServerTickCallback(chip::EndpointId endpoint);
 
 //
-// WiFi Network Diagnostics Cluster
+// Wi-Fi Network Diagnostics Cluster
 //
 
 /**
@@ -5567,7 +5567,7 @@ bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::ThreadNetworkDiagnostics::Commands::ResetCounts::DecodableType & commandData);
 /**
- * @brief WiFi Network Diagnostics Cluster ResetCounts Command callback (from client)
+ * @brief Wi-Fi Network Diagnostics Cluster ResetCounts Command callback (from client)
  */
 bool emberAfWiFiNetworkDiagnosticsClusterResetCountsCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,


### PR DESCRIPTION
###  Change overview
- Ref to SPEC, modified wifi network diagnostics cluster name, "WiFi" to "Wi-Fi", and regenerated zap files.

