### PR TITLE
[NXP][platform][common] Fix OTA issue to resume OTA after provider power off

### DIFF
--- a/src/platform/nxp/common/OTAImageProcessorImpl.cpp
+++ b/src/platform/nxp/common/OTAImageProcessorImpl.cpp
@@ -44,11 +44,6 @@ CHIP_ERROR OTAImageProcessorImpl::Apply()
 
 CHIP_ERROR OTAImageProcessorImpl::Abort()
 {
-    if (mImageFile == nullptr)
-    {
-        ChipLogError(SoftwareUpdate, "Invalid output image file supplied");
-        return CHIP_ERROR_INTERNAL;
-    }
     DeviceLayer::PlatformMgr().ScheduleWork(HandleAbort, reinterpret_cast<intptr_t>(this));
     return CHIP_NO_ERROR;
 }
@@ -308,6 +303,7 @@ void OTAImageProcessorImpl::HandleAbort(intptr_t context)
     }
 
     OTA_CancelImage();
+    OTA_ServiceDeInit();
 
     imageProcessor->ReleaseBlock();
 }

--- a/src/platform/nxp/common/OTAImageProcessorImpl.h
+++ b/src/platform/nxp/common/OTAImageProcessorImpl.h
@@ -47,7 +47,6 @@ public:
     static void TriggerNewRequestForData(intptr_t context);
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
-    void SetOTAImageFile(const char * imageFile) { mImageFile = imageFile; }
 
 private:
     //////////// Actual handlers for the OTAImageProcessorInterface ///////////////
@@ -75,7 +74,6 @@ private:
     OTADownloader * mDownloader;
     OTAImageHeaderParser mHeaderParser;
     uint32_t mSoftwareVersion;
-    const char * mImageFile = nullptr;
 
     /* Buffer used for transaction storage */
     uint8_t mPostedOperationsStorage[NB_PENDING_TRANSACTIONS * TRANSACTION_SZ];


### PR DESCRIPTION
OTA issue identify when running scenario:
- start OTA provider
- start OTA requestor (DUT)
- announce OTA update
- DUT start OTA update process block
- Power off OTA provider before the end of the transfer of all OTA file blocks
- Power on OTA provider
- announce OTA update
- DUT failed to resume the OTA process

Fix:
call OTA_ServiceDeInit(); init function during OTA process abort to restore OTA context

mImageFile variable is no longer needed, remove it
