### PR TITLE
[Fix] Possible fix for issue #229: Remove PICS from python PWRTL tests

### DIFF
--- a/src/python_testing/TC_PWRTL_2_1.py
+++ b/src/python_testing/TC_PWRTL_2_1.py
@@ -40,36 +40,35 @@ class TC_PWRTL_2_1(MatterBaseTest):
 
         attributes = Clusters.PowerTopology.Attributes
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = 1
+        
+        powertop_attr_list = Clusters.Objects.PowerTopology.Attributes.AttributeList
+        powertop_cluster = Clusters.Objects.PowerTopology
+        attribute_list = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=powertop_cluster, attribute=powertop_attr_list)
+        avail_endpoints_attr_id = Clusters.Objects.PowerTopology.Attributes.ActiveEndpoints.attribute_id
+        act_endpoints_attr_id = Clusters.Objects.PowerTopology.Attributes.AvailableEndpoints.attribute_id
 
         self.print_step(1, "Commissioning, already done")
 
-        if not self.check_pics("PWRTL.S.A0000"):
-            logging.info("Test skipped because PICS PWRTL.S.A0000 is not set")
-            return
-
         self.print_step(2, "Read AvailableAttributes attribute")
-        available_endpoints = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=Clusters.Objects.PowerTopology, attribute=attributes.AvailableEndpoints)
+        if avail_endpoints_attr_id in attribute_list:
+            available_endpoints = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=Clusters.Objects.PowerTopology, attribute=attributes.AvailableEndpoints)
 
-        if available_endpoints == NullValue:
-            logging.info("AvailableEndpoints is null")
-        else:
-            logging.info("AvailableEndpoints: %s" % (available_endpoints))
-
-            asserts.assert_less_equal(len(available_endpoints), 21,
-                                      "AvailableEndpoints length %d must be less than 21!" % len(available_endpoints))
-
-        if not self.check_pics("PWRTL.S.A0001"):
-            logging.info("Test skipped because PICS PWRTL.S.A0001 is not set")
-            return
+            if available_endpoints == NullValue or available_endpoints == []:
+                logging.info("AvailableEndpoints is null or an empty list")
+            else:
+                logging.info("AvailableEndpoints: %s" % (available_endpoints))
+                asserts.assert_less_equal(len(available_endpoints), 21,
+                                        "AvailableEndpoints length %d must be less than 21!" % len(available_endpoints))
 
         self.print_step(3, "Read ActiveEndpoints attribute")
-        active_endpoints = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=Clusters.Objects.PowerTopology,  attribute=attributes.ActiveEndpoints)
-        logging.info("ActiveEndpoints: %s" % (active_endpoints))
+        if act_endpoints_attr_id in attribute_list:
+            active_endpoints = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=Clusters.Objects.PowerTopology,  attribute=attributes.ActiveEndpoints)
+            logging.info("ActiveEndpoints: %s" % (active_endpoints))
 
-        if available_endpoints == NullValue:
-            asserts.assert_true(active_endpoints == NullValue,
-                                "ActiveEndpoints should be null when AvailableEndpoints is null: %s" % active_endpoints)
+            if available_endpoints == NullValue or available_endpoints == []:
+                asserts.assert_true(active_endpoints == NullValue or active_endpoints == [],
+                                    "ActiveEndpoints should be null when AvailableEndpoints is null: %s" % active_endpoints)
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_TIMESYNC_2_1.py
+++ b/src/python_testing/TC_TIMESYNC_2_1.py
@@ -42,16 +42,20 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
     @async_test_body
     async def test_TC_TIMESYNC_2_1(self):
         # Establishing features support
