### PR TITLE
Add SupportedCluster list to ContentAppPlatform

### DIFF
--- a/examples/tv-app/android/App/content-app/src/main/res/raw/static_matter_clusters
+++ b/examples/tv-app/android/App/content-app/src/main/res/raw/static_matter_clusters
@@ -19,6 +19,9 @@
       "features": [
         "AS"
       ]
+    },
+    {
+      "identifier": 1294
     }
   ]
 }

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/AppPlatformService.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/AppPlatformService.java
@@ -172,7 +172,6 @@ public class AppPlatformService {
               app.getAppName(),
               app.getProductId(),
               app.getVersion(),
-              app.getSupportedClusters(),
               mapSupportedClusters(app.getSupportedClusters()),
               desiredEndpointId,
               new ContentAppEndpointManagerImpl(context));
@@ -197,7 +196,7 @@ public class AppPlatformService {
 
   private Collection<ContentAppSupportedCluster> mapSupportedClusters(
       Collection<SupportedCluster> supportedClusters) {
-    supportedClusters
+    return supportedClusters
         .stream()
         .map(AppPlatformService::mapSupportedCluster)
         .collect(Collectors.toList());

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/AppPlatformService.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/AppPlatformService.java
@@ -24,13 +24,17 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.util.Log;
 import androidx.annotation.NonNull;
+import com.matter.tv.app.api.SupportedCluster;
 import com.matter.tv.server.handlers.ContentAppEndpointManagerImpl;
 import com.matter.tv.server.model.ContentApp;
 import com.matter.tv.server.receivers.ContentAppDiscoveryService;
 import com.matter.tv.server.tvapp.AppPlatform;
+import com.matter.tv.server.tvapp.ContentAppSupportedCluster;
 import com.matter.tv.server.utils.EndpointsDataStore;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * This class facilitates the communication with the ContentAppPlatform. It uses the JNI interface
@@ -168,6 +172,8 @@ public class AppPlatformService {
               app.getAppName(),
               app.getProductId(),
               app.getVersion(),
+              app.getSupportedClusters(),
+              mapSupportedCluster(app.getSupportedClusters()),
               desiredEndpointId,
               new ContentAppEndpointManagerImpl(context));
     } else {
@@ -178,6 +184,7 @@ public class AppPlatformService {
               app.getAppName(),
               app.getProductId(),
               app.getVersion(),
+              mapSupportedCluster(app.getSupportedClusters()),
               new ContentAppEndpointManagerImpl(context));
     }
     if (retEndpointId > 0) {
@@ -186,5 +193,17 @@ public class AppPlatformService {
     } else {
       Log.e(TAG, "Could not add content app as endpoint. App Name " + app.getAppName());
     }
+  }
+
+  private Collection<ContentAppSupportedCluster> mapSupportedClusters(Collection<SupportedCluster> supportedClusters) {
+    supportedClusters.stream().map(AppPlatformService::mapSupportedCluster).collect(Collectors.toList());
+  }
+
+  private static ContentAppSupportedCluster mapSupportedCluster(SupportedCluster cluster) {
+    return new ContentAppSupportedCluster(
+      cluster.clusterIdentifier,
+      cluster.features,
+      cluster.optionalCommandIdentifiers,
+      cluster.optionalAttributesIdentifiers);
   }
 }

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/AppPlatformService.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/AppPlatformService.java
@@ -173,7 +173,7 @@ public class AppPlatformService {
               app.getProductId(),
               app.getVersion(),
               app.getSupportedClusters(),
-              mapSupportedCluster(app.getSupportedClusters()),
+              mapSupportedClusters(app.getSupportedClusters()),
               desiredEndpointId,
               new ContentAppEndpointManagerImpl(context));
     } else {
@@ -184,7 +184,7 @@ public class AppPlatformService {
               app.getAppName(),
               app.getProductId(),
               app.getVersion(),
-              mapSupportedCluster(app.getSupportedClusters()),
+              mapSupportedClusters(app.getSupportedClusters()),
               new ContentAppEndpointManagerImpl(context));
     }
     if (retEndpointId > 0) {

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/AppPlatformService.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/AppPlatformService.java
@@ -195,15 +195,19 @@ public class AppPlatformService {
     }
   }
 
-  private Collection<ContentAppSupportedCluster> mapSupportedClusters(Collection<SupportedCluster> supportedClusters) {
-    supportedClusters.stream().map(AppPlatformService::mapSupportedCluster).collect(Collectors.toList());
+  private Collection<ContentAppSupportedCluster> mapSupportedClusters(
+      Collection<SupportedCluster> supportedClusters) {
+    supportedClusters
+        .stream()
+        .map(AppPlatformService::mapSupportedCluster)
+        .collect(Collectors.toList());
   }
 
   private static ContentAppSupportedCluster mapSupportedCluster(SupportedCluster cluster) {
     return new ContentAppSupportedCluster(
-      cluster.clusterIdentifier,
-      cluster.features,
-      cluster.optionalCommandIdentifiers,
-      cluster.optionalAttributesIdentifiers);
+        cluster.clusterIdentifier,
+        cluster.features,
+        cluster.optionalCommandIdentifiers,
+        cluster.optionalAttributesIdentifiers);
   }
 }

--- a/examples/tv-app/android/BUILD.gn
+++ b/examples/tv-app/android/BUILD.gn
@@ -122,6 +122,7 @@ android_library("java") {
     "java/src/com/matter/tv/server/tvapp/ChannelProgramResponse.java",
     "java/src/com/matter/tv/server/tvapp/Clusters.java",
     "java/src/com/matter/tv/server/tvapp/ContentAppEndpointManager.java",
+    "java/src/com/matter/tv/server/tvapp/ContentAppSupportedCluster.java",
     "java/src/com/matter/tv/server/tvapp/ContentLaunchBrandingInformation.java",
     "java/src/com/matter/tv/server/tvapp/ContentLaunchEntry.java",
     "java/src/com/matter/tv/server/tvapp/ContentLaunchManager.java",

--- a/examples/tv-app/android/java/AppImpl.cpp
+++ b/examples/tv-app/android/java/AppImpl.cpp
@@ -259,9 +259,28 @@ DataVersion gDataVersions[APP_LIBRARY_SIZE][ArraySize(contentAppClusters)];
 
 EmberAfDeviceType gContentAppDeviceType[] = { { DEVICE_TYPE_CONTENT_APP, 1 } };
 
+std::vector<SupportedCluster> make_default_supported_clusters(){
+    return std::vector<ContentApp::SupportedCluster>{
+        { Descriptor::Id },
+        { ApplicationBasic::Id },
+        { KeypadInput::Id },
+        { ApplicationLauncher::Id },
+        { AccountLogin::Id },
+        { ContentLauncher::Id },
+        { TargetNavigator::Id },
+        { Channel::Id }
+    };
+}
+
 } // anonymous namespace
 
-ContentAppFactoryImpl::ContentAppFactoryImpl() {}
+ContentAppFactoryImpl::ContentAppFactoryImpl() :
+    mContentApps{
+        new ContentAppImpl("Vendor1", 1, "exampleid", 11, "Version1", "20202021", make_default_supported_clusters(), nullptr, nullptr),
+        new ContentAppImpl("Vendor2", 65521, "exampleString", 32768, "Version2", "20202021", make_default_supported_clusters(), nullptr, nullptr),
+        new ContentAppImpl("Vendor3", 9050, "App3", 22, "Version3", "20202021", make_default_supported_clusters(), nullptr, nullptr),
+        new ContentAppImpl("TestSuiteVendor", 1111, "applicationId", 22, "v2", "20202021", make_default_supported_clusters(), nullptr, nullptr)
+    }{}
 
 uint16_t ContentAppFactoryImpl::GetPlatformCatalogVendorId()
 {

--- a/examples/tv-app/android/java/AppImpl.cpp
+++ b/examples/tv-app/android/java/AppImpl.cpp
@@ -339,10 +339,11 @@ ContentApp * ContentAppFactoryImpl::LoadContentApp(const CatalogVendorApp & vend
 }
 
 EndpointId ContentAppFactoryImpl::AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName,
-                                                uint16_t productId, const char * szApplicationVersion, jobject manager)
+                                                uint16_t productId, const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters,
+                                                jobject manager)
 {
     DataVersion * dataVersionBuf = new DataVersion[ArraySize(contentAppClusters)];
-    ContentAppImpl * app = new ContentAppImpl(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, "",
+    ContentAppImpl * app = new ContentAppImpl(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, "", std::move(supportedClusters),
                                               mAttributeDelegate, mCommandDelegate);
     EndpointId epId      = ContentAppPlatform::GetInstance().AddContentApp(
         app, &contentAppEndpoint, Span<DataVersion>(dataVersionBuf, ArraySize(contentAppClusters)),
@@ -355,11 +356,11 @@ EndpointId ContentAppFactoryImpl::AddContentApp(const char * szVendorName, uint1
 }
 
 EndpointId ContentAppFactoryImpl::AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName,
-                                                uint16_t productId, const char * szApplicationVersion, jobject manager,
-                                                EndpointId desiredEndpointId)
+                                                uint16_t productId, const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters,
+                                                EndpointId desiredEndpointId, jobject manager)
 {
     DataVersion * dataVersionBuf = new DataVersion[ArraySize(contentAppClusters)];
-    ContentAppImpl * app = new ContentAppImpl(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, "",
+    ContentAppImpl * app = new ContentAppImpl(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, "", std::move(supportedClusters),
                                               mAttributeDelegate, mCommandDelegate);
     EndpointId epId      = ContentAppPlatform::GetInstance().AddContentApp(
         app, &contentAppEndpoint, Span<DataVersion>(dataVersionBuf, ArraySize(contentAppClusters)),
@@ -480,21 +481,21 @@ CHIP_ERROR InitVideoPlayerPlatform(jobject contentAppEndpointManager)
 }
 
 EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                         const char * szApplicationVersion, jobject manager)
+                         const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters, jobject manager)
 {
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
     ChipLogProgress(DeviceLayer, "AppImpl: AddContentApp vendorId=%d applicationName=%s ", vendorId, szApplicationName);
-    return gFactory.AddContentApp(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, manager);
+    return gFactory.AddContentApp(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, std::move(supportedClusters), manager);
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
     return kInvalidEndpointId;
 }
 
 EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                         const char * szApplicationVersion, EndpointId endpointId, jobject manager)
