### PR TITLE
[Fabric-Admin] Add sync-device command to sync a device from another fabric

### DIFF
--- a/examples/fabric-admin/BUILD.gn
+++ b/examples/fabric-admin/BUILD.gn
@@ -61,6 +61,8 @@ static_library("fabric-admin-utils") {
     "${chip_root}/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp",
     "commands/clusters/ModelCommand.cpp",
     "commands/clusters/ModelCommand.h",
+    "commands/clusters/ReportCommand.cpp",
+    "commands/clusters/ReportCommand.h",
     "commands/common/CHIPCommand.cpp",
     "commands/common/CHIPCommand.h",
     "commands/common/Command.cpp",

--- a/examples/fabric-admin/commands/clusters/ReportCommand.cpp
+++ b/examples/fabric-admin/commands/clusters/ReportCommand.cpp
@@ -1,0 +1,80 @@
+/*
+ *   Copyright (c) 2024 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "ReportCommand.h"
+
+#include <app/InteractionModelEngine.h>
+#include <inttypes.h>
+
+using namespace ::chip;
+
+void ReportCommand::OnAttributeData(const app::ConcreteDataAttributePath & path, TLV::TLVReader * data,
+                                    const app::StatusIB & status)
+{
+    CHIP_ERROR error = status.ToChipError();
+    if (CHIP_NO_ERROR != error)
+    {
+        LogErrorOnFailure(RemoteDataModelLogger::LogErrorAsJSON(path, status));
+
+        ChipLogError(NotSpecified, "Response Failure: %s", ErrorStr(error));
+        mError = error;
+        return;
+    }
+
+    if (data == nullptr)
+    {
+        ChipLogError(NotSpecified, "Response Failure: No Data");
+        mError = CHIP_ERROR_INTERNAL;
+        return;
+    }
+
+    LogErrorOnFailure(RemoteDataModelLogger::LogAttributeAsJSON(path, data));
+}
+
+void ReportCommand::OnEventData(const app::EventHeader & eventHeader, TLV::TLVReader * data, const app::StatusIB * status)
+{
+    if (status != nullptr)
+    {
+        CHIP_ERROR error = status->ToChipError();
+        if (CHIP_NO_ERROR != error)
+        {
+            LogErrorOnFailure(RemoteDataModelLogger::LogErrorAsJSON(eventHeader, *status));
+
+            ChipLogError(NotSpecified, "Response Failure: %s", ErrorStr(error));
+            mError = error;
+            return;
+        }
+    }
+
+    if (data == nullptr)
+    {
+        ChipLogError(NotSpecified, "Response Failure: No Data");
+        mError = CHIP_ERROR_INTERNAL;
+        return;
+    }
+
+    LogErrorOnFailure(RemoteDataModelLogger::LogEventAsJSON(eventHeader, data));
+
+    CHIP_ERROR error = DataModelLogger::LogEvent(eventHeader, data);
+    if (CHIP_NO_ERROR != error)
+    {
+        ChipLogError(NotSpecified, "Response Failure: Can not decode Data");
+        mError = error;
+        return;
+    }
+}

--- a/examples/fabric-admin/commands/clusters/ReportCommand.h
+++ b/examples/fabric-admin/commands/clusters/ReportCommand.h
@@ -32,69 +32,10 @@ public:
 
     /////////// ReadClient Callback Interface /////////
     void OnAttributeData(const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader * data,
-                         const chip::app::StatusIB & status) override
-    {
-        CHIP_ERROR error = status.ToChipError();
-        if (CHIP_NO_ERROR != error)
-        {
-            LogErrorOnFailure(RemoteDataModelLogger::LogErrorAsJSON(path, status));
-
-            ChipLogError(NotSpecified, "Response Failure: %s", chip::ErrorStr(error));
-            mError = error;
-            return;
-        }
-
-        if (data == nullptr)
-        {
-            ChipLogError(NotSpecified, "Response Failure: No Data");
-            mError = CHIP_ERROR_INTERNAL;
-            return;
-        }
-
-        LogErrorOnFailure(RemoteDataModelLogger::LogAttributeAsJSON(path, data));
-
-        error = DataModelLogger::LogAttribute(path, data);
-        if (CHIP_NO_ERROR != error)
-        {
-            ChipLogError(NotSpecified, "Response Failure: Can not decode Data");
-            mError = error;
-            return;
-        }
-    }
+                         const chip::app::StatusIB & status) override;
 
     void OnEventData(const chip::app::EventHeader & eventHeader, chip::TLV::TLVReader * data,
-                     const chip::app::StatusIB * status) override
-    {
-        if (status != nullptr)
-        {
-            CHIP_ERROR error = status->ToChipError();
-            if (CHIP_NO_ERROR != error)
-            {
-                LogErrorOnFailure(RemoteDataModelLogger::LogErrorAsJSON(eventHeader, *status));
-
-                ChipLogError(NotSpecified, "Response Failure: %s", chip::ErrorStr(error));
-                mError = error;
-                return;
-            }
-        }
-
-        if (data == nullptr)
-        {
-            ChipLogError(NotSpecified, "Response Failure: No Data");
-            mError = CHIP_ERROR_INTERNAL;
-            return;
-        }
-
-        LogErrorOnFailure(RemoteDataModelLogger::LogEventAsJSON(eventHeader, data));
-
-        CHIP_ERROR error = DataModelLogger::LogEvent(eventHeader, data);
-        if (CHIP_NO_ERROR != error)
-        {
-            ChipLogError(NotSpecified, "Response Failure: Can not decode Data");
-            mError = error;
-            return;
-        }
-    }
+                     const chip::app::StatusIB * status) override;
 
     void OnError(CHIP_ERROR error) override
     {

--- a/examples/fabric-admin/commands/common/Commands.cpp
+++ b/examples/fabric-admin/commands/common/Commands.cpp
@@ -150,6 +150,9 @@ static void DetectAndLogMismatchedDoubleQuotes(int argc, char ** argv)
 
 } // namespace
 
+// Define the static member
+Commands Commands::sInstance;
+
 void Commands::Register(const char * commandSetName, commands_list commandsList, const char * helpText, bool isCluster)
 {
     VerifyOrDieWithMsg(isCluster || helpText != nullptr, NotSpecified, "Non-cluster command sets must have help text");
@@ -337,6 +340,7 @@ Commands::CommandSetMap::iterator Commands::GetCommandSet(std::string commandSet
     {
         std::string key(commandSet.first);
         std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+
         if (key.compare(commandSetName) == 0)
         {
             return mCommandSets.find(commandSet.first);
@@ -344,6 +348,23 @@ Commands::CommandSetMap::iterator Commands::GetCommandSet(std::string commandSet
     }
 
     return mCommandSets.end();
+}
+
+Command * Commands::GetCommandByName(std::string commandSetName, std::string commandName)
+{
+    auto commandSetIter = GetCommandSet(commandSetName);
+    if (commandSetIter != mCommandSets.end())
+    {
+        auto & commandList = commandSetIter->second.commands;
+        for (auto & command : commandList)
+        {
+            if (command->GetName() == commandName)
+            {
+                return command.get();
+            }
+        }
+    }
+    return nullptr;
 }
 
 Command * Commands::GetCommand(CommandsVector & commands, std::string commandName)

--- a/examples/fabric-admin/commands/common/Commands.h
+++ b/examples/fabric-admin/commands/common/Commands.h
@@ -45,6 +45,8 @@ public:
     int Run(int argc, char ** argv);
     int RunInteractive(const char * command, const chip::Optional<char *> & storageDirectory, bool advertiseOperational);
 
+    Command * GetCommandByName(std::string commandSetName, std::string commandName);
+
 private:
     struct CommandSet
     {
@@ -87,4 +89,18 @@ private:
 #ifdef CONFIG_USE_LOCAL_STORAGE
     PersistentStorage mStorage;
 #endif // CONFIG_USE_LOCAL_STORAGE
+
+    friend Commands & CommandMgr();
+    static Commands sInstance;
 };
+
+/**
+ * Returns the public interface of the CommandManager singleton object.
+ *
+ * Applications should use this to access features of the CommandManager
+ * object.
+ */
+inline Commands & CommandMgr()
+{
+    return Commands::sInstance;
+}

--- a/examples/fabric-admin/commands/fabric-sync/Commands.h
+++ b/examples/fabric-admin/commands/fabric-sync/Commands.h
@@ -27,6 +27,7 @@ void registerCommandsFabricSync(Commands & commands, CredentialIssuerCommands * 
 
     commands_list clusterCommands = {
         make_unique<FabricSyncAddDeviceCommand>(credsIssuerConfig),
+        make_unique<FabricSyncDeviceCommand>(credsIssuerConfig),
     };
 
     commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for fabric synchronization.");

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -33,7 +33,7 @@ namespace {
 
 // Constants
 constexpr uint32_t kCommissionPrepareTimeMs = 500;
-constexpr uint16_t kMaxManaulCodeLength     = 11;
+constexpr uint16_t kMaxManaulCodeLength     = 21;
 constexpr uint16_t kSubscribeMinInterval    = 0;
 constexpr uint16_t kSubscribeMaxInterval    = 60;
 
@@ -94,6 +94,8 @@ void FabricSyncDeviceCommand::OnCommissioningComplete(chip::NodeId deviceId, CHI
 {
     if (mAssignedNodeId != deviceId)
     {
+        // Ignore if the deviceId does not match the mAssignedNodeId.
+        // This scenario should not occur because no other device should be commissioned during the fabric sync process.
         return;
     }
 

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -59,7 +59,7 @@ void FabricSyncDeviceCommand::OnCommissioningWindowOpened(NodeId deviceId, CHIP_
         if (error == CHIP_NO_ERROR)
         {
             char command[kMaxCommandSize];
-            NodeId nodeId = 2; // TODO: need to switch to dynamically assigned ID
+            NodeId nodeId = 2; // TODO: (Issue #33947) need to switch to dynamically assigned ID
             snprintf(command, sizeof(command), "pairing code %ld %s", nodeId, payloadBuffer);
 
             PairingCommand * pairingCommand = static_cast<PairingCommand *>(CommandMgr().GetCommandByName("pairing", "code"));
@@ -101,7 +101,7 @@ void FabricSyncDeviceCommand::OnCommissioningComplete(chip::NodeId deviceId, CHI
 
     if (err == CHIP_NO_ERROR)
     {
-        // TODO: AddSyncedDevice
+        // TODO: (Issue #33947) Add Synced Device to device manager
     }
     else
     {
@@ -113,7 +113,7 @@ void FabricSyncDeviceCommand::OnCommissioningComplete(chip::NodeId deviceId, CHI
 CHIP_ERROR FabricSyncDeviceCommand::RunCommand(EndpointId remoteId)
 {
     char command[kMaxCommandSize];
-    NodeId bridgeNodeId = 1; // TODO: need to switch to configured ID
+    NodeId bridgeNodeId = 1; // TODO: (Issue #33947) need to switch to configured ID
     snprintf(command, sizeof(command), "pairing open-commissioning-window %ld %d %d %d %d %d", bridgeNodeId, remoteId,
              kEnhancedCommissioningMethod, kWindowTimeout, kIteration, kDiscriminator);
 

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
@@ -20,6 +20,15 @@
 
 #include <commands/common/CHIPCommand.h>
 #include <commands/pairing/OpenCommissioningWindowCommand.h>
+#include <commands/pairing/PairingCommand.h>
+
+constexpr uint32_t kSetupPinCode               = 20202021;
+constexpr uint16_t kMaxCommandSize             = 64;
+constexpr uint16_t kDiscriminator              = 3840;
+constexpr uint16_t kWindowTimeout              = 300;
+constexpr uint16_t kIteration                  = 1000;
+constexpr uint16_t kAggragatorEndpointId       = 1;
+constexpr uint8_t kEnhancedCommissioningMethod = 1;
 
 class FabricSyncAddDeviceCommand : public CHIPCommand
 {
@@ -40,23 +49,25 @@ private:
     CHIP_ERROR RunCommand(NodeId remoteId);
 };
 
-class FabricSyncDeviceCommand : public CHIPCommand, CommissioningWindowDelegate
+class FabricSyncDeviceCommand : public CHIPCommand, public CommissioningWindowDelegate, public CommissioningDelegate
 {
 public:
     FabricSyncDeviceCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("sync-device", credIssuerCommands)
     {
-        AddArgument("endpointid", 0, UINT16_MAX, &mEndpointId);
+        AddArgument("endpointid", 0, UINT16_MAX, &mRemoteEndpointId);
     }
 
     void OnCommissioningWindowOpened(NodeId deviceId, CHIP_ERROR status, chip::SetupPayload payload) override;
+    void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err) override;
 
     /////////// CHIPCommand Interface /////////
-    CHIP_ERROR RunCommand() override { return RunCommand(mEndpointId); }
+    CHIP_ERROR RunCommand() override { return RunCommand(mRemoteEndpointId); }
 
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(1); }
 
 private:
-    chip::EndpointId mEndpointId;
+    chip::EndpointId mRemoteEndpointId = chip::kInvalidEndpointId;
+    chip::NodeId mAssignedNodeId       = chip::kUndefinedNodeId;
 
     CHIP_ERROR RunCommand(chip::EndpointId remoteId);
 };

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <commands/common/CHIPCommand.h>
+#include <commands/pairing/OpenCommissioningWindowCommand.h>
 
 class FabricSyncAddDeviceCommand : public CHIPCommand
 {
@@ -37,4 +38,25 @@ private:
     chip::NodeId mNodeId;
 
     CHIP_ERROR RunCommand(NodeId remoteId);
+};
+
+class FabricSyncDeviceCommand : public CHIPCommand, CommissioningWindowDelegate
+{
+public:
+    FabricSyncDeviceCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("sync-device", credIssuerCommands)
+    {
+        AddArgument("endpointid", 0, UINT16_MAX, &mEndpointId);
+    }
+
+    void OnCommissioningWindowOpened(NodeId deviceId, CHIP_ERROR status, chip::SetupPayload payload) override;
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override { return RunCommand(mEndpointId); }
+
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(1); }
+
+private:
+    chip::EndpointId mEndpointId;
+
+    CHIP_ERROR RunCommand(chip::EndpointId remoteId);
 };

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
@@ -22,12 +22,10 @@
 #include <commands/pairing/OpenCommissioningWindowCommand.h>
 #include <commands/pairing/PairingCommand.h>
 
-constexpr uint32_t kSetupPinCode               = 20202021;
 constexpr uint16_t kMaxCommandSize             = 64;
 constexpr uint16_t kDiscriminator              = 3840;
 constexpr uint16_t kWindowTimeout              = 300;
 constexpr uint16_t kIteration                  = 1000;
-constexpr uint16_t kAggragatorEndpointId       = 1;
 constexpr uint8_t kEnhancedCommissioningMethod = 1;
 
 class FabricSyncAddDeviceCommand : public CHIPCommand

--- a/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
+++ b/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
@@ -149,8 +149,6 @@ char * InteractiveStartCommand::GetCommand(char * command)
     command = new char[cmd.length() + 1];
     strcpy(command, cmd.c_str());
 
-    ChipLogProgress(NotSpecified, "GetCommand: %s", command);
-
     // Do not save empty lines
     if (command != nullptr && *command)
     {

--- a/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.cpp
+++ b/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.cpp
@@ -47,8 +47,14 @@ CHIP_ERROR OpenCommissioningWindowCommand::RunCommand()
 void OpenCommissioningWindowCommand::OnOpenCommissioningWindowResponse(void * context, NodeId remoteId, CHIP_ERROR err,
                                                                        chip::SetupPayload payload)
 {
-    LogErrorOnFailure(err);
+    OpenCommissioningWindowCommand * self = static_cast<OpenCommissioningWindowCommand *>(context);
+    if (self->mDelegate)
+    {
+        self->mDelegate->OnCommissioningWindowOpened(remoteId, err, payload);
+        self->UnregisterDelegate();
+    }
 
+    LogErrorOnFailure(err);
     OnOpenBasicCommissioningWindowResponse(context, remoteId, err);
 }
 

--- a/examples/fabric-admin/commands/pairing/PairingCommand.cpp
+++ b/examples/fabric-admin/commands/pairing/PairingCommand.cpp
@@ -30,6 +30,10 @@
 
 #include <string>
 
+#if defined(PW_RPC_ENABLED)
+#include <rpc/RpcClient.h>
+#endif
+
 using namespace ::chip;
 using namespace ::chip::Controller;
 
@@ -389,7 +393,11 @@ void PairingCommand::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
 {
     if (err == CHIP_NO_ERROR)
     {
-        ChipLogProgress(NotSpecified, "Device commissioning completed with success");
+        fprintf(stderr, "New device with Node ID: 0x%lx has been successfully added.\n", nodeId);
+
+#if defined(PW_RPC_ENABLED)
+        AddSynchronizedDevice(nodeId);
+#endif
     }
     else
     {

--- a/examples/fabric-admin/main.cpp
+++ b/examples/fabric-admin/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char * argv[])
     }
 
     ExampleCredentialIssuerCommands credIssuerCommands;
-    Commands commands;
+    Commands & commands = CommandMgr();
 
     registerCommandsFabricSync(commands, &credIssuerCommands);
     registerCommandsInteractive(commands, &credIssuerCommands);

--- a/examples/fabric-admin/rpc/RpcClient.cpp
+++ b/examples/fabric-admin/rpc/RpcClient.cpp
@@ -25,7 +25,6 @@
 
 #include "fabric_bridge_service/fabric_bridge_service.rpc.pb.h"
 #include "pw_assert/check.h"
-#include "pw_function/function.h"
 #include "pw_hdlc/decoder.h"
 #include "pw_hdlc/default_addresses.h"
 #include "pw_hdlc/rpc_channel.h"
@@ -70,7 +69,7 @@ CHIP_ERROR AddSynchronizedDevice(chip::NodeId nodeId)
 
     if (addSynchronizedDeviceCall.active())
     {
-        ChipLogError(NotSpecified, "OpenCommissioningWindow is in progress\n");
+        ChipLogError(NotSpecified, "Add Synchronized Device operation is in progress\n");
         return CHIP_ERROR_BUSY;
     }
 

--- a/examples/fabric-admin/rpc/RpcClient.h
+++ b/examples/fabric-admin/rpc/RpcClient.h
@@ -36,7 +36,7 @@ CHIP_ERROR InitRpcClient(uint16_t rpcServerPort);
  * @brief Adds a synchronized device to the RPC client.
  *
  * This function attempts to add a device identified by its `nodeId` to the synchronized device list.
- * It logs the progress and checks if an `OpenCommissioningWindow` operation is already in progress.
+ * It logs the progress and checks if an `AddSynchronizedDevice` operation is already in progress.
  * If an operation is in progress, it returns `CHIP_ERROR_BUSY`.
  *
  * @param nodeId The Node ID of the device to be added.


### PR DESCRIPTION
Add sync-device command in Fabric-Admin to sync a device from another fabric

```
>>> fabricsync sync-device ?
>>> INF  [1718310490.754297][260034:260034] CHIP:-: Command: fabricsync sync-device ? 
ERR  [1718310490.754567][260034:260034] CHIP:-: InitArgs: Invalid argument endpointid: ?
Usage:
   fabricsync sync-device endpointid [--log-file-path] [--paa-trust-store-path] [--cd-trust-store-path] [--commissioner-name] [--commissioner-nodeid] [--use-max-sized-certs] [--only-allow-trusted-cd-keys] [--trace_file] [--trace_log] [--trace_decode] [--trace-to] [--ble-adapter] [--storage-directory] [--commissioner-vendor-id]
```

Fixes #33911

