### PR TITLE
Log errors if AdvertiseOperational fails

### DIFF
--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -216,7 +216,7 @@ CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort, F
     gCommissionerDiscoveryController.SetCommissionerCallback(&gCommissionerCallback);
 
     // advertise operational since we are an admin
-    app::DnssdServer::Instance().AdvertiseOperational();
+    ReturnLogErrorOnFailure(app::DnssdServer::Instance().AdvertiseOperational());
 
     ChipLogProgress(Support,
                     "InitCommissioner nodeId=0x" ChipLogFormatX64 " fabric.fabricId=0x" ChipLogFormatX64 " fabricIndex=0x%x",

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -703,7 +703,7 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
     needRevert = false;
 
     // We might have a new operational identity, so we should start advertising it right away.
-    app::DnssdServer::Instance().AdvertiseOperational();
+    LogErrorOnFailure(app::DnssdServer::Instance().AdvertiseOperational());
 
     // Notify the attributes containing fabric metadata can be read with new data
     MatterReportingAttributeChangeCallback(commandPath.mEndpointId, OperationalCredentials::Id,

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -703,7 +703,11 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
     needRevert = false;
 
     // We might have a new operational identity, so we should start advertising it right away.
-    LogErrorOnFailure(app::DnssdServer::Instance().AdvertiseOperational());
+    err = app::DnssdServer::Instance().AdvertiseOperational();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "Operational advertising failed: %" CHIP_ERROR_FORMAT, err.Format());
+    }
 
     // Notify the attributes containing fabric metadata can be read with new data
     MatterReportingAttributeChangeCallback(commandPath.mEndpointId, OperationalCredentials::Id,

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -84,7 +84,7 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
     }
     else if (event->Type == DeviceLayer::DeviceEventType::kOperationalNetworkEnabled)
     {
-        app::DnssdServer::Instance().AdvertiseOperational();
+        LogErrorOnFailure(app::DnssdServer::Instance().AdvertiseOperational());
         ChipLogProgress(AppServer, "Operational advertising enabled");
     }
 #if CONFIG_NETWORK_LAYER_BLE

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -84,8 +84,15 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
     }
     else if (event->Type == DeviceLayer::DeviceEventType::kOperationalNetworkEnabled)
     {
-        LogErrorOnFailure(app::DnssdServer::Instance().AdvertiseOperational());
-        ChipLogProgress(AppServer, "Operational advertising enabled");
+        CHIP_ERROR err = app::DnssdServer::Instance().AdvertiseOperational();
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(AppServer, "Operational advertising failed: %" CHIP_ERROR_FORMAT, err.Format());
+        }
+        else
+        {
+            ChipLogProgress(AppServer, "Operational advertising enabled");
+        }
     }
 #if CONFIG_NETWORK_LAYER_BLE
     else if (event->Type == DeviceLayer::DeviceEventType::kCloseAllBleConnections)


### PR DESCRIPTION
Existing code would silently fail, so advertising errors are hard to debug.

> [!IMPORTANT]
> SRP advertisement seems to rely on being in state "initialized" until openthread connectivity is possible, so
> applications will likely log errors at boot time before commissioning.
> This change is probably still good as this would encourage us to clean up "error is expected" paths.