+                         const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters, EndpointId endpointId, jobject manager)
 {
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
     ChipLogProgress(DeviceLayer, "AppImpl: AddContentApp vendorId=%d applicationName=%s ", vendorId, szApplicationName);
-    return gFactory.AddContentApp(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, manager, endpointId);
+    return gFactory.AddContentApp(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, std::move(supportedClusters), endpointId, manager);
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
     return kInvalidEndpointId;
 }

--- a/examples/tv-app/android/java/AppImpl.cpp
+++ b/examples/tv-app/android/java/AppImpl.cpp
@@ -339,12 +339,12 @@ ContentApp * ContentAppFactoryImpl::LoadContentApp(const CatalogVendorApp & vend
 }
 
 EndpointId ContentAppFactoryImpl::AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName,
-                                                uint16_t productId, const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters,
-                                                jobject manager)
+                                                uint16_t productId, const char * szApplicationVersion,
+                                                std::vector<SupportedCluster> supportedClusters, jobject manager)
 {
     DataVersion * dataVersionBuf = new DataVersion[ArraySize(contentAppClusters)];
-    ContentAppImpl * app = new ContentAppImpl(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, "", std::move(supportedClusters),
-                                              mAttributeDelegate, mCommandDelegate);
+    ContentAppImpl * app = new ContentAppImpl(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, "",
+                                              std::move(supportedClusters), mAttributeDelegate, mCommandDelegate);
     EndpointId epId      = ContentAppPlatform::GetInstance().AddContentApp(
         app, &contentAppEndpoint, Span<DataVersion>(dataVersionBuf, ArraySize(contentAppClusters)),
         Span<const EmberAfDeviceType>(gContentAppDeviceType));
@@ -356,12 +356,13 @@ EndpointId ContentAppFactoryImpl::AddContentApp(const char * szVendorName, uint1
 }
 
 EndpointId ContentAppFactoryImpl::AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName,
-                                                uint16_t productId, const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters,
-                                                EndpointId desiredEndpointId, jobject manager)
+                                                uint16_t productId, const char * szApplicationVersion,
+                                                std::vector<SupportedCluster> supportedClusters, EndpointId desiredEndpointId,
+                                                jobject manager)
 {
     DataVersion * dataVersionBuf = new DataVersion[ArraySize(contentAppClusters)];
-    ContentAppImpl * app = new ContentAppImpl(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, "", std::move(supportedClusters),
-                                              mAttributeDelegate, mCommandDelegate);
+    ContentAppImpl * app = new ContentAppImpl(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, "",
+                                              std::move(supportedClusters), mAttributeDelegate, mCommandDelegate);
     EndpointId epId      = ContentAppPlatform::GetInstance().AddContentApp(
         app, &contentAppEndpoint, Span<DataVersion>(dataVersionBuf, ArraySize(contentAppClusters)),
         Span<const EmberAfDeviceType>(gContentAppDeviceType), desiredEndpointId);
@@ -485,17 +486,20 @@ EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const cha
 {
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
     ChipLogProgress(DeviceLayer, "AppImpl: AddContentApp vendorId=%d applicationName=%s ", vendorId, szApplicationName);
-    return gFactory.AddContentApp(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, std::move(supportedClusters), manager);
+    return gFactory.AddContentApp(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion,
+                                  std::move(supportedClusters), manager);
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
     return kInvalidEndpointId;
 }
 
 EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                         const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters, EndpointId endpointId, jobject manager)
+                         const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters, EndpointId endpointId,
+                         jobject manager)
 {
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
     ChipLogProgress(DeviceLayer, "AppImpl: AddContentApp vendorId=%d applicationName=%s ", vendorId, szApplicationName);
-    return gFactory.AddContentApp(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, std::move(supportedClusters), endpointId, manager);
+    return gFactory.AddContentApp(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion,
+                                  std::move(supportedClusters), endpointId, manager);
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
     return kInvalidEndpointId;
 }

--- a/examples/tv-app/android/java/AppImpl.cpp
+++ b/examples/tv-app/android/java/AppImpl.cpp
@@ -259,28 +259,26 @@ DataVersion gDataVersions[APP_LIBRARY_SIZE][ArraySize(contentAppClusters)];
 
 EmberAfDeviceType gContentAppDeviceType[] = { { DEVICE_TYPE_CONTENT_APP, 1 } };
 
-std::vector<SupportedCluster> make_default_supported_clusters(){
-    return std::vector<ContentApp::SupportedCluster>{
-        { Descriptor::Id },
-        { ApplicationBasic::Id },
-        { KeypadInput::Id },
-        { ApplicationLauncher::Id },
-        { AccountLogin::Id },
-        { ContentLauncher::Id },
-        { TargetNavigator::Id },
-        { Channel::Id }
-    };
+std::vector<SupportedCluster> make_default_supported_clusters()
+{
+    return std::vector<ContentApp::SupportedCluster>{ { Descriptor::Id },      { ApplicationBasic::Id },
+                                                      { KeypadInput::Id },     { ApplicationLauncher::Id },
+                                                      { AccountLogin::Id },    { ContentLauncher::Id },
+                                                      { TargetNavigator::Id }, { Channel::Id } };
 }
 
 } // anonymous namespace
 
 ContentAppFactoryImpl::ContentAppFactoryImpl() :
