### PR TITLE
[Python] Use thread-safe futures for concurrent operations

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -601,7 +601,13 @@ class ChipDeviceControllerBase():
                 lambda: self._dmLib.pychip_DeviceController_EstablishPASESessionBLE(
                     self.devCtrl, setupPinCode, discriminator, nodeid)
             ).raise_on_error()
-            return self._pase_establishment_complete_future.result()
+
+            # TODO: This is a bit funky, but what the API returned with the previous
+            # implementation. We should revisit this.
+            err = self._pase_establishment_complete_future.result()
+            if not err.is_success:
+                return err.to_exception()
+            return None
         finally:
             self._pase_establishment_complete_future = None
 
@@ -615,7 +621,13 @@ class ChipDeviceControllerBase():
                 lambda: self._dmLib.pychip_DeviceController_EstablishPASESessionIP(
                     self.devCtrl, ipaddr.encode("utf-8"), setupPinCode, nodeid, port)
             ).raise_on_error()
-            return self._pase_establishment_complete_future.result()
+
+            # TODO: This is a bit funky, but what the API returned with the previous
+            # implementation. We should revisit this.
+            err = self._pase_establishment_complete_future.result()
+            if not err.is_success:
+                return err.to_exception()
+            return None
         finally:
             self._pase_establishment_complete_future = None
 
@@ -629,7 +641,13 @@ class ChipDeviceControllerBase():
                 lambda: self._dmLib.pychip_DeviceController_EstablishPASESession(
                     self.devCtrl, setUpCode.encode("utf-8"), nodeid)
             ).raise_on_error()
-            return self._pase_establishment_complete_future.result()
+
+            # TODO: This is a bit funky, but what the API returned with the previous
+            # implementation. We should revisit this.
+            err = self._pase_establishment_complete_future.result()
+            if not err.is_success:
+                return err.to_exception()
+            return None
         finally:
             self._pase_establishment_complete_future = None
 

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -545,7 +545,11 @@ class ChipDeviceControllerBase():
                     self.devCtrl, discriminator, setupPinCode, nodeid)
             ).raise_on_error()
 
-            return self._commissioning_complete_future.result()
+            # TODO: Change return None. Only returning on success is not useful.
+            # but that is what the previous implementation did.
+            res = self._commissioning_complete_future.result()
+            res.raise_on_error()
+            return res
         finally:
             self._commissioning_complete_future = None
 


### PR DESCRIPTION
Instead of using quasi-global variables in the ChipStack singleton use device controller local futures to store results from callbacks. This has several advantages, namely:
- Avoid unnecessary shared state between device controllers
- Avoid unnecessary shared state between various operations within a device controller (those who don't share callbacks could be called from different threads now)
- Explicitly set Futures to None to detect spurious/unexpected callbacks
- Better code readability
- concurrent.futures are thread-safe
- Will make asyncio transition easier

This change shouldn't change the external API.

This allows us to get rid of the rather complicated `CallAsyncWithCompleteCallback`. While at it, also get rid of the largely unused `DCState` enum.
