### PR TITLE
Add more `--break-system-packages` for pip install for cirque

### DIFF
--- a/src/test_driver/linux-cirque/CommissioningFailureOnReportTest.py
+++ b/src/test_driver/linux-cirque/CommissioningFailureOnReportTest.py
@@ -91,11 +91,11 @@ class TestCommissioningFailure(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "

--- a/src/test_driver/linux-cirque/CommissioningFailureTest.py
+++ b/src/test_driver/linux-cirque/CommissioningFailureTest.py
@@ -91,11 +91,11 @@ class TestCommissioningFailure(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {}".format(

--- a/src/test_driver/linux-cirque/CommissioningTest.py
+++ b/src/test_driver/linux-cirque/CommissioningTest.py
@@ -132,11 +132,11 @@ class TestCommissioner(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "

--- a/src/test_driver/linux-cirque/CommissioningWindowTest.py
+++ b/src/test_driver/linux-cirque/CommissioningWindowTest.py
@@ -95,11 +95,11 @@ class TestCommissioningWindow(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = ("gdb -return-child-result -q -ex run -ex bt "

--- a/src/test_driver/linux-cirque/FailsafeTest.py
+++ b/src/test_driver/linux-cirque/FailsafeTest.py
@@ -91,11 +91,11 @@ class TestFailsafe(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {}".format(

--- a/src/test_driver/linux-cirque/MobileDeviceTest.py
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.py
@@ -91,11 +91,11 @@ class TestPythonController(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "

--- a/src/test_driver/linux-cirque/PythonCommissioningTest.py
+++ b/src/test_driver/linux-cirque/PythonCommissioningTest.py
@@ -104,11 +104,11 @@ class TestCommissioner(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -d {} --paa-trust-store-path {} --nodeid {}".format(

--- a/src/test_driver/linux-cirque/SplitCommissioningTest.py
+++ b/src/test_driver/linux-cirque/SplitCommissioningTest.py
@@ -98,11 +98,11 @@ class TestSplitCommissioning(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "

--- a/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
@@ -125,11 +125,11 @@ class TestSubscriptionResumptionCapacity(CHIPVirtualHome):
         self.reset_thread_devices(server_ids)
 
         for req_device_id in req_ids:
-            self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
                 CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-            self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
                 CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-            self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
                 CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command1 = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
@@ -102,11 +102,11 @@ class TestSubscriptionResumption(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTimeoutTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTimeoutTest.py
@@ -103,11 +103,11 @@ class TestSubscriptionResumptionTimeout(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "


### PR DESCRIPTION
Realistically these tests should be fixed/updated to use virtualenv and not dirty the system python, however for now patch them to make them work.

Created #33950 to use virtualenvs for cirque.