### PR TITLE
[Python] Convert async API functions to python asyncio

### DIFF
--- a/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
@@ -153,6 +153,4 @@ async def main(setup_code, yaml_path, node_id, pics_file):
 
 
 if __name__ == '__main__':
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
-    loop.close()
+    asyncio.run(main())

--- a/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
@@ -101,7 +101,7 @@ async def execute_test(yaml, runner):
     '--pics-file',
     default=None,
     help='Optional PICS file')
-def main(setup_code, yaml_path, node_id, pics_file):
+async def main(setup_code, yaml_path, node_id, pics_file):
     # Setting up python environment for running YAML CI tests using python parser.
     with tempfile.NamedTemporaryFile() as chip_stack_storage:
         chip.native.Init()
@@ -122,7 +122,7 @@ def main(setup_code, yaml_path, node_id, pics_file):
         # Creating and commissioning to a single controller to match what is currently done when
         # running.
         dev_ctrl = ca_list[0].adminList[0].NewController()
-        dev_ctrl.CommissionWithCode(setup_code, node_id)
+        await dev_ctrl.CommissionWithCode(setup_code, node_id)
 
         def _StackShutDown():
             # Tearing down chip stack. If not done in the correct order test will fail.
@@ -143,7 +143,7 @@ def main(setup_code, yaml_path, node_id, pics_file):
             runner = ReplTestRunner(
                 clusters_definitions, certificate_authority_manager, dev_ctrl)
 
-            asyncio.run(execute_test(yaml, runner))
+            await execute_test(yaml, runner)
 
         except Exception:
             print(traceback.format_exc())
@@ -153,4 +153,6 @@ def main(setup_code, yaml_path, node_id, pics_file):
 
 
 if __name__ == '__main__':
-    main()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())
+    loop.close()

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -227,6 +227,12 @@ def _singleton(cls):
 
 
 class CallbackContext:
+    """A context manager for handling callbacks that are expected to be called exactly once.
+
+    The context manager makes sure that no concurrent operations which use the same callback
+    handlers are executed.
+    """
+
     def __init__(self, lock: asyncio.Lock) -> None:
         self._lock = lock
         self._future = None
@@ -248,6 +254,11 @@ class CallbackContext:
 
 
 class CommissioningContext(CallbackContext):
+    """A context manager for handling commissioning callbacks that are expected to be called exactly once.
+
+    This context also resets commissioning related device controller state.
+    """
+
     def __init__(self, devCtrl: ChipDeviceController, lock: asyncio.Lock) -> None:
         super().__init__(lock)
         self._devCtrl = devCtrl

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -241,6 +241,8 @@ class CallbackContext:
         return self._future
 
     async def __aexit__(self, exc_type, exc_value, traceback):
+        if not self._future.done():
+            raise RuntimeError("CallbackContext future not completed")
         self._future = None
         self._lock.release()
 

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -593,15 +593,16 @@ class ChipDeviceControllerBase():
 
             return await asyncio.futures.wrap_future(ctx.future)
 
-    def UnpairDevice(self, nodeid: int) -> None:
+    async def UnpairDevice(self, nodeid: int) -> None:
         self.CheckIsActive()
 
         with self._unpair_device_context as ctx:
-            self._ChipStack.Call(
+            res = await self._ChipStack.CallAsync(
                 lambda: self._dmLib.pychip_DeviceController_UnpairDevice(
                     self.devCtrl, nodeid, self.cbHandleDeviceUnpairCompleteFunct)
-            ).raise_on_error()
-            ctx.future.result()
+            )
+            res.raise_on_error()
+            return await asyncio.futures.wrap_future(ctx.future)
 
     def CloseBLEConnection(self):
         self.CheckIsActive()
@@ -781,8 +782,8 @@ class ChipDeviceControllerBase():
         kOriginalSetupCode = 0,
         kTokenWithRandomPin = 1,
 
