### PR TITLE
Simplify the implementation of `run_tv_casting_test.py` for easier addition of future test sequences that verifies that Linux tv-casting-app continues to work with Linux tv-app.

### DIFF
--- a/scripts/tests/linux/tv_casting_test_sequence_utils.py
+++ b/scripts/tests/linux/tv_casting_test_sequence_utils.py
@@ -24,6 +24,7 @@ represent individual steps in a test sequence (Step), and a class to represent a
 Additionally, it provides helper functions to retrieve specific test sequences or all defined test sequences.
 """
 
+
 class App(Enum):
     """An enumeration of the supported applications."""
 
@@ -59,7 +60,8 @@ class Step:
     ):
         # Validate that either `output_msg` or `input_cmd` is provided, but not both.
         if output_msg is not None and input_cmd is not None:
-            raise ValueError('Step cannot contain both `output_msg` and `input_cmd`. Either `output_msg` or `input_cmd` should be provided.')
+            raise ValueError(
+                'Step cannot contain both `output_msg` and `input_cmd`. Either `output_msg` or `input_cmd` should be provided.')
         elif output_msg is None and input_cmd is None:
             raise ValueError('Step must contain either `output_msg` or `input_cmd`. Both are `None`.')
 
@@ -87,7 +89,6 @@ class Sequence:
         self.name = name
         self.steps = steps
 
-
     @staticmethod
     def get_test_sequence_by_name(test_sequences: List['Sequence'], test_sequence_name: str) -> Optional['Sequence']:
         """Retrieve a test sequence from a list of sequences by its name."""
@@ -97,11 +98,10 @@ class Sequence:
                 return sequence
         return None
 
-
     @staticmethod
     def get_test_sequences() -> List['Sequence']:
         """Retrieve all the test sequences to validate the casting experience between the Linux tv-casting-app and the Linux tv-app."""
 
         from linux.tv_casting_test_sequences import test_sequences
-        
+
         return test_sequences

--- a/scripts/tests/linux/tv_casting_test_sequence_utils.py
+++ b/scripts/tests/linux/tv_casting_test_sequence_utils.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env -S python3 -B
+
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from typing import List, Optional
+
+"""
+This file defines the utility classes for creating and managing test sequences to validate the casting experience between 
+the Linux tv-casting-app and the Linux tv-app. It includes an enumeration for the supported applications (App), a class to 
+represent individual steps in a test sequence (Step), and a class to represent a complete test sequence (Sequence). 
+Additionally, it provides helper functions to retrieve specific test sequences or all defined test sequences.
+"""
+
+class App(Enum):
+    """An enumeration of the supported applications."""
+
+    TV_APP = 'tv-app'
+    TV_CASTING_APP = 'tv-casting-app'
+
+
+class Step:
+    """A class to represent a step in a test sequence for validation.
+
+    A `Step` object contains attributes relevant to a test step where each object contains:
+    - `app` subprocess to parse for `output_msg` or send `input_cmd`
+    - `timeout_sec` specified the timeout duration for parsing the `output_msg` (optional, defaults to DEFAULT_TIMEOUT_SEC)
+    - `output_msg` or `input_cmd` (mutually exclusive)
+
+    For output message blocks, define the start line, relevant lines, and the last line. If the last line contains trivial closing 
+    characters (e.g., closing brackets, braces, or commas), include the line before it with actual content. For example:
+        `Step(subprocess_='tv-casting-app', output_msg=['InvokeResponseMessage =', 'exampleData', 'InteractionModelRevision =', '},'])`
+
+    For input commands, define the command string with placeholders for variables that need to be updated. For example:
+        `Step(subprocess_='tv-casting-app', input_cmd='cast request 0\n')`
+    """
+
+    # The maximum default time to wait while parsing for output string(s).
+    DEFAULT_TIMEOUT_SEC = 10
+
+    def __init__(
+        self,
+        app: App,
+        timeout_sec: Optional[int] = DEFAULT_TIMEOUT_SEC,
+        output_msg: Optional[List[str]] = None,
+        input_cmd: Optional[str] = None,
+    ):
+        # Validate that either `output_msg` or `input_cmd` is provided, but not both.
+        if output_msg is not None and input_cmd is not None:
+            raise ValueError('Step cannot contain both `output_msg` and `input_cmd`. Either `output_msg` or `input_cmd` should be provided.')
+        elif output_msg is None and input_cmd is None:
+            raise ValueError('Step must contain either `output_msg` or `input_cmd`. Both are `None`.')
+
+        # Define either `App.TV_APP` or `App.TV_CASTING_APP` on which we need to parse for `output_msg` or send `input_cmd`.
+        self.app = app
+
+        # Define the maximum time in seconds for timeout while parsing for the `output_msg`. If not provided, then we use the DEFAULT_TIMEOUT_SEC.
+        self.timeout_sec = timeout_sec
+
+        # Define the `output_msg` that we need to parse for in a list format.
+        self.output_msg = output_msg
+
+        # Define the `input_cmd` that we need to send to either the `App.TV_APP` or `App.TV_CASTING_APP`.
+        self.input_cmd = input_cmd
+
+
+class Sequence:
+    """A class representing a sequence of steps for testing the casting experience between the Linux tv-casting-app and the tv-app.
+
+    A Sequence object needs to be defined with an appropriate test sequence `name` along with its list of `Step` objects that will
+    be used for validating the casting experience.
+    """
+
+    def __init__(self, name: str, steps: List[Step]):
+        self.name = name
+        self.steps = steps
+
+
+    @staticmethod
+    def get_test_sequence_by_name(test_sequences: List['Sequence'], test_sequence_name: str) -> Optional['Sequence']:
+        """Retrieve a test sequence from a list of sequences by its name."""
+
+        for sequence in test_sequences:
+            if sequence.name == test_sequence_name:
+                return sequence
+        return None
+
+
+    @staticmethod
+    def get_test_sequences() -> List['Sequence']:
+        """Retrieve all the test sequences to validate the casting experience between the Linux tv-casting-app and the Linux tv-app."""
+
+        from linux.tv_casting_test_sequences import test_sequences
+        
+        return test_sequences

--- a/scripts/tests/linux/tv_casting_test_sequences.py
+++ b/scripts/tests/linux/tv_casting_test_sequences.py
@@ -25,7 +25,7 @@ followed by the same for the tv-casting-app. On the other hand, at the end of ea
 be stopped by providing the `STOP_APP` string as the `input_cmd`. As noted in the example below of `example_test_sequence`, the first
 four steps pertain to starting the apps while the last two are for signaling stopping the apps. 
 
-Note: `START_APP` and `STOP_APP` are reserved for signaling the starting and stopping of an apps.
+Note: `START_APP` and `STOP_APP` are reserved for signaling the starting and stopping of apps.
 
 Example:
      test_sequences = [

--- a/scripts/tests/linux/tv_casting_test_sequences.py
+++ b/scripts/tests/linux/tv_casting_test_sequences.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env -S python3 -B
+
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+from enum import Enum
+from typing import List, Optional
+
+"""
+Define the test sequences with the relevant steps that will be used in the `scripts/tests/run_tv_casting_test.py` for 
+validating the casting experience between the Linux tv-casting-app and the Linux tv-app.
+"""
+
+# The maximum amount of time to wait for the Linux tv-app to start before timeout.
+TV_APP_MAX_START_WAIT_SEC = 2
+
+# The maximum default time to wait while parsing for output string(s).
+DEFAULT_TIMEOUT_SEC = 10
+
+# Values that identify the Linux tv-app and are noted in the 'Device Configuration' in the Linux tv-app output
+# as well as under the 'Discovered Commissioner' details in the Linux tv-casting-app output.
+VENDOR_ID = 0xFFF1   # Spec 7.20.2.1 MEI code: test vendor IDs are 0xFFF1 to 0xFFF4
+PRODUCT_ID = 0x8001  # Test product id
+DEVICE_TYPE_CASTING_VIDEO_PLAYER = 0x23    # Device type library 10.3: Casting Video Player
+
+TEST_TV_CASTING_APP_DEVICE_NAME = 'Test TV casting app'  # Test device name for identifying the tv-casting-app
+
+# Values to verify the subscription state against from the `ReportDataMessage` in the Linux tv-casting-app output.
+CLUSTER_MEDIA_PLAYBACK = '0x506'  # Application Cluster Spec 6.10.3 Cluster ID: Media Playback
+ATTRIBUTE_CURRENT_PLAYBACK_STATE = '0x0000_0000'  # Application Cluster Spec 6.10.6 Attribute ID: Current State of Playback
+
+
+class App(Enum):
+    """An enumeration of the supported applications."""
+
+    TV_APP = 'tv-app'
+    TV_CASTING_APP = 'tv-casting-app'
+
+
+class Step:
+    """A class to represent a step in a test sequence for validation.
+
+    A Step object contains attributes relevant to a test step where each object contains:
+    - `app` subprocess to parse for `output_msg` or `send input_cmd`
+    - `timeout_sec` specified the timeout duration for parsing the `output_msg` (optional, defaults to DEFAULT_TIMEOUT_SEC)
+    - `output_msg` or `input_cmd` (mutually exclusive)
+
+    Note: The first entry in the test sequence list of steps should always be the output string to verify that the tv-app 
+    is up and running.
+
+    For output message blocks, define the start line, relevant lines, and the last line. If the last line contains trivial closing 
+    characters (e.g., closing brackets, braces, or commas), include the line before it with actual content. For example:
+        `Step(subprocess_='tv-casting-app', output_msg=['InvokeResponseMessage =', 'exampleData', 'InteractionModelRevision =', '},'])`
+
+    For input commands, define the command string with placeholders for variables that need to be updated. For example:
+        `Step(subprocess_='tv-casting-app', input_cmd='cast request 0\n')`
+    """
+
+    def __init__(
+        self,
+        app: App,
+        timeout_sec: Optional[int] = DEFAULT_TIMEOUT_SEC,
+        output_msg: Optional[List[str]] = None,
+        input_cmd: Optional[str] = None,
+    ):
+        # Validate that either `output_msg` or `input_cmd` is provided, but not both.
+        if output_msg is not None and input_cmd is not None:
+            logging.error('Step cannot contain both `output_msg` and `input_cmd`. Either `output_msg` or `input_cmd` should be provided.')
+            sys.exit(1)
+        elif output_msg is None and input_cmd is None:
+            logging.error('Step must contain either `output_msg` or `input_cmd`. Both are `None`.')
+            sys.exit(1)
+
+        # Define either `App.TV_APP` or `App.TV_CASTING_APP` on which we need to parse for `output_msg` or send `input_cmd`.
+        self.app = app
+
+        # Define the maximum time in seconds for timeout while parsing for the `output_msg`. If not provided, then we use the DEFAULT_TIMEOUT_SEC.
+        self.timeout_sec = timeout_sec
+
+        # Define the `output_msg` that we need to parse for in a list format.
+        self.output_msg = output_msg
+
+        # Define the `input_cmd` that we need to send to either the `App.TV_APP` or `App.TV_CASTING_APP`.
+        self.input_cmd = input_cmd
+
+
+class Sequence:
+    """A class representing a sequence of steps for testing the casting experience between the Linux tv-casting-app and the tv-app.
+
+    A Sequence object needs to be defined with an appropriate test sequence `name` along with its list of `Step` objects that will
+    be used for validating the casting experience.
+    """
+
+    def __init__(self, name: str, steps: List[Step]):
+        self.name = name
+        self.steps = steps
+
+
+def get_test_sequence_by_name(test_sequences: List[Sequence], test_sequence_name: str) -> Optional[Sequence]:
+    """Retrieve a test sequence from a list of sequences by its name."""
+
+    for sequence in test_sequences:
+        if sequence.name == test_sequence_name:
+            return sequence
+    return None
+
+
+def get_test_sequences() -> List[Sequence]:
+    """Retrieve all the test sequences to validate the casting experience between the Linux tv-casting-app and the Linux tv-app."""
+
+    test_sequences = [
+        Sequence(
+            name='commissionee_generated_passcode_test',
+            steps=[
+                # Validate that the tv-app is up and running.
+                Step(app=App.TV_APP, timeout_sec=TV_APP_MAX_START_WAIT_SEC, output_msg=['Started commissioner']),
+
+                # Validate that there is a valid discovered commissioner with {VENDOR_ID}, {PRODUCT_ID}, and {DEVICE_TYPE_CASTING_VIDEO_PLAYER} in the tv-casting-app output.
+                Step(app=App.TV_CASTING_APP, output_msg=['Discovered Commissioner #0', f'Vendor ID: {VENDOR_ID}', f'Product ID: {PRODUCT_ID}',
+                                                         f'Device Type: {DEVICE_TYPE_CASTING_VIDEO_PLAYER}', 'Supports Commissioner Generated Passcode: true']),
+
+                # Validate that we are ready to send `cast request` command to the tv-casting-app subprocess.
+                Step(app=App.TV_CASTING_APP, output_msg=['Example: cast request 0']),
+
+                # Send `cast request {valid_discovered_commissioner_number}\n` command to the tv-casting-app subprocess.
+                Step(app=App.TV_CASTING_APP, input_cmd='cast request 0\n'),
+
+                # Validate that the `Identification Declaration` message block in the tv-casting-app output has the expected values for `device Name`, `vendor id`, and `product id`.
+                Step(app=App.TV_CASTING_APP, output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
+                                                         f'vendor id: {VENDOR_ID}', f'product id: {PRODUCT_ID}', 'Identification Declaration End']),
+
+                # Validate that the `Identification Declaration` message block in the tv-app output has the expected values for `device Name`, `vendor id`, and `product id`.
+                Step(app=App.TV_APP, output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
+                                                 f'vendor id: {VENDOR_ID}', f'product id: {PRODUCT_ID}', 'Identification Declaration End']),
+
+                # Validate that we received the cast request from the tv-casting-app on the tv-app output.
+                Step(app=App.TV_APP,
+                     output_msg=['PROMPT USER: Test TV casting app is requesting permission to cast to this TV, approve?']),
+
+                # Validate that we received the instructions on the tv-app output for sending the `controller ux ok` command.
+                Step(app=App.TV_APP, output_msg=['Via Shell Enter: controller ux ok|cancel']),
+
+                # Send `controller ux ok` command to the tv-app subprocess.
+                Step(app=App.TV_APP, input_cmd='controller ux ok\n'),
+
+                # Validate that pairing succeeded between the tv-casting-app and the tv-app.
+                Step(app=App.TV_APP, output_msg=['Secure Pairing Success']),
+
+                # Validate that commissioning succeeded in the tv-casting-app output.
+                Step(app=App.TV_CASTING_APP, output_msg=['Commissioning completed successfully']),
+
+                # Validate that commissioning succeeded in the tv-app output.
+                Step(app=App.TV_APP, output_msg=['------PROMPT USER: commissioning success']),
+
+                # Validate the subscription state by looking at the `Cluster` and `Attribute` values in the `ReportDataMessage` block in the tv-casting-app output.
+                Step(app=App.TV_CASTING_APP, output_msg=[
+                    'ReportDataMessage =', f'Cluster = {CLUSTER_MEDIA_PLAYBACK}', f'Attribute = {ATTRIBUTE_CURRENT_PLAYBACK_STATE}', 'InteractionModelRevision =', '}']),
+
+                # Validate the LaunchURL in the tv-app output.
+                Step(app=App.TV_APP,
+                     output_msg=['ContentLauncherManager::HandleLaunchUrl TEST CASE ContentURL=https://www.test.com/videoid DisplayString=Test video']),
+
+                # Validate the LaunchURL in the tv-casting-app output.
+                Step(app=App.TV_CASTING_APP, output_msg=['InvokeResponseMessage =',
+                                                         'exampleData', 'InteractionModelRevision =', '},'])
+            ]
+        )
+    ]
+
+    return test_sequences

--- a/scripts/tests/linux/tv_casting_test_sequences.py
+++ b/scripts/tests/linux/tv_casting_test_sequences.py
@@ -78,75 +78,75 @@ CLUSTER_MEDIA_PLAYBACK = '0x506'  # Application Cluster Spec 6.10.3 Cluster ID: 
 ATTRIBUTE_CURRENT_PLAYBACK_STATE = '0x0000_0000'  # Application Cluster Spec 6.10.6 Attribute ID: Current State of Playback
 
 test_sequences = [
-     Sequence(
-          name='commissionee_generated_passcode_test',
-          steps=[
-               # Signal to start the tv-app.
-               Step(app=App.TV_APP, input_cmd=START_APP),
+    Sequence(
+        name='commissionee_generated_passcode_test',
+        steps=[
+             # Signal to start the tv-app.
+            Step(app=App.TV_APP, input_cmd=START_APP),
 
-               # Validate that the tv-app is up and running.
-               Step(app=App.TV_APP, timeout_sec=APP_MAX_START_WAIT_SEC, output_msg=['Started commissioner']),
+            # Validate that the tv-app is up and running.
+            Step(app=App.TV_APP, timeout_sec=APP_MAX_START_WAIT_SEC, output_msg=['Started commissioner']),
 
-               # Signal to start the tv-casting-app.
-               Step(app=App.TV_CASTING_APP, input_cmd=START_APP),
+            # Signal to start the tv-casting-app.
+            Step(app=App.TV_CASTING_APP, input_cmd=START_APP),
 
-               # Validate that the server is properly initialized in the tv-casting-app output.
-               Step(app=App.TV_CASTING_APP, timeout_sec=APP_MAX_START_WAIT_SEC, output_msg=['Server initialization complete']),
+            # Validate that the server is properly initialized in the tv-casting-app output.
+            Step(app=App.TV_CASTING_APP, timeout_sec=APP_MAX_START_WAIT_SEC, output_msg=['Server initialization complete']),
 
-               # Validate that there is a valid discovered commissioner with {VENDOR_ID}, {PRODUCT_ID}, and {DEVICE_TYPE_CASTING_VIDEO_PLAYER} in the tv-casting-app output.
-               Step(app=App.TV_CASTING_APP, output_msg=['Discovered Commissioner #0', f'Vendor ID: {VENDOR_ID}', f'Product ID: {PRODUCT_ID}',
-                                                       f'Device Type: {DEVICE_TYPE_CASTING_VIDEO_PLAYER}', 'Supports Commissioner Generated Passcode: true']),
+            # Validate that there is a valid discovered commissioner with {VENDOR_ID}, {PRODUCT_ID}, and {DEVICE_TYPE_CASTING_VIDEO_PLAYER} in the tv-casting-app output.
+            Step(app=App.TV_CASTING_APP, output_msg=['Discovered Commissioner #0', f'Vendor ID: {VENDOR_ID}', f'Product ID: {PRODUCT_ID}',
+                                                     f'Device Type: {DEVICE_TYPE_CASTING_VIDEO_PLAYER}', 'Supports Commissioner Generated Passcode: true']),
 
-               # Validate that we are ready to send `cast request` command to the tv-casting-app subprocess.
-               Step(app=App.TV_CASTING_APP, output_msg=['Example: cast request 0']),
+            # Validate that we are ready to send `cast request` command to the tv-casting-app subprocess.
+            Step(app=App.TV_CASTING_APP, output_msg=['Example: cast request 0']),
 
-               # Send `cast request {valid_discovered_commissioner_number}\n` command to the tv-casting-app subprocess.
-               Step(app=App.TV_CASTING_APP, input_cmd='cast request 0\n'),
+            # Send `cast request {valid_discovered_commissioner_number}\n` command to the tv-casting-app subprocess.
+            Step(app=App.TV_CASTING_APP, input_cmd='cast request 0\n'),
 
-               # Validate that the `Identification Declaration` message block in the tv-casting-app output has the expected values for `device Name`, `vendor id`, and `product id`.
-               Step(app=App.TV_CASTING_APP, output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
-                                                       f'vendor id: {VENDOR_ID}', f'product id: {PRODUCT_ID}', 'Identification Declaration End']),
+            # Validate that the `Identification Declaration` message block in the tv-casting-app output has the expected values for `device Name`, `vendor id`, and `product id`.
+            Step(app=App.TV_CASTING_APP, output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
+                                                     f'vendor id: {VENDOR_ID}', f'product id: {PRODUCT_ID}', 'Identification Declaration End']),
 
-               # Validate that the `Identification Declaration` message block in the tv-app output has the expected values for `device Name`, `vendor id`, and `product id`.
-               Step(app=App.TV_APP, output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
+            # Validate that the `Identification Declaration` message block in the tv-app output has the expected values for `device Name`, `vendor id`, and `product id`.
+            Step(app=App.TV_APP, output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
                                              f'vendor id: {VENDOR_ID}', f'product id: {PRODUCT_ID}', 'Identification Declaration End']),
 
-               # Validate that we received the cast request from the tv-casting-app on the tv-app output.
-               Step(app=App.TV_APP,
-                    output_msg=['PROMPT USER: Test TV casting app is requesting permission to cast to this TV, approve?']),
+            # Validate that we received the cast request from the tv-casting-app on the tv-app output.
+            Step(app=App.TV_APP,
+                 output_msg=['PROMPT USER: Test TV casting app is requesting permission to cast to this TV, approve?']),
 
-               # Validate that we received the instructions on the tv-app output for sending the `controller ux ok` command.
-               Step(app=App.TV_APP, output_msg=['Via Shell Enter: controller ux ok|cancel']),
+            # Validate that we received the instructions on the tv-app output for sending the `controller ux ok` command.
+            Step(app=App.TV_APP, output_msg=['Via Shell Enter: controller ux ok|cancel']),
 
-               # Send `controller ux ok` command to the tv-app subprocess.
-               Step(app=App.TV_APP, input_cmd='controller ux ok\n'),
+            # Send `controller ux ok` command to the tv-app subprocess.
+            Step(app=App.TV_APP, input_cmd='controller ux ok\n'),
 
-               # Validate that pairing succeeded between the tv-casting-app and the tv-app.
-               Step(app=App.TV_APP, output_msg=['Secure Pairing Success']),
+            # Validate that pairing succeeded between the tv-casting-app and the tv-app.
+            Step(app=App.TV_APP, output_msg=['Secure Pairing Success']),
 
-               # Validate that commissioning succeeded in the tv-casting-app output.
-               Step(app=App.TV_CASTING_APP, output_msg=['Commissioning completed successfully']),
+            # Validate that commissioning succeeded in the tv-casting-app output.
+            Step(app=App.TV_CASTING_APP, output_msg=['Commissioning completed successfully']),
 
-               # Validate that commissioning succeeded in the tv-app output.
-               Step(app=App.TV_APP, output_msg=['------PROMPT USER: commissioning success']),
+            # Validate that commissioning succeeded in the tv-app output.
+            Step(app=App.TV_APP, output_msg=['------PROMPT USER: commissioning success']),
 
-               # Validate the subscription state by looking at the `Cluster` and `Attribute` values in the `ReportDataMessage` block in the tv-casting-app output.
-               Step(app=App.TV_CASTING_APP, output_msg=[
-               'ReportDataMessage =', f'Cluster = {CLUSTER_MEDIA_PLAYBACK}', f'Attribute = {ATTRIBUTE_CURRENT_PLAYBACK_STATE}', 'InteractionModelRevision =', '}']),
+            # Validate the subscription state by looking at the `Cluster` and `Attribute` values in the `ReportDataMessage` block in the tv-casting-app output.
+            Step(app=App.TV_CASTING_APP, output_msg=[
+                'ReportDataMessage =', f'Cluster = {CLUSTER_MEDIA_PLAYBACK}', f'Attribute = {ATTRIBUTE_CURRENT_PLAYBACK_STATE}', 'InteractionModelRevision =', '}']),
 
-               # Validate the LaunchURL in the tv-app output.
-               Step(app=App.TV_APP,
-                    output_msg=['ContentLauncherManager::HandleLaunchUrl TEST CASE ContentURL=https://www.test.com/videoid DisplayString=Test video']),
+            # Validate the LaunchURL in the tv-app output.
+            Step(app=App.TV_APP,
+                 output_msg=['ContentLauncherManager::HandleLaunchUrl TEST CASE ContentURL=https://www.test.com/videoid DisplayString=Test video']),
 
-               # Validate the LaunchURL in the tv-casting-app output.
-               Step(app=App.TV_CASTING_APP, output_msg=['InvokeResponseMessage =',
-                                                       'exampleData', 'InteractionModelRevision =', '},']),
+            # Validate the LaunchURL in the tv-casting-app output.
+            Step(app=App.TV_CASTING_APP, output_msg=['InvokeResponseMessage =',
+                                                     'exampleData', 'InteractionModelRevision =', '},']),
 
-               # Signal to stop the tv-casting-app as we finished validation.
-               Step(app=App.TV_CASTING_APP, input_cmd=STOP_APP),
+            # Signal to stop the tv-casting-app as we finished validation.
+            Step(app=App.TV_CASTING_APP, input_cmd=STOP_APP),
 
-               # Signal to stop the tv-app as we finished validation.
-               Step(app=App.TV_APP, input_cmd=STOP_APP)
-          ]
-     )
+            # Signal to stop the tv-app as we finished validation.
+            Step(app=App.TV_APP, input_cmd=STOP_APP)
+        ]
+    )
 ]

--- a/scripts/tests/linux/tv_casting_test_sequences.py
+++ b/scripts/tests/linux/tv_casting_test_sequences.py
@@ -14,21 +14,56 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-import sys
-from enum import Enum
-from typing import List, Optional
+from linux.tv_casting_test_sequence_utils import App, Sequence, Step
 
 """
