### PR TITLE
Update App Install Flow & Attribute Retrieval Status Errors

### DIFF
--- a/examples/tv-app/android/java/AppPlatform-JNI.cpp
+++ b/examples/tv-app/android/java/AppPlatform-JNI.cpp
@@ -128,7 +128,7 @@ std::vector<ContentApp::SupportedCluster> convert_to_cpp(JNIEnv * env, jobject s
     // Find Java classes. WARNING: Reflection
     jclass collectionClass = env->FindClass("java/util/Collection");
     jclass iteratorClass   = env->FindClass("java/util/Iterator");
-    jclass clusterClass    = env->FindClass("com/matter/tv/server/tvapp/SupportedCluster");
+    jclass clusterClass    = env->FindClass("com/matter/tv/server/tvapp/ContentAppSupportedCluster");
     if (collectionClass == nullptr || iteratorClass == nullptr || clusterClass == nullptr)
     {
         return {};

--- a/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
+++ b/examples/tv-app/android/java/MyUserPrompter-JNI.cpp
@@ -228,15 +228,6 @@ bool JNIMyUserPrompter::DisplaysPasscodeAndQRCode()
 }
 
 /**
- *  Called to prompt the user for consent to allow the app commissioneeName/vendorId/productId to be installed.
- * For example "[commissioneeName] is requesting permission to install app to this TV, approve?"
- */
-void JNIMyUserPrompter::PromptForAppInstallOKPermission(uint16_t vendorId, uint16_t productId, const char * commissioneeName)
-{
-    ChipLogError(Zcl, "JNIMyUserPrompter::PromptForAppInstallOKPermission Needs Implementation");
-}
-
-/**
  *   Called to display the given setup passcode to the user,
  * for commissioning the given commissioneeName with the given vendorId and productId,
  * and provide instructions for where to enter it in the commissionee (when pairingHint and pairingInstruction are provided).

--- a/examples/tv-app/android/java/MyUserPrompter-JNI.h
+++ b/examples/tv-app/android/java/MyUserPrompter-JNI.h
@@ -29,7 +29,6 @@ public:
     void PromptForCommissionOKPermission(uint16_t vendorId, uint16_t productId, const char * commissioneeName) override;
     void PromptForCommissionPasscode(uint16_t vendorId, uint16_t productId, const char * commissioneeName, uint16_t pairingHint,
                                      const char * pairingInstruction) override;
-    void PromptForAppInstallOKPermission(uint16_t vendorId, uint16_t productId, const char * commissioneeName) override;
     void HidePromptsOnCancel(uint16_t vendorId, uint16_t productId, const char * commissioneeName) override;
     bool DisplaysPasscodeAndQRCode() override;
     void PromptWithCommissionerPasscode(uint16_t vendorId, uint16_t productId, const char * commissioneeName, uint32_t passcode,

--- a/examples/tv-app/android/java/TVApp-JNI.cpp
+++ b/examples/tv-app/android/java/TVApp-JNI.cpp
@@ -240,6 +240,16 @@ class MyPincodeService : public PasscodeService
 };
 MyPincodeService gMyPincodeService;
 
+class MyAppInstallationService : public AppInstallationService
+{
+    bool LookupTargetContentApp(uint16_t vendorId, uint16_t productId) override
+    {
+        return ContentAppPlatform::GetInstance().LoadContentAppByClient(vendorId, productId) != nullptr;
+    }
+};
+
+MyAppInstallationService gMyAppInstallationService;
+
 class MyPostCommissioningListener : public PostCommissioningListener
 {
     void CommissioningCompleted(uint16_t vendorId, uint16_t productId, NodeId nodeId, Messaging::ExchangeManager & exchangeMgr,
@@ -372,6 +382,7 @@ void TvAppJNI::InitializeCommissioner(JNIMyUserPrompter * userPrompter)
     if (cdc != nullptr && userPrompter != nullptr)
     {
         cdc->SetPasscodeService(&gMyPincodeService);
+        cdc->SetAppInstallationService(&gMyAppInstallationService);
         cdc->SetUserPrompter(userPrompter);
         cdc->SetPostCommissioningListener(&gMyPostCommissioningListener);
     }

--- a/examples/tv-app/tv-common/include/AppTv.h
+++ b/examples/tv-app/tv-common/include/AppTv.h
@@ -149,6 +149,8 @@ public:
     void InstallContentApp(uint16_t vendorId, uint16_t productId);
     // Remove the app from the list of mContentApps
     bool UninstallContentApp(uint16_t vendorId, uint16_t productId);
+    // Print mContentApps and endpoints
+    void PrintInstalledApps();
 
 protected:
     std::vector<std::unique_ptr<ContentAppImpl>> mContentApps;

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -577,32 +577,32 @@ void ContentAppFactoryImpl::InstallContentApp(uint16_t vendorId, uint16_t produc
     ChipLogProgress(DeviceLayer, "ContentAppFactoryImpl: InstallContentApp vendorId=%d productId=%d ", vendorId, productId);
     if (vendorId == 1 && productId == 11)
     {
-        auto ptr = std::make_unique<ContentAppImpl>("Vendor1", vendorId, "exampleid", productId, "Version1",
-                                                                   "34567890", make_default_supported_clusters());
+        auto ptr = std::make_unique<ContentAppImpl>("Vendor1", vendorId, "exampleid", productId, "Version1", "34567890",
+                                                    make_default_supported_clusters());
         mContentApps.emplace_back(std::move(ptr));
     }
     else if (vendorId == 65521 && productId == 32769)
     {
-        auto ptr = std::make_unique<ContentAppImpl>("Vendor2", vendorId, "exampleString", productId, "Version2",
-                                                                   "20202021", make_default_supported_clusters());
+        auto ptr = std::make_unique<ContentAppImpl>("Vendor2", vendorId, "exampleString", productId, "Version2", "20202021",
+                                                    make_default_supported_clusters());
         mContentApps.emplace_back(std::move(ptr));
     }
     else if (vendorId == 9050 && productId == 22)
     {
         auto ptr = std::make_unique<ContentAppImpl>("Vendor3", vendorId, "App3", productId, "Version3", "20202021",
-                                                                   make_default_supported_clusters());
+                                                    make_default_supported_clusters());
         mContentApps.emplace_back(std::move(ptr));
     }
     else if (vendorId == 1111 && productId == 22)
     {
-        auto ptr = std::make_unique<ContentAppImpl>("TestSuiteVendor", vendorId, "applicationId", productId, "v2",
-                                                                   "20202021", make_default_supported_clusters());
+        auto ptr = std::make_unique<ContentAppImpl>("TestSuiteVendor", vendorId, "applicationId", productId, "v2", "20202021",
+                                                    make_default_supported_clusters());
         mContentApps.emplace_back(std::move(ptr));
     }
     else
     {
-        auto ptr = std::make_unique<ContentAppImpl>("NewAppVendor", vendorId, "newAppApplicationId", productId, "v2",
-                                                                   "20202021", make_default_supported_clusters());
+        auto ptr = std::make_unique<ContentAppImpl>("NewAppVendor", vendorId, "newAppApplicationId", productId, "v2", "20202021",
+                                                    make_default_supported_clusters());
         mContentApps.emplace_back(std::move(ptr));
     }
 }
@@ -641,7 +641,8 @@ void ContentAppFactoryImpl::PrintInstalledApps()
     {
         auto app = contentApp.get();
 
-        ChipLogProgress(DeviceLayer, "Content app vid=%d pid=%d is on ep=%d", app->GetApplicationBasicDelegate()->HandleGetVendorId(),
+        ChipLogProgress(DeviceLayer, "Content app vid=%d pid=%d is on ep=%d",
+                        app->GetApplicationBasicDelegate()->HandleGetVendorId(),
                         app->GetApplicationBasicDelegate()->HandleGetProductId(), app->GetEndpointId());
     }
 }

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -98,12 +98,6 @@ class MyUserPrompter : public UserPrompter
 
     // tv should override this with a dialog prompt
     inline void PromptCommissioningFailed(const char * commissioneeName, CHIP_ERROR error) override { return; }
-
-    // tv should override this with a dialog prompt
-    inline void PromptForAppInstallOKPermission(uint16_t vendorId, uint16_t productId, const char * commissioneeName) override
-    {
-        return;
-    }
 };
 
 MyUserPrompter gMyUserPrompter;
@@ -583,28 +577,33 @@ void ContentAppFactoryImpl::InstallContentApp(uint16_t vendorId, uint16_t produc
     ChipLogProgress(DeviceLayer, "ContentAppFactoryImpl: InstallContentApp vendorId=%d productId=%d ", vendorId, productId);
     if (vendorId == 1 && productId == 11)
     {
-        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("Vendor1", vendorId, "exampleid", productId, "Version1",
-                                                                   "34567890", make_default_supported_clusters()));
+        auto ptr = std::make_unique<ContentAppImpl>("Vendor1", vendorId, "exampleid", productId, "Version1",
+                                                                   "34567890", make_default_supported_clusters());
+        mContentApps.emplace_back(std::move(ptr));
     }
-    else if (vendorId == 65521 && productId == 32768)
+    else if (vendorId == 65521 && productId == 32769)
     {
-        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("Vendor2", vendorId, "exampleString", productId, "Version2",
-                                                                   "20202021", make_default_supported_clusters()));
+        auto ptr = std::make_unique<ContentAppImpl>("Vendor2", vendorId, "exampleString", productId, "Version2",
+                                                                   "20202021", make_default_supported_clusters());
+        mContentApps.emplace_back(std::move(ptr));
     }
     else if (vendorId == 9050 && productId == 22)
-    {
-        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("Vendor3", vendorId, "App3", productId, "Version3", "20202021",
-                                                                   make_default_supported_clusters()));
+    {   
+        auto ptr = std::make_unique<ContentAppImpl>("Vendor3", vendorId, "App3", productId, "Version3", "20202021",
+                                                                   make_default_supported_clusters());
+        mContentApps.emplace_back(std::move(ptr));
     }
     else if (vendorId == 1111 && productId == 22)
     {
-        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("TestSuiteVendor", vendorId, "applicationId", productId, "v2",
-                                                                   "20202021", make_default_supported_clusters()));
+        auto ptr = std::make_unique<ContentAppImpl>("TestSuiteVendor", vendorId, "applicationId", productId, "v2",
+                                                                   "20202021", make_default_supported_clusters());
+        mContentApps.emplace_back(std::move(ptr));
     }
     else
     {
-        mContentApps.emplace_back(std::make_unique<ContentAppImpl>("NewAppVendor", vendorId, "newAppApplicationId", productId, "v2",
-                                                                   "20202021", make_default_supported_clusters()));
+        auto ptr = std::make_unique<ContentAppImpl>("NewAppVendor", vendorId, "newAppApplicationId", productId, "v2",
+                                                                   "20202021", make_default_supported_clusters());
+        mContentApps.emplace_back(std::move(ptr));
     }
 }
 
@@ -627,12 +626,24 @@ bool ContentAppFactoryImpl::UninstallContentApp(uint16_t vendorId, uint16_t prod
                             app->GetApplicationBasicDelegate()->HandleGetVendorId(),
                             app->GetApplicationBasicDelegate()->HandleGetProductId());
             mContentApps.erase(mContentApps.begin() + index);
+            // TODO: call ContentAppPlatform->RemoveContentApp(ids...)
             return true;
         }
 
         index++;
     }
     return false;
+}
+
+void ContentAppFactoryImpl::PrintInstalledApps()
+{
+    for (auto & contentApp : mContentApps)
+    {
+        auto app = contentApp.get();
+
+        ChipLogProgress(DeviceLayer, "Content app vid=%d pid=%d is on ep=%d", app->GetApplicationBasicDelegate()->HandleGetVendorId(),
+                        app->GetApplicationBasicDelegate()->HandleGetProductId(), app->GetEndpointId());
+    }
 }
 
 Access::Privilege ContentAppFactoryImpl::GetVendorPrivilege(uint16_t vendorId)
@@ -689,12 +700,22 @@ std::list<ClusterId> ContentAppFactoryImpl::GetAllowedClusterListForStaticEndpoi
 CHIP_ERROR AppTvInit()
 {
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+    // test data for apps
+    constexpr uint16_t kApp1VendorId  = 1;
+    constexpr uint16_t kApp1ProductId = 11;
+    constexpr uint16_t kApp2VendorId  = 65521;
+    constexpr uint16_t kApp2ProductId = 32769;
+    constexpr uint16_t kApp3VendorId  = 9050;
+    constexpr uint16_t kApp3ProductId = 22;
+    constexpr uint16_t kApp4VendorId  = 1111;
+    constexpr uint16_t kApp4ProductId = 22;
+
     ContentAppPlatform::GetInstance().SetupAppPlatform();
     ContentAppPlatform::GetInstance().SetContentAppFactory(&gFactory);
-    gFactory.InstallContentApp((uint16_t) 1, (uint16_t) 11);
-    gFactory.InstallContentApp((uint16_t) 65521, (uint16_t) 32768);
-    gFactory.InstallContentApp((uint16_t) 9050, (uint16_t) 22);
-    gFactory.InstallContentApp((uint16_t) 1111, (uint16_t) 22);
+    gFactory.InstallContentApp(kApp1VendorId, kApp1ProductId);
+    gFactory.InstallContentApp(kApp2VendorId, kApp2ProductId);
+    gFactory.InstallContentApp(kApp3VendorId, kApp3ProductId);
+    gFactory.InstallContentApp(kApp4VendorId, kApp4ProductId);
     uint16_t value;
     if (DeviceLayer::GetDeviceInstanceInfoProvider()->GetVendorId(value) != CHIP_NO_ERROR)
     {

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -588,7 +588,7 @@ void ContentAppFactoryImpl::InstallContentApp(uint16_t vendorId, uint16_t produc
         mContentApps.emplace_back(std::move(ptr));
     }
     else if (vendorId == 9050 && productId == 22)
-    {   
+    {
         auto ptr = std::make_unique<ContentAppImpl>("Vendor3", vendorId, "App3", productId, "Version3", "20202021",
                                                                    make_default_supported_clusters());
         mContentApps.emplace_back(std::move(ptr));

--- a/src/controller/CommissionerDiscoveryController.cpp
+++ b/src/controller/CommissionerDiscoveryController.cpp
@@ -230,21 +230,7 @@ void CommissionerDiscoveryController::InternalOk()
     {
         ChipLogDetail(AppServer, "UX InternalOk: app not installed.");
 
-        // notify client that app will be installed
-        CommissionerDeclaration cd;
-        cd.SetErrorCode(CommissionerDeclaration::CdError::kAppInstallConsentPending);
-        mUdcServer->SendCDCMessage(cd, Transport::PeerAddress::UDP(client->GetPeerAddress().GetIPAddress(), client->GetCdPort()));
-
-        // dialog
-        ChipLogDetail(Controller, "------PROMPT USER: %s is requesting to install app on this TV. vendorId=%d, productId=%d",
-                      client->GetDeviceName(), client->GetVendorId(), client->GetProductId());
-
-        if (mUserPrompter != nullptr)
-        {
-            mUserPrompter->PromptForAppInstallOKPermission(client->GetVendorId(), client->GetProductId(), client->GetDeviceName());
-        }
-        ChipLogDetail(Controller, "------Via Shell Enter: app install <pid> <vid>");
-        return;
+        // TODO: Prepare app to be installed or add it to the mContentApps
     }
 
     if (client->GetUDCClientProcessingState() != UDCClientProcessingState::kPromptingUser)

--- a/src/controller/CommissionerDiscoveryController.h
+++ b/src/controller/CommissionerDiscoveryController.h
@@ -150,21 +150,6 @@ public:
      */
     virtual void PromptCommissioningFailed(const char * commissioneeName, CHIP_ERROR error) = 0;
 
-    /**
-     * @brief
-     *   Called to prompt the user for consent to allow the app commissioneeName/vendorId/productId to be installed.
-     * For example "[commissioneeName] is requesting permission to install app to this TV, approve?"
-     *
-     * If user responds with OK then implementor should call CommissionerRespondOk();
-     * If user responds with Cancel then implementor should call CommissionerRespondCancel();
-     *
-     *  @param[in]    vendorId           The vendorId in the DNS-SD advertisement of the requesting commissionee.
-     *  @param[in]    productId          The productId in the DNS-SD advertisement of the requesting commissionee.
-     *  @param[in]    commissioneeName   The commissioneeName in the DNS-SD advertisement of the requesting commissionee.
-     *
-     */
-    virtual void PromptForAppInstallOKPermission(uint16_t vendorId, uint16_t productId, const char * commissioneeName) = 0;
-
     virtual ~UserPrompter() = default;
 };
 
