### PR TITLE
make sure test event trigger delegate is not null before using it

### DIFF
--- a/examples/smoke-co-alarm-app/silabs/src/AppTask.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/AppTask.cpp
@@ -78,7 +78,10 @@ CHIP_ERROR AppTask::Init()
     }
 
     // Register Smoke & Co Test Event Trigger
-    Server::GetInstance().GetTestEventTriggerDelegate()->AddHandler(&AlarmMgr());
+    if (Server::GetInstance().GetTestEventTriggerDelegate() != nullptr)
+    {
+        Server::GetInstance().GetTestEventTriggerDelegate()->AddHandler(&AlarmMgr());
+    }
 
     sAlarmLED.Init(LIGHT_LED);
     sAlarmLED.Set(false);

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -359,7 +359,10 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
                      chip::app::InteractionModelEngine::GetInstance());
 
     // Register Test Event Trigger Handler
-    mTestEventTriggerDelegate->AddHandler(&mICDManager);
+    if (mTestEventTriggerDelegate != nullptr)
+    {
+        mTestEventTriggerDelegate->AddHandler(&mICDManager);
+    }
 
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
@@ -612,7 +615,10 @@ void Server::Shutdown()
     Credentials::SetGroupDataProvider(nullptr);
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     // Remove Test Event Trigger Handler
-    mTestEventTriggerDelegate->RemoveHandler(&mICDManager);
+    if (mTestEventTriggerDelegate != nullptr)
+    {
+        mTestEventTriggerDelegate->RemoveHandler(&mICDManager);
+    }
     mICDManager.Shutdown();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
     mAttributePersister.Shutdown();

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -182,6 +182,10 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     mReportScheduler = initParams.reportScheduler;
 
     mTestEventTriggerDelegate = initParams.testEventTriggerDelegate;
+    if (mTestEventTriggerDelegate == nullptr)
+    {
+        ChipLogProgress(AppServer, "WARNING: mTestEventTriggerDelegate is null");
+    }
 
     deviceInfoprovider = DeviceLayer::GetDeviceInfoProvider();
     if (deviceInfoprovider)


### PR DESCRIPTION
If an app is not setting the test event trigger delegate, while CHIP_CONFIG_ENABLE_ICD_SERVER is enabled, it would result in accessing a nonexistent memory.