### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-56 : Update Silabs docker SiSDK 2024.06.0 WiseConnect 3.3.0
+57 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=0e8032dfef7e02498f34ba0b5d5d2df71a62adb1
+ARG ZEPHYR_REVISION=ab81a585fca6a83b30e1f4e58a021113d6a3acb8
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- drivers: add W91 heartbeat module
- drivers: dts: yaml: config: add BLE HCI driver
- drivers: wifi: telink: Fix MAC
- drivers: hwinfo: spi-flash-id: add hwinfo driver
- drivers: wifi: telink: Set IPv6 from Zephyr
- drivers: wif: telink: Kconfig.w91: Fix priority
- drivers: heartbeat module bugfix
- drivers: removed assert() call in IPC
- riscv: telink: update start.s
- drivers: hwinfo: spi-flash-id: fix hwinfo driver warning
- drivers: config: minor update BLE/blocking/heartbeat
- drivers: wif: telink: Add WiFi state functionality
- dtsi: drivers: config: add module for setting ble mac address

Testing
Tested manually.

**Steps:**

- Build image
- Run docker
- Check if Telink examples able to be built successfully