### PR TITLE
Clear Aliro credentials when ClearCredential for all credentials happens.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -3038,6 +3038,24 @@ Status DoorLockServer::clearCredentials(chip::EndpointId endpointId, chip::Fabri
         ChipLogProgress(Zcl, "[clearCredentials] All face credentials were cleared [endpointId=%d]", endpointId);
     }
 
+    if (SupportsAliroProvisioning(endpointId))
+    {
+        for (auto & credentialType :
+             { CredentialTypeEnum::kAliroEvictableEndpointKey, CredentialTypeEnum::kAliroCredentialIssuerKey,
+               CredentialTypeEnum::kAliroNonEvictableEndpointKey })
+        {
+            auto status = clearCredentials(endpointId, modifier, sourceNodeId, credentialType);
+            if (Status::Success != status)
+            {
+                ChipLogError(Zcl,
+                             "[clearCredentials] Unable to clear all Aliro credentials [endpointId=%d,credentialType=%d,status=%d]",
+                             endpointId, to_underlying(credentialType), to_underlying(status));
+                return status;
+            }
+        }
+        ChipLogProgress(Zcl, "[clearCredentials] All Aliro credentials were cleared [endpointId=%d]", endpointId);
+    }
+
     return Status::Success;
 }
 


### PR DESCRIPTION
We were not clearing credentials of the Aliro types in this situation.
