### PR TITLE
displaying pw_unit_test logs on Android CHIPTest App

### DIFF
--- a/examples/android/CHIPTest/BUILD.gn
+++ b/examples/android/CHIPTest/BUILD.gn
@@ -33,7 +33,6 @@ shared_library("jni") {
     "${chip_root}/src/lib/support",
     "${chip_root}/src/lib/support:pw_tests_wrapper",
     "${chip_root}/src/lib/support:test_utils",
-    "${chip_root}/src/lib/support:testing_nlunit",
     "${chip_root}/src/lib/support/jsontlv",
     "${chip_root}/src/platform",
     "${chip_root}/src/platform/android",

--- a/examples/android/CHIPTest/app/src/main/cpp/CHIPTest-JNI.cpp
+++ b/examples/android/CHIPTest/app/src/main/cpp/CHIPTest-JNI.cpp
@@ -148,46 +148,9 @@ exit:
 
 namespace pw::unit_test {
 
-// This Class allows us to redirect
 class AndroidLoggingEventHandler : public pw::unit_test::LoggingEventHandler
 {
 public:
-    void TestProgramStart(const ProgramSummary & program_summary) override
-    {
-        onLog(PW_UNIT_TEST_GOOGLETEST_TEST_PROGRAM_START, program_summary.tests_to_run, program_summary.test_suites,
-              program_summary.test_suites != 1 ? "s" : "");
-    }
-
-    void TestSuiteStart(const TestSuite & test_suite) override
-    {
-        onLog(PW_UNIT_TEST_GOOGLETEST_TEST_SUITE_START, test_suite.test_to_run_count, test_suite.name);
-    }
-
-    void TestSuiteEnd(const TestSuite & test_suite) override
-    {
-        onLog(PW_UNIT_TEST_GOOGLETEST_TEST_SUITE_END, test_suite.test_to_run_count, test_suite.name);
-    }
-
-    void EnvironmentsTearDownEnd() override { onLog(PW_UNIT_TEST_GOOGLETEST_ENVIRONMENTS_TEAR_DOWN_END); }
-
-    void TestProgramEnd(const ProgramSummary & program_summary) override
-    {
-        onLog(PW_UNIT_TEST_GOOGLETEST_TEST_PROGRAM_END,
-              program_summary.tests_to_run - program_summary.tests_summary.skipped_tests -
-                  program_summary.tests_summary.disabled_tests,
-              program_summary.tests_to_run, program_summary.test_suites, program_summary.test_suites != 1 ? "s" : "");
-        onLog(PW_UNIT_TEST_GOOGLETEST_PASSED_SUMMARY, program_summary.tests_summary.passed_tests);
-        if (program_summary.tests_summary.skipped_tests || program_summary.tests_summary.disabled_tests)
-        {
-            onLog(PW_UNIT_TEST_GOOGLETEST_DISABLED_SUMMARY,
-                  program_summary.tests_summary.skipped_tests + program_summary.tests_summary.disabled_tests);
-        }
-        if (program_summary.tests_summary.failed_tests)
-        {
-            onLog(PW_UNIT_TEST_GOOGLETEST_FAILED_SUMMARY, program_summary.tests_summary.failed_tests);
-        }
-    }
-
     void RunAllTestsStart() override { onLog(PW_UNIT_TEST_GOOGLETEST_RUN_ALL_TESTS_START); }
 
     void RunAllTestsEnd(const RunTestsSummary & run_tests_summary) override


### PR DESCRIPTION
- allowing pw_unit_test logs to be displayed on the Android CHIPTest App.

- WARNING: the tests seem to be crashing, However, this App is not maintained anymore and the scope of this PR is just to make sure that we can print PW Unit Testing Logs in case this App starts being used again.

- Tested on Android Studio and an Android Phone:
   - Current Output after the change (the Tests/logs do not go beyond this point, this was also the case before this change): 
![Screenshot from 2024-06-17 11-50-02](https://github.com/project-chip/connectedhomeip/assets/43780877/ff12baa3-5566-444f-beae-9304d3ecb393)


