### PR TITLE
network-manager-app: Add support for OpenThread BR integration on OpenWrt

### DIFF
--- a/examples/network-manager-app/linux/BUILD.gn
+++ b/examples/network-manager-app/linux/BUILD.gn
@@ -15,11 +15,15 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
+declare_args() {
+  # Enable OpenWrt ubus integration
+  matter_enable_ubus = false
+}
+
 executable("matter-network-manager-app") {
   sources = [
     "include/CHIPProjectAppConfig.h",
     "main.cpp",
-    "tbrm.cpp",
   ]
 
   deps = [
@@ -28,7 +32,30 @@ executable("matter-network-manager-app") {
     "${chip_root}/src/lib",
   ]
 
+  libs = []
+  defines = []
   include_dirs = [ "include" ]
+
+  if (matter_enable_ubus) {
+    defines += [ "MATTER_ENABLE_UBUS=1" ]
+    sources += [
+      "ThreadBROpenThreadUbus.cpp",
+      "ThreadBROpenThreadUbus.h",
+      "UboxUtils.cpp",
+      "UboxUtils.h",
+      "UbusManager.cpp",
+      "UbusManager.h",
+      "UloopHandler.cpp",
+      "UloopHandler.h",
+    ]
+    libs += [
+      "ubox",
+      "ubus",
+    ]
+  } else {
+    sources += [ "ThreadBRFake.h" ]
+  }
+
   output_dir = root_out_dir
 }
 

--- a/examples/network-manager-app/linux/ThreadBRFake.h
+++ b/examples/network-manager-app/linux/ThreadBRFake.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2024 Project CHIP Authors
+ *    Copyright (c) 2024-2025 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,23 +15,16 @@
  *    limitations under the License.
  */
 
-#include <app/clusters/thread-border-router-management-server/thread-border-router-management-server.h>
-#include <app/server/Server.h>
-#include <lib/core/CHIPEncoding.h>
+#include <app/clusters/thread-border-router-management-server/thread-br-delegate.h>
+#include <clusters/ThreadBorderRouterManagement/Attributes.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
 #include <lib/support/ThreadOperationalDataset.h>
 #include <platform/CHIPDeviceLayer.h>
 
-#include <optional>
+namespace chip {
 
-using namespace chip;
-using namespace chip::literals;
-using namespace chip::app;
-using namespace chip::app::Clusters;
-
-namespace {
-class FakeBorderRouterDelegate final : public ThreadBorderRouterManagement::Delegate
+class FakeBorderRouterDelegate final : public app::Clusters::ThreadBorderRouterManagement::Delegate
 {
     CHIP_ERROR Init(AttributeChangeCallback * attributeChangeCallback) override
     {
@@ -126,9 +119,9 @@ private:
         self->mPendingDataset.Clear();
         // This could just call MatterReportingAttributeChangeCallback directly
         self->mAttributeChangeCallback->ReportAttributeChanged(
-            ThreadBorderRouterManagement::Attributes::ActiveDatasetTimestamp::Id);
+            app::Clusters::ThreadBorderRouterManagement::Attributes::ActiveDatasetTimestamp::Id);
         self->mAttributeChangeCallback->ReportAttributeChanged(
-            ThreadBorderRouterManagement::Attributes::PendingDatasetTimestamp::Id);
+            app::Clusters::ThreadBorderRouterManagement::Attributes::PendingDatasetTimestamp::Id);
     }
 
     AttributeChangeCallback * mAttributeChangeCallback;
@@ -139,13 +132,4 @@ private:
     uint32_t mActivateDatasetSequence;
 };
 
-FakeBorderRouterDelegate gBorderRouterDelegate{};
-} // namespace
-
-std::optional<ThreadBorderRouterManagement::ServerInstance> gThreadBorderRouterManagementServer;
-void emberAfThreadBorderRouterManagementClusterInitCallback(EndpointId endpoint)
-{
-    VerifyOrDie(!gThreadBorderRouterManagementServer);
-    gThreadBorderRouterManagementServer.emplace(endpoint, &gBorderRouterDelegate, Server::GetInstance().GetFailSafeContext())
-        .Init();
-}
+} // namespace chip

