### PR TITLE
[Silabs]Update silabs Docker image for new SDKs release

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-55 : Update to Ubuntu 24.04 as the base build image
+56 : Update Silabs docker SiSDK 2024.06.0 WiseConnect 3.3.0

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -13,15 +13,14 @@ RUN set -x \
     && : # last line
 
 
-# Clone Gecko SDK 4.4.2 (e359ba4)
-RUN wget https://github.com/SiliconLabs/gecko_sdk/releases/download/v4.4.2/gecko-sdk.zip -O /tmp/gecko_sdk.zip \
-    && unzip /tmp/gecko_sdk.zip -d /tmp/gecko_sdk \
-    && rm -rf /tmp/gecko_sdk.zip \
+# Download Simplicity SDK v2024.6.0 (a1a37fa)
+RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2024.6.0/sisdk-sdk.zip -O /tmp/simplicity_sdk.zip \
+    && unzip /tmp/simplicity_sdk.zip -d /tmp/simplicity_sdk \
+    && rm -rf /tmp/simplicity_sdk.zip \
     # Deleting files that are not needed to save space
-    && rm -rf /tmp/gecko_sdk/protocol/flex /tmp/gecko_sdk/protocol/z-wave /tmp/gecko_sdk/protocol/zigbee /tmp/gecko_sdk/protocol/wisun \
-    && find /tmp/gecko_sdk/protocol/bluetooth /tmp/gecko_sdk/platform -name "*.a" -type f -delete \
-    && find /tmp/gecko_sdk/protocol/openthread -name "*efr32mg21*" -delete \
-    && find /tmp/gecko_sdk/protocol/openthread -name "*efr32mg13*" -delete \
+    && rm -rf /tmp/simplicity_sdk/protocol/flex /tmp/simplicity_sdk/protocol/z-wave /tmp/simplicity_sdk/protocol/zigbee /tmp/simplicity_sdk/protocol/wisun \
+    && find /tmp/simplicity_sdk/protocol/bluetooth /tmp/simplicity_sdk/platform -name "*.a" -type f -delete \
+    && find /tmp/simplicity_sdk/protocol/openthread -name "*efr32mg21*" -delete \
     && : # last line
 
 # Clone WiSeConnect Wi-Fi and Bluetooth Software 2.8.2 (4fa5c5f)
@@ -30,8 +29,8 @@ RUN git clone --depth=1 --single-branch --branch=2.8.2 https://github.com/Silico
     rm -rf .git \
     && : # last line
 
-# Clone WiSeConnect SDK 3.1.3-matter-hotfix.4 (aa514d4)
-RUN git clone --depth=1 --single-branch --branch=v3.1.3-matter-hotfix.4 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
+# Clone WiSeConnect SDK v3.3.0 (e97a0ed)
+RUN git clone --depth=1 --single-branch --branch=v3.3.0 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
     cd /tmp/wifi_sdk && \
     rm -rf .git \
     && : # last line
@@ -63,12 +62,14 @@ RUN set -x \
     && rm /tmp/requirements.txt \
     && : # last line
 
-ENV GSDK_ROOT=/opt/silabs/gecko_sdk/
+# Keep GSDK_ROOT name until rename transition to SISDK is completed
+ENV GSDK_ROOT=/opt/silabs/simplicity_sdk/
+ENV SISDK_ROOT=/opt/silabs/simplicity_sdk/
 ENV WISECONNECT_SDK_ROOT=/opt/silabs/wiseconnect-wifi-bt-sdk/
 ENV WIFI_SDK_ROOT=/opt/silabs/wifi_sdk/
 ENV PATH="${PATH}:/opt/silabs/slc_cli/"
 
-COPY --from=build /tmp/gecko_sdk /opt/silabs/gecko_sdk
+COPY --from=build /tmp/simplicity_sdk /opt/silabs/simplicity_sdk
 COPY --from=build /tmp/wiseconnect-wifi-bt-sdk/ /opt/silabs/wiseconnect-wifi-bt-sdk/
 COPY --from=build /tmp/wifi_sdk /opt/silabs/wifi_sdk
 COPY --from=build /tmp/slc_cli /opt/silabs/slc_cli

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -60,7 +60,7 @@ COPY --from=bouffalolab /opt/bouffalolab_sdk /opt/bouffalolab_sdk
 
 COPY --from=asr /opt/asr /opt/asr
 
-COPY --from=efr32 /opt/silabs/gecko_sdk /opt/silabs/gecko_sdk
+COPY --from=efr32 /opt/silabs/simplicity_sdk /opt/silabs/simplicity_sdk
 COPY --from=efr32 /opt/silabs/wiseconnect-wifi-bt-sdk /opt/silabs/wiseconnect-wifi-bt-sdk
 COPY --from=efr32 /opt/silabs/wifi_sdk /opt/silabs/wifi_sdk
 
@@ -113,8 +113,10 @@ ENV AMEBA_PATH=/opt/ameba/ambd_sdk_with_chip_non_NDA
 ENV ANDROID_HOME=/opt/android/sdk
 ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r23c
 ENV CY_TOOLS_PATHS="/opt/ModusToolbox/tools_2.4"
-ENV SILABS_BOARD=BRD4161A
-ENV GSDK_ROOT=/opt/silabs/gecko_sdk/
+ENV SILABS_BOARD=BRD4186C
+# Keep GSDK_ROOT name until rename transition to SISDK is completed
+ENV GSDK_ROOT=/opt/silabs/simplicity_sdk/
+ENV SISDK_ROOT=/opt/silabs/simplicity_sdk/
 ENV WISECONNECT_SDK_ROOT=/opt/silabs/wiseconnect-wifi-bt-sdk/
 ENV WIFI_SDK_ROOT=/opt/silabs/wifi_sdk
 ENV IDF_PATH=/opt/espressif/esp-idf/


### PR DESCRIPTION
New SDK versions have been released. This PR updates our docker image as Silabs platform in CSA will be updated shortly to leverage those releases.

** Note: Our previously known Gecko SDK has been renamed to Simplicity SDK and changed location. Gecko SDK will remain in LTS for previous versions. **

