### PR TITLE
[Fabric-Admin] Allows Fabric Admin to process command other than console

### DIFF
--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -22,13 +22,6 @@
 #include <unistd.h>
 
 #if defined(PW_RPC_ENABLED)
-#include "pw_assert/check.h"
-#include "pw_hdlc/decoder.h"
-#include "pw_hdlc/default_addresses.h"
-#include "pw_hdlc/rpc_channel.h"
-#include "pw_rpc/client.h"
-#include "pw_stream/socket_stream.h"
-
 #include <rpc/RpcClient.h>
 #endif
 

--- a/examples/fabric-admin/commands/interactive/InteractiveCommands.h
+++ b/examples/fabric-admin/commands/interactive/InteractiveCommands.h
@@ -64,3 +64,5 @@ private:
     char * GetCommand(char * command);
     std::string GetHistoryFilePath() const;
 };
+
+void PushCommand(const std::string & command);

--- a/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.h
@@ -43,6 +43,7 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
+
     // We issue multiple data model operations for this command, and the default
     // timeout for those is 10 seconds, so default to 20 seconds.
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(mTimeout.ValueOr(20)); }


### PR DESCRIPTION
Currently, Fabric Admin is derived from chip-tool and can only process commands from the console. We need to enhance it to handle commands from other sources, such as Fabric Sync protocols.

Fixes #[33762](https://github.com/project-chip/connectedhomeip/issues/33762)