-        TSCfeat = self.wait_for_user_input(prompt_msg="Is TSC feature supported? (y or n)\n", input_msg="Is TSC feature supported? (y or n)\n", prompt_msg_placeholder="y or n")
-        NTPCfeat = self.wait_for_user_input(prompt_msg="Is NTPC feature supported? (y or n)\n", input_msg="Is NTPC feature supported? (y or n)\n", prompt_msg_placeholder="y or n", default_value='n')
-        NTPSfeat = self.wait_for_user_input(prompt_msg="Is NTPS feature supported? (y or n)\n", input_msg="Is NTPS feature supported? (y or n)\n", prompt_msg_placeholder="y or n", default_value='n')
-        TZfeat = self.wait_for_user_input(prompt_msg="Is TZ feature supported? (y or n)\n", input_msg="Is TZ feature supported? (y or n)\n", prompt_msg_placeholder="y or n")
+        TSCfeat = self.wait_for_user_input(prompt_msg="Is TSC feature supported? (y or n)\n",
+                                           input_msg="Is TSC feature supported? (y or n)\n", prompt_msg_placeholder="y or n")
+        NTPCfeat = self.wait_for_user_input(prompt_msg="Is NTPC feature supported? (y or n)\n",
+                                            input_msg="Is NTPC feature supported? (y or n)\n", prompt_msg_placeholder="y or n", default_value='n')
+        NTPSfeat = self.wait_for_user_input(prompt_msg="Is NTPS feature supported? (y or n)\n",
+                                            input_msg="Is NTPS feature supported? (y or n)\n", prompt_msg_placeholder="y or n", default_value='n')
+        TZfeat = self.wait_for_user_input(prompt_msg="Is TZ feature supported? (y or n)\n",
+                                          input_msg="Is TZ feature supported? (y or n)\n", prompt_msg_placeholder="y or n")
 
         endpoint = self.user_params.get("endpoint", 0)
 
         self.print_step(1, "Commissioning, already done")
         attributes = Clusters.TimeSynchronization.Attributes
-        
+
         self.print_step(2, "Read Granularity attribute")
         granularity_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.Granularity)
         asserts.assert_less(granularity_dut, Clusters.TimeSynchronization.Enums.GranularityEnum.kUnknownEnumValue,
@@ -65,14 +69,13 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
         self.print_step(4, "Read TrustedTimeSource")
         if TSCfeat == 'y':
             trusted_time_source = await self.read_ts_attribute_expect_success(endpoint=endpoint,
-                                                                                attribute=attributes.TrustedTimeSource)
+                                                                              attribute=attributes.TrustedTimeSource)
             if trusted_time_source is not NullValue:
                 asserts.assert_less_equal(trusted_time_source.fabricIndex, 0xFE,
-                                            "FabricIndex for the TrustedTimeSource is out of range")
+                                          "FabricIndex for the TrustedTimeSource is out of range")
                 asserts.assert_greater_equal(trusted_time_source.fabricIndex, 1,
-                                                "FabricIndex for the TrustedTimeSource is out of range")
+                                             "FabricIndex for the TrustedTimeSource is out of range")
 
-        
         self.print_step(5, "Read DefaultNTP")
         if NTPCfeat == 'y':
             default_ntp = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.DefaultNTP)
@@ -110,10 +113,10 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
             last_valid_starting = -1
             for dst in dst_dut:
                 asserts.assert_greater(dst.validStarting, last_valid_starting,
-                                        "DSTOffset list must be sorted by ValidStarting time")
+                                       "DSTOffset list must be sorted by ValidStarting time")
                 last_valid_starting = dst.validStarting
                 asserts.assert_greater_equal(dst.validStarting, last_valid_until,
-                                                "DSTOffset list must have every ValidStarting > ValidUntil of the previous entry")
+                                             "DSTOffset list must have every ValidStarting > ValidUntil of the previous entry")
                 last_valid_until = dst.validUntil
                 if dst.validUntil is NullValue or dst.validUntil is None:
                     asserts.assert_equal(dst, dst_dut[-1], "DSTOffset list must have Null ValidUntil at the end")
@@ -157,7 +160,7 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
         if NTPSfeat == 'y':
             # bool typechecking happens in the test read functions, so all we need to do here is do the read
             await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.NTPServerAvailable)
-        
+
         self.print_step(12, "Read TimeZoneListMaxSize")
         if TZfeat == 'y':
             size = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeZoneListMaxSize)
