### PR TITLE
Add new AddStatus overloads using ClusterStatusCode

### DIFF
--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -120,12 +120,13 @@ public:
      * of buffer space) to the caller. `context` is an optional (if not nullptr)
      * debug string to include in logging.
      */
-    virtual CHIP_ERROR FallibleAddStatus(const ConcreteCommandPath & aRequestCommandPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus,
-                                 const char * context = nullptr) = 0;
+    virtual CHIP_ERROR FallibleAddStatus(const ConcreteCommandPath & aRequestCommandPath,
+                                         const Protocols::InteractionModel::ClusterStatusCode & aStatus,
+                                         const char * context = nullptr) = 0;
     CHIP_ERROR FallibleAddStatus(const ConcreteCommandPath & aRequestCommandPath, const Protocols::InteractionModel::Status aStatus,
                                  const char * context = nullptr)
     {
-        return FallibleAddStatus(aRequestCommandPath, Protocols::InteractionModel::ClusterStatusCode{aStatus}, context);
+        return FallibleAddStatus(aRequestCommandPath, Protocols::InteractionModel::ClusterStatusCode{ aStatus }, context);
     }
 
     /**
@@ -133,22 +134,24 @@ public:
      * and failure to register the status is checked with VerifyOrDie. `context` is an optional (if not nullptr)
      * debug string to include in logging.
      */
-    virtual void AddStatus(const ConcreteCommandPath & aRequestCommandPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus,
-                   const char * context = nullptr) = 0;
+    virtual void AddStatus(const ConcreteCommandPath & aRequestCommandPath,
+                           const Protocols::InteractionModel::ClusterStatusCode & aStatus, const char * context = nullptr) = 0;
     void AddStatus(const ConcreteCommandPath & aRequestCommandPath, const Protocols::InteractionModel::Status aStatus,
                    const char * context = nullptr)
     {
-        AddStatus(aRequestCommandPath, Protocols::InteractionModel::ClusterStatusCode{aStatus}, context);
+        AddStatus(aRequestCommandPath, Protocols::InteractionModel::ClusterStatusCode{ aStatus }, context);
     }
 
     /**
      * Sets the response to indicate Success with a cluster-specific status code `aClusterStatus` included.
      *
-     * NOTE: For regular success, what you want is AddStatus/FailibleAddStatus(aRequestCommandPath, InteractionModel::Status::Success).
+     * NOTE: For regular success, what you want is AddStatus/FailibleAddStatus(aRequestCommandPath,
+     * InteractionModel::Status::Success).
      */
     virtual CHIP_ERROR AddClusterSpecificSuccess(const ConcreteCommandPath & aRequestCommandPath, ClusterStatus aClusterStatus)
     {
-        return FallibleAddStatus(aRequestCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(aClusterStatus));
+        return FallibleAddStatus(aRequestCommandPath,
+                                 Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(aClusterStatus));
     }
 
     /**
@@ -156,7 +159,8 @@ public:
      */
     virtual CHIP_ERROR AddClusterSpecificFailure(const ConcreteCommandPath & aRequestCommandPath, ClusterStatus aClusterStatus)
     {
-        return FallibleAddStatus(aRequestCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(aClusterStatus));
+        return FallibleAddStatus(aRequestCommandPath,
+                                 Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(aClusterStatus));
     }
 
     /**

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -25,6 +25,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/IntrusiveList.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {
 namespace app {
@@ -116,21 +117,47 @@ public:
 
     /**
      * Adds the given command status and returns any failures in adding statuses (e.g. out
-     * of buffer space) to the caller
+     * of buffer space) to the caller. `context` is an optional (if not nullptr)
+     * debug string to include in logging.
      */
-    virtual CHIP_ERROR FallibleAddStatus(const ConcreteCommandPath & aRequestCommandPath,
-                                         const Protocols::InteractionModel::Status aStatus, const char * context = nullptr) = 0;
+    virtual CHIP_ERROR FallibleAddStatus(const ConcreteCommandPath & aRequestCommandPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus,
+                                 const char * context = nullptr) = 0;
+    CHIP_ERROR FallibleAddStatus(const ConcreteCommandPath & aRequestCommandPath, const Protocols::InteractionModel::Status aStatus,
+                                 const char * context = nullptr)
+    {
+        return FallibleAddStatus(aRequestCommandPath, Protocols::InteractionModel::ClusterStatusCode{aStatus}, context);
+    }
 
     /**
-     * Adds a status when the caller is unable to handle any failures. Logging is performed
-     * and failure to register the status is checked with VerifyOrDie.
+     * Adds an IM global or Cluster status when the caller is unable to handle any failures. Logging is performed
+     * and failure to register the status is checked with VerifyOrDie. `context` is an optional (if not nullptr)
+     * debug string to include in logging.
      */
-    virtual void AddStatus(const ConcreteCommandPath & aCommandPath, const Protocols::InteractionModel::Status aStatus,
-                           const char * context = nullptr) = 0;
+    virtual void AddStatus(const ConcreteCommandPath & aRequestCommandPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus,
+                   const char * context = nullptr) = 0;
+    void AddStatus(const ConcreteCommandPath & aRequestCommandPath, const Protocols::InteractionModel::Status aStatus,
+                   const char * context = nullptr)
+    {
+        AddStatus(aRequestCommandPath, Protocols::InteractionModel::ClusterStatusCode{aStatus}, context);
+    }
 
-    virtual CHIP_ERROR AddClusterSpecificSuccess(const ConcreteCommandPath & aRequestCommandPath, ClusterStatus aClusterStatus) = 0;
+    /**
+     * Sets the response to indicate Success with a cluster-specific status code `aClusterStatus` included.
+     *
+     * NOTE: For regular success, what you want is AddStatus/FailibleAddStatus(aRequestCommandPath, InteractionModel::Status::Success).
+     */
+    virtual CHIP_ERROR AddClusterSpecificSuccess(const ConcreteCommandPath & aRequestCommandPath, ClusterStatus aClusterStatus)
+    {
+        return FallibleAddStatus(aRequestCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(aClusterStatus));
+    }
 