-    mContentApps{
-        new ContentAppImpl("Vendor1", 1, "exampleid", 11, "Version1", "20202021", make_default_supported_clusters(), nullptr, nullptr),
-        new ContentAppImpl("Vendor2", 65521, "exampleString", 32768, "Version2", "20202021", make_default_supported_clusters(), nullptr, nullptr),
-        new ContentAppImpl("Vendor3", 9050, "App3", 22, "Version3", "20202021", make_default_supported_clusters(), nullptr, nullptr),
-        new ContentAppImpl("TestSuiteVendor", 1111, "applicationId", 22, "v2", "20202021", make_default_supported_clusters(), nullptr, nullptr)
-    }{}
+    mContentApps{ new ContentAppImpl("Vendor1", 1, "exampleid", 11, "Version1", "20202021", make_default_supported_clusters(),
+                                     nullptr, nullptr),
+                  new ContentAppImpl("Vendor2", 65521, "exampleString", 32768, "Version2", "20202021",
+                                     make_default_supported_clusters(), nullptr, nullptr),
+                  new ContentAppImpl("Vendor3", 9050, "App3", 22, "Version3", "20202021", make_default_supported_clusters(),
+                                     nullptr, nullptr),
+                  new ContentAppImpl("TestSuiteVendor", 1111, "applicationId", 22, "v2", "20202021",
+                                     make_default_supported_clusters(), nullptr, nullptr) }
+{}
 
 uint16_t ContentAppFactoryImpl::GetPlatformCatalogVendorId()
 {

--- a/examples/tv-app/android/java/AppImpl.h
+++ b/examples/tv-app/android/java/AppImpl.h
@@ -199,14 +199,9 @@ public:
     void setContentAppCommandDelegate(ContentAppCommandDelegate * commandDelegate);
 
 protected:
-    std::vector<ContentAppImpl *> mContentApps{
-        new ContentAppImpl("Vendor1", 1, "exampleid", 11, "Version1", "20202021", {}, nullptr, nullptr),
-        new ContentAppImpl("Vendor2", 65521, "exampleString", 32768, "Version2", "20202021", {}, nullptr, nullptr),
-        new ContentAppImpl("Vendor3", 9050, "App3", 22, "Version3", "20202021", {}, nullptr, nullptr),
-        new ContentAppImpl("TestSuiteVendor", 1111, "applicationId", 22, "v2", "20202021", {}, nullptr, nullptr)
-    };
+    // TODO: Update to use unique_ptr instead of raw pointers
+    std::vector<ContentAppImpl *> mContentApps;
     std::vector<DataVersion *> mDataVersions{};
-
     std::vector<uint16_t> mAdminVendorIds{};
 
 private:

--- a/examples/tv-app/android/java/AppImpl.h
+++ b/examples/tv-app/android/java/AppImpl.h
@@ -57,11 +57,12 @@
 
 CHIP_ERROR InitVideoPlayerPlatform(jobject contentAppEndpointManager);
 EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                         const char * szApplicationVersion, std::vector<chip::AppPlatform::ContentApp::SupportedCluster> supportedClusters,
-                         jobject manager);
+                         const char * szApplicationVersion,
+                         std::vector<chip::AppPlatform::ContentApp::SupportedCluster> supportedClusters, jobject manager);
 EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                         const char * szApplicationVersion, std::vector<chip::AppPlatform::ContentApp::SupportedCluster> supportedClusters,
-                         EndpointId endpointId, jobject manager);
+                         const char * szApplicationVersion,
+                         std::vector<chip::AppPlatform::ContentApp::SupportedCluster> supportedClusters, EndpointId endpointId,
+                         jobject manager);
 EndpointId RemoveContentApp(EndpointId epId);
 void ReportAttributeChange(EndpointId epId, chip::ClusterId clusterId, chip::AttributeId attributeId);
 
@@ -165,8 +166,7 @@ public:
     ContentApp * LoadContentApp(const CatalogVendorApp & vendorApp) override;
 
     EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                             const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters,
-                             jobject manager);
+                             const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters, jobject manager);
 
     EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
                              const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters,

--- a/examples/tv-app/android/java/AppImpl.h
+++ b/examples/tv-app/android/java/AppImpl.h
@@ -31,6 +31,7 @@
 #include <lib/support/JniReferences.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <vector>
 
 #include "../include/account-login/AccountLoginManager.h"
 #include "../include/application-basic/ApplicationBasicManager.h"
@@ -56,9 +57,11 @@
 
 CHIP_ERROR InitVideoPlayerPlatform(jobject contentAppEndpointManager);
 EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                         const char * szApplicationVersion, jobject manager);
+                         const char * szApplicationVersion, std::vector<chip::AppPlatform::ContentApp::SupportedCluster> supportedClusters,
+                         jobject manager);
 EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                         const char * szApplicationVersion, EndpointId endpointId, jobject manager);
+                         const char * szApplicationVersion, std::vector<chip::AppPlatform::ContentApp::SupportedCluster> supportedClusters,
+                         EndpointId endpointId, jobject manager);
 EndpointId RemoveContentApp(EndpointId epId);
 void ReportAttributeChange(EndpointId epId, chip::ClusterId clusterId, chip::AttributeId attributeId);
 
@@ -81,6 +84,7 @@ using TargetNavigatorDelegate     = app::Clusters::TargetNavigator::Delegate;
 using SupportedProtocolsBitmap    = app::Clusters::ContentLauncher::SupportedProtocolsBitmap;
 using ContentAppAttributeDelegate = chip::AppPlatform::ContentAppAttributeDelegate;
 using ContentAppCommandDelegate   = chip::AppPlatform::ContentAppCommandDelegate;
+using SupportedCluster            = chip::AppPlatform::ContentApp::SupportedCluster;
 
 static const int kCatalogVendorId = CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID;
 
@@ -91,8 +95,9 @@ class DLL_EXPORT ContentAppImpl : public ContentApp
 {
 public:
     ContentAppImpl(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                   const char * szApplicationVersion, const char * setupPIN, ContentAppAttributeDelegate * attributeDelegate,
-                   ContentAppCommandDelegate * commandDelegate) :
+                   const char * szApplicationVersion, const char * setupPIN, std::vector<SupportedCluster> supportedClusters,
+                   ContentAppAttributeDelegate * attributeDelegate, ContentAppCommandDelegate * commandDelegate) :
+        ContentApp{ supportedClusters },
         mApplicationBasicDelegate(kCatalogVendorId, BuildAppId(vendorId), szVendorName, vendorId, szApplicationName, productId,
                                   szApplicationVersion),
         mAccountLoginDelegate(commandDelegate, setupPIN),
@@ -160,10 +165,12 @@ public:
     ContentApp * LoadContentApp(const CatalogVendorApp & vendorApp) override;
 
     EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                             const char * szApplicationVersion, jobject manager);
+                             const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters,
+                             jobject manager);
 
     EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                             const char * szApplicationVersion, jobject manager, EndpointId desiredEndpointId);
+                             const char * szApplicationVersion, std::vector<SupportedCluster> supportedClusters,
+                             EndpointId desiredEndpointId, jobject manager);
 
     EndpointId RemoveContentApp(EndpointId epId);
 
@@ -193,10 +200,10 @@ public:
 
 protected:
     std::vector<ContentAppImpl *> mContentApps{
-        new ContentAppImpl("Vendor1", 1, "exampleid", 11, "Version1", "20202021", nullptr, nullptr),
-        new ContentAppImpl("Vendor2", 65521, "exampleString", 32768, "Version2", "20202021", nullptr, nullptr),
-        new ContentAppImpl("Vendor3", 9050, "App3", 22, "Version3", "20202021", nullptr, nullptr),
-        new ContentAppImpl("TestSuiteVendor", 1111, "applicationId", 22, "v2", "20202021", nullptr, nullptr)
+        new ContentAppImpl("Vendor1", 1, "exampleid", 11, "Version1", "20202021", {}, nullptr, nullptr),
+        new ContentAppImpl("Vendor2", 65521, "exampleString", 32768, "Version2", "20202021", {}, nullptr, nullptr),
+        new ContentAppImpl("Vendor3", 9050, "App3", 22, "Version3", "20202021", {}, nullptr, nullptr),
+        new ContentAppImpl("TestSuiteVendor", 1111, "applicationId", 22, "v2", "20202021", {}, nullptr, nullptr)
     };
     std::vector<DataVersion *> mDataVersions{};
 

--- a/examples/tv-app/android/java/AppPlatform-JNI.cpp
+++ b/examples/tv-app/android/java/AppPlatform-JNI.cpp
@@ -18,12 +18,12 @@
 
 #include "AppImpl.h"
 
+#include <app/app-platform/ContentApp.h>
 #include <jni.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPJNIError.h>
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
-#include <app/app-platform/ContentApp.h>
 
 using namespace chip;
 using namespace chip::app;
@@ -36,7 +36,7 @@ using namespace chip::Credentials;
  */
 
 // Forward declaration
-std::vector<ContentApp::SupportedCluster> convert_to_cpp(JNIEnv* env, jobject supportedClusters);
+std::vector<ContentApp::SupportedCluster> convert_to_cpp(JNIEnv * env, jobject supportedClusters);
 
 #define JNI_METHOD(RETURN, METHOD_NAME)                                                                                            \
     extern "C" JNIEXPORT RETURN JNICALL Java_com_matter_tv_server_tvapp_AppPlatform_##METHOD_NAME
@@ -48,8 +48,8 @@ JNI_METHOD(void, nativeInit)(JNIEnv *, jobject app, jobject contentAppEndpointMa
 }
 
 JNI_METHOD(jint, addContentApp)
-(JNIEnv *, jobject, jstring vendorName, jint vendorId, jstring appName, jint productId, jstring appVersion, jobject supportedClusters,
- jobject manager)
+(JNIEnv *, jobject, jstring vendorName, jint vendorId, jstring appName, jint productId, jstring appVersion,
+ jobject supportedClusters, jobject manager)
 {
     chip::DeviceLayer::StackLock lock;
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
@@ -63,8 +63,8 @@ JNI_METHOD(jint, addContentApp)
 }
 
 JNI_METHOD(jint, addContentAppAtEndpoint)
