### PR TITLE
[NXP] Add ICD _SetPollingInterval and set minimum ActiveModeThreshold to 5 seconds

### DIFF
--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -618,6 +618,16 @@ CHIP_ERROR ConnectivityManagerImpl::_DisconnectNetwork(void)
 
     return err;
 }
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+CHIP_ERROR ConnectivityManagerImpl::_SetPollingInterval(System::Clock::Milliseconds32 pollingInterval)
+{
+    /*
+     * ToDo: Call API to put device into sleep
+     */
+    return CHIP_NO_ERROR;
+}
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #endif
 
 } // namespace DeviceLayer

--- a/src/platform/nxp/common/ConnectivityManagerImpl.h
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.h
@@ -87,6 +87,9 @@ public:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     void StartWiFiManagement();
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #if CHIP_ENABLE_OPENTHREAD
     Inet::InterfaceId GetExternalInterface();
     Inet::InterfaceId GetThreadInterface();

--- a/third_party/nxp/nxp_sdk.gni
+++ b/third_party/nxp/nxp_sdk.gni
@@ -53,7 +53,7 @@ declare_args() {
 
   nxp_idle_mode_duration_s = 600  # 10min Idle Mode Interval
   nxp_active_mode_duration_ms = 10000  # 10s Active Mode Interval
-  nxp_active_mode_threshold_ms = 1000  # 1s Active Mode Threshold
+  nxp_active_mode_threshold_ms = 5000  # 5s Active Mode Threshold
   nxp_icd_supported_clients_per_fabric = 2  # 2 registration slots per fabric
 }
 


### PR DESCRIPTION
Add the _SetPollingInterval for Wi-Fi SIT ICDM function, The minimum ActiveModeThreshold value for a LIT ICD is 5 seconds.
During initialization, the app would stuck in an assert if the app was configured
  as a LIT ICD:
  
  VerifyOrDieWithMsg(ICDConfigurationData::GetInstance().GetMinLitActiveModeThreshold() <=
                     ICDConfigurationData::GetInstance().GetActiveModeThreshold(),
                     AppServer, "The minimum ActiveModeThreshold value for a LIT ICD is 5 seconds.");
  
  Setting the default value of nxp_active_mode_threshold_ms to 5000ms fixes the issue.
