### PR TITLE
Apply ColorTempPhysicalMaxMireds when ColorTemperatureMaximumMireds f…

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -2697,7 +2697,7 @@ bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, 
     {
         colorTemperatureMinimum = tempPhysicalMin;
     }
-    if (colorTemperatureMaximum > tempPhysicalMax)
+    if ((colorTemperatureMaximum == 0) || (colorTemperatureMaximum > tempPhysicalMax))
     {
         colorTemperatureMaximum = tempPhysicalMax;
     }
@@ -2808,7 +2808,7 @@ bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, 
     {
         colorTemperatureMinimum = tempPhysicalMin;
     }
-    if (colorTemperatureMaximum > tempPhysicalMax)
+    if ((colorTemperatureMaximum == 0) || (colorTemperatureMaximum > tempPhysicalMax))
     {
         colorTemperatureMaximum = tempPhysicalMax;
     }

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -2693,10 +2693,15 @@ bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, 
         return true;
     }
 
+    // Per spec, colorTemperatureMinimumMireds field is limited to ColorTempPhysicalMinMireds and
+    // when colorTemperatureMinimumMireds field is 0, ColorTempPhysicalMinMireds shall be used (always >= to 0)
     if (colorTemperatureMinimum < tempPhysicalMin)
     {
         colorTemperatureMinimum = tempPhysicalMin;
     }