-Define the test sequences with the relevant steps that will be used in the `scripts/tests/run_tv_casting_test.py` for 
-validating the casting experience between the Linux tv-casting-app and the Linux tv-app.
+In this file, we define the test sequences with the relevant steps that will be used in the `scripts/tests/run_tv_casting_test.py` 
+for validating the casting experience between the Linux tv-casting-app and the Linux tv-app. 
+
+At the beginning of each test sequence we need to indicate the start up of the tv-app using the `START_APP` string as the `input_cmd`
+followed by the same for the tv-casting-app. On the other hand, at the end of each test sequence we need to ensure that each app will 
+be stopped by providing the `STOP_APP` string as the `input_cmd`. As noted in the example below of `example_test_sequence`, the first
+four steps pertain to starting the apps while the last two are for signaling stopping the apps. 
+
+Note: `START_APP` and `STOP_APP` are reserved for signaling the starting and stopping of an apps.
+
+Example:
+     test_sequences = [
+          Sequence(
+               name='example_test_sequence',
+               step=[
+                    # Signal to start the tv-app.
+                    Step(app=App.TV_APP, input_cmd=START_APP),
+
+                    # Validate that the tv-app is up and running.
+                    Step(app=App.TV_APP, timeout_sec=APP_MAX_START_WAIT_SEC, output_msg=['Started commissioner']),
+
+                    # Signal to start the tv-casting-app.
+                    Step(app=App.TV_CASTING_APP, input_cmd=START_APP),
+
+                    # Validate that the server is properly initialized in the tv-casting-app output.
+                    Step(app=App.TV_CASTING_APP, timeout_sec=APP_MAX_START_WAIT_SEC, output_msg=['Server initialization complete']),
+
+                    # Additional steps for testing the casting experience.
+
+                    # Signal to stop the tv-casting-app as we finished validation.
+                    Step(app=App.TV_CASTING_APP, input_cmd=STOP_APP),
+
+                    # Signal to stop the tv-app as we finished validation.
+                    Step(app=App.TV_APP, input_cmd=STOP_APP)
+               ]
+          )
+     ]
 """
 
-# The maximum amount of time to wait for the Linux tv-app to start before timeout.
-TV_APP_MAX_START_WAIT_SEC = 2
+# Signal to start the app.
+START_APP = 'START'
 
-# The maximum default time to wait while parsing for output string(s).
-DEFAULT_TIMEOUT_SEC = 10
+# Signal to stop the app.
+STOP_APP = 'STOP'
+
+# The maximum amount of time to wait for the Linux tv-app or Linux tv-casting-app to start before timeout.
+APP_MAX_START_WAIT_SEC = 2
 
 # Values that identify the Linux tv-app and are noted in the 'Device Configuration' in the Linux tv-app output
 # as well as under the 'Discovered Commissioner' details in the Linux tv-casting-app output.
@@ -42,142 +77,76 @@ TEST_TV_CASTING_APP_DEVICE_NAME = 'Test TV casting app'  # Test device name for 
 CLUSTER_MEDIA_PLAYBACK = '0x506'  # Application Cluster Spec 6.10.3 Cluster ID: Media Playback
 ATTRIBUTE_CURRENT_PLAYBACK_STATE = '0x0000_0000'  # Application Cluster Spec 6.10.6 Attribute ID: Current State of Playback
 
+test_sequences = [
+     Sequence(
+          name='commissionee_generated_passcode_test',
+          steps=[
+               # Signal to start the tv-app.
+               Step(app=App.TV_APP, input_cmd=START_APP),
 
-class App(Enum):
-    """An enumeration of the supported applications."""
+               # Validate that the tv-app is up and running.
+               Step(app=App.TV_APP, timeout_sec=APP_MAX_START_WAIT_SEC, output_msg=['Started commissioner']),
 
-    TV_APP = 'tv-app'
-    TV_CASTING_APP = 'tv-casting-app'
+               # Signal to start the tv-casting-app.
+               Step(app=App.TV_CASTING_APP, input_cmd=START_APP),
 
+               # Validate that the server is properly initialized in the tv-casting-app output.
+               Step(app=App.TV_CASTING_APP, timeout_sec=APP_MAX_START_WAIT_SEC, output_msg=['Server initialization complete']),
 
-class Step:
-    """A class to represent a step in a test sequence for validation.
+               # Validate that there is a valid discovered commissioner with {VENDOR_ID}, {PRODUCT_ID}, and {DEVICE_TYPE_CASTING_VIDEO_PLAYER} in the tv-casting-app output.
+               Step(app=App.TV_CASTING_APP, output_msg=['Discovered Commissioner #0', f'Vendor ID: {VENDOR_ID}', f'Product ID: {PRODUCT_ID}',
+                                                       f'Device Type: {DEVICE_TYPE_CASTING_VIDEO_PLAYER}', 'Supports Commissioner Generated Passcode: true']),
 
