### PR TITLE
changes to allow LP_EM_CC1354P10_1 build

### DIFF
--- a/examples/lock-app/cc13x4_26x4/README.md
+++ b/examples/lock-app/cc13x4_26x4/README.md
@@ -85,8 +85,9 @@ Ninja to build the executable.
 
     ```
 
--   If your target Launchpad is the cc1354P10_1, then you will need to update the
-    args.gni accordingly:
+-   If your target Launchpad is the cc1354P10_1, then you will need to update
+    the args.gni accordingly:
+
     ```
     --- a/examples/lock-app/cc13x4_26x4/args.gni
     +++ b/examples/lock-app/cc13x4_26x4/args.gni

--- a/examples/lock-app/cc13x4_26x4/README.md
+++ b/examples/lock-app/cc13x4_26x4/README.md
@@ -85,6 +85,19 @@ Ninja to build the executable.
 
     ```
 
+-   If your target Launchpad is the cc1354P10_1, then you will need to update the
+    args.gni accordingly:
+    ```
+    --- a/examples/lock-app/cc13x4_26x4/args.gni
+    +++ b/examples/lock-app/cc13x4_26x4/args.gni
+    @@ -20,7 +20,7 @@ ti_simplelink_sdk_target = get_label_info(":sdk", "label_no_toolchain")
+     ti_simplelink_sysconfig_target =
+         get_label_info(":sysconfig", "label_no_toolchain")
+
+    -ti_simplelink_board = "LP_EM_CC1354P10_6"
+    +ti_simplelink_board = "LP_EM_CC1354P10_1"
+    ```
+
 -   Run the build to produce a default executable. By default on Linux both the
     TI SimpleLink SDK and Sysconfig are located in a `ti` folder in the user's
     home directory, and you must provide the absolute path to them. For example

--- a/examples/lock-app/cc13x4_26x4/chip.syscfg
+++ b/examples/lock-app/cc13x4_26x4/chip.syscfg
@@ -191,7 +191,7 @@ ble.numOfAdvSets                                          = 1;
 ble.lockProject                                           = true;
 ble.oneLibSizeOpt                                         = true;
 ble.maxPDUSize                                            = 255;
-ble.radioConfig.codeExportConfig.$name                    = "ti_devices_radioconfig_code_export_param1";
+ble.radioConfig.codeExportConfig.$name                    = "ti_devices_radioconfig_code_export_param0";
 ble.connUpdateParamsPeripheral.$name                      = "ti_ble5stack_general_ble_conn_update_params0";
 ble.connUpdateParamsPeripheral.reqMinConnInt               = 30;
 ble.connUpdateParamsPeripheral.reqMaxConnInt               = 50;
@@ -199,7 +199,8 @@ ble.connUpdateParamsPeripheral.reqMaxConnInt               = 50;
 ble.advSet1.$name                                         = "ti_ble5stack_broadcaster_advertisement_set0";
 ble.advSet1.advParam1.$name                               = "ti_ble5stack_broadcaster_advertisement_params0";
 
-ble.rfDesign                                 = "LP_EM_CC1354P10_6";
+const boardName = system.deviceData.board.name;
+ble.rfDesign                                 = boardName;
 
 ble.thorPg = 2;
 /* DMM */


### PR DESCRIPTION
Changing the default build target from `LP_EM_CC1354P10_6` to `LP_EM_CC1354P10_1` requires changes in multiple place and is not intuitive.

This PR make it easier to change the build target to `LP_EM_CC1354P10_1` and has been documented in the README.

