### PR TITLE
[Python] Fix DeviceProxyWrapper __del__

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -268,7 +268,7 @@ class DeviceProxyWrapper():
 
     def __del__(self):
         # Commissionee device proxies are owned by the DeviceCommissioner. See #33031
-        if (self._proxyType == self.DeviceProxyType.OPERATIONAL and self.self._dmLib is not None and hasattr(builtins, 'chipStack') and builtins.chipStack is not None):
+        if (self._proxyType == self.DeviceProxyType.OPERATIONAL and self._dmLib is not None and hasattr(builtins, 'chipStack') and builtins.chipStack is not None):
             # This destructor is called from any threading context, including on the Matter threading context.
             # So, we cannot call chipStack.Call or chipStack.CallAsyncWithCompleteCallback which waits for the posted work to
             # actually be executed. Instead, we just post/schedule the work and move on.


### PR DESCRIPTION
During some tests (e.g. TC_IDM_1_2) the following unrelated Exception is being raised:
```
Exception ignored in: <function DeviceProxyWrapper.__del__ at 0x7f12177b7a60>
Traceback (most recent call last):
  File "/__w/connectedhomeip/connectedhomeip/out/venv/lib/python3.9/site-packages/chip/ChipDeviceCtrl.py", line 306, in __del__
    if (self._proxyType == self.DeviceProxyType.OPERATIONAL and self.self._dmLib is not None and hasattr(builtins, 'chipStack') and builtins.chipStack is not None):
AttributeError: 'DeviceProxyWrapper' object has no attribute 'self'
Exception ignored in: <function DeviceProxyWrapper.__del__ at 0x7f12177b7a60>
Traceback (most recent call last):
  File "/__w/connectedhomeip/connectedhomeip/out/venv/lib/python3.9/site-packages/chip/ChipDeviceCtrl.py", line 306, in __del__
    if (self._proxyType == self.DeviceProxyType.OPERATIONAL and self.self._dmLib is not None and hasattr(builtins, 'chipStack') and builtins.chipStack is not None):
AttributeError: 'DeviceProxyWrapper' object has no attribute 'self'
```

This fixes the issue by removing the extra `self` in the condition.