-    A Step object contains attributes relevant to a test step where each object contains:
-    - `app` subprocess to parse for `output_msg` or `send input_cmd`
-    - `timeout_sec` specified the timeout duration for parsing the `output_msg` (optional, defaults to DEFAULT_TIMEOUT_SEC)
-    - `output_msg` or `input_cmd` (mutually exclusive)
+               # Validate that we are ready to send `cast request` command to the tv-casting-app subprocess.
+               Step(app=App.TV_CASTING_APP, output_msg=['Example: cast request 0']),
 
-    Note: The first entry in the test sequence list of steps should always be the output string to verify that the tv-app 
-    is up and running.
+               # Send `cast request {valid_discovered_commissioner_number}\n` command to the tv-casting-app subprocess.
+               Step(app=App.TV_CASTING_APP, input_cmd='cast request 0\n'),
 
-    For output message blocks, define the start line, relevant lines, and the last line. If the last line contains trivial closing 
-    characters (e.g., closing brackets, braces, or commas), include the line before it with actual content. For example:
-        `Step(subprocess_='tv-casting-app', output_msg=['InvokeResponseMessage =', 'exampleData', 'InteractionModelRevision =', '},'])`
+               # Validate that the `Identification Declaration` message block in the tv-casting-app output has the expected values for `device Name`, `vendor id`, and `product id`.
+               Step(app=App.TV_CASTING_APP, output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
+                                                       f'vendor id: {VENDOR_ID}', f'product id: {PRODUCT_ID}', 'Identification Declaration End']),
 