@@ -173,6 +176,7 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
         # bool typechecking happens in the test read functions, so all we need to do here is do the read
         if NTPCfeat == 'y':
             await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.SupportsDNSResolve)
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_TIMESYNC_2_1.py
+++ b/src/python_testing/TC_TIMESYNC_2_1.py
@@ -30,7 +30,6 @@ from chip.clusters.Types import NullValue
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main, utc_time_in_matter_epoch
 from mobly import asserts
 
-
 class TC_TIMESYNC_2_1(MatterBaseTest):
     async def read_ts_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.TimeSynchronization
@@ -41,21 +40,18 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
 
     @async_test_body
     async def test_TC_TIMESYNC_2_1(self):
-        # Establishing features support
-        TSCfeat = self.wait_for_user_input(prompt_msg="Is TSC feature supported? (y or n)\n",
-                                           input_msg="Is TSC feature supported? (y or n)\n", prompt_msg_placeholder="y or n")
-        NTPCfeat = self.wait_for_user_input(prompt_msg="Is NTPC feature supported? (y or n)\n",
-                                            input_msg="Is NTPC feature supported? (y or n)\n", prompt_msg_placeholder="y or n", default_value='n')
-        NTPSfeat = self.wait_for_user_input(prompt_msg="Is NTPS feature supported? (y or n)\n",
-                                            input_msg="Is NTPS feature supported? (y or n)\n", prompt_msg_placeholder="y or n", default_value='n')
-        TZfeat = self.wait_for_user_input(prompt_msg="Is TZ feature supported? (y or n)\n",
-                                          input_msg="Is TZ feature supported? (y or n)\n", prompt_msg_placeholder="y or n")
-
         endpoint = self.user_params.get("endpoint", 0)
+        features = await self.read_single_attribute(dev_ctrl=self.default_controller, node_id=self.dut_node_id,
+                                                    endpoint=endpoint, attribute=Clusters.TimeSynchronization.Attributes.FeatureMap)
+        self.supports_time_zone = bool(features & Clusters.TimeSynchronization.Bitmaps.Feature.kTimeZone)
+        self.supports_ntpc = bool(features & Clusters.TimeSynchronization.Bitmaps.Feature.kNTPClient)
+        self.supports_ntps = bool(features & Clusters.TimeSynchronization.Bitmaps.Feature.kNTPServer)
+        self.supports_trusted_time_source = bool(features & Clusters.TimeSynchronization.Bitmaps.Feature.kTimeSyncClient)
+
 
         self.print_step(1, "Commissioning, already done")
         attributes = Clusters.TimeSynchronization.Attributes
-
+        
         self.print_step(2, "Read Granularity attribute")
         granularity_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.Granularity)
         asserts.assert_less(granularity_dut, Clusters.TimeSynchronization.Enums.GranularityEnum.kUnknownEnumValue,
@@ -67,17 +63,16 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
                             "TimeSource is not in valid range")
 
         self.print_step(4, "Read TrustedTimeSource")
-        if TSCfeat == 'y':
-            trusted_time_source = await self.read_ts_attribute_expect_success(endpoint=endpoint,
-                                                                              attribute=attributes.TrustedTimeSource)
-            if trusted_time_source is not NullValue:
-                asserts.assert_less_equal(trusted_time_source.fabricIndex, 0xFE,
-                                          "FabricIndex for the TrustedTimeSource is out of range")
-                asserts.assert_greater_equal(trusted_time_source.fabricIndex, 1,
-                                             "FabricIndex for the TrustedTimeSource is out of range")
+        trusted_time_source = await self.read_ts_attribute_expect_success(endpoint=endpoint,
+                                                                            attribute=attributes.TrustedTimeSource)
+        if trusted_time_source is not NullValue:
+            asserts.assert_less_equal(trusted_time_source.fabricIndex, 0xFE,
+                                        "FabricIndex for the TrustedTimeSource is out of range")
+            asserts.assert_greater_equal(trusted_time_source.fabricIndex, 1,
+                                        "FabricIndex for the TrustedTimeSource is out of range")
 
         self.print_step(5, "Read DefaultNTP")
-        if NTPCfeat == 'y':
+        if self.supports_ntpc:
             default_ntp = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.DefaultNTP)
             if default_ntp is not NullValue:
                 asserts.assert_less_equal(len(default_ntp), 128, "DefaultNTP length must be less than 128")
