### PR TITLE
reset StartUpCurrentLevel to ensure test repetitions

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_LVL_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_2_2.yaml
@@ -39,6 +39,9 @@ config:
     StartUpCurrentLevelConfigValue:
         type: int8u
         defaultValue: 5
+    StartUpCurrentLevelConfigResetValue:
+        type: int8u
+        defaultValue: 100
 
 tests:
     - label:
@@ -229,6 +232,16 @@ tests:
           constraints:
               type: int8u
               notValue: StartUpCurrentLevelValue
+
+    #This is a reset step that is needed to reset the value of the attribute to another value then the one used in 6b in order to ensure successful test repetitions.
+    - label:
+            "writes back StartUpCurrentLevel attribute to the DUT with
+            a different value than that in 6c"
+      PICS: LVL.S.A4000
+      command: "writeAttribute"
+      attribute: "StartUpCurrentLevel"
+      arguments:
+          value: StartUpCurrentLevelConfigResetValue
 
     #This is a reset step that is needed to reset the value of the attribute to the default values so as to not effect other test cases.
     - label: "writes back default value of OnOffTransitionTime attribute"


### PR DESCRIPTION
[TC-LVL-2.2] The added test step resets the StartUpCurrentLevel to another value then the one used in 6b.

Test step 6c checks if writing to the attribute StartUpCurrentLevel was successful by comparing its initial value with the value (5) written in step 6b. If the initial value and the value written in step 6b differ, the step is considered successful. However, if the test case is executed back-to-back, StartUpCurrentLevel remains unchanged between test runs, causing test step 6c to fail.