-    virtual CHIP_ERROR AddClusterSpecificFailure(const ConcreteCommandPath & aRequestCommandPath, ClusterStatus aClusterStatus) = 0;
+    /**
+     * Sets the response to indicate Failure with a cluster-specific status code `aClusterStatus` included.
+     */
+    virtual CHIP_ERROR AddClusterSpecificFailure(const ConcreteCommandPath & aRequestCommandPath, ClusterStatus aClusterStatus)
+    {
+        return FallibleAddStatus(aRequestCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(aClusterStatus));
+    }
 
     /**
      * GetAccessingFabricIndex() may only be called during synchronous command

--- a/src/app/CommandHandlerImpl.cpp
+++ b/src/app/CommandHandlerImpl.cpp
@@ -30,8 +30,8 @@
 #include <lib/support/TypeTraits.h>
 #include <messaging/ExchangeContext.h>
 #include <platform/LockTracker.h>
-#include <protocols/secure_channel/Constants.h>
 #include <protocols/interaction_model/StatusCode.h>
+#include <protocols/secure_channel/Constants.h>
 
 namespace chip {
 namespace app {
@@ -593,8 +593,8 @@ CHIP_ERROR CommandHandlerImpl::AddStatusInternal(const ConcreteCommandPath & aCo
     return TryAddingResponse([&]() -> CHIP_ERROR { return TryAddStatusInternal(aCommandPath, aStatus); });
 }
 
-void CommandHandlerImpl::AddStatus(const ConcreteCommandPath & aCommandPath, const Protocols::InteractionModel::ClusterStatusCode& status,
-                                   const char * context)
+void CommandHandlerImpl::AddStatus(const ConcreteCommandPath & aCommandPath,
+                                   const Protocols::InteractionModel::ClusterStatusCode & status, const char * context)
 {
 
     CHIP_ERROR error = FallibleAddStatus(aCommandPath, status, context);
@@ -611,7 +611,8 @@ void CommandHandlerImpl::AddStatus(const ConcreteCommandPath & aCommandPath, con
     }
 }
 
-CHIP_ERROR CommandHandlerImpl::FallibleAddStatus(const ConcreteCommandPath & path, const Protocols::InteractionModel::ClusterStatusCode& status,
+CHIP_ERROR CommandHandlerImpl::FallibleAddStatus(const ConcreteCommandPath & path,
+                                                 const Protocols::InteractionModel::ClusterStatusCode & status,
                                                  const char * context)
 {
     if (!status.IsSuccess())
@@ -629,10 +630,11 @@ CHIP_ERROR CommandHandlerImpl::FallibleAddStatus(const ConcreteCommandPath & pat
 
     if (status.HasClusterSpecificCode())
     {
-      return AddStatusInternal(path, StatusIB{(status.IsSuccess() ? Status::Success : Status::Failure), status.GetClusterSpecificCode().Value()});
+        return AddStatusInternal(
+            path, StatusIB{ (status.IsSuccess() ? Status::Success : Status::Failure), status.GetClusterSpecificCode().Value() });
     }
 
-    return AddStatusInternal(path, StatusIB{status.GetStatus()});
+    return AddStatusInternal(path, StatusIB{ status.GetStatus() });
 }
 
 CHIP_ERROR CommandHandlerImpl::PrepareInvokeResponseCommand(const ConcreteCommandPath & aResponseCommandPath,

--- a/src/app/CommandHandlerImpl.cpp
+++ b/src/app/CommandHandlerImpl.cpp
@@ -19,10 +19,10 @@
 
 #include <access/AccessControl.h>
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/MessageDef/StatusIB.h>
 #include <app/RequiredPrivilege.h>
 #include <app/StatusResponse.h>
 #include <app/util/MatterCallbacks.h>
-#include <app/MessageDef/StatusIB.h>
 #include <credentials/GroupDataProvider.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/TLVData.h>
@@ -626,16 +626,19 @@ CHIP_ERROR CommandHandlerImpl::FallibleAddStatus(const ConcreteCommandPath & pat
         if (status.HasClusterSpecificCode())
         {
             ChipLogError(DataManagement,
-                        "Endpoint=%u Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " status " ChipLogFormatIMStatus " ClusterSpecificCode=%u (%s)",
-                        path.mEndpointId, ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mCommandId),
-                        ChipLogValueIMStatus(status.GetStatus()), static_cast<unsigned>(status.GetClusterSpecificCode().Value()), context);
+                         "Endpoint=%u Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " status " ChipLogFormatIMStatus
+                         " ClusterSpecificCode=%u (%s)",
+                         path.mEndpointId, ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mCommandId),
+                         ChipLogValueIMStatus(status.GetStatus()), static_cast<unsigned>(status.GetClusterSpecificCode().Value()),
+                         context);
         }
         else
         {
             ChipLogError(DataManagement,
-                        "Endpoint=%u Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " status " ChipLogFormatIMStatus " (%s)",
-                        path.mEndpointId, ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mCommandId),
-                        ChipLogValueIMStatus(status.GetStatus()), context);
+                         "Endpoint=%u Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI " status " ChipLogFormatIMStatus
+                         " (%s)",
+                         path.mEndpointId, ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mCommandId),
+                         ChipLogValueIMStatus(status.GetStatus()), context);
         }
     }
 

--- a/src/app/CommandHandlerImpl.h
+++ b/src/app/CommandHandlerImpl.h
@@ -120,9 +120,10 @@ public:
 
     void FlushAcksRightAwayOnSlowCommand() override;
 
-    CHIP_ERROR FallibleAddStatus(const ConcreteCommandPath & aRequestCommandPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus,
+    CHIP_ERROR FallibleAddStatus(const ConcreteCommandPath & aRequestCommandPath,
+                                 const Protocols::InteractionModel::ClusterStatusCode & aStatus,
                                  const char * context = nullptr) override;
-    void AddStatus(const ConcreteCommandPath & aCommandPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus,
+    void AddStatus(const ConcreteCommandPath & aCommandPath, const Protocols::InteractionModel::ClusterStatusCode & aStatus,
                    const char * context = nullptr) override;
 
     CHIP_ERROR AddResponseData(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,

--- a/src/app/CommandHandlerImpl.h
+++ b/src/app/CommandHandlerImpl.h
@@ -29,6 +29,7 @@
 #include <messaging/Flags.h>
 #include <protocols/Protocols.h>
 #include <protocols/interaction_model/Constants.h>
+#include <protocols/interaction_model/StatusCode.h>
 #include <system/SystemPacketBuffer.h>
 #include <system/TLVPacketBufferBackingStore.h>
 
@@ -114,15 +115,15 @@ public:
     /**************** CommandHandler interface implementation ***********************/
 
     using CommandHandler::AddResponseData;