@@ -92,7 +87,7 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
                 asserts.assert_true(is_web_addr or is_ip_addr, "Returned DefaultNTP value is not a IP address or web address")
 
         self.print_step(6, "Read TimeZone")
-        if TZfeat == 'y':
+        if self.supports_time_zone:
             tz_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeZone)
             asserts.assert_greater_equal(len(tz_dut), 1, "TimeZone must have at least one entry in the list")
             asserts.assert_less_equal(len(tz_dut), 2, "TimeZone may have a maximum of two entries in the list")
@@ -107,16 +102,16 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
                 asserts.assert_not_equal(tz_dut[1].validAt, 0, "TimeZone list second entry must have a non-zero ValidAt time")
 
         self.print_step(7, "Read DSTOffset")
-        if TZfeat == 'y':
+        if self.supports_time_zone:
             dst_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.DSTOffset)
             last_valid_until = -1
             last_valid_starting = -1
             for dst in dst_dut:
                 asserts.assert_greater(dst.validStarting, last_valid_starting,
-                                       "DSTOffset list must be sorted by ValidStarting time")
+                                        "DSTOffset list must be sorted by ValidStarting time")
                 last_valid_starting = dst.validStarting
                 asserts.assert_greater_equal(dst.validStarting, last_valid_until,
-                                             "DSTOffset list must have every ValidStarting > ValidUntil of the previous entry")
+                                                "DSTOffset list must have every ValidStarting > ValidUntil of the previous entry")
                 last_valid_until = dst.validUntil
                 if dst.validUntil is NullValue or dst.validUntil is None:
                     asserts.assert_equal(dst, dst_dut[-1], "DSTOffset list must have Null ValidUntil at the end")
@@ -136,7 +131,7 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
             asserts.assert_less_equal(delta, toleranace, "UTC time is not within tolerance of TH")
 
         self.print_step(9, "Read LocalTime")
-        if TZfeat == 'y':
+        if self.supports_time_zone:
             utc_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.UTCTime)
             local_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.LocalTime)
             if utc_dut is NullValue:
@@ -151,32 +146,30 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
                 asserts.assert_less_equal(delta, toleranace, "Local time caluclation is not within tolerance of calculated value")
 
         self.print_step(10, "Read TimeZoneDatabase")
-        if TZfeat == 'y':
+        if self.supports_time_zone:
             tz_db_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeZoneDatabase)
             asserts.assert_less(tz_db_dut, Clusters.TimeSynchronization.Enums.TimeZoneDatabaseEnum.kUnknownEnumValue,
                                 "TimeZoneDatabase is not in valid range")
 
         self.print_step(11, "Read NTPServerAvailable")
-        if NTPSfeat == 'y':
+        if self.supports_ntps:        
             # bool typechecking happens in the test read functions, so all we need to do here is do the read
             await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.NTPServerAvailable)
-
+        
         self.print_step(12, "Read TimeZoneListMaxSize")
-        if TZfeat == 'y':
-            size = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeZoneListMaxSize)
-            asserts.assert_greater_equal(size, 1, "TimeZoneListMaxSize must be at least 1")
-            asserts.assert_less_equal(size, 2, "TimeZoneListMaxSize must be max 2")
+        size = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeZoneListMaxSize)
+        asserts.assert_greater_equal(size, 1, "TimeZoneListMaxSize must be at least 1")
+        asserts.assert_less_equal(size, 2, "TimeZoneListMaxSize must be max 2")
 
         self.print_step(13, "Read DSTOffsetListMaxSize")
-        if TZfeat == 'y':
+        if self.supports_time_zone:
             size = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.DSTOffsetListMaxSize)
             asserts.assert_greater_equal(size, 1, "DSTOffsetListMaxSize must be at least 1")
 
         self.print_step(14, "Read SupportsDNSResolve")
         # bool typechecking happens in the test read functions, so all we need to do here is do the read
-        if NTPCfeat == 'y':
+        if self.supports_ntpc:        
             await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.SupportsDNSResolve)