-    For input commands, define the command string with placeholders for variables that need to be updated. For example:
-        `Step(subprocess_='tv-casting-app', input_cmd='cast request 0\n')`
-    """
+               # Validate that the `Identification Declaration` message block in the tv-app output has the expected values for `device Name`, `vendor id`, and `product id`.
+               Step(app=App.TV_APP, output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
+                                             f'vendor id: {VENDOR_ID}', f'product id: {PRODUCT_ID}', 'Identification Declaration End']),
 
-    def __init__(
-        self,
-        app: App,
-        timeout_sec: Optional[int] = DEFAULT_TIMEOUT_SEC,
-        output_msg: Optional[List[str]] = None,
-        input_cmd: Optional[str] = None,
-    ):
-        # Validate that either `output_msg` or `input_cmd` is provided, but not both.
-        if output_msg is not None and input_cmd is not None:
-            logging.error('Step cannot contain both `output_msg` and `input_cmd`. Either `output_msg` or `input_cmd` should be provided.')
-            sys.exit(1)
-        elif output_msg is None and input_cmd is None:
-            logging.error('Step must contain either `output_msg` or `input_cmd`. Both are `None`.')
-            sys.exit(1)
+               # Validate that we received the cast request from the tv-casting-app on the tv-app output.
+               Step(app=App.TV_APP,
+                    output_msg=['PROMPT USER: Test TV casting app is requesting permission to cast to this TV, approve?']),
 
-        # Define either `App.TV_APP` or `App.TV_CASTING_APP` on which we need to parse for `output_msg` or send `input_cmd`.
-        self.app = app
+               # Validate that we received the instructions on the tv-app output for sending the `controller ux ok` command.
+               Step(app=App.TV_APP, output_msg=['Via Shell Enter: controller ux ok|cancel']),
 
-        # Define the maximum time in seconds for timeout while parsing for the `output_msg`. If not provided, then we use the DEFAULT_TIMEOUT_SEC.
-        self.timeout_sec = timeout_sec
+               # Send `controller ux ok` command to the tv-app subprocess.
+               Step(app=App.TV_APP, input_cmd='controller ux ok\n'),
 
-        # Define the `output_msg` that we need to parse for in a list format.
-        self.output_msg = output_msg
+               # Validate that pairing succeeded between the tv-casting-app and the tv-app.
+               Step(app=App.TV_APP, output_msg=['Secure Pairing Success']),
 
-        # Define the `input_cmd` that we need to send to either the `App.TV_APP` or `App.TV_CASTING_APP`.
-        self.input_cmd = input_cmd
+               # Validate that commissioning succeeded in the tv-casting-app output.
+               Step(app=App.TV_CASTING_APP, output_msg=['Commissioning completed successfully']),
 
+               # Validate that commissioning succeeded in the tv-app output.
+               Step(app=App.TV_APP, output_msg=['------PROMPT USER: commissioning success']),
 
-class Sequence:
-    """A class representing a sequence of steps for testing the casting experience between the Linux tv-casting-app and the tv-app.
+               # Validate the subscription state by looking at the `Cluster` and `Attribute` values in the `ReportDataMessage` block in the tv-casting-app output.
+               Step(app=App.TV_CASTING_APP, output_msg=[
+               'ReportDataMessage =', f'Cluster = {CLUSTER_MEDIA_PLAYBACK}', f'Attribute = {ATTRIBUTE_CURRENT_PLAYBACK_STATE}', 'InteractionModelRevision =', '}']),
 
-    A Sequence object needs to be defined with an appropriate test sequence `name` along with its list of `Step` objects that will
-    be used for validating the casting experience.
-    """
+               # Validate the LaunchURL in the tv-app output.
+               Step(app=App.TV_APP,
+                    output_msg=['ContentLauncherManager::HandleLaunchUrl TEST CASE ContentURL=https://www.test.com/videoid DisplayString=Test video']),
 
-    def __init__(self, name: str, steps: List[Step]):
-        self.name = name
-        self.steps = steps
+               # Validate the LaunchURL in the tv-casting-app output.
+               Step(app=App.TV_CASTING_APP, output_msg=['InvokeResponseMessage =',
+                                                       'exampleData', 'InteractionModelRevision =', '},']),
 
+               # Signal to stop the tv-casting-app as we finished validation.
+               Step(app=App.TV_CASTING_APP, input_cmd=STOP_APP),
 
-def get_test_sequence_by_name(test_sequences: List[Sequence], test_sequence_name: str) -> Optional[Sequence]:
-    """Retrieve a test sequence from a list of sequences by its name."""
-
-    for sequence in test_sequences:
-        if sequence.name == test_sequence_name:
-            return sequence
-    return None
-
-
-def get_test_sequences() -> List[Sequence]:
-    """Retrieve all the test sequences to validate the casting experience between the Linux tv-casting-app and the Linux tv-app."""
-
-    test_sequences = [
-        Sequence(
-            name='commissionee_generated_passcode_test',
-            steps=[
-                # Validate that the tv-app is up and running.
-                Step(app=App.TV_APP, timeout_sec=TV_APP_MAX_START_WAIT_SEC, output_msg=['Started commissioner']),
-
-                # Validate that there is a valid discovered commissioner with {VENDOR_ID}, {PRODUCT_ID}, and {DEVICE_TYPE_CASTING_VIDEO_PLAYER} in the tv-casting-app output.
-                Step(app=App.TV_CASTING_APP, output_msg=['Discovered Commissioner #0', f'Vendor ID: {VENDOR_ID}', f'Product ID: {PRODUCT_ID}',
-                                                         f'Device Type: {DEVICE_TYPE_CASTING_VIDEO_PLAYER}', 'Supports Commissioner Generated Passcode: true']),
-
-                # Validate that we are ready to send `cast request` command to the tv-casting-app subprocess.
-                Step(app=App.TV_CASTING_APP, output_msg=['Example: cast request 0']),
-
-                # Send `cast request {valid_discovered_commissioner_number}\n` command to the tv-casting-app subprocess.
-                Step(app=App.TV_CASTING_APP, input_cmd='cast request 0\n'),
-
-                # Validate that the `Identification Declaration` message block in the tv-casting-app output has the expected values for `device Name`, `vendor id`, and `product id`.
-                Step(app=App.TV_CASTING_APP, output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
-                                                         f'vendor id: {VENDOR_ID}', f'product id: {PRODUCT_ID}', 'Identification Declaration End']),
-
-                # Validate that the `Identification Declaration` message block in the tv-app output has the expected values for `device Name`, `vendor id`, and `product id`.
-                Step(app=App.TV_APP, output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
-                                                 f'vendor id: {VENDOR_ID}', f'product id: {PRODUCT_ID}', 'Identification Declaration End']),
-
-                # Validate that we received the cast request from the tv-casting-app on the tv-app output.
-                Step(app=App.TV_APP,
-                     output_msg=['PROMPT USER: Test TV casting app is requesting permission to cast to this TV, approve?']),
-
-                # Validate that we received the instructions on the tv-app output for sending the `controller ux ok` command.
-                Step(app=App.TV_APP, output_msg=['Via Shell Enter: controller ux ok|cancel']),
-
-                # Send `controller ux ok` command to the tv-app subprocess.
-                Step(app=App.TV_APP, input_cmd='controller ux ok\n'),
-
-                # Validate that pairing succeeded between the tv-casting-app and the tv-app.
-                Step(app=App.TV_APP, output_msg=['Secure Pairing Success']),
-
-                # Validate that commissioning succeeded in the tv-casting-app output.
-                Step(app=App.TV_CASTING_APP, output_msg=['Commissioning completed successfully']),
-
-                # Validate that commissioning succeeded in the tv-app output.
-                Step(app=App.TV_APP, output_msg=['------PROMPT USER: commissioning success']),
-
-                # Validate the subscription state by looking at the `Cluster` and `Attribute` values in the `ReportDataMessage` block in the tv-casting-app output.
-                Step(app=App.TV_CASTING_APP, output_msg=[
-                    'ReportDataMessage =', f'Cluster = {CLUSTER_MEDIA_PLAYBACK}', f'Attribute = {ATTRIBUTE_CURRENT_PLAYBACK_STATE}', 'InteractionModelRevision =', '}']),
-
-                # Validate the LaunchURL in the tv-app output.
-                Step(app=App.TV_APP,
-                     output_msg=['ContentLauncherManager::HandleLaunchUrl TEST CASE ContentURL=https://www.test.com/videoid DisplayString=Test video']),
-
-                # Validate the LaunchURL in the tv-casting-app output.
-                Step(app=App.TV_CASTING_APP, output_msg=['InvokeResponseMessage =',
-                                                         'exampleData', 'InteractionModelRevision =', '},'])
-            ]
-        )
-    ]
-
-    return test_sequences
+               # Signal to stop the tv-app as we finished validation.
+               Step(app=App.TV_APP, input_cmd=STOP_APP)
+          ]
+     )
+]

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -16,20 +16,22 @@
 
 import logging
 import os
+import signal
 import subprocess
 import sys
 import tempfile
 import time
+from linux.tv_casting_test_sequence_utils import App, Sequence, Step
+from linux.tv_casting_test_sequences import START_APP, STOP_APP
 from typing import List, TextIO, Tuple
 
 import click
-import linux.tv_casting_test_sequences as tv_casting_test_sequences
 
 """
-This script is designed to validate the casting experience between the Linux tv-casting-app and the Linux tv-app.
+This script can be used to validate the casting experience between the Linux tv-casting-app and the Linux tv-app.
 
