### PR TITLE
[Draft] Re-Implement App Install flow

### DIFF
--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -5324,6 +5324,10 @@ cluster ApplicationBasic = 1293 {
     kActiveVisibleFocus = 1;
     kActiveHidden = 2;
     kActiveVisibleNotFocus = 3;
+    kNotInstalled = 4;
+    kInstalling = 5;
+    kInstallationFailed = 6;
+    kInstalled = 7;
   }
 
   struct ApplicationStruct {

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -8014,6 +8014,10 @@ cluster ApplicationBasic = 1293 {
     kActiveVisibleFocus = 1;
     kActiveHidden = 2;
     kActiveVisibleNotFocus = 3;
+    kNotInstalled = 4;
+    kInstalling = 5;
+    kInstallationFailed = 6;
+    kInstalled = 7;
   }
 
   struct ApplicationStruct {
@@ -8046,6 +8050,10 @@ cluster ApplicationBasic = 1293 {
     kActiveVisibleFocus = 1;
     kActiveHidden = 2;
     kActiveVisibleNotFocus = 3;
+    kNotInstalled = 4;
+    kInstalling = 5;
+    kInstallationFailed = 6;
+    kInstalled = 7;
   }
 
   struct ApplicationStruct {

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -7971,6 +7971,10 @@ cluster ApplicationBasic = 1293 {
     kActiveVisibleFocus = 1;
     kActiveHidden = 2;
     kActiveVisibleNotFocus = 3;
+    kNotInstalled = 4;
+    kInstalling = 5;
+    kInstallationFailed = 6;
+    kInstalled = 7;
   }
 
   struct ApplicationStruct {
@@ -8003,6 +8007,10 @@ cluster ApplicationBasic = 1293 {
     kActiveVisibleFocus = 1;
     kActiveHidden = 2;
     kActiveVisibleNotFocus = 3;
+    kNotInstalled = 4;
+    kInstalling = 5;
+    kInstallationFailed = 6;
+    kInstalled = 7;
   }
 
   struct ApplicationStruct {

--- a/examples/tv-app/android/java/AppPlatform-JNI.cpp
+++ b/examples/tv-app/android/java/AppPlatform-JNI.cpp
@@ -128,7 +128,7 @@ std::vector<ContentApp::SupportedCluster> convert_to_cpp(JNIEnv * env, jobject s
     // Find Java classes. WARNING: Reflection
     jclass collectionClass = env->FindClass("java/util/Collection");
     jclass iteratorClass   = env->FindClass("java/util/Iterator");
-    jclass clusterClass    = env->FindClass("com/matter/tv/server/tvapp/SupportedCluster");
+    jclass clusterClass    = env->FindClass("com/matter/tv/server/tvapp/ContentAppSupportedCluster");
     if (collectionClass == nullptr || iteratorClass == nullptr || clusterClass == nullptr)
     {
         return {};

--- a/examples/tv-app/android/java/TVApp-JNI.cpp
+++ b/examples/tv-app/android/java/TVApp-JNI.cpp
@@ -240,6 +240,21 @@ class MyPincodeService : public PasscodeService
 };
 MyPincodeService gMyPincodeService;
 
+class MyAppInstallationService : public AppInstallationService
+{
+    bool LookupTargetContentApp(uint16_t vendorId, uint16_t productId) override
+    {
+        return ContentAppPlatform::GetInstance().LoadContentAppByClient(vendorId, productId) != nullptr;
+    }
+
+    void AddUninstalledContentApp(uint16_t vendorId, uint16_t productId) override
+    {
+        // TODO: Add Uninstall Content App For Android
+    }
+};
+
+MyAppInstallationService gMyAppInstallationService;
+
 class MyPostCommissioningListener : public PostCommissioningListener
 {
     void CommissioningCompleted(uint16_t vendorId, uint16_t productId, NodeId nodeId, Messaging::ExchangeManager & exchangeMgr,
@@ -372,6 +387,7 @@ void TvAppJNI::InitializeCommissioner(JNIMyUserPrompter * userPrompter)
     if (cdc != nullptr && userPrompter != nullptr)
     {
         cdc->SetPasscodeService(&gMyPincodeService);
+        cdc->SetAppInstallationService(&gMyAppInstallationService);
         cdc->SetUserPrompter(userPrompter);
         cdc->SetPostCommissioningListener(&gMyPostCommissioningListener);
     }

--- a/examples/tv-app/tv-common/include/AppTv.h
+++ b/examples/tv-app/tv-common/include/AppTv.h
@@ -149,6 +149,10 @@ public:
     void InstallContentApp(uint16_t vendorId, uint16_t productId);
     // Remove the app from the list of mContentApps
     bool UninstallContentApp(uint16_t vendorId, uint16_t productId);
+    // Add uninstalled content app to the list of mContentApps
+    void AddUninstalledContentApp(uint16_t vendorId, uint16_t productId);
+    // Print mContentApps and endpoints
+    void PrintInstalledApps();
 
 protected:
     std::vector<std::unique_ptr<ContentAppImpl>> mContentApps;

--- a/examples/tv-app/tv-common/shell/AppTvShellCommands.cpp
+++ b/examples/tv-app/tv-common/shell/AppTvShellCommands.cpp
@@ -205,6 +205,15 @@ static CHIP_ERROR PrintAllCommands()
     streamer_printf(sout,
                     "  add-admin-vendor <vid>         Add vendor ID to list which will receive admin privileges. Usage: app "
                     "add-admin-vendor 65521\r\n");
+    streamer_printf(sout,
+                    "  app list              List installed apps. Usage: app list");
+    streamer_printf(sout,
+                    "  app install <vid> <pid>        Install app with given vendor ID  and product ID. Usage: app install "
+                    "65521 32768\r\n");
+    streamer_printf(
+        sout,
+        "  app uninstall <vid> <pid>        Uinstall app at given vendor ID  and product ID. Usage: app uninstall "
+        "65521 32768\r\n");
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
     streamer_printf(sout, "  print-app-access     Print all ACLs for app platform fabric. Usage: app print-app-access\r\n");
@@ -240,6 +249,19 @@ static CHIP_ERROR AppPlatformHandler(int argc, char ** argv)
         factory->AddAdminVendorId(vid);
 
         ChipLogProgress(DeviceLayer, "added admin-vendor");
+
+        return CHIP_NO_ERROR;
+    }
+
+    else if (strcmp(argv[0], "list") == 0)
+    {
+        if (argc > 1)
+        {
+            return PrintAllCommands();
+        }
+
+        ContentAppFactoryImpl * factory = GetContentAppFactoryImpl();
+        factory->PrintInstalledApps();
 
         return CHIP_NO_ERROR;
     }

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -2988,6 +2988,10 @@ cluster ApplicationBasic = 1293 {
     kActiveVisibleFocus = 1;
     kActiveHidden = 2;
     kActiveVisibleNotFocus = 3;
+    kNotInstalled = 4;
+    kInstalling = 5;
+    kInstallationFailed = 6;
+    kInstalled = 7;
   }
 
   struct ApplicationStruct {

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -2450,6 +2450,10 @@ cluster ApplicationBasic = 1293 {
     kActiveVisibleFocus = 1;
     kActiveHidden = 2;
     kActiveVisibleNotFocus = 3;
+    kNotInstalled = 4;
+    kInstalling = 5;
+    kInstallationFailed = 6;
+    kInstalled = 7;
   }
 
   struct ApplicationStruct {

--- a/src/app/clusters/application-basic-server/application-basic-delegate.h
+++ b/src/app/clusters/application-basic-server/application-basic-delegate.h
@@ -91,7 +91,7 @@ public:
 
 protected:
     CatalogVendorApp mCatalogVendorApp;
-    ApplicationStatusEnum mApplicationStatus = ApplicationStatusEnum::kStopped;
+    ApplicationStatusEnum mApplicationStatus = ApplicationStatusEnum::kNotInstalled;
 };
 
 } // namespace ApplicationBasic

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -225,6 +225,7 @@ CHIP_ERROR ApplicationBasicAttrAccess::ReadApplicationAttribute(app::AttributeVa
 
 CHIP_ERROR ApplicationBasicAttrAccess::ReadStatusAttribute(app::AttributeValueEncoder & aEncoder, Delegate * delegate)
 {
+    ChipLogProgress(DeviceLayer, "Here 1");
     ApplicationStatusEnum status = delegate->HandleGetStatus();
     return aEncoder.Encode(status);
 }

--- a/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
@@ -51,5 +51,9 @@ limitations under the License.
     <item name="ActiveVisibleFocus" value="0x01"/>
     <item name="ActiveHidden" value="0x02"/>
     <item name="ActiveVisibleNotFocus" value="0x03"/>
+    <item name="NotInstalled" value="0x04"/>
+    <item name="Installing" value="0x05"/>
+    <item name="InstallationFailed" value="0x06"/>
+    <item name="Installed" value="0x07"/>
   </enum>
 </configurator>

--- a/src/controller/CommissionerDiscoveryController.cpp
+++ b/src/controller/CommissionerDiscoveryController.cpp
@@ -230,21 +230,7 @@ void CommissionerDiscoveryController::InternalOk()
     {
         ChipLogDetail(AppServer, "UX InternalOk: app not installed.");
 
-        // notify client that app will be installed
-        CommissionerDeclaration cd;
-        cd.SetErrorCode(CommissionerDeclaration::CdError::kAppInstallConsentPending);
-        mUdcServer->SendCDCMessage(cd, Transport::PeerAddress::UDP(client->GetPeerAddress().GetIPAddress(), client->GetCdPort()));
-
-        // dialog
-        ChipLogDetail(Controller, "------PROMPT USER: %s is requesting to install app on this TV. vendorId=%d, productId=%d",
-                      client->GetDeviceName(), client->GetVendorId(), client->GetProductId());
-
-        if (mUserPrompter != nullptr)
-        {
-            mUserPrompter->PromptForAppInstallOKPermission(client->GetVendorId(), client->GetProductId(), client->GetDeviceName());
-        }
-        ChipLogDetail(Controller, "------Via Shell Enter: app install <pid> <vid>");
-        return;
+        mAppInstallationService->AddUninstalledContentApp(client->GetVendorId(), client->GetProductId());
     }
 
     if (client->GetUDCClientProcessingState() != UDCClientProcessingState::kPromptingUser)

--- a/src/controller/CommissionerDiscoveryController.h
+++ b/src/controller/CommissionerDiscoveryController.h
@@ -150,21 +150,6 @@ public:
      */
     virtual void PromptCommissioningFailed(const char * commissioneeName, CHIP_ERROR error) = 0;
 
-    /**
-     * @brief
-     *   Called to prompt the user for consent to allow the app commissioneeName/vendorId/productId to be installed.
-     * For example "[commissioneeName] is requesting permission to install app to this TV, approve?"
-     *
-     * If user responds with OK then implementor should call CommissionerRespondOk();
-     * If user responds with Cancel then implementor should call CommissionerRespondCancel();
-     *
-     *  @param[in]    vendorId           The vendorId in the DNS-SD advertisement of the requesting commissionee.
-     *  @param[in]    productId          The productId in the DNS-SD advertisement of the requesting commissionee.
-     *  @param[in]    commissioneeName   The commissioneeName in the DNS-SD advertisement of the requesting commissionee.
-     *
-     */
-    virtual void PromptForAppInstallOKPermission(uint16_t vendorId, uint16_t productId, const char * commissioneeName) = 0;
-
     virtual ~UserPrompter() = default;
 };
 
@@ -227,13 +212,22 @@ public:
      *   Called to check if the given target app is available to the commissione with th given
      *   vendorId/productId
      *
-     * This will be called by the main chip thread so any blocking work should be moved to a separate thread.
-     *
      *  @param[in]    vendorId           The vendorId in the DNS-SD advertisement of the requesting commissionee.
      *  @param[in]    productId          The productId in the DNS-SD advertisement of the requesting commissionee.
      *
      */
     virtual bool LookupTargetContentApp(uint16_t vendorId, uint16_t productId) = 0;
+
+    /**
+     * @brief
+     *   Called to add uninstalled content app to the list of mContentApps
+     *   vendorId/productId
+     *
+     *  @param[in]    vendorId           The vendorId in the DNS-SD advertisement of the requesting commissionee.
+     *  @param[in]    productId          The productId in the DNS-SD advertisement of the requesting commissionee.
+     *
+     */
+    virtual void AddUninstalledContentApp(uint16_t vendorId, uint16_t productId) = 0;
 
     virtual ~AppInstallationService() = default;
 };

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -8633,6 +8633,10 @@ cluster ApplicationBasic = 1293 {
     kActiveVisibleFocus = 1;
     kActiveHidden = 2;
     kActiveVisibleNotFocus = 3;
+    kNotInstalled = 4;
+    kInstalling = 5;
+    kInstallationFailed = 6;
+    kInstalled = 7;
   }
 
   struct ApplicationStruct {

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -44246,11 +44246,15 @@ class ApplicationBasic(Cluster):
             kActiveVisibleFocus = 0x01
             kActiveHidden = 0x02
             kActiveVisibleNotFocus = 0x03
+            kNotInstalled = 0x04
+            kInstalling = 0x05
+            kInstallationFailed = 0x06
+            kInstalled = 0x07
             # All received enum values that are not listed above will be mapped
             # to kUnknownEnumValue. This is a helper enum value that should only
             # be used by code to process how it handles receiving and unknown
             # enum value. This specific should never be transmitted.
-            kUnknownEnumValue = 4,
+            kUnknownEnumValue = 8,
 
     class Structs:
         @dataclass

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -20194,6 +20194,10 @@ typedef NS_ENUM(uint8_t, MTRApplicationBasicApplicationStatus) {
     MTRApplicationBasicApplicationStatusActiveVisibleFocus MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x01,
     MTRApplicationBasicApplicationStatusActiveHidden MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x02,
     MTRApplicationBasicApplicationStatusActiveVisibleNotFocus MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x03,
+    MTRApplicationBasicApplicationStatusNotInstalled MTR_PROVISIONALLY_AVAILABLE = 0x04,
+    MTRApplicationBasicApplicationStatusInstalling MTR_PROVISIONALLY_AVAILABLE = 0x05,
+    MTRApplicationBasicApplicationStatusInstallationFailed MTR_PROVISIONALLY_AVAILABLE = 0x06,
+    MTRApplicationBasicApplicationStatusInstalled MTR_PROVISIONALLY_AVAILABLE = 0x07,
 } MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_OPTIONS(uint32_t, MTRContentControlFeature) {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
@@ -3088,6 +3088,10 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(ApplicationBasic::Appli
     case EnumType::kActiveVisibleFocus:
     case EnumType::kActiveHidden:
     case EnumType::kActiveVisibleNotFocus:
+    case EnumType::kNotInstalled:
+    case EnumType::kInstalling:
+    case EnumType::kInstallationFailed:
+    case EnumType::kInstalled:
         return val;
     default:
         return EnumType::kUnknownEnumValue;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -4794,11 +4794,15 @@ enum class ApplicationStatusEnum : uint8_t
     kActiveVisibleFocus    = 0x01,
     kActiveHidden          = 0x02,
     kActiveVisibleNotFocus = 0x03,
+    kNotInstalled          = 0x04,
+    kInstalling            = 0x05,
+    kInstallationFailed    = 0x06,
+    kInstalled             = 0x07,
     // All received enum values that are not listed above will be mapped
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 4,
+    kUnknownEnumValue = 8,
 };
 } // namespace ApplicationBasic
 


### PR DESCRIPTION
Re-Implementing application installation flow

#### Problem
Current application installation flow blocks commissioning and has too crude functionality that cannot provide great UX (providing installation percentage etc.)

#### Change overview
- Updated pre-commissioning part of app install flow and removed blocking of commissioning if app is not installed
- Add app when it is not installed
- Extend application basic cluster with: installed, not installed, installation failed and installation completed

#### Tests
1. Build the TV app using command:
`scripts/examples/gn_build_example.sh examples/tv-app/linux out/debug/`

2. Build the TV casting app using command:
`scripts/examples/gn_build_example.sh examples/tv-casting-app/linux out/debug/`

3. Start TV App
`out/debug/chip-tv-app`

4. Start TV Casting App
`out/debug/chip-tv-casting-app`

5. On TV App: Uninstall the app 
`app uninstall 65521 32769`

6. On TV Casting App: Send casting request to the tv-app using 
`cast request 0`

7. On TV App: Accepted the Cast request from the tv-casting app
`controller ux ok`

8. On TV casting app: Send Application Basic command
`cast cluster applicationbasic read status 0 4`

_Note that you'll see the response `Status: 4` which stands for `kNotInstalled`_

---------- **TBA** --------
9. On TV app: Run App install command
`app install 65521 32769`

_This should update the app status to `kInstalled`_