### PR TITLE
[Python] Reset chip error in test commissioner

### DIFF
--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -259,6 +259,7 @@ public:
         mPrematureCompleteAfter = chip::Controller::CommissioningStage::kError;
         mReadCommissioningInfo  = chip::Controller::ReadCommissioningInfo();
         mNeedsDST               = false;
+        mCompletionError        = CHIP_NO_ERROR;
     }
     bool GetTestCommissionerUsed() { return mTestCommissionerUsed; }
     void OnCommissioningSuccess(chip::PeerId peerId) { mReceivedCommissioningSuccess = true; }

--- a/src/python_testing/TC_CGEN_2_4.py
+++ b/src/python_testing/TC_CGEN_2_4.py
@@ -104,12 +104,9 @@ class TC_CGEN_2_4(MatterBaseTest):
         logging.info('Step 16 - TH2 fully commissions the DUT')
         self.th2.ResetTestCommissioner()
 
-        ctx = asserts.assert_raises(ChipStackError)
-        with ctx:
-            self.th2.CommissionOnNetwork(
-                nodeId=self.dut_node_id, setupPinCode=params.setupPinCode,
-                filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.discriminator)
-        asserts.assert_true(ctx.exception.chip_error.sdk_code == 0x02, 'Unexpected error code returned from CommissioningComplete')
+        self.th2.CommissionOnNetwork(
+            nodeId=self.dut_node_id, setupPinCode=params.setupPinCode,
+            filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.discriminator)
         logging.info('Commissioning complete done.')
 
         logging.info('Step 17 - TH1 sends an arm failsafe')


### PR DESCRIPTION
Make sure to reset the chip error in test commissioner on reset. This avoid spurious errors. The Python side reads the error as soon as mTestCommissionerUsed is set, which happens unconditionally. Hence clearing the error is necessary.
