### PR TITLE
[Fabric-Bridge] Don't track device changes for synced devices

### DIFF
--- a/examples/fabric-bridge-app/linux/Device.cpp
+++ b/examples/fabric-bridge-app/linux/Device.cpp
@@ -25,10 +25,9 @@
 
 using namespace chip::app::Clusters::Actions;
 
-Device::Device(const char * szDeviceName, std::string szLocation)
+Device::Device(chip::NodeId nodeId, const char * name)
 {
-    chip::Platform::CopyString(mName, szDeviceName);
-    mLocation   = szLocation;
+    chip::Platform::CopyString(mName, name);
     mReachable  = false;
     mEndpointId = 0;
 }
@@ -38,13 +37,11 @@ bool Device::IsReachable()
     return mReachable;
 }
 
-void Device::SetReachable(bool aReachable)
+void Device::SetReachable(bool reachable)
 {
-    bool changed = (mReachable != aReachable);
+    mReachable = reachable;
 
-    mReachable = aReachable;
-
-    if (aReachable)
+    if (reachable)
     {
         ChipLogProgress(NotSpecified, "Device[%s]: ONLINE", mName);
     }
@@ -52,23 +49,11 @@ void Device::SetReachable(bool aReachable)
     {
         ChipLogProgress(NotSpecified, "Device[%s]: OFFLINE", mName);
     }
-
-    if (changed)
-    {
-        HandleDeviceChange(this, kChanged_Reachable);
-    }
 }
 
-void Device::SetName(const char * szName)
+void Device::SetName(const char * name)
 {
-    bool changed = (strncmp(mName, szName, sizeof(mName)) != 0);
+    ChipLogProgress(NotSpecified, "Device[%s]: New Name=\"%s\"", mName, name);
 
-    ChipLogProgress(NotSpecified, "Device[%s]: New Name=\"%s\"", mName, szName);
-
-    chip::Platform::CopyString(mName, szName);
-
-    if (changed)
-    {
-        HandleDeviceChange(this, kChanged_Name);
-    }
+    chip::Platform::CopyString(mName, name);
 }

--- a/examples/fabric-bridge-app/linux/DeviceManager.cpp
+++ b/examples/fabric-bridge-app/linux/DeviceManager.cpp
@@ -43,8 +43,13 @@ using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 using namespace chip::app::Clusters;
 
+class DeviceManager;
+
 namespace {
+
 constexpr uint8_t kMaxRetries = 10;
+DeviceManager gDeviceManager;
+
 } // namespace
 
 DeviceManager::DeviceManager()
@@ -127,4 +132,9 @@ Device * DeviceManager::GetDevice(uint16_t index) const
         return mDevices[index];
     }
     return nullptr;
+}
+
+DeviceManager * GetDeviceManager()
+{
+    return &gDeviceManager;
 }

--- a/examples/fabric-bridge-app/linux/DeviceManager.cpp
+++ b/examples/fabric-bridge-app/linux/DeviceManager.cpp
@@ -43,16 +43,16 @@ using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 using namespace chip::app::Clusters;
 
-class DeviceManager;
-
 namespace {
 
 constexpr uint8_t kMaxRetries = 10;
-DeviceManager gDeviceManager;
 
 } // namespace
 
-DeviceManager::DeviceManager()
+// Define the static member
+DeviceManager DeviceManager::sInstance;
+
+void DeviceManager::Init()
 {
     memset(mDevices, 0, sizeof(mDevices));
     mFirstDynamicEndpointId = static_cast<chip::EndpointId>(
@@ -132,9 +132,4 @@ Device * DeviceManager::GetDevice(uint16_t index) const
         return mDevices[index];
     }
     return nullptr;
-}
-
-DeviceManager * GetDeviceManager()
-{
-    return &gDeviceManager;
 }

--- a/examples/fabric-bridge-app/linux/include/Device.h
+++ b/examples/fabric-bridge-app/linux/include/Device.h
@@ -32,21 +32,13 @@ class Device
 public:
     static const int kDeviceNameSize = 32;
 
-    enum Changed_t
-    {
-        kChanged_Reachable = 1u << 0,
-        kChanged_Location  = 1u << 1,
-        kChanged_Name      = 1u << 2,
-        kChanged_Last      = kChanged_Name,
-    } Changed;
-
-    Device(const char * szDeviceName, std::string szLocation);
+    Device(chip::NodeId nodeId, const char * name);
     virtual ~Device() {}
 
     bool IsReachable();
-    void SetReachable(bool aReachable);
-    void SetName(const char * szDeviceName);
-    void SetLocation(std::string szLocation);
+    void SetReachable(bool reachable);
+    void SetName(const char * name);
+    void SetLocation(std::string location) { mLocation = location; };
     inline void SetEndpointId(chip::EndpointId id) { mEndpointId = id; };
     inline chip::EndpointId GetEndpointId() { return mEndpointId; };
     inline void SetParentEndpointId(chip::EndpointId id) { mParentEndpointId = id; };
@@ -56,13 +48,11 @@ public:
     inline std::string GetZone() { return mZone; };
     inline void SetZone(std::string zone) { mZone = zone; };
 
-private:
-    virtual void HandleDeviceChange(Device * device, Device::Changed_t changeMask) = 0;
-
 protected:
     bool mReachable;
     char mName[kDeviceNameSize];
     std::string mLocation;
+    chip::NodeId mNodeId;
     chip::EndpointId mEndpointId;
     chip::EndpointId mParentEndpointId;
     std::string mZone;

