### PR TITLE
[OnOff] reset onTime on off with LVL cluster

### DIFF
--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -452,12 +452,12 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
                 ChipLogProgress(Zcl, "ERR: writing on/off %x", to_underlying(status));
                 return status;
             }
+        }
 
-            if (SupportsLightingApplications(endpoint))
-            {
-                ChipLogProgress(Zcl, "Off completed. reset OnTime to  0");
-                Attributes::OnTime::Set(endpoint, 0); // Reset onTime
-            }
+        if (SupportsLightingApplications(endpoint))
+        {
+            ChipLogProgress(Zcl, "Off completed. reset OnTime to  0");
+            Attributes::OnTime::Set(endpoint, 0); // Reset onTime
         }
     }
 


### PR DESCRIPTION
If an endpoint has the OnOff and the LevelControl cluster enabled, the onTime attribute is not reset in every case. See 1.5.7.1.1 and 1.5.7.4.3.

This PR resets the onTime attribute if the LevelControl cluster is enabled and a command triggers the EP to turn off.

It also fixes some tests in TC-OO-2.3.