-It runs a series of test sequences that check for expected output lines from the tv-casting-app and the tv-app in a deterministic order. 
-If these lines are not found, it indicates an issue with the casting experience.
+It runs a series of test sequences that check for expected output lines from the tv-casting-app and the tv-app in 
+a deterministic order. If these lines are not found, it indicates an issue with the casting experience.
 """
 
 # Configure logging format.
@@ -84,23 +86,48 @@ def handle_casting_failure(test_sequence_name: str, log_file_paths: List[str]):
     sys.exit(1)
 
 
+def stop_app(test_sequence_name: str, app_name: str, app: subprocess.Popen):
+    """Stop the given `app` subprocess."""
+
+    app.terminate()
+    app_exit_code = app.wait()
+
+    if app.poll() is None:
+        logging.error(f'{test_sequence_name}: Failed to stop running {app_name}. Process is still running.')
+    else:
+        if app_exit_code < 0:
+            signal_number = -app_exit_code
+            if signal_number == signal.SIGTERM.value:
+                logging.info(f'{test_sequence_name}: {app_name} stopped by {signal_number} (SIGTERM) signal.')
+                return True
+            else:
+                logging.error(f'{test_sequence_name}: {app_name} stopped by signal {signal_number} instead of {signal.SIGTERM.value} (SIGTERM).')
+        else:
+            logging.error(f'{test_sequence_name}: {app_name} exited with unexpected exit code {app_exit_code}.')
+    
+    return False
+
+
 def parse_output_msg_in_subprocess(
     tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
     tv_app_info: Tuple[subprocess.Popen, TextIO],
     log_paths: List[str],
     test_sequence_name: str,
-    test_sequence_step: tv_casting_test_sequences.Step
+    test_sequence_step: Step
 ):
     """Parse the output of a given `app` subprocess and validate its output against the expected `output_msg` in the given `Step`."""
+    
+    if not test_sequence_step.output_msg:
+        logging.error(f'{test_sequence_name} - No output message provided in the test sequence step.')
+        return False
 
-    app_subprocess, app_log_file = (tv_casting_app_info if test_sequence_step.app ==
-                                    tv_casting_test_sequences.App.TV_CASTING_APP else tv_app_info)
+    app_subprocess, app_log_file = (tv_casting_app_info if test_sequence_step.app == App.TV_CASTING_APP else tv_app_info)
 
     start_wait_time = time.time()
     msg_block = []
 
-    i = 0
-    while i < len(test_sequence_step.output_msg):
+    current_index = 0
+    while current_index < len(test_sequence_step.output_msg):
         # Check if we exceeded the maximum wait time to parse for the output string(s).
         if time.time() - start_wait_time > test_sequence_step.timeout_sec:
             logging.error(
@@ -113,21 +140,21 @@ def parse_output_msg_in_subprocess(
             app_log_file.write(output_line)
             app_log_file.flush()
 
-            if (test_sequence_step.output_msg[i] in output_line):
+            if (test_sequence_step.output_msg[current_index] in output_line):
                 msg_block.append(output_line.rstrip('\n'))
-                i += 1
+                current_index += 1
             elif msg_block:
                 msg_block.append(output_line.rstrip('\n'))
                 if (test_sequence_step.output_msg[0] in output_line):
                     msg_block.clear()
                     msg_block.append(output_line.rstrip('\n'))
-                    i = 1
+                    current_index = 1
                 # Sanity check that `Discovered Commissioner #0` is the valid commissioner.
                 elif 'Discovered Commissioner #' in output_line:
                     logging.error(f'{test_sequence_name} - The valid discovered commissioner should be `Discovered Commissioner #0`.')
                     handle_casting_failure(test_sequence_name, log_paths)
 
-            if i == len(test_sequence_step.output_msg):
+            if current_index == len(test_sequence_step.output_msg):
                 logging.info(f'{test_sequence_name} - Found the expected output string(s) in the {test_sequence_step.app.value} subprocess:')
                 for line in msg_block:
                     logging.info(f'{test_sequence_name} - {line}')
@@ -139,12 +166,15 @@ def send_input_cmd_to_subprocess(
     tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
     tv_app_info: Tuple[subprocess.Popen, TextIO],
     test_sequence_name: str,
-    test_sequence_step: tv_casting_test_sequences.Step
+    test_sequence_step: Step
 ):
     """Send a given input command (`input_cmd`) from the `Step` to its given `app` subprocess."""
 
-    app_subprocess, app_log_file = (tv_casting_app_info if test_sequence_step.app ==
-                                    tv_casting_test_sequences.App.TV_CASTING_APP else tv_app_info)
+    if not test_sequence_step.input_cmd:
+        logging.error(f'{test_sequence_name} - No input command provided in the test sequence step.')
+        return False
+
+    app_subprocess, app_log_file = (tv_casting_app_info if test_sequence_step.app == App.TV_CASTING_APP else tv_app_info)
 
     app_subprocess.stdin.write(test_sequence_step.input_cmd)
     app_subprocess.stdin.flush()
@@ -157,6 +187,73 @@ def send_input_cmd_to_subprocess(
 
     logging.info(f'{test_sequence_name} - Sent `{next_line}` to the {test_sequence_step.app.value} subprocess.')
 
+    return True
+
+
+def handle_output_msg(
+    tv_casting_app_info: Tuple[subprocess.Popen, TextIO], 
+    tv_app_info: Tuple[subprocess.Popen, TextIO], 
+    log_paths: List[str], 
+    test_sequence_name: str, 
+    test_sequence_step: Step
+):
+    """Handle the output message (`output_msg`) from a test sequence step."""
+    
+    if not parse_output_msg_in_subprocess(tv_casting_app_info, tv_app_info, log_paths, test_sequence_name, test_sequence_step):
+        handle_casting_failure(test_sequence_name, log_paths)
+
+
+def handle_input_cmd(
+    tv_casting_app_info: Tuple[subprocess.Popen, TextIO], 
+    tv_app_info: Tuple[subprocess.Popen, TextIO], 
+    log_paths: List[str], 
+    test_sequence_name: str, 
+    test_sequence_step: Step
+):
+    """Handle the input command (`input_cmd`) from a test sequence step."""
+
+    tv_casting_app_process, tv_casting_app_log_file = tv_casting_app_info
+    tv_app_process, tv_app_log_file = tv_app_info
+
+    if test_sequence_step.input_cmd == STOP_APP:
+        if test_sequence_step.app == App.TV_CASTING_APP:
+            # Stop the tv-casting-app subprocess.
+            if not stop_app(test_sequence_name, test_sequence_step.app.value, tv_casting_app_process):
+                handle_casting_failure(test_sequence_name, log_paths)
+        elif test_sequence_step.app == App.TV_APP:
+            # Stop the tv-app subprocess.
+            if not stop_app(test_sequence_name, test_sequence_step.app.value, tv_app_process):
+                handle_casting_failure(test_sequence_name, log_paths)
+    else:
+        if not send_input_cmd_to_subprocess(tv_casting_app_info, tv_app_info, test_sequence_name, test_sequence_step):
+            handle_casting_failure(test_sequence_name, log_paths)
+
+
+def run_test_sequence_steps(
+    current_index: int, 
+    test_sequence_name: str, 
+    test_sequence_steps: List[Step], 
+    tv_casting_app_info: Tuple[subprocess.Popen, TextIO], 
+    tv_app_info: Tuple[subprocess.Popen, TextIO], 
+    log_paths: List[str]
+):
+    """Run through the test steps from a test sequence starting from the current index and perform actions based on the presence of `output_msg` or `input_cmd`."""
+
+    if test_sequence_steps is None:
+        logging.error('No test sequence steps provided.')
+
+    while current_index < len(test_sequence_steps):
+        # Current step in the list of steps.
+        test_sequence_step = test_sequence_steps[current_index]
+
+        # A test sequence step contains either an output_msg or input_cmd entry.
+        if test_sequence_step.output_msg:
+            handle_output_msg(tv_casting_app_info, tv_app_info, log_paths, test_sequence_name, test_sequence_step)
+        elif test_sequence_step.input_cmd:
+            handle_input_cmd(tv_casting_app_info, tv_app_info, log_paths, test_sequence_name, test_sequence_step)
+
+        current_index += 1
+
 
 @click.command()
 @click.option('--tv-app-rel-path', type=str, default='out/tv-app/chip-tv-app', help='Path to the Linux tv-app executable.')
@@ -168,12 +265,29 @@ def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path):
     For example: python3 run_tv_casting_test.py --tv-app-rel-path=path/to/tv-app
                  --tv-casting-app-rel-path=path/to/tv-casting-app
     """
+
     # Store the log files to a temporary directory.
     with tempfile.TemporaryDirectory() as temp_dir:
         linux_tv_app_log_path = os.path.join(temp_dir, LINUX_TV_APP_LOGS)
         linux_tv_casting_app_log_path = os.path.join(temp_dir, LINUX_TV_CASTING_APP_LOGS)
 
+        print(temp_dir) # SHAO remove when done
+
         with open(linux_tv_app_log_path, 'w') as linux_tv_app_log_file, open(linux_tv_casting_app_log_path, 'w') as linux_tv_casting_app_log_file:
+
+            # Get all the test sequences.
+            test_sequences = Sequence.get_test_sequences()
+
+            # Get the test sequence of interest.
+            test_sequence = Sequence.get_test_sequence_by_name(test_sequences, 'commissionee_generated_passcode_test')
+
+            if not test_sequence:
+                logging.error('No test sequence found by the test sequence name provided.')
+                handle_casting_failure(None, [])
+
+            # At this point, we have retrieved the test sequence of interest.
+            test_sequence_name = test_sequence.name
+            test_sequence_steps = test_sequence.steps
 
             # Configure command options to disable stdout buffering during tests.
             disable_stdout_buffering_cmd = []
@@ -181,24 +295,27 @@ def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path):
             if sys.platform == 'darwin' or sys.platform == 'linux':
                 disable_stdout_buffering_cmd = ['stdbuf', '-o0', '-i0']
 
+            current_index = 0
+            if test_sequence_steps[current_index].input_cmd != START_APP:
+                raise ValueError(f'{test_sequence_name}: The first step in the test sequence must contain `START_APP` as `input_cmd` to indicate starting the tv-app.')
+            elif test_sequence_steps[current_index].app != App.TV_APP:
+                raise ValueError(f'{test_sequence_name}: The first step in the test sequence must be to start up the tv-app.')
+            current_index += 1
+
             tv_app_abs_path = os.path.abspath(tv_app_rel_path)
             # Run the Linux tv-app subprocess.
             with ProcessManager(disable_stdout_buffering_cmd + [tv_app_abs_path], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as tv_app_process:
                 tv_app_info = (tv_app_process, linux_tv_app_log_file)
 
-                test_sequences = tv_casting_test_sequences.get_test_sequences()
-                test_sequence = tv_casting_test_sequences.get_test_sequence_by_name(
-                    test_sequences, 'commissionee_generated_passcode_test')
-                if not test_sequence:
-                    logging.error('No test sequence found by the test sequence name provided.')
-                    handle_casting_failure(None, [linux_tv_app_log_path])
-
-                test_sequence_name = test_sequence.name
-                test_sequence_steps = test_sequence.steps
-
                 # Verify that the tv-app is up and running.
-                if not parse_output_msg_in_subprocess(None, tv_app_info, [linux_tv_app_log_path], test_sequence_name, test_sequence_steps[0]):
-                    handle_casting_failure(test_sequence_name, [linux_tv_app_log_path])
+                handle_output_msg(None, tv_app_info, [linux_tv_app_log_path], test_sequence_name, test_sequence_steps[current_index])
+                current_index += 1
+
+                if test_sequence_steps[current_index].input_cmd != START_APP:
+                    raise ValueError(f'{test_sequence_name}: The third step in the test sequence must contain `START_APP` as `input_cmd` to indicate starting the tv-casting-app.')
+                elif test_sequence_steps[current_index].app != App.TV_CASTING_APP:
+                    raise ValueError(f'{test_sequence_name}: The third step in the test sequence must be to start up the tv-casting-app.')
+                current_index += 1
 
                 tv_casting_app_abs_path = os.path.abspath(tv_casting_app_rel_path)
                 # Run the Linux tv-casting-app subprocess.
@@ -206,17 +323,11 @@ def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path):
                     log_paths = [linux_tv_app_log_path, linux_tv_casting_app_log_path]
                     tv_casting_app_info = (tv_casting_app_process, linux_tv_casting_app_log_file)
 
