### PR TITLE
Avoid errors when using on-network commissioning

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -377,6 +377,9 @@ bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData &
     case Dnssd::DiscoveryFilterType::kLongDiscriminator:
         discriminatorMatches = (nodeData.longDiscriminator == mCurrentFilter.code);
         break;
+    case Dnssd::DiscoveryFilterType::kNone:
+        ChipLogDetail(Controller, "Filter type none; all matches will fail");
+        return false;
     default:
         ChipLogError(Controller, "Unknown filter type; all matches will fail");
         return false;

--- a/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptPairingDeviceDiscoveryDelegate.cpp
@@ -32,6 +32,9 @@ void ScriptPairingDeviceDiscoveryDelegate::OnDiscoveredDevice(const Dnssd::Commi
     nodeData.ipAddress[0].ToString(buf);
     ChipLogProgress(chipTool, "Discovered Device: %s:%u", buf, port);
 
+    // Stop active discovery.
+    mActiveDeviceCommissioner->StopCommissionableDiscovery();
+
     // Cancel discovery timer.
     chip::DeviceLayer::SystemLayer().CancelTimer(OnDiscoveredTimeout, this);
 


### PR DESCRIPTION
When on network commissioning is used from Python we currently don't stop discovery even though we already found a device. Future devices found won't be processed, so it is fine to stop discovery of commissionable nodes at this point.

This effectively aligns behavior with SetUpCodePairer when `kDiscoveryNetworkOnlyWithoutPASEAutoRetry` is used.

Also avoid "Unknown filter type; all matches will fail" errors in the log: If the filter type is set to None, it wasn't the SetUpCodePairer which set up the discovery. Avoid printing errors in this case.

A potential alternative to this would be to skip notifying the SetUpCodePairer in `DeviceCommissioner::OnNodeDiscovered` in this case.
