### PR TITLE
[Silabs] Removing the 917 SoC condition from the NVM

### DIFF
--- a/src/platform/silabs/SilabsConfig.cpp
+++ b/src/platform/silabs/SilabsConfig.cpp
@@ -33,7 +33,6 @@
 #include <nvm3_hal_flash.h>
 #include <nvm3_lock.h>
 
-#ifndef SLI_SI91X_MCU_INTERFACE // 917soc/wifi-sdk implements the same nvm3 lock/unlock mechanism and it currently can't be overide.
 #include <FreeRTOS.h>
 #include <semphr.h>
 // Substitute the GSDK weak nvm3_lockBegin and nvm3_lockEnd
@@ -58,7 +57,6 @@ void nvm3_lockEnd(void)
     VerifyOrDie(nvm3_Sem != NULL);
     xSemaphoreGive(nvm3_Sem);
 }
-#endif // !SLI_SI91X_MCU_INTERFACE
 
 namespace chip {
 namespace DeviceLayer {
@@ -78,9 +76,7 @@ CHIP_ERROR SilabsConfig::Init()
 
 void SilabsConfig::DeInit()
 {
-#ifndef SLI_SI91X_MCU_INTERFACE
     vSemaphoreDelete(nvm3_Sem);
-#endif // !SLI_SI91X_MCU_INTERFACE
     nvm3_close(nvm3_defaultHandle);
 }
 


### PR DESCRIPTION
The 917 SoC was having the issue with the nvm open since the lock and unlock operations were taken by the default rather than the SilabsConfig.cpp

`NVM3_LOCK_OVERRIDE` was added in sdk.gni but this was not removed.