### PR TITLE
Pass largepayload flag into CommandSender in IM test app.

### DIFF
--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -252,7 +252,9 @@ protected:
             chip::app::CommandPathParams commandPath = { endpointId, clusterId, commandId,
                                                          (chip::app::CommandPathFlags::kEndpointIdValid) };
             auto commandSender                       = std::make_unique<chip::app::CommandSender>(
-                mCallback, device->GetExchangeManager(), mTimedInteractionTimeoutMs.HasValue(), mSuppressResponse.ValueOr(false));
+                mCallback, device->GetExchangeManager(), mTimedInteractionTimeoutMs.HasValue(), mSuppressResponse.ValueOr(false),
+                device->GetSecureSession().Value()->AllowsLargePayload());
+
             VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
 
             chip::app::CommandSender::AddRequestDataParameters addRequestDataParams(mTimedInteractionTimeoutMs);


### PR DESCRIPTION
Use the session information from DeviceProxy to construct CommandSender for large payload if session supports it.