-                    i = 1
-                    while i < len(test_sequence_steps):
-                        test_sequence_step = test_sequence_steps[i]
+                    # Verify that the server initialization is completed in the tv-casting-app output.
+                    handle_output_msg(tv_casting_app_info, tv_app_info, log_paths, test_sequence_name, test_sequence_steps[current_index])
+                    current_index += 1
 
-                        if test_sequence_step.output_msg:
-                            if not parse_output_msg_in_subprocess(tv_casting_app_info, tv_app_info, log_paths, test_sequence_name, test_sequence_step):
-                                handle_casting_failure(test_sequence_name, log_paths)
-                        elif test_sequence_step.input_cmd:
-                            send_input_cmd_to_subprocess(tv_casting_app_info, tv_app_info, test_sequence_name, test_sequence_step)
-
-                        i += 1
+                    run_test_sequence_steps(current_index, test_sequence_name, test_sequence_steps, tv_casting_app_info, tv_app_info, log_paths)
 
 
 if __name__ == '__main__':

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -16,68 +16,28 @@
 
 import logging
 import os
-import re
 import subprocess
 import sys
 import tempfile
 import time
-from typing import List, Optional, TextIO, Tuple
+from typing import List, TextIO, Tuple
 
 import click
+import linux.tv_casting_test_sequences as tv_casting_test_sequences
 
 """
-This test script automates the verification of the casting experience between the Linux tv-casting-app and the Linux tv-app.
+This script is designed to validate the casting experience between the Linux tv-casting-app and the Linux tv-app.
 
-It checks for expected output lines from the tv-casting-app and the tv-app in a deterministic order. If these lines are not 
-found, it indicates an issue with the casting experience.
-
-The script currently verifies the general casting flow that includes discovery, commissioning, launchURL, and subscription 
-state. Future updates will enable testing different workflows like the commissioner-generated passcode flow.
-
-To add a new workflow, define a test sequence list with Step objects containing:
-- `subprocess` to parse for output_msg or send input_cmd
-- `timeout_sec` specified the timeout duration for parsing the `output_msg` (optional, defaults to DEFAULT_TIMEOUT_SEC)
-- `output_msg` or `input_cmd` (mutually exclusive)
-- `commissioner_number_handler` (optional if we need to update the commissioner number variable in the `input_cmd`)
-
-Note: The first entry in the test sequence list should always be the output string to verify that the tv-app is up and running.
-
-For output message blocks, define the start line, relevant lines, and the last line. If the last line contains trivial closing 
-characters (e.g., closing brackets, braces, or commas), include the line before it with actual content. For example:
-    `Step(subprocess_='tv-casting-app', output_msg=['InvokeResponseMessage =', 'exampleData', 'InteractionModelRevision =', '},'])`
-
-For input commands, define the command string with placeholders for variables that need to be updated. For example:
-    `Step(subprocess_='tv-casting-app', input_cmd='cast request {valid_discovered_commissioner_number}\n', 
-        commissioner_number_handler=commissioner_number_handler)`
-The `commissioner_number_handler` is passed in to help update the `valid_discovered_commissioner_number` placeholder with the 
-actual valid discovered commissioner number.
-
-Users should add a click.option for the desired test flow and update the `examples-linux-tv-casting-app.yaml` workflow file for 
-CI testing of additional flows (to be implemented in future PR(s)).
+It runs a series of test sequences that check for expected output lines from the tv-casting-app and the tv-app in a deterministic order. 
+If these lines are not found, it indicates an issue with the casting experience.
 """
-
 
 # Configure logging format.
 logging.basicConfig(level=logging.INFO, format='%(levelname)s - %(message)s')
 
-# The maximum amount of time to wait for the Linux tv-app to start before timeout.
-TV_APP_MAX_START_WAIT_SEC = 2
-
 # File names of logs for the Linux tv-casting-app and the Linux tv-app.
 LINUX_TV_APP_LOGS = 'Linux-tv-app-logs.txt'
 LINUX_TV_CASTING_APP_LOGS = 'Linux-tv-casting-app-logs.txt'
-
-# Values that identify the Linux tv-app and are noted in the 'Device Configuration' in the Linux tv-app output
-# as well as under the 'Discovered Commissioner' details in the Linux tv-casting-app output.
-VENDOR_ID = 0xFFF1   # Spec 7.20.2.1 MEI code: test vendor IDs are 0xFFF1 to 0xFFF4
-PRODUCT_ID = 0x8001  # Test product id
-DEVICE_TYPE_CASTING_VIDEO_PLAYER = 0x23    # Device type library 10.3: Casting Video Player
-
-TEST_TV_CASTING_APP_DEVICE_NAME = 'Test TV casting app'  # Test device name for identifying the tv-casting-app
-
-# Values to verify the subscription state against from the `ReportDataMessage` in the Linux tv-casting-app output.
-CLUSTER_MEDIA_PLAYBACK = '0x506'  # Application Cluster Spec 6.10.3 Cluster ID: Media Playback
-ATTRIBUTE_CURRENT_PLAYBACK_STATE = '0x0000_0000'  # Application Cluster Spec 6.10.6 Attribute ID: Current State of Playback
 
 
 class ProcessManager:
@@ -101,85 +61,6 @@ class ProcessManager:
         self.process.wait()
 
 
-class LogValueExtractor:
-    """A utility class for extracting values from log lines.
-
-    This class provides a centralized way to extract values from log lines and manage the error handling and logging process.
-    """
-
-    def __init__(self, log_paths: List[str]):
-        self.log_paths = log_paths
-
-    def extract_from(self, line: str, value_name: str):
-        if value_name in line:
-            try:
-                return extract_value_from_string(line, value_name, self.log_paths)
-            except ValueError:
-                logging.error(f'Failed to extract `{value_name}` value from line: {line}')
-                handle_casting_failure(self.log_paths)
-        return None
-
-
-class CommissionerNumberHandler:
-    """A class to manage updating the commissioner number placeholder.
-
-    This class provides functionality to update the commissioner number placeholder in an input command with the actual valid discovered commissioner number.
-    """
-
-    INVALID_COMMISSIONER_NUMBER = '-1'
-
-    def __init__(self):
-        self._current_commissioner_number = self.INVALID_COMMISSIONER_NUMBER
-
-    @property
-    def commissioner_number(self) -> str:
-        return self._current_commissioner_number
-
-    @commissioner_number.setter
-    def commissioner_number(self, new_value: str):
-        self._current_commissioner_number = new_value
-
-    def is_valid(self) -> bool:
-        return self._current_commissioner_number != self.INVALID_COMMISSIONER_NUMBER
-
-
-class Step:
-    """A class to represent a step in a test sequence for validation.
-
-    A Step object contains attributes relevant to a test step.
-    """
-
-    # The maximum default time to wait while parsing for output string(s).
-    DEFAULT_TIMEOUT_SEC = 10
-
-    def __init__(
-        self,
-        subprocess_: str,
-        timeout_sec: Optional[int] = DEFAULT_TIMEOUT_SEC,
-        output_msg: Optional[List[str]] = None,
-        input_cmd: Optional[str] = None,
-        commissioner_number_handler: Optional[CommissionerNumberHandler] = None
-    ):
-        self.subprocess_ = subprocess_
-        self.timeout_sec = timeout_sec
-        self.output_msg = output_msg
-        self.input_cmd = input_cmd
-        self.commissioner_number_handler = commissioner_number_handler
-
-    @property
-    def input_cmd(self):
-        if self._input_cmd is None:
-            return None
-        elif self.commissioner_number_handler is None:
-            return self._input_cmd
-        else:
-            return self._input_cmd.format(valid_discovered_commissioner_number=self.commissioner_number_handler.commissioner_number)
-
-    @input_cmd.setter
-    def input_cmd(self, new_input_cmd: str):
-        self._input_cmd = new_input_cmd
-
-
 def dump_temporary_logs_to_console(log_file_path: str):
     """Dump log file to the console; log file will be removed once the function exits."""
     """Write the entire content of `log_file_path` to the console."""
@@ -190,129 +71,40 @@ def dump_temporary_logs_to_console(log_file_path: str):
             print(line.rstrip())
 
 
-def handle_casting_failure(log_file_paths: List[str]):
-    """Dump log files to console, exit on error."""
+def handle_casting_failure(test_sequence_name: str, log_file_paths: List[str]):
+    """Log failure of validation of test sequence as error, dump log files to console, exit on error."""
+    logging.error(f'{test_sequence_name} - Validation of test sequence failed.')
 
     for log_file_path in log_file_paths:
         try:
             dump_temporary_logs_to_console(log_file_path)
         except Exception as e:
-            logging.exception(f'Failed to dump {log_file_path}: {e}')
+            logging.exception(f'{test_sequence_name} - Failed to dump {log_file_path}: {e}')
 
     sys.exit(1)
