### PR TITLE
Linux tv-casting-app enable AccountLogin cluster

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ApplicationBasicReadVendorIDExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ApplicationBasicReadVendorIDExampleFragment.java
@@ -77,6 +77,12 @@ public class ApplicationBasicReadVendorIDExampleFragment extends Fragment {
         v -> {
           Endpoint endpoint;
           if (useCommissionerGeneratedPasscode) {
+            // For the example Commissioner-Generated passcode commissioning flow, run demo
+            // interactions with the Endpoint with ID DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW = 1. For this
+            // flow, we commissioned with the Target Content Application with Vendor ID 1111. Since
+            // this target content application does not report its Endpoint's Vendor IDs, we find
+            // the desired endpoint based on the Endpoint ID. See
+            // connectedhomeip/examples/tv-app/tv-common/include/AppTv.h.
             endpoint =
                 EndpointSelectorExample.selectEndpointById(
                     selectedCastingPlayer, DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW);

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ContentLauncherLaunchURLExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ContentLauncherLaunchURLExampleFragment.java
@@ -77,6 +77,12 @@ public class ContentLauncherLaunchURLExampleFragment extends Fragment {
         v -> {
           Endpoint endpoint;
           if (useCommissionerGeneratedPasscode) {
+            // For the example Commissioner-Generated passcode commissioning flow, run demo
+            // interactions with the Endpoint with ID DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW = 1. For this
+            // flow, we commissioned with the Target Content Application with Vendor ID 1111. Since
+            // this target content application does not report its Endpoint's Vendor IDs, we find
+            // the desired endpoint based on the Endpoint ID. See
+            // connectedhomeip/examples/tv-app/tv-common/include/AppTv.h.
             endpoint =
                 EndpointSelectorExample.selectEndpointById(
                     selectedCastingPlayer, DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW);

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/MediaPlaybackSubscribeToCurrentStateExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/MediaPlaybackSubscribeToCurrentStateExampleFragment.java
@@ -79,6 +79,11 @@ public class MediaPlaybackSubscribeToCurrentStateExampleFragment extends Fragmen
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     Endpoint endpoint;
     if (useCommissionerGeneratedPasscode) {
+      // For the example Commissioner-Generated passcode commissioning flow, run demo interactions
+      // with the Endpoint with ID DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW = 1. For this flow, we
+      // commissioned with the Target Content Application with Vendor ID 1111. Since this target
+      // content application does not report its Endpoint's Vendor IDs, we find the desired endpoint
+      // based on the Endpoint ID. See connectedhomeip/examples/tv-app/tv-common/include/AppTv.h.
       endpoint =
           EndpointSelectorExample.selectEndpointById(
               selectedCastingPlayer, DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW);

--- a/examples/tv-casting-app/tv-casting-common/clusters/Clusters.h
+++ b/examples/tv-casting-app/tv-casting-common/clusters/Clusters.h
@@ -67,6 +67,28 @@ public:
 };
 }; // namespace application_basic
 
+namespace account_login {
+class AccountLoginCluster : public core::BaseCluster
+{
+public:
+    AccountLoginCluster(memory::Weak<core::Endpoint> endpoint) : core::BaseCluster(endpoint) {}
+
+    void SetUp()
+    {
+        ChipLogProgress(AppServer, "Setting up AccountLoginCluster on EndpointId: %d", GetEndpoint().lock()->GetId());
+
+        RegisterCommand(chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Id,
+                        new core::Command<chip::app::Clusters::AccountLogin::Commands::GetSetupPIN::Type>(GetEndpoint()));
+        RegisterCommand(chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::Id,
+                        new core::Command<chip::app::Clusters::AccountLogin::Commands::GetSetupPINResponse::Type>(GetEndpoint()));
+        RegisterCommand(chip::app::Clusters::AccountLogin::Commands::Login::Id,
+                        new core::Command<chip::app::Clusters::AccountLogin::Commands::Login::Type>(GetEndpoint()));
+        RegisterCommand(chip::app::Clusters::AccountLogin::Commands::Logout::Id,
+                        new core::Command<chip::app::Clusters::AccountLogin::Commands::Logout::Type>(GetEndpoint()));
+    }
+};
+}; // namespace account_login
+
 namespace application_launcher {
 class ApplicationLauncherCluster : public core::BaseCluster
 {


### PR DESCRIPTION

Enabled the AccountLogin cluster in the Linux examples/tv-casting-app example app.

**Change summary**

1.	In connectedhomeip/examples/tv-casting-app/tv-casting-common/clusters/Clusters.h enabled the AccountLogin cluster.
2.	Added clarifying notes to the Android example tv-casting-app demo interactions (attribute reads and commands).

**Testing**

Verified build and tested locally with the Linux tv-casting-app example CLI app and the Linux tv-app (CastingPlayer). 
