### PR TITLE
Update cirque pip flags to allow breaking system packages

### DIFF
--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -114,8 +114,6 @@ function cirquetest_bootstrap() {
     set -ex
 
     cd "$REPO_DIR"/third_party/cirque/repo
-    pip3 uninstall -y setuptools --break-system-packages
-    pip3 install --break-system-packages setuptools==65.7.0
     pip3 install --break-system-packages pycodestyle==2.5.0 wheel
 
     make NO_GRPC=1 install -j

--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -114,9 +114,9 @@ function cirquetest_bootstrap() {
     set -ex
 
     cd "$REPO_DIR"/third_party/cirque/repo
-    pip3 uninstall -y setuptools
-    pip3 install setuptools==65.7.0
-    pip3 install pycodestyle==2.5.0 wheel
+    pip3 uninstall -y setuptools --break-system-packages
+    pip3 install --break-system-packages setuptools==65.7.0
+    pip3 install --break-system-packages pycodestyle==2.5.0 wheel
 
     make NO_GRPC=1 install -j
 
@@ -125,7 +125,7 @@ function cirquetest_bootstrap() {
     "$REPO_DIR"/integrations/docker/images/stage-2/chip-cirque-device-base/build.sh --build-arg OT_BR_POSIX_CHECKOUT="$OT_BR_POSIX_CHECKOUT"
 
     __cirquetest_build_ot_lazy
-    pip3 install -r requirements_nogrpc.txt
+    pip3 install --break-system-packages -r requirements_nogrpc.txt
 
     echo "OpenThread Version: $OPENTHREAD_CHECKOUT"
     echo "ot-br-posix Version: $OT_BR_POSIX_CHECKOUT"


### PR DESCRIPTION
Ubuntu 24.04 update requires this and it seems cirque always pulls the latest build (rather than being fixed).
We should probably force cirque to use specific versions instead, however for now this seems to be the quick fix.