-
-
-def extract_value_from_string(line: str, value_name: str, log_paths) -> str:
-    """Extract and return value from given input string.
-
-    Some string examples as they are received from the Linux tv-casting-app output:
-    1. On 'darwin' machines:
-        \x1b[0;32m[1714582264602] [77989:2286038] [SVR] Discovered Commissioner #0\x1b[0m
-        The integer value to be extracted here is '0'.
-
-    2. On 'linux' machines:
-        [1716224958.576320][6906:6906] CHIP:SVR: Discovered Commissioner #0
-    """
-    log_line_pattern = ''
-    if sys.platform == 'darwin':
-        log_line_pattern = r'\x1b\[0;\d+m\[\d+\] \[\d+:\d+\] \[[A-Z]{1,3}\] (.+)\x1b\[0m'
-    elif sys.platform == 'linux':
-        log_line_pattern = r'\[\d+\.\d+\]\[\d+:\d+\] [A-Z]{1,4}:[A-Z]{1,3}: (.+)'
-
-    log_line_match = re.search(log_line_pattern, line)
-
-    if log_line_match:
-        log_text_of_interest = log_line_match.group(1)
-
-        if '#' in log_text_of_interest:
-            delimiter = '#'
-
-        return log_text_of_interest.split(delimiter)[-1].strip(' ')
-    else:
-        raise ValueError(f'Could not extract {value_name} from the following line: {line}')
-
-
-def get_general_flow_test_sequence(commissioner_number_handler: CommissionerNumberHandler) -> List[Step]:
-    """Retrieve the test sequence pertaining to the general flow for validating the casting experience between the Linux tv-casting-app and the Linux tv-app."""
-
-    general_flow_test_sequence = [
-        # Validate that the tv-app is up and running.
-        Step(subprocess_='tv-app', timeout_sec=TV_APP_MAX_START_WAIT_SEC, output_msg=['Started commissioner']),
-
-        # Validate that there is a valid discovered commissioner with {VENDOR_ID}, {PRODUCT_ID}, and {DEVICE_TYPE_CASTING_VIDEO_PLAYER} in the tv-casting-app output.
-        Step(subprocess_='tv-casting-app', output_msg=['Discovered Commissioner #', f'Vendor ID: {VENDOR_ID}', f'Product ID: {PRODUCT_ID}',
-             f'Device Type: {DEVICE_TYPE_CASTING_VIDEO_PLAYER}', 'Supports Commissioner Generated Passcode: true']),
-
-        # Validate that we are ready to send `cast request` command to the tv-casting-app subprocess.
-        Step(subprocess_='tv-casting-app', output_msg=['Example: cast request 0']),
-
-        # Send `cast request {valid_discovered_commissioner_number}\n` command to the tv-casting-app subprocess.
-        Step(subprocess_='tv-casting-app',
-             input_cmd='cast request {valid_discovered_commissioner_number}\n', commissioner_number_handler=commissioner_number_handler),
-
-        # Validate that the `Identification Declaration` message block in the tv-casting-app output has the expected values for `device Name`, `vendor id`, and `product id`.
-        Step(subprocess_='tv-casting-app', output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
-             f'vendor id: {VENDOR_ID}', f'product id: {PRODUCT_ID}', 'Identification Declaration End']),
-
-        # Validate that the `Identification Declaration` message block in the tv-app output has the expected values for `device Name`, `vendor id`, and `product id`.
-        Step(subprocess_='tv-app', output_msg=['Identification Declaration Start', f'device Name: {TEST_TV_CASTING_APP_DEVICE_NAME}',
-             f'vendor id: {VENDOR_ID}', f'product id: {PRODUCT_ID}', 'Identification Declaration End']),
-
-        # Validate that we received the cast request from the tv-casting-app on the tv-app output.
-        Step(subprocess_='tv-app',
-             output_msg=['PROMPT USER: Test TV casting app is requesting permission to cast to this TV, approve?']),
-
-        # Validate that we received the instructions on the tv-app output for sending the `controller ux ok` command.
-        Step(subprocess_='tv-app', output_msg=['Via Shell Enter: controller ux ok|cancel']),
-
-        # Send `controller ux ok` command to the tv-app subprocess.
-        Step(subprocess_='tv-app', input_cmd='controller ux ok\n'),
-
-        # Validate that pairing succeeded between the tv-casting-app and the tv-app.
-        Step(subprocess_='tv-app', output_msg=['Secure Pairing Success']),
-
-        # Validate that commissioning succeeded in the tv-casting-app output.
-        Step(subprocess_='tv-casting-app', output_msg=['Commissioning completed successfully']),
-
-        # Validate that commissioning succeeded in the tv-app output.
-        Step(subprocess_='tv-app', output_msg=['------PROMPT USER: commissioning success']),
-
-        # Validate the subscription state by looking at the `Cluster` and `Attribute` values in the `ReportDataMessage` block in the tv-casting-app output.
-        Step(subprocess_='tv-casting-app', output_msg=[
-             'ReportDataMessage =', f'Cluster = {CLUSTER_MEDIA_PLAYBACK}', f'Attribute = {ATTRIBUTE_CURRENT_PLAYBACK_STATE}', 'InteractionModelRevision =', '}']),
-
-        # Validate the LaunchURL in the tv-app output.
-        Step(subprocess_='tv-app',
-             output_msg=['ContentLauncherManager::HandleLaunchUrl TEST CASE ContentURL=https://www.test.com/videoid DisplayString=Test video']),
-
-        # Validate the LaunchURL in the tv-casting-app output.
-        Step(subprocess_='tv-casting-app', output_msg=['InvokeResponseMessage =',
-             'exampleData', 'InteractionModelRevision =', '},'])
-    ]
-
-    return general_flow_test_sequence
 
 
 def parse_output_msg_in_subprocess(
     tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
     tv_app_info: Tuple[subprocess.Popen, TextIO],
     log_paths: List[str],
-    step: Step,
-    commissioner_number_handler: CommissionerNumberHandler
+    test_sequence_name: str,
+    test_sequence_step: tv_casting_test_sequences.Step
 ):
-    """Parse the output of a given `subprocess` and validate its output against the expected `output_msg` in the given `Step`."""
+    """Parse the output of a given `app` subprocess and validate its output against the expected `output_msg` in the given `Step`."""
 
-    app_subprocess, app_log_file = (tv_casting_app_info if step.subprocess_ == 'tv-casting-app' else tv_app_info)
+    app_subprocess, app_log_file = (tv_casting_app_info if test_sequence_step.app ==
+                                    tv_casting_test_sequences.App.TV_CASTING_APP else tv_app_info)
 
     start_wait_time = time.time()
     msg_block = []
 
     i = 0
-    while i < len(step.output_msg):
+    while i < len(test_sequence_step.output_msg):
         # Check if we exceeded the maximum wait time to parse for the output string(s).
-        if time.time() - start_wait_time > step.timeout_sec:
+        if time.time() - start_wait_time > test_sequence_step.timeout_sec:
             logging.error(
-                f'Did not find the expected output string(s) in the {step.subprocess_} subprocess within the timeout: {step.output_msg}')
+                f'{test_sequence_name} - Did not find the expected output string(s) in the {test_sequence_step.app.value} subprocess within the timeout: {test_sequence_step.output_msg}')
             return False
 
         output_line = app_subprocess.stdout.readline()
