### PR TITLE
[ESP32] Adding few logs related for displaying event ids for ESP32 platform specific events

### DIFF
--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -119,6 +119,7 @@ void PlatformManagerImpl::HandleESPSystemEvent(void * arg, esp_event_base_t even
     event.Platform.ESPSystemEvent.Id   = eventId;
     if (eventBase == IP_EVENT)
     {
+        ChipLogProgress(DeviceLayer, "Posting ESPSystemEvent: IP Event with eventId : %ld", eventId);
         switch (eventId)
         {
         case IP_EVENT_STA_GOT_IP:
@@ -138,6 +139,7 @@ void PlatformManagerImpl::HandleESPSystemEvent(void * arg, esp_event_base_t even
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     else if (eventBase == WIFI_EVENT)
     {
+        ChipLogProgress(DeviceLayer, "Posting ESPSystemEvent: Wifi Event with eventId : %ld", eventId);
         switch (eventId)
         {
         case WIFI_EVENT_SCAN_DONE:
@@ -181,7 +183,10 @@ void PlatformManagerImpl::HandleESPSystemEvent(void * arg, esp_event_base_t even
         }
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
+    else
+    {
+        ChipLogProgress(DeviceLayer, "Posting ESPSystemEvent with eventId : %ld", eventId);
+    }
     sInstance.PostEventOrDie(&event);
 }
 


### PR DESCRIPTION
**Change Overview**
- Added logs to display the ESP32 platform specific system events event type and event ids to get a
  better understanding of the events being posted to the platform event queue.
  
**Testing** 
- Tested the changes with lighting-app esp32.
