### PR TITLE
Proposed changes to split tests into separate binaries for efr32 [Version 1]

### DIFF
--- a/build/chip/tests.gni
+++ b/build/chip/tests.gni
@@ -36,7 +36,8 @@ declare_args() {
 
 declare_args() {
   # Use source_set instead of static_lib for tests.
-  chip_build_test_static_libraries = chip_device_platform != "efr32"
+  chip_build_test_static_libraries = chip_device_platform != "efr32"  #++++
+  #chip_build_test_static_libraries = true
 }
 
 declare_args() {

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -270,6 +270,11 @@ class Efr32Builder(GnBuilder):
 
         if self.app == Efr32App.UNIT_TEST:
             # Include test runner python wheels
+            for root, dirs, files in os.walk(os.path.join(self.output_dir, 'chip_pw_test_runner_wheels')):
+                for file in files:
+                    items["chip_pw_test_runner_wheels/" +
+                          file] = os.path.join(root, file)
+            # TODO [PW_MIGRATION]: remove the nl wheels once transition away from nlunit-test is completed
             for root, dirs, files in os.walk(os.path.join(self.output_dir, 'chip_nl_test_runner_wheels')):
                 for file in files:
                     items["chip_nl_test_runner_wheels/" +

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -77,7 +77,7 @@ class Efr32App(Enum):
         elif self == Efr32App.PUMP:
             return 'pump_app.flashbundle.txt'
         elif self == Efr32App.UNIT_TEST:
-            return 'efr32_device_tests.flashbundle.txt'
+            return 'efr32_device_tests.flashbundle.txt'  # ++++ target name has changed
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -215,6 +215,7 @@ class HostApp(Enum):
         elif self == HostApp.PYTHON_BINDINGS:
             yield 'controller/python'  # Directory containing WHL files
         elif self == HostApp.EFR32_TEST_RUNNER:
+            yield 'chip_pw_test_runner_wheels'
             yield 'chip_nl_test_runner_wheels'
         elif self == HostApp.TV_CASTING:
             yield 'chip-tv-casting-app'

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -59,16 +59,22 @@ if (chip_build_tests) {
       "${chip_root}/src/access/tests",
       "${chip_root}/src/crypto/tests",
       "${chip_root}/src/inet/tests",
-      "${chip_root}/src/lib/address_resolve/tests",
-      "${chip_root}/src/lib/asn1/tests",
-      "${chip_root}/src/lib/core/tests",
-      "${chip_root}/src/messaging/tests",
-      "${chip_root}/src/protocols/bdx/tests",
-      "${chip_root}/src/protocols/interaction_model/tests",
-      "${chip_root}/src/protocols/user_directed_commissioning/tests",
-      "${chip_root}/src/transport/retransmit/tests",
-      "${chip_root}/src/app/icd/server/tests",
     ]
+
+    # Skip on efr32 due to flash limitations.
+    if (chip_device_platform != "efr32") {
+      tests += [
+        "${chip_root}/src/lib/address_resolve/tests",
+        "${chip_root}/src/lib/asn1/tests",
+        "${chip_root}/src/lib/core/tests",
+        "${chip_root}/src/messaging/tests",
+        "${chip_root}/src/protocols/bdx/tests",
+        "${chip_root}/src/protocols/interaction_model/tests",
+        "${chip_root}/src/protocols/user_directed_commissioning/tests",
+        "${chip_root}/src/transport/retransmit/tests",
+        "${chip_root}/src/app/icd/server/tests",
+      ]
+    }
 
     # Skip DNSSD tests for Mbed platform due to flash memory size limitations
     if (current_os != "mbed") {

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -59,22 +59,22 @@ if (chip_build_tests) {
       "${chip_root}/src/access/tests",
       "${chip_root}/src/crypto/tests",
       "${chip_root}/src/inet/tests",
+      "${chip_root}/src/lib/address_resolve/tests",
+      "${chip_root}/src/lib/asn1/tests",
+      "${chip_root}/src/lib/core/tests",
+      "${chip_root}/src/messaging/tests",
+      "${chip_root}/src/protocols/bdx/tests",
+      "${chip_root}/src/protocols/interaction_model/tests",
+      "${chip_root}/src/protocols/user_directed_commissioning/tests",
+      "${chip_root}/src/transport/retransmit/tests",
+      "${chip_root}/src/app/icd/server/tests",
+      "${chip_root}/src/app/tests",
+      "${chip_root}/src/lib/format/tests",
+      "${chip_root}/src/protocols/secure_channel/tests",
+      "${chip_root}/src/protocols/secure_channel/tests:tests_nltest",
+      "${chip_root}/src/system/tests",
+      "${chip_root}/src/transport/tests",
     ]
-
-    # Skip on efr32 due to flash limitations.
-    if (chip_device_platform != "efr32") {
-      tests += [
-        "${chip_root}/src/lib/address_resolve/tests",
-        "${chip_root}/src/lib/asn1/tests",
-        "${chip_root}/src/lib/core/tests",
-        "${chip_root}/src/messaging/tests",
-        "${chip_root}/src/protocols/bdx/tests",
-        "${chip_root}/src/protocols/interaction_model/tests",
-        "${chip_root}/src/protocols/user_directed_commissioning/tests",
-        "${chip_root}/src/transport/retransmit/tests",
-        "${chip_root}/src/app/icd/server/tests",
-      ]
-    }
 
     # Skip DNSSD tests for Mbed platform due to flash memory size limitations
     if (current_os != "mbed") {
@@ -90,25 +90,18 @@ if (chip_build_tests) {
       tests += [ "${chip_root}/src/lib/dnssd/minimal_mdns/records/tests" ]
     }
 
-    if (current_os != "zephyr" && current_os != "mbed" &&
-        chip_device_platform != "efr32") {
+    if (current_os != "zephyr" && current_os != "mbed") {
       tests += [
         "${chip_root}/src/setup_payload/tests",
         "${chip_root}/src/transport/raw/tests",
       ]
     }
 
-    # Skip on efr32 due to flash and/or ram limitations.
+    # Won't build on efr32.  openr.c:(.text._open_r+0x10): warning: _open is not implemented and will always fail due to flash and/or ram limitations.
     if (chip_device_platform != "efr32") {
       tests += [
-        "${chip_root}/src/app/tests",
         "${chip_root}/src/credentials/tests",
-        "${chip_root}/src/lib/format/tests",
         "${chip_root}/src/lib/support/tests",
-        "${chip_root}/src/protocols/secure_channel/tests",
-        "${chip_root}/src/protocols/secure_channel/tests:tests_nltest",
-        "${chip_root}/src/system/tests",
-        "${chip_root}/src/transport/tests",
       ]
 
       if (matter_enable_tracing_support &&
@@ -121,8 +114,7 @@ if (chip_build_tests) {
       tests += [ "${chip_root}/src/lib/dnssd/minimal_mdns/tests" ]
     }
 
-    if (chip_device_platform != "esp32" && chip_device_platform != "efr32" &&
-        chip_device_platform != "ameba") {
+    if (chip_device_platform != "esp32" && chip_device_platform != "ameba") {
       tests += [ "${chip_root}/src/platform/tests" ]
     }
 

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -23,8 +23,7 @@ chip_test_suite("tests") {
 
   test_sources = [ "TestCommissionableNodeController.cpp" ]
 
-  if (chip_device_platform != "mbed" && chip_device_platform != "efr32" &&
-      chip_device_platform != "esp32") {
+  if (chip_device_platform != "mbed" && chip_device_platform != "esp32") {
     test_sources += [ "TestServerCommandDispatch.cpp" ]
     test_sources += [ "TestEventChunking.cpp" ]
     test_sources += [ "TestEventCaching.cpp" ]

--- a/src/credentials/tests/BUILD.gn
+++ b/src/credentials/tests/BUILD.gn
@@ -56,7 +56,8 @@ chip_test_suite("tests") {
   ]
 
   # DUTVectors test requires <dirent.h> which is not supported on all platforms
-  if (chip_device_platform != "openiotsdk" && chip_device_platform != "nxp") {
+  if (chip_device_platform != "openiotsdk" && chip_device_platform != "nxp" &&
+      chip_device_platform != "efr32") {
     test_sources += [ "TestCommissionerDUTVectors.cpp" ]
   }
 

--- a/src/lib/core/tests/BUILD.gn
+++ b/src/lib/core/tests/BUILD.gn
@@ -30,13 +30,8 @@ chip_test_suite("tests") {
     "TestOptional.cpp",
     "TestReferenceCounted.cpp",
     "TestTLV.cpp",
+    "TestTLVVectorWriter.cpp",
   ]
-
-  # requires large amount of heap for multiple unfragmented 10k buffers
-  # skip for efr32 to allow flash space for other tests
-  if (chip_device_platform != "efr32") {
-    test_sources += [ "TestTLVVectorWriter.cpp" ]
-  }
 
   cflags = [ "-Wconversion" ]
 

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -130,6 +130,9 @@ group("efr32") {
 
 group("runner") {
   deps = [
+    "${efr32_project_dir}/py:pw_test_runner.install",
+    "${efr32_project_dir}/py:pw_test_runner_wheel",
+    # TODO [PW_MIGRATION]: remove the following when transition from nlunit-test is complete.
     "${efr32_project_dir}/py:nl_test_runner.install",
     "${efr32_project_dir}/py:nl_test_runner_wheel",
   ]

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -63,71 +63,6 @@ efr32_sdk("sdk") {
   ]
 }
 
-# silabs_executable("efr32_device_tests") {
-#   output_name = "matter-silabs-device_tests.out"
-
-#   defines = [ "PW_RPC_ENABLED" ]
-#   sources = [
-#     "${chip_root}/examples/common/pigweed/RpcService.cpp",
-#     "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
-#     "${examples_common_plat_dir}/PigweedLogger.cpp",
-#     "${examples_common_plat_dir}/heap_4_silabs.c",
-#     "${examples_common_plat_dir}/syscalls_stubs.cpp",
-#     "${examples_plat_dir}/uart.cpp",
-#     "src/main.cpp",
-#   ]
-
-#   deps = [
-#     ":nl_test_service.nanopb_rpc",
-#     ":sdk",
-#     "$dir_pw_unit_test:rpc_service",
-#     "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
-#     "${chip_root}/examples/common/pigweed:system_rpc_server",
-#     "${chip_root}/src:tests",
-#     "${chip_root}/src/lib",
-#     "${chip_root}/src/lib/support:pw_tests_wrapper",
-#     "${chip_root}/src/lib/support:testing_nlunit",
-#     "${examples_common_plat_dir}/pw_sys_io:pw_sys_io_silabs",
-#     "${nlunit_test_root}:nlunit-test",
-#   ]
-
-#   # OpenThread Settings
-#   if (chip_enable_openthread) {
-#     deps += [
-#       "${chip_root}/third_party/openthread:openthread",
-#       "${chip_root}/third_party/openthread:openthread-platform",
-#       "${examples_plat_dir}:efr-matter-shell",
-#     ]
-#   }
-
-#   # Attestation Credentials
-#   deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
-
-#   # Factory Data Provider
-#   if (use_efr32_factory_data_provider) {
-#     deps += [ "${examples_plat_dir}:silabs-factory-data-provider" ]
-#   }
-
-#   deps += pw_build_LINK_DEPS
-
-#   include_dirs = [ "${chip_root}/examples/common/pigweed/efr32" ]
-
-#   ldscript = "${examples_common_plat_dir}/ldscripts/${silabs_family}.ld"
-
-#   inputs = [ ldscript ]
-
-#   ldflags = [
-#     "-T" + rebase_path(ldscript, root_build_dir),
-#     "-Wl,--no-warn-rwx-segment",
-#   ]
-
-#   output_dir = root_out_dir
-# }
-
-# group("efr32") {
-#   deps = [ ":efr32_device_tests" ]
-# }
-
 
 _tests = [
   "${chip_root}/src/app/interaction-model/tests",
@@ -176,6 +111,7 @@ if (chip_device_platform != "efr32") {
 
   _tests += [ "${chip_root}/src/controller/tests" ]
 }
+
 
 copy_py_files = true  # Copy silabs_firmware_utils.py and firmware_utils.py to the output directory only the first time silabs_executable is called.
 _deps = []
@@ -250,21 +186,14 @@ foreach(_test, _tests) {
   _deps += [ ":efr32_device_tests--${_test_suffix}" ]
 }
 
-group("efr32_device_tests") {
-  deps = _deps
-}
-
 group("efr32") {
-  deps = [ ":efr32_device_tests" ]  #++++ Should we get rid of "efr32_device_tests" and move its contents here?
+  deps = _deps
 }
 
 group("runner") {
   deps = [
     "${efr32_project_dir}/py:pw_test_runner.install",
     "${efr32_project_dir}/py:pw_test_runner_wheel",
-    # TODO [PW_MIGRATION]: remove the following when transition from nlunit-test is complete.
-    #++++"${efr32_project_dir}/py:nl_test_runner.install",
-    #++++"${efr32_project_dir}/py:nl_test_runner_wheel",
   ]
 }
 

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -63,69 +63,199 @@ efr32_sdk("sdk") {
   ]
 }
 
-silabs_executable("efr32_device_tests") {
-  output_name = "matter-silabs-device_tests.out"
+# silabs_executable("efr32_device_tests") {
+#   output_name = "matter-silabs-device_tests.out"
 
-  defines = [ "PW_RPC_ENABLED" ]
-  sources = [
-    "${chip_root}/examples/common/pigweed/RpcService.cpp",
-    "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
-    "${examples_common_plat_dir}/PigweedLogger.cpp",
-    "${examples_common_plat_dir}/heap_4_silabs.c",
-    "${examples_common_plat_dir}/syscalls_stubs.cpp",
-    "${examples_plat_dir}/uart.cpp",
-    "src/main.cpp",
-  ]
+#   defines = [ "PW_RPC_ENABLED" ]
+#   sources = [
+#     "${chip_root}/examples/common/pigweed/RpcService.cpp",
+#     "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
+#     "${examples_common_plat_dir}/PigweedLogger.cpp",
+#     "${examples_common_plat_dir}/heap_4_silabs.c",
+#     "${examples_common_plat_dir}/syscalls_stubs.cpp",
+#     "${examples_plat_dir}/uart.cpp",
+#     "src/main.cpp",
+#   ]
 
-  deps = [
-    ":nl_test_service.nanopb_rpc",
-    ":sdk",
-    "$dir_pw_unit_test:rpc_service",
-    "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
-    "${chip_root}/examples/common/pigweed:system_rpc_server",
-    "${chip_root}/src:tests",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/lib/support:pw_tests_wrapper",
-    "${chip_root}/src/lib/support:testing_nlunit",
-    "${examples_common_plat_dir}/pw_sys_io:pw_sys_io_silabs",
-    "${nlunit_test_root}:nlunit-test",
-  ]
+#   deps = [
+#     ":nl_test_service.nanopb_rpc",
+#     ":sdk",
+#     "$dir_pw_unit_test:rpc_service",
+#     "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
+#     "${chip_root}/examples/common/pigweed:system_rpc_server",
+#     "${chip_root}/src:tests",
+#     "${chip_root}/src/lib",
+#     "${chip_root}/src/lib/support:pw_tests_wrapper",
+#     "${chip_root}/src/lib/support:testing_nlunit",
+#     "${examples_common_plat_dir}/pw_sys_io:pw_sys_io_silabs",
+#     "${nlunit_test_root}:nlunit-test",
+#   ]
 
-  # OpenThread Settings
-  if (chip_enable_openthread) {
-    deps += [
-      "${chip_root}/third_party/openthread:openthread",
-      "${chip_root}/third_party/openthread:openthread-platform",
-      "${examples_plat_dir}:efr-matter-shell",
+#   # OpenThread Settings
+#   if (chip_enable_openthread) {
+#     deps += [
+#       "${chip_root}/third_party/openthread:openthread",
+#       "${chip_root}/third_party/openthread:openthread-platform",
+#       "${examples_plat_dir}:efr-matter-shell",
+#     ]
+#   }
+
+#   # Attestation Credentials
+#   deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
+
+#   # Factory Data Provider
+#   if (use_efr32_factory_data_provider) {
+#     deps += [ "${examples_plat_dir}:silabs-factory-data-provider" ]
+#   }
+
+#   deps += pw_build_LINK_DEPS
+
+#   include_dirs = [ "${chip_root}/examples/common/pigweed/efr32" ]
+
+#   ldscript = "${examples_common_plat_dir}/ldscripts/${silabs_family}.ld"
+
+#   inputs = [ ldscript ]
+
+#   ldflags = [
+#     "-T" + rebase_path(ldscript, root_build_dir),
+#     "-Wl,--no-warn-rwx-segment",
+#   ]
+
+#   output_dir = root_out_dir
+# }
+
+# group("efr32") {
+#   deps = [ ":efr32_device_tests" ]
+# }
+
+
+_tests = [
+  "${chip_root}/src/app/interaction-model/tests",
+  "${chip_root}/src/access/tests",
+  "${chip_root}/src/crypto/tests",
+  "${chip_root}/src/inet/tests",
+  "${chip_root}/src/lib/address_resolve/tests",
+  "${chip_root}/src/lib/asn1/tests",
+  "${chip_root}/src/lib/core/tests",
+  "${chip_root}/src/messaging/tests",
+  "${chip_root}/src/protocols/bdx/tests",
+  "${chip_root}/src/protocols/interaction_model/tests",
+  "${chip_root}/src/protocols/user_directed_commissioning/tests",
+  "${chip_root}/src/transport/retransmit/tests",
+  "${chip_root}/src/app/icd/server/tests",
+  "${chip_root}/src/lib/dnssd/minimal_mdns/core/tests",
+  "${chip_root}/src/lib/dnssd/minimal_mdns/responders/tests",
+  "${chip_root}/src/lib/dnssd/minimal_mdns/tests",
+  "${chip_root}/src/lib/dnssd/tests",
+  "${chip_root}/src/lib/dnssd/minimal_mdns/records/tests",
+  "${chip_root}/src/setup_payload/tests",
+  "${chip_root}/src/transport/raw/tests",
+  "${chip_root}/src/app/tests",
+  #"${chip_root}/src/credentials/tests",  # openr.c:(.text._open_r+0x10): warning: _open is not implemented and will always fail
+  "${chip_root}/src/lib/format/tests",
+  #"${chip_root}/src/lib/support/tests",  # openr.c:(.text._open_r+0x10): warning: _open is not implemented and will always fail
+  "${chip_root}/src/protocols/secure_channel/tests",
+  "${chip_root}/src/system/tests",
+  "${chip_root}/src/transport/tests",
+  "${chip_root}/src/platform/tests",
+  "${chip_root}/src/lib/shell/tests",
+]
+
+if (defined(matter_enable_tracing_support) && matter_enable_tracing_support &&
+    defined(matter_trace_config) && matter_trace_config == "${chip_root}/src/tracing/multiplexed") {
+  _tests += [ "${chip_root}/src/tracing/tests" ]
+}
+
+if (defined(matter_enable_tracing_support) && chip_config_network_layer_ble) {
+  _tests += [ "${chip_root}/src/ble/tests" ]
+}
+
+if (chip_device_platform != "efr32") {
+  # Doesn't compile on ef32. Multiple definitions issues with attribute storage and overflows flash memory.
+  _tests += [ "${chip_root}/src/controller/tests/data_model" ]
+
+  _tests += [ "${chip_root}/src/controller/tests" ]
+}
+
+copy_py_files = true  # Copy silabs_firmware_utils.py and firmware_utils.py to the output directory only the first time silabs_executable is called.
+_deps = []
+foreach(_test, _tests) {
+  _test_suffix = string_replace(_test, "/tests", "")
+  _test_suffix = string_replace(_test_suffix, "${chip_root}/src/", "")
+  _test_suffix = string_replace(_test_suffix, "/", "-")
+
+  silabs_executable("efr32_device_tests--${_test_suffix}") {
+    output_name = "matter-silabs-device_tests--${_test_suffix}.out"
+
+    defines = [ "PW_RPC_ENABLED" ]
+    sources = [
+      "${chip_root}/examples/common/pigweed/RpcService.cpp",
+      "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
+      "${examples_common_plat_dir}/PigweedLogger.cpp",
+      "${examples_common_plat_dir}/heap_4_silabs.c",
+      "${examples_common_plat_dir}/syscalls_stubs.cpp",
+      "${examples_plat_dir}/uart.cpp",
+      "src/main.cpp",
     ]
+
+    deps = [
+      ":nl_test_service.nanopb_rpc",
+      ":sdk",
+      "$dir_pw_unit_test:rpc_service",
+      "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
+      "${chip_root}/examples/common/pigweed:system_rpc_server",
+      "${_test}:tests",
+      "${chip_root}/src/lib",
+      "${chip_root}/src/lib/support:pw_tests_wrapper",
+      "${chip_root}/src/lib/support:testing_nlunit",
+      "${examples_common_plat_dir}/pw_sys_io:pw_sys_io_silabs",
+      "${nlunit_test_root}:nlunit-test",
+    ]
+
+    # OpenThread Settings
+    if (chip_enable_openthread) {
+      deps += [
+        "${chip_root}/third_party/openthread:openthread",
+        "${chip_root}/third_party/openthread:openthread-platform",
+        "${examples_plat_dir}:efr-matter-shell",
+      ]
+    }
+
+    # Attestation Credentials
+    deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
+
+    # Factory Data Provider
+    if (use_efr32_factory_data_provider) {
+      deps += [ "${examples_plat_dir}:silabs-factory-data-provider" ]
+    }
+
+    deps += pw_build_LINK_DEPS
+
+    include_dirs = [ "${chip_root}/examples/common/pigweed/efr32" ]
+
+    ldscript = "${examples_common_plat_dir}/ldscripts/${silabs_family}.ld"
+
+    inputs = [ ldscript ]
+
+    ldflags = [
+      "-T" + rebase_path(ldscript, root_build_dir),
+      "-Wl,--no-warn-rwx-segment",
+    ]
+
+    output_dir = root_out_dir
   }
+  
+  copy_py_files = false  # Don't copy them next time.
 
-  # Attestation Credentials
-  deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
+  _deps += [ ":efr32_device_tests--${_test_suffix}" ]
+}
 
-  # Factory Data Provider
-  if (use_efr32_factory_data_provider) {
-    deps += [ "${examples_plat_dir}:silabs-factory-data-provider" ]
-  }
-
-  deps += pw_build_LINK_DEPS
-
-  include_dirs = [ "${chip_root}/examples/common/pigweed/efr32" ]
-
-  ldscript = "${examples_common_plat_dir}/ldscripts/${silabs_family}.ld"
-
-  inputs = [ ldscript ]
-
-  ldflags = [
-    "-T" + rebase_path(ldscript, root_build_dir),
-    "-Wl,--no-warn-rwx-segment",
-  ]
-
-  output_dir = root_out_dir
+group("efr32_device_tests") {
+  deps = _deps
 }
 
 group("efr32") {
-  deps = [ ":efr32_device_tests" ]
+  deps = [ ":efr32_device_tests" ]  #++++ Should we get rid of "efr32_device_tests" and move its contents here?
 }
 
 group("runner") {
@@ -133,8 +263,8 @@ group("runner") {
     "${efr32_project_dir}/py:pw_test_runner.install",
     "${efr32_project_dir}/py:pw_test_runner_wheel",
     # TODO [PW_MIGRATION]: remove the following when transition from nlunit-test is complete.
-    "${efr32_project_dir}/py:nl_test_runner.install",
-    "${efr32_project_dir}/py:nl_test_runner_wheel",
+    #++++"${efr32_project_dir}/py:nl_test_runner.install",
+    #++++"${efr32_project_dir}/py:nl_test_runner_wheel",
   ]
 }
 

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -1,6 +1,6 @@
 #CHIP EFR32 Test Driver
 
-This builds and runs the NLUnitTest on the efr32 device
+This builds and runs the PW Unit Tests on the efr32 device
 
 <hr>
 
@@ -14,7 +14,7 @@ This builds and runs the NLUnitTest on the efr32 device
 
 ## Introduction
 
-This builds a test binary which contains the NLUnitTests and can be flashed onto
+This builds a test binary which contains the pw_unit_test and can be flashed onto
 a device. The device is controlled using the included RPCs, through the python
 test runner.
 
@@ -99,7 +99,7 @@ Or build using build script from the root
 
     ```
     cd <connectedhomeip>
-    ./scripts/build/build_examples.py --target linux-x64-nl-test-runner build
+    ./scripts/build/build_examples.py --target linux-x64-pw-test-runner build
     ```
 
 The runner will be installed into the venv and python wheels will be packaged in
@@ -108,7 +108,7 @@ the output folder for deploying.
 Then the python wheels need to installed using pip3.
 
     ```
-    pip3 install out/debug/chip_nl_test_runner_wheels/*.whl
+    pip3 install out/debug/chip_pw_test_runner_wheels/*.whl
     ```
 
 Other python libraries may need to be installed such as
@@ -117,8 +117,8 @@ Other python libraries may need to be installed such as
     pip3 install pyserial
     ```
 
--   To run the tests:
+To run all tests:
 
     ```
-    python -m nl_test_runner.nl_test_runner -d /dev/ttyACM1 -f out/debug/matter-silabs-device_tests.s37 -o out.log
+    python -m pw_test_runner.pw_test_runner -d /dev/ttyACM1 -f out/debug -o out.log
     ```

--- a/src/test_driver/efr32/args.gni
+++ b/src/test_driver/efr32/args.gni
@@ -24,7 +24,8 @@ chip_enable_pw_rpc = true
 chip_build_tests = true
 chip_enable_openthread = true
 chip_openthread_ftd = false  # use mtd as it is smaller.
-chip_monolithic_tests = true
+
+chip_monolithic_tests = true  #++++
 
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"

--- a/src/test_driver/efr32/py/setup.cfg
+++ b/src/test_driver/efr32/py/setup.cfg
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 [metadata]
-name = nl_test_runner
+name = pw_test_runner
 version = 0.0.1
 
 [options]

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -44,9 +44,8 @@ chip_test_suite("tests") {
     "TestSessionManagerDispatch.cpp",
   ]
 
-  if (chip_device_platform != "mbed" && chip_device_platform != "efr32" &&
-      chip_device_platform != "esp32" && chip_device_platform != "nrfconnect" &&
-      chip_device_platform != "nxp") {
+  if (chip_device_platform != "mbed" && chip_device_platform != "esp32" &&
+      chip_device_platform != "nrfconnect" && chip_device_platform != "nxp") {
     test_sources += [ "TestSecureSessionTable.cpp" ]
   }
 

--- a/third_party/silabs/silabs_executable.gni
+++ b/third_party/silabs/silabs_executable.gni
@@ -61,14 +61,16 @@ template("silabs_executable") {
     flashing_image_name = output_base_name + ".rps"
   }
 
-  flashing_runtime_target = target_name + ".flashing_runtime"
   flashing_script_inputs = [
     "${chip_root}/scripts/flashing/silabs_firmware_utils.py",
     "${chip_root}/scripts/flashing/firmware_utils.py",
   ]
-  copy(flashing_runtime_target) {
-    sources = flashing_script_inputs
-    outputs = [ "${root_out_dir}/{{source_file_part}}" ]
+  if (defined(invoker.copy_py_files) && invoker.copy_py_files) {  #++++ added this
+    flashing_runtime_target = target_name + ".flashing_runtime"
+    copy(flashing_runtime_target) {
+      sources = flashing_script_inputs
+      outputs = [ "${root_out_dir}/{{source_file_part}}" ]
+    }
   }
 
   flashing_script_generator =
@@ -80,7 +82,9 @@ template("silabs_executable") {
   flashbundle_name = "${target_name}.flashbundle.txt"
   flashable_executable(flash_target_name) {
     forward_variables_from(invoker, "*")
-    data_deps = [ ":${flashing_runtime_target}" ]
+    if (defined(invoker.copy_py_files) && invoker.copy_py_files) {  #++++ added this
+      data_deps = [ ":${flashing_runtime_target}" ]
+    }
   }
 
   # Add a target which generates the hex file in addition to s37.


### PR DESCRIPTION
REPLACED BY:  [34769](https://github.com/project-chip/connectedhomeip/pull/34769)

The approach here is to keep the `silabs_executable` targets inside `src/test_driver/efr32/BUILD.gn` and to leave `chip_test_suite` alone without any knowledge of efr32.

This creates a `.s37` file for each test suite.  I have tested the build process and it seems to generate the correct files, with each `.s37` file only having the tests for that particular suite.  However without the hardware I have not yet flashed and run them on a device, so I can only judge by the `.map` file what's inside them.  But in general I believe this PR is functional and does what it's supposed to do.

Note that even though there's a binary for each test directory (rather than a binary for each individual test source within that directory), each of the binaries is able to build without a complaint about flash size limitations.  So that means so far none of our test directories are too large to fit on the device.  So we could get away with 20-something binaries instead of 200-something if we wanted to go this route.

(This is a work in progress, so please ignore any commented-out code and print statements.)

The drawback to this approach is that it requires `src/test_driver/efr32/BUILD.gn` to have a list of all test directories. This is not ideal since it will need to be updated any time a new test directory is created.  To avoid this I have made another version which moves the `silabs_executable` target into `chip_test_suite`.  See [Version 2](https://github.com/project-chip/connectedhomeip/pull/33790).