+
+    // Per spec, colorTemperatureMaximumMireds field is limited to ColorTempPhysicalMaxMireds and
+    // when colorTemperatureMaximumMireds field is 0, ColorTempPhysicalMaxMireds shall be used
     if ((colorTemperatureMaximum == 0) || (colorTemperatureMaximum > tempPhysicalMax))
     {
         colorTemperatureMaximum = tempPhysicalMax;
@@ -2804,10 +2809,15 @@ bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, 
     Attributes::ColorTempPhysicalMinMireds::Get(endpoint, &tempPhysicalMin);
     Attributes::ColorTempPhysicalMaxMireds::Get(endpoint, &tempPhysicalMax);
 
+    // Per spec, colorTemperatureMinimumMireds field is limited to ColorTempPhysicalMinMireds and
+    // when colorTemperatureMinimumMireds field is 0, ColorTempPhysicalMinMireds shall be used (always >= to 0)
     if (colorTemperatureMinimum < tempPhysicalMin)
     {
         colorTemperatureMinimum = tempPhysicalMin;
     }
+
+    // Per spec, colorTemperatureMaximumMireds field is limited to ColorTempPhysicalMaxMireds and
+    // when colorTemperatureMaximumMireds field is 0, ColorTempPhysicalMaxMireds shall be used
     if ((colorTemperatureMaximum == 0) || (colorTemperatureMaximum > tempPhysicalMax))
     {
         colorTemperatureMaximum = tempPhysicalMax;

--- a/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
@@ -373,7 +373,7 @@ tests:
       arguments:
           values:
               - name: "MoveMode"
-                value: 1
+                value: 3
               - name: "Rate"
                 value: 65535
               - name: "ColorTemperatureMinimumMireds"

--- a/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
@@ -364,6 +364,83 @@ tests:
           constraints:
               minValue: 0
               maxValue: 3
+    - label:
+          "Step 6a: TH sends MoveColorTemperature command to DUT with MoveMode =
+          0x03(down), Rate = 65535 (max value) with ColorTemperatureMinimumMireds of 0"
+      PICS: CC.S.F04 && CC.S.C4b.Rsp
+      command: MoveColorTemperature
+      arguments:
+          values:
+              - name: "MoveMode"
+                value: 1
+              - name: "Rate"
+                value: 65535
+              - name: "ColorTemperatureMinimumMireds"
+                value: 0
+              - name: "ColorTemperatureMaximumMireds"
+                value: ColorTempPhysicalMaxMiredsValue
+              - name: "OptionsMask"
+                value: 0
+              - name: "OptionsOverride"
+                value: 0
+
+    - label: "Wait 100ms"
+      PICS: CC.S.F04
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: 100
+
+    - label: "Step 6b: TH reads ColorTemperatureMireds attribute from DUT."
+      PICS: CC.S.F04 && CC.S.A0007 && CC.S.C4b.Rsp
+      command: "readAttribute"
+      attribute: "ColorTemperatureMireds"
+      response:
+          value: ColorTempPhysicalMinMiredsValue
+          constraints:
+              minValue: ColorTempPhysicalMinMiredsValue
+              maxValue: ColorTempPhysicalMaxMiredsValue
+    
+    - label:
+          "Step 7a: TH sends MoveColorTemperature command to DUT with MoveMode =
+          0x01(up), Rate = 65535 (max value) with ColorTemperatureMaximumMireds of 0"
+      PICS: CC.S.F04 && CC.S.C4b.Rsp
+      command: MoveColorTemperature
+      arguments:
+          values:
+              - name: "MoveMode"
+                value: 1
+              - name: "Rate"
+                value: 65535
+              - name: "ColorTemperatureMinimumMireds"
+                value: ColorTempPhysicalMinMiredsValue
+              - name: "ColorTemperatureMaximumMireds"
+                value: 0
+              - name: "OptionsMask"
+                value: 0
+              - name: "OptionsOverride"
+                value: 0
+
+    - label: "Wait 100ms"
+      PICS: CC.S.F04
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: 100
+
+    - label: "Step 7b: TH reads ColorTemperatureMireds attribute from DUT."
+      PICS: CC.S.F04 && CC.S.A0007 && CC.S.C4b.Rsp
+      command: "readAttribute"
+      attribute: "ColorTemperatureMireds"
+      response:
+          value: ColorTempPhysicalMaxMiredsValue
+          constraints:
+              minValue: ColorTempPhysicalMinMiredsValue
+              maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Turn off light that we turned on"
       PICS: OO.S.C00.Rsp

--- a/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
@@ -385,14 +385,14 @@ tests:
               - name: "OptionsOverride"
                 value: 0
 
-    - label: "Wait 100ms"
+    - label: "Wait 1s"
       PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
           values:
               - name: "ms"
-                value: 100
+                value: 1000
 
     - label: "Step 6b: TH reads ColorTemperatureMireds attribute from DUT."
       PICS: CC.S.F04 && CC.S.A0007 && CC.S.C4b.Rsp
@@ -425,14 +425,14 @@ tests:
               - name: "OptionsOverride"
                 value: 0
 
-    - label: "Wait 100ms"
+    - label: "Wait 1s"
       PICS: CC.S.F04
       cluster: "DelayCommands"
       command: "WaitForMs"
       arguments:
           values:
               - name: "ms"
-                value: 100
+                value: 1000
 
     - label: "Step 7b: TH reads ColorTemperatureMireds attribute from DUT."
       PICS: CC.S.F04 && CC.S.A0007 && CC.S.C4b.Rsp

--- a/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
@@ -402,7 +402,7 @@ tests:
           constraints:
               minValue: ColorTempPhysicalMinMiredsValue
               maxValue: ColorTempPhysicalMaxMiredsValue
-    
+
     - label:
           "Step 7a: TH sends MoveColorTemperature command to DUT with MoveMode =
           0x01(up), Rate = 65535 (max value) with ColorTemperatureMaximumMireds of 0"

--- a/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_2.yaml
@@ -366,7 +366,8 @@ tests:
               maxValue: 3
     - label:
           "Step 6a: TH sends MoveColorTemperature command to DUT with MoveMode =
-          0x03(down), Rate = 65535 (max value) with ColorTemperatureMinimumMireds of 0"
+          0x03(down), Rate = 65535 (max value) with
+          ColorTemperatureMinimumMireds of 0"
       PICS: CC.S.F04 && CC.S.C4b.Rsp
       command: MoveColorTemperature
       arguments:
@@ -405,7 +406,8 @@ tests:
 
     - label:
           "Step 7a: TH sends MoveColorTemperature command to DUT with MoveMode =
-          0x01(up), Rate = 65535 (max value) with ColorTemperatureMaximumMireds of 0"
+          0x01(up), Rate = 65535 (max value) with ColorTemperatureMaximumMireds
+          of 0"
       PICS: CC.S.F04 && CC.S.C4b.Rsp
       command: MoveColorTemperature
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CC_6_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_3.yaml
@@ -289,7 +289,8 @@ tests:
 
     - label:
           "Step 5a: TH sends StepColorTemperature command to DUT with StepMode =
-          0x01 (up), StepSize = ColorTempPhysicalMaxMireds and TransitionTime = 0 (instant)."
+          0x01 (up), StepSize = ColorTempPhysicalMaxMireds and TransitionTime =
+          0 (instant)."
       PICS: CC.S.F04 && CC.S.C4c.Rsp
       command: "StepColorTemperature"
       arguments:
@@ -297,8 +298,7 @@ tests:
               - name: "StepMode"
                 value: 1
               - name: "StepSize"
-                value:
-                    ColorTempPhysicalMaxMiredsValue
+                value: ColorTempPhysicalMaxMiredsValue
               - name: "ColorTemperatureMinimumMireds"
                 value: ColorTempPhysicalMinMiredsValue
               - name: "ColorTemperatureMaximumMireds"
@@ -331,7 +331,8 @@ tests:
 
     - label:
           "Step 6a: TH sends StepColorTemperature command to DUT with StepMode =
-          0x03 (down), StepSize = ColorTempPhysicalMaxMireds and TransitionTime = 0 (instant)."
+          0x03 (down), StepSize = ColorTempPhysicalMaxMireds and TransitionTime
+          = 0 (instant)."
       PICS: CC.S.F04 && CC.S.C4c.Rsp
       command: "StepColorTemperature"
       arguments:
@@ -339,8 +340,7 @@ tests:
               - name: "StepMode"
                 value: 3
               - name: "StepSize"
-                value:
-                    ColorTempPhysicalMaxMiredsValue
+                value: ColorTempPhysicalMaxMiredsValue
               - name: "ColorTemperatureMinimumMireds"
                 value: 0
               - name: "ColorTemperatureMaximumMireds"

--- a/src/app/tests/suites/certification/Test_TC_CC_6_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_3.yaml
@@ -286,6 +286,90 @@ tests:
           constraints:
               minValue: 0
               maxValue: 3
+    
+    - label:
+          "Step 5a: TH sends StepColorTemperature command to DUT with StepMode =
+          0x01 (up), StepSize = ColorTempPhysicalMaxMireds and TransitionTime = 0 (instant)."
+      PICS: CC.S.F04 && CC.S.C4c.Rsp
+      command: "StepColorTemperature"
+      arguments:
+          values:
+              - name: "StepMode"
+                value: 1
+              - name: "StepSize"
+                value:
+                    ColorTempPhysicalMaxMiredsValue
+              - name: "ColorTemperatureMinimumMireds"
+                value: ColorTempPhysicalMinMiredsValue
+              - name: "ColorTemperatureMaximumMireds"
+                value: 0
+              - name: "TransitionTime"
+                value: 0
+              - name: "OptionsMask"
+                value: 0
+              - name: "OptionsOverride"
+                value: 0
+
+    - label: "Wait 100ms"
+      PICS: CC.S.F04
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: 100
+
+    - label: "Step 5b: TH reads ColorTemperatureMireds attribute from DUT."
+      PICS: CC.S.F04 && CC.S.A0007 && CC.S.C4c.Rsp
+      command: "readAttribute"
+      attribute: "ColorTemperatureMireds"
+      response:
+          value: ColorTempPhysicalMaxMiredsValue
+          constraints:
+              minValue: ColorTempPhysicalMinMiredsValue
+              maxValue: ColorTempPhysicalMaxMiredsValue
+    
+    - label:
+          "Step 6a: TH sends StepColorTemperature command to DUT with StepMode =
+          0x03 (down), StepSize = ColorTempPhysicalMaxMireds and TransitionTime = 0 (instant)."
+      PICS: CC.S.F04 && CC.S.C4c.Rsp
+      command: "StepColorTemperature"
+      arguments:
+          values:
+              - name: "StepMode"
+                value: 3
+              - name: "StepSize"
+                value:
+                    ColorTempPhysicalMaxMiredsValue
+              - name: "ColorTemperatureMinimumMireds"
+                value: 0
+              - name: "ColorTemperatureMaximumMireds"
+                value: ColorTempPhysicalMaxMiredsValue
+              - name: "TransitionTime"
+                value: 0
+              - name: "OptionsMask"
+                value: 0
+              - name: "OptionsOverride"
+                value: 0
+
+    - label: "Wait 100ms"
+      PICS: CC.S.F04
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: 100
+
+    - label: "Step 6b: TH reads ColorTemperatureMireds attribute from DUT."
+      PICS: CC.S.F04 && CC.S.A0007 && CC.S.C4c.Rsp
+      command: "readAttribute"
+      attribute: "ColorTemperatureMireds"
+      response:
+          value: ColorTempPhysicalMinMiredsValue
+          constraints:
+              minValue: ColorTempPhysicalMinMiredsValue
+              maxValue: ColorTempPhysicalMaxMiredsValue
 
     - label: "Turn Off light that we turned on"
       PICS: OO.S.C00.Rsp

--- a/src/app/tests/suites/certification/Test_TC_CC_6_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_6_3.yaml
@@ -286,7 +286,7 @@ tests:
           constraints:
               minValue: 0
               maxValue: 3
-    
+
     - label:
           "Step 5a: TH sends StepColorTemperature command to DUT with StepMode =
           0x01 (up), StepSize = ColorTempPhysicalMaxMireds and TransitionTime = 0 (instant)."
@@ -328,7 +328,7 @@ tests:
           constraints:
               minValue: ColorTempPhysicalMinMiredsValue
               maxValue: ColorTempPhysicalMaxMiredsValue
-    
+
     - label:
           "Step 6a: TH sends StepColorTemperature command to DUT with StepMode =
           0x03 (down), StepSize = ColorTempPhysicalMaxMireds and TransitionTime = 0 (instant)."


### PR DESCRIPTION
…ield is 0 for `MoveColorTemperature` and `StepColorTemperature` commands.

Add test steps to TC_CC_6.2 and TC_CC_6.3 to validate the behaviour (tied with test plan pr [4235](https://github.com/CHIP-Specifications/chip-test-plans/pull/4235))

fixes #33903 
