### PR TITLE
Remove unnecessary error log from CurrentFabricRemover

### DIFF
--- a/src/controller/CurrentFabricRemover.cpp
+++ b/src/controller/CurrentFabricRemover.cpp
@@ -146,7 +146,9 @@ void CurrentFabricRemover::OnCommandFailure(void * context, CHIP_ERROR err)
 void CurrentFabricRemover::FinishRemoveCurrentFabric(void * context, CHIP_ERROR err)
 {
     if (err != CHIP_NO_ERROR)
+    {
         ChipLogError(Controller, "Remove Current Fabric Failed : %" CHIP_ERROR_FORMAT, err.Format());
+    }
     auto * self     = static_cast<CurrentFabricRemover *>(context);
     self->mNextStep = Step::kAcceptRemoveFabricStart;
     if (self->mCurrentFabricRemoveCallback != nullptr)

--- a/src/controller/CurrentFabricRemover.cpp
+++ b/src/controller/CurrentFabricRemover.cpp
@@ -145,7 +145,8 @@ void CurrentFabricRemover::OnCommandFailure(void * context, CHIP_ERROR err)
 
 void CurrentFabricRemover::FinishRemoveCurrentFabric(void * context, CHIP_ERROR err)
 {
-    ChipLogError(Controller, "Remove Current Fabric Result : %" CHIP_ERROR_FORMAT, err.Format());
+    if (err != CHIP_NO_ERROR)
+        ChipLogError(Controller, "Remove Current Fabric Failed : %" CHIP_ERROR_FORMAT, err.Format());
     auto * self     = static_cast<CurrentFabricRemover *>(context);
     self->mNextStep = Step::kAcceptRemoveFabricStart;
     if (self->mCurrentFabricRemoveCallback != nullptr)


### PR DESCRIPTION
Currently, when the CurrentFabricRemover is successful it logs the following error with err log level:

Remove Current Fabric Result : src/controller/CurrentFabricRemover.cpp:133: Success

Get rid of the message if successful, it is confusing.
