### PR TITLE
Generate LockUserChange events when clearing a credential.

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -171,6 +171,7 @@ def _GetDarwinFrameworkToolUnsupportedTests() -> Set[str]:
     """Tests that fail in darwin-framework-tool for some reason"""
     return {
         "DL_LockUnlock",  # darwin-framework-tool does not currently support reading or subscribing to Events
+        "DL_UsersAndCredentials",  # darwin-framework-tool does not currently support reading or subscribing to Events
         "Test_AddNewFabricFromExistingFabric",  # darwin-framework-tool does not support the GetCommissionerRootCertificate command.
         # The name of the arguments once converted differs for chip-tool and darwin-framework-tool (attribute-ids vs attribute-id. See #31934)
         "TestAttributesById",

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -951,7 +951,7 @@ void DoorLockServer::clearCredentialCommandHandler(
     }
 
     commandObj->AddStatus(commandPath,
-                          clearCredential(commandPath.mEndpointId, modifier, sourceNodeId, credentialType, credentialIndex, false));
+                          clearCredential(commandPath.mEndpointId, modifier, sourceNodeId, credentialType, credentialIndex, true));
 }
 
 void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -951,7 +951,8 @@ void DoorLockServer::clearCredentialCommandHandler(
     }
 
     commandObj->AddStatus(commandPath,
-                          clearCredential(commandPath.mEndpointId, modifier, sourceNodeId, credentialType, credentialIndex, /* sendUserChangeEvent = */ true ));
+                          clearCredential(commandPath.mEndpointId, modifier, sourceNodeId, credentialType, credentialIndex,
+                                          /* sendUserChangeEvent = */ true));
 }
 
 void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -951,7 +951,7 @@ void DoorLockServer::clearCredentialCommandHandler(
     }
 
     commandObj->AddStatus(commandPath,
-                          clearCredential(commandPath.mEndpointId, modifier, sourceNodeId, credentialType, credentialIndex, true));
+                          clearCredential(commandPath.mEndpointId, modifier, sourceNodeId, credentialType, credentialIndex, /* sendUserChangeEvent = */ true ));
 }
 
 void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,

--- a/src/app/tests/suites/DL_UsersAndCredentials.yaml
+++ b/src/app/tests/suites/DL_UsersAndCredentials.yaml
@@ -2051,6 +2051,23 @@ tests:
               - name: "NextUserIndex"
                 value: 2
 
+    - label: "Make sure a LockUserChange event was generated"
+      command: "readEvent"
+      event: "LockUserChange"
+      # I wish there were a way to not hardcode this 25, but it's experimentally
+      # determined: doing a read without an eventNumber filter here shows 24
+      # LockUserChange events before this removal.
+      eventNumber: 25
+      response:
+          value:
+              {
+                  LockDataType: LockDataTypeEnum.PIN,
+                  DataOperationType: DataOperationTypeEnum.Clear,
+                  OperationSource: OperationSourceEnum.Remote,
+                  UserIndex: 1,
+                  DataIndex: 1,
+              }
+
     - label: "Clear the second PIN credential"
       command: "ClearCredential"
       timedInteractionTimeoutMs: 10000


### PR DESCRIPTION
We were passing false for sendUserChangeEvent at all callsites of clearCredential(), which is not correct for the "clear a single credential" case.  The other cases generate their own LockUserChange events.
