### PR TITLE
Stop using weak functions for Aliro command callbacks.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-delegate.h
+++ b/src/app/clusters/door-lock-server/door-lock-delegate.h
@@ -125,6 +125,24 @@ public:
      * @return The max number of Aliro endpoint keys supported.
      */
     virtual uint16_t GetNumberOfAliroEndpointKeysSupported() = 0;
+
+    /**
+     * Set the Aliro reader configuration for the lock.  The various arguments
+     * have already been checked for constraints and consistency with the
+     * FeatureMap.
+     *
+     * @param[in] signingKey Signing key component of the Reader's key pair.
+     * @param[in] verificationKey Verification key component of the Reader's key pair.
+     * @param[in] groupIdentifier Reader group identifier for the lock.
+     * @param[in] groupResolvingKey Group resolving key for the lock if Aliro BLE UWB feature is supported
+     */
+    virtual CHIP_ERROR SetAliroReaderConfig(const ByteSpan & signingKey, const ByteSpan & verificationKey,
+                                            const ByteSpan & groupIdentifier, const Optional<ByteSpan> & groupResolvingKey) = 0;
+
+    /**
+     * Clear the Aliro reader configuration for the lock.
+     */
+    virtual CHIP_ERROR ClearAliroReaderConfig() = 0;
 };
 
 } // namespace DoorLock