--- a/examples/network-manager-app/linux/ThreadBROpenThreadUbus.cpp
+++ b/examples/network-manager-app/linux/ThreadBROpenThreadUbus.cpp
@@ -1,0 +1,160 @@
+/*
+ *    Copyright (c) 2024-2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "ThreadBROpenThreadUbus.h"
+
+#include "UboxUtils.h"
+
+#include <clusters/ThreadBorderRouterManagement/Attributes.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
+#include <lib/support/ThreadOperationalDataset.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#include <libubus.h>
+#include <optional>
+
+using namespace chip::ubus;
+using namespace chip::app::Clusters::ThreadBorderRouterManagement::Attributes;
+
+namespace chip {
+
+static constexpr int kInvokeTimeout = 2000;
+
+CHIP_ERROR OpenThreadUbusBorderRouterDelegate::Init(AttributeChangeCallback * attributeChangeCallback)
+{
+    mAttributeChangeCallback = attributeChangeCallback;
+
+    mOtbr.SetResolvedCallback([](UbusWatch & watch, void * appState) {
+        auto * self = static_cast<decltype(this)>(appState);
+        ubus_invoke(&self->mUbusManager.Context(), watch.ObjectID(), "status", nullptr,
+                    ([](ubus_request * req, int type, blob_attr * msg) {
+                        static_cast<decltype(this)>(req->priv)->OnDataReceived(msg, false);
+                    }),
+                    self, kInvokeTimeout);
+    });
+    mOtbr.SetNotificationCallback([](UbusWatch & watch, void * appState, ubus_request_data * req, const char * notification,
+                                     blob_attr * msg) { static_cast<decltype(this)>(appState)->OnDataReceived(msg, true); });
+    mUbusManager.Register(mOtbr);
+
+    return CHIP_NO_ERROR;
+}
+
+void OpenThreadUbusBorderRouterDelegate::GetBorderRouterName(MutableCharSpan & borderRouterName)
+{
+    CopyCharSpanToMutableCharSpan("OpenThread BorderRouter"_span, borderRouterName);
+}
+
+CHIP_ERROR OpenThreadUbusBorderRouterDelegate::GetBorderAgentId(MutableByteSpan & borderAgentId)
+{
+    return CopySpanToMutableSpan(mBorderAgentIDValid ? ByteSpan(mBorderAgentID) : ByteSpan(), borderAgentId);
+}
+
+uint16_t OpenThreadUbusBorderRouterDelegate::GetThreadVersion()
+{
+    return /* Thread 1.4.0 */ 5;
+}
+
+bool OpenThreadUbusBorderRouterDelegate::GetInterfaceEnabled()
+{
+    return !mActiveDataset.IsEmpty();
+}
+
+CHIP_ERROR OpenThreadUbusBorderRouterDelegate::GetDataset(Thread::OperationalDataset & dataset, DatasetType type)
+{
+    VerifyOrReturnError(type == DatasetType::kActive, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!mActiveDataset.IsEmpty(), CHIP_ERROR_NOT_FOUND);
+    dataset = mActiveDataset;
+    return CHIP_NO_ERROR;
+}
+
+using ErrorField = BlobMsgField<uint16_t, CHIP_CTST("Error")>;
+
+void OpenThreadUbusBorderRouterDelegate::SetActiveDataset(const Thread::OperationalDataset & activeDataset, uint32_t sequenceNum,
+                                                          ActivateDatasetCallback * callback)
+{
+    CHIP_ERROR err = CHIP_ERROR_INTERNAL;
+    VerifyOrExit(activeDataset.IsCommissioned(), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(mActiveDataset.IsEmpty(), err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mActivateDatasetCallback == nullptr, err = CHIP_ERROR_BUSY);
+    VerifyOrExit(mOtbr.Resolved() && mBorderAgentIDValid, err = CHIP_ERROR_NOT_CONNECTED);
+
+    {
+        BlobMsgBuf buf;
+        buf.Add("dataset", activeDataset.AsByteSpan());
+        ChipLogDetail(AppServer, "SetActiveDataset invoking on %d", mOtbr.ObjectID());
+        VerifyOrExit(!ubus_invoke(&mUbusManager.Context(), mOtbr.ObjectID(), "provision", buf.head,
+                                  ([](ubus_request * req, int type, blob_attr * msg) {
+                                      ErrorField otError;
+                                      VerifyOrReturn(BlobMsgParse(msg, otError) && otError.value_or(0) == 0);
+                                      *static_cast<decltype(err) *>(req->priv) = CHIP_NO_ERROR;
+                                  }),
+                                  &err, kInvokeTimeout),
+                     err = CHIP_ERROR_INTERNAL);
+    }
+
+    mActiveDataset           = activeDataset;
+    mActivateDatasetCallback = callback;
+    mActivateDatasetSequence = sequenceNum;
+    return;
+
+exit:
+    callback->OnActivateDatasetComplete(sequenceNum, err);
+}
+
+void OpenThreadUbusBorderRouterDelegate::OnDataReceived(blob_attr * msg, bool notification)
+{
+    BlobMsgField<ByteSpan, CHIP_CTST("BorderAgentId")> borderAgentID;
+    BlobMsgField<ByteSpan, CHIP_CTST("ActiveDataset")> activeDataset;
+    BlobMsgField<bool, CHIP_CTST("Attached")> attached;
+    BlobMsgParse(msg, borderAgentID, attached, activeDataset);
+
+    if (!mBorderAgentIDValid && borderAgentID.has_value() && borderAgentID->size() == sizeof(mBorderAgentID))
+    {
+        ChipLogProgress(AppServer, "Received OTBR BorderAgentId");
+        memcpy(mBorderAgentID, borderAgentID->data(), sizeof(mBorderAgentID));
+        mBorderAgentIDValid = true;
+    }
+
+    if (activeDataset.has_value())
+    {
+        Thread::OperationalDatasetView dataset;
+        if (dataset.Init(activeDataset.value()) == CHIP_NO_ERROR)
+        {
+            ChipLogProgress(AppServer, "Received OTBR ActiveDataset (size = %lu)",
+                            static_cast<unsigned long>(activeDataset->size()));
+            mActiveDataset = dataset;
+            if (notification)
+            {
+                mAttributeChangeCallback->ReportAttributeChanged(ActiveDatasetTimestamp::Id);
+            }
+        }
+    }
+
+    if (attached.has_value())
+    {
+        ChipLogProgress(AppServer, "Received OTBR Attached = %d", attached.value());
+        if (attached.value() && mActivateDatasetCallback)
+        {
+            auto * callback          = mActivateDatasetCallback;
+            mActivateDatasetCallback = nullptr;
+            callback->OnActivateDatasetComplete(mActivateDatasetSequence, CHIP_NO_ERROR);
+        }
+    }
+}
+
+} // namespace chip

--- a/examples/network-manager-app/linux/ThreadBROpenThreadUbus.h
+++ b/examples/network-manager-app/linux/ThreadBROpenThreadUbus.h
@@ -1,0 +1,63 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "UbusManager.h"
+#include <app/clusters/thread-border-router-management-server/thread-br-delegate.h>
+
+struct blob_attr;
+
+namespace chip {
+
+class OpenThreadUbusBorderRouterDelegate final : public app::Clusters::ThreadBorderRouterManagement::Delegate
+{
+public:
+    OpenThreadUbusBorderRouterDelegate(ubus::UbusManager & ubusManager) : mUbusManager(ubusManager) {}
+
+    CHIP_ERROR Init(AttributeChangeCallback * attributeChangeCallback) override;
+
+    void GetBorderRouterName(MutableCharSpan & borderRouterName) override;
+    CHIP_ERROR GetBorderAgentId(MutableByteSpan & borderAgentId) override;
+    uint16_t GetThreadVersion() override;
+    bool GetInterfaceEnabled() override;
+    CHIP_ERROR GetDataset(Thread::OperationalDataset & dataset, DatasetType type) override;
+    void SetActiveDataset(const Thread::OperationalDataset & activeDataset, uint32_t sequenceNum,
+                          ActivateDatasetCallback * callback) override;
+
+    bool GetPanChangeSupported() override { return false; }
+    CHIP_ERROR CommitActiveDataset() override { return CHIP_NO_ERROR; }
+    CHIP_ERROR RevertActiveDataset() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR SetPendingDataset(const chip::Thread::OperationalDataset &) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+private:
+    void OnDataReceived(blob_attr * msg, bool notification);
+
+    AttributeChangeCallback * mAttributeChangeCallback;
+
+    ubus::UbusManager & mUbusManager;
+    ubus::UbusWatch mOtbr{ "otbr", this };
+
+    bool mBorderAgentIDValid = false;
+    uint8_t mBorderAgentID[app::Clusters::ThreadBorderRouterManagement::kBorderAgentIdLength];
+
+    Thread::OperationalDataset mActiveDataset;
+    ActivateDatasetCallback * mActivateDatasetCallback = nullptr;
+    uint32_t mActivateDatasetSequence;
+};
+
+} // namespace chip

--- a/examples/network-manager-app/linux/UboxUtils.cpp
+++ b/examples/network-manager-app/linux/UboxUtils.cpp
@@ -1,0 +1,60 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "UboxUtils.h"
+
+#include <lib/support/BytesToHex.h>
+#include <lib/support/CodeUtils.h>
+
+namespace chip {
+namespace ubus {
+
+namespace detail {
+int BlobMsgType<ByteSpan>::get(blob_attr * attr, ByteSpan & value)
+{
+    char * str     = blobmsg_get_string(attr);
+    size_t len     = strlen(str);
+    uint8_t * bin  = reinterpret_cast<uint8_t *>(str); // decode in-place
+    size_t decoded = Encoding::HexToBytes(str, len, bin, len);
+    VerifyOrReturnValue(len == 0 || decoded > 0, false);
+    value = ByteSpan(bin, decoded);
+    return 0;
+}
+
+int BlobMsgType<ByteSpan>::add(blob_buf * buf, const char * name, ByteSpan const & value)
+{
+    unsigned len = HEX_ENCODED_LENGTH(value.size()) + 1 /* for null termination */;
+    char * str   = static_cast<char *>(blobmsg_alloc_string_buffer(buf, name, len));
+    VerifyOrReturnValue(str != nullptr, -1);
+    SuccessOrDie(Encoding::BytesToLowercaseHexString(value.data(), value.size(), str, len));
+    blobmsg_add_string_buffer(buf);
+    return 0;
+}
+} // namespace detail
+
+bool BlobMsgBuf::AddFormat(const char * name, const char * format, ...)
+{
+    VerifyOrReturnValue(!HasError(), false);
+    va_list args;
+    va_start(args, format);
+    int status = blobmsg_vprintf(this, name, format, args);
+    va_end(args);
+    return Check(status);
+}
+
+} // namespace ubus
+} // namespace chip

