### PR TITLE
[NXP][platform] Fixing RAM buffer alignment issue on NXP platforms

### DIFF
--- a/src/platform/nxp/common/NXPConfig.cpp
+++ b/src/platform/nxp/common/NXPConfig.cpp
@@ -84,14 +84,14 @@ typedef struct
 {
     uint16_t chipConfigRamBufferLen;
     uint16_t padding;
-    uint8_t chipConfigRamBuffer[CONFIG_CHIP_NVM_RAMBUFFER_SIZE_KEY_INT];
+    uint8_t chipConfigRamBuffer[CONFIG_CHIP_NVM_RAMBUFFER_SIZE_KEY_INT] __attribute__((aligned(4)));
 } ChipConfigRamStructKeyInt;
 
 typedef struct
 {
     uint16_t chipConfigRamBufferLen;
     uint16_t padding;
-    uint8_t chipConfigRamBuffer[CONFIG_CHIP_NVM_RAMBUFFER_SIZE_KEY_STRING];
+    uint8_t chipConfigRamBuffer[CONFIG_CHIP_NVM_RAMBUFFER_SIZE_KEY_STRING] __attribute__((aligned(4)));
 } ChipConfigRamStructKeyString;
 
 /* File system containing only integer keys */
@@ -193,6 +193,14 @@ CHIP_ERROR NXPConfig::Init()
 {
     if (!isInitialized)
     {
+        /*
+         * Make sure to check that read buffers are always 4 bytes aligned,
+         * as NXP flash drivers may mandate the alignment of dst read buffer to 4 bytes
+         */
+        static_assert(alignof(chipConfigRamStructKeyInt.chipConfigRamBuffer) == 4,
+                      "Wrong buffer alignment, it must be 4 bytes aligned");
+        static_assert(alignof(chipConfigRamStructKeyString.chipConfigRamBuffer) == 4,
+                      "Wrong buffer alignment, it must be 4 bytes aligned");
         ramStorageInit();
 
 #if (CHIP_PLAT_NVM_SUPPORT == CHIP_PLAT_NVM_FWK)


### PR DESCRIPTION
Issue description: 

An issue may happen on NXP platforms supporting Matter with the RAM storage module + littlefs due to a RAM buffer alignment issue preventing the device to load matter file system data in RAM.

Fix proposed: 

As the NXP mflash_drv_read function mandates the alignment of dst read buffer to 4 bytes, make sure to always align read buffers to 4 bytes.


