### PR TITLE
Proposed changes to split tests into separate binaries for efr32 [Version 1.5]

### DIFF
--- a/build/chip/chip_test_suite.gni
+++ b/build/chip/chip_test_suite.gni
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#++++ DEBUG: These flags control whether we're creating a binary for each test suite or each individual test source.  This is a temporary solution while debugging.
 enable_efr32_build_per_suite = false  #++++ TODO: Figure out how to enable things based on `chip_device_platform == "efr32"` which is not currently in scope.
 enable_efr32_build_per_testsource = true  #++++ TODO: Figure out how to enable things based on `chip_device_platform == "efr32"` which is not currently in scope.
 

--- a/build/chip/chip_test_suite.gni
+++ b/build/chip/chip_test_suite.gni
@@ -12,12 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+enable_efr32_build_per_suite = false  #++++ TODO: Figure out how to enable things based on `chip_device_platform == "efr32"` which is not currently in scope.
+enable_efr32_build_per_testsource = true  #++++ TODO: Figure out how to enable things based on `chip_device_platform == "efr32"` which is not currently in scope.
+
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+if (enable_efr32_build_per_suite || enable_efr32_build_per_testsource) {
+  import("//build_overrides/efr32_sdk.gni")  # Defines efr32_sdk_build_root
+  import("//build_overrides/nlunit_test.gni")  # Defines nlunit_test_root
+}
 
 import("${chip_root}/build/chip/chip_test.gni")
 import("${chip_root}/build/chip/tests.gni")
 import("${dir_pw_unit_test}/test.gni")
+if (enable_efr32_build_per_suite || enable_efr32_build_per_testsource) {
+  import("${efr32_sdk_build_root}/efr32_sdk.gni")
+  import("${efr32_sdk_build_root}/silabs_executable.gni")
+  #import("$dir_pw_protobuf_compiler/proto.gni")
+
+  #++++ TODO: Figure out how to get access to these variables from src/test_driver/efr32/BUILD.gn so we don't have to set them explicitly here.
+  examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
+  examples_common_plat_dir = "${chip_root}/examples/platform/silabs"
+  #efr32_project_dir = "${chip_root}/src/test_driver/efr32"
+}
 
 assert(chip_build_tests)
 
@@ -78,6 +95,115 @@ template("chip_test_suite") {
     invoker.sources += invoker.test_sources
   }
 
