### PR TITLE
[nrfconnect] Remove shell initialization from chef app

### DIFF
--- a/examples/chef/nrfconnect/main.cpp
+++ b/examples/chef/nrfconnect/main.cpp
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-#include <lib/shell/Engine.h>
-
 #include <app/server/Dnssd.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/support/Base64.h>
@@ -35,10 +33,6 @@
 
 #include <zephyr/logging/log.h>
 
-#if CONFIG_ENABLE_CHIP_SHELL || CONFIG_CHIP_LIB_SHELL
-#include <ChipShellCollection.h>
-#endif
-
 #ifdef CONFIG_CHIP_PW_RPC
 #include "Rpc.h"
 #endif
@@ -53,7 +47,6 @@
 LOG_MODULE_REGISTER(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
 using namespace chip;
-using namespace chip::Shell;
 using namespace chip::DeviceLayer;
 
 namespace {
@@ -159,27 +152,7 @@ int main()
         ChipLogError(AppServer, "OpenBasicCommissioningWindow() failed");
     }
 
-#if CONFIG_CHIP_LIB_SHELL
-    int rc = Engine::Root().Init();
-    if (rc != 0)
-    {
-        ChipLogError(AppServer, "Streamer initialization failed: %d", rc);
-        return 1;
-    }
-
-    cmd_misc_init();
-    cmd_otcli_init();
-#endif
-
-#if CHIP_SHELL_ENABLE_CMD_SERVER
-    cmd_app_server_init();
-#endif
-
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer);
-
-#if CONFIG_CHIP_LIB_SHELL
-    Engine::Root().RunMainLoop();
-#endif
 
     return 0;
 }


### PR DESCRIPTION
On Zephyr-based platforms, shell commands are initialized automatically on the system boot so they don't have to be manually registered (e.g. OpenThread shell commands are available using the "ot cmd" prefix).

In fact, initializing OpenThread CLI at this stage replaces the SRP client callback registered by the Matter stack and breaks SRP in chef app.