@@ -226,8 +211,6 @@ public:
      * @brief
      *   Called to check if the given target app is available to the commissione with th given
      *   vendorId/productId
-     *
-     * This will be called by the main chip thread so any blocking work should be moved to a separate thread.
      *
      *  @param[in]    vendorId           The vendorId in the DNS-SD advertisement of the requesting commissionee.
      *  @param[in]    productId          The productId in the DNS-SD advertisement of the requesting commissionee.


### PR DESCRIPTION
Resolving issues from [33445](https://github.com/project-chip/connectedhomeip/pull/33445) and from [33827](https://github.com/project-chip/connectedhomeip/pull/33827)

#### Problem
1. Reporting supported clusters has a reflection error
2. App Installation Service is not added for android and that blocks the commissioning flow

#### Change overview
- Resolved reflection error
- Added and update app installation service for both linux and android

#### Tests 1
1. Build the TV app using command:
`scripts/examples/gn_build_example.sh examples/tv-app/linux out/debug/`

3. Build the TV casting app using command:
`scripts/examples/gn_build_example.sh examples/tv-casting-app/linux out/debug/`

4. Start TV App
`out/debug/chip-tv-app`

5. Start TV Casting App
`out/debug/chip-tv-casting-app`

6. On TV App: Uninstall the app 
`app uninstall 65521 32769`

7. On TV Casting App: Send casting request to the tv-app using 
`cast request 0`

8. On TV App: Accepted the Cast request from the tv-casting app
`controller ux ok`

9. On TV App: Enter the PIN code (passcode)
`controller ux ok 20202021`

#### Tests 2
1. Build and installed TV Android Platform app
`scripts/examples/gn_android_example.sh examples/tv-app/android out/android-arm-chip-tvserver`

2. Build the TV casting app using command:
`scripts/examples/gn_build_example.sh examples/tv-casting-app/linux out/debug/`

3. Build and installed TV Android Content app
4. Run TV Platform App and saw that correct supported cluster list was reported.