### PR TITLE
[Linux] Verify BLE service before reporting new connection

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_CNET_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CNET_4_2.yaml
@@ -56,7 +56,7 @@ tests:
           [1698660637.937911][6429:6431] CHIP:IN: Clearing BLE pending packets.
           [1698660637.938582][6429:6431] CHIP:BLE: Auto-closing end point's BLE connection.
           [1698660637.938645][6429:6431] CHIP:DL: Closing BLE GATT connection (con 0xffff9c034bb0)
-          [1698660637.938805][6429:6430] CHIP:DL: BluezDisconnect peer=F7:D4:24:D2:4A:1F
+          [1698660637.938805][6429:6430] CHIP:DL: Close BLE connection: peer=F7:D4:24:D2:4A:1F
           [1698660638.365208][6429:6431] CHIP:IN: SecureSession[0xffff9400f900]: MarkForEviction Type:1 LSID:62220
           [1698660638.365311][6429:6431] CHIP:SC: SecureSession[0xffff9400f900, LSID:62220]: State change 'kActive' --> 'kPendingEviction'
           [1698660638.365440][6429:6431] CHIP:IN: SecureSession[0xffff9400f900]: Released - Type:1 LSID:62220

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -476,58 +476,37 @@ void BLEManagerImpl::HandleSubscribeOpComplete(BLE_CONNECTION_OBJECT conId, bool
 
 void BLEManagerImpl::HandleTXCharChanged(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len)
 {
-    CHIP_ERROR err                 = CHIP_NO_ERROR;
-    System::PacketBufferHandle buf = System::PacketBufferHandle::NewWithData(value, len);
+    System::PacketBufferHandle buf(System::PacketBufferHandle::NewWithData(value, len));
+    VerifyOrReturn(!buf.IsNull(), ChipLogError(DeviceLayer, "Failed to allocate packet buffer in %s", __func__));
 
     ChipLogDetail(DeviceLayer, "Indication received, conn = %p", conId);
 
     ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformLinuxBLEIndicationReceived,
-                           .Platform = { .BLEIndicationReceived = { .mConnection = conId } } };
-
-    VerifyOrExit(!buf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
-
-    event.Platform.BLEIndicationReceived.mData = std::move(buf).UnsafeRelease();
+                           .Platform = {
+                               .BLEIndicationReceived = { .mConnection = conId, .mData = std::move(buf).UnsafeRelease() } } };
     PlatformMgr().PostEventOrDie(&event);
-
-exit:
-    if (err != CHIP_NO_ERROR)
-        ChipLogError(DeviceLayer, "HandleTXCharChanged() failed: %s", ErrorStr(err));
 }
 
 void BLEManagerImpl::HandleRXCharWrite(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    System::PacketBufferHandle buf;
-
     // Copy the data to a packet buffer.
-    buf = System::PacketBufferHandle::NewWithData(value, len);
-    VerifyOrExit(!buf.IsNull(), err = CHIP_ERROR_NO_MEMORY);
+    System::PacketBufferHandle buf(System::PacketBufferHandle::NewWithData(value, len));
+    VerifyOrReturn(!buf.IsNull(), ChipLogError(DeviceLayer, "Failed to allocate packet buffer in %s", __func__));
+
+    ChipLogProgress(Ble, "Write request received, conn = %p", conId);
 
     // Post an event to the Chip queue to deliver the data into the Chip stack.
-    {
-        ChipLogProgress(Ble, "Write request received debug %p", conId);
-        ChipDeviceEvent event{ .Type                  = DeviceEventType::kCHIPoBLEWriteReceived,
-                               .CHIPoBLEWriteReceived = { .ConId = conId, .Data = std::move(buf).UnsafeRelease() } };
-        PlatformMgr().PostEventOrDie(&event);
-    }
-
-exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
-    }
+    ChipDeviceEvent event{ .Type                  = DeviceEventType::kCHIPoBLEWriteReceived,
+                           .CHIPoBLEWriteReceived = { .ConId = conId, .Data = std::move(buf).UnsafeRelease() } };
+    PlatformMgr().PostEventOrDie(&event);
 }
 
