### PR TITLE
[Python] Convert DiscoverCommissionableNodes to asyncio

### DIFF
--- a/src/controller/python/chip/commissioning/pase.py
+++ b/src/controller/python/chip/commissioning/pase.py
@@ -48,8 +48,8 @@ async def establish_session(devCtrl: ChipDeviceCtrl.ChipDeviceControllerBase, pa
     if isinstance(parameter, commissioning.PaseOverBLEParameters):
         await devCtrl.EstablishPASESessionBLE(parameter.setup_pin, parameter.discriminator, parameter.temporary_nodeid)
     elif isinstance(parameter, commissioning.PaseOverIPParameters):
-        device = devCtrl.DiscoverCommissionableNodes(filterType=discovery.FilterType.LONG_DISCRIMINATOR,
-                                                     filter=parameter.long_discriminator, stopOnFirst=True)
+        device = await devCtrl.DiscoverCommissionableNodes(filterType=discovery.FilterType.LONG_DISCRIMINATOR,
+                                                           filter=parameter.long_discriminator, stopOnFirst=True)
         if not device:
             raise ValueError("No commissionable device found")
         selected_address = None

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -712,7 +712,7 @@ class DiscoveryCommandAction(BaseAction):
         self.filterType, self.filter = DiscoveryCommandAction._filter_for_step(test_step)
 
     async def run_action(self, dev_ctrl: ChipDeviceController) -> _ActionResult:
-        devices = dev_ctrl.DiscoverCommissionableNodes(
+        devices = await dev_ctrl.DiscoverCommissionableNodes(
             filterType=self.filterType, filter=self.filter, stopOnFirst=True, timeoutSecond=5)
 
         # Devices will be a list: [CommissionableNode(), ...]

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -210,10 +210,10 @@ class BaseTestHelper:
             return None
         return ctypes.string_at(addrStrStorage).decode("utf-8")
 
-    def TestDiscovery(self, discriminator: int):
+    async def TestDiscovery(self, discriminator: int):
         self.logger.info(
             f"Discovering commissionable nodes with discriminator {discriminator}")
-        res = self.devCtrl.DiscoverCommissionableNodes(
+        res = await self.devCtrl.DiscoverCommissionableNodes(
             chip.discovery.FilterType.LONG_DISCRIMINATOR, discriminator, stopOnFirst=True, timeoutSecond=3)
         if not res:
             self.logger.info(
@@ -337,7 +337,7 @@ class BaseTestHelper:
 
     async def TestOnNetworkCommissioning(self, discriminator: int, setuppin: int, nodeid: int, ip_override: str = None):
         self.logger.info("Testing discovery")
-        device = self.TestDiscovery(discriminator=discriminator)
+        device = await self.TestDiscovery(discriminator=discriminator)
         if not device:
             self.logger.info("Failed to discover any devices.")
             return False

--- a/src/controller/python/test/test_scripts/commissioning_test.py
+++ b/src/controller/python/test/test_scripts/commissioning_test.py
@@ -125,7 +125,7 @@ async def main():
         nodeid=112233, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=True)
 
     logger.info("Testing discovery")
-    FailIfNot(test.TestDiscovery(discriminator=options.discriminator),
+    FailIfNot(await test.TestDiscovery(discriminator=options.discriminator),
               "Failed to discover any devices.")
 
     FailIfNot(test.SetNetworkCommissioningParameters(dataset=TEST_THREAD_NETWORK_DATASET_TLV),

--- a/src/controller/python/test/test_scripts/failsafe_tests.py
+++ b/src/controller/python/test/test_scripts/failsafe_tests.py
@@ -88,7 +88,7 @@ async def main():
         nodeid=112233, paaTrustStorePath=options.paaTrustStorePath, testCommissioner=False)
 
     logger.info("Testing discovery")
-    FailIfNot(test.TestDiscovery(discriminator=TEST_DISCRIMINATOR),
+    FailIfNot(await test.TestDiscovery(discriminator=TEST_DISCRIMINATOR),
               "Failed to discover any devices.")
 
     FailIfNot(test.SetNetworkCommissioningParameters(dataset=TEST_THREAD_NETWORK_DATASET_TLV),

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -59,7 +59,7 @@ ALL_TESTS = ['network_commissioning', 'datamodel']
 
 async def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
     logger.info("Testing discovery")
-    device = test.TestDiscovery(discriminator=discriminator)
+    device = await test.TestDiscovery(discriminator=discriminator)
     FailIfNot(device, "Failed to discover any devices.")
 
     address = device.addresses[0]

--- a/src/python_testing/TC_IDM_1_2.py
+++ b/src/python_testing/TC_IDM_1_2.py
@@ -195,7 +195,7 @@ class TC_IDM_1_2(MatterBaseTest):
         new_fabric_admin = new_certificate_authority.NewFabricAdmin(vendorId=0xFFF1, fabricId=self.matter_test_config.fabric_id + 1)
         TH2 = new_fabric_admin.NewController(nodeId=112233)
 
-        devices = TH2.DiscoverCommissionableNodes(
+        devices = await TH2.DiscoverCommissionableNodes(
             filterType=Discovery.FilterType.LONG_DISCRIMINATOR, filter=discriminator, stopOnFirst=False)
         # For some reason, the devices returned here aren't filtered, so filter ourselves
         device = next(filter(lambda d: d.commissioningMode == 2 and d.longDiscriminator == discriminator, devices))

--- a/src/python_testing/TC_OPCREDS_3_1.py
+++ b/src/python_testing/TC_OPCREDS_3_1.py
@@ -34,7 +34,7 @@ class TC_OPCREDS_3_1(MatterBaseTest):
         if dev_ctrl is None:
             dev_ctrl = self.default_controller
 
-        devices = dev_ctrl.DiscoverCommissionableNodes(
+        devices = await dev_ctrl.DiscoverCommissionableNodes(
             filterType=Discovery.FilterType.LONG_DISCRIMINATOR, filter=longDiscriminator, stopOnFirst=False)
         # For some reason, the devices returned here aren't filtered, so filter ourselves
         device = next(filter(lambda d: d.commissioningMode ==


### PR DESCRIPTION
Make the discovery of commissionable nodes Python asyncio APIs as well.  This avoids blocking the event loop when using the API.

The implementation is also safe to be used with the Python asyncio wait_for() function: The discovery process will be cancelled if the timeout is reached.