### PR TITLE
[Tizen] Improve memory management in BLE module

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -546,6 +546,7 @@ void BLEManagerImpl::OnScanComplete()
 
 void BLEManagerImpl::OnScanError(CHIP_ERROR err)
 {
+    BleConnectionDelegate::OnConnectionError(mBLEScanConfig.mAppState, err);
     ChipLogDetail(Ble, "BLE scan error: %" CHIP_ERROR_FORMAT, err.Format());
 }
 

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -996,7 +996,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
 
     ChipLogProgress(DeviceLayer, "Initialize Tizen BLE Layer");
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BLEManagerImpl * self) { return self->_InitImpl(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BLEManagerImpl * self) { return self->_InitImpl(); }, this);
     SuccessOrExit(err);
 
     // The hash table key is stored in the BLEConnection structure

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -175,8 +175,6 @@ private:
 
     void DriveBLEState();
 
-    void InitiateScan(BleScanState scanType);
-
     void AdapterStateChangedCb(int result, bt_adapter_state_e adapterState);
     void AdvertisingStateChangedCb(int result, bt_advertiser_h advertiser, bt_adapter_le_advertising_state_e advState);
     void NotificationStateChangedCb(bool notify, bt_gatt_server_h server, bt_gatt_h gattHandle);
@@ -188,6 +186,10 @@ private:
     void GattConnectionStateChangedCb(int result, bool connected, const char * remoteAddress);
     static void WriteCompletedCb(int result, bt_gatt_h gattHandle, void * userData);
     static void CharacteristicNotificationCb(bt_gatt_h characteristic, char * value, int len, void * userData);
+
+    // ==== BLE Scan.
+    void InitiateScan(BleScanState scanType);
+    static void HandleScanTimeout(chip::System::Layer *, void * appState);
 
     // ==== Connection.
     void AddConnectionData(const char * remoteAddr);

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -136,7 +136,7 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
+    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
     CHIP_ERROR CancelConnection() override;
 
     //  ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -140,7 +140,8 @@ private:
     CHIP_ERROR CancelConnection() override;
 
     //  ===== Members that implement virtual methods on ChipDeviceScannerDelegate
-    void OnDeviceScanned(void * device, const Ble::ChipBLEDeviceIdentificationInfo & info) override;
+    void OnDeviceScanned(const bt_adapter_le_device_scan_result_info_s & scanInfo,
+                         const Ble::ChipBLEDeviceIdentificationInfo & info) override;
     void OnScanComplete() override;
     void OnScanError(CHIP_ERROR err) override;
 

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -214,8 +214,8 @@ private:
 
     // ==== Connection.
     CHIP_ERROR ConnectChipThing(const char * address);
-    void NotifyBLEConnectionEstablished(BLE_CONNECTION_OBJECT conId, CHIP_ERROR error);
-    void NotifyBLEDisconnection(BLE_CONNECTION_OBJECT conId, CHIP_ERROR error);
+    void NotifyBLEConnectionEstablished(BLE_CONNECTION_OBJECT conId);
+    void NotifyBLEDisconnection(BLE_CONNECTION_OBJECT conId);
     void NotifyHandleNewConnection(BLE_CONNECTION_OBJECT conId);
     void NotifyHandleConnectFailed(CHIP_ERROR error);
     void NotifyHandleWriteComplete(BLE_CONNECTION_OBJECT conId);

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -90,6 +90,9 @@ class BLEManagerImpl final : public BLEManager,
     friend BLEManager;
 
 public:
+    BLEManagerImpl() : mDeviceScanner(this) {}
+    ~BLEManagerImpl() = default;
+
     CHIP_ERROR ConfigureBle(uint32_t aAdapterId, bool aIsCentral);
 
 private:
@@ -133,11 +136,11 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
+    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
     CHIP_ERROR CancelConnection() override;
 
     //  ===== Members that implement virtual methods on ChipDeviceScannerDelegate
-    void OnChipDeviceScanned(void * device, const Ble::ChipBLEDeviceIdentificationInfo & info) override;
+    void OnDeviceScanned(void * device, const Ble::ChipBLEDeviceIdentificationInfo & info) override;
     void OnScanComplete() override;
     void OnScanError(CHIP_ERROR err) override;
 
@@ -232,8 +235,9 @@ private:
     /* Connection Hash Table Map */
     GHashTable * mConnectionMap = nullptr;
 
+    ChipDeviceScanner mDeviceScanner;
     BLEScanConfig mBLEScanConfig;