--- a/src/app/clusters/door-lock-server/door-lock-server-callback.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-callback.cpp
@@ -242,15 +242,3 @@ emberAfPluginDoorLockGetFaceCredentialLengthConstraints(chip::EndpointId endpoin
 {
     return false;
 }
-
-bool __attribute__((weak))
-emberAfPluginDoorLockSetAliroReaderConfig(EndpointId endpointId, const ByteSpan & signingKey, const ByteSpan & verificationKey,
-                                          const ByteSpan & groupIdentifier, const Optional<ByteSpan> groupResolvingKey)
-{
-    return false;
-}
-
-bool __attribute__((weak)) emberAfPluginDoorLockClearAliroReaderConfig(chip::EndpointId endpointId)
-{
-    return false;
-}

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -90,7 +90,7 @@ class DoorLockClusterFabricDelegate : public chip::FabricTable::Delegate
 {
     void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override
     {
-        for (auto endpointId : EnabledEndpointsWithServerCluster(chip::app::Clusters::DoorLock::Id))
+        for (auto endpointId : EnabledEndpointsWithServerCluster(Clusters::DoorLock::Id))
         {
             if (!DoorLockServer::Instance().OnFabricRemoved(endpointId, fabricIndex))
             {
@@ -3641,7 +3641,7 @@ void DoorLockServer::SendEvent(chip::EndpointId endpointId, T & event)
 
 template <typename T>
 bool DoorLockServer::GetAttribute(chip::EndpointId endpointId, chip::AttributeId attributeId,
-                                  Status (*getFn)(chip::EndpointId endpointId, T * value), T & value) const
+                                  Status (*getFn)(chip::EndpointId endpointId, T * value), T & value)
 {
     Status status = getFn(endpointId, &value);
     bool success  = (Status::Success == status);
@@ -3927,12 +3927,26 @@ void DoorLockServer::setAliroReaderConfigCommandHandler(CommandHandler * command
     }
 
     Delegate * delegate = GetDelegate(endpointID);
-    VerifyOrReturn(delegate != nullptr, ChipLogError(Zcl, "Delegate is null"));
-
-    // If Aliro BLE UWB feature is supported and groupResolvingKey is not provided in the command, return INVALID_COMMAND.
-    if (SupportsAliroBLEUWB(endpointID) && !groupResolvingKey.HasValue())
+    if (!delegate)
     {
-        ChipLogProgress(Zcl, "[SetAliroReaderConfig] Aliro BLE UWB supported but Group Resolving Key is not provided");
+        ChipLogError(Zcl, "Door Lock delegate is null");
+        commandObj->AddStatus(commandPath, Status::Failure);
+        return;
+    }
+
+    // The GroupResolvingKey must be provided if and only if the Aliro BLE UWB
+    // feature is supported.  Otherwise, return INVALID_COMMAND
+    const bool supportsAliroBLEUWB = SupportsAliroBLEUWB(endpointID);
+    if (supportsAliroBLEUWB != groupResolvingKey.HasValue())
+    {
+        if (supportsAliroBLEUWB)
+        {
+            ChipLogError(Zcl, "[SetAliroReaderConfig] Aliro BLE UWB supported but Group Resolving Key is not provided");
+        }
+        else
+        {
+            ChipLogError(Zcl, "[SetAliroReaderConfig] Aliro BLE UWB not supported but Group Resolving Key is provided");
+        }
         commandObj->AddStatus(commandPath, Status::InvalidCommand);
         return;
     }
@@ -3959,19 +3973,27 @@ void DoorLockServer::setAliroReaderConfigCommandHandler(CommandHandler * command
     // INVALID_IN_STATE.
     if (err != CHIP_NO_ERROR || !readerVerificationKey.empty())
     {
-        ChipLogProgress(
-            Zcl, "[SetAliroReaderConfig] Aliro reader verification key was not read or is not null. Return INVALID_IN_STATE");
+        ChipLogError(Zcl, "[SetAliroReaderConfig] Aliro reader verification key was not read or is not null.");
         commandObj->AddStatus(commandPath, Status::InvalidInState);
         return;
     }
 
-    Status status = Status::Success;
-    if (!emberAfPluginDoorLockSetAliroReaderConfig(endpointID, signingKey, verificationKey, groupIdentifier, groupResolvingKey))
+    err = delegate->SetAliroReaderConfig(signingKey, verificationKey, groupIdentifier, groupResolvingKey);
+    if (err != CHIP_NO_ERROR)
     {
         ChipLogProgress(Zcl, "[SetAliroReaderConfig] Unable to set aliro reader config [endpointId=%d]", endpointID);
-        status = Status::Failure;
     }
-    sendClusterResponse(commandObj, commandPath, ClusterStatusCode(status));
+    else
+    {
+        // Various attributes changed; mark them dirty.
+        MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroReaderVerificationKey::Id);
+        MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroReaderGroupIdentifier::Id);
+        if (supportsAliroBLEUWB)
+        {
+            MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroGroupResolvingKey::Id);
+        }
+    }
+    sendClusterResponse(commandObj, commandPath, ClusterStatusCode(StatusIB(err).mStatus));
 }
 
 void DoorLockServer::clearAliroReaderConfigCommandHandler(CommandHandler * commandObj, const ConcreteCommandPath & commandPath)
@@ -3987,13 +4009,41 @@ void DoorLockServer::clearAliroReaderConfigCommandHandler(CommandHandler * comma
         return;
     }
 
-    Status status = Status::Success;
-    if (!emberAfPluginDoorLockClearAliroReaderConfig(endpointID))
+    Delegate * delegate = GetDelegate(endpointID);
+    if (!delegate)
     {
-        ChipLogProgress(Zcl, "[SetAliroReaderConfig] Unable to set aliro reader config [endpointId=%d]", endpointID);
-        status = Status::Failure;
+        ChipLogError(Zcl, "Door Lock delegate is null");
+        commandObj->AddStatus(commandPath, Status::Failure);
+        return;
     }
-    sendClusterResponse(commandObj, commandPath, ClusterStatusCode(status));
+
+    uint8_t buffer[kAliroReaderVerificationKeySize];
+    MutableByteSpan readerVerificationKey(buffer);
+    CHIP_ERROR err = delegate->GetAliroReaderVerificationKey(readerVerificationKey);
+    if (err != CHIP_NO_ERROR && readerVerificationKey.empty())
+    {
+        // No reader config to start with.  Just return without marking any
+        // attributes as dirty.
+        commandObj->AddStatus(commandPath, Status::Success);
+        return;
+    }
+
+    err = delegate->ClearAliroReaderConfig();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "[SetAliroReaderConfig] Unable to set aliro reader config [endpointId=%d]", endpointID);
+    }
+    else
+    {
+        // Various attributes changed; mark them dirty.
+        MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroReaderVerificationKey::Id);
+        MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroReaderGroupIdentifier::Id);
+        if (SupportsAliroBLEUWB(endpointID))
+        {
+            MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroGroupResolvingKey::Id);
+        }
+    }
+    sendClusterResponse(commandObj, commandPath, ClusterStatusCode(StatusIB(err).mStatus));
 }
 
 // =============================================================================


### PR DESCRIPTION
We have a delegate; we should just make use of the delegate.  This is not a breaking change because nothing implements Aliro bits yet.

Also:

* Fixes some incorrect early returns that did not respond to commands.
* Fixes some validity checks that were not quite correct per spec.
* Fixes some logging levels for errors.
* Adds missing "mark these attributes dirty" bits.
* Marks various functions that don't touch our members as static.