-
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_TIMESYNC_2_1.py
+++ b/src/python_testing/TC_TIMESYNC_2_1.py
@@ -51,7 +51,7 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
 
         self.print_step(1, "Commissioning, already done")
         attributes = Clusters.TimeSynchronization.Attributes
-        
+
         self.print_step(2, "Read Granularity attribute")
         granularity_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.Granularity)
         asserts.assert_less(granularity_dut, Clusters.TimeSynchronization.Enums.GranularityEnum.kUnknownEnumValue,
@@ -69,7 +69,7 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
             asserts.assert_less_equal(trusted_time_source.fabricIndex, 0xFE,
                                         "FabricIndex for the TrustedTimeSource is out of range")
             asserts.assert_greater_equal(trusted_time_source.fabricIndex, 1,
-                                        "FabricIndex for the TrustedTimeSource is out of range")
+                                            "FabricIndex for the TrustedTimeSource is out of range")
 
         self.print_step(5, "Read DefaultNTP")
         if self.supports_ntpc:

--- a/src/python_testing/TC_TIMESYNC_2_1.py
+++ b/src/python_testing/TC_TIMESYNC_2_1.py
@@ -41,40 +41,40 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
 
     @async_test_body
     async def test_TC_TIMESYNC_2_1(self):
+        # Establishing features support
+        TSCfeat = self.wait_for_user_input(prompt_msg="Is TSC feature supported? (y or n)\n", input_msg="Is TSC feature supported? (y or n)\n", prompt_msg_placeholder="y or n")
+        NTPCfeat = self.wait_for_user_input(prompt_msg="Is NTPC feature supported? (y or n)\n", input_msg="Is NTPC feature supported? (y or n)\n", prompt_msg_placeholder="y or n", default_value='n')
+        NTPSfeat = self.wait_for_user_input(prompt_msg="Is NTPS feature supported? (y or n)\n", input_msg="Is NTPS feature supported? (y or n)\n", prompt_msg_placeholder="y or n", default_value='n')
+        TZfeat = self.wait_for_user_input(prompt_msg="Is TZ feature supported? (y or n)\n", input_msg="Is TZ feature supported? (y or n)\n", prompt_msg_placeholder="y or n")
 
         endpoint = self.user_params.get("endpoint", 0)
 
         self.print_step(1, "Commissioning, already done")
         attributes = Clusters.TimeSynchronization.Attributes
-
+        
         self.print_step(2, "Read Granularity attribute")
-        if self.check_pics("TIMESYNC.S.A0001"):
-            granularity_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.Granularity)
-            asserts.assert_less(granularity_dut, Clusters.TimeSynchronization.Enums.GranularityEnum.kUnknownEnumValue,
-                                "Granularity is not in valid range")
-        else:
-            asserts.assert_true(False, "Granularity is a mandatory attribute and must be present in the PICS file")
+        granularity_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.Granularity)
+        asserts.assert_less(granularity_dut, Clusters.TimeSynchronization.Enums.GranularityEnum.kUnknownEnumValue,
+                            "Granularity is not in valid range")
 
         self.print_step(3, "Read TimeSource")
-        if self.check_pics("TIMESYNC.S.A0002"):
-            time_source = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeSource)
-            asserts.assert_less(time_source, Clusters.TimeSynchronization.Enums.TimeSourceEnum.kUnknownEnumValue,
-                                "TimeSource is not in valid range")
+        time_source = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeSource)
+        asserts.assert_less(time_source, Clusters.TimeSynchronization.Enums.TimeSourceEnum.kUnknownEnumValue,
+                            "TimeSource is not in valid range")
 
         self.print_step(4, "Read TrustedTimeSource")
-        if self.check_pics("TIMESYNC.S.A0003"):
+        if TSCfeat == 'y':
             trusted_time_source = await self.read_ts_attribute_expect_success(endpoint=endpoint,
-                                                                              attribute=attributes.TrustedTimeSource)
+                                                                                attribute=attributes.TrustedTimeSource)
             if trusted_time_source is not NullValue:
                 asserts.assert_less_equal(trusted_time_source.fabricIndex, 0xFE,
-                                          "FabricIndex for the TrustedTimeSource is out of range")
+                                            "FabricIndex for the TrustedTimeSource is out of range")
                 asserts.assert_greater_equal(trusted_time_source.fabricIndex, 1,
-                                             "FabricIndex for the TrustedTimeSource is out of range")
-        elif self.check_pics("TIMESYNC.S.F03"):
-            asserts.assert_true(False, "TrustedTimeSource is mandatory if the TSC feature (TIMESYNC.S.F03) is supported")
+                                                "FabricIndex for the TrustedTimeSource is out of range")
 
