### PR TITLE
[NXP] rw61x openthread and BT updates

### DIFF
--- a/examples/platform/nxp/rt/rw61x/app/project_include/openthread/OpenThreadConfig.h
+++ b/examples/platform/nxp/rt/rw61x/app/project_include/openthread/OpenThreadConfig.h
@@ -65,12 +65,9 @@
 #define OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE 1
 #define OPENTHREAD_CONFIG_ECDSA_ENABLE 1
 
-// Temporary workaround till we can enable this via the gn
-#ifdef SPINEL_INTERFACE_RPMSG
-#define OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE 1
-#else
+#ifndef OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
 #define OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE 0
-#endif /* SPINEL_INTERFACE_RPMSG */
+#endif /* OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE */
 
 /*
  * "ot-nxp/src/rw/rw612/platform/radio.c" has a dependency on

--- a/src/platform/nxp/rt/rw61x/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/rt/rw61x/PlatformManagerImpl.cpp
@@ -50,6 +50,8 @@
 #endif
 
 extern "C" void BOARD_InitHardware(void);
+extern "C" void otPlatSetResetFunction(void (*fp)(void));
+extern "C" void initiateResetInIdle(void);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 
@@ -205,6 +207,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
      */
     otPlatLogInit();
     otPlatRadioInit();
+    otPlatSetResetFunction(initiateResetInIdle);
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
@@ -305,6 +308,22 @@ void PlatformManagerImpl::ScheduleResetInIdle(void)
 bool PlatformManagerImpl::GetResetInIdleValue(void)
 {
     return resetInIdle;
+}
+
+extern "C" void initiateResetInIdle(void)
+{
+    PlatformMgr().Shutdown();
+    PlatformMgrImpl().ScheduleResetInIdle();
+}
+
+extern "C" void scheduleResetInIdle(void)
+{
+    PlatformMgrImpl().ScheduleResetInIdle();
+}
+
+extern "C" bool getResetInIdleValue(void)
+{
+    return PlatformMgrImpl().GetResetInIdleValue();
 }
 
 void PlatformManagerImpl::StopBLEConnectivity(void) {}

--- a/third_party/nxp/rt_sdk/transceiver/app_transceiver_config.h
+++ b/third_party/nxp/rt_sdk/transceiver/app_transceiver_config.h
@@ -41,5 +41,6 @@
 #endif /* WIFI_TRANSCEIVER_SUPPORT */
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+#define CONFIG_BT_DEVICE_NAME "NXP BLE test"
 #include "edgefast_bluetooth_config.h"
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE */

--- a/third_party/openthread/platforms/nxp/rt/rw61x/BUILD.gn
+++ b/third_party/openthread/platforms/nxp/rt/rw61x/BUILD.gn
@@ -26,6 +26,7 @@ import("${nxp_sdk_build_root}/${nxp_sdk_name}/${nxp_sdk_name}.gni")
 openthread_nxp_root = "${chip_root}/third_party/openthread/ot-nxp"
 
 config("openthread_rw61x_config") {
+  defines = []
   include_dirs = [
     "${openthread_nxp_root}/src/common",
     "${openthread_nxp_root}/src/common/br",
@@ -38,7 +39,7 @@ config("openthread_rw61x_config") {
     include_dirs += [ "${openthread_nxp_root}/src/common/spinel" ]
   }
   if (chip_enable_wifi && chip_enable_openthread) {
-    defines = [
+    defines += [
       "OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE=1",
       "OPENTHREAD_CONFIG_COMMISSIONER_ENABLE=1",
       "OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE=1",
@@ -53,6 +54,10 @@ config("openthread_rw61x_config") {
       "OPENTHREAD_CONFIG_GENERIC_TASKLET_ENABLE=1",
     ]
   }
+  # ot cli configs
+  defines += [
+    "OPENTHREAD_CONFIG_PING_SENDER_ENABLE=1"
+  ]
 }
 
 #Config used by the openthread stack to get the path to OpenthreadConfig.h


### PR DESCRIPTION
* Expose API to get or set reset in idle and add call to otPlatSetResetFunction to set reset function in OT to application function
*  Defining OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE as 0 by default. OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE was defined as 1 in the past as a temporary workaround due to some ot files dependences, no longer needed, so redefining OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE as 0 to avoid having unuseful commands within the otcli/matter-cli
* Enabling otcli ping command in the matter-cli
* Change the BLE name for TC-DD-2.1

