### PR TITLE
Improve error messages in Darwin DNS-SD implementation.

### DIFF
--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -350,7 +350,17 @@ BrowseContext::BrowseContext(void * cbContext, DnssdBrowseCallback cb, DnssdServ
 
 void BrowseContext::DispatchFailure(const char * errorStr, CHIP_ERROR err)
 {
-    ChipLogError(Discovery, "Mdns: Browse failure (%s)", errorStr);
+    if (err == CHIP_ERROR_CANCELLED && dispatchedSuccessOnce)
+    {
+        // We've been canceled after finding some devices.  Treat this as a
+        // success, because maybe (common case, in fact) those were the devices
+        // our consumer was looking for.
+        ChipLogProgress(Discovery, "Mdns: Browse canceled");
+    }
+    else
+    {
+        ChipLogError(Discovery, "Mdns: Browse failure (%s)", errorStr);
+    }
     callback(context, nullptr, 0, true, err);
     MdnsContexts::GetInstance().Remove(this);
 }
@@ -376,6 +386,8 @@ void BrowseContext::DispatchPartialSuccess()
     sDispatchedServices        = nullptr;
     sContextDispatchingSuccess = nullptr;
     services.clear();
+
+    dispatchedSuccessOnce = true;
 }
 
 void BrowseContext::OnBrowse(DNSServiceFlags flags, const char * name, const char * type, const char * domain, uint32_t interfaceId)

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -169,6 +169,7 @@ struct BrowseContext : public BrowseHandler
 {
     DnssdBrowseCallback callback;
     std::vector<std::pair<DnssdService, std::string>> services;
+    bool dispatchedSuccessOnce = false;
 
     BrowseContext(void * cbContext, DnssdBrowseCallback cb, DnssdServiceProtocol cbContextProtocol);
 


### PR DESCRIPTION
We shouldn't claim a canceled browse that found things is a failure.


