### PR TITLE
Make EncodableToTLV arguments const 

### DIFF
--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -155,7 +155,7 @@ public:
      * case AddResponseData fails.
      */
     virtual CHIP_ERROR AddResponseData(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
-                                       DataModel::EncodableToTLV & aEncodable) = 0;
+                                       const DataModel::EncodableToTLV & aEncodable) = 0;
 
     /**
      * Attempts to encode a response to a command.
@@ -171,7 +171,7 @@ public:
      * AddResponseData allows the caller to try to deal with any CHIP_ERRORs.
      */
     virtual void AddResponse(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
-                             DataModel::EncodableToTLV & aEncodable) = 0;
+                             const DataModel::EncodableToTLV & aEncodable) = 0;
 
     /**
      * Check whether the InvokeRequest we are handling is a timed invoke.

--- a/src/app/CommandHandlerImpl.cpp
+++ b/src/app/CommandHandlerImpl.cpp
@@ -114,7 +114,7 @@ Status CommandHandlerImpl::OnInvokeCommandRequest(CommandHandlerExchangeInterfac
 }
 
 CHIP_ERROR CommandHandlerImpl::TryAddResponseData(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
-                                                  DataModel::EncodableToTLV & aEncodable)
+                                                  const DataModel::EncodableToTLV & aEncodable)
 {
     ConcreteCommandPath responseCommandPath = { aRequestCommandPath.mEndpointId, aRequestCommandPath.mClusterId,
                                                 aResponseCommandId };
@@ -134,7 +134,7 @@ CHIP_ERROR CommandHandlerImpl::TryAddResponseData(const ConcreteCommandPath & aR
 }
 
 CHIP_ERROR CommandHandlerImpl::AddResponseData(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
-                                               DataModel::EncodableToTLV & aEncodable)
+                                               const DataModel::EncodableToTLV & aEncodable)
 {
     // Return early when response should not be sent out.
     VerifyOrReturnValue(ResponsesAccepted(), CHIP_NO_ERROR);
@@ -909,7 +909,7 @@ bool CommandHandlerImpl::IsTimedInvoke() const
 }
 
 void CommandHandlerImpl::AddResponse(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
-                                     DataModel::EncodableToTLV & aEncodable)
+                                     const DataModel::EncodableToTLV & aEncodable)
 {
     CHIP_ERROR err = AddResponseData(aRequestCommandPath, aResponseCommandId, aEncodable);
     if (err != CHIP_NO_ERROR)

--- a/src/app/CommandHandlerImpl.h
+++ b/src/app/CommandHandlerImpl.h
@@ -125,9 +125,9 @@ public:
     CHIP_ERROR AddClusterSpecificFailure(const ConcreteCommandPath & aRequestCommandPath, ClusterStatus aClusterStatus) override;
 
     CHIP_ERROR AddResponseData(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
-                               DataModel::EncodableToTLV & aEncodable) override;
+                               const DataModel::EncodableToTLV & aEncodable) override;
     void AddResponse(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
-                     DataModel::EncodableToTLV & aEncodable) override;
+                     const DataModel::EncodableToTLV & aEncodable) override;
 
     Access::SubjectDescriptor GetSubjectDescriptor() const override;
     FabricIndex GetAccessingFabricIndex() const override;
@@ -409,7 +409,7 @@ private:
      * @param [in] aEncodable the data to encode for the given aResponseCommandId
      */
     CHIP_ERROR TryAddResponseData(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
-                                  DataModel::EncodableToTLV & aEncodable);
+                                  const DataModel::EncodableToTLV & aEncodable);
 
     void SetExchangeInterface(CommandHandlerExchangeInterface * commandResponder);
 


### PR DESCRIPTION
`EncodeToTLV` method is const, so we can pass these objects as const as well.