+  if (enable_efr32_build_per_suite || enable_efr32_build_per_testsource) {
+    # Since target_name is usually "tests", we need a unique name to use in the executable target.
+    if (defined(invoker.output_name)) {
+      # Get it from the suite's output_name.
+      _unique_suite_name = invoker.output_name
+    } else {
+      # Some test suites don't have output_name defined. Use the first source file.
+      _unique_suite_name = string_replace(string_join("-", invoker.test_sources), ".cpp", "")
+    }
+  }
+
+  print("++++ SUITE ${_unique_suite_name}")
+  if (enable_efr32_build_per_suite) {
+    #++++ DEBUG: Disabled code that was used for testing an alternative implementaiton.
+    #
+    # pw_proto_library("nl_test_service--${_unique_suite_name}") {
+    #   sources = [ "${efr32_project_dir}/proto/nl_test.proto" ]
+    #   inputs = [ "${efr32_project_dir}/proto/nl_test.options" ]
+    #   deps = [ "$dir_pw_protobuf:common_protos" ]
+    #   strip_prefix = "${efr32_project_dir}/proto"
+    #   prefix = "nl_test_service"
+    # }
+    #
+    # efr32_sdk("sdk--${_unique_suite_name}") {
+    #   sources = [
+    #     "${efr32_project_dir}/include/CHIPProjectConfig.h",
+    #     "${examples_common_plat_dir}/FreeRTOSConfig.h",
+    #   ]
+    #
+    #   include_dirs = [
+    #     "${chip_root}/src/platform/silabs/efr32",
+    #     "${efr32_project_dir}/include",
+    #     "${examples_plat_dir}",
+    #     "${examples_common_plat_dir}",
+    #   ]
+    #
+    #   defines = [
+    #     "PW_RPC_ENABLED",
+    #
+    #     # Thread is built but test driver do not have the NETWORK_COMMISSIONING cluster or zap config.
+    #     "_NO_NETWORK_COMMISSIONING_DRIVER_",
+    #   ]
+    # }
+
+    silabs_executable("efr32_device_tests--${_unique_suite_name}") {
+      output_name = "matter-silabs-device_tests--${_unique_suite_name}.out"
+
+      defines = [ "PW_RPC_ENABLED" ]
+      sources = [
+        "${chip_root}/examples/common/pigweed/RpcService.cpp",
+        "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
+        "${chip_root}/src/test_driver/efr32/src/main.cpp",  #++++ replace absolute path
+        "${examples_common_plat_dir}/PigweedLogger.cpp",
+        "${examples_common_plat_dir}/heap_4_silabs.c",
+        "${examples_common_plat_dir}/syscalls_stubs.cpp",
+        "${examples_plat_dir}/uart.cpp",
+      ]
+
+      deps = [
+        #++++ DEBUG: Disabled code that was used for testing an alternative implementaiton.
+        # "${chip_root}/src/test_driver/efr32:nl_test_service.nanopb_rpc",  #++++ replace absolute path
+        # "${chip_root}/src/test_driver/efr32:sdk",  #++++ replace absolute path
+        #":nl_test_service--${_unique_suite_name}.nanopb_rpc",
+        #":sdk--${_unique_suite_name}",
+
+        "$dir_pw_unit_test:rpc_service",
+        "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
+        "${chip_root}/examples/common/pigweed:system_rpc_server",
+        "${chip_root}/src/lib",
+        "${chip_root}/src/lib/support:pw_tests_wrapper",
+        "${chip_root}/src/lib/support:testing_nlunit",
+        "${examples_common_plat_dir}/pw_sys_io:pw_sys_io_silabs",
+        "${nlunit_test_root}:nlunit-test",
+      ]
+
+      # OpenThread Settings
+      if (chip_enable_openthread) {
+        deps += [
+          "${chip_root}/third_party/openthread:openthread",
+          "${chip_root}/third_party/openthread:openthread-platform",
+          "${examples_plat_dir}:efr-matter-shell",
+        ]
+      }
+
+      # Attestation Credentials
+      deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
+
+      # Factory Data Provider
+      if (use_efr32_factory_data_provider) {
+        deps += [ "${examples_plat_dir}:silabs-factory-data-provider" ]
+      }
+
+      deps += pw_build_LINK_DEPS
+
+      include_dirs = [ "${chip_root}/examples/common/pigweed/efr32" ]
+
+      ldscript = "${examples_common_plat_dir}/ldscripts/${silabs_family}.ld"
+
+      inputs = [ ldscript ]
+
+      ldflags = [
+        "-T" + rebase_path(ldscript, root_build_dir),
+        "-Wl,--no-warn-rwx-segment",
+      ]
+
+      output_dir = root_out_dir
+    }
+  }
+
   if (chip_build_test_static_libraries) {
     _target_type = "static_library"
   } else {
@@ -93,13 +219,17 @@ template("chip_test_suite") {
     }
 
     deps = [ dir_pw_unit_test ]
+    if (enable_efr32_build_per_suite) {
+      deps += [ ":efr32_device_tests--${_unique_suite_name}" ]
+    }
 
     if (current_os != "zephyr" && current_os != "mbed") {
       # Depend on stdio logging, and have it take precedence over the default platform backend
       public_deps += [ "${chip_root}/src/platform/logging:force_stdio" ]
     }
   }
