### PR TITLE
Fix compile crash on glib compilation with glib dev install

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -59,7 +59,6 @@ RUN set -x \
     libdmalloc-dev \
     libgif-dev \
     libgirepository-1.0-1 \
-    libgirepository1.0-dev \
     libglib2.0-dev \
     libical-dev \
     libjpeg-dev \
@@ -163,6 +162,16 @@ RUN case ${TARGETPLATFORM} in \
     && return 1 ;\
     ;; \
     esac
+
+# Sanitizer compilation fails if this is installed before 
+# glib recompile.
+RUN set -x \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --fix-missing --no-install-recommends \
+    libgirepository1.0-dev \
+    && rm -rf /var/lib/apt/lists/ \
+    && : # last line
+
 
 # Some things that save space
 # Protoc goes from 108M to 4.6M

--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -163,7 +163,7 @@ RUN case ${TARGETPLATFORM} in \
     ;; \
     esac
 
-# Sanitizer compilation fails if this is installed before 
+# Sanitizer compilation fails if this is installed before
 # glib recompile.
 RUN set -x \
     && apt-get update \

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-58 : Add libgirepository1.0-dev to the base image, to make build_python.sh work (assume we want this everywhere)
+59 : Install order fix for glib with enabled thread sanitizer.


### PR DESCRIPTION
After #34016 compiling glib separately with thread sanitizers seems to crash. Moved the install of the dev library to after the glib compile.

### Tested

chip-build image now builds.