### PR TITLE
Remove 'contents of test directory' output.

### DIFF
--- a/scripts/tests/run_java_test.py
+++ b/scripts/tests/run_java_test.py
@@ -54,9 +54,6 @@ def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: 
         if retcode != 0:
             raise Exception("Failed to remove /tmp/chip* for factory reset.")
 
-        print("Contents of test directory: %s" % os.getcwd())
-        print(subprocess.check_output(["ls -l"], shell=True).decode('utf-8'))
-
         # Remove native app KVS if that was used
         kvs_match = re.search(r"--KVS (?P<kvs_path>[^ ]+)", app_args)
         if kvs_match:

--- a/scripts/tests/run_kotlin_test.py
+++ b/scripts/tests/run_kotlin_test.py
@@ -53,9 +53,6 @@ def main(app: str, app_args: str, tool_path: str, tool_cluster: str, tool_args: 
         if retcode != 0:
             raise Exception("Failed to remove /tmp/chip* for factory reset.")
 
-        print("Contents of test directory: %s" % os.getcwd())
-        print(subprocess.check_output(["ls -l"], shell=True).decode('utf-8'))
-
         # Remove native app KVS if that was used
         kvs_match = re.search(r"--KVS (?P<kvs_path>[^ ]+)", app_args)
         if kvs_match:

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -99,9 +99,6 @@ def main(app: str, factoryreset: bool, factoryreset_app_only: bool, app_args: st
         if retcode != 0:
             raise Exception("Failed to remove /tmp/chip* for factory reset.")
 
-        print("Contents of test directory: %s" % os.getcwd())
-        print(subprocess.check_output(["ls -l"], shell=True).decode('utf-8'))
-
         # Remove native app KVS if that was used
         kvs_match = re.search(r"--KVS (?P<kvs_path>[^ ]+)", app_args)
         if kvs_match:


### PR DESCRIPTION
This does not seem useful right now: it just outputs a "ls -l" on connectedhomip and it is unclear why
we have it.

I think this is debug output that was left in after #22292 and we never cleaned it up.