-  if (chip_link_tests) {
+  if (chip_link_tests || enable_efr32_build_per_testsource) {  #++++ Temporary workaround rather than changing `chip_link_tests` and `chip_build_tests` in `tests.gni`
+    print("  ++++ LINK ${_unique_suite_name}")
     tests = []
 
     if (defined(invoker.test_sources)) {
@@ -109,6 +239,73 @@ template("chip_test_suite") {
         _test_output_dir = "${root_out_dir}/tests"
         if (defined(invoker.output_dir)) {
           _test_output_dir = invoker.output_dir
+        }
+
+        print("    ++++ TEST ${_unique_suite_name} -- ${_test_name}")
+        if (enable_efr32_build_per_testsource) {
+          silabs_executable("efr32_device_tests--${_unique_suite_name}--${_test_name}") {
+            output_name = "matter-silabs-device_tests--${_unique_suite_name}--${_test_name}.out"
+
+            defines = [ "PW_RPC_ENABLED" ]
+            sources = [
+              "${chip_root}/examples/common/pigweed/RpcService.cpp",
+              "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
+              "${chip_root}/src/test_driver/efr32/src/main.cpp",  #++++ replace absolute path
+              "${examples_common_plat_dir}/PigweedLogger.cpp",
+              "${examples_common_plat_dir}/heap_4_silabs.c",
+              "${examples_common_plat_dir}/syscalls_stubs.cpp",
+              "${examples_plat_dir}/uart.cpp",
+            ]
+
+            deps = [
+              #++++ DEBUG: Disabled code that was used for testing an alternative implementaiton.
+              # "${chip_root}/src/test_driver/efr32:nl_test_service.nanopb_rpc",  #++++ replace absolute path
+              # "${chip_root}/src/test_driver/efr32:sdk",  #++++ replace absolute path
+              #":nl_test_service--${_unique_suite_name}--${_test_name}.nanopb_rpc",
+              #":sdk--${_unique_suite_name}--${_test_name}",
+
+              "$dir_pw_unit_test:rpc_service",
+              "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
+              "${chip_root}/examples/common/pigweed:system_rpc_server",
+              "${chip_root}/src/lib",
+              "${chip_root}/src/lib/support:pw_tests_wrapper",
+              "${chip_root}/src/lib/support:testing_nlunit",
+              "${examples_common_plat_dir}/pw_sys_io:pw_sys_io_silabs",
+              "${nlunit_test_root}:nlunit-test",
+            ]
+
+            # OpenThread Settings
+            if (chip_enable_openthread) {
+              deps += [
+                "${chip_root}/third_party/openthread:openthread",
+                "${chip_root}/third_party/openthread:openthread-platform",
+                "${examples_plat_dir}:efr-matter-shell",
+              ]
+            }
+
+            # Attestation Credentials
+            deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
+
+            # Factory Data Provider
+            if (use_efr32_factory_data_provider) {
+              deps += [ "${examples_plat_dir}:silabs-factory-data-provider" ]
+            }
+
+            deps += pw_build_LINK_DEPS
+
+            include_dirs = [ "${chip_root}/examples/common/pigweed/efr32" ]
+
+            ldscript = "${examples_common_plat_dir}/ldscripts/${silabs_family}.ld"
+
+            inputs = [ ldscript ]
+
+            ldflags = [
+              "-T" + rebase_path(ldscript, root_build_dir),
+              "-Wl,--no-warn-rwx-segment",
+            ]
+
+            output_dir = root_out_dir
+          }
         }
 
         pw_test(_test_name) {
@@ -122,6 +319,9 @@ template("chip_test_suite") {
           public_deps += [ ":${_suite_name}.lib" ]
           sources = [ _test ]
           output_dir = _test_output_dir
+          if (enable_efr32_build_per_testsource) {
+            deps = [ ":efr32_device_tests--${_unique_suite_name}--${_test_name}" ]
+          }
         }
         tests += [ _test_name ]
       }

--- a/build/chip/tests.gni
+++ b/build/chip/tests.gni
@@ -36,7 +36,8 @@ declare_args() {
 
 declare_args() {
   # Use source_set instead of static_lib for tests.
-  chip_build_test_static_libraries = chip_device_platform != "efr32"
+  chip_build_test_static_libraries = true  #++++ With new test runner this should always be true.
+  #chip_build_test_static_libraries = chip_device_platform != "efr32"
 }
 
 declare_args() {

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -270,6 +270,11 @@ class Efr32Builder(GnBuilder):
 
         if self.app == Efr32App.UNIT_TEST:
             # Include test runner python wheels
+            for root, dirs, files in os.walk(os.path.join(self.output_dir, 'chip_pw_test_runner_wheels')):
+                for file in files:
+                    items["chip_pw_test_runner_wheels/" +
+                          file] = os.path.join(root, file)
+            # TODO [PW_MIGRATION]: remove the nl wheels once transition away from nlunit-test is completed
             for root, dirs, files in os.walk(os.path.join(self.output_dir, 'chip_nl_test_runner_wheels')):
                 for file in files:
                     items["chip_nl_test_runner_wheels/" +

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -215,6 +215,7 @@ class HostApp(Enum):
         elif self == HostApp.PYTHON_BINDINGS:
             yield 'controller/python'  # Directory containing WHL files
         elif self == HostApp.EFR32_TEST_RUNNER:
+            yield 'chip_pw_test_runner_wheels'
             yield 'chip_nl_test_runner_wheels'
         elif self == HostApp.TV_CASTING:
             yield 'chip-tv-casting-app'

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -59,16 +59,22 @@ if (chip_build_tests) {
       "${chip_root}/src/access/tests",
       "${chip_root}/src/crypto/tests",
       "${chip_root}/src/inet/tests",
-      "${chip_root}/src/lib/address_resolve/tests",
-      "${chip_root}/src/lib/asn1/tests",
-      "${chip_root}/src/lib/core/tests",
-      "${chip_root}/src/messaging/tests",
-      "${chip_root}/src/protocols/bdx/tests",
-      "${chip_root}/src/protocols/interaction_model/tests",
-      "${chip_root}/src/protocols/user_directed_commissioning/tests",
-      "${chip_root}/src/transport/retransmit/tests",
-      "${chip_root}/src/app/icd/server/tests",
     ]
+
+    # Skip on efr32 due to flash limitations.
+    if (chip_device_platform != "efr32") {
+      tests += [
+        "${chip_root}/src/lib/address_resolve/tests",
+        "${chip_root}/src/lib/asn1/tests",
+        "${chip_root}/src/lib/core/tests",
+        "${chip_root}/src/messaging/tests",
+        "${chip_root}/src/protocols/bdx/tests",
+        "${chip_root}/src/protocols/interaction_model/tests",
+        "${chip_root}/src/protocols/user_directed_commissioning/tests",
+        "${chip_root}/src/transport/retransmit/tests",
+        "${chip_root}/src/app/icd/server/tests",
+      ]
+    }
 
     # Skip DNSSD tests for Mbed platform due to flash memory size limitations
     if (current_os != "mbed") {

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -59,22 +59,22 @@ if (chip_build_tests) {
       "${chip_root}/src/access/tests",
       "${chip_root}/src/crypto/tests",
       "${chip_root}/src/inet/tests",
+      "${chip_root}/src/lib/address_resolve/tests",
+      "${chip_root}/src/lib/asn1/tests",
+      "${chip_root}/src/lib/core/tests",
+      "${chip_root}/src/messaging/tests",
+      "${chip_root}/src/protocols/bdx/tests",
+      "${chip_root}/src/protocols/interaction_model/tests",
+      "${chip_root}/src/protocols/user_directed_commissioning/tests",
+      "${chip_root}/src/transport/retransmit/tests",
+      "${chip_root}/src/app/icd/server/tests",
+      "${chip_root}/src/app/tests",
+      "${chip_root}/src/lib/format/tests",
+      "${chip_root}/src/protocols/secure_channel/tests",
+      "${chip_root}/src/protocols/secure_channel/tests:tests_nltest",
+      "${chip_root}/src/system/tests",
+      "${chip_root}/src/transport/tests",
     ]
-
-    # Skip on efr32 due to flash limitations.
-    if (chip_device_platform != "efr32") {
-      tests += [
-        "${chip_root}/src/lib/address_resolve/tests",
-        "${chip_root}/src/lib/asn1/tests",
-        "${chip_root}/src/lib/core/tests",
-        "${chip_root}/src/messaging/tests",
-        "${chip_root}/src/protocols/bdx/tests",
-        "${chip_root}/src/protocols/interaction_model/tests",
-        "${chip_root}/src/protocols/user_directed_commissioning/tests",
-        "${chip_root}/src/transport/retransmit/tests",
-        "${chip_root}/src/app/icd/server/tests",
-      ]
-    }
 
     # Skip DNSSD tests for Mbed platform due to flash memory size limitations
     if (current_os != "mbed") {
@@ -90,25 +90,18 @@ if (chip_build_tests) {
       tests += [ "${chip_root}/src/lib/dnssd/minimal_mdns/records/tests" ]
     }
 
-    if (current_os != "zephyr" && current_os != "mbed" &&
-        chip_device_platform != "efr32") {
+    if (current_os != "zephyr" && current_os != "mbed") {
       tests += [
         "${chip_root}/src/setup_payload/tests",
         "${chip_root}/src/transport/raw/tests",
       ]
     }
 
-    # Skip on efr32 due to flash and/or ram limitations.
+    # Won't build on efr32.  openr.c:(.text._open_r+0x10): warning: _open is not implemented and will always fail due to flash and/or ram limitations.
     if (chip_device_platform != "efr32") {
       tests += [
-        "${chip_root}/src/app/tests",
         "${chip_root}/src/credentials/tests",
-        "${chip_root}/src/lib/format/tests",
         "${chip_root}/src/lib/support/tests",
-        "${chip_root}/src/protocols/secure_channel/tests",
-        "${chip_root}/src/protocols/secure_channel/tests:tests_nltest",
-        "${chip_root}/src/system/tests",
-        "${chip_root}/src/transport/tests",
       ]
 
       if (matter_enable_tracing_support &&
@@ -121,8 +114,7 @@ if (chip_build_tests) {
       tests += [ "${chip_root}/src/lib/dnssd/minimal_mdns/tests" ]
     }
 
-    if (chip_device_platform != "esp32" && chip_device_platform != "efr32" &&
-        chip_device_platform != "ameba") {
+    if (chip_device_platform != "esp32" && chip_device_platform != "ameba") {
       tests += [ "${chip_root}/src/platform/tests" ]
     }
 

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -23,8 +23,7 @@ chip_test_suite("tests") {
 
   test_sources = [ "TestCommissionableNodeController.cpp" ]
 
-  if (chip_device_platform != "mbed" && chip_device_platform != "efr32" &&
-      chip_device_platform != "esp32") {
+  if (chip_device_platform != "mbed" && chip_device_platform != "esp32") {
     test_sources += [ "TestServerCommandDispatch.cpp" ]
     test_sources += [ "TestEventChunking.cpp" ]
     test_sources += [ "TestEventCaching.cpp" ]

--- a/src/lib/core/tests/BUILD.gn
+++ b/src/lib/core/tests/BUILD.gn
@@ -30,13 +30,8 @@ chip_test_suite("tests") {
     "TestOptional.cpp",
     "TestReferenceCounted.cpp",
     "TestTLV.cpp",
+    "TestTLVVectorWriter.cpp",
   ]
-
-  # requires large amount of heap for multiple unfragmented 10k buffers
-  # skip for efr32 to allow flash space for other tests
-  if (chip_device_platform != "efr32") {
-    test_sources += [ "TestTLVVectorWriter.cpp" ]
-  }
 
   cflags = [ "-Wconversion" ]
 

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -130,6 +130,9 @@ group("efr32") {
 
 group("runner") {
   deps = [
+    "${efr32_project_dir}/py:pw_test_runner.install",
+    "${efr32_project_dir}/py:pw_test_runner_wheel",
+    # TODO [PW_MIGRATION]: remove the following when transition from nlunit-test is complete.
     "${efr32_project_dir}/py:nl_test_runner.install",
     "${efr32_project_dir}/py:nl_test_runner_wheel",
   ]

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -19,7 +19,6 @@ import("//build_overrides/pigweed.gni")
 
 import("${build_root}/config/defaults.gni")
 import("${efr32_sdk_build_root}/efr32_sdk.gni")
-import("${efr32_sdk_build_root}/silabs_executable.gni")
 
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/src/platform/device.gni")
@@ -63,78 +62,18 @@ efr32_sdk("sdk") {
   ]
 }
 
-silabs_executable("efr32_device_tests") {
-  output_name = "matter-silabs-device_tests.out"
-
-  defines = [ "PW_RPC_ENABLED" ]
-  sources = [
-    "${chip_root}/examples/common/pigweed/RpcService.cpp",
-    "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
-    "${examples_common_plat_dir}/PigweedLogger.cpp",
-    "${examples_common_plat_dir}/heap_4_silabs.c",
-    "${examples_common_plat_dir}/syscalls_stubs.cpp",
-    "${examples_plat_dir}/uart.cpp",
-    "src/main.cpp",
-  ]
-
-  deps = [
-    ":nl_test_service.nanopb_rpc",
-    ":sdk",
-    "$dir_pw_unit_test:rpc_service",
-    "${chip_root}/config/efr32/lib/pw_rpc:pw_rpc",
-    "${chip_root}/examples/common/pigweed:system_rpc_server",
-    "${chip_root}/src:tests",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/lib/support:pw_tests_wrapper",
-    "${chip_root}/src/lib/support:testing_nlunit",
-    "${examples_common_plat_dir}/pw_sys_io:pw_sys_io_silabs",
-    "${nlunit_test_root}:nlunit-test",
-  ]
-
-  # OpenThread Settings
-  if (chip_enable_openthread) {
-    deps += [
-      "${chip_root}/third_party/openthread:openthread",
-      "${chip_root}/third_party/openthread:openthread-platform",
-      "${examples_plat_dir}:efr-matter-shell",
-    ]
-  }
-
-  # Attestation Credentials
-  deps += [ "${examples_plat_dir}:efr32-attestation-credentials" ]
-
-  # Factory Data Provider
-  if (use_efr32_factory_data_provider) {
-    deps += [ "${examples_plat_dir}:silabs-factory-data-provider" ]
-  }
-
-  deps += pw_build_LINK_DEPS
-
-  include_dirs = [ "${chip_root}/examples/common/pigweed/efr32" ]
-
-  ldscript = "${examples_common_plat_dir}/ldscripts/${silabs_family}.ld"
-
-  inputs = [ ldscript ]
-
-  ldflags = [
-    "-T" + rebase_path(ldscript, root_build_dir),
-    "-Wl,--no-warn-rwx-segment",
-  ]
-
-  output_dir = root_out_dir
-}
-
 group("efr32") {
-  deps = [ ":efr32_device_tests" ]
+  deps = [
+    ":nl_test_service.nanopb_rpc",  #++++ belongs here or in chip_test_suite->silabs_executable?
+    ":sdk",                         #++++ belongs here or in chip_test_suite->silabs_executable?
+    "${chip_root}/src:tests",
+  ]
 }
 
 group("runner") {
   deps = [
     "${efr32_project_dir}/py:pw_test_runner.install",
     "${efr32_project_dir}/py:pw_test_runner_wheel",
-    # TODO [PW_MIGRATION]: remove the following when transition from nlunit-test is complete.
-    "${efr32_project_dir}/py:nl_test_runner.install",
-    "${efr32_project_dir}/py:nl_test_runner_wheel",
   ]
 }
 

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -1,6 +1,6 @@
 #CHIP EFR32 Test Driver
 
-This builds and runs the NLUnitTest on the efr32 device
+This builds and runs the PW Unit Tests on the efr32 device
 
 <hr>
 
@@ -14,7 +14,7 @@ This builds and runs the NLUnitTest on the efr32 device
 
 ## Introduction
 
-This builds a test binary which contains the NLUnitTests and can be flashed onto
+This builds a test binary which contains the pw_unit_test and can be flashed onto
 a device. The device is controlled using the included RPCs, through the python
 test runner.
 
@@ -99,7 +99,7 @@ Or build using build script from the root
 
     ```
     cd <connectedhomeip>
-    ./scripts/build/build_examples.py --target linux-x64-nl-test-runner build
+    ./scripts/build/build_examples.py --target linux-x64-pw-test-runner build
     ```
 
 The runner will be installed into the venv and python wheels will be packaged in
@@ -108,7 +108,7 @@ the output folder for deploying.
 Then the python wheels need to installed using pip3.
 
     ```
-    pip3 install out/debug/chip_nl_test_runner_wheels/*.whl
+    pip3 install out/debug/chip_pw_test_runner_wheels/*.whl
     ```
 
 Other python libraries may need to be installed such as
@@ -117,8 +117,8 @@ Other python libraries may need to be installed such as
     pip3 install pyserial
     ```
 
--   To run the tests:
+To run all tests:
 
     ```
-    python -m nl_test_runner.nl_test_runner -d /dev/ttyACM1 -f out/debug/matter-silabs-device_tests.s37 -o out.log
+    python -m pw_test_runner.pw_test_runner -d /dev/ttyACM1 -f out/debug -o out.log
     ```

--- a/src/test_driver/efr32/args.gni
+++ b/src/test_driver/efr32/args.gni
@@ -24,7 +24,8 @@ chip_enable_pw_rpc = true
 chip_build_tests = true
 chip_enable_openthread = true
 chip_openthread_ftd = false  # use mtd as it is smaller.
-chip_monolithic_tests = true
+chip_monolithic_tests = false  #++++ With new test runner this should always be false.
+#chip_monolithic_tests = true
 
 openthread_external_platform =
     "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"

--- a/src/test_driver/efr32/py/setup.cfg
+++ b/src/test_driver/efr32/py/setup.cfg
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 [metadata]
-name = nl_test_runner
+name = pw_test_runner
 version = 0.0.1
 
 [options]

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -44,9 +44,8 @@ chip_test_suite("tests") {
     "TestSessionManagerDispatch.cpp",
   ]
 
-  if (chip_device_platform != "mbed" && chip_device_platform != "efr32" &&
-      chip_device_platform != "esp32" && chip_device_platform != "nrfconnect" &&
-      chip_device_platform != "nxp") {
+  if (chip_device_platform != "mbed" && chip_device_platform != "esp32" &&
+      chip_device_platform != "nrfconnect" && chip_device_platform != "nxp") {
     test_sources += [ "TestSecureSessionTable.cpp" ]
   }
 

--- a/third_party/silabs/silabs_executable.gni
+++ b/third_party/silabs/silabs_executable.gni
@@ -68,7 +68,7 @@ template("silabs_executable") {
   ]
   copy(flashing_runtime_target) {
     sources = flashing_script_inputs
-    outputs = [ "${root_out_dir}/{{source_file_part}}" ]
+    outputs = [ "${root_out_dir}/${target_name}--{{source_file_part}}" ]
   }
 
   flashing_script_generator =


### PR DESCRIPTION
The approach here is to move the `silabs_executable` target into `chip_test_suite`.  The advantage is that we don't need to update anything if we add a new directory of tests, since it will make a new efr32 binary target each time `chip_test_suite` gets invoked.  The disadvantage is that it moves a lot of efr32-specific stuff into `chip_test_suite`, which may not be desirable.

In this version I experimented with creating a binary for each test suite (e.g. `src/messaging/tests`) versus creating a binary for each test source (e.g. `src/messaging/tests/TestExchange.cpp`).  There are some debug flags at the top of `build/chip/chip_test_suite.gni` that control which one is being implemented.  It is currently set to create a binary for each test source.

So far I have not gotten this to build successfully, probably due to `nl_test_service` being defined in the wrong place.  Solving this issue is the next step, however I wanted to stop and get some feedback about the overall approach before going further.

(This is a work in progress, so please ignore any commented-out code and print statements.)
