### PR TITLE
Bump specification revision to 1.4

### DIFF
--- a/src/app/SpecificationDefinedRevisions.h
+++ b/src/app/SpecificationDefinedRevisions.h
@@ -41,7 +41,7 @@ inline constexpr uint8_t kInteractionModelRevisionTag               = 0xFF;
  * See section 7.1.1. "Revision History" in the "Data Model Specification"
  * chapter of the core Matter specification.
  */
-inline constexpr uint16_t kDataModelRevision = 17;
+inline constexpr uint16_t kDataModelRevision = 18;
 
 /*
  * A number identifying the specification version against which the
@@ -50,7 +50,7 @@ inline constexpr uint16_t kDataModelRevision = 17;
  * See section 11.1.5.22. "SpecificationVersion Attribute" in "Service and
  * Device Management" chapter of the core Matter specification.
  */
-inline constexpr uint32_t kSpecificationVersion = 0x01030000;
+inline constexpr uint32_t kSpecificationVersion = 0x01040000;
 
 } // namespace Revision
 } // namespace chip

--- a/src/app/tests/suites/TestBasicInformation.yaml
+++ b/src/app/tests/suites/TestBasicInformation.yaml
@@ -206,8 +206,8 @@ tests:
       command: "readAttribute"
       attribute: "SpecificationVersion"
       response:
-          # For now all-clusters-app has a version 1.3.
-          value: 0x01030000
+          # For now all-clusters-app has a version 1.4.
+          value: 0x01040000
 
     - label: "Read the Max Paths Per Invoke value"
       command: "readAttribute"

--- a/src/app/tests/suites/TestCASERecovery.yaml
+++ b/src/app/tests/suites/TestCASERecovery.yaml
@@ -33,7 +33,9 @@ tests:
       command: "readAttribute"
       attribute: "DataModelRevision"
       response:
-          value: 17
+          constraints:
+              type: int16u
+              minValue: 17
 
     - label: "Reboot the server"
       cluster: "SystemCommands"
@@ -72,4 +74,6 @@ tests:
       command: "readAttribute"
       attribute: "DataModelRevision"
       response:
-          value: 17
+          constraints:
+              type: int16u
+              minValue: 17

--- a/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
@@ -86,7 +86,6 @@ tests:
                 value: "y"
 
     - label: "Step 2: TH reads DataModelRevision from the DUT."
-      PICS: BINFO.S.A0000
       command: "readAttribute"
       attribute: "DataModelRevision"
       response:
@@ -96,7 +95,6 @@ tests:
               type: int16u
 
     - label: "Step 3: TH writes DataModelRevision as '0x1124' "
-      PICS: BINFO.S.A0000
       command: "writeAttribute"
       attribute: "DataModelRevision"
       arguments:
@@ -105,7 +103,6 @@ tests:
           error: UNSUPPORTED_WRITE
 
     - label: "Step 4: TH reads DataModelRevision from the DUT."
-      PICS: BINFO.S.A0000
       command: "readAttribute"
       attribute: "DataModelRevision"
       response:
@@ -718,48 +715,22 @@ tests:
       response:
           value: ProductAppearancevalue
 
-    - label: "Step 62: TH reads SpecificationVersion from the DUT."
-      PICS: BINFO.S.A0015
-      command: "readAttribute"
-      attribute: "SpecificationVersion"
-      response:
-          saveAs: SpecificationVersionValue
-
-    - label:
-          "Step 62: If the SpecificationVersion value is absent or zero this
-          step cannot be verified, move on to the next step"
-      PICS: BINFO.S.A0015
-      cluster: "EqualityCommands"
-      command: "UnsignedNumberEquals"
-      arguments:
-          values:
-              - name: "Value1"
-                value: SpecificationVersionValue
-              - name: "Value2"
-                value: null
-      response:
-          - values:
-                - name: "Equals"
-                  saveAs: IsExpectedValue
-
     - label:
           "Step 62: SpecificationVersion value should in the inclusive range of
-          (0x01040000 to 0x01050000) and the lower 8 bits are set to zero."
+          (0x01040000 to 0x0104FF00) and the lower 8 bits are set to zero."
       runIf: "!IsExpectedValue"
-      PICS: BINFO.S.A0015
       command: "readAttribute"
       attribute: "SpecificationVersion"
       response:
           value: SpecificationVersionValue
           constraints:
-              minValue: 0x0104000000
-              maxValue: 4294967295
+              minValue: 0x01040000
+              maxValue: 0x0104FF00
               hasMasksClear: [0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80]
 
     - label:
           "Step 63: TH sends Write request message to DUT to change the value of
           SpecificationVersion to '0x0103AAF1'."
-      PICS: BINFO.S.A0015
       command: "writeAttribute"
       attribute: "SpecificationVersion"
       arguments:
@@ -768,7 +739,6 @@ tests:
           error: UNSUPPORTED_WRITE
 
     - label: "Step 64: TH reads SpecificationVersion attribute from DUT"
-      PICS: BINFO.S.A0015
       command: "readAttribute"
       attribute: "SpecificationVersion"
       response:

--- a/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
@@ -90,12 +90,10 @@ tests:
       command: "readAttribute"
       attribute: "DataModelRevision"
       response:
-          value: 17
+          value: 18
           saveAs: DataModelRevisionValue
           constraints:
               type: int16u
-              minValue: 0
-              maxValue: 65534
 
     - label: "Step 3: TH writes DataModelRevision as '0x1124' "
       PICS: BINFO.S.A0000
@@ -746,7 +744,7 @@ tests:
 
     - label:
           "Step 62: SpecificationVersion value should in the inclusive range of
-          (0 to 4294967295) and the initial 7 bits are set to zero."
+          (0x01040000 to 0x01050000) and the lower 8 bits are set to zero."
       runIf: "!IsExpectedValue"
       PICS: BINFO.S.A0015
       command: "readAttribute"
@@ -754,9 +752,9 @@ tests:
       response:
           value: SpecificationVersionValue
           constraints:
-              minValue: 0
+              minValue: 0x0104000000
               maxValue: 4294967295
-              hasMasksClear: [0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40]
+              hasMasksClear: [0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80]
 
     - label:
           "Step 63: TH sends Write request message to DUT to change the value of

--- a/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
@@ -718,11 +718,10 @@ tests:
     - label:
           "Step 62: SpecificationVersion value should in the inclusive range of
           (0x01040000 to 0x0104FF00) and the lower 8 bits are set to zero."
-      runIf: "!IsExpectedValue"
       command: "readAttribute"
       attribute: "SpecificationVersion"
       response:
-          value: SpecificationVersionValue
+          saveAs: SpecificationVersionValue
           constraints:
               minValue: 0x01040000
               maxValue: 0x0104FF00


### PR DESCRIPTION
- Set SpecificationVersion attribute of basic info to 0x01_04_00_00
- Update tests as needed

See https://github.com/CHIP-Specifications/chip-test-plans/pull/4238 for test plan change.