### PR TITLE
[Python] Add TriggerResubscribeIfScheduled to SubscriptionTransaction

### DIFF
--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -465,6 +465,13 @@ class SubscriptionTransaction:
             lambda: handle.pychip_ReadClient_OverrideLivenessTimeout(self._readTransaction._pReadClient, timeoutMs)
         )
 
+    async def TriggerResubscribeIfScheduled(self, reason: str):
+        handle = chip.native.GetLibraryHandle()
+        await builtins.chipStack.CallAsync(
+            lambda: handle.pychip_ReadClient_TriggerResubscribeIfScheduled(
+                self._readTransaction._pReadClient, reason.encode("utf-8"))
+        )
+
     def GetReportingIntervalsSeconds(self) -> Tuple[int, int]:
         '''
         Retrieve the reporting intervals associated with an active subscription.

--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -464,6 +464,12 @@ void pychip_ReadClient_OverrideLivenessTimeout(ReadClient * pReadClient, uint32_
     pReadClient->OverrideLivenessTimeout(System::Clock::Milliseconds32(livenessTimeoutMs));
 }
 
+void pychip_ReadClient_TriggerResubscribeIfScheduled(ReadClient * pReadClient, const char * reason)
+{
+    VerifyOrDie(pReadClient != nullptr);
+    pReadClient->TriggerResubscribeIfScheduled(reason);
+}
+
 PyChipError pychip_ReadClient_GetReportingIntervals(ReadClient * pReadClient, uint16_t * minIntervalSec, uint16_t * maxIntervalSec)
 {
     VerifyOrDie(pReadClient != nullptr);


### PR DESCRIPTION
Add TriggerResubscribeIfScheduled to SubscriptionTransaction. If the ReadClient currently has a resubscription attempt scheduled, This function allows to trigger that attempt immediately. This is useful when the server side is up and communicating, and it's a good time to try to resubscribe.
