### PR TITLE
[Android] Implement remove ICD Client Info

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/UnpairDeviceFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/UnpairDeviceFragment.kt
@@ -8,11 +8,13 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import chip.devicecontroller.ChipDeviceController
+import chip.devicecontroller.ChipICDClient
 import chip.devicecontroller.UnpairDeviceCallback
 import com.google.chip.chiptool.ChipClient
 import com.google.chip.chiptool.R
 import com.google.chip.chiptool.clusterclient.AddressUpdateFragment
 import com.google.chip.chiptool.databinding.UnpairDeviceFragmentBinding
+import com.google.chip.chiptool.util.DeviceIdUtil
 import kotlinx.coroutines.*
 
 class UnpairDeviceFragment : Fragment() {
@@ -63,6 +65,21 @@ class UnpairDeviceFragment : Fragment() {
       addressUpdateFragment.deviceId,
       ChipUnpairDeviceCallback()
     )
+
+    // Remove ICD Client info
+    if (addressUpdateFragment.isICDDevice()) {
+      ChipICDClient.removeICDClientInfo(
+        deviceController.fabricIndex,
+        addressUpdateFragment.deviceId
+      )
+
+      Log.d(TAG, "ICDClientInfo : ${ChipICDClient.getICDClientInfo(deviceController.fabricIndex)}")
+    }
+    requireActivity().runOnUiThread {
+      Log.d(TAG, "remove : ${addressUpdateFragment.deviceId}")
+      DeviceIdUtil.removeCommissionedNodeId(requireContext(), addressUpdateFragment.deviceId)
+      addressUpdateFragment.updateDeviceIdSpinner()
+    }
   }
 
   companion object {

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/UnpairDeviceFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/UnpairDeviceFragment.kt
@@ -68,10 +68,7 @@ class UnpairDeviceFragment : Fragment() {
 
     // Remove ICD Client info
     if (addressUpdateFragment.isICDDevice()) {
-      ChipICDClient.removeICDClientInfo(
-        deviceController.fabricIndex,
-        addressUpdateFragment.deviceId
-      )
+      ChipICDClient.clearICDClientInfo(deviceController.fabricIndex, addressUpdateFragment.deviceId)
 
       Log.d(TAG, "ICDClientInfo : ${ChipICDClient.getICDClientInfo(deviceController.fabricIndex)}")
     }

--- a/src/controller/java/AndroidICDClient.cpp
+++ b/src/controller/java/AndroidICDClient.cpp
@@ -28,7 +28,8 @@
 #include <lib/support/JniTypeWrappers.h>
 
 chip::app::DefaultICDClientStorage sICDClientStorage;
-static CHIP_ERROR ParseICDClientInfo(JNIEnv * env, jint jFabricIndex, jobject jIcdClientInfo, chip::app::ICDClientInfo & icdClientInfo);
+static CHIP_ERROR ParseICDClientInfo(JNIEnv * env, jint jFabricIndex, jobject jIcdClientInfo,
+                                     chip::app::ICDClientInfo & icdClientInfo);
 
 jobject getICDClientInfo(JNIEnv * env, const char * icdClientInfoSign, jint jFabricIndex)
 {
@@ -103,7 +104,8 @@ CHIP_ERROR StoreICDEntryWithKey(JNIEnv * env, jint jFabricIndex, jobject jicdCli
     chip::JniByteArray jniKey(env, jKey);
 
     err = ParseICDClientInfo(env, jFabricIndex, jicdClientInfo, clientInfo);
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, err, ChipLogError(Controller, "Failed to parse ICD Client info: %" CHIP_ERROR_FORMAT, err.Format()));
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, err,
+                        ChipLogError(Controller, "Failed to parse ICD Client info: %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = getICDClientStorage()->SetKey(clientInfo, jniKey.byteSpan());
 
@@ -126,7 +128,8 @@ CHIP_ERROR RemoveICDEntryWithKey(JNIEnv * env, jint jFabricIndex, jobject jicdCl
 
     chip::app::ICDClientInfo info;
     err = ParseICDClientInfo(env, jFabricIndex, jicdClientInfo, info);
-    VerifyOrReturnValue(err == CHIP_NO_ERROR, err, ChipLogError(Controller, "Failed to parse ICD Client info: %" CHIP_ERROR_FORMAT, err.Format()));
+    VerifyOrReturnValue(err == CHIP_NO_ERROR, err,
+                        ChipLogError(Controller, "Failed to parse ICD Client info: %" CHIP_ERROR_FORMAT, err.Format()));
 
     getICDClientStorage()->RemoveKey(info);
 
@@ -150,37 +153,44 @@ CHIP_ERROR ParseICDClientInfo(JNIEnv * env, jint jFabricIndex, jobject jIcdClien
 {
     VerifyOrReturnError(jIcdClientInfo != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    jmethodID getPeerNodeIdMethod  = nullptr;
-    jmethodID getStartCounterMethod   = nullptr;
-    jmethodID getOffsetMethod = nullptr;
+    jmethodID getPeerNodeIdMethod       = nullptr;
+    jmethodID getStartCounterMethod     = nullptr;
+    jmethodID getOffsetMethod           = nullptr;
     jmethodID getMonitoredSubjectMethod = nullptr;
-    jmethodID getIcdAesKeyMethod = nullptr;
-    jmethodID getIcdHmacKeyMethod = nullptr;
+    jmethodID getIcdAesKeyMethod        = nullptr;
+    jmethodID getIcdHmacKeyMethod       = nullptr;
 
-    ReturnErrorOnFailure(chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getPeerNodeId", "()J", &getPeerNodeIdMethod));
-    ReturnErrorOnFailure(chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getStartCounter", "()J", &getStartCounterMethod));
+    ReturnErrorOnFailure(
+        chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getPeerNodeId", "()J", &getPeerNodeIdMethod));
+    ReturnErrorOnFailure(
+        chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getStartCounter", "()J", &getStartCounterMethod));
     ReturnErrorOnFailure(chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getOffset", "()J", &getOffsetMethod));
-    ReturnErrorOnFailure(chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getMonitoredSubject", "()J", &getMonitoredSubjectMethod));
-    ReturnErrorOnFailure(chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getIcdAesKey", "()[B", &getIcdAesKeyMethod));
-    ReturnErrorOnFailure(chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getIcdHmacKey", "()[B", &getIcdHmacKeyMethod));
+    ReturnErrorOnFailure(chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getMonitoredSubject", "()J",
+                                                                       &getMonitoredSubjectMethod));
+    ReturnErrorOnFailure(
+        chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getIcdAesKey", "()[B", &getIcdAesKeyMethod));
+    ReturnErrorOnFailure(
+        chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getIcdHmacKey", "()[B", &getIcdHmacKeyMethod));
 
-    jlong jPeerNodeId  = env->CallLongMethod(jIcdClientInfo, getPeerNodeIdMethod);
-    jlong jStartCounter   = env->CallLongMethod(jIcdClientInfo, getStartCounterMethod);
-    jlong jOffset = env->CallLongMethod(jIcdClientInfo, getOffsetMethod);
+    jlong jPeerNodeId       = env->CallLongMethod(jIcdClientInfo, getPeerNodeIdMethod);
+    jlong jStartCounter     = env->CallLongMethod(jIcdClientInfo, getStartCounterMethod);
+    jlong jOffset           = env->CallLongMethod(jIcdClientInfo, getOffsetMethod);
     jlong jMonitoredSubject = env->CallLongMethod(jIcdClientInfo, getMonitoredSubjectMethod);
-    jbyteArray jIcdAesKey = static_cast<jbyteArray>(env->CallObjectMethod(jIcdClientInfo, getIcdAesKeyMethod));
-    jbyteArray jIcdHmacKey = static_cast<jbyteArray>(env->CallObjectMethod(jIcdClientInfo, getIcdHmacKeyMethod));
+    jbyteArray jIcdAesKey   = static_cast<jbyteArray>(env->CallObjectMethod(jIcdClientInfo, getIcdAesKeyMethod));
+    jbyteArray jIcdHmacKey  = static_cast<jbyteArray>(env->CallObjectMethod(jIcdClientInfo, getIcdHmacKeyMethod));
 
     chip::ScopedNodeId scopedNodeId(static_cast<chip::NodeId>(jPeerNodeId), static_cast<chip::FabricIndex>(jFabricIndex));
     chip::JniByteArray jniIcdAesKey(env, jIcdAesKey);
     chip::JniByteArray jniIcdHmacKey(env, jIcdHmacKey);
 
-    icdClientInfo.peer_node  = scopedNodeId;
-    icdClientInfo.start_icd_counter   = static_cast<uint32_t>(jStartCounter);
-    icdClientInfo.offset = static_cast<uint32_t>(jOffset);
+    icdClientInfo.peer_node         = scopedNodeId;
+    icdClientInfo.start_icd_counter = static_cast<uint32_t>(jStartCounter);
+    icdClientInfo.offset            = static_cast<uint32_t>(jOffset);
     icdClientInfo.monitored_subject = static_cast<uint64_t>(jMonitoredSubject);
-    memcpy(icdClientInfo.aes_key_handle.AsMutable<chip::Crypto::Symmetric128BitsKeyByteArray>(), jniIcdAesKey.data(), sizeof(chip::Crypto::Symmetric128BitsKeyByteArray));
-    memcpy(icdClientInfo.hmac_key_handle.AsMutable<chip::Crypto::Symmetric128BitsKeyByteArray>(), jniIcdHmacKey.data(), sizeof(chip::Crypto::Symmetric128BitsKeyByteArray));
+    memcpy(icdClientInfo.aes_key_handle.AsMutable<chip::Crypto::Symmetric128BitsKeyByteArray>(), jniIcdAesKey.data(),
+           sizeof(chip::Crypto::Symmetric128BitsKeyByteArray));
+    memcpy(icdClientInfo.hmac_key_handle.AsMutable<chip::Crypto::Symmetric128BitsKeyByteArray>(), jniIcdHmacKey.data(),
+           sizeof(chip::Crypto::Symmetric128BitsKeyByteArray));
 
     return CHIP_NO_ERROR;
 }

--- a/src/controller/java/AndroidICDClient.cpp
+++ b/src/controller/java/AndroidICDClient.cpp
@@ -127,7 +127,7 @@ CHIP_ERROR RemoveICDEntryWithKey(JNIEnv * env, jint jFabricIndex, jobject jicdCl
     chip::app::ICDClientInfo info;
     err = ParseICDClientInfo(env, jFabricIndex, jicdClientInfo, info);
     VerifyOrReturnValue(err == CHIP_NO_ERROR, err, ChipLogError(Controller, "Failed to parse ICD Client info: %" CHIP_ERROR_FORMAT, err.Format()));
-    
+
     getICDClientStorage()->RemoveKey(info);
 
     return err;

--- a/src/controller/java/AndroidICDClient.cpp
+++ b/src/controller/java/AndroidICDClient.cpp
@@ -93,6 +93,19 @@ jobject getICDClientInfo(JNIEnv * env, const char * icdClientInfoSign, jint jFab
     return jInfo;
 }
 
+jlong removeICDClientInfo(JNIEnv * env, jint jFabricIndex, jlong jNodeId)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    chip::ScopedNodeId scopedNodeId(static_cast<chip::NodeId>(jNodeId), static_cast<chip::FabricIndex>(jFabricIndex));
+    err = getICDClientStorage()->DeleteEntry(scopedNodeId);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "removeICDClientInfo error!: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+    return static_cast<jlong>(err.AsInteger());
+}
+
 chip::app::DefaultICDClientStorage * getICDClientStorage()
 {
     return &sICDClientStorage;

--- a/src/controller/java/AndroidICDClient.h
+++ b/src/controller/java/AndroidICDClient.h
@@ -29,4 +29,6 @@
 
 jobject getICDClientInfo(JNIEnv * env, const char * icdClientInfoSign, jint jFabricIndex);
 
+jlong removeICDClientInfo(JNIEnv * env, jint jFabricIndex, jlong jNodeId);
+
 chip::app::DefaultICDClientStorage * getICDClientStorage();

--- a/src/controller/java/AndroidICDClient.h
+++ b/src/controller/java/AndroidICDClient.h
@@ -29,6 +29,10 @@
 
 jobject getICDClientInfo(JNIEnv * env, const char * icdClientInfoSign, jint jFabricIndex);
 
-jlong removeICDClientInfo(JNIEnv * env, jint jFabricIndex, jlong jNodeId);
+CHIP_ERROR StoreICDEntryWithKey(JNIEnv * env, jint jFabricIndex, jobject jicdClientInfo, jbyteArray jKey);
+
+CHIP_ERROR RemoveICDEntryWithKey(JNIEnv * env, jint jFabricIndex, jobject jicdClientInfo);
+
+CHIP_ERROR ClearICDClientInfo(JNIEnv * env, jint jFabricIndex, jlong jNodeId);
 
 chip::app::DefaultICDClientStorage * getICDClientStorage();

--- a/src/controller/java/CHIPICDClient-JNI.cpp
+++ b/src/controller/java/CHIPICDClient-JNI.cpp
@@ -28,8 +28,20 @@ JNI_METHOD(jobject, getICDClientInfo)(JNIEnv * env, jobject self, jint jFabricIn
     return getICDClientInfo(env, "chip/devicecontroller/ICDClientInfo", jFabricIndex);
 }
 
-JNI_METHOD(void, removeICDClientInfo)(JNIEnv * env, jobject self, jint jFabricIndex, jlong jNodeId)
+JNI_METHOD(void, storeICDEntryWithKey)(JNIEnv * env, jobject self, jint jFabricIndex, jobject jicdClientInfo, jbyteArray jKey)
 {
     chip::DeviceLayer::StackLock lock;
-    removeICDClientInfo(env, jFabricIndex, jNodeId);
+    StoreICDEntryWithKey(env, jFabricIndex, jicdClientInfo, jKey);
+}
+
+JNI_METHOD(void, removeICDEntryWithKey)(JNIEnv * env, jobject self, jint jFabricIndex, jobject jicdClientInfo)
+{
+    chip::DeviceLayer::StackLock lock;
+    RemoveICDEntryWithKey(env, jFabricIndex, jicdClientInfo);
+}
+
+JNI_METHOD(void, clearICDClientInfo)(JNIEnv * env, jobject self, jint jFabricIndex, jlong jNodeId)
+{
+    chip::DeviceLayer::StackLock lock;
+    ClearICDClientInfo(env, jFabricIndex, jNodeId);
 }

--- a/src/controller/java/CHIPICDClient-JNI.cpp
+++ b/src/controller/java/CHIPICDClient-JNI.cpp
@@ -27,3 +27,9 @@ JNI_METHOD(jobject, getICDClientInfo)(JNIEnv * env, jobject self, jint jFabricIn
 
     return getICDClientInfo(env, "chip/devicecontroller/ICDClientInfo", jFabricIndex);
 }
+
+JNI_METHOD(void, removeICDClientInfo)(JNIEnv * env, jobject self, jint jFabricIndex, jlong jNodeId)
+{
+    chip::DeviceLayer::StackLock lock;
+    removeICDClientInfo(env, jFabricIndex, jNodeId);
+}

--- a/src/controller/java/MatterICDClient-JNI.cpp
+++ b/src/controller/java/MatterICDClient-JNI.cpp
@@ -28,8 +28,20 @@ JNI_METHOD(jobject, getICDClientInfo)(JNIEnv * env, jobject self, jint jFabricIn
     return getICDClientInfo(env, "matter/controller/ICDClientInfo", jFabricIndex);
 }
 
-JNI_METHOD(void, removeICDClientInfo)(JNIEnv * env, jobject self, jint jFabricIndex, jlong jNodeId)
+JNI_METHOD(void, storeICDEntryWithKey)(JNIEnv * env, jobject self, jint jFabricIndex, jobject jicdClientInfo, jbyteArray jKey)
 {
     chip::DeviceLayer::StackLock lock;
-    removeICDClientInfo(env, jFabricIndex, jNodeId);
+    StoreICDEntryWithKey(env, jFabricIndex, jicdClientInfo, jKey);
+}
+
+JNI_METHOD(void, removeICDEntryWithKey)(JNIEnv * env, jobject self, jint jFabricIndex, jobject jicdClientInfo)
+{
+    chip::DeviceLayer::StackLock lock;
+    RemoveICDEntryWithKey(env, jFabricIndex, jicdClientInfo);
+}
+
+JNI_METHOD(void, clearICDClientInfo)(JNIEnv * env, jobject self, jint jFabricIndex, jlong jNodeId)
+{
+    chip::DeviceLayer::StackLock lock;
+    ClearICDClientInfo(env, jFabricIndex, jNodeId);
 }

--- a/src/controller/java/MatterICDClient-JNI.cpp
+++ b/src/controller/java/MatterICDClient-JNI.cpp
@@ -27,3 +27,9 @@ JNI_METHOD(jobject, getICDClientInfo)(JNIEnv * env, jobject self, jint jFabricIn
 
     return getICDClientInfo(env, "matter/controller/ICDClientInfo", jFabricIndex);
 }
+
+JNI_METHOD(void, removeICDClientInfo)(JNIEnv * env, jobject self, jint jFabricIndex, jlong jNodeId)
+{
+    chip::DeviceLayer::StackLock lock;
+    removeICDClientInfo(env, jFabricIndex, jNodeId);
+}

--- a/src/controller/java/src/chip/devicecontroller/ChipICDClient.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipICDClient.java
@@ -30,5 +30,7 @@ public class ChipICDClient {
     return clientInfo.stream().anyMatch(info -> info.getPeerNodeId() == deviceId);
   }
 
+  public static native void removeICDClientInfo(int fabricIndex, long deviceId);
+
   public static native List<ICDClientInfo> getICDClientInfo(int fabricIndex);
 }

--- a/src/controller/java/src/chip/devicecontroller/ChipICDClient.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipICDClient.java
@@ -30,7 +30,11 @@ public class ChipICDClient {
     return clientInfo.stream().anyMatch(info -> info.getPeerNodeId() == deviceId);
   }
 
-  public static native void removeICDClientInfo(int fabricIndex, long deviceId);
+  public static native void storeICDEntryWithKey(int fabricIndex, ICDClientInfo icdClientInfo, byte[] key);
+
+  public static native void removeICDEntryWithKey(int fabricIndex, ICDClientInfo icdClientInfo);
+
+  public static native void clearICDClientInfo(int fabricIndex, long deviceId);
 
   public static native List<ICDClientInfo> getICDClientInfo(int fabricIndex);
 }

--- a/src/controller/java/src/chip/devicecontroller/ChipICDClient.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipICDClient.java
@@ -30,7 +30,8 @@ public class ChipICDClient {
     return clientInfo.stream().anyMatch(info -> info.getPeerNodeId() == deviceId);
   }
 
-  public static native void storeICDEntryWithKey(int fabricIndex, ICDClientInfo icdClientInfo, byte[] key);
+  public static native void storeICDEntryWithKey(
+      int fabricIndex, ICDClientInfo icdClientInfo, byte[] key);
 
   public static native void removeICDEntryWithKey(int fabricIndex, ICDClientInfo icdClientInfo);
 

--- a/src/controller/java/src/matter/controller/MatterICDClientImpl.kt
+++ b/src/controller/java/src/matter/controller/MatterICDClientImpl.kt
@@ -24,7 +24,11 @@ object MatterICDClientImpl {
     return clientInfo.firstOrNull { it.peerNodeId == deviceId } != null
   }
 
-  external fun getICDClientInfo(fabricIndex: Int): List<ICDClientInfo>?
+  external fun storeICDEntryWithKey(fabricIndex: Int, icdClientInfo: ICDClientInfo, key: ByteArray)
 
-  external fun removeICDClientInfo(fabricIndex: Int, deviceId: Long)
+  external fun removeICDEntryWithKey(fabricIndex: Int, icdClientInfo: ICDClientInfo)
+
+  external fun clearICDClientInfo(fabricIndex: Int, deviceId: Long)
+
+  external fun getICDClientInfo(fabricIndex: Int): List<ICDClientInfo>?
 }

--- a/src/controller/java/src/matter/controller/MatterICDClientImpl.kt
+++ b/src/controller/java/src/matter/controller/MatterICDClientImpl.kt
@@ -25,4 +25,6 @@ object MatterICDClientImpl {
   }
 
   external fun getICDClientInfo(fabricIndex: Int): List<ICDClientInfo>?
+
+  external fun removeICDClientInfo(fabricIndex: Int, deviceId: Long)
 }


### PR DESCRIPTION
Fix #33742 

1. Add removeICDClientInfo method for Android / Java / Kotlin.
2. Add to call this method in UnpairDeviceFragment

Fix #33227
 -> I think this issue is also related. (Also add store, remove method).