### PR TITLE
Enable additional adv data on Linux as a reference platform

### DIFF
--- a/examples/chip-tool/args.gni
+++ b/examples/chip-tool/args.gni
@@ -29,6 +29,7 @@ matter_log_json_payload_hex = true
 matter_log_json_payload_decode_full = true
 
 chip_enable_additional_data_advertising = true
+chip_enable_rotating_device_id = true
 
 # make chip-tool very strict by default
 chip_tlv_validate_char_string_on_read = true

--- a/examples/chip-tool/args.gni
+++ b/examples/chip-tool/args.gni
@@ -28,6 +28,8 @@ matter_enable_tracing_support = true
 matter_log_json_payload_hex = true
 matter_log_json_payload_decode_full = true
 
+chip_enable_additional_data_advertising = true
+
 # make chip-tool very strict by default
 chip_tlv_validate_char_string_on_read = true
 chip_tlv_validate_char_string_on_write = true

--- a/examples/chip-tool/args.gni
+++ b/examples/chip-tool/args.gni
@@ -28,9 +28,6 @@ matter_enable_tracing_support = true
 matter_log_json_payload_hex = true
 matter_log_json_payload_decode_full = true
 
-chip_enable_additional_data_advertising = true
-chip_enable_rotating_device_id = true
-
 # make chip-tool very strict by default
 chip_tlv_validate_char_string_on_read = true
 chip_tlv_validate_char_string_on_write = true

--- a/examples/lighting-app/linux/args.gni
+++ b/examples/lighting-app/linux/args.gni
@@ -29,5 +29,6 @@ chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 matter_enable_tracing_support = true
 
 chip_enable_additional_data_advertising = true
+chip_enable_rotating_device_id = true
 
 chip_enable_read_client = false

--- a/examples/lighting-app/linux/args.gni
+++ b/examples/lighting-app/linux/args.gni
@@ -28,4 +28,6 @@ chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 matter_enable_tracing_support = true
 
+chip_enable_additional_data_advertising = true
+
 chip_enable_read_client = false

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -413,7 +413,7 @@ static void UpdateAdditionalDataCharacteristic(BluezGattCharacteristic1 * charac
                                                                          additionalDataFields);
     SuccessOrExit(err);
 
-    data = g_memdup(bufferHandle->Start(), bufferHandle->DataLength());
+    data = g_memdup2(bufferHandle->Start(), bufferHandle->DataLength());
 
     cValue = g_variant_new_from_data(G_VARIANT_TYPE("ay"), data, bufferHandle->DataLength(), TRUE, g_free, data);
     bluez_gatt_characteristic1_set_value(characteristic, cValue);

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -75,6 +75,10 @@
 #include "BluezConnection.h"
 #include "Types.h"
 
+#if !GLIB_CHECK_VERSION(2, 68, 0)
+#define g_memdup2(mem, size) g_memdup(mem, static_cast<unsigned int>(size))
+#endif
+
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {


### PR DESCRIPTION
### Problem

Linux is a reference platform for verification purposes, so all features should be able to compile and functional on that platform.

### Changes

- enable additional advertising data on lighting-app
- use `g_memdup2()`, since `g_memdup()` is deprecated since glib 2.68

### Testing

CI will verify potential build breaks.