-void BLEManagerImpl::CHIPoBluez_ConnectionClosed(BLE_CONNECTION_OBJECT conId)
+void BLEManagerImpl::HandleConnectionClosed(BLE_CONNECTION_OBJECT conId)
 {
-    ChipLogProgress(DeviceLayer, "Bluez notify CHIPoBluez connection disconnected");
-
     // If this was a CHIPoBLE connection, post an event to deliver a connection error to the CHIPoBLE layer.
-    {
-        ChipDeviceEvent event{ .Type                    = DeviceEventType::kCHIPoBLEConnectionError,
-                               .CHIPoBLEConnectionError = { .ConId = conId, .Reason = BLE_ERROR_REMOTE_DEVICE_DISCONNECTED } };
-        PlatformMgr().PostEventOrDie(&event);
-    }
+    ChipDeviceEvent event{ .Type                    = DeviceEventType::kCHIPoBLEConnectionError,
+                           .CHIPoBLEConnectionError = { .ConId = conId, .Reason = BLE_ERROR_REMOTE_DEVICE_DISCONNECTED } };
+    PlatformMgr().PostEventOrDie(&event);
 }
 
 void BLEManagerImpl::HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT conId)
@@ -535,15 +514,14 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT conId)
     VerifyOrReturn(conId != BLE_CONNECTION_UNINITIALIZED,
                    ChipLogError(DeviceLayer, "BLE connection is not initialized in %s", __func__));
 
+    ChipLogProgress(DeviceLayer, "CHIPoBLE %s received", conId->IsNotifyAcquired() ? "subscribe" : "unsubscribe");
+
     // Post an event to the Chip queue to process either a CHIPoBLE Subscribe or Unsubscribe based on
     // whether the client is enabling or disabling indications.
     ChipDeviceEvent event{ .Type = conId->IsNotifyAcquired() ? static_cast<uint16_t>(DeviceEventType::kCHIPoBLESubscribe)
                                                              : static_cast<uint16_t>(DeviceEventType::kCHIPoBLEUnsubscribe),
                            .CHIPoBLESubscribe = { .ConId = conId } };
     PlatformMgr().PostEventOrDie(&event);
-
-    ChipLogProgress(DeviceLayer, "CHIPoBLE %s received",
-                    (event.Type == DeviceEventType::kCHIPoBLESubscribe) ? "subscribe" : "unsubscribe");
 }
 
 void BLEManagerImpl::HandleTXComplete(BLE_CONNECTION_OBJECT conId)

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -87,7 +87,7 @@ public:
     static void HandleSubscribeOpComplete(BLE_CONNECTION_OBJECT conId, bool subscribed);
     static void HandleTXCharChanged(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len);
     static void HandleRXCharWrite(BLE_CONNECTION_OBJECT user_data, const uint8_t * value, size_t len);
-    static void CHIPoBluez_ConnectionClosed(BLE_CONNECTION_OBJECT user_data);
+    static void HandleConnectionClosed(BLE_CONNECTION_OBJECT user_data);
     static void HandleTXCharCCCDWrite(BLE_CONNECTION_OBJECT user_data);
     static void HandleTXComplete(BLE_CONNECTION_OBJECT user_data);
 
@@ -136,7 +136,7 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
+    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -136,7 +136,7 @@ private:
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
     void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
-    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override {};
+    void NewConnection(BleLayer * bleLayer, void * appState, BLE_CONNECTION_OBJECT connObj) override{};
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -77,7 +77,8 @@ BluezConnection::IOChannel::~IOChannel()
 
 BluezConnection::ConnectionDataBundle::ConnectionDataBundle(const BluezConnection & aConn,
                                                             const chip::System::PacketBufferHandle & aBuf) :
-    mConn(aConn), mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
+    mConn(aConn),
+    mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
 {}
 
 CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -74,8 +74,7 @@ BluezConnection::IOChannel::~IOChannel()
 
 BluezConnection::ConnectionDataBundle::ConnectionDataBundle(const BluezConnection & aConn,
                                                             const chip::System::PacketBufferHandle & aBuf) :
-    mConn(aConn),
-    mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
+    mConn(aConn), mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
 {}
 
 CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
