### PR TITLE
Remove redundant attributes from LogV implementation

### DIFF
--- a/src/platform/ESP32/Logging.cpp
+++ b/src/platform/ESP32/Logging.cpp
@@ -3,7 +3,6 @@
 #include <platform/logging/LogV.h>
 
 #include <lib/core/CHIPConfig.h>
-#include <lib/support/EnforceFormat.h>
 #include <lib/support/logging/Constants.h>
 
 #include <stdio.h>
@@ -19,7 +18,7 @@ namespace chip {
 namespace Logging {
 namespace Platform {
 
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     char tag[11];
 

--- a/src/platform/Linux/Logging.cpp
+++ b/src/platform/Linux/Logging.cpp
@@ -1,9 +1,9 @@
 /* See Project CHIP LICENSE file for licensing information. */
 
-#include <lib/core/CHIPConfig.h>
-#include <lib/support/EnforceFormat.h>
-#include <lib/support/logging/Constants.h>
 #include <platform/logging/LogV.h>
+
+#include <lib/core/CHIPConfig.h>
+#include <lib/support/logging/Constants.h>
 
 #include <cinttypes>
 #include <cstdio>
@@ -35,7 +35,7 @@ namespace Platform {
 /**
  * CHIP log output functions.
  */
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     struct timeval tv;
 

--- a/src/platform/NuttX/Logging.cpp
+++ b/src/platform/NuttX/Logging.cpp
@@ -1,9 +1,9 @@
 /* See Project CHIP LICENSE file for licensing information. */
 
-#include <lib/core/CHIPConfig.h>
-#include <lib/support/EnforceFormat.h>
-#include <lib/support/logging/Constants.h>
 #include <platform/logging/LogV.h>
+
+#include <lib/core/CHIPConfig.h>
+#include <lib/support/logging/Constants.h>
 
 #include <cinttypes>
 #include <cstdio>
@@ -35,7 +35,7 @@ namespace Platform {
 /**
  * CHIP log output functions.
  */
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     struct timeval tv;
 

--- a/src/platform/Tizen/Logging.cpp
+++ b/src/platform/Tizen/Logging.cpp
@@ -15,15 +15,15 @@
  *    limitations under the License.
  */
 
+#include <platform/logging/LogV.h>
+
 #include <cstdint>
 #include <cstdio>
 
 #include <dlog.h>
 
 #include <lib/core/CHIPConfig.h>
-#include <lib/support/EnforceFormat.h>
 #include <lib/support/logging/Constants.h>
-#include <platform/logging/LogV.h>
 
 namespace chip {
 namespace Logging {
@@ -32,7 +32,7 @@ namespace Platform {
 /**
  * CHIP log output functions.
  */
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     static constexpr char kLogTag[] = "CHIP";
 

--- a/src/platform/Zephyr/Logging.cpp
+++ b/src/platform/Zephyr/Logging.cpp
@@ -3,7 +3,6 @@
 #include <platform/logging/LogV.h>
 
 #include <lib/core/CHIPConfig.h>
-#include <lib/support/EnforceFormat.h>
 #include <lib/support/logging/Constants.h>
 
 #include <zephyr/kernel.h>
@@ -42,7 +41,7 @@ namespace Platform {
  * CHIP log output function.
  */
 
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
     snprintfcb(formattedMsg, sizeof(formattedMsg), "[%s]", module);

--- a/src/platform/logging/impl/android/Logging.cpp
+++ b/src/platform/logging/impl/android/Logging.cpp
@@ -1,8 +1,8 @@
 /* See Project chip LICENSE file for licensing information. */
 
-#include <lib/support/EnforceFormat.h>
-#include <lib/support/logging/Constants.h>
 #include <platform/logging/LogV.h>
+
+#include <lib/support/logging/Constants.h>
 
 #include <android/log.h>
 
@@ -10,7 +10,7 @@ namespace chip {
 namespace Logging {
 namespace Platform {
 
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     int priority = (category == kLogCategory_Error) ? ANDROID_LOG_ERROR : ANDROID_LOG_DEBUG;
     __android_log_vprint(priority, module, msg, v);

--- a/src/platform/logging/impl/stdio/Logging.cpp
+++ b/src/platform/logging/impl/stdio/Logging.cpp
@@ -1,8 +1,8 @@
 /* See Project CHIP LICENSE file for licensing information. */
 
-#include <lib/support/EnforceFormat.h>
-#include <lib/support/logging/Constants.h>
 #include <platform/logging/LogV.h>
+
+#include <lib/support/logging/Constants.h>
 
 #include <stdio.h>
 
@@ -10,7 +10,7 @@ namespace chip {
 namespace Logging {
 namespace Platform {
 
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     printf("CHIP:%s: ", module);
     vprintf(msg, v);

--- a/src/platform/logging/impl/stdio/darwin/Logging.cpp
+++ b/src/platform/logging/impl/stdio/darwin/Logging.cpp
@@ -15,10 +15,10 @@
  *    limitations under the License.
  */
 
-#include <lib/core/CHIPConfig.h>
-#include <lib/support/EnforceFormat.h>
-#include <lib/support/logging/Constants.h>
 #include <platform/logging/LogV.h>
+
+#include <lib/core/CHIPConfig.h>
+#include <lib/support/logging/Constants.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <sys/time.h>
@@ -28,7 +28,7 @@ namespace chip {
 namespace Logging {
 namespace Platform {
 
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     timeval time;
     gettimeofday(&time, nullptr);

--- a/src/platform/mbed/Logging.cpp
+++ b/src/platform/mbed/Logging.cpp
@@ -21,14 +21,14 @@
  *          Logging implementation for Mbed platform
  */
 
-#include <lib/core/CHIPConfig.h>
-#include <lib/support/EnforceFormat.h>
-#include <lib/support/logging/CHIPLogging.h>
-#include <lib/support/logging/Constants.h>
 #include <platform/logging/LogV.h>
 
 #include <stdio.h>
 #include <string.h>
+
+#include <lib/core/CHIPConfig.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <lib/support/logging/Constants.h>
 
 #include "mbed-trace/mbed_trace.h"
 
@@ -66,7 +66,7 @@ char logMsgBuffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
 /**
  * CHIP log output functions.
  */
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     size_t prefixLen = 0;
     snprintf(logMsgBuffer, sizeof(logMsgBuffer), "[%s]", module);

--- a/src/platform/nxp/k32w/k32w0/Logging.cpp
+++ b/src/platform/nxp/k32w/k32w0/Logging.cpp
@@ -2,7 +2,9 @@
 
 #include <platform/logging/LogV.h>
 
+#include <cstring>
 #include <inttypes.h>
+
 #include <lib/core/CHIPConfig.h>
 #include <lib/support/EnforceFormat.h>
 #include <lib/support/logging/Constants.h>
@@ -10,7 +12,6 @@
 #include <src/lib/support/CodeUtils.h>
 
 #include "fsl_debug_console.h"
-#include <cstring>
 
 #define K32W_LOG_MODULE_NAME chip
 #define EOL_CHARS "\r\n" /* End of Line Characters */
@@ -128,7 +129,7 @@ namespace Platform {
 /**
  * CHIP log output function.
  */
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     (void) module;
     (void) category;

--- a/src/platform/nxp/k32w/k32w1/Logging.cpp
+++ b/src/platform/nxp/k32w/k32w1/Logging.cpp
@@ -146,7 +146,7 @@ namespace Platform {
 /**
  * CHIP log output function.
  */
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     (void) module;
     (void) category;

--- a/src/platform/openiotsdk/Logging.cpp
+++ b/src/platform/openiotsdk/Logging.cpp
@@ -22,11 +22,11 @@
  *          for Open IOT SDK platform.
  */
 
+#include <platform/logging/LogV.h>
+
 #include <lib/core/CHIPConfig.h>
-#include <lib/support/EnforceFormat.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <lib/support/logging/Constants.h>
-#include <platform/logging/LogV.h>
 
 #include <stdio.h>
 #include <string.h>
@@ -50,7 +50,7 @@ namespace Platform {
 /**
  * CHIP log output functions.
  */
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     char logMsgBuffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
 

--- a/src/platform/qpg/Logging.cpp
+++ b/src/platform/qpg/Logging.cpp
@@ -5,7 +5,6 @@
 
 #include <lib/core/CHIPConfig.h>
 #include <lib/support/CHIPPlatformMemory.h>
-#include <lib/support/EnforceFormat.h>
 #include <lib/support/logging/Constants.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <system/SystemClock.h>
@@ -67,7 +66,7 @@ static size_t AddTimeStampAndPrefixStr(char * logBuffer, const char * prefix, si
  * CHIP log output function.
  */
 
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
     size_t formattedMsgLen;

--- a/src/platform/webos/Logging.cpp
+++ b/src/platform/webos/Logging.cpp
@@ -1,7 +1,5 @@
 /* See Project CHIP LICENSE file for licensing information. */
 
-#include <lib/support/EnforceFormat.h>
-#include <lib/support/logging/Constants.h>
 #include <platform/logging/LogV.h>
 
 #include <cinttypes>
@@ -9,6 +7,8 @@
 #include <sys/syscall.h>
 #include <sys/time.h>
 #include <unistd.h>
+
+#include <lib/support/logging/Constants.h>
 
 #ifdef USE_SYSLOG
 #include <syslog.h>
@@ -33,7 +33,7 @@ namespace Platform {
 /**
  * CHIP log output functions.
  */
-void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char * msg, va_list v)
+void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
     struct timeval tv;
 


### PR DESCRIPTION
The function was already declared with ENFORCE_FORMAT(3, 0), so there is no need to repeat this attribute in the definition.