+    using CommandHandler::AddStatus;
+    using CommandHandler::FallibleAddStatus;
 
     void FlushAcksRightAwayOnSlowCommand() override;
 
-    CHIP_ERROR FallibleAddStatus(const ConcreteCommandPath & aRequestCommandPath, const Protocols::InteractionModel::Status aStatus,
+    CHIP_ERROR FallibleAddStatus(const ConcreteCommandPath & aRequestCommandPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus,
                                  const char * context = nullptr) override;
-    void AddStatus(const ConcreteCommandPath & aCommandPath, const Protocols::InteractionModel::Status aStatus,
+    void AddStatus(const ConcreteCommandPath & aCommandPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus,
                    const char * context = nullptr) override;
-    CHIP_ERROR AddClusterSpecificSuccess(const ConcreteCommandPath & aRequestCommandPath, ClusterStatus aClusterStatus) override;
-    CHIP_ERROR AddClusterSpecificFailure(const ConcreteCommandPath & aRequestCommandPath, ClusterStatus aClusterStatus) override;
 
     CHIP_ERROR AddResponseData(const ConcreteCommandPath & aRequestCommandPath, CommandId aResponseCommandId,
                                const DataModel::EncodableToTLV & aEncodable) override;

--- a/src/app/CommandResponseHelper.h
+++ b/src/app/CommandResponseHelper.h
@@ -21,6 +21,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <protocols/interaction_model/Constants.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {
 namespace app {
@@ -40,9 +41,21 @@ public:
         return CHIP_NO_ERROR;
     };
 
+    // WARNING: Do not use for basic response-payload-free success, as SUCCESS status
+    // code should be handled without a cluster-specific status.
     CHIP_ERROR Success(ClusterStatus aClusterStatus)
     {
-        CHIP_ERROR err = mCommandHandler->AddClusterSpecificSuccess(mCommandPath, aClusterStatus);
+        CHIP_ERROR err = mCommandHandler->FallibleAddStatus(mCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(aClusterStatus));
+        if (err == CHIP_NO_ERROR)
+        {
+            mSentResponse = true;
+        }
+        return err;
+    }
+
+    CHIP_ERROR Success()
+    {
+        CHIP_ERROR err = mCommandHandler->FallibleAddStatus(mCommandPath, Protocols::InteractionModel::Status::Success);
         if (err == CHIP_NO_ERROR)
         {
             mSentResponse = true;
@@ -62,7 +75,7 @@ public:
 
     CHIP_ERROR Failure(ClusterStatus aClusterStatus)
     {
-        CHIP_ERROR err = mCommandHandler->AddClusterSpecificFailure(mCommandPath, aClusterStatus);
+        CHIP_ERROR err = mCommandHandler->FallibleAddStatus(mCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(aClusterStatus));
         if (err == CHIP_NO_ERROR)
         {
             mSentResponse = true;

--- a/src/app/CommandResponseHelper.h
+++ b/src/app/CommandResponseHelper.h
@@ -44,14 +44,14 @@ public:
     CHIP_ERROR Success()
     {
         CHIP_ERROR err = mCommandHandler->FallibleAddStatus(mCommandPath, Protocols::InteractionModel::Status::Success);
-        mSentResponse = (err == CHIP_NO_ERROR);
+        mSentResponse  = (err == CHIP_NO_ERROR);
         return err;
     }
 
     CHIP_ERROR Failure(Protocols::InteractionModel::Status aStatus)
     {
         CHIP_ERROR err = mCommandHandler->FallibleAddStatus(mCommandPath, aStatus);
-        mSentResponse = (err == CHIP_NO_ERROR);
+        mSentResponse  = (err == CHIP_NO_ERROR);
         return err;
     }
 

--- a/src/app/CommandResponseHelper.h
+++ b/src/app/CommandResponseHelper.h
@@ -45,7 +45,8 @@ public:
     // code should be handled without a cluster-specific status.
     CHIP_ERROR Success(ClusterStatus aClusterStatus)
     {
-        CHIP_ERROR err = mCommandHandler->FallibleAddStatus(mCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(aClusterStatus));
+        CHIP_ERROR err = mCommandHandler->FallibleAddStatus(
+            mCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(aClusterStatus));
         if (err == CHIP_NO_ERROR)
         {
             mSentResponse = true;
@@ -75,7 +76,8 @@ public:
 
     CHIP_ERROR Failure(ClusterStatus aClusterStatus)
     {
-        CHIP_ERROR err = mCommandHandler->FallibleAddStatus(mCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(aClusterStatus));
+        CHIP_ERROR err = mCommandHandler->FallibleAddStatus(
+            mCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(aClusterStatus));
         if (err == CHIP_NO_ERROR)
         {
             mSentResponse = true;

--- a/src/app/CommandResponseHelper.h
+++ b/src/app/CommandResponseHelper.h
@@ -39,38 +39,19 @@ public:
         mCommandHandler->AddResponse(mCommandPath, aResponse);
         mSentResponse = true;
         return CHIP_NO_ERROR;
-    };
-
-    // WARNING: Do not use for basic response-payload-free success, as SUCCESS status
-    // code should be handled without a cluster-specific status.
-    CHIP_ERROR Success(ClusterStatus aClusterStatus)
-    {
-        CHIP_ERROR err = mCommandHandler->FallibleAddStatus(
-            mCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(aClusterStatus));
-        if (err == CHIP_NO_ERROR)
-        {
-            mSentResponse = true;
-        }
-        return err;
     }
 
     CHIP_ERROR Success()
     {
         CHIP_ERROR err = mCommandHandler->FallibleAddStatus(mCommandPath, Protocols::InteractionModel::Status::Success);
-        if (err == CHIP_NO_ERROR)
-        {
-            mSentResponse = true;
-        }
+        mSentResponse = (err == CHIP_NO_ERROR);
         return err;
     }
 
     CHIP_ERROR Failure(Protocols::InteractionModel::Status aStatus)
     {
         CHIP_ERROR err = mCommandHandler->FallibleAddStatus(mCommandPath, aStatus);
-        if (err == CHIP_NO_ERROR)
-        {
-            mSentResponse = true;
-        }
+        mSentResponse = (err == CHIP_NO_ERROR);
         return err;
     }
 
@@ -78,10 +59,7 @@ public:
     {
         CHIP_ERROR err = mCommandHandler->FallibleAddStatus(
             mCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(aClusterStatus));
-        if (err == CHIP_NO_ERROR)
-        {
-            mSentResponse = true;
-        }
+        mSentResponse = (err == CHIP_NO_ERROR);
         return err;
     }
 

--- a/src/app/MessageDef/StatusIB.h
+++ b/src/app/MessageDef/StatusIB.h
@@ -48,13 +48,14 @@ struct StatusIB
         mStatus(imStatus), mClusterStatus(clusterStatus)
     {}
 
-    explicit StatusIB(const Protocols::InteractionModel::ClusterStatusCode& statusCode) : mStatus(statusCode.GetStatus())
+    explicit StatusIB(const Protocols::InteractionModel::ClusterStatusCode & statusCode) : mStatus(statusCode.GetStatus())
     {
         // NOTE: Cluster-specific codes are only valid on SUCCESS/FAILURE IM status (7.10.7. Status Codes)
         chip::Optional<ClusterStatus> clusterStatus = statusCode.GetClusterSpecificCode();
         if (clusterStatus.HasValue())
         {
-            mStatus = statusCode.IsSuccess() ? Protocols::InteractionModel::Status::Success : Protocols::InteractionModel::Status::Failure;
+            mStatus        = statusCode.IsSuccess() ? Protocols::InteractionModel::Status::Success
+                                                    : Protocols::InteractionModel::Status::Failure;
             mClusterStatus = clusterStatus;
         }
     }

--- a/src/app/MessageDef/StatusIB.h
+++ b/src/app/MessageDef/StatusIB.h
@@ -34,6 +34,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <protocols/interaction_model/Constants.h>
+#include <protocols/interaction_model/StatusCode.h>
 #include <protocols/secure_channel/Constants.h>
 
 namespace chip {
@@ -41,10 +42,23 @@ namespace app {
 struct StatusIB
 {
     StatusIB() = default;
-    StatusIB(Protocols::InteractionModel::Status imStatus) : mStatus(imStatus) {}
-    StatusIB(Protocols::InteractionModel::Status imStatus, ClusterStatus clusterStatus) :
+    explicit StatusIB(Protocols::InteractionModel::Status imStatus) : mStatus(imStatus) {}
+
+    explicit StatusIB(Protocols::InteractionModel::Status imStatus, ClusterStatus clusterStatus) :
         mStatus(imStatus), mClusterStatus(clusterStatus)
     {}
+
+    explicit StatusIB(const Protocols::InteractionModel::ClusterStatusCode& statusCode) : mStatus(statusCode.GetStatus())
+    {
+        // NOTE: Cluster-specific codes are only valid on SUCCESS/FAILURE IM status (7.10.7. Status Codes)
+        chip::Optional<ClusterStatus> clusterStatus = statusCode.GetClusterSpecificCode();
+        if (clusterStatus.HasValue())
+        {
+            mStatus = statusCode.IsSuccess() ? Protocols::InteractionModel::Status::Success : Protocols::InteractionModel::Status::Failure;
+            mClusterStatus = clusterStatus;
+        }
+    }
+
     explicit StatusIB(CHIP_ERROR error) { InitFromChipError(error); }
 
     enum class Tag : uint8_t

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -228,12 +228,6 @@ public:
      */
     CHIP_ERROR SendWriteRequest(const SessionHandle & session, System::Clock::Timeout timeout = System::Clock::kZero);
 
-    /**
-     *  Shutdown the WriteClient. This terminates this instance
-     *  of the object and releases all held resources.
-     */
-    void Shutdown();
-
 private:
     friend class TestWriteInteraction;
     friend class InteractionModelEngine;

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -616,13 +616,16 @@ exit:
     return status;
 }
 
-CHIP_ERROR WriteHandler::AddStatus(const ConcreteDataAttributePath & aPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus)
+CHIP_ERROR WriteHandler::AddStatus(const ConcreteDataAttributePath & aPath,
+                                   const Protocols::InteractionModel::ClusterStatusCode & aStatus)
 {
-    if (aStatus.HasClusterSpecificCode()) {
-      return AddStatusInternal(aPath, StatusIB{(aStatus.IsSuccess() ? Status::Success : Status::Failure), aStatus.GetClusterSpecificCode().Value()});
+    if (aStatus.HasClusterSpecificCode())
+    {
+        return AddStatusInternal(
+            aPath, StatusIB{ (aStatus.IsSuccess() ? Status::Success : Status::Failure), aStatus.GetClusterSpecificCode().Value() });
     }
 
-    return AddStatusInternal(aPath, StatusIB{aStatus.GetStatus()});
+    return AddStatusInternal(aPath, StatusIB{ aStatus.GetStatus() });
 }
 
 CHIP_ERROR WriteHandler::AddClusterSpecificSuccess(const ConcreteDataAttributePath & aPath, ClusterStatus aClusterStatus)

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -315,7 +315,7 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataIBs(TLV::TLVReader & aAttributeData
             // it with Busy status code.
             (dataAttributePath.IsListItemOperation() && !IsSameAttribute(mProcessingAttributePath, dataAttributePath)))
         {
-            err = AddStatus(dataAttributePath, StatusIB(Status::Busy));
+            err = AddStatusInternal(dataAttributePath, StatusIB(Status::Busy));
             continue;
         }
 
@@ -353,7 +353,7 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataIBs(TLV::TLVReader & aAttributeData
         if (err != CHIP_NO_ERROR)
         {
             mWriteResponseBuilder.GetWriteResponses().Rollback(backup);
-            err = AddStatus(dataAttributePath, StatusIB(err));
+            err = AddStatusInternal(dataAttributePath, StatusIB(err));
         }
 
         DataModelCallbacks::GetInstance()->AttributeOperation(DataModelCallbacks::OperationType::Write,
@@ -616,22 +616,26 @@ exit:
     return status;
 }
 
-CHIP_ERROR WriteHandler::AddStatus(const ConcreteDataAttributePath & aPath, const Protocols::InteractionModel::Status aStatus)
+CHIP_ERROR WriteHandler::AddStatus(const ConcreteDataAttributePath & aPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus)
 {
-    return AddStatus(aPath, StatusIB(aStatus));
+    if (aStatus.HasClusterSpecificCode()) {
+      return AddStatusInternal(aPath, StatusIB{(aStatus.IsSuccess() ? Status::Success : Status::Failure), aStatus.GetClusterSpecificCode().Value()});
+    }
+
+    return AddStatusInternal(aPath, StatusIB{aStatus.GetStatus()});
 }
 
 CHIP_ERROR WriteHandler::AddClusterSpecificSuccess(const ConcreteDataAttributePath & aPath, ClusterStatus aClusterStatus)
 {
-    return AddStatus(aPath, StatusIB(Status::Success, aClusterStatus));
+    return AddStatus(aPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(aClusterStatus));
 }
 
 CHIP_ERROR WriteHandler::AddClusterSpecificFailure(const ConcreteDataAttributePath & aPath, ClusterStatus aClusterStatus)
 {
-    return AddStatus(aPath, StatusIB(Status::Failure, aClusterStatus));
+    return AddStatus(aPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(aClusterStatus));
 }
 
-CHIP_ERROR WriteHandler::AddStatus(const ConcreteDataAttributePath & aPath, const StatusIB & aStatus)
+CHIP_ERROR WriteHandler::AddStatusInternal(const ConcreteDataAttributePath & aPath, const StatusIB & aStatus)
 {
     AttributeStatusIBs::Builder & writeResponses   = mWriteResponseBuilder.GetWriteResponses();
     AttributeStatusIB::Builder & attributeStatusIB = writeResponses.CreateAttributeStatus();

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -21,6 +21,7 @@
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/EventPathIB.h>
+#include <app/MessageDef/StatusIB.h>
 #include <app/StatusResponse.h>
 #include <app/WriteHandler.h>
 #include <app/reporting/Engine.h>
@@ -28,6 +29,7 @@
 #include <app/util/ember-compatibility-functions.h>
 #include <credentials/GroupDataProvider.h>
 #include <lib/support/TypeTraits.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {
 namespace app {
@@ -619,13 +621,7 @@ exit:
 CHIP_ERROR WriteHandler::AddStatus(const ConcreteDataAttributePath & aPath,
                                    const Protocols::InteractionModel::ClusterStatusCode & aStatus)
 {
-    if (aStatus.HasClusterSpecificCode())
-    {
-        return AddStatusInternal(
-            aPath, StatusIB{ (aStatus.IsSuccess() ? Status::Success : Status::Failure), aStatus.GetClusterSpecificCode().Value() });
-    }
-
-    return AddStatusInternal(aPath, StatusIB{ aStatus.GetStatus() });
+    return AddStatusInternal(aPath, StatusIB{ aStatus });
 }
 
 CHIP_ERROR WriteHandler::AddClusterSpecificSuccess(const ConcreteDataAttributePath & aPath, ClusterStatus aClusterStatus)

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -31,6 +31,7 @@
 #include <messaging/Flags.h>
 #include <protocols/Protocols.h>
 #include <protocols/interaction_model/Constants.h>
+#include <protocols/interaction_model/StatusCode.h>
 #include <system/SystemPacketBuffer.h>
 #include <system/TLVPacketBufferBackingStore.h>
 

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -100,10 +100,10 @@ public:
     CHIP_ERROR ProcessAttributeDataIBs(TLV::TLVReader & aAttributeDataIBsReader);
     CHIP_ERROR ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttributeDataIBsReader);
 
-    CHIP_ERROR AddStatus(const ConcreteDataAttributePath & aPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus);
+    CHIP_ERROR AddStatus(const ConcreteDataAttributePath & aPath, const Protocols::InteractionModel::ClusterStatusCode & aStatus);
     CHIP_ERROR AddStatus(const ConcreteDataAttributePath & aPath, const Protocols::InteractionModel::Status aStatus)
     {
-        return AddStatus(aPath, Protocols::InteractionModel::ClusterStatusCode{aStatus});
+        return AddStatus(aPath, Protocols::InteractionModel::ClusterStatusCode{ aStatus });
     }
 
     CHIP_ERROR AddClusterSpecificSuccess(const ConcreteDataAttributePath & aAttributePathParams, ClusterStatus aClusterStatus);

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -100,11 +100,14 @@ public:
     CHIP_ERROR ProcessAttributeDataIBs(TLV::TLVReader & aAttributeDataIBsReader);
     CHIP_ERROR ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttributeDataIBsReader);
 
-    CHIP_ERROR AddStatus(const ConcreteDataAttributePath & aPath, const Protocols::InteractionModel::Status aStatus);
+    CHIP_ERROR AddStatus(const ConcreteDataAttributePath & aPath, const Protocols::InteractionModel::ClusterStatusCode& aStatus);
+    CHIP_ERROR AddStatus(const ConcreteDataAttributePath & aPath, const Protocols::InteractionModel::Status aStatus)
+    {
+        return AddStatus(aPath, Protocols::InteractionModel::ClusterStatusCode{aStatus});
+    }
 
-    CHIP_ERROR AddClusterSpecificSuccess(const ConcreteDataAttributePath & aAttributePathParams, uint8_t aClusterStatus);
-
-    CHIP_ERROR AddClusterSpecificFailure(const ConcreteDataAttributePath & aAttributePathParams, uint8_t aClusterStatus);
+    CHIP_ERROR AddClusterSpecificSuccess(const ConcreteDataAttributePath & aAttributePathParams, ClusterStatus aClusterStatus);
+    CHIP_ERROR AddClusterSpecificFailure(const ConcreteDataAttributePath & aAttributePathParams, ClusterStatus aClusterStatus);
 
     FabricIndex GetAccessingFabricIndex() const;
 
@@ -166,7 +169,7 @@ private:
     // ProcessGroupAttributeDataIBs.
     CHIP_ERROR DeliverFinalListWriteEndForGroupWrite(bool writeWasSuccessful);
 
-    CHIP_ERROR AddStatus(const ConcreteDataAttributePath & aPath, const StatusIB & aStatus);
+    CHIP_ERROR AddStatusInternal(const ConcreteDataAttributePath & aPath, const StatusIB & aStatus);
 
 private:
     // ExchangeDelegate

--- a/src/app/data-model-interface/InvokeResponder.h
+++ b/src/app/data-model-interface/InvokeResponder.h
@@ -138,7 +138,7 @@ public:
     {
         if (mCompleteState != CompleteState::kComplete)
         {
-            mWriter->Complete(Protocols::InteractionModel::Status::Failure);
+            mWriter->Complete(StatusIB{Protocols::InteractionModel::Status::Failure});
         }
     }
 

--- a/src/app/data-model-interface/InvokeResponder.h
+++ b/src/app/data-model-interface/InvokeResponder.h
@@ -138,7 +138,7 @@ public:
     {
         if (mCompleteState != CompleteState::kComplete)
         {
-            mWriter->Complete(StatusIB{Protocols::InteractionModel::Status::Failure});
+            mWriter->Complete(StatusIB{ Protocols::InteractionModel::Status::Failure });
         }
     }
 

--- a/src/app/tests/TestStatusIB.cpp
+++ b/src/app/tests/TestStatusIB.cpp
@@ -161,4 +161,24 @@ TEST_F(TestStatusIB, TestStatusIBEqualityOperator)
     EXPECT_NE(invalid_argument, StatusIB(CHIP_NO_ERROR));
 }
 
+TEST_F(TestStatusIB, ConversionsFromClusterStatusCodeWork)
+{
+    StatusIB successWithCode {ClusterStatusCode::ClusterSpecificSuccess(123u)};
+    EXPECT_EQ(successWithCode.mStatus, Status::Success);
+    EXPECT_TRUE(successWithCode.IsSuccess());
+    ASSERT_TRUE(successWithCode.mClusterStatus.HasValue());
+    EXPECT_EQ(successWithCode.mClusterStatus.Value(), 123u);
+
+    StatusIB failureWithCode {ClusterStatusCode::ClusterSpecificFailure(42u)};
+    EXPECT_EQ(failureWithCode.mStatus, Status::Failure);
+    EXPECT_FALSE(failureWithCode.IsSuccess());
+    ASSERT_TRUE(failureWithCode.mClusterStatus.HasValue());
+    EXPECT_EQ(failureWithCode.mClusterStatus.Value(), 42u);
+
+    StatusIB imStatusInClusterStatusCode{ClusterStatusCode{Status::ConstraintError}};
+    EXPECT_EQ(imStatusInClusterStatusCode.mStatus, Status::ConstraintError);
+    EXPECT_FALSE(imStatusInClusterStatusCode.IsSuccess());
+    EXPECT_FALSE(imStatusInClusterStatusCode.mClusterStatus.HasValue());
+}
+
 } // namespace

--- a/src/app/tests/TestStatusIB.cpp
+++ b/src/app/tests/TestStatusIB.cpp
@@ -163,19 +163,19 @@ TEST_F(TestStatusIB, TestStatusIBEqualityOperator)
 
 TEST_F(TestStatusIB, ConversionsFromClusterStatusCodeWork)
 {
-    StatusIB successWithCode {ClusterStatusCode::ClusterSpecificSuccess(123u)};
+    StatusIB successWithCode{ ClusterStatusCode::ClusterSpecificSuccess(123u) };
     EXPECT_EQ(successWithCode.mStatus, Status::Success);
     EXPECT_TRUE(successWithCode.IsSuccess());
     ASSERT_TRUE(successWithCode.mClusterStatus.HasValue());
     EXPECT_EQ(successWithCode.mClusterStatus.Value(), 123u);
 
-    StatusIB failureWithCode {ClusterStatusCode::ClusterSpecificFailure(42u)};
+    StatusIB failureWithCode{ ClusterStatusCode::ClusterSpecificFailure(42u) };
     EXPECT_EQ(failureWithCode.mStatus, Status::Failure);
     EXPECT_FALSE(failureWithCode.IsSuccess());
     ASSERT_TRUE(failureWithCode.mClusterStatus.HasValue());
     EXPECT_EQ(failureWithCode.mClusterStatus.Value(), 42u);
 
-    StatusIB imStatusInClusterStatusCode{ClusterStatusCode{Status::ConstraintError}};
+    StatusIB imStatusInClusterStatusCode{ ClusterStatusCode{ Status::ConstraintError } };
     EXPECT_EQ(imStatusInClusterStatusCode.mStatus, Status::ConstraintError);
     EXPECT_FALSE(imStatusInClusterStatusCode.IsSuccess());
     EXPECT_FALSE(imStatusInClusterStatusCode.mClusterStatus.HasValue());

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -492,9 +492,7 @@ TEST_F(TestCommands, TestSuccessNoDataResponseWithClusterStatus)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) {
-        onFailureWasCalled = true;
-    };
+    auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) { onFailureWasCalled = true; };
 
     responseDirective = kSendSuccessStatusCodeWithClusterStatus;
 

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -37,6 +37,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <messaging/tests/MessagingContext.h>
 #include <protocols/interaction_model/Constants.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 using TestContext = chip::Test::AppContext;
 
@@ -144,11 +145,11 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip
         }
         else if (responseDirective == kSendSuccessStatusCodeWithClusterStatus)
         {
-            apCommandObj->AddClusterSpecificSuccess(aCommandPath, kTestSuccessClusterStatus);
+            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(kTestSuccessClusterStatus));
         }
         else if (responseDirective == kSendErrorWithClusterStatus)
         {
-            apCommandObj->AddClusterSpecificFailure(aCommandPath, kTestFailureClusterStatus);
+            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(kTestFailureClusterStatus));
         }
         else if (responseDirective == kAsync)
         {
@@ -489,7 +490,9 @@ TEST_F(TestCommands, TestSuccessNoDataResponseWithClusterStatus)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) { onFailureWasCalled = true; };
+    auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) {
+      printf("   ----> %" CHIP_ERROR_FORMAT "\n", aError.Format());
+      onFailureWasCalled = true; };
 
     responseDirective = kSendSuccessStatusCodeWithClusterStatus;
 

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -145,11 +145,13 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip
         }
         else if (responseDirective == kSendSuccessStatusCodeWithClusterStatus)
         {
-            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(kTestSuccessClusterStatus));
+            apCommandObj->AddStatus(
+                aCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(kTestSuccessClusterStatus));
         }
         else if (responseDirective == kSendErrorWithClusterStatus)
         {
-            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(kTestFailureClusterStatus));
+            apCommandObj->AddStatus(
+                aCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(kTestFailureClusterStatus));
         }
         else if (responseDirective == kAsync)
         {
@@ -491,8 +493,9 @@ TEST_F(TestCommands, TestSuccessNoDataResponseWithClusterStatus)
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
     auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) {
-      printf("   ----> %" CHIP_ERROR_FORMAT "\n", aError.Format());
-      onFailureWasCalled = true; };
+        printf("   ----> %" CHIP_ERROR_FORMAT "\n", aError.Format());
+        onFailureWasCalled = true;
+    };
 
     responseDirective = kSendSuccessStatusCodeWithClusterStatus;
 

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -493,7 +493,6 @@ TEST_F(TestCommands, TestSuccessNoDataResponseWithClusterStatus)
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
     auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) {
-        printf("   ----> %" CHIP_ERROR_FORMAT "\n", aError.Format());
         onFailureWasCalled = true;
     };
 

--- a/src/controller/tests/data_model/TestWrite.cpp
+++ b/src/controller/tests/data_model/TestWrite.cpp
@@ -562,7 +562,8 @@ TEST_F(TestWrite, TestWriteClusterSpecificStatuses)
         WriteClient writeClient(&mpContext->GetExchangeManager(), this->GetWriteCallback(), Optional<uint16_t>::Missing());
         AttributePathParams attributePath{ kTestEndpointId, Clusters::UnitTesting::Id,
                                            Clusters::UnitTesting::Attributes::Int8u::Id };
-        ASSERT_EQ(writeClient.EncodeAttribute(attributePath, 1u), CHIP_NO_ERROR);
+        constexpr uint8_t attributeValue = 1u;
+        ASSERT_EQ(writeClient.EncodeAttribute(attributePath, attributeValue), CHIP_NO_ERROR);
         ASSERT_EQ(writeClient.SendWriteRequest(sessionHandle), CHIP_NO_ERROR);
 
         mpContext->DrainAndServiceIO();
@@ -593,7 +594,9 @@ TEST_F(TestWrite, TestWriteClusterSpecificStatuses)
         WriteClient writeClient(&mpContext->GetExchangeManager(), this->GetWriteCallback(), Optional<uint16_t>::Missing());
         AttributePathParams attributePath{ kTestEndpointId, Clusters::UnitTesting::Id,
                                            Clusters::UnitTesting::Attributes::Int8u::Id };
-        ASSERT_EQ(writeClient.EncodeAttribute(attributePath, 2u), CHIP_NO_ERROR);
+
+        constexpr uint8_t attributeValue = 2u;
+        ASSERT_EQ(writeClient.EncodeAttribute(attributePath, attributeValue), CHIP_NO_ERROR);
         ASSERT_EQ(writeClient.SendWriteRequest(sessionHandle), CHIP_NO_ERROR);
 
         mpContext->DrainAndServiceIO();

--- a/src/controller/tests/data_model/TestWrite.cpp
+++ b/src/controller/tests/data_model/TestWrite.cpp
@@ -57,7 +57,7 @@ enum ResponseDirective
     kSendClusterSpecificFailure,
 };
 
-ResponseDirective gResponseDirective;
+ResponseDirective gResponseDirective = kSendAttributeSuccess;
 
 } // namespace
 

