### PR TITLE
[ESP32] Fixing NULL MAC Address Issue for Thread devices in ESP32.

### DIFF
--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -38,6 +38,7 @@
 #else
 #include "esp_spi_flash.h"
 #endif
+#include "esp_mac.h"
 #include "esp_system.h"
 #include "esp_wifi.h"
 
@@ -222,6 +223,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             ifp->type          = GetInterfaceType(esp_netif_get_desc(ifa));
             ifp->offPremiseServicesReachableIPv4.SetNull();
             ifp->offPremiseServicesReachableIPv6.SetNull();
+#if !CHIP_DEVICE_CONFIG_ENABLE_THREAD
             if (esp_netif_get_mac(ifa, ifp->MacAddress) != ESP_OK)
             {
                 ChipLogError(DeviceLayer, "Failed to get network hardware address");
@@ -230,6 +232,18 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             {
                 ifp->hardwareAddress = ByteSpan(ifp->MacAddress, 6);
             }
+#else
+            uint8_t macAddress[8] = { 0 };
+            if (esp_read_mac(macAddress, ESP_MAC_IEEE802154) != ESP_OK)
+            {
+                ChipLogError(DeviceLayer, "Failed to get network hardware address");
+            }
+            else
+            {
+                ifp->hardwareAddress = ByteSpan(macAddress, 8);
+            }
+#endif
+
 #ifndef CONFIG_DISABLE_IPV4
             if (esp_netif_get_ip_info(ifa, &ipv4_info) == ESP_OK)
             {


### PR DESCRIPTION
**Problem**
- The mac address read using read network-interfaces of the general-commissioning cluster using chip-tool returned NULL value in case of thread.

**Change Overview:**
- Fixed the issue by providing an api in case of thread devices to retrieve the mac address.

**Testing**
- Tested the lighting-app esp32 with esp32h2 and esp32c6-thread with and without the changes.
