### PR TITLE
[OnOff] offWithEffectCommand , OnWithRecallGlobalSceneCommand, Global Scene

### DIFF
--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -622,12 +622,7 @@ bool OnOffServer::offWithEffectCommand(app::CommandHandler * commandObj, const a
         if (globalSceneControl)
         {
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-            GroupId groupId = ZCL_SCENES_GLOBAL_SCENE_GROUP_ID;
-            if (commandObj->GetExchangeContext()->IsGroupExchangeContext())
-            {
-                groupId = commandObj->GetExchangeContext()->GetSessionHandle()->AsIncomingGroupSession()->GetGroupId();
-            }
-            ScenesManagement::ScenesServer::Instance().StoreCurrentScene(fabric, endpoint, groupId,
+            ScenesManagement::ScenesServer::Instance().StoreCurrentScene(fabric, endpoint, ZCL_SCENES_GLOBAL_SCENE_GROUP_ID,
                                                                          ZCL_SCENES_GLOBAL_SCENE_SCENE_ID);
 #endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
             OnOff::Attributes::GlobalSceneControl::Set(endpoint, false);
@@ -683,13 +678,8 @@ bool OnOffServer::OnWithRecallGlobalSceneCommand(app::CommandHandler * commandOb
     }
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    GroupId groupId = ZCL_SCENES_GLOBAL_SCENE_GROUP_ID;
-    if (commandObj->GetExchangeContext()->IsGroupExchangeContext())
-    {
-        groupId = commandObj->GetExchangeContext()->GetSessionHandle()->AsIncomingGroupSession()->GetGroupId();
-    }
-
-    ScenesManagement::ScenesServer::Instance().RecallScene(fabric, endpoint, groupId, ZCL_SCENES_GLOBAL_SCENE_SCENE_ID);
+    ScenesManagement::ScenesServer::Instance().RecallScene(fabric, endpoint, ZCL_SCENES_GLOBAL_SCENE_GROUP_ID,
+                                                           ZCL_SCENES_GLOBAL_SCENE_SCENE_ID);
 #endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
 
     OnOff::Attributes::GlobalSceneControl::Set(endpoint, true);


### PR DESCRIPTION
Removed the condition that made the global scene saved in another group if the offWithEffectCommand or OnWithRecallGlobalSceneCommand were received as a groupcast.