--- a/examples/network-manager-app/linux/UboxUtils.h
+++ b/examples/network-manager-app/linux/UboxUtils.h
@@ -1,0 +1,271 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/support/CompileTimeString.h>
+#include <lib/support/EnforceFormat.h>
+#include <lib/support/Span.h>
+#include <lib/support/TypeTraits.h>
+
+#include <memory>
+#include <optional>
+
+extern "C" {
+#include <libubox/blobmsg.h>
+}
+
+namespace chip {
+namespace ubus {
+
+namespace detail {
+
+// Exposes type id and blobmsg_{get,add}_* functions for a type
+template <typename T>
+struct BlobMsgType
+{
+    static_assert(!TemplatedTrueType<T>(), "Type is not supported by blob_msg");
+    static constexpr enum blobmsg_type id = BLOBMSG_TYPE_UNSPEC;
+    static int get(blob_attr * attr, T & value) { return -1; }
+    static int add(blob_buf * buf, const char * name, T value) { return -1; }
+};
+
+// Specializations for types natively supported by blobmsg_get_* and blobmsg_add_*
+// clang-format off
+#define _CHIP_BLOBMSG_NATIVE_TYPE(_T, _id, _get, _add)                                                                             \
+    template <> struct BlobMsgType<_T>                                                                                             \
+    {                                                                                                                              \
+        static constexpr enum blobmsg_type id = _id;                                                                               \
+        static int get(blob_attr * attr, _T & value) { value = _get(attr); return 0; }                                             \
+        static int add(blob_buf * buf, const char * name, _T value) { return _add(buf, name, value); }                             \
+    }
+_CHIP_BLOBMSG_NATIVE_TYPE(const char *, BLOBMSG_TYPE_STRING, blobmsg_get_string, blobmsg_add_string);
+_CHIP_BLOBMSG_NATIVE_TYPE(bool,         BLOBMSG_TYPE_BOOL,   blobmsg_get_u8,     blobmsg_add_u8);
+_CHIP_BLOBMSG_NATIVE_TYPE(double,       BLOBMSG_TYPE_DOUBLE, blobmsg_get_double, blobmsg_add_double);
+_CHIP_BLOBMSG_NATIVE_TYPE(uint8_t,      BLOBMSG_TYPE_INT8,   blobmsg_get_u8,     blobmsg_add_u8);
+_CHIP_BLOBMSG_NATIVE_TYPE(int8_t,       BLOBMSG_TYPE_INT8,   blobmsg_get_u8,     blobmsg_add_u8);
+_CHIP_BLOBMSG_NATIVE_TYPE(uint16_t,     BLOBMSG_TYPE_INT16,  blobmsg_get_u16,    blobmsg_add_u16);
+_CHIP_BLOBMSG_NATIVE_TYPE(int16_t,      BLOBMSG_TYPE_INT16,  blobmsg_get_u16,    blobmsg_add_u16);
+_CHIP_BLOBMSG_NATIVE_TYPE(uint32_t,     BLOBMSG_TYPE_INT32,  blobmsg_get_u32,    blobmsg_add_u32);
+_CHIP_BLOBMSG_NATIVE_TYPE(int32_t,      BLOBMSG_TYPE_INT32,  blobmsg_get_u32,    blobmsg_add_u32);
+_CHIP_BLOBMSG_NATIVE_TYPE(uint64_t,     BLOBMSG_TYPE_INT64,  blobmsg_get_u64,    blobmsg_add_u64);
+_CHIP_BLOBMSG_NATIVE_TYPE(int64_t,      BLOBMSG_TYPE_INT64,  blobmsg_get_u64,    blobmsg_add_u64);
+#undef _CHIP_BLOBMSG_NATIVE_TYPE
+// clang-format on
+
+// Specialization for mapping ByteSpan to a hex-encoded BLOBMSG_TYPE_STRING
+// Note that decoding is performed in-place, i.e. is destructive.
+template <>
+struct BlobMsgType<ByteSpan>
+{
+    static constexpr enum blobmsg_type id = BLOBMSG_TYPE_STRING;
+    static int get(blob_attr * attr, ByteSpan & value);
+    static int add(blob_buf * buf, const char * name, ByteSpan const & value);
+};
+
+// Non-optional value wrapper - similar to std::optional but always contains a value
+template <typename T>
+struct NonOptional
+{
+    T & value() { return mValue; }
+    const T & value() const { return mValue; }
+
+    operator T &() { return mValue; }
+    operator const T &() const { return mValue; }
+
+    NonOptional & operator=(const T & val)
+    {
+        mValue = val;
+        return *this;
+    }
+
+    void reset() { mValue = T{}; }
+
+private:
+    T mValue{};
+};
+
+// Name-independent parts of BlobMsgField
+template <typename T, bool Required>
+struct BlobMsgFieldBase : public std::conditional_t<Required, NonOptional<T>, std::optional<T>>
+{
+    using Base = std::conditional_t<Required, NonOptional<T>, std::optional<T>>;
+    using Impl = BlobMsgType<T>;
+    using Base::Base;
+    using Base::operator=;
+
+    using ValueType = T;
+    static constexpr bool required() { return Required; }
+
+    bool Decode(blob_attr * attr)
+    {
+        if (!attr)
+        {
+            if constexpr (required())
+            {
+                return false;
+            }
+            else
+            {
+                this->reset();
+                return true;
+            }
+        }
+
+        T value;
+        VerifyOrReturnValue(Impl::get(attr, value) == 0, false);
+        Base::operator=(value);
+        return true;
+    }
+};
+
+} // namespace detail
+
+// A field that can be read from or written in blob_msg format.
+// The field type captures the field name as a compile-time string,
+// so a matching blobmsg_policy can be generated automatically.
+//
+// By default fields are optional, i.e. derive from use std::optional.
+// Passing Required=true (or using BlobMsgRequiredField) creates makes
+// the field non-optional. BlobMsgParse() will fail is any required
+// fields are missing.
+template <typename T, typename NameCTST, bool Required = false>
+struct BlobMsgField final : public detail::BlobMsgFieldBase<T, Required>
+{
+    using Base = detail::BlobMsgFieldBase<T, Required>;
+    using Base::Base;
+    using Base::operator=;
+    using typename Base::Impl;
+
+    static constexpr const char * name() { return NameCTST::c_str(); }
+    static constexpr blobmsg_policy policy() { return { .name = name(), .type = Impl::id }; }
+};
+
+// Alias for a required BlobMsgField
+template <typename T, typename NameCTST>
+using BlobMsgRequiredField = BlobMsgField<T, NameCTST, true>;
+
+// Parses the specified fields using blobmsg_parse() and returns true on success.
+// Fails (i.e. returns false) if blobmsg_parse() fails, any required field is not
+// present, or decoding of any field fails. Note that fields that are present with
+// the wrong type are ignored by blobmsg_parse() and not treated as an error.
+//
+// Note: This function accepts both plain and extended blob_attrs, i.e. works with
+// both message payloads and nested tables.
+template <typename... BlobMsgFields>
+bool BlobMsgParse(blob_attr * attr, BlobMsgFields &... fields)
+{
+    static constexpr blobmsg_policy policy[] = { BlobMsgFields::policy()... };
+    blob_attr * values[sizeof...(BlobMsgFields)];
+    VerifyOrReturnValue(!blobmsg_parse_attr(policy, sizeof...(BlobMsgFields), values, attr), false);
+    return [&]<size_t... Is>(std::index_sequence<Is...>) {
+        return (fields.Decode(values[Is]) && ...);
+    }(std::index_sequence_for<BlobMsgFields...>{});
+}
+
+// A RAII helper for automatically closing nested tables / arrays with BlobMsgBuf.
+class BlobMsgCookie
+{
+public:
+    BlobMsgCookie(blob_buf * buf, void * cookie) : mCookie(cookie, Deleter{ buf }) {}
+    /* implicit */ operator bool() const { return mCookie.get() != nullptr; }
+
+private:
+    struct Deleter
+    {
+        blob_buf * mBuf;
+        void operator()(void * cookie) { blob_nest_end(mBuf, cookie); }
+    };
+
+    std::unique_ptr<void, Deleter> mCookie;
+};
+
+// A thin wrapper around blob_buf with automatic resource management
+struct BlobMsgBuf final : public blob_buf
+{
+    BlobMsgBuf() : blob_buf{} { Clear(); }
+    ~BlobMsgBuf() { blob_buf_free(this); }
+
+    // Returns true if the buffer has encounter an allocation error.
+    // Once in an error state any subsequent add operations will have no effect.
+    // Individual operations return true on success.
+    bool HasError() const { return this->head == nullptr; }
+
+    // Clears the buffer and resets the error state.
+    bool Clear() { return Check(blob_buf_init(this, 0)); }
+
+    ///// Encoding methods with explicit field names
+
+    template <typename T>
+    bool Add(const char * name, T value)
+    {
+        return !HasError() && Check(detail::BlobMsgType<T>::add(this, name, value));
+    }
+
+    bool AddFormat(const char * name, const char * format, ...) ENFORCE_FORMAT(3, 4);
+    BlobMsgCookie AddArray(const char * name) { return AddNested(name, /* array = */ true); }
+    BlobMsgCookie AddTable(const char * name) { return AddNested(name, /* array = */ false); }
+
+    ///// Encoding methods based on BlobMsgField types or instances
+
+    // Adds a value, with the name given by a BlogMsgField type, which must be an explicit template argument.
+    // Example: buf.Add<ErrorField>(0);
+    template <typename BlobMsgField> // explicit
+    bool Add(typename BlobMsgField::ValueType value)
+    {
+        return Add(BlobMsgField::name(), value);
+    }
+
+    // Adds a BlogMsgField instance. If the field is optional and absent, nothing is encoded.
+    template <typename BlobMsgField, typename = typename BlobMsgField::ValueType>
+    bool Add(BlobMsgField const & field)
+    {
+        if constexpr (field.required())
+        {
+            return Add(field.name(), field.value());
+        }
+        else
+        {
+            return AddOptional(field.name(), field);
+        }
+    }
+
+private:
+    BlobMsgCookie AddNested(const char * name, bool array)
+    {
+        return BlobMsgCookie(this, !HasError() ? blobmsg_open_nested(this, name, array) : nullptr);
+    }
+
+    template <typename T>
+    bool AddOptional(const char * name, std::optional<T> const & optional)
+    {
+        return !HasError() && (!optional.has_value() || Check(detail::BlobMsgType<T>::add(this, name, optional.value())));
+    }
+
+    bool Check(int status)
+    {
+        if (status != 0)
+        {
+            this->head = nullptr;
+            return false;
+        }
+        return true;
+    }
+};
+
+} // namespace ubus
+} // namespace chip

