### PR TITLE
[Darwin] MTRDevice subscription pool test timeout should be increased

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -35,7 +35,7 @@ static const uint16_t kPairingTimeoutInSeconds = 10;
 static const uint16_t kTimeoutInSeconds = 3;
 static NSString * kOnboardingPayload = @"MT:-24J0AFN00KA0648G00";
 static const uint16_t kTestVendorId = 0xFFF1u;
-static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 10;
+static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
 
 @interface MTRPerControllerStorageTestsControllerDelegate : NSObject <MTRDeviceControllerDelegate>
 @property (nonatomic, strong) XCTestExpectation * expectation;


### PR DESCRIPTION
@bzbarsky-apple saw that the subscription pool test sometimes times out: https://github.com/project-chip/connectedhomeip/actions/runs/9420981505/job/25954550177?pr=33810

This patch increases the base subscription setup time from 10 to 30 seconds, seems 10 may be too low for the CI machines.