### PR TITLE
Close TCP connection when received message size is too large.

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -331,7 +331,10 @@ CHIP_ERROR TCPBase::ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const Pe
         uint32_t messageSize = LittleEndian::Get32(messageSizeBuf);
         if (messageSize >= kMaxTCPMessageSize)
         {
-            // This message is too long for upper layers.
+            // Message is too big for this node to process. Disconnect from peer.
+            ChipLogError(Inet, "Received TCP message of length %" PRIu32 " exceeds limit.", messageSize);
+            CloseConnectionInternal(state, CHIP_ERROR_MESSAGE_TOO_LONG, SuppressCallback::No);
+
             return CHIP_ERROR_MESSAGE_TOO_LONG;
         }
         // The subtraction will not underflow because we successfully read kPacketSizeBytes.

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -682,7 +682,9 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
     EXPECT_EQ(err, CHIP_ERROR_MESSAGE_TOO_LONG);
     EXPECT_EQ(gMockTransportMgrDelegate.mReceiveHandlerCallCount, 0);
 
-    gMockTransportMgrDelegate.DisconnectTest(tcp, addr);
+    // The receipt of a message exceeding the allowed size should have
+    // closed the connection.
+    EXPECT_EQ(TestAccess::GetEndpoint(state), nullptr);
 }
 
 } // namespace


### PR DESCRIPTION
 Close TCP connection when received message size is too large.
    
    When the framing length value of a received message is larger
    than what the local node can process, abort the connection
    with the peer.
    
    Sending a StatusResponse message back to the peer as a
    notification may not be feasible in all circumstances for
    reasons, such as:
    1) It would require a cross-layered feedback up to the Exchange
       layer to generate such a message in response to a failure at the
       transport layer.
    2) A Status Response is sent in response to a message on an
       ExchangeContext and that may not be the case in scnearios
       where this message is the first unsolicited message.
    
    The receiver could drain out the bits from the offending message
    and move on to the next message in the stream but that may not
    guarantee correct behavior and would consume resources unnecessarily.
    
    Given that the peer was already aware of the max length this node was
    willing to receive during its TCP advertisement, it seems prudent
    to fail fast and close the connection.


Fixes #33307.