@@ -321,26 +113,24 @@ def parse_output_msg_in_subprocess(
             app_log_file.write(output_line)
             app_log_file.flush()
 
-            if (step.output_msg[i] in output_line):
+            if (test_sequence_step.output_msg[i] in output_line):
                 msg_block.append(output_line.rstrip('\n'))
                 i += 1
             elif msg_block:
                 msg_block.append(output_line.rstrip('\n'))
-                if (step.output_msg[0] in output_line):
+                if (test_sequence_step.output_msg[0] in output_line):
                     msg_block.clear()
                     msg_block.append(output_line.rstrip('\n'))
                     i = 1
+                # Sanity check that `Discovered Commissioner #0` is the valid commissioner.
+                elif 'Discovered Commissioner #' in output_line:
+                    logging.error(f'{test_sequence_name} - The valid discovered commissioner should be `Discovered Commissioner #0`.')
+                    handle_casting_failure(test_sequence_name, log_paths)
 
-            if i == len(step.output_msg):
-                logging.info(f'Found the expected output string(s) in the {step.subprocess_} subprocess:')
+            if i == len(test_sequence_step.output_msg):
+                logging.info(f'{test_sequence_name} - Found the expected output string(s) in the {test_sequence_step.app.value} subprocess:')
                 for line in msg_block:
-                    if 'Discovered Commissioner #' in line:
-                        log_value_extractor = LogValueExtractor(log_paths)
-                        # Update the current commissioner number to the valid discovered commissioner number
-                        commissioner_number_handler.commissioner_number = log_value_extractor.extract_from(
-                            line, 'Discovered Commissioner #')
-
-                    logging.info(line)
+                    logging.info(f'{test_sequence_name} - {line}')
 
                 return True
 
@@ -348,13 +138,15 @@ def parse_output_msg_in_subprocess(
 def send_input_cmd_to_subprocess(
     tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
     tv_app_info: Tuple[subprocess.Popen, TextIO],
-    step: Step
+    test_sequence_name: str,
+    test_sequence_step: tv_casting_test_sequences.Step
 ):
-    """Send a given input command (`input_cmd`) from the `Step` to its given `subprocess`."""
+    """Send a given input command (`input_cmd`) from the `Step` to its given `app` subprocess."""
 
-    app_subprocess, app_log_file = (tv_casting_app_info if step.subprocess_ == 'tv-casting-app' else tv_app_info)
+    app_subprocess, app_log_file = (tv_casting_app_info if test_sequence_step.app ==
+                                    tv_casting_test_sequences.App.TV_CASTING_APP else tv_app_info)
 
-    app_subprocess.stdin.write(step.input_cmd)
+    app_subprocess.stdin.write(test_sequence_step.input_cmd)
     app_subprocess.stdin.flush()
 
     # Read in the next line which should be the `input_cmd` that was issued.
@@ -363,7 +155,7 @@ def send_input_cmd_to_subprocess(
     app_log_file.flush()
     next_line = next_line.rstrip('\n')
 
-    logging.info(f'Sent `{next_line}` to the {step.subprocess_} subprocess.')
+    logging.info(f'{test_sequence_name} - Sent `{next_line}` to the {test_sequence_step.app.value} subprocess.')
 
 
 @click.command()
@@ -394,12 +186,19 @@ def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path):
             with ProcessManager(disable_stdout_buffering_cmd + [tv_app_abs_path], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as tv_app_process:
                 tv_app_info = (tv_app_process, linux_tv_app_log_file)
 
-                commissioner_number_handler = CommissionerNumberHandler()
-                test_sequence = get_general_flow_test_sequence(commissioner_number_handler)
+                test_sequences = tv_casting_test_sequences.get_test_sequences()
+                test_sequence = tv_casting_test_sequences.get_test_sequence_by_name(
+                    test_sequences, 'commissionee_generated_passcode_test')
+                if not test_sequence:
+                    logging.error('No test sequence found by the test sequence name provided.')
+                    handle_casting_failure(None, [linux_tv_app_log_path])
+
+                test_sequence_name = test_sequence.name
+                test_sequence_steps = test_sequence.steps
 
                 # Verify that the tv-app is up and running.
-                if not parse_output_msg_in_subprocess(None, tv_app_info, [linux_tv_app_log_path], test_sequence[0], commissioner_number_handler):
-                    handle_casting_failure([linux_tv_app_log_path])
+                if not parse_output_msg_in_subprocess(None, tv_app_info, [linux_tv_app_log_path], test_sequence_name, test_sequence_steps[0]):
+                    handle_casting_failure(test_sequence_name, [linux_tv_app_log_path])
 
                 tv_casting_app_abs_path = os.path.abspath(tv_casting_app_rel_path)
                 # Run the Linux tv-casting-app subprocess.
@@ -408,14 +207,14 @@ def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path):
                     tv_casting_app_info = (tv_casting_app_process, linux_tv_casting_app_log_file)
 
                     i = 1
-                    while i < len(test_sequence):
-                        step = test_sequence[i]
+                    while i < len(test_sequence_steps):
+                        test_sequence_step = test_sequence_steps[i]
 
-                        if step.output_msg:
-                            if not parse_output_msg_in_subprocess(tv_casting_app_info, tv_app_info, log_paths, step, commissioner_number_handler):
-                                handle_casting_failure(log_paths)
-                        elif step.input_cmd:
-                            send_input_cmd_to_subprocess(tv_casting_app_info, tv_app_info, step)
+                        if test_sequence_step.output_msg:
+                            if not parse_output_msg_in_subprocess(tv_casting_app_info, tv_app_info, log_paths, test_sequence_name, test_sequence_step):
+                                handle_casting_failure(test_sequence_name, log_paths)
+                        elif test_sequence_step.input_cmd:
+                            send_input_cmd_to_subprocess(tv_casting_app_info, tv_app_info, test_sequence_name, test_sequence_step)
 
                         i += 1
 

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -21,11 +21,11 @@ import subprocess
 import sys
 import tempfile
 import time
-from linux.tv_casting_test_sequence_utils import App, Sequence, Step
-from linux.tv_casting_test_sequences import START_APP, STOP_APP
 from typing import List, TextIO, Tuple
 
 import click
+from linux.tv_casting_test_sequence_utils import App, Sequence, Step
+from linux.tv_casting_test_sequences import START_APP, STOP_APP
 
 """
 This script can be used to validate the casting experience between the Linux tv-casting-app and the Linux tv-app.
@@ -101,10 +101,11 @@ def stop_app(test_sequence_name: str, app_name: str, app: subprocess.Popen):
                 logging.info(f'{test_sequence_name}: {app_name} stopped by {signal_number} (SIGTERM) signal.')
                 return True
             else:
-                logging.error(f'{test_sequence_name}: {app_name} stopped by signal {signal_number} instead of {signal.SIGTERM.value} (SIGTERM).')
+                logging.error(
+                    f'{test_sequence_name}: {app_name} stopped by signal {signal_number} instead of {signal.SIGTERM.value} (SIGTERM).')
         else:
             logging.error(f'{test_sequence_name}: {app_name} exited with unexpected exit code {app_exit_code}.')
-    
+
     return False
 
 
@@ -116,7 +117,7 @@ def parse_output_msg_in_subprocess(
     test_sequence_step: Step
 ):
     """Parse the output of a given `app` subprocess and validate its output against the expected `output_msg` in the given `Step`."""
-    
+
     if not test_sequence_step.output_msg:
         logging.error(f'{test_sequence_name} - No output message provided in the test sequence step.')
         return False
@@ -191,23 +192,23 @@ def send_input_cmd_to_subprocess(
 
 
 def handle_output_msg(
-    tv_casting_app_info: Tuple[subprocess.Popen, TextIO], 
-    tv_app_info: Tuple[subprocess.Popen, TextIO], 
-    log_paths: List[str], 
-    test_sequence_name: str, 
+    tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
+    tv_app_info: Tuple[subprocess.Popen, TextIO],
+    log_paths: List[str],
+    test_sequence_name: str,
     test_sequence_step: Step
 ):
     """Handle the output message (`output_msg`) from a test sequence step."""
-    
+
     if not parse_output_msg_in_subprocess(tv_casting_app_info, tv_app_info, log_paths, test_sequence_name, test_sequence_step):
         handle_casting_failure(test_sequence_name, log_paths)
 
 
 def handle_input_cmd(
-    tv_casting_app_info: Tuple[subprocess.Popen, TextIO], 
-    tv_app_info: Tuple[subprocess.Popen, TextIO], 
-    log_paths: List[str], 
-    test_sequence_name: str, 
+    tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
+    tv_app_info: Tuple[subprocess.Popen, TextIO],
+    log_paths: List[str],
+    test_sequence_name: str,
     test_sequence_step: Step
 ):
     """Handle the input command (`input_cmd`) from a test sequence step."""
@@ -230,11 +231,11 @@ def handle_input_cmd(
 
 
 def run_test_sequence_steps(
-    current_index: int, 
-    test_sequence_name: str, 
-    test_sequence_steps: List[Step], 
-    tv_casting_app_info: Tuple[subprocess.Popen, TextIO], 
-    tv_app_info: Tuple[subprocess.Popen, TextIO], 
+    current_index: int,
+    test_sequence_name: str,
+    test_sequence_steps: List[Step],
+    tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
+    tv_app_info: Tuple[subprocess.Popen, TextIO],
     log_paths: List[str]
 ):
     """Run through the test steps from a test sequence starting from the current index and perform actions based on the presence of `output_msg` or `input_cmd`."""
@@ -271,8 +272,6 @@ def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path):
         linux_tv_app_log_path = os.path.join(temp_dir, LINUX_TV_APP_LOGS)
         linux_tv_casting_app_log_path = os.path.join(temp_dir, LINUX_TV_CASTING_APP_LOGS)
 
-        print(temp_dir) # SHAO remove when done
-
         with open(linux_tv_app_log_path, 'w') as linux_tv_app_log_file, open(linux_tv_casting_app_log_path, 'w') as linux_tv_casting_app_log_file:
 
             # Get all the test sequences.
@@ -297,7 +296,8 @@ def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path):
 
             current_index = 0
             if test_sequence_steps[current_index].input_cmd != START_APP:
-                raise ValueError(f'{test_sequence_name}: The first step in the test sequence must contain `START_APP` as `input_cmd` to indicate starting the tv-app.')
+                raise ValueError(
+                    f'{test_sequence_name}: The first step in the test sequence must contain `START_APP` as `input_cmd` to indicate starting the tv-app.')
             elif test_sequence_steps[current_index].app != App.TV_APP:
                 raise ValueError(f'{test_sequence_name}: The first step in the test sequence must be to start up the tv-app.')
             current_index += 1
@@ -308,13 +308,16 @@ def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path):
                 tv_app_info = (tv_app_process, linux_tv_app_log_file)
 
                 # Verify that the tv-app is up and running.
-                handle_output_msg(None, tv_app_info, [linux_tv_app_log_path], test_sequence_name, test_sequence_steps[current_index])
+                handle_output_msg(None, tv_app_info, [linux_tv_app_log_path],
+                                  test_sequence_name, test_sequence_steps[current_index])
                 current_index += 1
 
                 if test_sequence_steps[current_index].input_cmd != START_APP:
-                    raise ValueError(f'{test_sequence_name}: The third step in the test sequence must contain `START_APP` as `input_cmd` to indicate starting the tv-casting-app.')
+                    raise ValueError(
+                        f'{test_sequence_name}: The third step in the test sequence must contain `START_APP` as `input_cmd` to indicate starting the tv-casting-app.')
                 elif test_sequence_steps[current_index].app != App.TV_CASTING_APP:
-                    raise ValueError(f'{test_sequence_name}: The third step in the test sequence must be to start up the tv-casting-app.')
+                    raise ValueError(
+                        f'{test_sequence_name}: The third step in the test sequence must be to start up the tv-casting-app.')
                 current_index += 1
 
                 tv_casting_app_abs_path = os.path.abspath(tv_casting_app_rel_path)
@@ -324,10 +327,12 @@ def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path):
                     tv_casting_app_info = (tv_casting_app_process, linux_tv_casting_app_log_file)
 
                     # Verify that the server initialization is completed in the tv-casting-app output.
-                    handle_output_msg(tv_casting_app_info, tv_app_info, log_paths, test_sequence_name, test_sequence_steps[current_index])
+                    handle_output_msg(tv_casting_app_info, tv_app_info, log_paths,
+                                      test_sequence_name, test_sequence_steps[current_index])
                     current_index += 1
 
-                    run_test_sequence_steps(current_index, test_sequence_name, test_sequence_steps, tv_casting_app_info, tv_app_info, log_paths)
+                    run_test_sequence_steps(current_index, test_sequence_name, test_sequence_steps,
+                                            tv_casting_app_info, tv_app_info, log_paths)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Problem**
There is currently a CI check [implementation](https://github.com/project-chip/connectedhomeip/blob/master/scripts/tests/run_tv_casting_test.py) that verifies that the Linux tv-casting-app continues to work with the Linux tv-app whenever a PR is created. However, adding new test sequences is not that simple as we would need to keep defining new functions for parsing output messages of interest and/or sending input commands. Therefore, we want to improve the design flow to make it easier to add new test cases in the future.

**Solution**
The new design will allow users to define a new test `Sequence` consisting of a test sequence name and a list of `Step` objects. Each `Step` contains the relevant information needed to either parse for output string(s) of interest or send input command. Essentially, to add a new flow, we need to define a test sequence list of `Step` objects containing:
- `subprocess` to parse for output_msg or send input_cmd
- `timeout_sec` specified the timeout duration for parsing the `output_msg` (optional, defaults to DEFAULT_TIMEOUT_SEC)
- `output_msg` or `input_cmd` (mutually exclusive)

Note that there could be multiple instances of a particular output message block so we would need to parse them block-by-block. For this reason, we would need to define the start line, relevant lines we are looking for within the message block, and the last line. If the last line contains trivial closing characters (e.g., closing brackets, braces, or commas), we also need to include the line before it with actual log content. For example:
`Step(subprocess_='tv-casting-app', output_msg=['InvokeResponseMessage =', 'exampleData', 'InteractionModelRevision =', '},'])`

For input commands, we need to define the command as a string followed by `\n`. For example:
`Step(subprocess_='tv-casting-app', input_cmd='cast request 0\n')`

In short, this PR aims to improve the existing test script implementation to follow a new design flow where user can provide test sequence(s) consisting of test steps of output strings or input commands that the test should validate for.

**Testing**
Tested the `run_tv_casting_test.py` script locally to ensure that it still works as expected.