### PR TITLE
Fix comments to right variable

### DIFF
--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -102,8 +102,6 @@ public:
      * @param [in] callback the derived callback which inherit from ReadClient::Callback
      * @param [in] highestReceivedEventNumber optional highest received event number, if cache receive the events with the number
      *             less than or equal to this value, skip those events
-     * @param [in] cacheData boolean to decide whether this cache would store attribute/event data/status,
-     *             the default is true.
      */
     ClusterStateCacheT(Callback & callback, Optional<EventNumber> highestReceivedEventNumber = Optional<EventNumber>::Missing()) :
         mCallback(callback), mBufferedReader(*this)

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -136,7 +136,7 @@ public:
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy the object.
          *
-         * @param[in] apCommandSender The command sender object that initiated the command transaction.
+         * @param[in] commandSender   The command sender object that initiated the command transaction.
          * @param[in] aResponseData   Information pertaining to the response.
          */
         virtual void OnResponse(CommandSender * commandSender, const ResponseData & aResponseData) {}
@@ -149,7 +149,7 @@ public:
          * The CommandSender object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy the object.
          *
-         * @param apCommandSender The CommandSender object that initiated the transaction.
+         * @param commandSender   The CommandSender object that initiated the transaction.
          * @param aNoResponseData Details about the request without a response.
          */
         virtual void OnNoResponse(CommandSender * commandSender, const NoResponseData & aNoResponseData) {}

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -375,7 +375,7 @@ public:
      * @param[in] noc                                NOC in CHIP certificate format.
      * @param[in] icac                               ICAC in CHIP certificate format. If no icac is present, an empty
      *                                               ByteSpan should be passed.
-     * @param[in] externalOperationalKeypair         External operational keypair. If null, use keypair in OperationalKeystore.
+     * @param[in] operationalKeypair                 External operational keypair. If null, use keypair in OperationalKeystore.
      * @param[in] operationalKeypairExternalOwned    If true, external operational keypair must outlive the fabric.
      *                                               If false, the keypair is copied and owned in heap of a FabricInfo.
      *


### PR DESCRIPTION
Some variable names in the C++ documentation were incorrect, so I modified them.
