### PR TITLE
Allow CommandSender request to be built using DataModel::EncodableToTLV

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -537,8 +537,8 @@ CHIP_ERROR CommandSender::FinishCommand(FinishCommandParameters & aFinishCommand
     return FinishCommandInternal(aFinishCommandParams);
 }
 
-CHIP_ERROR CommandSender::AddRequestData(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
-                                         AddRequestDataParameters & aAddRequestDataParams)
+CHIP_ERROR CommandSender::AddRequest(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
+                                     AddRequestDataParameters & aAddRequestDataParams)
 {
     PrepareCommandParameters prepareCommandParams(aAddRequestDataParams);
     ReturnErrorOnFailure(PrepareCommand(aCommandPath, prepareCommandParams));

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -537,8 +537,8 @@ CHIP_ERROR CommandSender::FinishCommand(FinishCommandParameters & aFinishCommand
     return FinishCommandInternal(aFinishCommandParams);
 }
 
-CHIP_ERROR CommandSender::AddRequest(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
-                                     AddRequestDataParameters & aAddRequestDataParams)
+CHIP_ERROR CommandSender::AddRequestData(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
+                                         AddRequestDataParameters & aAddRequestDataParams)
 {
     PrepareCommandParameters prepareCommandParams(aAddRequestDataParams);
     ReturnErrorOnFailure(PrepareCommand(aCommandPath, prepareCommandParams));

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -537,7 +537,8 @@ CHIP_ERROR CommandSender::FinishCommand(FinishCommandParameters & aFinishCommand
     return FinishCommandInternal(aFinishCommandParams);
 }
 
-CHIP_ERROR CommandSender::AddRequestDataInternal(const CommandPathParams & aCommandPath, DataModel::EncodableToTLV & aEncodable,
+CHIP_ERROR CommandSender::AddRequestDataInternal(const CommandPathParams & aCommandPath,
+                                                 const DataModel::EncodableToTLV & aEncodable,
                                                  AddRequestDataParameters & aAddRequestDataParams)
 {
     PrepareCommandParameters prepareCommandParams(aAddRequestDataParams);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -537,8 +537,7 @@ CHIP_ERROR CommandSender::FinishCommand(FinishCommandParameters & aFinishCommand
     return FinishCommandInternal(aFinishCommandParams);
 }
 
-CHIP_ERROR CommandSender::AddRequestData(const CommandPathParams & aCommandPath,
-                                         const DataModel::EncodableToTLV & aEncodable,
+CHIP_ERROR CommandSender::AddRequestData(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
                                          AddRequestDataParameters & aAddRequestDataParams)
 {
     PrepareCommandParameters prepareCommandParams(aAddRequestDataParams);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -537,6 +537,19 @@ CHIP_ERROR CommandSender::FinishCommand(FinishCommandParameters & aFinishCommand
     return FinishCommandInternal(aFinishCommandParams);
 }
 
+CHIP_ERROR CommandSender::AddRequestDataInternal(
+    const CommandPathParams & aCommandPath, DataModel::EncodableToTLV & aEncodable,
+    AddRequestDataParameters & aAddRequestDataParams)
+{
+    PrepareCommandParameters prepareCommandParams(aAddRequestDataParams);
+    ReturnErrorOnFailure(PrepareCommand(aCommandPath, prepareCommandParams));
+    TLV::TLVWriter * writer = GetCommandDataIBTLVWriter();
+    VerifyOrReturnError(writer != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    ReturnErrorOnFailure(aEncodable.EncodeTo(*writer, TLV::ContextTag(CommandDataIB::Tag::kFields)));
+    FinishCommandParameters finishCommandParams(aAddRequestDataParams);
+    return FinishCommand(finishCommandParams);
+}
+
 CHIP_ERROR CommandSender::FinishCommandInternal(FinishCommandParameters & aFinishCommandParams)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -537,9 +537,8 @@ CHIP_ERROR CommandSender::FinishCommand(FinishCommandParameters & aFinishCommand
     return FinishCommandInternal(aFinishCommandParams);
 }
 
-CHIP_ERROR CommandSender::AddRequestDataInternal(
-    const CommandPathParams & aCommandPath, DataModel::EncodableToTLV & aEncodable,
-    AddRequestDataParameters & aAddRequestDataParams)
+CHIP_ERROR CommandSender::AddRequestDataInternal(const CommandPathParams & aCommandPath, DataModel::EncodableToTLV & aEncodable,
+                                                 AddRequestDataParameters & aAddRequestDataParams)
 {
     PrepareCommandParameters prepareCommandParams(aAddRequestDataParams);
     ReturnErrorOnFailure(PrepareCommand(aCommandPath, prepareCommandParams));

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -537,9 +537,9 @@ CHIP_ERROR CommandSender::FinishCommand(FinishCommandParameters & aFinishCommand
     return FinishCommandInternal(aFinishCommandParams);
 }
 
-CHIP_ERROR CommandSender::AddRequestDataInternal(const CommandPathParams & aCommandPath,
-                                                 const DataModel::EncodableToTLV & aEncodable,
-                                                 AddRequestDataParameters & aAddRequestDataParams)
+CHIP_ERROR CommandSender::AddRequestData(const CommandPathParams & aCommandPath,
+                                         const DataModel::EncodableToTLV & aEncodable,
+                                         AddRequestDataParameters & aAddRequestDataParams)
 {
     PrepareCommandParameters prepareCommandParams(aAddRequestDataParams);
     ReturnErrorOnFailure(PrepareCommand(aCommandPath, prepareCommandParams));

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -390,7 +390,7 @@ public:
      * invoke interaction. If the caller wants that certainty they should call the templated
      * version of AddRequestData.
      */
-    CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, DataModel::EncodableToTLV & aEncodable,
+    CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
                               AddRequestDataParameters & aAddRequestDataParams)
     {
         return AddRequestDataInternal(aCommandPath, aEncodable, aAddRequestDataParams);
@@ -473,7 +473,8 @@ public:
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
 private:
-    CHIP_ERROR AddRequestDataInternal(const CommandPathParams & aCommandPath, DataModel::EncodableToTLV & aEncodable,
+    CHIP_ERROR AddRequestDataInternal(const CommandPathParams & aCommandPath,
+                                      const DataModel::EncodableToTLV & aEncodable,
                                       AddRequestDataParameters & aAddRequestDataParams);
 
     CHIP_ERROR FinishCommandInternal(FinishCommandParameters & aFinishCommandParams);

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -389,8 +389,8 @@ public:
      * invoke interaction. If the caller wants that to fail before sending the command, they should call
      * the templated version of AddRequestData.
      */
-    CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
-                              AddRequestDataParameters & aAddRequestDataParams);
+    CHIP_ERROR AddRequest(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
+                          AddRequestDataParameters & aAddRequestDataParams);
 
     /**
      * API for adding a data request.  The template parameter T is generally
@@ -416,8 +416,7 @@ public:
                             CHIP_ERROR_INVALID_ARGUMENT);
 
         DataModel::EncodableType<CommandDataT> encoder(aData);
-        DataModel::EncodableToTLV & encodable = encoder;
-        return AddRequestData(aCommandPath, encodable, aAddRequestDataParams);
+        return AddRequest(aCommandPath, encoder, aAddRequestDataParams);
     }
 
     template <typename CommandDataT>

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -414,12 +414,21 @@ public:
 
     template <typename CommandDataT>
     CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, const CommandDataT & aData,
+                              AddRequestDataParameters & aAddRequestDataParams)
+    {
+        VerifyOrReturnError(!CommandDataT::MustUseTimedInvoke() || aAddRequestDataParams.timedInvokeTimeoutMs.HasValue(),
+                            CHIP_ERROR_INVALID_ARGUMENT);
+
+        DataModel::EncodableType<CommandDataT> encoder(aData);
+        return AddRequestDataInternal(aCommandPath, encoder, aAddRequestDataParams);
+    }
+
+    template <typename CommandDataT>
+    CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, const CommandDataT & aData,
                               const Optional<uint16_t> & aTimedInvokeTimeoutMs)
     {
-        VerifyOrReturnError(!CommandDataT::MustUseTimedInvoke() || aTimedInvokeTimeoutMs.HasValue(), CHIP_ERROR_INVALID_ARGUMENT);
         AddRequestDataParameters addRequestDataParams(aTimedInvokeTimeoutMs);
-        DataModel::EncodableType<CommandDataT> encoder(aData);
-        return AddRequestData(aCommandPath, encoder, addRequestDataParams);
+        return AddRequestData(aCommandPath, aData, addRequestDataParams);
     }
 
     /**

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -389,8 +389,7 @@ public:
      * This API does not validate if command provided requires timed invoke. If caller
      * wants that certainty they should call templated version of AddRequestData.
      */
-    CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath,
-                              DataModel::EncodableToTLV & aEncodable,
+    CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, DataModel::EncodableToTLV & aEncodable,
                               AddRequestDataParameters & aAddRequestDataParams)
     {
         return AddRequestDataInternal(aCommandPath, aEncodable, aAddRequestDataParams);
@@ -417,8 +416,7 @@ public:
     CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, const CommandDataT & aData,
                               const Optional<uint16_t> & aTimedInvokeTimeoutMs)
     {
-        VerifyOrReturnError(!CommandDataT::MustUseTimedInvoke() || aTimedInvokeTimeoutMs.HasValue(),
-                            CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(!CommandDataT::MustUseTimedInvoke() || aTimedInvokeTimeoutMs.HasValue(), CHIP_ERROR_INVALID_ARGUMENT);
         AddRequestDataParameters addRequestDataParams(aTimedInvokeTimeoutMs);
         DataModel::EncodableType<CommandDataT> encoder(aData);
         return AddRequestData(aCommandPath, encoder, addRequestDataParams);
@@ -465,8 +463,7 @@ public:
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
 private:
-    CHIP_ERROR AddRequestDataInternal(const CommandPathParams & aCommandPath,
-                                      DataModel::EncodableToTLV & aEncodable,
+    CHIP_ERROR AddRequestDataInternal(const CommandPathParams & aCommandPath, DataModel::EncodableToTLV & aEncodable,
                                       AddRequestDataParameters & aAddRequestDataParams);
 
     CHIP_ERROR FinishCommandInternal(FinishCommandParameters & aFinishCommandParams);

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -379,9 +379,9 @@ public:
     /**
      * API for adding request data using DataModel::EncodableToTLV.
      *
-     * @param [in] aCommandPath  The path of the command being requested.
-     * @param [in] aEncodable - an encodable that places the command data structure
-     *             for `aAddRequestDataParams` into a TLV Writer.
+     * @param [in] aCommandPath The path of the command being requested.
+     * @param [in] aEncodable The request data to encode into the
+     *             `CommandFields` member of `CommandDataIB`.
      * @param [in] aAddRequestDataParams parameters associated with building the
      *             InvokeRequestMessage that are associated with this request.
      *

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -389,8 +389,8 @@ public:
      * invoke interaction. If the caller wants that to fail before sending the command, they should call
      * the templated version of AddRequestData.
      */
-    CHIP_ERROR AddRequest(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
-                          AddRequestDataParameters & aAddRequestDataParams);
+    CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
+                              AddRequestDataParameters & aAddRequestDataParams);
 
     /**
      * API for adding a data request.  The template parameter T is generally
@@ -408,7 +408,7 @@ public:
         return AddRequestData(aCommandPath, aData, addRequestDataParams);
     }
 
-    template <typename CommandDataT>
+    template <typename CommandDataT, typename std::enable_if_t<!std::is_base_of_v<DataModel::EncodableToTLV, CommandDataT>, int> = 0>
     CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, const CommandDataT & aData,
                               AddRequestDataParameters & aAddRequestDataParams)
     {
@@ -416,7 +416,7 @@ public:
                             CHIP_ERROR_INVALID_ARGUMENT);
 
         DataModel::EncodableType<CommandDataT> encodable(aData);
-        return AddRequest(aCommandPath, encodable, aAddRequestDataParams);
+        return AddRequestData(aCommandPath, encodable, aAddRequestDataParams);
     }
 
     template <typename CommandDataT>
@@ -446,7 +446,7 @@ public:
                                                   AddRequestDataParameters & aAddRequestDataParams)
     {
         DataModel::EncodableType<CommandDataT> encodable(aData);
-        return AddRequest(aCommandPath, encodable, aAddRequestDataParams);
+        return AddRequestData(aCommandPath, encodable, aAddRequestDataParams);
     }
 
     CHIP_ERROR TestOnlyFinishCommand(FinishCommandParameters & aFinishCommandParams)

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -473,8 +473,7 @@ public:
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
 private:
-    CHIP_ERROR AddRequestDataInternal(const CommandPathParams & aCommandPath,
-                                      const DataModel::EncodableToTLV & aEncodable,
+    CHIP_ERROR AddRequestDataInternal(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
                                       AddRequestDataParameters & aAddRequestDataParams);
 
     CHIP_ERROR FinishCommandInternal(FinishCommandParameters & aFinishCommandParams);

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -446,8 +446,7 @@ public:
                                                   AddRequestDataParameters & aAddRequestDataParams)
     {
         DataModel::EncodableType<CommandDataT> encoder(aData);
-        DataModel::EncodableToTLV & encodable = encoder;
-        return AddRequestData(aCommandPath, encodable, aAddRequestDataParams);
+        return AddRequest(aCommandPath, encodable, aAddRequestDataParams);
     }
 
     CHIP_ERROR TestOnlyFinishCommand(FinishCommandParameters & aFinishCommandParams)

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -408,7 +408,8 @@ public:
         return AddRequestData(aCommandPath, aData, addRequestDataParams);
     }
 
-    template <typename CommandDataT, typename std::enable_if_t<!std::is_base_of_v<DataModel::EncodableToTLV, CommandDataT>, int> = 0>
+    template <typename CommandDataT,
+              typename std::enable_if_t<!std::is_base_of_v<DataModel::EncodableToTLV, CommandDataT>, int> = 0>
     CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, const CommandDataT & aData,
                               AddRequestDataParameters & aAddRequestDataParams)
     {

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -377,24 +377,20 @@ public:
     TLV::TLVWriter * GetCommandDataIBTLVWriter();
 
     /**
-     * API for adding request data.  The `aEncodable` is generally expected to encode
-     * a ClusterName::Commands::CommandName::Type struct, however any object should work.
+     * API for adding request data using DataModel::EncodableToTLV.
      *
      * @param [in] aCommandPath  The path of the command being requested.
      * @param [in] aEncodable - an encodable that places the command data structure
-     *             for `aResponseCommandId` into a TLV Writer.
+     *             for `aAddRequestDataParams` into a TLV Writer.
      * @param [in] aAddRequestDataParams parameters associated with building the
      *             InvokeRequestMessage that are associated with this request.
      *
-     * This API does not validate if the command provided requires interaction use a timed
-     * invoke interaction. If the caller wants that certainty they should call the templated
-     * version of AddRequestData.
+     * This API will not fail if this is an untimed invoke but the command provided requires a timed
+     * invoke interaction. If the caller wants that to fail before sending the command, they should call
+     * the templated version of AddRequestData.
      */
     CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
-                              AddRequestDataParameters & aAddRequestDataParams)
-    {
-        return AddRequestDataInternal(aCommandPath, aEncodable, aAddRequestDataParams);
-    }
+                              AddRequestDataParameters & aAddRequestDataParams);
 
     /**
      * API for adding a data request.  The template parameter T is generally
@@ -420,7 +416,8 @@ public:
                             CHIP_ERROR_INVALID_ARGUMENT);
 
         DataModel::EncodableType<CommandDataT> encoder(aData);
-        return AddRequestDataInternal(aCommandPath, encoder, aAddRequestDataParams);
+        DataModel::EncodableToTLV & encodable = encoder;
+        return AddRequestData(aCommandPath, encodable, aAddRequestDataParams);
     }
 
     template <typename CommandDataT>
@@ -450,7 +447,8 @@ public:
                                                   AddRequestDataParameters & aAddRequestDataParams)
     {
         DataModel::EncodableType<CommandDataT> encoder(aData);
-        return AddRequestDataInternal(aCommandPath, encoder, aAddRequestDataParams);
+        DataModel::EncodableToTLV & encodable = encoder;
+        return AddRequestData(aCommandPath, encodable, aAddRequestDataParams);
     }
 
     CHIP_ERROR TestOnlyFinishCommand(FinishCommandParameters & aFinishCommandParams)
@@ -472,9 +470,6 @@ public:
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
 private:
-    CHIP_ERROR AddRequestDataInternal(const CommandPathParams & aCommandPath, const DataModel::EncodableToTLV & aEncodable,
-                                      AddRequestDataParameters & aAddRequestDataParams);
-
     CHIP_ERROR FinishCommandInternal(FinishCommandParameters & aFinishCommandParams);
 
 public:

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -377,7 +377,7 @@ public:
     TLV::TLVWriter * GetCommandDataIBTLVWriter();
 
     /**
-     * API for adding a request data.  The `aEncodable` is generally expected to encode
+     * API for adding request data.  The `aEncodable` is generally expected to encode
      * a ClusterName::Commands::CommandName::Type struct, however any object should work.
      *
      * @param [in] aCommandPath  The path of the command being requested.
@@ -386,8 +386,9 @@ public:
      * @param [in] aAddRequestDataParams parameters associated with building the
      *             InvokeRequestMessage that are associated with this request.
      *
-     * This API does not validate if command provided requires timed invoke. If caller
-     * wants that certainty they should call templated version of AddRequestData.
+     * This API does not validate if the command provided requires interaction use a timed
+     * invoke interaction. If the caller wants that certainty they should call the templated
+     * version of AddRequestData.
      */
     CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, DataModel::EncodableToTLV & aEncodable,
                               AddRequestDataParameters & aAddRequestDataParams)

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -415,8 +415,8 @@ public:
         VerifyOrReturnError(!CommandDataT::MustUseTimedInvoke() || aAddRequestDataParams.timedInvokeTimeoutMs.HasValue(),
                             CHIP_ERROR_INVALID_ARGUMENT);
 
-        DataModel::EncodableType<CommandDataT> encoder(aData);
-        return AddRequest(aCommandPath, encoder, aAddRequestDataParams);
+        DataModel::EncodableType<CommandDataT> encodable(aData);
+        return AddRequest(aCommandPath, encodable, aAddRequestDataParams);
     }
 
     template <typename CommandDataT>
@@ -445,7 +445,7 @@ public:
     CHIP_ERROR TestOnlyAddRequestDataNoTimedCheck(const CommandPathParams & aCommandPath, const CommandDataT & aData,
                                                   AddRequestDataParameters & aAddRequestDataParams)
     {
-        DataModel::EncodableType<CommandDataT> encoder(aData);
+        DataModel::EncodableType<CommandDataT> encodable(aData);
         return AddRequest(aCommandPath, encodable, aAddRequestDataParams);
     }
 

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -409,8 +409,7 @@ public:
     CHIP_ERROR AddRequestData(const CommandPathParams & aCommandPath, const CommandDataT & aData)
     {
         AddRequestDataParameters addRequestDataParams;
-        DataModel::EncodableType<CommandDataT> encoder(aData);
-        return AddRequestData(aCommandPath, encoder, addRequestDataParams);
+        return AddRequestData(aCommandPath, aData, addRequestDataParams);
     }
 
     template <typename CommandDataT>


### PR DESCRIPTION
Add new AddRequestData API so that clients don't need to call raw CommandSender APIs, and we can move towards removing access to TLVWriter.

The newly AddRequestData does bypass check that time invoke does in fact provide a timeout, the reality is that things outside of SDK heavily use the raw CommandSender APIs (PrepareCommand/FinishCommand) to build their own requests bypassing this check already. We still allow clients to call the older API for building the request.

