### PR TITLE
[Fabric Bridge] Overwrite the default implementation of Administrator Commissioning C…

### DIFF
--- a/examples/fabric-bridge-app/linux/main.cpp
+++ b/examples/fabric-bridge-app/linux/main.cpp
@@ -130,6 +130,8 @@ void AdministratorCommissioningCommandHandler::InvokeCommand(HandlerContext & ha
 
 #if defined(PW_RPC_FABRIC_BRIDGE_SERVICE) && PW_RPC_FABRIC_BRIDGE_SERVICE
     Device * device = DeviceMgr().GetDevice(endpointId);
+
+    // TODO: issues:#33784, need to make OpenCommissioningWindow synchronous
     if (device != nullptr && OpenCommissioningWindow(device->GetNodeId()) == CHIP_NO_ERROR)
     {
         ChipLogProgress(NotSpecified, "Commissioning window is now open");
@@ -139,6 +141,9 @@ void AdministratorCommissioningCommandHandler::InvokeCommand(HandlerContext & ha
         status = Status::Failure;
         ChipLogProgress(NotSpecified, "Commissioning window is failed to open");
     }
+#else
+    status = Status::Failure;
+    ChipLogProgress(NotSpecified, "Commissioning window failed to open: PW_RPC_FABRIC_BRIDGE_SERVICE not defined");
 #endif // defined(PW_RPC_FABRIC_BRIDGE_SERVICE) && PW_RPC_FABRIC_BRIDGE_SERVICE
 
     handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, status);


### PR DESCRIPTION
Each Bridged Node contains Administrator Commissioning Cluster, we need to overwrite the default implementation ([https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/admin[…]tor-commissioning-server/administrator-commissioning-server.cpp](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp#L143)) in the Bridged Node endpoint, such as we it receive OCW command, instead of default operations, it needs to notify the Fabric Admin to open the commissioning window

Fixes #33764 
