### PR TITLE
[NXP] rw61x gn updates: add common example GN args file, fix building error

### DIFF
--- a/examples/all-clusters-app/nxp/rt/rw61x/.gn
+++ b/examples/all-clusters-app/nxp/rt/rw61x/.gn
@@ -27,6 +27,8 @@ default_args = {
   target_os = "freertos"
 
   import("//args.gni")
+  # Import common example GN args
+  import("${chip_root}/examples/platform/nxp/common/gn/args.gni")
 
   # Import default platform configs
   import("${chip_root}/src/platform/nxp/rt/rw61x/args.gni")

--- a/examples/platform/nxp/common/gn/args.gni
+++ b/examples/platform/nxp/common/gn/args.gni
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("//build_overrides/openthread.gni")
+
+# Referencing openthread version from ot-nxp
+if (!(openthread_root == "")){
+  openthread_root = "${chip_root}/third_party/openthread/ot-nxp/openthread"
+}

--- a/examples/thermostat/nxp/rt/rw61x/.gn
+++ b/examples/thermostat/nxp/rt/rw61x/.gn
@@ -27,6 +27,8 @@ default_args = {
   target_os = "freertos"
 
   import("//args.gni")
+  # Import common example GN args
+  import("${chip_root}/examples/platform/nxp/common/gn/args.gni")
 
   # Import default platform configs
   import("${chip_root}/src/platform/nxp/rt/rw61x/args.gni")

--- a/third_party/nxp/rt_sdk/rw61x/rw61x.gni
+++ b/third_party/nxp/rt_sdk/rw61x/rw61x.gni
@@ -205,7 +205,7 @@ template("rw61x_sdk_drivers") {
     libs = []
 
     if (defined(invoker.defines)) {
-      defines += invoker.defines
+      defines = invoker.defines
     } else {
       defines = []
     }


### PR DESCRIPTION
* Adding new GN file to reference openthread version from ot-nxp
* Thermostat app: Importing common example GN args file
* All cluster app: Importing common example GN args file
* Fix the building error if "defines" exists in the invoker