-    std::unique_ptr<ChipDeviceScanner> mDeviceScanner;
+
     bt_gatt_client_h mGattClient = nullptr;
 };
 

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -148,7 +148,8 @@ CHIP_ERROR ChipDeviceScanner::StartScan(ScanFilterType filterType, const ScanFil
     SetupScanFilter(filterType, filterData);
 
     // All set to trigger LE Scan
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
     SuccessOrExit(err);
 
     return CHIP_NO_ERROR;

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -38,6 +38,8 @@
 #include <platform/GLibTypeDeleter.h>
 #include <platform/PlatformManager.h>
 
+#include "ErrorUtils.h"
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
@@ -54,16 +56,15 @@ static void __PrintLEScanData(const bt_adapter_le_service_data_s & data)
     ChipLogByteSpan(DeviceLayer, ByteSpan(reinterpret_cast<uint8_t *>(data.service_data), data.service_data_len));
 }
 
-static bool __IsChipThingDevice(bt_adapter_le_device_scan_result_info_s * info,
-                                chip::Ble::ChipBLEDeviceIdentificationInfo & aDeviceInfo)
+static bool __IsChipThingDevice(const bt_adapter_le_device_scan_result_info_s & scanInfo,
+                                chip::Ble::ChipBLEDeviceIdentificationInfo & info)
 {
-    VerifyOrReturnError(info != nullptr, false);
-
     int count                               = 0;
     bt_adapter_le_service_data_s * dataList = nullptr;
     bool isChipDevice                       = false;
 
-    if (bt_adapter_le_get_scan_result_service_data_list(info, BT_ADAPTER_LE_PACKET_ADVERTISING, &dataList, &count) == BT_ERROR_NONE)
+    if (bt_adapter_le_get_scan_result_service_data_list(&scanInfo, BT_ADAPTER_LE_PACKET_ADVERTISING, &dataList, &count) ==
+        BT_ERROR_NONE)
     {
         for (int i = 0; i < count; i++)
         {
@@ -71,7 +72,7 @@ static bool __IsChipThingDevice(bt_adapter_le_device_scan_result_info_s * info,
                 strcasecmp(dataList[i].service_uuid, chip::Ble::CHIP_BLE_SERVICE_SHORT_UUID_STR) == 0)
             {
                 __PrintLEScanData(dataList[i]);
-                memcpy(&aDeviceInfo, dataList[i].service_data, dataList[i].service_data_len);
+                memcpy(&info, dataList[i].service_data, dataList[i].service_data_len);
                 isChipDevice = true;
                 break;
             }
@@ -82,19 +83,19 @@ static bool __IsChipThingDevice(bt_adapter_le_device_scan_result_info_s * info,
     return isChipDevice;
 }
 
-void ChipDeviceScanner::LeScanResultCb(int result, bt_adapter_le_device_scan_result_info_s * info, void * userData)
+void ChipDeviceScanner::LeScanResultCb(int result, bt_adapter_le_device_scan_result_info_s * scanInfo)
 {
-    VerifyOrReturn(info != nullptr);
+    VerifyOrReturn(result == BT_ERROR_NONE, mDelegate->OnScanError(TizenToChipError(result)));
+    VerifyOrReturn(scanInfo != nullptr, mDelegate->OnScanError(CHIP_ERROR_INTERNAL));
 
-    auto self = reinterpret_cast<ChipDeviceScanner *>(userData);
-    chip::Ble::ChipBLEDeviceIdentificationInfo deviceInfo;
+    ChipLogProgress(DeviceLayer, "LE device reported: %s", scanInfo->remote_address);
 
-    ChipLogProgress(DeviceLayer, "LE device reported: %s", info->remote_address);
-    VerifyOrReturn(__IsChipThingDevice(info, deviceInfo),
-                   ChipLogDetail(Ble, "Device %s does not look like a CHIP device", info->remote_address));
+    chip::Ble::ChipBLEDeviceIdentificationInfo info;
+    VerifyOrReturn(__IsChipThingDevice(*scanInfo, info),
+                   ChipLogDetail(Ble, "Device %s does not look like a CHIP device", scanInfo->remote_address));
 
     // Report probable CHIP device to BLEMgrImp class
-    self->mDelegate->OnDeviceScanned(info, deviceInfo);
+    mDelegate->OnDeviceScanned(*scanInfo, info);
 }
 
 gboolean ChipDeviceScanner::TimerExpiredCb(void * userData)
@@ -105,20 +106,22 @@ gboolean ChipDeviceScanner::TimerExpiredCb(void * userData)
     return G_SOURCE_REMOVE;
 }
 
-CHIP_ERROR ChipDeviceScanner::TriggerScan(ChipDeviceScanner * self)
+CHIP_ERROR ChipDeviceScanner::StartScanImpl()
 {
-    GAutoPtr<GSource> idleSource;
     int ret;
 
-    // Trigger LE Scan
-    ret = bt_adapter_le_start_scan(LeScanResultCb, self);
+    ret = bt_adapter_le_start_scan(
+        +[](int result, bt_adapter_le_device_scan_result_info_s * scanInfo, void * self) {
+            return reinterpret_cast<ChipDeviceScanner *>(self)->LeScanResultCb(result, scanInfo);
+        },
+        this);
     VerifyOrReturnValue(ret == BT_ERROR_NONE, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "bt_adapter_le_start_scan() failed: %s", get_error_message(ret)));
-    self->mIsScanning = true;
+    mIsScanning = true;
 
     // Setup timer for scan timeout
-    idleSource = GAutoPtr<GSource>(g_timeout_source_new(self->mScanTimeoutMs));
-    g_source_set_callback(idleSource.get(), TimerExpiredCb, self, nullptr);
+    GAutoPtr<GSource> idleSource = GAutoPtr<GSource>(g_timeout_source_new(mScanTimeoutMs));
+    g_source_set_callback(idleSource.get(), TimerExpiredCb, this, nullptr);
     g_source_set_priority(idleSource.get(), G_PRIORITY_HIGH_IDLE);
     g_source_attach(idleSource.get(), g_main_context_get_thread_default());
 
@@ -157,7 +160,7 @@ CHIP_ERROR ChipDeviceScanner::StartScan(System::Clock::Timeout timeout, ScanFilt
                                         const ScanFilterData & filterData)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    ReturnErrorCodeIf(mIsScanning, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mIsScanning, CHIP_ERROR_INCORRECT_STATE);
 
     // Scan Filter Setup if supported: silently bypass error & do filterless scan in case of error
     SetupScanFilter(filterType, filterData);
@@ -166,7 +169,7 @@ CHIP_ERROR ChipDeviceScanner::StartScan(System::Clock::Timeout timeout, ScanFilt
 
     // All set to trigger LE Scan
     ChipLogProgress(DeviceLayer, "Start CHIP BLE scan: timeout=%ums", mScanTimeoutMs);
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(TriggerScan, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](ChipDeviceScanner * self) { return self->StartScanImpl(); }, this);
     SuccessOrExit(err);
 
     return CHIP_NO_ERROR;

--- a/src/platform/Tizen/ChipDeviceScanner.h
+++ b/src/platform/Tizen/ChipDeviceScanner.h
@@ -82,15 +82,14 @@ public:
     ChipDeviceScanner(ChipDeviceScannerDelegate * delegate) : mDelegate(delegate){};
     ~ChipDeviceScanner() { StopScan(); }
 
-    /// Initiate a scan for devices, with the given timeout & scan filter data
-    CHIP_ERROR StartScan(System::Clock::Timeout timeout, ScanFilterType filterType, const ScanFilterData & filterData);
+    /// Initiate a scan for devices, with the given scan filter data
+    CHIP_ERROR StartScan(ScanFilterType filterType, const ScanFilterData & filterData);
 
     /// Stop any currently running scan
     CHIP_ERROR StopScan();
 
 private:
     void LeScanResultCb(int result, bt_adapter_le_device_scan_result_info_s * scanInfo);
-    static gboolean TimerExpiredCb(void * userData);
     CHIP_ERROR StartScanImpl();
 
     int CreateLEScanFilter(ScanFilterType filterType);
@@ -101,7 +100,6 @@ private:
     ChipDeviceScannerDelegate * mDelegate;
     bool mIsScanning             = false;
     bool mIsStopping             = false;
-    unsigned int mScanTimeoutMs  = 10000;
     bt_scan_filter_h mScanFilter = nullptr;
 };
 

--- a/src/platform/Tizen/ChipDeviceScanner.h
+++ b/src/platform/Tizen/ChipDeviceScanner.h
@@ -63,7 +63,8 @@ public:
     virtual ~ChipDeviceScannerDelegate() {}
 
     // Called when a CHIP device was found
-    virtual void OnDeviceScanned(void * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info) = 0;
+    virtual void OnDeviceScanned(const bt_adapter_le_device_scan_result_info_s & scanInfo,
+                                 const Ble::ChipBLEDeviceIdentificationInfo & info) = 0;
 
     // Called when a scan was completed (stopped or timed out)
     virtual void OnScanComplete() = 0;
@@ -88,9 +89,9 @@ public:
     CHIP_ERROR StopScan();
 
 private:
-    static void LeScanResultCb(int result, bt_adapter_le_device_scan_result_info_s * info, void * userData);
+    void LeScanResultCb(int result, bt_adapter_le_device_scan_result_info_s * scanInfo);
     static gboolean TimerExpiredCb(void * userData);
-    static CHIP_ERROR TriggerScan(ChipDeviceScanner * userData);
+    CHIP_ERROR StartScanImpl();
 
     int CreateLEScanFilter(ScanFilterType filterType);
     int RegisterScanFilter(ScanFilterType filterType, const ScanFilterData & filterData);


### PR DESCRIPTION
### Problem

Since Tizen is a Linux like OS, the BLE management can be "synchronized" with Linux platform implementation.

### Changes

- make BLE device scanner object an on the stack member of BLE manager
- fix BLE scanning timeout management (sync with Linux implementation)
- if possible do not pass args via pointers but rather by const refs

### Testing

Locally tested BLE commissioning Tizen (controller) - Linux (app)