-(JNIEnv *, jobject, jstring vendorName, jint vendorId, jstring appName, jint productId, jstring appVersion, jobject supportedClusters, jint endpointId,
- jobject manager)
+(JNIEnv *, jobject, jstring vendorName, jint vendorId, jstring appName, jint productId, jstring appVersion,
+ jobject supportedClusters, jint endpointId, jobject manager)
 {
     chip::DeviceLayer::StackLock lock;
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
@@ -72,8 +72,9 @@ JNI_METHOD(jint, addContentAppAtEndpoint)
     JniUtfString vName(env, vendorName);
     JniUtfString aName(env, appName);
     JniUtfString aVersion(env, appVersion);
-    EndpointId epId = AddContentApp(vName.c_str(), static_cast<uint16_t>(vendorId), aName.c_str(), static_cast<uint16_t>(productId),
-                                    aVersion.c_str(), convert_to_cpp(env, supportedClusters), static_cast<EndpointId>(endpointId), manager);
+    EndpointId epId =
+        AddContentApp(vName.c_str(), static_cast<uint16_t>(vendorId), aName.c_str(), static_cast<uint16_t>(productId),
+                      aVersion.c_str(), convert_to_cpp(env, supportedClusters), static_cast<EndpointId>(endpointId), manager);
     return static_cast<uint16_t>(epId);
 }
 
@@ -99,12 +100,15 @@ JNI_METHOD(void, addSelfVendorAsAdmin)
     AddSelfVendorAsAdmin();
 }
 
