### PR TITLE
Enable ReadHandler to support large payloads

### DIFF
--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -921,14 +921,12 @@ void ReadHandler::ClearStateFlag(ReadHandlerFlags aFlag)
 
 size_t ReadHandler::GetReportBufferMaxSize()
 {
-    size_t maxBufSize                  = kMaxSecureSduLengthBytes;
     Transport::SecureSession * session = GetSession();
     if (session && session->AllowsLargePayload())
     {
-        maxBufSize = kMaxLargeSecureSduLengthBytes;
+        return kMaxLargeSecureSduLengthBytes;
     }
-
-    return maxBufSize;
+    return kMaxSecureSduLengthBytes;
 }
 
 } // namespace app

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -919,5 +919,17 @@ void ReadHandler::ClearStateFlag(ReadHandlerFlags aFlag)
     SetStateFlag(aFlag, false);
 }
 
+size_t ReadHandler::GetReportBufferMaxSize()
+{
+    size_t maxBufSize                  = chip::app::kMaxSecureSduLengthBytes;
+    Transport::SecureSession * session = GetSession();
+    if (session && session->AllowsLargePayload())
+    {
+        maxBufSize = chip::app::kMaxLargeSecureSduLengthBytes;
+    }
+
+    return maxBufSize;
+}
+
 } // namespace app
 } // namespace chip

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -921,11 +921,11 @@ void ReadHandler::ClearStateFlag(ReadHandlerFlags aFlag)
 
 size_t ReadHandler::GetReportBufferMaxSize()
 {
-    size_t maxBufSize                  = chip::app::kMaxSecureSduLengthBytes;
+    size_t maxBufSize                  = kMaxSecureSduLengthBytes;
     Transport::SecureSession * session = GetSession();
     if (session && session->AllowsLargePayload())
     {
-        maxBufSize = chip::app::kMaxLargeSecureSduLengthBytes;
+        maxBufSize = kMaxLargeSecureSduLengthBytes;
     }
 
     return maxBufSize;

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -335,9 +335,10 @@ private:
 
     /*
      * Get the appropriate size of a packet buffer to allocate for encoding a Report message.
-     * Depending on the underlying session, which may or may not support large
-     * payloads, a buffer with the corresponding max size would be allocated.
+     * This size might depend on the underlying session used by the ReadHandler.
      *
+     * The size returned here is the size not including the various prepended headers
+     * (what System::PacketBuffer calls the "available size").
      */
     size_t GetReportBufferMaxSize();
 

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -333,6 +333,14 @@ private:
      */
     CHIP_ERROR SendReportData(System::PacketBufferHandle && aPayload, bool aMoreChunks);
 
+    /*
+     * Get the appropriate size of a packet buffer to allocate for encoding a Report message.
+     * Depending on the underlying session, which may or may not support large
+     * payloads, a buffer with the corresponding max size would be allocated.
+     *
+     */
+    size_t GetReportBufferMaxSize();
+
     /**
      *  Returns whether this ReadHandler represents a subscription that was created by the other side of the provided exchange.
      */

--- a/src/app/StatusResponse.h
+++ b/src/app/StatusResponse.h
@@ -26,7 +26,8 @@
 
 namespace chip {
 namespace app {
-static constexpr size_t kMaxSecureSduLengthBytes = kMaxAppMessageLen + kMaxTagLen;
+static constexpr size_t kMaxSecureSduLengthBytes      = kMaxAppMessageLen + kMaxTagLen;
+static constexpr size_t kMaxLargeSecureSduLengthBytes = kMaxLargeAppMessageLen + kMaxTagLen;
 
 class StatusResponse
 {


### PR DESCRIPTION
When sending reports, if the session established with the peer supports large payloads, the ReadHandler would allocate a large buffer to, potentially, fit more cluster data.


