### PR TITLE
Stop using MSEC_PER_SEC without directly including relevant headers.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRConversion.h
+++ b/src/darwin/Framework/CHIP/MTRConversion.h
@@ -19,6 +19,7 @@
 
 #import <Foundation/Foundation.h>
 
+#include <chrono>
 #include <lib/core/CASEAuthTag.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/Optional.h>
@@ -38,6 +39,12 @@ AsNumber(chip::Optional<T> optional)
 inline NSDate * MatterEpochSecondsAsDate(uint32_t matterEpochSeconds)
 {
     return [NSDate dateWithTimeIntervalSince1970:(chip::kChipEpochSecondsSinceUnixEpoch + (NSTimeInterval) matterEpochSeconds)];
+}
+
+template <typename Rep, typename Period>
+inline NSTimeInterval DurationToTimeInterval(std::chrono::duration<Rep, Period> duration)
+{
+    return std::chrono::duration<NSTimeInterval>(duration).count();
 }
 
 /**

--- a/src/darwin/Framework/CHIP/MTRDeviceConnectionBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceConnectionBridge.mm
@@ -17,6 +17,7 @@
 
 #import "MTRDeviceConnectionBridge.h"
 #import "MTRBaseDevice_Internal.h"
+#import "MTRConversion.h"
 #import "MTRError_Internal.h"
 
 void MTRDeviceConnectionBridge::OnConnected(
@@ -31,7 +32,7 @@ void MTRDeviceConnectionBridge::OnConnectionFailure(void * context, const chip::
 {
     NSNumber * retryDelay;
     if (failureInfo.requestedBusyDelay.HasValue()) {
-        retryDelay = @(static_cast<double>(failureInfo.requestedBusyDelay.Value().count()) / MSEC_PER_SEC);
+        retryDelay = @(DurationToTimeInterval(failureInfo.requestedBusyDelay.Value()));
     }
     auto * object = static_cast<MTRDeviceConnectionBridge *>(context);
     object->mCompletionHandler(nil, chip::NullOptional, [MTRError errorForCHIPErrorCode:failureInfo.error], retryDelay);


### PR DESCRIPTION
And stop doing time math by hand, use duration_cast.

Fixes https://github.com/project-chip/connectedhomeip/issues/33793
