### PR TITLE
ESP32: Fix to connect to wifi using shell command

### DIFF
--- a/examples/platform/esp32/common/Esp32AppServer.cpp
+++ b/examples/platform/esp32/common/Esp32AppServer.cpp
@@ -38,6 +38,10 @@
 #endif // CONFIG_BT_ENABLED
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
+#ifdef CONFIG_ENABLE_CHIP_SHELL
+#include <lib/shell/commands/WiFi.h>
+#endif
+
 #include <string.h>
 
 using namespace chip;
@@ -147,6 +151,9 @@ void Esp32AppServer::Init(AppDelegate * sAppDelegate)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     sWiFiNetworkCommissioningInstance.Init();
+#ifdef CONFIG_ENABLE_CHIP_SHELL
+    chip::Shell::SetWiFiDriver(&(chip::DeviceLayer::NetworkCommissioning::ESPWiFiDriver::GetInstance()));
+#endif
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
     sEthernetNetworkCommissioningInstance.Init();


### PR DESCRIPTION
- Fix an issue that 'matter wifi connect' doesn't work on ESP32 by calling chip::Shell::SetWiFiDriver
- As-Is
```
  > matter wifi connect <ssid> <password>
  Error: 45
```
- To-Be
```
> matter wifi connect <ssid> <password>

I (14646) chip[SH]: Adding/Updating network _<ssid>_
I (14646) chip[SH]: Connecting to network
I (14646) chip[NP]: ESP NetworkCommissioningDelegate: SSID: _<ssid>_
W (14656) wifi:Haven't to connect to a suitable AP now!
I (14656) chip[DL]: WiFi station mode change: Enabled -> Disabled
I (14706) chip[DL]: Changing ESP WiFi mode: STA -> STA+AP
I (14716) wifi:mode : sta (3c:61:05:07:32:9c) + softAP (fa:4d:9b:35:8c:3a)
I (14716) wifi:Total power save buffer number: 16
I (14716) wifi:Init max length of beacon: 752/752
I (14726) wifi:Init max length of beacon: 752/752

I (14746) chip[DL]: WiFi station mode change: Disabled -> Enabled
Done
W (14746) wifi:Haven't to connect to a suitable AP now!
I (14746) chip[DL]: I (14746) esp_netif_lwip: DHCP server started on interface WIFI_AP_DEF with IP: 192.168.4.1
Attempting to connect WiFi station interface
I (14766) chip[DL]:                                                                                                                                                                                                                                                                     
I (14776) wifi:new:<1,1>, old:<1,1>, ap:<1,1>, sta:<1,1>, prof:1

> I (15016) wifi:state: init -> auth (b0)
I (15026) chip[DL]: Done driving station state, nothing else to do...
I (15026) wifi:state: auth -> assoc (0)
I (15026) chip[DL]: Attempting to connect WiFi station interface
E (15026) wifi:sta is connecting, return error
E (15046) chip[DL]: esp_wifi_connect() failed: ESP_ERR_WIFI_CONN
I (15046) chip[DL]: Attempting to connect WiFi station interface
I (15046) wifi:state: assoc -> run (10)
E (15056) wifi:sta is connecting, return error
E (15056) chip[DL]: esp_wifi_connect() failed: ESP_ERR_WIFI_CONN
I (15066) chip[DL]: WIFI_EVENT_AP_START
I (15076) chip[DL]: WiFi AP state change: NotActive -> Active
I (15076) chip[DL]: Changing ESP WiFi mode: STA+AP -> STA
I (15086) wifi:<ba-add>idx:0 (ifx:0, 90:9f:33:66:a7:3e), tid:0, ssn:0, winSize:64
I (15086) wifi:mode : sta (3c:61:05:07:32:9c)
I (15096) chip[DL]: Posting ESPSystemEvent: Wifi Event with eventId : 13
I (15106) chip[DL]: WiFi AP state change: Active -> Deactivating
I (15106) app-devicecallbacks: Current free heap: 41320

I (15116) chip[DL]: WIFI_EVENT_AP_STOP
I (15116) chip[DL]: WiFi AP state change: Deactivating -> NotActive
I (15126) app-devicecallbacks: Current free heap: 41592

I (15136) wifi:connected with _<ssid>_, aid = 2, channel 1, 40U, bssid = _<AP MAC Address>_
I (15136) wifi:security: WPA2-PSK, phy: bgn, rssi: -32
I (15236) wifi:pm start, type: 1

I (15236) wifi:AP's beacon interval = 102400 us, DTIM period = 3
I (15246) chip[DL]: Posting ESPSystemEvent: Wifi Event with eventId : 4
I (15246) chip[DL]: WIFI_EVENT_STA_CONNECTED
I (15246) chip[DL]: WiFi station state change: Connecting -> Connecting_Succeeded
I (15266) chip[DL]: WiFi station state change: Connecting_Succeeded -> Connected
I (15266) chip[DL]: WiFi station interface connected
I (15276) chip[ZCL]: WiFiDiagnosticsDelegate: OnConnectionStatusChanged
I (15286) chip[DL]: Done driving station state, nothing else to do...
I (15296) app-devicecallbacks: Current free heap: 40972

```