@@ -113,27 +112,26 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
                 if ((BluezIsCharOnService(char1, mService.get()) == TRUE) &&
                     (strcmp(bluez_gatt_characteristic1_get_uuid(char1), Ble::CHIP_BLE_CHAR_1_UUID_STR) == 0))
                 {
+                    ChipLogDetail(DeviceLayer, "C1 found: %s", Ble::CHIP_BLE_CHAR_1_UUID_STR);
                     mC1.reset(char1);
                 }
                 else if ((BluezIsCharOnService(char1, mService.get()) == TRUE) &&
                          (strcmp(bluez_gatt_characteristic1_get_uuid(char1), Ble::CHIP_BLE_CHAR_2_UUID_STR) == 0))
                 {
+                    ChipLogDetail(DeviceLayer, "C2 found: %s", Ble::CHIP_BLE_CHAR_2_UUID_STR);
                     mC2.reset(char1);
                 }
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
                 else if ((BluezIsCharOnService(char1, mService.get()) == TRUE) &&
                          (strcmp(bluez_gatt_characteristic1_get_uuid(char1), Ble::CHIP_BLE_CHAR_3_UUID_STR) == 0))
                 {
+                    ChipLogDetail(DeviceLayer, "C3 found: %s", Ble::CHIP_BLE_CHAR_3_UUID_STR);
                     mC3.reset(char1);
                 }
 #endif
                 else
                 {
                     g_object_unref(char1);
-                }
-                if (mC1 && mC2)
-                {
-                    break;
                 }
             }
         }

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -135,18 +135,18 @@ CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)
 
     VerifyOrReturnError(mC1, BLE_ERROR_NOT_CHIP_DEVICE,
                         ChipLogError(DeviceLayer, "C1 (%s) not found on %s", Ble::CHIP_BLE_CHAR_1_UUID_STR, GetPeerAddress()));