-    def OpenCommissioningWindow(self, nodeid: int, timeout: int, iteration: int,
-                                discriminator: int, option: CommissioningWindowPasscode) -> CommissioningParameters:
+    async def OpenCommissioningWindow(self, nodeid: int, timeout: int, iteration: int,
+                                      discriminator: int, option: CommissioningWindowPasscode) -> CommissioningParameters:
         ''' Opens a commissioning window on the device with the given nodeid.
             nodeid:        Node id of the device
             timeout:       Command timeout
@@ -799,12 +800,13 @@ class ChipDeviceControllerBase():
         self.CheckIsActive()
 
         with self._open_window_context as ctx:
-            self._ChipStack.Call(
+            res = await self._ChipStack.CallAsync(
                 lambda: self._dmLib.pychip_DeviceController_OpenCommissioningWindow(
                     self.devCtrl, self.pairingDelegate, nodeid, timeout, iteration, discriminator, option)
-            ).raise_on_error()
+            )
+            res.raise_on_error()
 
-            return ctx.future.result()
+            return await asyncio.futures.wrap_future(ctx.future)
 
     def GetCompressedFabricId(self):
         self.CheckIsActive()

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -2095,17 +2095,18 @@ class ChipDeviceController(ChipDeviceControllerBase):
         self._issue_node_chain_context.future.set_result(nocChain)
         return
 
-    def IssueNOCChain(self, csr: Clusters.OperationalCredentials.Commands.CSRResponse, nodeId: int):
+    async def IssueNOCChain(self, csr: Clusters.OperationalCredentials.Commands.CSRResponse, nodeId: int):
         """Issue an NOC chain using the associated OperationalCredentialsDelegate.
         The NOC chain will be provided in TLV cert format."""
         self.CheckIsActive()
 
         with self._issue_node_chain_context as ctx:
-            self._ChipStack.Call(
+            res = await self._ChipStack.CallAsync(
                 lambda: self._dmLib.pychip_DeviceController_IssueNOCChain(
                     self.devCtrl, py_object(self), csr.NOCSRElements, len(csr.NOCSRElements), nodeId)
-            ).raise_on_error()
-            return ctx.future.result()
+            )
+            res.raise_on_error()
+            return await asyncio.futures.wrap_future(ctx.future)
 
 
 class BareChipDeviceController(ChipDeviceControllerBase):

--- a/src/controller/python/chip/commissioning/pase.py
+++ b/src/controller/python/chip/commissioning/pase.py
@@ -44,9 +44,9 @@ class ContextManager:
             self.devCtrl.CloseBLEConnection(self.is_ble)
 
 
-def establish_session(devCtrl: ChipDeviceCtrl.ChipDeviceControllerBase, parameter: commissioning.PaseParameters) -> ContextManager:
+async def establish_session(devCtrl: ChipDeviceCtrl.ChipDeviceControllerBase, parameter: commissioning.PaseParameters) -> ContextManager:
     if isinstance(parameter, commissioning.PaseOverBLEParameters):
-        devCtrl.EstablishPASESessionBLE(parameter.setup_pin, parameter.discriminator, parameter.temporary_nodeid)
+        await devCtrl.EstablishPASESessionBLE(parameter.setup_pin, parameter.discriminator, parameter.temporary_nodeid)
     elif isinstance(parameter, commissioning.PaseOverIPParameters):
         device = devCtrl.DiscoverCommissionableNodes(filterType=discovery.FilterType.LONG_DISCRIMINATOR,
                                                      filter=parameter.long_discriminator, stopOnFirst=True)
@@ -63,7 +63,7 @@ def establish_session(devCtrl: ChipDeviceCtrl.ChipDeviceControllerBase, paramete
             break
         if selected_address is None:
             raise ValueError("The node for commissioning does not contains routable ip addresses information")
-        devCtrl.EstablishPASESessionIP(selected_address, parameter.setup_pin, parameter.temporary_nodeid)
+        await devCtrl.EstablishPASESessionIP(selected_address, parameter.setup_pin, parameter.temporary_nodeid)
     else:
         raise TypeError("Expect PaseOverBLEParameters or PaseOverIPParameters for establishing PASE session")
     return ContextManager(

--- a/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
+++ b/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
@@ -167,7 +167,7 @@ async def AddNOCForNewFabricFromExisting(commissionerDevCtrl, newFabricDevCtrl, 
 
     csrForAddNOC = await commissionerDevCtrl.SendCommand(existingNodeId, 0, opCreds.Commands.CSRRequest(CSRNonce=os.urandom(32)))
 
-    chainForAddNOC = newFabricDevCtrl.IssueNOCChain(csrForAddNOC, newNodeId)
+    chainForAddNOC = await newFabricDevCtrl.IssueNOCChain(csrForAddNOC, newNodeId)
     if (chainForAddNOC.rcacBytes is None or
             chainForAddNOC.icacBytes is None or
             chainForAddNOC.nocBytes is None or chainForAddNOC.ipkBytes is None):
@@ -225,7 +225,7 @@ async def UpdateNOC(devCtrl, existingNodeId, newNodeId):
         return False
     csrForUpdateNOC = await devCtrl.SendCommand(
         existingNodeId, 0, opCreds.Commands.CSRRequest(CSRNonce=os.urandom(32), isForUpdateNOC=True))
-    chainForUpdateNOC = devCtrl.IssueNOCChain(csrForUpdateNOC, newNodeId)
+    chainForUpdateNOC = await devCtrl.IssueNOCChain(csrForUpdateNOC, newNodeId)
     if (chainForUpdateNOC.rcacBytes is None or
             chainForUpdateNOC.icacBytes is None or
             chainForUpdateNOC.nocBytes is None or chainForUpdateNOC.ipkBytes is None):

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -665,7 +665,7 @@ class CommissionerCommandAction(BaseAction):
             return _ActionResult(status=_ActionStatus.SUCCESS, response=_GetCommissionerNodeIdResult(dev_ctrl.nodeId))
 
         try:
-            dev_ctrl.CommissionWithCode(self._setup_payload, self._node_id)
+            await dev_ctrl.CommissionWithCode(self._setup_payload, self._node_id)
             return _ActionResult(status=_ActionStatus.SUCCESS, response=None)
         except ChipStackError:
             return _ActionResult(status=_ActionStatus.ERROR, response=None)

--- a/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
+++ b/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
@@ -59,7 +59,7 @@ class Runner(TestRunner):
         # device with the provided node id.
         if self._node_id_to_commission is not None:
             # Magic value is the defaults expected for YAML tests.
-            dev_ctrl.CommissionWithCode('MT:-24J0AFN00KA0648G00', self._node_id_to_commission)
+            await dev_ctrl.CommissionWithCode('MT:-24J0AFN00KA0648G00', self._node_id_to_commission)
 
         self._chip_stack = chip_stack
         self._certificate_authority_manager = certificate_authority_manager

--- a/src/controller/python/test/test_scripts/commissioning_failure_test.py
+++ b/src/controller/python/test/test_scripts/commissioning_failure_test.py
@@ -136,9 +136,7 @@ async def main():
 
 if __name__ == "__main__":
     try:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(main())
-        loop.close()
+        asyncio.run(main())
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/commissioning_failure_test.py
+++ b/src/controller/python/test/test_scripts/commissioning_failure_test.py
@@ -46,7 +46,7 @@ LIGHTING_ENDPOINT_ID = 1
 GROUP_ID = 0
 
 
-def main():
+async def main():
     optParser = OptionParser()
     optParser.add_option(
         "-t",
@@ -98,32 +98,32 @@ def main():
     # TODO: Start at stage 2 once handling for arming failsafe on pase is done.
     if options.report:
         for testFailureStage in range(3, 21):
-            FailIfNot(test.TestPaseOnly(ip=options.deviceAddress1,
-                                        setuppin=20202021,
-                                        nodeid=1),
+            FailIfNot(await test.TestPaseOnly(ip=options.deviceAddress1,
+                                              setuppin=20202021,
+                                              nodeid=1),
                       "Failed to establish PASE connection with device")
-            FailIfNot(test.TestCommissionFailureOnReport(1, testFailureStage),
+            FailIfNot(await test.TestCommissionFailureOnReport(1, testFailureStage),
                       "Commissioning failure tests failed for simulated report failure on stage {}".format(testFailureStage))
 
     else:
         for testFailureStage in range(3, 21):
-            FailIfNot(test.TestPaseOnly(ip=options.deviceAddress1,
-                                        setuppin=20202021,
-                                        nodeid=1),
+            FailIfNot(await test.TestPaseOnly(ip=options.deviceAddress1,
+                                              setuppin=20202021,
+                                              nodeid=1),
                       "Failed to establish PASE connection with device")
-            FailIfNot(test.TestCommissionFailure(1, testFailureStage),
+            FailIfNot(await test.TestCommissionFailure(1, testFailureStage),
                       "Commissioning failure tests failed for simulated stage failure on stage {}".format(testFailureStage))
 
     # Ensure we can still commission for real
-    FailIfNot(test.TestPaseOnly(ip=options.deviceAddress1,
-                                setuppin=20202021,
-                                nodeid=1),
+    FailIfNot(await test.TestPaseOnly(ip=options.deviceAddress1,
+                                      setuppin=20202021,
+                                      nodeid=1),
               "Failed to establish PASE connection with device")
-    FailIfNot(test.TestCommissionFailure(1, 0), "Failed to commission device")
+    FailIfNot(await test.TestCommissionFailure(1, 0), "Failed to commission device")
 
     logger.info("Testing on off cluster")
-    FailIfNot(asyncio.run(test.TestOnOffCluster(nodeid=1,
-                                                endpoint=LIGHTING_ENDPOINT_ID)), "Failed to test on off cluster")
+    FailIfNot(await test.TestOnOffCluster(nodeid=1,
+                                          endpoint=LIGHTING_ENDPOINT_ID), "Failed to test on off cluster")
 
     timeoutTicker.stop()
 
@@ -136,7 +136,9 @@ def main():
 
 if __name__ == "__main__":
     try:
-        main()
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())
+        loop.close()
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/commissioning_test.py
+++ b/src/controller/python/test/test_scripts/commissioning_test.py
@@ -164,9 +164,7 @@ async def main():
 
 if __name__ == "__main__":
     try:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(main())
-        loop.close()
+        asyncio.run(main())
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/commissioning_test.py
+++ b/src/controller/python/test/test_scripts/commissioning_test.py
@@ -47,7 +47,7 @@ LIGHTING_ENDPOINT_ID = 1
 GROUP_ID = 0
 
 
-def main():
+async def main():
     optParser = OptionParser()
     optParser.add_option(
         "-t",
@@ -133,22 +133,22 @@ def main():
 
     if options.deviceAddress:
         logger.info("Testing commissioning (IP)")
-        FailIfNot(test.TestCommissioning(ip=options.deviceAddress,
-                                         setuppin=20202021,
-                                         nodeid=options.nodeid),
+        FailIfNot(await test.TestCommissioning(ip=options.deviceAddress,
+                                               setuppin=20202021,
+                                               nodeid=options.nodeid),
                   "Failed to finish commissioning")
     elif options.setupPayload:
         logger.info("Testing commissioning (w/ Setup Payload)")
-        FailIfNot(test.TestCommissioningWithSetupPayload(setupPayload=options.setupPayload,
-                                                         nodeid=options.nodeid,
-                                                         discoveryType=options.discoveryType),
+        FailIfNot(await test.TestCommissioningWithSetupPayload(setupPayload=options.setupPayload,
+                                                               nodeid=options.nodeid,
+                                                               discoveryType=options.discoveryType),
                   "Failed to finish commissioning")
     else:
         TestFail("Must provide device address or setup payload to commissioning the device")
 
     logger.info("Testing on off cluster")
-    FailIfNot(asyncio.run(test.TestOnOffCluster(nodeid=options.nodeid,
-                                                endpoint=LIGHTING_ENDPOINT_ID)), "Failed to test on off cluster")
+    FailIfNot(await test.TestOnOffCluster(nodeid=options.nodeid,
+                                          endpoint=LIGHTING_ENDPOINT_ID), "Failed to test on off cluster")
 
     FailIfNot(test.TestUsedTestCommissioner(),
               "Test commissioner check failed")
@@ -164,7 +164,9 @@ def main():
 
 if __name__ == "__main__":
     try:
-        main()
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())
+        loop.close()
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/commissioning_window_test.py
+++ b/src/controller/python/test/test_scripts/commissioning_window_test.py
@@ -89,9 +89,9 @@ async def main():
               "Failed to finish network commissioning")
 
     logger.info("Commissioning DUT from first commissioner")
-    FailIfNot(test.TestPaseOnly(ip=options.deviceAddress, setuppin=20202021, nodeid=1),
+    FailIfNot(await test.TestPaseOnly(ip=options.deviceAddress, setuppin=20202021, nodeid=1),
               "Unable to establish PASE connection to device")
-    FailIfNot(test.TestCommissionOnly(nodeid=1), "Unable to commission device")
+    FailIfNot(await test.TestCommissionOnly(nodeid=1), "Unable to commission device")
 
     logger.info("Creating controller on a new fabric")
     FailIfNot(test.CreateNewFabricController(), "Unable to create new controller")
@@ -103,7 +103,7 @@ async def main():
               "RevokeCommissioning test failed")
 
     logger.info("Test Enhanced Commissioning Window")
-    FailIfNot(test.TestEnhancedCommissioningWindow(ip=options.deviceAddress, nodeid=1), "EnhancedCommissioningWindow open failed")
+    FailIfNot(await test.TestEnhancedCommissioningWindow(ip=options.deviceAddress, nodeid=1), "EnhancedCommissioningWindow open failed")
 
     timeoutTicker.stop()
 

--- a/src/controller/python/test/test_scripts/example_python_commissioning_flow.py
+++ b/src/controller/python/test/test_scripts/example_python_commissioning_flow.py
@@ -32,7 +32,7 @@ class ExampleCustomMatterCommissioningFlow(commissioning_flow_blocks.Commissioni
 
     async def commission(self, parameter: commissioning.Parameters):
         # The example uses PASE, however, the blocks uses a node_id, which supports both PASE and CASE.
-        with pase.establish_session(devCtrl=self._devCtrl, parameter=parameter.pase_param) as device:
+        with await pase.establish_session(devCtrl=self._devCtrl, parameter=parameter.pase_param) as device:
             node_id = device.node_id
 
             self._logger.info("Sending ArmFailSafe to device")
@@ -68,7 +68,7 @@ class ExampleCredentialProvider:
 
     async def get_commissionee_credentials(self, request: commissioning.GetCommissioneeCredentialsRequest) -> commissioning.GetCommissioneeCredentialsResponse:
         node_id = random.randint(100000, 999999)
-        nocChain = self._devCtrl.IssueNOCChain(Clusters.OperationalCredentials.Commands.CSRResponse(
+        nocChain = await self._devCtrl.IssueNOCChain(Clusters.OperationalCredentials.Commands.CSRResponse(
             NOCSRElements=request.csr_elements, attestationSignature=request.attestation_signature), nodeId=node_id)
         return commissioning.GetCommissioneeCredentialsResponse(
             rcac=nocChain.rcacBytes,

--- a/src/controller/python/test/test_scripts/failsafe_tests.py
+++ b/src/controller/python/test/test_scripts/failsafe_tests.py
@@ -46,7 +46,7 @@ LIGHTING_ENDPOINT_ID = 1
 GROUP_ID = 0
 
 
-def main():
+async def main():
     optParser = OptionParser()
     optParser.add_option(
         "-t",
@@ -95,12 +95,12 @@ def main():
               "Failed to finish network commissioning")
 
     logger.info("Testing commissioning")
-    FailIfNot(test.TestCommissioning(ip=options.deviceAddress,
-                                     setuppin=20202021,
-                                     nodeid=1),
+    FailIfNot(await test.TestCommissioning(ip=options.deviceAddress,
+                                           setuppin=20202021,
+                                           nodeid=1),
               "Failed to finish key exchange")
 
-    FailIfNot(asyncio.run(test.TestFailsafe(nodeid=1)), "Failed failsafe test")
+    FailIfNot(await test.TestFailsafe(nodeid=1), "Failed failsafe test")
 
     timeoutTicker.stop()
 
@@ -113,7 +113,9 @@ def main():
 
 if __name__ == "__main__":
     try:
-        main()
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())
+        loop.close()
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/failsafe_tests.py
+++ b/src/controller/python/test/test_scripts/failsafe_tests.py
@@ -113,9 +113,7 @@ async def main():
 
 if __name__ == "__main__":
     try:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(main())
-        loop.close()
+        asyncio.run(main())
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -57,7 +57,7 @@ TEST_DEVICE_NODE_ID = 1
 ALL_TESTS = ['network_commissioning', 'datamodel']
 
 
-def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
+async def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
     logger.info("Testing discovery")
     device = test.TestDiscovery(discriminator=discriminator)
     FailIfNot(device, "Failed to discover any devices.")
@@ -71,27 +71,27 @@ def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: 
         address = address_override
 
     logger.info("Testing commissioning")
-    FailIfNot(test.TestCommissioning(ip=address,
-                                     setuppin=setup_pin,
-                                     nodeid=device_nodeid),
+    FailIfNot(await test.TestCommissioning(ip=address,
+                                           setuppin=setup_pin,
+                                           nodeid=device_nodeid),
               "Failed to finish key exchange")
 
     logger.info("Testing multi-controller setup on the same fabric")
-    FailIfNot(asyncio.run(test.TestMultiControllerFabric(nodeid=device_nodeid)), "Failed the multi-controller test")
+    FailIfNot(await test.TestMultiControllerFabric(nodeid=device_nodeid), "Failed the multi-controller test")
 
     logger.info("Testing CATs used on controllers")
-    FailIfNot(asyncio.run(test.TestControllerCATValues(nodeid=device_nodeid)), "Failed the controller CAT test")
+    FailIfNot(await test.TestControllerCATValues(nodeid=device_nodeid), "Failed the controller CAT test")
 
-    ok = asyncio.run(test.TestMultiFabric(ip=address,
-                                          setuppin=20202021,
-                                          nodeid=1))
+    ok = await test.TestMultiFabric(ip=address,
+                                    setuppin=20202021,
+                                    nodeid=1)
     FailIfNot(ok, "Failed to commission multi-fabric")
 
-    FailIfNot(asyncio.run(test.TestAddUpdateRemoveFabric(nodeid=device_nodeid)),
+    FailIfNot(await test.TestAddUpdateRemoveFabric(nodeid=device_nodeid),
               "Failed AddUpdateRemoveFabric test")
 
     logger.info("Testing CASE Eviction")
-    FailIfNot(asyncio.run(test.TestCaseEviction(device_nodeid)), "Failed TestCaseEviction")
+    FailIfNot(await test.TestCaseEviction(device_nodeid), "Failed TestCaseEviction")
 
     logger.info("Testing closing sessions")
     FailIfNot(test.TestCloseSession(nodeid=device_nodeid), "Failed to close sessions")
@@ -163,8 +163,8 @@ def do_tests(controller_nodeid, device_nodeid, address, timeout, discriminator, 
 
     chip.logging.RedirectToPythonLogging()
 
-    ethernet_commissioning(test, discriminator, setup_pin, address,
-                           device_nodeid)
+    asyncio.run(ethernet_commissioning(test, discriminator, setup_pin, address,
+                                       device_nodeid))
 
     logger.info("Testing resolve")
     FailIfNot(test.TestResolve(nodeid=device_nodeid),

--- a/src/controller/python/test/test_scripts/python_commissioning_flow_test.py
+++ b/src/controller/python/test/test_scripts/python_commissioning_flow_test.py
@@ -126,7 +126,7 @@ def main():
 
         async def get_commissionee_credentials(self, request: commissioning.GetCommissioneeCredentialsRequest) -> commissioning.GetCommissioneeCredentialsResponse:
             node_id = random.randint(100000, 999999)
-            nocChain = self._devCtrl.IssueNOCChain(Clusters.OperationalCredentials.Commands.CSRResponse(
+            nocChain = await self._devCtrl.IssueNOCChain(Clusters.OperationalCredentials.Commands.CSRResponse(
                 NOCSRElements=request.csr_elements, attestationSignature=request.attestation_signature), nodeId=node_id)
             return commissioning.GetCommissioneeCredentialsResponse(
                 rcac=nocChain.rcacBytes[1:],

--- a/src/controller/python/test/test_scripts/split_commissioning_test.py
+++ b/src/controller/python/test/test_scripts/split_commissioning_test.py
@@ -137,9 +137,7 @@ async def main():
 
 if __name__ == "__main__":
     try:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(main())
-        loop.close()
+        asyncio.run(main())
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/split_commissioning_test.py
+++ b/src/controller/python/test/test_scripts/split_commissioning_test.py
@@ -46,7 +46,7 @@ LIGHTING_ENDPOINT_ID = 1
 GROUP_ID = 0
 
 
-def main():
+async def main():
     optParser = OptionParser()
     optParser.add_option(
         "-t",
@@ -97,34 +97,34 @@ def main():
               "Failed to finish network commissioning")
 
     logger.info("Testing PASE connection to device 1")
-    FailIfNot(test.TestPaseOnly(ip=options.deviceAddress1,
-                                setuppin=20202021,
-                                nodeid=1),
+    FailIfNot(await test.TestPaseOnly(ip=options.deviceAddress1,
+                                      setuppin=20202021,
+                                      nodeid=1),
               "Failed to establish PASE connection with device 1")
 
     logger.info("Testing PASE connection to device 2")
-    FailIfNot(test.TestPaseOnly(ip=options.deviceAddress2,
-                                setuppin=20202021,
-                                nodeid=2),
+    FailIfNot(await test.TestPaseOnly(ip=options.deviceAddress2,
+                                      setuppin=20202021,
+                                      nodeid=2),
               "Failed to establish PASE connection with device 2")
 
     logger.info("Attempting to execute a fabric-scoped command during PASE before AddNOC")
-    FailIfNot(test.TestFabricScopedCommandDuringPase(nodeid=1),
+    FailIfNot(await test.TestFabricScopedCommandDuringPase(nodeid=1),
               "Did not get UNSUPPORTED_ACCESS for fabric-scoped command during PASE")
 
-    FailIfNot(test.TestCommissionOnly(nodeid=1),
+    FailIfNot(await test.TestCommissionOnly(nodeid=1),
               "Failed to commission device 1")
 
-    FailIfNot(test.TestCommissionOnly(nodeid=2),
+    FailIfNot(await test.TestCommissionOnly(nodeid=2),
               "Failed to commission device 2")
 
     logger.info("Testing on off cluster on device 1")
-    FailIfNot(asyncio.run(test.TestOnOffCluster(nodeid=1,
-                                                endpoint=LIGHTING_ENDPOINT_ID)), "Failed to test on off cluster on device 1")
+    FailIfNot(await test.TestOnOffCluster(nodeid=1,
+                                          endpoint=LIGHTING_ENDPOINT_ID), "Failed to test on off cluster on device 1")
 
     logger.info("Testing on off cluster on device 2")
-    FailIfNot(asyncio.run(test.TestOnOffCluster(nodeid=2,
-                                                endpoint=LIGHTING_ENDPOINT_ID)), "Failed to test on off cluster on device 2")
+    FailIfNot(await test.TestOnOffCluster(nodeid=2,
+                                          endpoint=LIGHTING_ENDPOINT_ID), "Failed to test on off cluster on device 2")
 
     timeoutTicker.stop()
 
@@ -137,7 +137,9 @@ def main():
 
 if __name__ == "__main__":
     try:
-        main()
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())
+        loop.close()
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
@@ -129,9 +129,7 @@ async def main():
 
 if __name__ == "__main__":
     try:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(main())
-        loop.close()
+        asyncio.run(main())
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl1.py
@@ -32,7 +32,7 @@ TEST_SETUPPIN = 20202021
 TEST_ENDPOINT_ID = 0
 
 
-def main():
+async def main():
     optParser = OptionParser()
     optParser.add_option(
         "-t",
@@ -110,12 +110,12 @@ def main():
         nodeid=112233, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=True)
 
     FailIfNot(
-        test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
-        "Failed on on-network commissioing")
+        await test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
+        "Failed on on-network commissioning")
 
     FailIfNot(
-        asyncio.run(test.TestSubscriptionResumptionCapacityStep1(
-            options.nodeid, TEST_ENDPOINT_ID, options.setuppin, options.subscriptionCapacity)),
+        await test.TestSubscriptionResumptionCapacityStep1(
+            options.nodeid, TEST_ENDPOINT_ID, options.setuppin, options.subscriptionCapacity),
         "Failed on step 1 of testing subscription resumption capacity")
 
     timeoutTicker.stop()
@@ -129,7 +129,9 @@ def main():
 
 if __name__ == "__main__":
     try:
-        main()
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())
+        loop.close()
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
@@ -141,9 +141,7 @@ async def main():
 
 if __name__ == "__main__":
     try:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(main())
-        loop.close()
+        asyncio.run(main())
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_capacity_test_ctrl2.py
@@ -34,7 +34,7 @@ TEST_ENDPOINT_ID = 0
 TEST_SSH_PORT = 2222
 
 
-def main():
+async def main():
     optParser = OptionParser()
     optParser.add_option(
         "-t",
@@ -122,13 +122,12 @@ def main():
         nodeid=112244, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=True)
 
     FailIfNot(
-        test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
-        "Failed on on-network commissioing")
+        await test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
+        "Failed on on-network commissioning")
 
     FailIfNot(
-        asyncio.run(
-            test.TestSubscriptionResumptionCapacityStep2(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
-                                                         TEST_SSH_PORT, options.remoteServerApp, options.subscriptionCapacity)),
+        await test.TestSubscriptionResumptionCapacityStep2(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
+                                                           TEST_SSH_PORT, options.remoteServerApp, options.subscriptionCapacity),
         "Failed on testing subscription resumption capacity")
 
     timeoutTicker.stop()
@@ -142,7 +141,9 @@ def main():
 
 if __name__ == "__main__":
     try:
-        main()
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())
+        loop.close()
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/subscription_resumption_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_test.py
@@ -34,7 +34,7 @@ TEST_ENDPOINT_ID = 0
 TEST_SSH_PORT = 2222
 
 
-def main():
+async def main():
     optParser = OptionParser()
     optParser.add_option(
         "-t",
@@ -112,12 +112,12 @@ def main():
         nodeid=112233, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=True)
 
     FailIfNot(
-        test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
-        "Failed on on-network commissioing")
+        await test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
+        "Failed on on-network commissioning")
 
     FailIfNot(
-        asyncio.run(test.TestSubscriptionResumption(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
-                                                    TEST_SSH_PORT, options.remoteServerApp)), "Failed to resume subscription")
+        await test.TestSubscriptionResumption(options.nodeid, TEST_ENDPOINT_ID, options.deviceAddress,
+                                              TEST_SSH_PORT, options.remoteServerApp), "Failed to resume subscription")
 
     timeoutTicker.stop()
 
@@ -130,7 +130,9 @@ def main():
 
 if __name__ == "__main__":
     try:
-        main()
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())
+        loop.close()
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/subscription_resumption_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_test.py
@@ -130,9 +130,7 @@ async def main():
 
 if __name__ == "__main__":
     try:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(main())
-        loop.close()
+        asyncio.run(main())
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/subscription_resumption_timeout_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_timeout_test.py
@@ -33,7 +33,7 @@ TEST_SETUPPIN = 20202021
 TEST_ENDPOINT_ID = 0
 
 
-def main():
+async def main():
     optParser = OptionParser()
     optParser.add_option(
         "-t",
@@ -102,13 +102,13 @@ def main():
         nodeid=112233, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=True)
 
     FailIfNot(
-        test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
+        await test.TestOnNetworkCommissioning(options.discriminator, options.setuppin, options.nodeid, options.deviceAddress),
         "Failed on on-network commissioning")
 
     try:
-        asyncio.run(test.devCtrl.ReadAttribute(options.nodeid,
-                                               [(TEST_ENDPOINT_ID, Clusters.BasicInformation.Attributes.NodeLabel)],
-                                               None, False, reportInterval=(1, 2), keepSubscriptions=True, autoResubscribe=False))
+        await test.devCtrl.ReadAttribute(options.nodeid,
+                                         [(TEST_ENDPOINT_ID, Clusters.BasicInformation.Attributes.NodeLabel)],
+                                         None, False, reportInterval=(1, 2), keepSubscriptions=True, autoResubscribe=False)
     except Exception as ex:
         TestFail(f"Failed to subscribe attribute: {ex}")
 
@@ -123,7 +123,9 @@ def main():
 
 if __name__ == "__main__":
     try:
-        main()
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())
+        loop.close()
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/controller/python/test/test_scripts/subscription_resumption_timeout_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_timeout_test.py
@@ -123,9 +123,7 @@ async def main():
 
 if __name__ == "__main__":
     try:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(main())
-        loop.close()
+        asyncio.run(main())
     except Exception as ex:
         logger.exception(ex)
         TestFail("Exception occurred when running tests.")

--- a/src/python_testing/TC_ACE_1_5.py
+++ b/src/python_testing/TC_ACE_1_5.py
@@ -51,10 +51,10 @@ class TC_ACE_1_5(MatterBaseTest):
         self.th2 = new_fabric_admin.NewController(nodeId=TH2_nodeid,
                                                   paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path))
 
-        params = self.openCommissioningWindow(self.th1, self.dut_node_id)
+        params = await self.openCommissioningWindow(self.th1, self.dut_node_id)
         self.print_step(2, "TH1 opens the commissioning window on the DUT")
 
-        self.th2.CommissionOnNetwork(
+        await self.th2.CommissionOnNetwork(
             nodeId=self.dut_node_id, setupPinCode=params.commissioningParameters.setupPinCode,
             filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=params.randomDiscriminator)
         logging.info('Commissioning complete done. Successful.')

--- a/src/python_testing/TC_CGEN_2_4.py
+++ b/src/python_testing/TC_CGEN_2_4.py
@@ -42,9 +42,9 @@ kSendNOC = 19
 
 class TC_CGEN_2_4(MatterBaseTest):
 
-    def OpenCommissioningWindow(self) -> CommissioningParameters:
+    async def OpenCommissioningWindow(self) -> CommissioningParameters:
         try:
-            params = self.th1.OpenCommissioningWindow(
+            params = await self.th1.OpenCommissioningWindow(
                 nodeid=self.dut_node_id, timeout=600, iteration=10000, discriminator=self.discriminator, option=1)
             return params
 
@@ -56,14 +56,14 @@ class TC_CGEN_2_4(MatterBaseTest):
             self, stage: int, expectedErrorPart: chip.native.ErrorSDKPart, expectedErrCode: int):
 
         logging.info("-----------------Fail on step {}-------------------------".format(stage))
-        params = self.OpenCommissioningWindow()
+        params = await self.OpenCommissioningWindow()
         self.th2.ResetTestCommissioner()
         # This will run the commissioning up to the point where stage x is run and the
         # response is sent before the test commissioner simulates a failure
         self.th2.SetTestCommissionerPrematureCompleteAfter(stage)
         ctx = asserts.assert_raises(ChipStackError)
         with ctx:
-            self.th2.CommissionOnNetwork(
+            await self.th2.CommissionOnNetwork(
                 nodeId=self.dut_node_id, setupPinCode=params.setupPinCode,
                 filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.discriminator)
         errcode = ctx.exception.chip_error
@@ -99,12 +99,12 @@ class TC_CGEN_2_4(MatterBaseTest):
         await self.CommissionToStageSendCompleteAndCleanup(kSendNOC, chip.native.ErrorSDKPart.IM_CLUSTER_STATUS, 0x02)
 
         logging.info('Step 15 - TH1 opens a commissioning window')
-        params = self.OpenCommissioningWindow()
+        params = await self.OpenCommissioningWindow()
 
         logging.info('Step 16 - TH2 fully commissions the DUT')
         self.th2.ResetTestCommissioner()
 
-        self.th2.CommissionOnNetwork(
+        await self.th2.CommissionOnNetwork(
             nodeId=self.dut_node_id, setupPinCode=params.setupPinCode,
             filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.discriminator)
         logging.info('Commissioning complete done.')

--- a/src/python_testing/TC_DA_1_5.py
+++ b/src/python_testing/TC_DA_1_5.py
@@ -162,7 +162,7 @@ class TC_DA_1_5(MatterBaseTest):
         await self.send_single_cmd(cmd=gcomm.Commands.ArmFailSafe(expiryLengthSeconds=0, breadcrumb=1))
 
         self.print_step(13, "Open commissioning window")
-        params = self.default_controller.OpenCommissioningWindow(
+        params = await self.default_controller.OpenCommissioningWindow(
             nodeid=self.dut_node_id, timeout=600, iteration=10000, discriminator=1234, option=1)
 
         self.print_step(14, "Commission to TH2")
@@ -170,7 +170,7 @@ class TC_DA_1_5(MatterBaseTest):
         new_fabric_admin = new_certificate_authority.NewFabricAdmin(vendorId=0xFFF1, fabricId=2)
         TH2 = new_fabric_admin.NewController(nodeId=112233)
 
-        TH2.CommissionOnNetwork(
+        await TH2.CommissionOnNetwork(
             nodeId=self.dut_node_id, setupPinCode=params.setupPinCode,
             filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=1234)
 

--- a/src/python_testing/TC_IDM_1_2.py
+++ b/src/python_testing/TC_IDM_1_2.py
@@ -187,7 +187,7 @@ class TC_IDM_1_2(MatterBaseTest):
         # To get a PASE session, we need an open commissioning window
         discriminator = random.randint(0, 4095)
 
-        params = self.default_controller.OpenCommissioningWindow(
+        params = await self.default_controller.OpenCommissioningWindow(
             nodeid=self.dut_node_id, timeout=600, iteration=10000, discriminator=discriminator, option=1)
 
         # TH2 = new controller that's not connected over CASE
@@ -201,14 +201,14 @@ class TC_IDM_1_2(MatterBaseTest):
         device = next(filter(lambda d: d.commissioningMode == 2 and d.longDiscriminator == discriminator, devices))
         for a in device.addresses:
             try:
-                TH2.EstablishPASESessionIP(ipaddr=a, setupPinCode=params.setupPinCode,
-                                           nodeid=self.dut_node_id+1, port=device.port)
+                await TH2.EstablishPASESessionIP(ipaddr=a, setupPinCode=params.setupPinCode,
+                                                 nodeid=self.dut_node_id+1, port=device.port)
                 break
             except ChipStackError:
                 continue
 
         try:
-            TH2.GetConnectedDeviceSync(nodeid=self.dut_node_id+1, allowPASE=True, timeoutMs=1000)
+            await TH2.GetConnectedDevice(nodeid=self.dut_node_id+1, allowPASE=True, timeoutMs=1000)
         except TimeoutError:
             asserts.fail("Unable to establish a PASE session to the device")
 
@@ -263,7 +263,7 @@ class TC_IDM_1_2(MatterBaseTest):
 
         # Try with RevokeCommissioning
         # First open a commissioning window for us to revoke, so we know this command is able to succeed absent this error
-        _ = self.default_controller.OpenCommissioningWindow(
+        _ = await self.default_controller.OpenCommissioningWindow(
             nodeid=self.dut_node_id, timeout=600, iteration=10000, discriminator=discriminator, option=1)
         cmd = FakeRevokeCommissioning()
         try:

--- a/src/python_testing/TC_OPCREDS_3_1.py
+++ b/src/python_testing/TC_OPCREDS_3_1.py
@@ -30,7 +30,7 @@ from mobly import asserts
 
 
 class TC_OPCREDS_3_1(MatterBaseTest):
-    def FindAndEstablishPase(self, longDiscriminator: int, setupPinCode: int, nodeid: int, dev_ctrl: ChipDeviceCtrl = None):
+    async def FindAndEstablishPase(self, longDiscriminator: int, setupPinCode: int, nodeid: int, dev_ctrl: ChipDeviceCtrl = None):
         if dev_ctrl is None:
             dev_ctrl = self.default_controller
 
@@ -41,8 +41,8 @@ class TC_OPCREDS_3_1(MatterBaseTest):
                       Discovery.FilterType.LONG_DISCRIMINATOR and d.longDiscriminator == longDiscriminator, devices))
         for a in device.addresses:
             try:
-                dev_ctrl.EstablishPASESessionIP(ipaddr=a, setupPinCode=setupPinCode,
-                                                nodeid=nodeid, port=device.port)
+                await dev_ctrl.EstablishPASESessionIP(ipaddr=a, setupPinCode=setupPinCode,
+                                                      nodeid=nodeid, port=device.port)
                 break
             except ChipStackError:
                 continue
@@ -51,11 +51,11 @@ class TC_OPCREDS_3_1(MatterBaseTest):
         except TimeoutError:
             asserts.fail("Unable to establish a PASE session to the device")
 
-    def OpenCommissioningWindow(self, dev_ctrl: ChipDeviceCtrl, node_id: int):
+    async def OpenCommissioningWindow(self, dev_ctrl: ChipDeviceCtrl, node_id: int):
         # TODO: abstract this in the base layer? Do we do this a lot?
         longDiscriminator = random.randint(0, 4095)
         try:
-            params = dev_ctrl.OpenCommissioningWindow(
+            params = await dev_ctrl.OpenCommissioningWindow(
                 nodeid=node_id, timeout=600, iteration=10000, discriminator=longDiscriminator, option=ChipDeviceCtrl.ChipDeviceControllerBase.CommissioningWindowPasscode.kTokenWithRandomPin)
         except Exception as e:
             logging.exception('Error running OpenCommissioningWindow %s', e)
@@ -85,7 +85,7 @@ class TC_OPCREDS_3_1(MatterBaseTest):
                             "Device fabric table is full - please remove one fabric and retry")
 
         self.print_step(1, "TH0 opens a commissioning window on the DUT")
-        longDiscriminator, params = self.OpenCommissioningWindow(self.default_controller, self.dut_node_id)
+        longDiscriminator, params = await self.OpenCommissioningWindow(self.default_controller, self.dut_node_id)
 
         self.print_step(
             2, "TH0 reads the BasicCommissioningInfo field from the General commissioning cluster saves MaxCumulativeFailsafeSeconds as `failsafe_max`")
@@ -94,8 +94,8 @@ class TC_OPCREDS_3_1(MatterBaseTest):
 
         self.print_step(3, "TH1 opens a PASE connection to the DUT")
         newNodeId = self.dut_node_id + 1
-        self.FindAndEstablishPase(dev_ctrl=TH1, longDiscriminator=longDiscriminator,
-                                  setupPinCode=params.setupPinCode, nodeid=newNodeId)
+        await self.FindAndEstablishPase(dev_ctrl=TH1, longDiscriminator=longDiscriminator,
+                                        setupPinCode=params.setupPinCode, nodeid=newNodeId)
 
         self.print_step(4, "TH1 sends ArmFailSafe command to the DUT with the ExpiryLengthSeconds field set to failsafe_max")
         resp = await self.send_single_cmd(dev_ctrl=TH1, node_id=newNodeId, cmd=Clusters.GeneralCommissioning.Commands.ArmFailSafe(failsafe_max))
@@ -109,7 +109,7 @@ class TC_OPCREDS_3_1(MatterBaseTest):
         self.print_step(6, "TH1 obtains or generates the NOC, the Root CA Certificate and ICAC using csrResponse and selects an IPK. The certificates shall have their subjects padded with additional data such that they are each the maximum certificate size of 400 bytes when encoded in the MatterCertificateEncoding.")
         # Our CA is set up to maximize cert chains already
         # Extract the RCAC public key and save as `Root_Public_Key_TH1`
-        TH1_certs_real = TH1.IssueNOCChain(csrResponse, newNodeId)
+        TH1_certs_real = await TH1.IssueNOCChain(csrResponse, newNodeId)
         if (TH1_certs_real.rcacBytes is None or
                 TH1_certs_real.icacBytes is None or
                 TH1_certs_real.nocBytes is None or TH1_certs_real.ipkBytes is None):
@@ -125,7 +125,7 @@ class TC_OPCREDS_3_1(MatterBaseTest):
         TH1_CA_fake = self.certificate_authority_manager.NewCertificateAuthority()
         TH1_fabric_admin_fake = TH1_CA_fake.NewFabricAdmin(vendorId=0xFFF1, fabricId=2)
         TH1_fake = TH1_fabric_admin_fake.NewController(nodeId=self.default_controller.nodeId)
-        TH1_certs_fake = TH1_fake.IssueNOCChain(csrResponse, newNodeId)
+        TH1_certs_fake = await TH1_fake.IssueNOCChain(csrResponse, newNodeId)
         if (TH1_certs_fake.rcacBytes is None or
                 TH1_certs_fake.icacBytes is None or
                 TH1_certs_fake.nocBytes is None or TH1_certs_real.ipkBytes is None):
@@ -361,7 +361,7 @@ class TC_OPCREDS_3_1(MatterBaseTest):
         asserts.assert_equal(len(fabrics), fabrics_original_size, "Fabric list size does not match original")
 
         self.print_step(37, "TH1 fully commissions DUT onto the fabric using a set of valid certificates")
-        TH1.Commission(newNodeId)
+        await TH1.Commission(newNodeId)
 
         self.print_step(
             38, "TH1 reads the TrustedRootCertificates list from DUT and verify that there are trusted_root_original_size + 1 entries")
@@ -404,7 +404,7 @@ class TC_OPCREDS_3_1(MatterBaseTest):
             resp.statusCode, opcreds.Enums.NodeOperationalCertStatusEnum.kOk, "Failure on UpdateFabricLabel")
 
         self.print_step(44, "TH1 sends an OpenCommissioningWindow command to the Administrator Commissioning cluster")
-        longDiscriminator, params = self.OpenCommissioningWindow(TH1, newNodeId)
+        longDiscriminator, params = await self.OpenCommissioningWindow(TH1, newNodeId)
 
         self.print_step(45, "TH2 commissions the DUT")
         TH2_CA = self.certificate_authority_manager.NewCertificateAuthority(maximizeCertChains=True)
@@ -413,7 +413,7 @@ class TC_OPCREDS_3_1(MatterBaseTest):
         TH2_nodeid = self.default_controller.nodeId+2
         TH2 = TH2_fabric_admin.NewController(nodeId=TH2_nodeid)
         TH2_dut_nodeid = self.dut_node_id+2
-        TH2.CommissionOnNetwork(
+        await TH2.CommissionOnNetwork(
             nodeId=TH2_dut_nodeid, setupPinCode=params.setupPinCode,
             filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=longDiscriminator)
 
@@ -484,7 +484,7 @@ class TC_OPCREDS_3_1(MatterBaseTest):
         temp_CA = self.certificate_authority_manager.NewCertificateAuthority()
         temp_fabric_admin = temp_CA.NewFabricAdmin(vendorId=0xFFF1, fabricId=3)
         temp_controller = temp_fabric_admin.NewController(nodeId=self.default_controller.nodeId)
-        temp_certs = temp_controller.IssueNOCChain(csrResponse, newNodeId)
+        temp_certs = await temp_controller.IssueNOCChain(csrResponse, newNodeId)
         if (temp_certs.rcacBytes is None or
                 temp_certs.icacBytes is None or
                 temp_certs.nocBytes is None or temp_certs.ipkBytes is None):
@@ -521,7 +521,7 @@ class TC_OPCREDS_3_1(MatterBaseTest):
 
         self.print_step(61, "TH1 obtains or generates a NOC and ICAC using the CSR elements from the previous step with a different NodeID, but the same Root CA Certificate and fabric ID as step <<TH1-gen-real-creds>>. Save as `Node_Operational_Certificates_TH1_fabric_conflict` and `Intermediate_Certificate_TH1_fabric_conflict`|")
         anotherNodeId = newNodeId + 1
-        TH1_certs_fabric_conflict = TH1.IssueNOCChain(csrResponse_new, anotherNodeId)
+        TH1_certs_fabric_conflict = await TH1.IssueNOCChain(csrResponse_new, anotherNodeId)
         if (TH1_certs_fabric_conflict.rcacBytes is None or
                 TH1_certs_fabric_conflict.icacBytes is None or
                 TH1_certs_fabric_conflict.nocBytes is None or TH1_certs_fabric_conflict.ipkBytes is None):
@@ -565,7 +565,7 @@ class TC_OPCREDS_3_1(MatterBaseTest):
                             "Unexpected response type for UpdateNOC csr request")
 
         self.print_step(68, "TH1 obtains or generates a NOC, Root CA Certificate, ICAC using the CSR elements from the previous step")
-        TH1_certs_3 = TH1.IssueNOCChain(csrResponse, anotherNodeId)
+        TH1_certs_3 = await TH1.IssueNOCChain(csrResponse, anotherNodeId)
         if (TH1_certs_3.rcacBytes is None or
                 TH1_certs_3.icacBytes is None or
                 TH1_certs_3.nocBytes is None or TH1_certs_3.ipkBytes is None):

--- a/src/python_testing/TC_TIMESYNC_2_13.py
+++ b/src/python_testing/TC_TIMESYNC_2_13.py
@@ -45,7 +45,7 @@ class TC_TIMESYNC_2_13(MatterBaseTest):
         self.print_step(0, "Commissioning, already done")
 
         self.print_step(1, "TH1 opens a commissioning window")
-        params = self.default_controller.OpenCommissioningWindow(
+        params = await self.default_controller.OpenCommissioningWindow(
             nodeid=self.dut_node_id, timeout=600, iteration=10000, discriminator=1234, option=1)
 
         self.print_step(2, "Commission to TH2")
@@ -53,7 +53,7 @@ class TC_TIMESYNC_2_13(MatterBaseTest):
         new_fabric_admin = new_certificate_authority.NewFabricAdmin(vendorId=0xFFF1, fabricId=2)
         TH2 = new_fabric_admin.NewController(nodeId=112233)
 
-        TH2.CommissionOnNetwork(
+        await TH2.CommissionOnNetwork(
             nodeId=self.dut_node_id, setupPinCode=params.setupPinCode,
             filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=1234)
 

--- a/src/python_testing/TestCommissioningTimeSync.py
+++ b/src/python_testing/TestCommissioningTimeSync.py
@@ -56,9 +56,9 @@ class TestCommissioningTimeSync(MatterBaseTest):
         return super().teardown_test()
 
     async def commission_and_base_checks(self):
-        params = self.default_controller.OpenCommissioningWindow(
+        params = await self.default_controller.OpenCommissioningWindow(
             nodeid=self.dut_node_id, timeout=600, iteration=10000, discriminator=1234, option=1)
-        self.commissioner.CommissionOnNetwork(
+        await self.commissioner.CommissionOnNetwork(
             nodeId=self.dut_node_id, setupPinCode=params.setupPinCode,
             filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=1234)
         self.commissioned = True

--- a/src/python_testing/basic_composition_support.py
+++ b/src/python_testing/basic_composition_support.py
@@ -98,10 +98,10 @@ def MatterTlvToJson(tlv_data: dict[int, Any]) -> dict[str, Any]:
 
 
 class BasicCompositionTests:
-    def connect_over_pase(self, dev_ctrl):
+    async def connect_over_pase(self, dev_ctrl):
         setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
         asserts.assert_true(setupCode, "Require either --qr-code or --manual-code.")
-        dev_ctrl.FindOrEstablishPASESession(setupCode, self.dut_node_id)
+        await dev_ctrl.FindOrEstablishPASESession(setupCode, self.dut_node_id)
 
     def dump_wildcard(self, dump_device_composition_path: typing.Optional[str]):
         node_dump_dict = {endpoint_id: MatterTlvToJson(self.endpoints_tlv[endpoint_id]) for endpoint_id in self.endpoints_tlv}
@@ -121,7 +121,7 @@ class BasicCompositionTests:
         dump_device_composition_path: Optional[str] = self.user_params.get("dump_device_composition_path", None)
 
         if do_test_over_pase:
-            self.connect_over_pase(dev_ctrl)
+            await self.connect_over_pase(dev_ctrl)
             node_id = self.dut_node_id
         else:
             # Using the already commissioned node

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -766,11 +766,11 @@ class MatterBaseTest(base_test.BaseTestClass):
         pics_key = pics_key.strip()
         return pics_key in picsd and picsd[pics_key]
 
-    def openCommissioningWindow(self, dev_ctrl: ChipDeviceCtrl, node_id: int) -> CustomCommissioningParameters:
+    async def openCommissioningWindow(self, dev_ctrl: ChipDeviceCtrl, node_id: int) -> CustomCommissioningParameters:
         rnd_discriminator = random.randint(0, 4095)
         try:
-            commissioning_params = dev_ctrl.OpenCommissioningWindow(nodeid=node_id, timeout=900, iteration=1000,
-                                                                    discriminator=rnd_discriminator, option=1)
+            commissioning_params = await dev_ctrl.OpenCommissioningWindow(nodeid=node_id, timeout=900, iteration=1000,
+                                                                          discriminator=rnd_discriminator, option=1)
             params = CustomCommissioningParameters(commissioning_params, rnd_discriminator)
             return params
 
@@ -1524,10 +1524,10 @@ class CommissionDeviceTest(MatterBaseTest):
                          (conf.root_of_trust_index, conf.fabric_id, node_id))
             logging.info("Commissioning method: %s" % conf.commissioning_method)
 
-            if not self._commission_device(commission_idx):
+            if not asyncio.run(self._commission_device(commission_idx)):
                 raise signals.TestAbortAll("Failed to commission node")
 
-    def _commission_device(self, i) -> bool:
+    async def _commission_device(self, i) -> bool:
         dev_ctrl = self.default_controller
         conf = self.matter_test_config
 
@@ -1543,7 +1543,7 @@ class CommissionDeviceTest(MatterBaseTest):
 
         if conf.commissioning_method == "on-network":
             try:
-                dev_ctrl.CommissionOnNetwork(
+                await dev_ctrl.CommissionOnNetwork(
                     nodeId=conf.dut_node_ids[i],
                     setupPinCode=info.passcode,
                     filterType=info.filter_type,
@@ -1555,7 +1555,7 @@ class CommissionDeviceTest(MatterBaseTest):
                 return False
         elif conf.commissioning_method == "ble-wifi":
             try:
-                dev_ctrl.CommissionWiFi(
+                await dev_ctrl.CommissionWiFi(
                     info.filter_value,
                     info.passcode,
                     conf.dut_node_ids[i],
@@ -1569,7 +1569,7 @@ class CommissionDeviceTest(MatterBaseTest):
                 return False
         elif conf.commissioning_method == "ble-thread":
             try:
-                dev_ctrl.CommissionThread(
+                await dev_ctrl.CommissionThread(
                     info.filter_value,
                     info.passcode,
                     conf.dut_node_ids[i],
@@ -1583,7 +1583,7 @@ class CommissionDeviceTest(MatterBaseTest):
         elif conf.commissioning_method == "on-network-ip":
             try:
                 logging.warning("==== USING A DIRECT IP COMMISSIONING METHOD NOT SUPPORTED IN THE LONG TERM ====")
-                dev_ctrl.CommissionIP(
+                await dev_ctrl.CommissionIP(
                     ipaddr=conf.commissionee_ip_address_just_for_testing,
                     setupPinCode=info.passcode, nodeid=conf.dut_node_ids[i]
                 )


### PR DESCRIPTION
Convert API functions which are waiting for a callback to Python co-routines (async functions). This allows to use this API functions without blocking the asyncio event loop, which is crucial for a responsive asyncio application.

The change takes care of locking the individual functions so that independent asyncio tasks can't interfere with each other: E.g. if two asyncio tasks try to commission a device, the second asyncio task trying to commission too will wait for the first asyncio task to complete commission first.