+        
         self.print_step(5, "Read DefaultNTP")
-        if self.check_pics("TIMESYNC.S.A0004"):
+        if NTPCfeat == 'y':
             default_ntp = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.DefaultNTP)
             if default_ntp is not NullValue:
                 asserts.assert_less_equal(len(default_ntp), 128, "DefaultNTP length must be less than 128")
@@ -87,11 +87,9 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
                     is_ip_addr = False
                     pass
                 asserts.assert_true(is_web_addr or is_ip_addr, "Returned DefaultNTP value is not a IP address or web address")
-        elif self.check_pics("TIMESYNC.S.F01"):
-            asserts.assert_true(False, "DefaultNTP is mandatory if the NTPC (TIMESYNC.S.F01) feature is supported")
 
         self.print_step(6, "Read TimeZone")
-        if self.check_pics("TIMESYNC.S.A0005"):
+        if TZfeat == 'y':
             tz_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeZone)
             asserts.assert_greater_equal(len(tz_dut), 1, "TimeZone must have at least one entry in the list")
             asserts.assert_less_equal(len(tz_dut), 2, "TimeZone may have a maximum of two entries in the list")
@@ -104,45 +102,38 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
             asserts.assert_equal(tz_dut[0].validAt, 0, "TimeZone list first entry must have a 0 ValidAt time")
             if len(tz_dut) > 1:
                 asserts.assert_not_equal(tz_dut[1].validAt, 0, "TimeZone list second entry must have a non-zero ValidAt time")
-        elif self.check_pics("TIMESYNC.S.F00"):
-            asserts.assert_true(False, "TimeZone is mandatory if the TZ (TIMESYNC.S.F00) feature is supported")
 
         self.print_step(7, "Read DSTOffset")
-        if self.check_pics("TIMESYNC.S.A0006"):
+        if TZfeat == 'y':
             dst_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.DSTOffset)
             last_valid_until = -1
             last_valid_starting = -1
             for dst in dst_dut:
                 asserts.assert_greater(dst.validStarting, last_valid_starting,
-                                       "DSTOffset list must be sorted by ValidStarting time")
+                                        "DSTOffset list must be sorted by ValidStarting time")
                 last_valid_starting = dst.validStarting
                 asserts.assert_greater_equal(dst.validStarting, last_valid_until,
-                                             "DSTOffset list must have every ValidStarting > ValidUntil of the previous entry")
+                                                "DSTOffset list must have every ValidStarting > ValidUntil of the previous entry")
                 last_valid_until = dst.validUntil
                 if dst.validUntil is NullValue or dst.validUntil is None:
                     asserts.assert_equal(dst, dst_dut[-1], "DSTOffset list must have Null ValidUntil at the end")
-        elif self.check_pics("TIMESYNC.S.F00"):
-            asserts.assert_true(False, "DSTOffset is mandatory if the TZ (TIMESYNC.S.F00) feature is supported")
 
         self.print_step(8, "Read UTCTime")
-        if self.check_pics("TIMESYNC.S.A0000"):
-            utc_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.UTCTime)
-            if utc_dut is NullValue:
-                asserts.assert_equal(granularity_dut, Clusters.TimeSynchronization.Enums.GranularityEnum.kNoTimeGranularity)
-            else:
-                asserts.assert_not_equal(granularity_dut, Clusters.TimeSynchronization.Enums.GranularityEnum.kNoTimeGranularity)
-                if granularity_dut is Clusters.TimeSynchronization.Enums.GranularityEnum.kMinutesGranularity:
-                    toleranace = timedelta(minutes=10)
-                else:
-                    toleranace = timedelta(minutes=1)
-                delta_us = abs(utc_dut - utc_time_in_matter_epoch())
-                delta = timedelta(microseconds=delta_us)
-                asserts.assert_less_equal(delta, toleranace, "UTC time is not within tolerance of TH")
+        utc_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.UTCTime)
+        if utc_dut is NullValue:
+            asserts.assert_equal(granularity_dut, Clusters.TimeSynchronization.Enums.GranularityEnum.kNoTimeGranularity)
         else:
-            asserts.assert_true(False, "UTCTime is a mandatory attribute and must be present in the PICS file")
+            asserts.assert_not_equal(granularity_dut, Clusters.TimeSynchronization.Enums.GranularityEnum.kNoTimeGranularity)
+            if granularity_dut is Clusters.TimeSynchronization.Enums.GranularityEnum.kMinutesGranularity:
+                toleranace = timedelta(minutes=10)
+            else:
+                toleranace = timedelta(minutes=1)
+            delta_us = abs(utc_dut - utc_time_in_matter_epoch())
+            delta = timedelta(microseconds=delta_us)
+            asserts.assert_less_equal(delta, toleranace, "UTC time is not within tolerance of TH")
 
         self.print_step(9, "Read LocalTime")
-        if self.check_pics("TIMESYNC.S.A0007"):
+        if TZfeat == 'y':
             utc_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.UTCTime)
             local_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.LocalTime)
             if utc_dut is NullValue:
@@ -155,46 +146,33 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
                 delta = timedelta(microseconds=delta_us)
                 toleranace = timedelta(minutes=1)
                 asserts.assert_less_equal(delta, toleranace, "Local time caluclation is not within tolerance of calculated value")
-        elif self.check_pics("TIMESYNC.S.F00"):
-            asserts.assert_true(False, "LocalTime is mandatory if the TZ (TIMESYNC.S.F00) feature is supported")
 
         self.print_step(10, "Read TimeZoneDatabase")
-        if self.check_pics("TIMESYNC.S.A0008"):
+        if TZfeat == 'y':
             tz_db_dut = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeZoneDatabase)
             asserts.assert_less(tz_db_dut, Clusters.TimeSynchronization.Enums.TimeZoneDatabaseEnum.kUnknownEnumValue,
                                 "TimeZoneDatabase is not in valid range")
-        elif self.check_pics("TIMESYNC.S.F00"):
-            asserts.assert_true(False, "TimeZoneDatabase is mandatory if the TZ (TIMESYNC.S.F00) feature is supported")
 
         self.print_step(11, "Read NTPServerAvailable")
-        if self.check_pics("TIMESYNC.S.A0009"):
+        if NTPSfeat == 'y':
             # bool typechecking happens in the test read functions, so all we need to do here is do the read
             await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.NTPServerAvailable)
-        elif self.check_pics("TIMESYNC.S.F02"):
-            asserts.assert_true(False, "NTPServerAvailable is mandatory if the NTPS (TIMESYNC.S.F02) feature is supported")
-
+        
         self.print_step(12, "Read TimeZoneListMaxSize")
-        if self.check_pics("TIMESYNC.S.A000a"):
+        if TZfeat == 'y':
             size = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeZoneListMaxSize)
             asserts.assert_greater_equal(size, 1, "TimeZoneListMaxSize must be at least 1")
             asserts.assert_less_equal(size, 2, "TimeZoneListMaxSize must be max 2")
-        elif self.check_pics("TIMESYNC.S.F00"):
-            asserts.assert_true(False, "TimeZoneListMaxSize is mandatory if the TZ (TIMESYNC.S.F00) feature is supported")
 
         self.print_step(13, "Read DSTOffsetListMaxSize")
-        if self.check_pics("TIMESYNC.S.A000b"):
+        if TZfeat == 'y':
             size = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.DSTOffsetListMaxSize)
             asserts.assert_greater_equal(size, 1, "DSTOffsetListMaxSize must be at least 1")
-        elif self.check_pics("TIMESYNC.S.F00"):
-            asserts.assert_true(False, "DSTOffsetListMaxSize is mandatory if the TZ (TIMESYNC.S.F00) feature is supported")
 
         self.print_step(14, "Read SupportsDNSResolve")