-std::vector<uint32_t> consume_and_convert_to_cpp(JNIEnv* env, jobject intArrayObject) {
+std::vector<uint32_t> consume_and_convert_to_cpp(JNIEnv * env, jobject intArrayObject)
+{
     std::vector<uint32_t> uintVector;
-    if (intArrayObject != nullptr) {
-        jsize length = env->GetArrayLength(static_cast<jintArray>(intArrayObject));
-        jint* elements = env->GetIntArrayElements(static_cast<jintArray>(intArrayObject), nullptr);
-        if (elements != nullptr) {
+    if (intArrayObject != nullptr)
+    {
+        jsize length    = env->GetArrayLength(static_cast<jintArray>(intArrayObject));
+        jint * elements = env->GetIntArrayElements(static_cast<jintArray>(intArrayObject), nullptr);
+        if (elements != nullptr)
+        {
             // OBS: Implicit type ambiguation from int32_t to uint32_t
             uintVector.assign(elements, elements + length);
             env->ReleaseIntArrayElements(static_cast<jintArray>(intArrayObject), elements, JNI_ABORT);
@@ -114,57 +118,63 @@ std::vector<uint32_t> consume_and_convert_to_cpp(JNIEnv* env, jobject intArrayOb
     return uintVector;
 }
 
-std::vector<ContentApp::SupportedCluster> convert_to_cpp(JNIEnv* env, jobject supportedClustersObject) {
-    if (supportedClustersObject == nullptr || env == nullptr) {
+std::vector<ContentApp::SupportedCluster> convert_to_cpp(JNIEnv * env, jobject supportedClustersObject)
+{
+    if (supportedClustersObject == nullptr || env == nullptr)
+    {
         return {};
     }
 
     // Find Java classes. WARNING: Reflection
     jclass collectionClass = env->FindClass("java/util/Collection");
-    jclass iteratorClass = env->FindClass("java/util/Iterator");
-    jclass clusterClass = env->FindClass("com/matter/tv/server/tvapp/SupportedCluster");
-    if (collectionClass == nullptr || iteratorClass == nullptr || clusterClass == nullptr) {
+    jclass iteratorClass   = env->FindClass("java/util/Iterator");
+    jclass clusterClass    = env->FindClass("com/matter/tv/server/tvapp/SupportedCluster");
+    if (collectionClass == nullptr || iteratorClass == nullptr || clusterClass == nullptr)
+    {
         return {};
     }
 
     // Find Java methods. WARNING: Reflection
     jmethodID iteratorMethod = env->GetMethodID(collectionClass, "iterator", "()Ljava/util/Iterator;");
-    jmethodID hasNextMethod = env->GetMethodID(iteratorClass, "hasNext", "()Z");
-    jmethodID nextMethod = env->GetMethodID(iteratorClass, "next", "()Ljava/lang/Object;");
-    if (iteratorMethod == nullptr || hasNextMethod == nullptr || nextMethod == nullptr) {
+    jmethodID hasNextMethod  = env->GetMethodID(iteratorClass, "hasNext", "()Z");
+    jmethodID nextMethod     = env->GetMethodID(iteratorClass, "next", "()Ljava/lang/Object;");
+    if (iteratorMethod == nullptr || hasNextMethod == nullptr || nextMethod == nullptr)
+    {
         return {};
     }
 
     // Find Java SupportedCluster fields. WARNING: Reflection
-    jfieldID clusterIdentifierField = env->GetFieldID(clusterClass, "clusterIdentifier", "I");
-    jfieldID featuresField = env->GetFieldID(clusterClass, "features", "I");
-    jfieldID optionalCommandIdentifiersField = env->GetFieldID(clusterClass, "optionalCommandIdentifiers", "[I");
+    jfieldID clusterIdentifierField             = env->GetFieldID(clusterClass, "clusterIdentifier", "I");
+    jfieldID featuresField                      = env->GetFieldID(clusterClass, "features", "I");
+    jfieldID optionalCommandIdentifiersField    = env->GetFieldID(clusterClass, "optionalCommandIdentifiers", "[I");
     jfieldID optionalAttributesIdentifiersField = env->GetFieldID(clusterClass, "optionalAttributesIdentifiers", "[I");
-    if (clusterIdentifierField == nullptr || featuresField == nullptr || optionalCommandIdentifiersField == nullptr || optionalAttributesIdentifiersField == nullptr) {
+    if (clusterIdentifierField == nullptr || featuresField == nullptr || optionalCommandIdentifiersField == nullptr ||
+        optionalAttributesIdentifiersField == nullptr)
+    {
         return {};
     }
 
     // Find Set Iterator Object
     jobject iteratorObject = env->CallObjectMethod(supportedClustersObject, iteratorMethod);
-    if (iteratorObject == nullptr) {
+    if (iteratorObject == nullptr)
+    {
         return {};
     }
 
     // Iterate over the Java Collection and convert each SupportedCluster
     std::vector<SupportedCluster> supportedClusters;
-    while (env->CallBooleanMethod(iteratorObject, hasNextMethod)) {
+    while (env->CallBooleanMethod(iteratorObject, hasNextMethod))
+    {
         jobject clusterObject = env->CallObjectMethod(iteratorObject, nextMethod);
-        if (clusterObject != nullptr) {
-            jint clusterIdentifier = env->GetIntField(clusterObject, clusterIdentifierField);
-            jint features = env->GetIntField(clusterObject, featuresField);
-            jobject commandIdsObject = env->GetObjectField(clusterObject, optionalCommandIdentifiersField);
+        if (clusterObject != nullptr)
+        {
+            jint clusterIdentifier     = env->GetIntField(clusterObject, clusterIdentifierField);
+            jint features              = env->GetIntField(clusterObject, featuresField);
+            jobject commandIdsObject   = env->GetObjectField(clusterObject, optionalCommandIdentifiersField);
             jobject attributeIdsObject = env->GetObjectField(clusterObject, optionalAttributesIdentifiersField);
             // OBS: Implicit type ambiguation from int32_t to uint32_t
-            supportedClusters.emplace_back(
-                clusterIdentifier,
-                features,
-                consume_and_convert_to_cpp(env, commandIdsObject),
-                consume_and_convert_to_cpp(env, attributeIdsObject));
+            supportedClusters.emplace_back(clusterIdentifier, features, consume_and_convert_to_cpp(env, commandIdsObject),
+                                           consume_and_convert_to_cpp(env, attributeIdsObject));
             env->DeleteLocalRef(clusterObject);
         }
     }

--- a/examples/tv-app/android/java/AppPlatform-JNI.cpp
+++ b/examples/tv-app/android/java/AppPlatform-JNI.cpp
@@ -23,6 +23,7 @@
 #include <lib/support/CHIPJNIError.h>
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
+#include <app/app-platform/ContentApp.h>
 
 using namespace chip;
 using namespace chip::app;
@@ -34,6 +35,9 @@ using namespace chip::Credentials;
  * com.matter.tv.server.tvapp.AppPlatform class.
  */
 
+// Forward declaration
+std::vector<ContentApp::SupportedCluster> convert_to_cpp(JNIEnv* env, jobject supportedClusters);
+
 #define JNI_METHOD(RETURN, METHOD_NAME)                                                                                            \
     extern "C" JNIEXPORT RETURN JNICALL Java_com_matter_tv_server_tvapp_AppPlatform_##METHOD_NAME
 
@@ -44,21 +48,7 @@ JNI_METHOD(void, nativeInit)(JNIEnv *, jobject app, jobject contentAppEndpointMa
 }
 
 JNI_METHOD(jint, addContentApp)
-(JNIEnv *, jobject, jstring vendorName, jint vendorId, jstring appName, jint productId, jstring appVersion, jobject manager)
-{
-    chip::DeviceLayer::StackLock lock;
-    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-
-    JniUtfString vName(env, vendorName);
-    JniUtfString aName(env, appName);
-    JniUtfString aVersion(env, appVersion);
-    EndpointId epId = AddContentApp(vName.c_str(), static_cast<uint16_t>(vendorId), aName.c_str(), static_cast<uint16_t>(productId),
-                                    aVersion.c_str(), manager);
-    return static_cast<uint16_t>(epId);
-}
-
-JNI_METHOD(jint, addContentAppAtEndpoint)
-(JNIEnv *, jobject, jstring vendorName, jint vendorId, jstring appName, jint productId, jstring appVersion, jint endpointId,
+(JNIEnv *, jobject, jstring vendorName, jint vendorId, jstring appName, jint productId, jstring appVersion, jobject supportedClusters,
  jobject manager)
 {
     chip::DeviceLayer::StackLock lock;
@@ -68,7 +58,22 @@ JNI_METHOD(jint, addContentAppAtEndpoint)
     JniUtfString aName(env, appName);
     JniUtfString aVersion(env, appVersion);
     EndpointId epId = AddContentApp(vName.c_str(), static_cast<uint16_t>(vendorId), aName.c_str(), static_cast<uint16_t>(productId),
-                                    aVersion.c_str(), static_cast<EndpointId>(endpointId), manager);
+                                    aVersion.c_str(), convert_to_cpp(env, supportedClusters), manager);
+    return static_cast<uint16_t>(epId);
+}
+
+JNI_METHOD(jint, addContentAppAtEndpoint)
+(JNIEnv *, jobject, jstring vendorName, jint vendorId, jstring appName, jint productId, jstring appVersion, jobject supportedClusters, jint endpointId,
+ jobject manager)
+{
+    chip::DeviceLayer::StackLock lock;
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+
+    JniUtfString vName(env, vendorName);
+    JniUtfString aName(env, appName);
+    JniUtfString aVersion(env, appVersion);
+    EndpointId epId = AddContentApp(vName.c_str(), static_cast<uint16_t>(vendorId), aName.c_str(), static_cast<uint16_t>(productId),
+                                    aVersion.c_str(), convert_to_cpp(env, supportedClusters), static_cast<EndpointId>(endpointId), manager);
     return static_cast<uint16_t>(epId);
 }
 
@@ -92,4 +97,78 @@ JNI_METHOD(void, addSelfVendorAsAdmin)
 (JNIEnv *, jobject, jint endpointId, jint clusterId, jint attributeId)
 {
     AddSelfVendorAsAdmin();
+}
+
+std::vector<uint32_t> consume_and_convert_to_cpp(JNIEnv* env, jobject intArrayObject) {
+    std::vector<uint32_t> uintVector;
+    if (intArrayObject != nullptr) {
+        jsize length = env->GetArrayLength(static_cast<jintArray>(intArrayObject));
+        jint* elements = env->GetIntArrayElements(static_cast<jintArray>(intArrayObject), nullptr);
+        if (elements != nullptr) {
+            // OBS: Implicit type ambiguation from int32_t to uint32_t
+            uintVector.assign(elements, elements + length);
+            env->ReleaseIntArrayElements(static_cast<jintArray>(intArrayObject), elements, JNI_ABORT);
+        }
+        env->DeleteLocalRef(intArrayObject);
+    }
+    return uintVector;
+}
+
+std::vector<ContentApp::SupportedCluster> convert_to_cpp(JNIEnv* env, jobject supportedClustersObject) {
+    if (supportedClustersObject == nullptr || env == nullptr) {
+        return {};
+    }
+
+    // Find Java classes. WARNING: Reflection
+    jclass collectionClass = env->FindClass("java/util/Collection");
+    jclass iteratorClass = env->FindClass("java/util/Iterator");
+    jclass clusterClass = env->FindClass("com/matter/tv/server/tvapp/SupportedCluster");
+    if (collectionClass == nullptr || iteratorClass == nullptr || clusterClass == nullptr) {
+        return {};
+    }
+
+    // Find Java methods. WARNING: Reflection
+    jmethodID iteratorMethod = env->GetMethodID(collectionClass, "iterator", "()Ljava/util/Iterator;");
+    jmethodID hasNextMethod = env->GetMethodID(iteratorClass, "hasNext", "()Z");
+    jmethodID nextMethod = env->GetMethodID(iteratorClass, "next", "()Ljava/lang/Object;");
+    if (iteratorMethod == nullptr || hasNextMethod == nullptr || nextMethod == nullptr) {
+        return {};
+    }
+
+    // Find Java SupportedCluster fields. WARNING: Reflection
+    jfieldID clusterIdentifierField = env->GetFieldID(clusterClass, "clusterIdentifier", "I");
+    jfieldID featuresField = env->GetFieldID(clusterClass, "features", "I");
+    jfieldID optionalCommandIdentifiersField = env->GetFieldID(clusterClass, "optionalCommandIdentifiers", "[I");
+    jfieldID optionalAttributesIdentifiersField = env->GetFieldID(clusterClass, "optionalAttributesIdentifiers", "[I");
+    if (clusterIdentifierField == nullptr || featuresField == nullptr || optionalCommandIdentifiersField == nullptr || optionalAttributesIdentifiersField == nullptr) {
+        return {};
+    }
+
+    // Find Set Iterator Object
+    jobject iteratorObject = env->CallObjectMethod(supportedClustersObject, iteratorMethod);
+    if (iteratorObject == nullptr) {
+        return {};
+    }
+
+    // Iterate over the Java Collection and convert each SupportedCluster
+    std::vector<SupportedCluster> supportedClusters;
+    while (env->CallBooleanMethod(iteratorObject, hasNextMethod)) {
+        jobject clusterObject = env->CallObjectMethod(iteratorObject, nextMethod);
+        if (clusterObject != nullptr) {
+            jint clusterIdentifier = env->GetIntField(clusterObject, clusterIdentifierField);
+            jint features = env->GetIntField(clusterObject, featuresField);
+            jobject commandIdsObject = env->GetObjectField(clusterObject, optionalCommandIdentifiersField);
+            jobject attributeIdsObject = env->GetObjectField(clusterObject, optionalAttributesIdentifiersField);
+            // OBS: Implicit type ambiguation from int32_t to uint32_t
+            supportedClusters.emplace_back(
+                clusterIdentifier,
+                features,
+                consume_and_convert_to_cpp(env, commandIdsObject),
+                consume_and_convert_to_cpp(env, attributeIdsObject));
+            env->DeleteLocalRef(clusterObject);
+        }
+    }
+    env->DeleteLocalRef(iteratorObject);
+
+    return supportedClusters;
 }

--- a/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/AppPlatform.java
+++ b/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/AppPlatform.java
@@ -17,6 +17,8 @@
  */
 package com.matter.tv.server.tvapp;
 
+import java.util.Collection;
+
 /*
  *   This class is provides the JNI interface to the linux layer of the ContentAppPlatform
  */
@@ -37,6 +39,7 @@ public class AppPlatform {
       String appName,
       int productId,
       String appVersion,
+      Collection<ContentAppSupportedCluster> supportedClusters,
       ContentAppEndpointManager manager);
 
   // Method to add a content app at an existing endpoint after restart of the matter server
@@ -46,6 +49,7 @@ public class AppPlatform {
       String appName,
       int productId,
       String appVersion,
+      Collection<ContentAppSupportedCluster> supportedClusters,
       int endpointId,
       ContentAppEndpointManager manager);
 

--- a/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/ContentAppSupportedCluster.java
+++ b/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/ContentAppSupportedCluster.java
@@ -21,14 +21,19 @@ package com.matter.tv.server.tvapp;
  * Mirrors com.matter.tv.app.api.SupportedCluster.aidl
  */
 public class ContentAppSupportedCluster {
-    public ContentAppSupportedCluster(int clusterIdentifier, int features, int[] optionalCommandIdentifiers, int[] optionalAttributesIdentifiers) {
-        this.clusterIdentifier = clusterIdentifier;
-        this.features = features;
-        this.optionalCommandIdentifiers = optionalCommandIdentifiers;
-        this.optionalAttributesIdentifiers = optionalAttributesIdentifiers;
-    }
-    int clusterIdentifier;
-    int features;
-    int[] optionalCommandIdentifiers;
-    int[] optionalAttributesIdentifiers;
+  public ContentAppSupportedCluster(
+      int clusterIdentifier,
+      int features,
+      int[] optionalCommandIdentifiers,
+      int[] optionalAttributesIdentifiers) {
+    this.clusterIdentifier = clusterIdentifier;
+    this.features = features;
+    this.optionalCommandIdentifiers = optionalCommandIdentifiers;
+    this.optionalAttributesIdentifiers = optionalAttributesIdentifiers;
+  }
+
+  int clusterIdentifier;
+  int features;
+  int[] optionalCommandIdentifiers;
+  int[] optionalAttributesIdentifiers;
 }

--- a/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/ContentAppSupportedCluster.java
+++ b/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/ContentAppSupportedCluster.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright (c) 2024 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.matter.tv.server.tvapp;
+
+/*
+ * Mirrors com.matter.tv.app.api.SupportedCluster.aidl
+ */
+public class ContentAppSupportedCluster {
+    public ContentAppSupportedCluster(int clusterIdentifier, int features, int[] optionalCommandIdentifiers, int[] optionalAttributesIdentifiers) {
+        this.clusterIdentifier = clusterIdentifier;
+        this.features = features;
+        this.optionalCommandIdentifiers = optionalCommandIdentifiers;
+        this.optionalAttributesIdentifiers = optionalAttributesIdentifiers;
+    }
+    int clusterIdentifier;
+    int features;
+    int[] optionalCommandIdentifiers;
+    int[] optionalAttributesIdentifiers;
+}

--- a/examples/tv-app/tv-common/include/AppTv.h
+++ b/examples/tv-app/tv-common/include/AppTv.h
@@ -63,17 +63,20 @@ using KeypadInputDelegate         = app::Clusters::KeypadInput::Delegate;
 using MediaPlaybackDelegate       = app::Clusters::MediaPlayback::Delegate;
 using TargetNavigatorDelegate     = app::Clusters::TargetNavigator::Delegate;
 using SupportedProtocolsBitmap    = app::Clusters::ContentLauncher::SupportedProtocolsBitmap;
+using SupportedCluster            = chip::AppPlatform::ContentApp::SupportedCluster;
 
 static const int kCatalogVendorId = CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID;
 
 // for this platform, appid is just vendor id
 #define BuildAppId(vid) std::to_string(vid).c_str()
 
+
 class DLL_EXPORT ContentAppImpl : public ContentApp
 {
 public:
     ContentAppImpl(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
-                   const char * szApplicationVersion, const char * setupPIN) :
+                   const char * szApplicationVersion, const char * setupPIN, std::vector<SupportedCluster> supportedClusters) :
+        ContentApp{ supportedClusters },
         mApplicationBasicDelegate(kCatalogVendorId, BuildAppId(vendorId), szVendorName, vendorId, szApplicationName, productId,
                                   szApplicationVersion),
         mAccountLoginDelegate(setupPIN),

--- a/examples/tv-app/tv-common/include/AppTv.h
+++ b/examples/tv-app/tv-common/include/AppTv.h
@@ -70,7 +70,6 @@ static const int kCatalogVendorId = CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID;
 // for this platform, appid is just vendor id
 #define BuildAppId(vid) std::to_string(vid).c_str()
 
-
 class DLL_EXPORT ContentAppImpl : public ContentApp
 {
 public:

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -573,30 +573,41 @@ void ContentAppFactoryImpl::AddAdminVendorId(uint16_t vendorId)
 
 void ContentAppFactoryImpl::InstallContentApp(uint16_t vendorId, uint16_t productId)
 {
+    auto make_default_supported_clusters = [](){ return std::vector<ContentApp::SupportedCluster>{
+        { Descriptor::Id },
+        { ApplicationBasic::Id },
+        { KeypadInput::Id },
+        { ApplicationLauncher::Id },
+        { AccountLogin::Id },
+        { ContentLauncher::Id },
+        { TargetNavigator::Id },
+        { Channel::Id }};
+    };
+
     ChipLogProgress(DeviceLayer, "ContentAppFactoryImpl: InstallContentApp vendorId=%d productId=%d ", vendorId, productId);
     if (vendorId == 1 && productId == 11)
     {
         mContentApps.emplace_back(
-            std::make_unique<ContentAppImpl>("Vendor1", vendorId, "exampleid", productId, "Version1", "34567890"));
+            std::make_unique<ContentAppImpl>("Vendor1", vendorId, "exampleid", productId, "Version1", "34567890", make_default_supported_clusters()));
     }
     else if (vendorId == 65521 && productId == 32768)
     {
         mContentApps.emplace_back(
-            std::make_unique<ContentAppImpl>("Vendor2", vendorId, "exampleString", productId, "Version2", "20202021"));
+            std::make_unique<ContentAppImpl>("Vendor2", vendorId, "exampleString", productId, "Version2", "20202021", make_default_supported_clusters()));
     }
     else if (vendorId == 9050 && productId == 22)
     {
-        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("Vendor3", vendorId, "App3", productId, "Version3", "20202021"));
+        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("Vendor3", vendorId, "App3", productId, "Version3", "20202021", make_default_supported_clusters()));
     }
     else if (vendorId == 1111 && productId == 22)
     {
         mContentApps.emplace_back(
-            std::make_unique<ContentAppImpl>("TestSuiteVendor", vendorId, "applicationId", productId, "v2", "20202021"));
+            std::make_unique<ContentAppImpl>("TestSuiteVendor", vendorId, "applicationId", productId, "v2", "20202021", make_default_supported_clusters()));
     }
     else
     {
         mContentApps.emplace_back(
-            std::make_unique<ContentAppImpl>("NewAppVendor", vendorId, "newAppApplicationId", productId, "v2", "20202021"));
+            std::make_unique<ContentAppImpl>("NewAppVendor", vendorId, "newAppApplicationId", productId, "v2", "20202021", make_default_supported_clusters()));
     }
 }
 

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -573,41 +573,38 @@ void ContentAppFactoryImpl::AddAdminVendorId(uint16_t vendorId)
 
 void ContentAppFactoryImpl::InstallContentApp(uint16_t vendorId, uint16_t productId)
 {
-    auto make_default_supported_clusters = [](){ return std::vector<ContentApp::SupportedCluster>{
-        { Descriptor::Id },
-        { ApplicationBasic::Id },
-        { KeypadInput::Id },
-        { ApplicationLauncher::Id },
-        { AccountLogin::Id },
-        { ContentLauncher::Id },
-        { TargetNavigator::Id },
-        { Channel::Id }};
+    auto make_default_supported_clusters = []() {
+        return std::vector<ContentApp::SupportedCluster>{ { Descriptor::Id },      { ApplicationBasic::Id },
+                                                          { KeypadInput::Id },     { ApplicationLauncher::Id },
+                                                          { AccountLogin::Id },    { ContentLauncher::Id },
+                                                          { TargetNavigator::Id }, { Channel::Id } };
     };
 
     ChipLogProgress(DeviceLayer, "ContentAppFactoryImpl: InstallContentApp vendorId=%d productId=%d ", vendorId, productId);
     if (vendorId == 1 && productId == 11)
     {
-        mContentApps.emplace_back(
-            std::make_unique<ContentAppImpl>("Vendor1", vendorId, "exampleid", productId, "Version1", "34567890", make_default_supported_clusters()));
+        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("Vendor1", vendorId, "exampleid", productId, "Version1",
+                                                                   "34567890", make_default_supported_clusters()));
     }
     else if (vendorId == 65521 && productId == 32768)
     {
-        mContentApps.emplace_back(
-            std::make_unique<ContentAppImpl>("Vendor2", vendorId, "exampleString", productId, "Version2", "20202021", make_default_supported_clusters()));
+        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("Vendor2", vendorId, "exampleString", productId, "Version2",
+                                                                   "20202021", make_default_supported_clusters()));
     }
     else if (vendorId == 9050 && productId == 22)
     {
-        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("Vendor3", vendorId, "App3", productId, "Version3", "20202021", make_default_supported_clusters()));
+        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("Vendor3", vendorId, "App3", productId, "Version3", "20202021",
+                                                                   make_default_supported_clusters()));
     }
     else if (vendorId == 1111 && productId == 22)
     {
-        mContentApps.emplace_back(
-            std::make_unique<ContentAppImpl>("TestSuiteVendor", vendorId, "applicationId", productId, "v2", "20202021", make_default_supported_clusters()));
+        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("TestSuiteVendor", vendorId, "applicationId", productId, "v2",
+                                                                   "20202021", make_default_supported_clusters()));
     }
     else
     {
-        mContentApps.emplace_back(
-            std::make_unique<ContentAppImpl>("NewAppVendor", vendorId, "newAppApplicationId", productId, "v2", "20202021", make_default_supported_clusters()));
+        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("NewAppVendor", vendorId, "newAppApplicationId", productId, "v2",
+                                                                   "20202021", make_default_supported_clusters()));
     }
 }
 

--- a/src/app/app-platform/ContentApp.cpp
+++ b/src/app/app-platform/ContentApp.cpp
@@ -94,9 +94,12 @@ void ContentApp::SendAppObserverCommand(chip::Controller::DeviceCommissioner * c
     ChipLogProgress(Controller, "Completed send of AppObserver command");
 }
 
-bool ContentApp::HasSupportedCluster(chip::ClusterId clusterId) const {
-    for (const auto& supportedCluster : mSupportedClusters) {
-        if (clusterId == supportedCluster.clusterIdentifier) {
+bool ContentApp::HasSupportedCluster(chip::ClusterId clusterId) const
+{
+    for (const auto & supportedCluster : mSupportedClusters)
+    {
+        if (clusterId == supportedCluster.clusterIdentifier)
+        {
             return true;
         }
     }

--- a/src/app/app-platform/ContentApp.cpp
+++ b/src/app/app-platform/ContentApp.cpp
@@ -98,7 +98,7 @@ bool ContentApp::HasSupportedCluster(chip::ClusterId clusterId) const
 {
     for (const auto & supportedCluster : mSupportedClusters)
     {
-        if (clusterId == supportedCluster.clusterIdentifier)
+        if (clusterId == supportedCluster.mClusterIdentifier)
         {
             return true;
         }

--- a/src/app/app-platform/ContentApp.cpp
+++ b/src/app/app-platform/ContentApp.cpp
@@ -94,6 +94,15 @@ void ContentApp::SendAppObserverCommand(chip::Controller::DeviceCommissioner * c
     ChipLogProgress(Controller, "Completed send of AppObserver command");
 }
 
+bool ContentApp::HasSupportedCluster(chip::ClusterId clusterId) const {
+    for (const auto& supportedCluster : mSupportedClusters) {
+        if (clusterId == supportedCluster.clusterIdentifier) {
+            return true;
+        }
+    }
+    return false;
+}
+
 CHIP_ERROR ContentAppClientCommandSender::SendContentAppMessage(chip::Controller::DeviceCommissioner * commissioner,
                                                                 chip::NodeId destinationId, chip::EndpointId endPointId,
                                                                 char * data, char * encodingHint)

--- a/src/app/app-platform/ContentApp.h
+++ b/src/app/app-platform/ContentApp.h
@@ -34,8 +34,8 @@
 #include <app/clusters/target-navigator-server/target-navigator-delegate.h>
 #include <app/util/attribute-storage.h>
 #include <controller/CHIPDeviceController.h>
-#include <protocols/interaction_model/StatusCode.h>
 #include <lib/core/DataModelTypes.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 #include <string>
 #include <vector>
@@ -96,18 +96,18 @@ private:
 class DLL_EXPORT ContentApp
 {
 public:
-
-    struct SupportedCluster {
-        chip::ClusterId clusterIdentifier { chip::kInvalidClusterId };
-        uint32_t features { 0 };
+    struct SupportedCluster
+    {
+        chip::ClusterId clusterIdentifier{ chip::kInvalidClusterId };
+        uint32_t features{ 0 };
         std::vector<chip::CommandId> optionalCommandIdentifiers;
         std::vector<chip::AttributeId> optionalAttributesIdentifiers;
 
-        SupportedCluster(chip::ClusterId clusterId, uint32_t feats, const std::vector<chip::CommandId>& commandIds, const std::vector<chip::AttributeId>& attributeIds) :
+        SupportedCluster(chip::ClusterId clusterId, uint32_t feats, const std::vector<chip::CommandId> & commandIds,
+                         const std::vector<chip::AttributeId> & attributeIds) :
             clusterIdentifier{ clusterId },
-            features{ feats },
-            optionalCommandIdentifiers{ commandIds },
-            optionalAttributesIdentifiers{ attributeIds } {}
+            features{ feats }, optionalCommandIdentifiers{ commandIds }, optionalAttributesIdentifiers{ attributeIds }
+        {}
     };
 
     ContentApp(std::vector<SupportedCluster> supportedClusters) : mSupportedClusters{ supportedClusters } {}
@@ -117,7 +117,7 @@ public:
     inline void SetEndpointId(EndpointId id) { mEndpointId = id; };
     inline EndpointId GetEndpointId() { return mEndpointId; };
 
-    const std::vector<SupportedCluster>& GetSupportedClusters() const { return mSupportedClusters; };
+    const std::vector<SupportedCluster> & GetSupportedClusters() const { return mSupportedClusters; };
     bool HasSupportedCluster(chip::ClusterId clusterId) const;
 
     virtual AccountLoginDelegate * GetAccountLoginDelegate()               = 0;

--- a/src/app/app-platform/ContentApp.h
+++ b/src/app/app-platform/ContentApp.h
@@ -102,10 +102,10 @@ public:
         std::vector<chip::CommandId> optionalCommandIdentifiers;
         std::vector<chip::AttributeId> optionalAttributesIdentifiers;
 
-        SupportedCluster(chip::ClusterId clusterId, uint32_t feats, const std::vector<chip::CommandId> & commandIds,
+        SupportedCluster(chip::ClusterId clusterId, uint32_t features, const std::vector<chip::CommandId> & commandIds,
                          const std::vector<chip::AttributeId> & attributeIds) :
             clusterIdentifier{ clusterId },
-            features{ feats }, optionalCommandIdentifiers{ commandIds }, optionalAttributesIdentifiers{ attributeIds }
+            features{ features }, optionalCommandIdentifiers{ commandIds }, optionalAttributesIdentifiers{ attributeIds }
         {}
     };
 

--- a/src/app/app-platform/ContentApp.h
+++ b/src/app/app-platform/ContentApp.h
@@ -35,8 +35,10 @@
 #include <app/util/attribute-storage.h>
 #include <controller/CHIPDeviceController.h>
 #include <protocols/interaction_model/StatusCode.h>
+#include <lib/core/DataModelTypes.h>
 
 #include <string>
+#include <vector>
 
 namespace chip {
 namespace AppPlatform {
@@ -94,10 +96,29 @@ private:
 class DLL_EXPORT ContentApp
 {
 public:
+
+    struct SupportedCluster {
+        chip::ClusterId clusterIdentifier { chip::kInvalidClusterId };
+        uint32_t features { 0 };
+        std::vector<chip::CommandId> optionalCommandIdentifiers;
+        std::vector<chip::AttributeId> optionalAttributesIdentifiers;
+
+        SupportedCluster(chip::ClusterId clusterId, uint32_t feats, const std::vector<chip::CommandId>& commandIds, const std::vector<chip::AttributeId>& attributeIds) :
+            clusterIdentifier{ clusterId },
+            features{ feats },
+            optionalCommandIdentifiers{ commandIds },
+            optionalAttributesIdentifiers{ attributeIds } {}
+    };
+
+    ContentApp(std::vector<SupportedCluster> supportedClusters) : mSupportedClusters{ supportedClusters } {}
+
     virtual ~ContentApp() = default;
 
     inline void SetEndpointId(EndpointId id) { mEndpointId = id; };
     inline EndpointId GetEndpointId() { return mEndpointId; };
+
+    const std::vector<SupportedCluster>& GetSupportedClusters() const { return mSupportedClusters; };
+    bool HasSupportedCluster(chip::ClusterId clusterId) const; 
 
     virtual AccountLoginDelegate * GetAccountLoginDelegate()               = 0;
     virtual ApplicationBasicDelegate * GetApplicationBasicDelegate()       = 0;
@@ -122,6 +143,7 @@ public:
 
 protected:
     EndpointId mEndpointId = 0;
+    std::vector<SupportedCluster> mSupportedClusters;
 
     uint8_t mClientNodeCount     = 0;
     uint8_t mNextClientNodeIndex = 0;

--- a/src/app/app-platform/ContentApp.h
+++ b/src/app/app-platform/ContentApp.h
@@ -110,6 +110,7 @@ public:
         {}
     };
 
+    ContentApp() = default;
     ContentApp(std::vector<SupportedCluster> supportedClusters) : mSupportedClusters{ supportedClusters } {}
 
     virtual ~ContentApp() = default;

--- a/src/app/app-platform/ContentApp.h
+++ b/src/app/app-platform/ContentApp.h
@@ -118,7 +118,7 @@ public:
     inline EndpointId GetEndpointId() { return mEndpointId; };
 
     const std::vector<SupportedCluster>& GetSupportedClusters() const { return mSupportedClusters; };
-    bool HasSupportedCluster(chip::ClusterId clusterId) const; 
+    bool HasSupportedCluster(chip::ClusterId clusterId) const;
 
     virtual AccountLoginDelegate * GetAccountLoginDelegate()               = 0;
     virtual ApplicationBasicDelegate * GetApplicationBasicDelegate()       = 0;

--- a/src/app/app-platform/ContentApp.h
+++ b/src/app/app-platform/ContentApp.h
@@ -108,9 +108,7 @@ public:
             mFeatures{ features }, mOptionalCommandIdentifiers{ commandIds }, mOptionalAttributesIdentifiers{ attributeIds }
         {}
 
-        SupportedCluster(chip::ClusterId clusterId) :
-            mClusterIdentifier{ clusterId }
-        {}
+        SupportedCluster(chip::ClusterId clusterId) : mClusterIdentifier{ clusterId } {}
     };
 
     ContentApp(std::vector<SupportedCluster> supportedClusters) : mSupportedClusters{ supportedClusters } {}

--- a/src/app/app-platform/ContentApp.h
+++ b/src/app/app-platform/ContentApp.h
@@ -97,18 +97,18 @@ class DLL_EXPORT ContentApp
 public:
     struct SupportedCluster
     {
-        chip::ClusterId mClusterIdentifier{ chip::kInvalidClusterId };
+        chip::ClusterId mClusterIdentifier{ kInvalidClusterId };
         uint32_t mFeatures{ 0 };
-        std::vector<chip::CommandId> mOptionalCommandIdentifiers;
-        std::vector<chip::AttributeId> mOptionalAttributesIdentifiers;
+        std::vector<CommandId> mOptionalCommandIdentifiers;
+        std::vector<AttributeId> mOptionalAttributesIdentifiers;
 
-        SupportedCluster(chip::ClusterId clusterId, uint32_t features, const std::vector<chip::CommandId> & commandIds,
-                         const std::vector<chip::AttributeId> & attributeIds) :
+        SupportedCluster(ClusterId clusterId, uint32_t features, const std::vector<CommandId> & commandIds,
+                         const std::vector<AttributeId> & attributeIds) :
             mClusterIdentifier{ clusterId },
             mFeatures{ features }, mOptionalCommandIdentifiers{ commandIds }, mOptionalAttributesIdentifiers{ attributeIds }
         {}
 
-        SupportedCluster(chip::ClusterId clusterId) : mClusterIdentifier{ clusterId } {}
+        SupportedCluster(ClusterId clusterId) : mClusterIdentifier{ clusterId } {}
     };
 
     ContentApp(std::vector<SupportedCluster> supportedClusters) : mSupportedClusters{ supportedClusters } {}
@@ -119,7 +119,7 @@ public:
     inline EndpointId GetEndpointId() { return mEndpointId; };
 
     const std::vector<SupportedCluster> & GetSupportedClusters() const { return mSupportedClusters; };
-    bool HasSupportedCluster(chip::ClusterId clusterId) const;
+    bool HasSupportedCluster(ClusterId clusterId) const;
 
     virtual AccountLoginDelegate * GetAccountLoginDelegate()               = 0;
     virtual ApplicationBasicDelegate * GetApplicationBasicDelegate()       = 0;

--- a/src/app/app-platform/ContentApp.h
+++ b/src/app/app-platform/ContentApp.h
@@ -97,15 +97,15 @@ class DLL_EXPORT ContentApp
 public:
     struct SupportedCluster
     {
-        chip::ClusterId clusterIdentifier{ chip::kInvalidClusterId };
-        uint32_t features{ 0 };
-        std::vector<chip::CommandId> optionalCommandIdentifiers;
-        std::vector<chip::AttributeId> optionalAttributesIdentifiers;
+        chip::ClusterId mClusterIdentifier{ chip::kInvalidClusterId };
+        uint32_t mFeatures{ 0 };
+        std::vector<chip::CommandId> mOptionalCommandIdentifiers;
+        std::vector<chip::AttributeId> mOptionalAttributesIdentifiers;
 
         SupportedCluster(chip::ClusterId clusterId, uint32_t features, const std::vector<chip::CommandId> & commandIds,
                          const std::vector<chip::AttributeId> & attributeIds) :
-            clusterIdentifier{ clusterId },
-            features{ features }, optionalCommandIdentifiers{ commandIds }, optionalAttributesIdentifiers{ attributeIds }
+            mClusterIdentifier{ clusterId },
+            mFeatures{ features }, mOptionalCommandIdentifiers{ commandIds }, mOptionalAttributesIdentifiers{ attributeIds }
         {}
     };
 

--- a/src/app/app-platform/ContentApp.h
+++ b/src/app/app-platform/ContentApp.h
@@ -38,7 +38,6 @@
 #include <protocols/interaction_model/StatusCode.h>
 
 #include <string>
-#include <vector>
 
 namespace chip {
 namespace AppPlatform {

--- a/src/app/app-platform/ContentApp.h
+++ b/src/app/app-platform/ContentApp.h
@@ -107,9 +107,12 @@ public:
             mClusterIdentifier{ clusterId },
             mFeatures{ features }, mOptionalCommandIdentifiers{ commandIds }, mOptionalAttributesIdentifiers{ attributeIds }
         {}
+
+        SupportedCluster(chip::ClusterId clusterId) :
+            mClusterIdentifier{ clusterId }
+        {}
     };
 
-    ContentApp() = default;
     ContentApp(std::vector<SupportedCluster> supportedClusters) : mSupportedClusters{ supportedClusters } {}
 
     virtual ~ContentApp() = default;

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -502,7 +502,7 @@ bool ContentAppPlatform::HasTargetContentApp(uint16_t vendorId, uint16_t product
         return true;
     }
 
-    if (!app->HasSupportedCluster(chip::app::Clusters::AccountLogin::Id))
+    if (!app->HasSupportedCluster(AccountLogin::Id))
     {
         ChipLogProgress(DeviceLayer, "AccountLogin cluster not supported for app with vendor id=%d \r\n", vendorId);
         return true;
@@ -534,7 +534,7 @@ uint32_t ContentAppPlatform::GetPasscodeFromContentApp(uint16_t vendorId, uint16
         return 0;
     }
 
-    if (!app->HasSupportedCluster(chip::app::Clusters::AccountLogin::Id))
+    if (!app->HasSupportedCluster(AccountLogin::Id))
     {
         ChipLogProgress(DeviceLayer, "AccountLogin cluster not supported for app with vendor id=%d \r\n", vendorId);
         return 0;

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -502,6 +502,12 @@ bool ContentAppPlatform::HasTargetContentApp(uint16_t vendorId, uint16_t product
         return true;
     }
 
+    if (!app->HasSupportedCluster(chip::app::Clusters::AccountLogin::Id))
+    {
+        ChipLogProgress(DeviceLayer, "AccountLogin cluster not supported for app with vendor id=%d \r\n", vendorId);
+        return true;
+    }
+
     static const size_t kSetupPasscodeSize = 12;
     char mSetupPasscode[kSetupPasscodeSize];
 

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -528,6 +528,12 @@ uint32_t ContentAppPlatform::GetPasscodeFromContentApp(uint16_t vendorId, uint16
         return 0;
     }
 
+    if (!app->HasSupportedCluster(chip::app::Clusters::AccountLogin::Id))
+    {
+        ChipLogProgress(DeviceLayer, "AccountLogin cluster not supported for app with vendor id=%d \r\n", vendorId);
+        return 0;
+    }
+
     static const size_t kSetupPasscodeSize = 12;
     char mSetupPasscode[kSetupPasscodeSize];
 


### PR DESCRIPTION
[Problem]
The ContentAppPlatform does not know which clusters each ContentApp supports.

Currently the ContentApp is queried to get the passcode as long as the AccountLoginDelegate is present whether or not the installed ContentApp has declared support for AccountLogin cluster in its manifest.

[Solution]
Extend the native ContentApp with a SupportedCluster list. The list is initialized from the Android AppPlatformService whenever an installed ContentApp is discovered and added to the native AppPlatform.

This list is used to check if AccountLogin cluster is supported before querying the ContentApp for the passcode.

[Test]
The feature is tested end-to-end using a native Linux casting-app and and an Android platform-app and content-app. The content-app static_matter_clusters raw asset was manipulated to verify that the clusters are parsed correctly and that the passcode is only retrievable when the AccountLogin cluster is declared.

