### PR TITLE
Add option to ChipTool to allow session setup for large payloads.

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -44,8 +44,11 @@ CHIP_ERROR ModelCommand::RunCommand()
         return SendCommand(commissioneeDeviceProxy, mEndPointId);
     }
 
+    // Check whether the session needs to allow large payload support.
+    TransportPayloadCapability transportPayloadCapability =
+        AllowLargePayload() ? TransportPayloadCapability::kLargePayload : TransportPayloadCapability::kMRPPayload;
     return CurrentCommissioner().GetConnectedDevice(mDestinationId, &mOnDeviceConnectedCallback,
-                                                    &mOnDeviceConnectionFailureCallback);
+                                                    &mOnDeviceConnectionFailureCallback, transportPayloadCapability);
 }
 
 void ModelCommand::OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
@@ -133,4 +136,9 @@ bool ModelCommand::IsPeerLIT()
 {
     CheckPeerICDType();
     return mIsPeerLIT.ValueOr(false);
+}
+
+bool ModelCommand::AllowLargePayload()
+{
+    return mAllowLargePayload.ValueOr(false);
 }

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -57,6 +57,9 @@ public:
             "Whether to treat the peer as a LIT ICD. false: Always no, true: Always yes, (not set): Yes if the peer is registered "
             "to this controller.");
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
+        AddArgument("allow-large-payload", 0, 1, &mAllowLargePayload,
+                    "If true, indicates that the session should allow large application payloads (which requires a TCP connection)."
+                    "Defaults to false, which uses a UDP+MRP session.");
     }
 
     /////////// CHIPCommand Interface /////////
@@ -82,8 +85,11 @@ private:
     chip::NodeId mDestinationId;
     std::vector<chip::EndpointId> mEndPointId;
     chip::Optional<bool> mIsPeerLIT;
+    chip::Optional<bool> mAllowLargePayload;
 
     void CheckPeerICDType();
+
+    bool AllowLargePayload();
 
     static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
                                     const chip::SessionHandle & sessionHandle);


### PR DESCRIPTION
By default, assumed false.
When set to 1, it will trigger an attempt to set up a session over TCP to support large payload transfers.
E.g., ./chip-tool onoff read on-off 15 2 --allow-large-payload 1

Fixes #29697
