### PR TITLE
Update ESP32 images to make it works with ubuntu:24.04

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-59 : Install order fix for glib with enabled thread sanitizer.
+60 : Add missing xz for esp32, upfate location of qemu-system-xtensa

--- a/integrations/docker/images/stage-2/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-esp32/Dockerfile
@@ -6,6 +6,7 @@ RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
     git \
+    xz-utils \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line

--- a/integrations/docker/images/stage-3/chip-build-esp32-qemu/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-esp32-qemu/Dockerfile
@@ -19,4 +19,4 @@ RUN set -x \
     && : # last line
 
 ENV QEMU_ESP32_DIR=/opt/espressif/qemu
-ENV QEMU_ESP32=/opt/espressif/qemu/xtensa-softmmu/qemu-system-xtensa
+ENV QEMU_ESP32=/opt/espressif/qemu/qemu-system-xtensa


### PR DESCRIPTION
## Problem

1. Missing xz executable in chip-build-esp32
2. Wrong path for qemu-system-xtensa after changing `espressif/qemu` to version `v9.0.0`

## Changes
1. Add missing package
2. Fix path in `chip-build-esp32-qemu`

