### PR TITLE
Use BoringSSL for python controller build

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -184,7 +184,7 @@ export SYSTEM_VERSION_COMPAT=0
 # Make all possible human redable tracing available.
 tracing_options="matter_log_json_payload_hex=true matter_log_json_payload_decode_full=true matter_enable_tracing_support=true"
 
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="$tracing_options chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg chip_config_network_layer_ble=$enable_ble chip_enable_ble=$enable_ble"
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="$tracing_options chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg chip_config_network_layer_ble=$enable_ble chip_enable_ble=$enable_ble chip_crypto=\"boringssl\""
 
 function ninja_target() {
     # Print the ninja target required to build a gn label.


### PR DESCRIPTION
Problem:
- OpenSSL can vary per build machine, causing non-hermetic builds

This PR:
- Selects boringssl (built from tree) as default CHIP crypto backend for Python controller

Testing done:
- All Python unit tests and integration tests still pass