--- a/src/protocols/interaction_model/StatusCode.h
+++ b/src/protocols/interaction_model/StatusCode.h
@@ -97,7 +97,7 @@ public:
      *             (e.g. chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen)
      * @return a ClusterStatusCode instance properly configured.
      */
-    template <typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+    template <typename T, typename std::enable_if_t<std::is_enum<T>::value, bool> = true>
     static ClusterStatusCode ClusterSpecificFailure(T cluster_specific_code)
     {
         static_assert(std::numeric_limits<std::underlying_type_t<T>>::max() <= std::numeric_limits<ClusterStatus>::max(),
@@ -119,7 +119,7 @@ public:
      *             (e.g. chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kBasicWindowOpen)
      * @return a ClusterStatusCode instance properly configured.
      */
-    template <typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
+    template <typename T, typename std::enable_if_t<std::is_enum<T>::value, bool> = true>
     static ClusterStatusCode ClusterSpecificSuccess(T cluster_specific_code)
     {
         static_assert(std::numeric_limits<std::underlying_type_t<T>>::max() <= std::numeric_limits<ClusterStatus>::max(),

--- a/src/protocols/interaction_model/StatusCode.h
+++ b/src/protocols/interaction_model/StatusCode.h
@@ -18,6 +18,8 @@
 #pragma once
 
 #include <limits>
+#include <type_traits>
+
 #include <stdint.h>
 
 #include <lib/core/CHIPConfig.h>
@@ -58,10 +60,6 @@ const char * StatusName(Status status);
  * are the components of a StatusIB, used in many IM actions, in a
  * way which allows both of them to carry together.
  *
- * This can be used everywhere a `Status` is used, but it is lossy
- * to the cluster-specific code if used in place of `Status` when
- * the cluster-specific code is set.
- *
  * This class can only be directly constructed from a `Status`. To
  * attach a cluster-specific-code, please use the `ClusterSpecificFailure()`
  * and `ClusterSpecificSuccess()` factory methods.
@@ -75,13 +73,13 @@ public:
     ClusterStatusCode(const ClusterStatusCode & other)             = default;
     ClusterStatusCode & operator=(const ClusterStatusCode & other) = default;
 
-    bool operator==(const ClusterStatusCode & other)
+    bool operator==(const ClusterStatusCode & other) const
     {
         return (this->mStatus == other.mStatus) && (this->HasClusterSpecificCode() == other.HasClusterSpecificCode()) &&
             (this->GetClusterSpecificCode() == other.GetClusterSpecificCode());
     }
 
-    bool operator!=(const ClusterStatusCode & other) { return !(*this == other); }
+    bool operator!=(const ClusterStatusCode & other) const { return !(*this == other); }
 
     ClusterStatusCode & operator=(const Status & status)
     {
@@ -99,12 +97,17 @@ public:
      *             (e.g. chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen)
      * @return a ClusterStatusCode instance properly configured.
      */
-    template <typename T>
+    template <typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
     static ClusterStatusCode ClusterSpecificFailure(T cluster_specific_code)
     {
         static_assert(std::numeric_limits<std::underlying_type_t<T>>::max() <= std::numeric_limits<ClusterStatus>::max(),
                       "Type used must fit in uint8_t");
         return ClusterStatusCode(Status::Failure, chip::to_underlying(cluster_specific_code));
+    }
+
+    static ClusterStatusCode ClusterSpecificFailure(ClusterStatus cluster_specific_code)
+    {
+        return ClusterStatusCode(Status::Failure, cluster_specific_code);
     }
 
     /**
@@ -116,12 +119,17 @@ public:
      *             (e.g. chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kBasicWindowOpen)
      * @return a ClusterStatusCode instance properly configured.
      */
-    template <typename T>
+    template <typename T, std::enable_if_t<std::is_enum<T>::value, bool> = true>
     static ClusterStatusCode ClusterSpecificSuccess(T cluster_specific_code)
     {
         static_assert(std::numeric_limits<std::underlying_type_t<T>>::max() <= std::numeric_limits<ClusterStatus>::max(),
                       "Type used must fit in uint8_t");
         return ClusterStatusCode(Status::Success, chip::to_underlying(cluster_specific_code));
+    }
+
+    static ClusterStatusCode ClusterSpecificSuccess(ClusterStatus cluster_specific_code)
+    {
+        return ClusterStatusCode(Status::Success, cluster_specific_code);
     }
 
     /// @return true if the core Status associated with this ClusterStatusCode is the one for success.
@@ -142,9 +150,6 @@ public:
         }
         return mClusterSpecificCode;
     }
-
-    // Automatic conversions to common types, using the status code alone.
-    operator Status() const { return mStatus; }
 
 private:
     ClusterStatusCode() = delete;

--- a/src/protocols/interaction_model/tests/TestStatusCode.cpp
+++ b/src/protocols/interaction_model/tests/TestStatusCode.cpp
@@ -40,26 +40,22 @@ TEST(TestStatusCode, TestClusterStatusCode)
     // Basic usage as a Status.
     {
         ClusterStatusCode status_code_success{ Status::Success };
-        EXPECT_EQ(status_code_success, Status::Success);
         EXPECT_EQ(status_code_success.GetStatus(), Status::Success);
         EXPECT_FALSE(status_code_success.HasClusterSpecificCode());
         EXPECT_EQ(status_code_success.GetClusterSpecificCode(), chip::NullOptional);
         EXPECT_TRUE(status_code_success.IsSuccess());
 
         ClusterStatusCode status_code_failure{ Status::Failure };
-        EXPECT_EQ(status_code_failure, Status::Failure);
         EXPECT_EQ(status_code_failure.GetStatus(), Status::Failure);
         EXPECT_FALSE(status_code_failure.HasClusterSpecificCode());
         EXPECT_FALSE(status_code_failure.IsSuccess());
 
         ClusterStatusCode status_code_unsupported_ep{ Status::UnsupportedEndpoint };
-        EXPECT_EQ(status_code_unsupported_ep, Status::UnsupportedEndpoint);
         EXPECT_EQ(status_code_unsupported_ep.GetStatus(), Status::UnsupportedEndpoint);
         EXPECT_FALSE(status_code_unsupported_ep.HasClusterSpecificCode());
         EXPECT_FALSE(status_code_unsupported_ep.IsSuccess());
 
         ClusterStatusCode status_code_invalid_in_state{ Status::InvalidInState };
-        EXPECT_EQ(status_code_invalid_in_state, Status::InvalidInState);
         EXPECT_EQ(status_code_invalid_in_state.GetStatus(), Status::InvalidInState);
         EXPECT_FALSE(status_code_invalid_in_state.HasClusterSpecificCode());
         EXPECT_FALSE(status_code_invalid_in_state.IsSuccess());
@@ -74,13 +70,13 @@ TEST(TestStatusCode, TestClusterStatusCode)
     // Cluster-specific usage.
     {
         ClusterStatusCode status_code_success = ClusterStatusCode::ClusterSpecificSuccess(RobotoClusterStatus::kSauceSuccess);
-        EXPECT_EQ(status_code_success, Status::Success);
+        EXPECT_EQ(status_code_success.GetStatus(), Status::Success);
         EXPECT_TRUE(status_code_success.HasClusterSpecificCode());
         EXPECT_EQ(status_code_success.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoClusterStatus::kSauceSuccess));
         EXPECT_TRUE(status_code_success.IsSuccess());
 
         ClusterStatusCode status_code_failure = ClusterStatusCode::ClusterSpecificFailure(RobotoClusterStatus::kSandwichError);
-        EXPECT_EQ(status_code_failure, Status::Failure);
+        EXPECT_EQ(status_code_failure.GetStatus(), Status::Failure);
         EXPECT_TRUE(status_code_failure.HasClusterSpecificCode());
         EXPECT_EQ(status_code_failure.GetClusterSpecificCode(), static_cast<uint8_t>(RobotoClusterStatus::kSandwichError));
         EXPECT_FALSE(status_code_failure.IsSuccess());


### PR DESCRIPTION
- CommandHandler and WriteHandler did not have a way to cleanly just `AddStatus` with a cluster-specific status code (to eventually harmonize handling methods to always return just a ClusterStatusCode).

This PR:

- Introduces an `AddStatus` overload for `ClusterStatusCode` to CommandHandler and WriteHandler.
- Removes the unimplemented `WriteClient::Shutdown` method.
- Adds notes to the `AddClusterSpecificSuccess` and `AddClusterSpecificFailure`.
- Removes implicit conversion from `ClusterStatusCode` to `Status`
  - Was never used and was error-prone/lossy

Fixes #31120

Testing done:
- Updated necessary unit tests.
- Added unit tests for cluster specific statuses on writes.
- Integration tests still pass.