--- a/examples/network-manager-app/linux/UboxUtils.h
+++ b/examples/network-manager-app/linux/UboxUtils.h
@@ -139,7 +139,7 @@ struct BlobMsgFieldBase : public std::conditional_t<Required, NonOptional<T>, st
 // The field type captures the field name as a compile-time string,
 // so a matching blobmsg_policy can be generated automatically.
 //
-// By default fields are optional, i.e. derive from use std::optional.
+// By default fields are optional, i.e. derive from std::optional.
 // Passing Required=true (or using BlobMsgRequiredField) creates makes
 // the field non-optional. BlobMsgParse() will fail is any required
 // fields are missing.

--- a/examples/network-manager-app/linux/UbusManager.cpp
+++ b/examples/network-manager-app/linux/UbusManager.cpp
@@ -1,0 +1,297 @@
+/*
+ *    Copyright (c) 2024-2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "UbusManager.h"
+
+#include "UboxUtils.h"
+#include "UloopHandler.h"
+
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <system/SystemLayer.h>
+
+#include <assert.h>
+#include <type_traits>
+
+#ifndef CHIP_UBUS_DEBUGGING
+#define CHIP_UBUS_DEBUGGING 0
+#endif
+
+namespace chip {
+namespace ubus {
+
+inline constexpr auto kReconnectTimeout = System::Clock::Seconds16(2);
+
+namespace {
+bool CheckAndLog(int status, const char * func)
+{
+    if (status != UBUS_STATUS_OK)
+    {
+        ChipLogError(DeviceLayer, "Ubus error: %s() %s", func, ubus_strerror(status));
+        return false;
+    }
+#if CHIP_UBUS_DEBUGGING
+    ChipLogDetail(DeviceLayer, "%s() OK", func);
+#endif
+    return true;
+}
+
+} // namespace
+
+CHIP_ERROR UbusManager::Init()
+{
+    VerifyOrReturnError(!mInitialized, CHIP_ERROR_INCORRECT_STATE);
+
+    UloopHandler::Register();
+    if (!Connect())
+    {
+        UloopHandler::Unregister();
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    ChipLogDetail(DeviceLayer, "Connected to ubus");
+    Context().connection_lost = [](ubus_context * ctx) { static_cast<UbusManager *>(ctx)->HandleConnectionLost(); };
+    ubus_add_uloop(&Context());
+    mInitialized = true;
+    return CHIP_NO_ERROR;
+}
+
+void UbusManager::Shutdown()
+{
+    VerifyOrReturn(mInitialized);
+    mWatches.Clear();
+    if (Connected())
+    {
+        ubus_shutdown(&Context());
+    }
+    else
+    {
+        uloop_timeout_cancel(&ReconnectTimer());
+    }
+    UloopHandler::Unregister();
+    mInitialized = false;
+}
+
+void UbusManager::HandleConnectionLost()
+{
+    ChipLogProgress(DeviceLayer, "Ubus connection lost, reconnection will be attempted periodically");
+    // ubus_shutdown(&Context());
+
+    ResetEventHandler();
+    for (auto & watch : mWatches)
+    {
+        if (watch.mID != 0)
+        {
+            Lost(watch);
+        }
+        watch.ResetSubscriber();
+    }
+
+    AttemptReconnect();
+}
+
+void UbusManager::AttemptReconnect()
+{
+    // Use ubus_connect_ctx() instead of ubus_reconnect(). The latter provides support for
+    // automatic re-registration of objects and re-establishment of subscriptions (those with
+    // a non-null ubus_subscriber.new_obj_cb), however these mechanisms have some important
+    // limitations:
+    //  - The resolved object id of the target object(s) for an ubus_subcriber is not exposed,
+    //    but since we want to be able to perform method calls on target objects, the automatic
+    //    resubscription support is not sufficient to implement UbusWatch.
+    //  - There is no API for removing objects (including subscribers / event listeners) from the
+    //    ubus_context while not connected to ubusd, making it impossible to safely free their
+    //    ubus_object in that state.
+    // Using ubus_connect_ctx() re-initializes the context, and any relevant objects (event
+    // listeners, subscriptions, ...) are then re-established explicitly.
+    if (!Connect())
+    {
+        ReconnectTimer().cb = [](uloop_timeout * timeout) {
+            static_cast<UbusManager *>(timeout)->AttemptReconnect(); // downcast from base class
+        };
+        uloop_timeout_set(&ReconnectTimer(), std::chrono::duration_cast<System::Clock::Milliseconds32>(kReconnectTimeout).count());
+        return;
+    }
+
+    ChipLogProgress(DeviceLayer, "Ubus connection restored");
+    ReconnectTimer().cb = nullptr; // cb == nullptr -> Connected() = true
+    ubus_add_uloop(&Context());
+
+    RegisterEventHandler();
+    LookupAll();
+}
+
+bool UbusManager::Connect()
+{
+    UloopSignalGuard guard; // ubus_connect_ctx() indirectly calls ubus_init()
+    return CheckAndLog(ubus_connect_ctx(&Context(), mUbusSocketPath), "ubus_connect_ctx");
+}
+
+void UbusManager::Register(UbusWatch & watch)
+{
+    VerifyOrDie(mInitialized);
+    mWatches.PushBack(&watch);
+    if (Connected())
+    {
+        RegisterEventHandler();
+        Lookup(watch);
+    }
+}
+
+void UbusManager::Unregister(UbusWatch & watch)
+{
+    VerifyOrDie(mInitialized);
+    mWatches.Remove(&watch);
+    watch.mID = 0;
+
+    if (Connected())
+    {
+        Unsubscribe(watch);
+        UnregisterEventHandler();
+    }
+
+    if (watch.SubscriberActive())
+    {
+        // Failure to unsubscribe is problematic, because it means ubus_subscriber.obj
+        // is still internaly referenced by the ubus_context. Force a cleanup of the context.
+        HandleConnectionLost();
+    }
+}
+
+void UbusManager::RegisterEventHandler()
+{
+    VerifyOrReturn(!EventHandlerActive() && !mWatches.Empty());
+    VerifyOrReturn(
+        CheckAndLog(ubus_register_event_handler(&Context(), &EventHandler(), "ubus.object.*"), "ubus_register_event_handler"));
+    EventHandler().cb = [](ubus_context * ctx, ubus_event_handler * ev, const char * type, blob_attr * msg) {
+        static_cast<UbusManager *>(ev)->HandleEvent(type, msg); // downcast from base class pointer
+    };
+}
+
+void UbusManager::UnregisterEventHandler()
+{
+    VerifyOrReturn(EventHandlerActive() && mWatches.Empty());
+    VerifyOrReturn(CheckAndLog(ubus_unregister_event_handler(&Context(), &EventHandler()), "ubus_unregister_event_handler"));
+    ResetEventHandler(); // only if successfully unregistered
+}
+
+void UbusManager::Lookup(UbusWatch & watch)
+{
+    uint32_t id;
+    int status = ubus_lookup_id(&Context(), watch.mName, &id);
+    VerifyOrReturn(status != UBUS_STATUS_NOT_FOUND); // don't log "not found"
+    VerifyOrReturn(CheckAndLog(status, "ubus_lookup_id"));
+    Resolved(watch, id);
+}
+
+void UbusManager::LookupAll()
+{
+    VerifyOrReturn(!mWatches.Empty());
+    ubus_lookup(
+        &Context(), nullptr,
+        [](ubus_context * ctx, ubus_object_data * data, void * priv) {
+            auto * self = static_cast<UbusManager *>(ctx); // downcast from base class
+            for (auto & watch : self->mWatches)
+            {
+                if (!strcmp(data->path, watch.mName))
+                {
+                    self->Resolved(watch, data->id);
+                }
+            }
+        },
+        nullptr);
+}
+
+void UbusManager::Subscribe(UbusWatch & watch)
+{
+    if (!watch.SubscriberActive())
+    {
+        VerifyOrReturn(CheckAndLog(ubus_register_subscriber(&Context(), &watch.Subscriber()), "ubus_register_subscriber"));
+        watch.Subscriber().cb = [](ubus_context * ctx, ubus_object * sub, ubus_request_data * req, const char * type,
+                                   struct blob_attr * msg) {
+            auto * receiver = static_cast<UbusWatch *>(container_of(sub, ubus_subscriber, obj)); // downcast from base class
+            static_cast<UbusManager *>(ctx)->HandleNotification(*receiver, req, type, msg);
+            return 0;
+        };
+    }
+    CheckAndLog(ubus_subscribe(&Context(), &watch.Subscriber(), watch.mID), "ubus_subscribe");
+}
+
+void UbusManager::Unsubscribe(UbusWatch & watch)
+{
+    VerifyOrReturn(watch.SubscriberActive());
+    // Unregistering the subscriber also cleans up subscriptions.
+    CheckAndLog(ubus_unregister_subscriber(&Context(), &watch.Subscriber()), "ubus_unregister_subscriber");
+}
+
+void UbusManager::Resolved(UbusWatch & watch, uint32_t id)
+{
+    watch.mID = id;
+    ChipLogDetail(DeviceLayer, "Resolved ubus object %s (0x%08x)", watch.mName, id);
+
+    if (watch.mNotificationCb != nullptr)
+    {
+        Subscribe(watch);
+    }
+
+    VerifyOrReturn(watch.mResolvedCb != nullptr);
+    watch.mResolvedCb(watch, watch.mAppState);
+}
+
+void UbusManager::Lost(UbusWatch & watch)
+{
+    watch.mID = 0;
+    VerifyOrReturn(watch.mLostCb != nullptr);
+    watch.mLostCb(watch, watch.mAppState);
+}
+
+void UbusManager::HandleEvent(const char * type, blob_attr * msg)
+{
+    bool add = !strcmp(type, "ubus.object.add");
+    VerifyOrReturn(add || !strcmp(type, "ubus.object.remove"));
+
+    BlobMsgRequiredField<uint32_t, CHIP_CTST("id")> id;
+    BlobMsgRequiredField<const char *, CHIP_CTST("path")> path;
+    VerifyOrReturn(BlobMsgParse(msg, id, path) && id != 0);
+
+    for (auto & watch : mWatches)
+    {
+        if (!strcmp(path, watch.mName))
+        {
+            if (add)
+            {
+                Resolved(watch, id);
+            }
+            else if (id == watch.mID)
+            {
+                // The subscription (if any) was cleaned up by ubusd; keep the subscriber.
+                ChipLogDetail(DeviceLayer, "Lost ubus object %s (0x%08x) - removed", path.value(), id.value());
+                Lost(watch);
+            }
+        }
+    }
+}
+
+void UbusManager::HandleNotification(UbusWatch & watch, ubus_request_data * req, const char * type, blob_attr * msg)
+{
+    ChipLogDetail(DeviceLayer, "Received ubus notification %s.%s", watch.mName, type);
+    VerifyOrReturn(watch.mNotificationCb);
+    watch.mNotificationCb(watch, watch.mAppState, req, type, msg);
+}
+
+} // namespace ubus
+} // namespace chip

--- a/examples/network-manager-app/linux/UbusManager.h
+++ b/examples/network-manager-app/linux/UbusManager.h
@@ -1,0 +1,148 @@
+/*
+ *    Copyright (c) 2024-2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/IntrusiveList.h>
+
+#include <optional>
+#include <signal.h>
+
+extern "C" {
+#include <libubus.h>
+#undef fallthrough // from libubox/utils.h, interferes with the standard attribute
+}
+
+namespace chip {
+namespace ubus {
+
+class UbusWatch;
+
+// Maintains a connection to ubus and makes it available to other components.
+class UbusManager : private ubus_context, private uloop_timeout, private ubus_event_handler
+{
+public:
+    // Creates an UbusManager. A non-null socket path can be specified for testing purposes.
+    UbusManager(const char * ubusSocketPath = nullptr) :
+        ubus_context{}, uloop_timeout{}, ubus_event_handler{}, mUbusSocketPath(ubusSocketPath)
+    {}
+    ~UbusManager() { Shutdown(); }
+
+    CHIP_ERROR Init();
+    void Shutdown();
+
+    ubus_context & Context() { return *this; }
+    void Register(UbusWatch & watch);
+    void Unregister(UbusWatch & watch);
+
+private:
+    const char * const mUbusSocketPath;
+    IntrusiveList<UbusWatch> mWatches{};
+    bool mInitialized = false;
+
+    ///// Connection management
+
+    uloop_timeout & ReconnectTimer() { return *this; }
+    bool Connected() { return ReconnectTimer().cb == nullptr; }
+    void HandleConnectionLost();
+    void AttemptReconnect();
+    bool Connect();
+
+    ///// Watch / subcription management
+
+    ubus_event_handler & EventHandler() { return *this; }
+    bool EventHandlerActive() { return EventHandler().cb != nullptr; }
+    void ResetEventHandler() { memset(&EventHandler(), 0, sizeof(EventHandler())); }
+    void RegisterEventHandler();
+    void UnregisterEventHandler();
+
+    void Lookup(UbusWatch & watch);
+    void LookupAll();
+    void Subscribe(UbusWatch & watch);
+    void Unsubscribe(UbusWatch & watch);
+    void Resolved(UbusWatch & watch, uint32_t id);
+    void Lost(UbusWatch & watch);
+    void HandleEvent(const char * type, blob_attr * msg);
+    void HandleNotification(UbusWatch & watch, ubus_request_data * req, const char * type, blob_attr * msg);
+};
+
+// Represents a named ubus object being tracked, and optionally subscribed to.
+class UbusWatch final : public IntrusiveListNodeBase<>, private ubus_subscriber
+{
+public:
+    using ResolvedCallback     = void (*)(UbusWatch & watch, void * appState);
+    using LostCallback         = void (*)(UbusWatch & watch, void * appState);
+    using NotificationCallback = void (*)(UbusWatch & watch, void * appState, ubus_request_data * req, const char * notification,
+                                          blob_attr * msg);
+
+    UbusWatch(const char * name, void * appState = nullptr) : ubus_subscriber{}, mAppState(appState), mName(name) {}
+
+    const char * Name() { return mName; }
+    UbusWatch & SetName(const char * name)
+    {
+        VerifyOrDie(!IsInList());
+        mName = name;
+        return *this;
+    }
+
+    // Sets the callback to call when the object becomes available.
+    UbusWatch & SetResolvedCallback(ResolvedCallback resolvedCb)
+    {
+        VerifyOrDie(!IsInList());
+        mResolvedCb = resolvedCb;
+        return *this;
+    }
+
+    // Sets the callback to call when the object becomes unavailable.
+    UbusWatch & SetLostCallback(LostCallback lostCb)
+    {
+        VerifyOrDie(!IsInList());
+        mLostCb = lostCb;
+        return *this;
+    }
+
+    UbusWatch & SetNotificationCallback(NotificationCallback notificationCb)
+    {
+        VerifyOrDie(!IsInList());
+        mNotificationCb = notificationCb;
+        return *this;
+    }
+
+    // The resolved object id, or 0 if not currently resolved.
+    uint32_t ObjectID() const { return mID; }
+    bool Resolved() const { return ObjectID() != 0; }
+
+private:
+    friend class UbusManager;
+
+    ubus_subscriber & Subscriber() { return *this; }
+    bool SubscriberActive() { return Subscriber().cb != nullptr; }
+    void ResetSubscriber() { memset(&Subscriber(), 0, sizeof(Subscriber())); }
+    void Reset() { mID = 0; }
+
+    void * const mAppState;
+    const char * mName;
+    ResolvedCallback mResolvedCb;
+    LostCallback mLostCb;
+    NotificationCallback mNotificationCb;
+
+    uint32_t mID = 0;
+};
+
+} // namespace ubus
+} // namespace chip

--- a/examples/network-manager-app/linux/UloopHandler.cpp
+++ b/examples/network-manager-app/linux/UloopHandler.cpp
@@ -1,0 +1,183 @@
+/*
+ *    Copyright (c) 2024-2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "UloopHandler.h"
+
+#include <lib/core/CHIPConfig.h>
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
+
+#include <chrono>
+
+extern "C" {
+#include <libubox/uloop.h>
+}
+
+#ifndef CHIP_ULOOP_DEBUGGING
+#define CHIP_ULOOP_DEBUGGING 0
+#endif
+
+namespace chip {
+namespace ubus {
+
+namespace {
+System::LayerSocketsLoop & SystemLayer()
+{
+    return static_cast<System::LayerSocketsLoop &>(DeviceLayer::SystemLayer());
+}
+} // namespace
+
+///// UloopHandler
+
+UloopHandler UloopHandler::gInstance;
+int UloopHandler::gRegistered = 0;
+
+CHIP_ERROR UloopHandler::Register()
+{
+    VerifyOrReturnError(gRegistered++ == 0, CHIP_NO_ERROR);
+
+    if (uloop_fd_set_cb != nullptr)
+    {
+        gRegistered = 0;
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    ChipLogDetail(DeviceLayer, "Registering uloop handler");
+    uloop_fd_set_cb      = &UloopFdSet;
+    uloop_handle_sigchld = false;
+    {
+        UloopSignalGuard guard;
+        uloop_init();
+    }
+    SystemLayer().AddLoopHandler(gInstance);
+
+    return CHIP_NO_ERROR;
+}
+
+void UloopHandler::Unregister()
+{
+    auto count = gRegistered--;
+    VerifyOrDie(count > 0);
+    VerifyOrReturn(count == 1);
+
+    ChipLogDetail(DeviceLayer, "Unregistering uloop handler");
+    SystemLayer().RemoveLoopHandler(gInstance);
+    uloop_done();
+    uloop_fd_set_cb = nullptr;
+}
+
+System::Clock::Timestamp UloopHandler::PrepareEvents(System::Clock::Timestamp now)
+{
+    std::chrono::duration<int, std::milli> timeout(uloop_get_next_timeout());
+    VerifyOrReturnValue(timeout.count() >= 0, System::Clock::Timestamp::max());
+#if CHIP_ULOOP_DEBUGGING
+    ChipLogDetail(DeviceLayer, "Next uloop timeout: %d", timeout.count());
+#endif
+    return now + std::chrono::duration_cast<System::Clock::Timestamp>(timeout);
+}
+
+void UloopHandler::HandleEvents()
+{
+    uloop_run_timeout(0);
+}
+
+void UloopHandler::UloopFdSet(uloop_fd * fd, unsigned int events)
+{
+#if CHIP_ULOOP_DEBUGGING
+    ChipLogDetail(DeviceLayer, "Uloop fd_set(%d, 0x%x)", fd->fd, events);
+#endif
+    VerifyOrDieWithMsg(!(events & ~(ULOOP_READ | ULOOP_WRITE | ULOOP_BLOCKING)), DeviceLayer,
+                       "Unsupported uloop fd_set events: 0x%x", events);
+
+    auto & system = SystemLayer();
+    System::SocketWatchToken watch;
+    CHIP_ERROR err = system.StartWatchingSocket(fd->fd, &watch); // or find existing watch
+    if (events != 0)
+    {
+        int changed = fd->flags ^ events;
+        if (changed & ULOOP_READ)
+        {
+            if (events & ULOOP_READ)
+            {
+                system.RequestCallbackOnPendingRead(watch);
+            }
+            else
+            {
+                system.ClearCallbackOnPendingRead(watch);
+            }
+        }
+        if (changed & ULOOP_WRITE)
+        {
+            if (events & ULOOP_WRITE)
+            {
+                system.RequestCallbackOnPendingWrite(watch);
+            }
+            else
+            {
+                system.ClearCallbackOnPendingWrite(watch);
+            }
+        }
+    }
+    else
+    {
+        VerifyOrReturn(err == CHIP_NO_ERROR); // shouldn't happen, but ignore
+        SuccessOrExit(err = system.StopWatchingSocket(&watch));
+    }
+
+    return;
+exit:
+    ChipLogError(DeviceLayer, "Failed to handle uloop fd_set(%d, %d): %" CHIP_ERROR_FORMAT, fd->fd, events, err.Format());
+}
+
+///// UloopSignalGuard
+
+UloopSignalGuard::UloopSignalGuard()
+{
+    Guard(SIGINT, mSigInt);
+    Guard(SIGTERM, mSigTerm);
+}
+
+UloopSignalGuard::~UloopSignalGuard()
+{
+    Restore(SIGINT, mSigInt);
+    Restore(SIGTERM, mSigTerm);
+}
+
+void UloopSignalGuard::Guard(int sig, struct sigaction & action)
+{
+    sigaction(sig, nullptr, &action);
+
+    // uloop will only touch signals set to SIG_DFL
+    VerifyOrReturn(action.sa_handler == SIG_DFL);
+
+    struct sigaction guard = {};
+    sigemptyset(&guard.sa_mask);
+    guard.sa_handler = [](int caught) {
+        signal(caught, SIG_DFL); // restore SIG_DFL (don't worry about masks etc)
+        raise(caught);           // re-raise the signal to the default handler
+    };
+    sigaction(sig, &guard, nullptr);
+}
+
+void UloopSignalGuard::Restore(int sig, struct sigaction & action)
+{
+    // Restore unconditionally (belt and suspenders ...)
+    sigaction(sig, &action, nullptr);
+}
+
+} // namespace ubus
+} // namespace chip

--- a/examples/network-manager-app/linux/UloopHandler.h
+++ b/examples/network-manager-app/linux/UloopHandler.h
@@ -1,0 +1,80 @@
+/*
+ *    Copyright (c) 2024-2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <system/SystemLayer.h>
+
+#include <csignal>
+
+extern "C" struct uloop_fd;
+
+namespace chip {
+namespace ubus {
+
+// Integrates uloop into the SystemLayer event loop.
+class UloopHandler final : private System::EventLoopHandler
+{
+public:
+    // Starts driving uloop via the SystemLayer event loop. May be called multiple times.
+    // Each successful call to Register() must be balanced by a call to Unregister().
+    static CHIP_ERROR Register();
+    static void Unregister();
+
+private:
+    constexpr UloopHandler() = default;
+
+    System::Clock::Timestamp PrepareEvents(System::Clock::Timestamp now) override;
+    void HandleEvents() override;
+
+    static void UloopFdSet(uloop_fd * fd, unsigned int events);
+
+    static UloopHandler gInstance;
+    static int gRegistered;
+};
+
+// RAII guard to protect signal handlers around uloop_init() calls
+//
+// uloop_init() will install its own SIGINT and SIGTERM handlers in certain
+// cases, which is generally undesirable when it  is integrated into the
+// Matter main loop via UloopHandler. This guard prevents modification of
+// those signal handlers, and/or restores the original handlers as needed.
+//
+// Note that ubus_connect() and its variants call uloop_init() indirectly.
+class UloopSignalGuard
+{
+public:
+    UloopSignalGuard();
+    ~UloopSignalGuard();
+
+    // Non-copyable and non-movable
+    UloopSignalGuard(const UloopSignalGuard &)             = delete;
+    UloopSignalGuard & operator=(const UloopSignalGuard &) = delete;
+    UloopSignalGuard(UloopSignalGuard &&)                  = delete;
+    UloopSignalGuard & operator=(UloopSignalGuard &&)      = delete;
+
+private:
+    static void Guard(int sig, struct sigaction & action);
+    static void Restore(int sig, struct sigaction & action);
+
+    struct sigaction mSigInt;
+    struct sigaction mSigTerm;
+};
+
+} // namespace ubus
+} // namespace chip

--- a/examples/network-manager-app/linux/args.gni
+++ b/examples/network-manager-app/linux/args.gni
@@ -23,7 +23,9 @@ chip_project_config_include_dirs = [
 
 chip_config_network_layer_ble = false
 
-# This enables AccessRestrictionList (ARL) support used by the NIM sample app
-chip_enable_access_restrictions = true
+# Wi-Fi and OpenThread support in the core are not needed for NIM
+chip_enable_wifi = false
+chip_enable_openthread = false
 
+chip_enable_access_restrictions = true
 matter_enable_tracing_support = true

--- a/examples/network-manager-app/linux/include/CHIPProjectAppConfig.h
+++ b/examples/network-manager-app/linux/include/CHIPProjectAppConfig.h
@@ -25,5 +25,9 @@
 // Sufficient space for ArlReviewEvent of several fabrics.
 #define CHIP_DEVICE_CONFIG_EVENT_LOGGING_INFO_BUFFER_SIZE (32 * 1024)
 
+#ifndef MATTER_ENABLE_UBUS
+#define MATTER_ENABLE_UBUS 0
+#endif
+
 // Inherit defaults from config/standalone/CHIPProjectConfig.h
 #include <CHIPProjectConfig.h>

--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
@@ -51,15 +51,13 @@ namespace ThreadNetworkDiagnostics {
  *         CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE = Is not a Runtime readable attribute. Use standard read
  *         All other errors should be treated as a read error and reported as such.
  *
- * @note This function implementation can compile in 3 different outcomes
+ * @note This function currently builds in two different variants:
  *       (1) CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK:
- *           - Generic implementation fetching the valid thread network data from the thread stack and encoding it respectively to
- *             the attributeID received.
- *       (2) CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK:
+ *           - Generic implementation fetching the valid thread network data from the thread stack
+ *             (via ThreadStackMgrImpl().OTInstance()) and encoding it respectively to the attributeID
+ *             received. This relies on an in-process OpenThread stack.
+ *       (2) Otherwise
  *           - Encode a NULL value for nullable attributes or 0 for the others.
- *           - Devices using the ot-br-posix dbus stack have not yet provided the API to fetch the needed thread informations.
- *       (3) None of the conditions above
- *           - returns CHIP_ERROR_NOT_IMPLEMENTED.
  */
 CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, app::AttributeValueEncoder & encoder)
 {
@@ -698,7 +696,7 @@ CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, a
     break;
     }
 