-        if self.check_pics("TIMESYNC.S.A0004"):
-            # bool typechecking happens in the test read functions, so all we need to do here is do the read
+        # bool typechecking happens in the test read functions, so all we need to do here is do the read
+        if NTPCfeat == 'y':
             await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.SupportsDNSResolve)
-        elif self.check_pics("TIMESYNC.S.F01"):
-            asserts.assert_true(False, "SupportsDNSResolve is mandatory if the NTPC (TIMESYNC.S.F01) feature is supported")
-
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_TIMESYNC_2_2.py
+++ b/src/python_testing/TC_TIMESYNC_2_2.py
@@ -30,6 +30,7 @@ from chip.interaction_model import InteractionModelError
 from matter_testing_support import MatterBaseTest, async_test_body, compare_time, default_matter_test_main, utc_time_in_matter_epoch
 from mobly import asserts
 
+
 class TC_TIMESYNC_2_2(MatterBaseTest):
     async def read_ts_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.TimeSynchronization
@@ -84,6 +85,7 @@ class TC_TIMESYNC_2_2(MatterBaseTest):
         source = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeSource)
         if utc_dut_initial is NullValue:
             asserts.assert_equal(source, Clusters.Objects.TimeSynchronization.Enums.TimeSourceEnum.kAdmin)
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_TIMESYNC_2_2.py
+++ b/src/python_testing/TC_TIMESYNC_2_2.py
@@ -30,14 +30,10 @@ from chip.interaction_model import InteractionModelError
 from matter_testing_support import MatterBaseTest, async_test_body, compare_time, default_matter_test_main, utc_time_in_matter_epoch
 from mobly import asserts
 
-
 class TC_TIMESYNC_2_2(MatterBaseTest):
     async def read_ts_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.TimeSynchronization
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
-
-    def pics_TC_TIMESYNC_2_2(self) -> list[str]:
-        return ["TIMESYNC.S"]
 
     @async_test_body
     async def test_TC_TIMESYNC_2_2(self):
@@ -85,11 +81,9 @@ class TC_TIMESYNC_2_2(MatterBaseTest):
         compare_time(received=utc_dut, utc=th_utc, tolerance=tolerance)
 
         self.print_step(5, "Read time source")
-        if self.check_pics("TIMESYNC.S.A0002"):
-            source = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeSource)
-            if utc_dut_initial is NullValue:
-                asserts.assert_equal(source, Clusters.Objects.TimeSynchronization.Enums.TimeSourceEnum.kAdmin)
-
+        source = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeSource)
+        if utc_dut_initial is NullValue:
+            asserts.assert_equal(source, Clusters.Objects.TimeSynchronization.Enums.TimeSourceEnum.kAdmin)
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_TIMESYNC_2_2.py
+++ b/src/python_testing/TC_TIMESYNC_2_2.py
@@ -30,7 +30,6 @@ from chip.interaction_model import InteractionModelError
 from matter_testing_support import MatterBaseTest, async_test_body, compare_time, default_matter_test_main, utc_time_in_matter_epoch
 from mobly import asserts
 
-
 class TC_TIMESYNC_2_2(MatterBaseTest):
     async def read_ts_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.TimeSynchronization
@@ -85,7 +84,6 @@ class TC_TIMESYNC_2_2(MatterBaseTest):
         source = await self.read_ts_attribute_expect_success(endpoint=endpoint, attribute=attributes.TimeSource)
         if utc_dut_initial is NullValue:
             asserts.assert_equal(source, Clusters.Objects.TimeSynchronization.Enums.TimeSourceEnum.kAdmin)
-
 
 if __name__ == "__main__":
     default_matter_test_main()


### PR DESCRIPTION
PR for possible fix of matter-test-scripts issue #229: Remove PICS from python PWRTL tests
- Removed PICS if statements from python TC_PWRTL_2_1 test module
- Used read_single_attribute_check_success() to get attribute ID's for available and active endpoints then compared attribute ID's with attribute list to verify DUT's supports those attributes.   
- Updated tests if statement checks as possible that empty lists might also be equivalent to NullValue when checking active and available endpoints on DUT's.