### PR TITLE
[Bridge Example] Fix dangling pointer when AddDeviceEndpoint failed

### DIFF
--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -287,8 +287,6 @@ int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const E
                     gCurrentEndpointId = gFirstDynamicEndpointId;
                 }
             }
-            // Clear gDevices[index] as all retries are exhausted
-            gDevices[index] = nullptr;
         }
         index++;
     }

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -278,6 +278,7 @@ int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const E
                 }
                 if (err != CHIP_ERROR_ENDPOINT_EXISTS)
                 {
+                    gDevices[index] = nullptr;
                     return -1;
                 }
                 // Handle wrap condition
@@ -286,6 +287,8 @@ int AddDeviceEndpoint(Device * dev, EmberAfEndpointType * ep, const Span<const E
                     gCurrentEndpointId = gFirstDynamicEndpointId;
                 }
             }
+            // Clear gDevices[index] as all retries are exhausted
+            gDevices[index] = nullptr;
         }
         index++;
     }

--- a/examples/fabric-bridge-app/linux/DeviceManager.cpp
+++ b/examples/fabric-bridge-app/linux/DeviceManager.cpp
@@ -161,6 +161,7 @@ int DeviceManager::AddDeviceEndpoint(Device * dev, chip::EndpointId parentEndpoi
                 }
                 if (err != CHIP_ERROR_ENDPOINT_EXISTS)
                 {
+                    mDevices[index] = nullptr;
                     return -1; // Return error as endpoint addition failed due to an error other than endpoint already exists
                 }
                 // Increment the endpoint ID and handle wrap condition
@@ -171,6 +172,7 @@ int DeviceManager::AddDeviceEndpoint(Device * dev, chip::EndpointId parentEndpoi
                 retryCount++;
             }
             ChipLogError(NotSpecified, "Failed to add dynamic endpoint after %d retries", kMaxRetries);
+            mDevices[index] = nullptr;
             return -1; // Return error as all retries are exhausted
         }
         index++;


### PR DESCRIPTION
Issue Summary: Inconsistent State of mDevices Array on Error Return
Description
In the current implementation of the DeviceManager::AddDeviceEndpoint function, there is a potential issue where the mDevices array can be left in an inconsistent state when errors occur. Specifically, when the function encounters an error and returns -1, it does not reset the mDevices[index] element back to nullptr. This can lead to the array containing invalid pointers, which can cause undefined behavior in subsequent operations.

Affected Function
DeviceManager::AddDeviceEndpoint


Fixes #33946