### PR TITLE
OpenThread: added Thread interface enabled support

### DIFF
--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -1101,6 +1101,15 @@ static_assert(CHIP_DEVICE_CONFIG_BLE_EXT_ADVERTISING_INTERVAL_MIN <= CHIP_DEVICE
 #define CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT 0
 #endif
 
+/**
+ * CHIP_DEVICE_CONFIG_ENABLE_THREAD_AUTOSTART
+ *
+ * Enable starting provisioned Thread network automatically after device power-up.
+ */
+#ifndef CHIP_DEVICE_CONFIG_ENABLE_THREAD_AUTOSTART
+#define CHIP_DEVICE_CONFIG_ENABLE_THREAD_AUTOSTART 1
+#endif
+
 // -------------------- Network Telemetry Configuration --------------------
 
 /**

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -95,6 +95,12 @@ CHIP_ERROR GenericThreadDriver::RevertConfiguration()
     // since the fail-safe was armed, so return with no error.
     ReturnErrorCodeIf(error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND, CHIP_NO_ERROR);
 
+    if (!GetEnabled())
+    {
+        // If backup is found, set InterfaceEnabled to default value (true).
+        ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Delete(kInterfaceEnabled));
+    }
+
     ChipLogProgress(NetworkProvisioning, "Reverting Thread operational dataset");
 
     if (error == CHIP_NO_ERROR)
@@ -166,6 +172,12 @@ void GenericThreadDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * c
 {
     NetworkCommissioning::Status status = MatchesNetworkId(mStagingNetwork, networkId);
 
+    if (!GetEnabled())
+    {
+        // Set InterfaceEnabled to default value (true).
+        ReturnOnFailure(PersistedStorage::KeyValueStoreMgr().Delete(kInterfaceEnabled));
+    }
+
     if (status == Status::kSuccess && BackupConfiguration() != CHIP_NO_ERROR)
     {
         status = Status::kUnknownError;
@@ -181,6 +193,31 @@ void GenericThreadDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * c
     {
         callback->OnResult(status, CharSpan(), 0);
     }
+}
+
+CHIP_ERROR GenericThreadDriver::SetEnabled(bool enabled)
+{
+    if (enabled == GetEnabled())
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Put(kInterfaceEnabled, &enabled, sizeof(enabled)));
+
+    if ((!enabled && DeviceLayer::ThreadStackMgrImpl().IsThreadEnabled()) ||
+        (enabled && DeviceLayer::ThreadStackMgrImpl().IsThreadProvisioned()))
+    {
+        ReturnErrorOnFailure(DeviceLayer::ThreadStackMgrImpl().SetThreadEnabled(enabled));
+    }
+    return CHIP_NO_ERROR;
+}
+
+bool GenericThreadDriver::GetEnabled()
+{
+    bool value;
+    // InterfaceEnabled default value is true.
+    VerifyOrReturnValue(PersistedStorage::KeyValueStoreMgr().Get(kInterfaceEnabled, &value, sizeof(value)) == CHIP_NO_ERROR, true);
+    return value;
 }
 
 void GenericThreadDriver::ScanNetworks(ThreadDriver::ScanCallback * callback)

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -268,7 +268,7 @@ CHIP_ERROR GenericThreadDriver::BackupConfiguration()
 void GenericThreadDriver::CheckInterfaceEnabled()
 {
     bool enabled = GetEnabled();
-    ChipLogProgress(DeviceLayer, "OpenThread InterfaceEnabled: %s", enabled ? "true" : "false");
+    ChipLogProgress(DeviceLayer, "OpenThread InterfaceEnabled: %d", enabled);
 #if !CHIP_DEVICE_CONFIG_ENABLE_THREAD_AUTOSTART
     // If the Thread interface is enabled and stack has been provisioned, but is not currently enabled, enable it now.
     if (enabled && ThreadStackMgrImpl().IsThreadProvisioned() && !ThreadStackMgrImpl().IsThreadEnabled())

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -99,7 +99,11 @@ CHIP_ERROR GenericThreadDriver::RevertConfiguration()
 
     if (!GetEnabled())
     {
-        // If backup is found, set InterfaceEnabled to default value (true).
+        // When reverting configuration, set InterfaceEnabled to default value (true).
+        // From the spec:
+        // If InterfaceEnabled is written to false on the same interface as that which is used to write the value, the Administrator
+        // could await the recovery of network configuration to prior safe values, before being able to communicate with the
+        // node again.
         ReturnErrorOnFailure(PersistedStorage::KeyValueStoreMgr().Delete(kInterfaceEnabled));
     }
 

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -267,11 +267,9 @@ CHIP_ERROR GenericThreadDriver::BackupConfiguration()
 
 void GenericThreadDriver::CheckInterfaceEnabled()
 {
-    bool enabled = GetEnabled();
-    ChipLogProgress(DeviceLayer, "OpenThread InterfaceEnabled: %d", enabled);
 #if !CHIP_DEVICE_CONFIG_ENABLE_THREAD_AUTOSTART
     // If the Thread interface is enabled and stack has been provisioned, but is not currently enabled, enable it now.
-    if (enabled && ThreadStackMgrImpl().IsThreadProvisioned() && !ThreadStackMgrImpl().IsThreadEnabled())
+    if (GetEnabled() && ThreadStackMgrImpl().IsThreadProvisioned() && !ThreadStackMgrImpl().IsThreadEnabled())
     {
         ReturnOnFailure(ThreadStackMgrImpl().SetThreadEnabled(true));
         ChipLogProgress(DeviceLayer, "OpenThread ifconfig up and thread start");

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
@@ -122,6 +122,7 @@ private:
     static void OnThreadStateChangeHandler(const ChipDeviceEvent * event, intptr_t arg);
     Status MatchesNetworkId(const Thread::OperationalDataset & dataset, const ByteSpan & networkId) const;
     CHIP_ERROR BackupConfiguration();
+    void CheckInterfaceEnabled();
 
     ThreadNetworkIterator mThreadIterator      = ThreadNetworkIterator(this);
     Thread::OperationalDataset mStagingNetwork = {};

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
@@ -90,6 +90,8 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new ThreadNetworkIterator(this); }
     CHIP_ERROR Init(Internal::BaseDriver::NetworkStatusChangeCallback * statusChangeCallback) override;
+    CHIP_ERROR SetEnabled(bool enabled) override;
+    bool GetEnabled() override;
     void Shutdown() override;
 
     // WirelessDriver
@@ -114,6 +116,7 @@ public:
     void ScanNetworks(ThreadDriver::ScanCallback * callback) override;
 
 private:
+    static constexpr const char * kInterfaceEnabled = "g/gtd/en";
     uint8_t scanNetworkTimeoutSeconds;
     uint8_t connectNetworkTimeout;
     static void OnThreadStateChangeHandler(const ChipDeviceEvent * event, intptr_t arg);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1094,6 +1094,9 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
     CHIP_ERROR err = CHIP_NO_ERROR;
     otError otErr  = OT_ERROR_NONE;
 
+    // If InterfaceEnabled is false, do not start Thread
+    bool InterfaceEnabled = true;
+
     // Arrange for OpenThread errors to be translated to text.
     RegisterOpenThreadErrorFormatter();
 
@@ -1131,8 +1134,12 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
     memset(&mSrpClient, 0, sizeof(mSrpClient));
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
+#ifndef _NO_NETWORK_COMMISSIONING_DRIVER_
+    InterfaceEnabled = sGenericThreadDriver.GetEnabled();
+#endif
+
     // If the Thread stack has been provisioned, but is not currently enabled, enable it now.
-    if (otThreadGetDeviceRole(mOTInst) == OT_DEVICE_ROLE_DISABLED && otDatasetIsCommissioned(otInst))
+    if (InterfaceEnabled && otThreadGetDeviceRole(mOTInst) == OT_DEVICE_ROLE_DISABLED && otDatasetIsCommissioned(otInst))
     {
         // Enable the Thread IPv6 interface.
         otErr = otIp6SetEnabled(otInst, true);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1094,9 +1094,6 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
     CHIP_ERROR err = CHIP_NO_ERROR;
     otError otErr  = OT_ERROR_NONE;
 
-    // If InterfaceEnabled is false, do not start Thread
-    bool InterfaceEnabled = true;
-
     // Arrange for OpenThread errors to be translated to text.
     RegisterOpenThreadErrorFormatter();
 
@@ -1134,12 +1131,9 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
     memset(&mSrpClient, 0, sizeof(mSrpClient));
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
-#ifndef _NO_NETWORK_COMMISSIONING_DRIVER_
-    InterfaceEnabled = sGenericThreadDriver.GetEnabled();
-#endif
-
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_AUTOSTART
     // If the Thread stack has been provisioned, but is not currently enabled, enable it now.
-    if (InterfaceEnabled && otThreadGetDeviceRole(mOTInst) == OT_DEVICE_ROLE_DISABLED && otDatasetIsCommissioned(otInst))
+    if (otThreadGetDeviceRole(mOTInst) == OT_DEVICE_ROLE_DISABLED && otDatasetIsCommissioned(otInst))
     {
         // Enable the Thread IPv6 interface.
         otErr = otIp6SetEnabled(otInst, true);
@@ -1150,6 +1144,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::DoInit(otInstanc
 
         ChipLogProgress(DeviceLayer, "OpenThread ifconfig up and thread start");
     }
+#endif
 
     initNetworkCommissioningThreadDriver();
 


### PR DESCRIPTION
### Change overview

Added support for enabling/disabling the OpenThread network interface.
- Set the interface to true or false, will connect or disconnect Thread.
- If the interface is set to false, Thread will not connect automatically during reboot.

Related PR: Auto-commissioner: support secondary network interface commissioning (#33801) 