### PR TITLE
Revert "Fixed the hardware macaddress isssue for thread interfaces (#34046)"

### DIFF
--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -38,7 +38,6 @@
 #else
 #include "esp_spi_flash.h"
 #endif
-#include "esp_mac.h"
 #include "esp_system.h"
 #include "esp_wifi.h"
 
@@ -223,7 +222,6 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             ifp->type          = GetInterfaceType(esp_netif_get_desc(ifa));
             ifp->offPremiseServicesReachableIPv4.SetNull();
             ifp->offPremiseServicesReachableIPv6.SetNull();
-#if !CHIP_DEVICE_CONFIG_ENABLE_THREAD
             if (esp_netif_get_mac(ifa, ifp->MacAddress) != ESP_OK)
             {
                 ChipLogError(DeviceLayer, "Failed to get network hardware address");
@@ -232,18 +230,6 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             {
                 ifp->hardwareAddress = ByteSpan(ifp->MacAddress, 6);
             }
-#else
-            uint8_t macAddress[8] = { 0 };
-            if (esp_read_mac(macAddress, ESP_MAC_IEEE802154) != ESP_OK)
-            {
-                ChipLogError(DeviceLayer, "Failed to get network hardware address");
-            }
-            else
-            {
-                ifp->hardwareAddress = ByteSpan(macAddress, 8);
-            }
-#endif
-
 #ifndef CONFIG_DISABLE_IPV4
             if (esp_netif_get_ip_info(ifa, &ipv4_info) == ESP_OK)
             {


### PR DESCRIPTION
This reverts commit 504608b09fee1ce5d02ad67be8dd7f639f70d5b6.

Commit creates a bytespan out of a value on the stack.