--- a/examples/fabric-bridge-app/linux/include/DeviceManager.h
+++ b/examples/fabric-bridge-app/linux/include/DeviceManager.h
@@ -66,3 +66,12 @@ private:
     chip::EndpointId mFirstDynamicEndpointId;
     Device * mDevices[CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT + 1];
 };
+
+/**
+ * Instance getter for the global DeviceManager.
+ *
+ * Callers have to externally synchronize usage of this function.
+ *
+ * @return The global DeviceManager. Assume never null.
+ */
+DeviceManager * GetDeviceManager();

--- a/examples/fabric-bridge-app/linux/include/DeviceManager.h
+++ b/examples/fabric-bridge-app/linux/include/DeviceManager.h
@@ -25,7 +25,9 @@
 class DeviceManager
 {
 public:
-    DeviceManager();
+    DeviceManager() = default;
+
+    void Init();
 
     /**
      * @brief Adds a device to a dynamic endpoint.
@@ -62,16 +64,22 @@ public:
     Device * GetDevice(uint16_t index) const;
 
 private:
+    friend DeviceManager & DeviceMgr();
+
+    static DeviceManager sInstance;
+
     chip::EndpointId mCurrentEndpointId;
     chip::EndpointId mFirstDynamicEndpointId;
     Device * mDevices[CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT + 1];
 };
 
 /**
- * Instance getter for the global DeviceManager.
+ * Returns the public interface of the DeviceManager singleton object.
  *
- * Callers have to externally synchronize usage of this function.
- *
- * @return The global DeviceManager. Assume never null.
+ * Applications should use this to access features of the DeviceManager
+ * object.
  */
-DeviceManager * GetDeviceManager();
+inline DeviceManager & DeviceMgr()
+{
+    return DeviceManager::sInstance;
+}

--- a/examples/fabric-bridge-app/linux/main.cpp
+++ b/examples/fabric-bridge-app/linux/main.cpp
@@ -109,6 +109,8 @@ void ApplicationInit()
     // Start a thread for bridge polling
     std::thread pollingThread(BridgePollingThread);
     pollingThread.detach();
+
+    DeviceMgr().Init();
 }
 
 void ApplicationShutdown() {}
@@ -133,7 +135,7 @@ Protocols::InteractionModel::Status emberAfExternalAttributeReadCallback(Endpoin
     uint16_t endpointIndex  = emberAfGetDynamicIndexFromEndpoint(endpoint);
     AttributeId attributeId = attributeMetadata->attributeId;
 
-    Device * dev = GetDeviceManager()->GetDevice(endpointIndex);
+    Device * dev = DeviceMgr().GetDevice(endpointIndex);
     if (dev != nullptr && clusterId == app::Clusters::BridgedDeviceBasicInformation::Id)
     {
         using namespace app::Clusters::BridgedDeviceBasicInformation::Attributes;
@@ -177,7 +179,7 @@ Protocols::InteractionModel::Status emberAfExternalAttributeWriteCallback(Endpoi
     uint16_t endpointIndex                  = emberAfGetDynamicIndexFromEndpoint(endpoint);
     Protocols::InteractionModel::Status ret = Protocols::InteractionModel::Status::Failure;
 
-    Device * dev = GetDeviceManager()->GetDevice(endpointIndex);
+    Device * dev = DeviceMgr().GetDevice(endpointIndex);
     if (dev != nullptr && dev->IsReachable())
     {
         ChipLogProgress(NotSpecified, "emberAfExternalAttributeWriteCallback: ep=%d, clusterId=%d", endpoint, clusterId);

--- a/examples/fabric-bridge-app/linux/main.cpp
+++ b/examples/fabric-bridge-app/linux/main.cpp
@@ -97,8 +97,6 @@ void AttemptRpcClientConnect(System::Layer * systemLayer, void * appState)
 }
 #endif // defined(PW_RPC_FABRIC_BRIDGE_SERVICE) && PW_RPC_FABRIC_BRIDGE_SERVICE
 
-DeviceManager gDeviceManager;
-
 } // namespace
 
 void ApplicationInit()
@@ -135,7 +133,7 @@ Protocols::InteractionModel::Status emberAfExternalAttributeReadCallback(Endpoin
     uint16_t endpointIndex  = emberAfGetDynamicIndexFromEndpoint(endpoint);
     AttributeId attributeId = attributeMetadata->attributeId;
 
-    Device * dev = gDeviceManager.GetDevice(endpointIndex);
+    Device * dev = GetDeviceManager()->GetDevice(endpointIndex);
     if (dev != nullptr && clusterId == app::Clusters::BridgedDeviceBasicInformation::Id)
     {
         using namespace app::Clusters::BridgedDeviceBasicInformation::Attributes;
@@ -179,7 +177,7 @@ Protocols::InteractionModel::Status emberAfExternalAttributeWriteCallback(Endpoi
     uint16_t endpointIndex                  = emberAfGetDynamicIndexFromEndpoint(endpoint);
     Protocols::InteractionModel::Status ret = Protocols::InteractionModel::Status::Failure;
 
-    Device * dev = gDeviceManager.GetDevice(endpointIndex);
+    Device * dev = GetDeviceManager()->GetDevice(endpointIndex);
     if (dev != nullptr && dev->IsReachable())
     {
         ChipLogProgress(NotSpecified, "emberAfExternalAttributeWriteCallback: ep=%d, clusterId=%d", endpoint, clusterId);


### PR DESCRIPTION
For the bridged device for fabric sync, they are not the physical devices proxy-ed by the bridge, but the Matter devices to be synced.

The bridge can not catch the changes of those devices, and there is nothing to do for those changes.