-#elif (CHIP_DEVICE_CONFIG_ENABLE_THREAD && CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
+#else
     switch (attributeId)
     {
     case Attributes::NeighborTable::Id:
@@ -860,8 +858,6 @@ CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, a
         err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
         break;
     }
-#else
-    err = CHIP_ERROR_NOT_IMPLEMENTED;
 #endif // (CHIP_DEVICE_CONFIG_ENABLE_THREAD && !CHIP_DEVICE_CONFIG_USES_OTBR_POSIX_DBUS_STACK)
     return err;
 }

--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
@@ -152,7 +152,7 @@ class ThreadDiagnosticsDelegate : public DeviceLayer::ThreadDiagnosticsDelegate
 
         Events::ConnectionStatus::Type event{ newConnectionStatus };
 
-        // ThreadNetworkDiagnostics cluster should exist only for endpoint 0.
+        // TODO: ThreadNetworkDiagnostics cluster can exist on other endpoints (SNI or NIM/TBR device types)
         if (emberAfContainsServer(kRootEndpointId, ThreadNetworkDiagnostics::Id))
         {
             // If Thread Network Diagnostics cluster is implemented on this endpoint
@@ -181,7 +181,7 @@ class ThreadDiagnosticsDelegate : public DeviceLayer::ThreadDiagnosticsDelegate
 
         Events::NetworkFaultChange::Type event{ currentList, previousList };
 
-        // ThreadNetworkDiagnostics cluster should exist only for endpoint 0.
+        // TODO: ThreadNetworkDiagnostics cluster can exist on other endpoints (SNI or NIM/TBR device types)
         if (emberAfContainsServer(kRootEndpointId, ThreadNetworkDiagnostics::Id))
         {
             // If Thread Network Diagnostics cluster is implemented on this endpoint

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -172,7 +172,11 @@ source_set("testing") {
 }
 
 source_set("type-traits") {
-  sources = [ "TypeTraits.h" ]
+  sources = [
+    "CompileTimeString.h",
+    "FunctionTraits.h",
+    "TypeTraits.h",
+  ]
 }
 
 source_set("static-support") {
@@ -211,7 +215,6 @@ static_library("support") {
     "FixedBufferAllocator.cpp",
     "FixedBufferAllocator.h",
     "Fold.h",
-    "FunctionTraits.h",
     "IniEscaping.cpp",
     "IniEscaping.h",
     "IntrusiveList.h",

--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -175,6 +175,9 @@ void LogBufferAsHex(const char * label, const ByteSpan & span);
  * @param dest_bytes the buffer to fill with the decoded bytes.
  * @param dest_size_max the total size of the buffer to be filled.
  *
+ * Note: src_hex and dest_bytes must not overlap, except for the special
+ * case of in-place decoding (dest_bytes == src_hex), which is supported.
+ *
  * @return 0 on errors:
  *           - dest_size_max not big enough.
  *           - src_size not even.

--- a/src/lib/support/CompileTimeString.h
+++ b/src/lib/support/CompileTimeString.h
@@ -1,0 +1,47 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+namespace chip {
+
+// A compile-time type representation of a string usable in C++ 17
+// (where non-type template parameters are quite restricted).
+template <char... Chars>
+struct CompileTimeStringType
+{
+    static constexpr const char * c_str() { return value; }
+
+private:
+    static constexpr char value[] = { Chars..., 0 };
+};
+
+template <typename T, T... chars>
+constexpr auto operator""_CompileTimeStringType()
+{
+    return CompileTimeStringType<chars...>{};
+}
+
+#define _CHIP_CTST(literal) "" literal##_CompileTimeStringType
+
+/**
+ * A type expression for a CompileTimeStringType representing the provided string literal.
+ *
+ * Example: CHIP_CTST("hello")
+ */
+#define CHIP_CTST(literal) decltype(_CHIP_CTST(literal))
+
+} // namespace chip

--- a/src/lib/support/tests/TestBytesToHex.cpp
+++ b/src/lib/support/tests/TestBytesToHex.cpp
@@ -321,6 +321,17 @@ TEST(TestBytesToHex, TestHexToBytesAndUint)
     EXPECT_EQ(test16Out, test16OutExpected);
 }
 
+TEST(TestBytesToHex, TestHexToBytesInPlace)
+{
+    // Test that HexToBytes can decode in-place (dest_bytes == src_hex)
+    uint8_t buffer[]         = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+    const uint8_t expected[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF };
+
+    size_t bytesWritten = HexToBytes(reinterpret_cast<char *>(buffer), sizeof(buffer), buffer, sizeof(buffer));
+    EXPECT_EQ(bytesWritten, sizeof(expected));
+    EXPECT_EQ(memcmp(buffer, expected, sizeof(expected)), 0);
+}
+
 #if CHIP_PROGRESS_LOGGING
 
 ENFORCE_FORMAT(3, 0) void AccumulateLogLineCallback(const char * module, uint8_t category, const char * msg, va_list args)

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -589,6 +589,7 @@ void LayerImplSelect::HandleEvents()
 
     if (!IsSelectResultValid())
     {
+        VerifyOrReturn(errno != EINTR); // EINTR is not really an error (and we don't use it for signal handling)
         ChipLogError(DeviceLayer, "Select failed: %" CHIP_ERROR_FORMAT, CHIP_ERROR_POSIX(errno).Format());
         return;
     }


### PR DESCRIPTION
### Summary

Add a new ThreadBROpenThreadUbus implementation of the TBRM delegate that interacts with otbr-agent via ubus. Rename the existing dummy implementation to ThreadBRFake.h.

Add some generic utilities for interacting with ubus (and the underlying uloop / ubox libraries) from C++. At the moment this lives under the network-manager example directory, but could move into platform/Linux in the core SDK at a later stage. (Future work based on this is likely to include interacting with hostapd via ubus, as well as exposing some information about the matter application itself, e.g. pairing status.)

### Testing

Tested manually on OpenWrt for now, since this integration code is not easy to meaningfully test in unit tests.