-    VerifyOrReturnError(mC1, BLE_ERROR_NOT_CHIP_DEVICE,
+    VerifyOrReturnError(mC2, BLE_ERROR_NOT_CHIP_DEVICE,
                         ChipLogError(DeviceLayer, "C2 (%s) not found on %s", Ble::CHIP_BLE_CHAR_2_UUID_STR, GetPeerAddress()));
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BluezConnection::BluezDisconnect(BluezConnection * conn)
+CHIP_ERROR BluezConnection::CloseConnectionImpl(BluezConnection * conn)
 {
     GAutoPtr<GError> error;
     gboolean success;
 
-    ChipLogDetail(DeviceLayer, "%s peer=%s", __func__, conn->GetPeerAddress());
+    ChipLogDetail(DeviceLayer, "Close BLE connection: peer=%s", conn->GetPeerAddress());
 
     success = bluez_device1_call_disconnect_sync(conn->mDevice.get(), nullptr, &error.GetReceiver());
     VerifyOrExit(success == TRUE, ChipLogError(DeviceLayer, "FAIL: Disconnect: %s", error->message));
@@ -157,7 +157,7 @@ exit:
 
 CHIP_ERROR BluezConnection::CloseConnection()
 {
-    return PlatformMgrImpl().GLibMatterContextInvokeSync(BluezDisconnect, this);
+    return PlatformMgrImpl().GLibMatterContextInvokeSync(CloseConnectionImpl, this);
 }
 
 const char * BluezConnection::GetPeerAddress() const

--- a/src/platform/Linux/bluez/BluezConnection.h
+++ b/src/platform/Linux/bluez/BluezConnection.h
@@ -99,7 +99,7 @@ private:
         GAutoPtr<GVariant> mData;
     };
 
-    static CHIP_ERROR BluezDisconnect(BluezConnection * apConn);
+    static CHIP_ERROR CloseConnectionImpl(BluezConnection * apConn);
 
     static gboolean WriteHandlerCallback(GIOChannel * aChannel, GIOCondition aCond, BluezConnection * apConn);
     static gboolean NotifyHandlerCallback(GIOChannel * aChannel, GIOCondition aCond, BluezConnection * apConn);

--- a/src/platform/Linux/bluez/BluezConnection.h
+++ b/src/platform/Linux/bluez/BluezConnection.h
@@ -39,8 +39,10 @@ class BluezEndpoint;
 class BluezConnection
 {
 public:
-    BluezConnection(const BluezEndpoint & aEndpoint, BluezDevice1 & aDevice);
+    BluezConnection(BluezDevice1 & aDevice) : mDevice(reinterpret_cast<BluezDevice1 *>(g_object_ref(&aDevice))) {}
     ~BluezConnection() = default;
+
+    CHIP_ERROR Init(const BluezEndpoint & aEndpoint);
 
     const char * GetPeerAddress() const;
 
@@ -96,8 +98,6 @@ private:
         const BluezConnection & mConn;
         GAutoPtr<GVariant> mData;
     };
-
-    CHIP_ERROR Init(const BluezEndpoint & aEndpoint);
 
     static CHIP_ERROR BluezDisconnect(BluezConnection * apConn);
 

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -550,7 +550,8 @@ CHIP_ERROR BluezEndpoint::Init(BluezAdapter1 * apAdapter, bool aIsCentral)
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to subscribe for notifications: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization: %" CHIP_ERROR_FORMAT, err.Format()));
 

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -442,7 +442,7 @@ void BluezEndpoint::SetupGattService()
 {
 
     static const char * const c1_flags[] = { "write", nullptr };
-    static const char * const c2_flags[] = { "read", "indicate", nullptr };
+    static const char * const c2_flags[] = { "indicate", nullptr };
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
     static const char * const c3_flags[] = { "read", nullptr };
 #endif


### PR DESCRIPTION
### Problem

Linux controller can attempt to perform BTP connection with not valid Matter GATT server (e.g. advertised as Matter, but in fact 0xFFF6 service is not there, or Matter service is available but with invalid characteristics).

### Changes

- Check for spec-compliant CHIPoBLE service before reporting new BLE connection to CHIPoBLE layer
- Remove "read" property from C2 (according to spec C2 should have "indication" property only)
- Fix discovery of C3 characteristic by the client
- Simplify some logic in the event posting helpers

### Testing

Tested BLE commissioning on linux-linux setup.

Logs, when attempting connection with fake Matter device:
```
CHIP:BLE: New device scanned: 00:15:83:E5:B0:54
CHIP:BLE: Device discriminator match. Attempting to connect.
CHIP:BLE: ChipDeviceScanner has stopped scanning!
CHIP:DL: ConnectDevice complete
CHIP:BLE: New device connected: 00:15:83:E5:B0:54
CHIP:DL: CHIP service found
CHIP:DL: Valid C1 characteristic found
CHIP:DL: No valid C2 (18ee2ef5-263d-4559-959f-4f9c429f9d12) on 00:15:83:E5:B0:54
CHIP:DL: HandlePlatformSpecificBLEEvent 16388
CHIP:DIS: Closing all BLE connections
CHIP:TOO: Pairing Failure: src/platform/Linux/bluez/BluezConnection.cpp:141: Ble Error 0x0000040F: BLE device doesn't seem to support chip
CHIP:CTL: Shutting down the commissioner
CHIP:CTL: Shutting down the controller
CHIP:IN: Expiring all sessions for fabric 0x1!!
CHIP:FP: Forgetting fabric 0x1
CHIP:TS: Pending Last Known Good Time: 2023-10-14T01:16:48
CHIP:TS: Previous Last Known Good Time: 2023-10-14T01:16:48
CHIP:TS: Reverted Last Known Good Time to previous value
CHIP:CTL: Shutting down the commissioner
CHIP:CTL: Shutting down the controller
CHIP:CTL: Shutting down the System State, this will teardown the CHIP Stack
CHIP:DMG: All ReadHandler-s are clean, clear GlobalDirtySet
CHIP:FP: Shutting down FabricTable
CHIP:TS: Pending Last Known Good Time: 2023-10-14T01:16:48
CHIP:TS: Previous Last Known Good Time: 2023-10-14T01:16:48
CHIP:TS: Reverted Last Known Good Time to previous value
CHIP:DL: writing settings to file (/tmp/chip_counters.ini-DjcwZO)
CHIP:DL: renamed tmp file to file (/tmp/chip_counters.ini)
CHIP:DL: NVS set: chip-counters/total-operational-hours = 0 (0x0)
CHIP:DL: Inet Layer shutdown
CHIP:DL: BLE Layer shutdown
CHIP:DL: System Layer shutdown
CHIP:TOO: Run command failure: src/platform/Linux/bluez/BluezConnection.cpp:141: Ble Error 0x0000040F: BLE device doesn't seem to support chip
```