### PR TITLE
[NXP] Fix TC-I-2.2 test failure

### DIFF
--- a/examples/all-clusters-app/nxp/common/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/nxp/common/main/DeviceCallbacks.cpp
@@ -57,7 +57,7 @@ void OnTriggerEffect(::Identify * identify)
 }
 
 Identify gIdentify0 = {
-    chip::EndpointId{ 1 },
+    chip::EndpointId{ 0 },
     [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
     [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
     chip::app::Clusters::Identify::IdentifyTypeEnum::kNone,

--- a/examples/thermostat/nxp/common/main/DeviceCallbacks.cpp
+++ b/examples/thermostat/nxp/common/main/DeviceCallbacks.cpp
@@ -57,7 +57,7 @@ void OnTriggerEffect(::Identify * identify)
 }
 
 Identify gIdentify0 = {
-    chip::EndpointId{ 1 },
+    chip::EndpointId{ 0 },
     [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
     [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
     chip::app::Clusters::Identify::IdentifyTypeEnum::kNone,


### PR DESCRIPTION
Fix TC-I-2.2 test failure (step2b step6b: The response value should be lower or equal to the constraint). This was due to an identify cluster initialization issue, it was initialized twice for endpoint 1 due to a typo error

