### PR TITLE
[Draft] [ESP32]: added Wi-Fi interface enabled support

### DIFF
--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -391,6 +391,11 @@ CHIP_ERROR ConnectivityManagerImpl::InitWiFi()
     mWiFiStationMode              = kWiFiStationMode_Disabled;
     mWiFiStationState             = kWiFiStationState_NotConnected;
     mWiFiStationReconnectInterval = System::Clock::Milliseconds32(CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL);
+    if (!NetworkCommissioning::ESPWiFiDriver::GetInstance().GetEnabled())
+    {
+        // If InterfaceEnabled is false, set mode to ApplicationControlled in order not to connect Wi-Fi automatically.
+        mWiFiStationMode = kWiFiStationMode_ApplicationControlled;
+    }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
     mLastAPDemandTime  = System::Clock::kZero;

--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -147,6 +147,11 @@ CHIP_ERROR ESPWiFiDriver::CommitConfiguration()
 CHIP_ERROR ESPWiFiDriver::RevertConfiguration()
 {
     mStagingNetwork = mSavedNetwork;
+    if (!GetEnabled())
+    {
+        // When reverting, set InterfaceEnabled to default value (true).
+        ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Delete(kInterfaceEnabled));
+    }
     return CHIP_NO_ERROR;
 }
 
@@ -196,6 +201,12 @@ Status ESPWiFiDriver::ReorderNetwork(ByteSpan networkId, uint8_t index, MutableC
 
 CHIP_ERROR ESPWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen)
 {
+    if (!GetEnabled())
+    {
+        // Set InterfaceEnabled to default value (true).
+        ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Delete(kInterfaceEnabled));
+    }
+
     // If device is already connected to WiFi, then disconnect the WiFi,
     // clear the WiFi configurations and add the newly provided WiFi configurations.
     if (chip::DeviceLayer::Internal::ESP32Utils::IsStationProvisioned())
@@ -305,6 +316,44 @@ exit:
         mpConnectCallback = nullptr;
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }
+}
+
+CHIP_ERROR ESPWiFiDriver::SetEnabled(bool enabled)
+{
+    if (enabled == GetEnabled())
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Put(kInterfaceEnabled, &enabled, sizeof(enabled)));
+
+    if (!enabled)
+    {
+        if (chip::DeviceLayer::Internal::ESP32Utils::IsStationProvisioned())
+        {
+            ChipLogProgress(DeviceLayer, "Disconnecting WiFi station interface");
+            esp_err_t err = esp_wifi_disconnect();
+            if (err != ESP_OK)
+            {
+                ChipLogError(DeviceLayer, "esp_wifi_disconnect() failed: %s", esp_err_to_name(err));
+                return chip::DeviceLayer::Internal::ESP32Utils::MapError(err);
+            }
+            return ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_ApplicationControlled);
+        }
+    }
+    else
+    {
+        ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Enabled));
+    }
+    return CHIP_NO_ERROR;
+}
+
+bool ESPWiFiDriver::GetEnabled()
+{
+    bool value;
+    // InterfaceEnabled default value is true.
+    VerifyOrReturnValue(PersistedStorage::KeyValueStoreMgr().Get(kInterfaceEnabled, &value, sizeof(value)) == CHIP_NO_ERROR, true);
+    return value;
 }
 
 CHIP_ERROR ESPWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -94,6 +94,8 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
+    CHIP_ERROR SetEnabled(bool enabled) override;
+    bool GetEnabled() override;
     void Shutdown() override;
 
     // WirelessDriver
@@ -131,6 +133,7 @@ public:
     }
 
 private:
+    static constexpr const char * kInterfaceEnabled = "g/esp/en";
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
     CHIP_ERROR StartScanWiFiNetworks(ByteSpan ssid);
 


### PR DESCRIPTION
### Change overview

Added support for enabling/disabling the Wi-Fi interface.
- Set the interface to true or false, will connect or disconnect Wi-Fi.
- If the interface is set to false, Wi-Fi will not connect automatically during reboot.

Related PR: Auto-commissioner: support secondary network interface commissioning (#33801) 

