### PR TITLE
Remove bugprone-casting-through-void check from .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,7 @@ Checks: >
   readability-redundant-string-init,
   -bugprone-assignment-in-if-condition,
   -bugprone-branch-clone,
+  -bugprone-casting-through-void, #TODO remove this after fixing issues in source code
   -bugprone-copy-constructor-init,
   -bugprone-easily-swappable-parameters,
   -bugprone-forward-declaration-namespace,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,7 +12,7 @@ Checks: >
   readability-redundant-string-init,
   -bugprone-assignment-in-if-condition,
   -bugprone-branch-clone,
-  -bugprone-casting-through-void, #TODO remove this after fixing issues in source code
+  -bugprone-casting-through-void, #TODO remove this after fixing issues in source code, issue 34008
   -bugprone-copy-constructor-init,
   -bugprone-easily-swappable-parameters,
   -bugprone-forward-declaration-namespace,


### PR DESCRIPTION
## Problem

In latest clang-tidy there is new check option [bugprone-casting-through-void](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/casting-through-void.html).
New version of clang-tidy is avaliable on latest ubuntu:24.04 based images. During build on new docker image CI report errors related to `bugprone-casting-through-void` Error can be found in #33979 

## Solution 
I want to stop checking casting-through-void for now and fix it in the future. Related issue #34008 

