### PR TITLE
 tv-casting-app updated APIs.md docs with new v1.3 Matter APIs

### DIFF
--- a/examples/tv-casting-app/APIs.md
+++ b/examples/tv-casting-app/APIs.md
@@ -249,7 +249,7 @@ client's lifecycle:
           return commissionableData;
         }
 
-        // If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature commissioning flow:
+        // If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature:
         public void updateCommissionableDataSetupPasscode(long setupPasscode, int discriminator) {
             commissionableData.setSetupPasscode(setupPasscode);
             commissionableData.setDiscriminator(discriminator);
@@ -281,7 +281,7 @@ client's lifecycle:
         return commissionableData
     }
 
-    // If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature commissioning flow:
+    // If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature:
     func update(_ newCommissionableData: MCCommissionableData) {
         self.commissionableData = newCommissionableData
     }
@@ -842,7 +842,7 @@ void ConnectionHandler(CHIP_ERROR err, matter::casting::core::CastingPlayer * ca
     }
 }
 
-// If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature commissioning flow:
+// If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature:
 // Define a callback to handle CastingPlayer’s CommissionerDeclaration messages.
 void CommissionerDeclarationCallback(const chip::Transport::PeerAddress & source,
                                      chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)
@@ -889,7 +889,7 @@ CHIP_ERROR result = idOptions.addTargetAppInfo(targetAppInfo);
 matter::casting::core::ConnectionCallbacks connectionCallbacks;
 connectionCallbacks.mOnConnectionComplete = ConnectionHandler;
 
-// If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature commissioning flow:
+// If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature:
 // Set the IdentificationDeclaration CommissionerPasscode flag to instruct the CastingPlayer /
 // Commissioner to use the Commissioner-generated Passcode for commissioning. Set the
 // CommissionerDeclarationCallback in ConnectionCallbacks.
@@ -921,7 +921,7 @@ IdentificationDeclarationOptions idOptions = new IdentificationDeclarationOption
 TargetAppInfo targetAppInfo = new TargetAppInfo(DESIRED_TARGET_APP_VENDOR_ID);
 idOptions.addTargetAppInfo(targetAppInfo);
 
-// If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature commissioning flow.
+// If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature.
 // Set the IdentificationDeclaration CommissionerPasscode flag to instruct the CastingPlayer /
 // Commissioner to use the Commissioner-generated Passcode for commissioning.
 idOptions = new IdentificationDeclarationOptions(commissionerPasscode:true);
@@ -959,7 +959,7 @@ ConnectionCallbacks connectionCallbacks =
                     });
         }
         },
-        // If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature commissioning flow.
+        // If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature.
         // Define a callback to handle CastingPlayer’s CommissionerDeclaration messages.
         // This can be null if using Casting Client / Commissionee generated passcode commissioning.
         new MatterCallback<CommissionerDeclaration>() {
@@ -1044,7 +1044,7 @@ func connect(selectedCastingPlayer: MCCastingPlayer?) {
         }
     }
 
-    // If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature commissioning flow.
+    // If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature.
     // Define a callback to handle CastingPlayer’s CommissionerDeclaration messages.
     let commissionerDeclarationCallback: (MCCommissionerDeclaration) -> Void = { commissionerDeclarationMessage in
         DispatchQueue.main.async {
@@ -1119,7 +1119,7 @@ func connect(selectedCastingPlayer: MCCastingPlayer?) {
     )
     identificationDeclarationOptions.addTargetAppInfo(targetAppInfo)
 
-    // If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature commissioning flow.
+    // If using the alternate CastingPlayer / Commissioner-Generated Passcode UDC feature.
     // Set the IdentificationDeclaration CommissionerPasscode flag to instruct the CastingPlayer /
     // Commissioner to use the Commissioner-generated Passcode for commissioning. Set the
     // CommissionerDeclarationCallback in MCConnectionCallbacks.

--- a/examples/tv-casting-app/APIs.md
+++ b/examples/tv-casting-app/APIs.md
@@ -929,7 +929,7 @@ CommissionerDeclaration message as follows:
    `StopConnecting` to alert the `CastingPlayer` that the commissioning attempt
    was canceled.
 1. The Casting Client should then update the commissioning session's PAKE
-   verifier with the user-entered Passcode using the API's described in the
+   verifier with the user-entered Passcode using the APIs described in the
    Initialize the Casting Client section above.
 1. Finally, the Casting Client should call `ContinueConnecting` to send a second
    IdentificationDeclaration message to the `CastingPlayer` with
@@ -1001,7 +1001,7 @@ targetCastingPlayer->VerifyOrEstablishConnection(connectionCallbacks,
 ...
 ```
 
-On Andorid, the Casting Client can connect to a `CastingPlayer`, using the
+On Android, the Casting Client can connect to a `CastingPlayer`, using the
 optional `CastingPlayer` / Commissioner-Generated Passcode UDC feature, by
 successfully calling `verifyOrEstablishConnection`, updating the PAKE verifier
 and then calling `continueConnecting` on the `CastingPlayer`.

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -128,12 +128,13 @@ public class ConnectionExampleFragment extends Fragment {
             () -> {
               Log.d(TAG, "onViewCreated() calling CastingPlayer.verifyOrEstablishConnection()");
 
-              IdentificationDeclarationOptions idOptions = new IdentificationDeclarationOptions();
+              IdentificationDeclarationOptions idOptions;
               TargetAppInfo targetAppInfo = new TargetAppInfo(DESIRED_TARGET_APP_VENDOR_ID);
 
               if (useCommissionerGeneratedPasscode) {
-                // Constructor to set only the commissionerPasscode.
-                idOptions = new IdentificationDeclarationOptions(true);
+                // Set commissionerPasscode to true for CastingPlayer/Commissioner-Generated
+                // passcode commissioning.
+                idOptions = new IdentificationDeclarationOptions(false, false, true, false, false);
                 targetAppInfo = new TargetAppInfo(DESIRED_TARGET_APP_VENDOR_ID_FOR_CGP_FLOW);
                 Log.d(
                     TAG,
@@ -142,6 +143,7 @@ public class ConnectionExampleFragment extends Fragment {
                         + ", useCommissionerGeneratedPasscode: "
                         + useCommissionerGeneratedPasscode);
               } else {
+                idOptions = new IdentificationDeclarationOptions();
                 Log.d(
                     TAG,
                     "onViewCreated() calling CastingPlayer.verifyOrEstablishConnection() Target Content Application Vendor ID: "

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -129,23 +129,23 @@ public class ConnectionExampleFragment extends Fragment {
               Log.d(TAG, "onViewCreated() calling CastingPlayer.verifyOrEstablishConnection()");
 
               IdentificationDeclarationOptions idOptions = new IdentificationDeclarationOptions();
-              TargetAppInfo targetAppInfo = new TargetAppInfo();
-              targetAppInfo.vendorId = DESIRED_TARGET_APP_VENDOR_ID;
+              TargetAppInfo targetAppInfo = new TargetAppInfo(DESIRED_TARGET_APP_VENDOR_ID);
 
               if (useCommissionerGeneratedPasscode) {
-                idOptions.commissionerPasscode = true;
-                targetAppInfo.vendorId = DESIRED_TARGET_APP_VENDOR_ID_FOR_CGP_FLOW;
+                // Constructor to set only the commissionerPasscode.
+                idOptions = new IdentificationDeclarationOptions(true);
+                targetAppInfo = new TargetAppInfo(DESIRED_TARGET_APP_VENDOR_ID_FOR_CGP_FLOW);
                 Log.d(
                     TAG,
                     "onViewCreated() calling CastingPlayer.verifyOrEstablishConnection() Target Content Application Vendor ID: "
-                        + targetAppInfo.vendorId
+                        + targetAppInfo.getVendorId()
                         + ", useCommissionerGeneratedPasscode: "
                         + useCommissionerGeneratedPasscode);
               } else {
                 Log.d(
                     TAG,
                     "onViewCreated() calling CastingPlayer.verifyOrEstablishConnection() Target Content Application Vendor ID: "
-                        + targetAppInfo.vendorId);
+                        + targetAppInfo.getVendorId());
               }
 
               idOptions.addTargetAppInfo(targetAppInfo);
@@ -242,21 +242,21 @@ public class ConnectionExampleFragment extends Fragment {
         new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int which) {
-            String passcode = input.getText().toString();
+            String userEnteredPasscode = input.getText().toString();
             Log.i(
                 TAG,
-                "displayPasscodeInputDialog() User entered CastingPlayer/Commissioner-Generated passcode: "
-                    + passcode);
+                "displayPasscodeInputDialog() user-entered CastingPlayer/Commissioner-Generated passcode: "
+                    + userEnteredPasscode);
 
             // Display the user entered passcode on the screen
             connectionFragmentStatusTextView.setText(
-                "Continue Connecting with user entered CastingPlayer/Commissioner-Generated passcode: "
-                    + passcode
+                "Continue Connecting with user-entered CastingPlayer/Commissioner-Generated passcode: "
+                    + userEnteredPasscode
                     + "\n\n");
 
             long passcodeLongValue = DEFAULT_COMMISSIONER_GENERATED_PASSCODE;
             try {
-              passcodeLongValue = Long.parseLong(passcode);
+              passcodeLongValue = Long.parseLong(userEnteredPasscode);
               Log.i(
                   TAG,
                   "displayPasscodeInputDialog() User entered CastingPlayer/Commissioner-Generated passcode: "
@@ -268,12 +268,12 @@ public class ConnectionExampleFragment extends Fragment {
                       + nfe);
               connectionFragmentStatusTextView.setText(
                   "User entered CastingPlayer/Commissioner-Generated passcode is not a valid integer: "
-                      + passcode
+                      + userEnteredPasscode
                       + "\n\n");
             }
 
-            // Update the CommissionableData DataProvider with the user entered
-            // CastingPlayer/Commissioner-Generated setup passcode. This is mandatory for
+            // Update the CommissionableData DataProvider with the user-entered
+            // CastingPlayer / Commissioner-Generated setup passcode. This is mandatory for
             // Commissioner-Generated passcode commissioning since the commissioning session's PAKE
             // verifier needs to be updated with the entered passcode.
             InitializationExample.commissionableDataProvider.updateCommissionableDataSetupPasscode(

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/InitializationExample.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/InitializationExample.java
@@ -28,10 +28,6 @@ import com.matter.casting.support.MatterError;
 
 public class InitializationExample {
   private static final String TAG = InitializationExample.class.getSimpleName();
-  // Dummy values for commissioning demonstration only. These are hard coded in the example tv-app:
-  // connectedhomeip/examples/tv-app/tv-common/src/AppTv.cpp
-  private static final long DUMMY_SETUP_PASSCODE = 20202021;
-  private static final int DUMMY_DISCRIMINATOR = 3874;
 
   /**
    * DataProvider implementation for the Unique ID that is used by the SDK to generate the Rotating
@@ -53,6 +49,12 @@ public class InitializationExample {
    * through commissioning
    */
   public static class CommissionableDataProvider implements DataProvider<CommissionableData> {
+    // Dummy values for commissioning demonstration only. These are hard coded in the example
+    // tv-app:
+    // connectedhomeip/examples/tv-app/tv-common/src/AppTv.cpp
+    private static final long DUMMY_SETUP_PASSCODE = 20202021;
+    private static final int DUMMY_DISCRIMINATOR = 3874;
+
     CommissionableData commissionableData =
         new CommissionableData(DUMMY_SETUP_PASSCODE, DUMMY_DISCRIMINATOR);
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
@@ -31,15 +31,6 @@ public class IdentificationDeclarationOptions {
   public IdentificationDeclarationOptions() {}
 
   /**
-   * Constructor to set only the commissionerPasscode.
-   *
-   * @param commissionerPasscode the commissioner passcode flag.
-   */
-  public IdentificationDeclarationOptions(boolean commissionerPasscode) {
-    this.commissionerPasscode = commissionerPasscode;
-  }
-
-  /**
    * Constructor to set all fields.
    *
    * @param noPasscode the no passcode flag.

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
@@ -27,21 +27,38 @@ public class IdentificationDeclarationOptions {
   private final short CHIP_DEVICE_CONFIG_UDC_MAX_TARGET_APPS =
       getChipDeviceConfigUdcMaxTargetApps();
 
+  /** Default constructor. */
   public IdentificationDeclarationOptions() {}
 
+  /**
+   * Constructor to set only the commissionerPasscode.
+   *
+   * @param commissionerPasscode the commissioner passcode flag.
+   */
+  public IdentificationDeclarationOptions(boolean commissionerPasscode) {
+    this.commissionerPasscode = commissionerPasscode;
+  }
+
+  /**
+   * Constructor to set all fields.
+   *
+   * @param noPasscode the no passcode flag.
+   * @param cdUponPasscodeDialog the cd upon passcode dialog flag.
+   * @param commissionerPasscode the commissioner passcode flag.
+   * @param commissionerPasscodeReady the commissioner passcode ready flag.
+   * @param cancelPasscode the cancel passcode flag.
+   */
   public IdentificationDeclarationOptions(
       boolean noPasscode,
       boolean cdUponPasscodeDialog,
       boolean commissionerPasscode,
       boolean commissionerPasscodeReady,
-      boolean cancelPasscode,
-      List<TargetAppInfo> targetAppInfos) {
+      boolean cancelPasscode) {
     this.noPasscode = noPasscode;
     this.cdUponPasscodeDialog = cdUponPasscodeDialog;
     this.commissionerPasscode = commissionerPasscode;
     this.commissionerPasscodeReady = commissionerPasscodeReady;
     this.cancelPasscode = cancelPasscode;
-    this.targetAppInfos = targetAppInfos != null ? targetAppInfos : new ArrayList<>();
   }
 
   /**
@@ -57,28 +74,28 @@ public class IdentificationDeclarationOptions {
    * Passcode input dialog, and instead send a CommissionerDeclaration message if a commissioning
    * Passcode is needed.
    */
-  public boolean noPasscode = false;
+  private boolean noPasscode = false;
   /**
    * Feature: Coordinate Passcode Dialogs - Flag to instruct the Commissioner to send a
    * CommissionerDeclaration message when the Passcode input dialog on the Commissioner has been
    * shown to the user.
    */
-  public boolean cdUponPasscodeDialog = false;
+  private boolean cdUponPasscodeDialog = false;
   /**
    * Feature: Commissioner-Generated Passcode - Flag to instruct the Commissioner to use the
    * Commissioner-generated Passcode for commissioning.
    */
-  public boolean commissionerPasscode = false;
+  private boolean commissionerPasscode = false;
   /**
    * Feature: Commissioner-Generated Passcode - Flag to indicate whether or not the Commissionee has
    * obtained the Commissioner Passcode from the user and is therefore ready for commissioning.
    */
-  public boolean commissionerPasscodeReady = false;
+  private boolean commissionerPasscodeReady = false;
   /**
    * Feature: Coordinate Passcode Dialogs Flag - to indicate when the Commissionee user has decided
    * to exit the commissioning process.
    */
-  public boolean cancelPasscode = false;
+  private boolean cancelPasscode = false;
   /**
    * Feature: Target Content Application - The set of content app Vendor IDs (and optionally,
    * Product IDs) that can be used for authentication. Also, if TargetAppInfo is passed in,
@@ -102,6 +119,26 @@ public class IdentificationDeclarationOptions {
     }
     targetAppInfos.add(targetAppInfo);
     return true;
+  }
+
+  public boolean isNoPasscode() {
+    return noPasscode;
+  }
+
+  public boolean isCdUponPasscodeDialog() {
+    return cdUponPasscodeDialog;
+  }
+
+  public boolean isCommissionerPasscode() {
+    return commissionerPasscode;
+  }
+
+  public boolean isCommissionerPasscodeReady() {
+    return commissionerPasscodeReady;
+  }
+
+  public boolean isCancelPasscode() {
+    return cancelPasscode;
   }
 
   public List<TargetAppInfo> getTargetAppInfoList() {
@@ -129,11 +166,7 @@ public class IdentificationDeclarationOptions {
     sb.append("IdentificationDeclarationOptions::targetAppInfos list: \n");
 
     for (TargetAppInfo targetAppInfo : targetAppInfos) {
-      sb.append("\t\tTargetAppInfo - Vendor ID: ")
-          .append(targetAppInfo.vendorId)
-          .append(", Product ID: ")
-          .append(targetAppInfo.productId)
-          .append("\n");
+      sb.append("\t\t").append(targetAppInfo.toString()).append("\n");
     }
 
     return sb.toString();

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java
@@ -166,7 +166,7 @@ public class IdentificationDeclarationOptions {
     sb.append("IdentificationDeclarationOptions::targetAppInfos list: \n");
 
     for (TargetAppInfo targetAppInfo : targetAppInfos) {
-      sb.append("\t\t").append(targetAppInfo.toString()).append("\n");
+      sb.append("\t\t").append(targetAppInfo).append("\n");
     }
 
     return sb.toString();

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/TargetAppInfo.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/TargetAppInfo.java
@@ -19,7 +19,65 @@ package com.matter.casting.support;
  */
 public class TargetAppInfo {
   /** Target Target Content Application Vendor ID, null means unspecified */
-  public Integer vendorId;
+  private Integer vendorId;
   /** Target Target Content Application Product ID, null means unspecified */
-  public Integer productId;
+  private Integer productId;
+
+  /**
+   * Constructor to set both vendorId and productId.
+   *
+   * @param vendorId the vendor ID, null means unspecified.
+   * @param productId the product ID, null means unspecified.
+   */
+  public TargetAppInfo(Integer vendorId, Integer productId) {
+    this.vendorId = vendorId;
+    this.productId = productId;
+  }
+
+  /**
+   * Constructor to set only the vendorId.
+   *
+   * @param vendorId the vendor ID, null means unspecified.
+   */
+  public TargetAppInfo(Integer vendorId) {
+    this.vendorId = vendorId;
+    this.productId = null; // product ID unspecified
+  }
+
+  /**
+   * Getter for vendorId.
+   *
+   * @return the vendor ID, null means unspecified.
+   */
+  public Integer getVendorId() {
+    return vendorId;
+  }
+
+  /**
+   * Getter for productId.
+   *
+   * @return the product ID, null means unspecified.
+   */
+  public Integer getProductId() {
+    return productId;
+  }
+
+  /**
+   * Returns both vendorId and productId as an array.
+   *
+   * @return an array with vendorId and productId.
+   */
+  public Integer[] getVendorAndProductId() {
+    return new Integer[] {vendorId, productId};
+  }
+
+  /**
+   * Returns a string representation of the object.
+   *
+   * @return a string representation of the object.
+   */
+  @Override
+  public String toString() {
+    return "TargetAppInfo Vendor ID:" + vendorId + ", Product ID:" + productId;
+  }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/TargetAppInfo.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/TargetAppInfo.java
@@ -41,7 +41,6 @@ public class TargetAppInfo {
    */
   public TargetAppInfo(Integer vendorId) {
     this.vendorId = vendorId;
-    this.productId = null; // product ID unspecified
   }
 
   /**
@@ -60,15 +59,6 @@ public class TargetAppInfo {
    */
   public Integer getProductId() {
     return productId;
-  }
-
-  /**
-   * Returns both vendorId and productId as an array.
-   *
-   * @return an array with vendorId and productId.
-   */
-  public Integer[] getVendorAndProductId() {
-    return new Integer[] {vendorId, productId};
   }
 
   /**

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleViewModel.swift
@@ -88,8 +88,18 @@ class MCConnectionExampleViewModel: ObservableObject {
                                 dataSource.update(newCommissionableData)
                                 self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, Updated MCAppParametersDataSource instance with new MCCommissionableData.")
                             } else {
-                                self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, InitializationExample.getAppParametersDataSource() failed")
+                                self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, InitializationExample.getAppParametersDataSource() failed, calling stopConnecting()")
                                 self.connectionStatus = "Failed to update the MCAppParametersDataSource with the user entered passcode: \n\nRoute back and try again."
+                                self.connectionSuccess = false
+                                // Since we failed to update the passcode, Attempt to cancel the connection attempt with
+                                // the CastingPlayer/Commissioner.
+                                let err = selectedCastingPlayer?.stopConnecting()
+                                if err == nil {
+                                    self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, InitializationExample.getAppParametersDataSource() failed, then stopConnecting() succeeded")
+                                } else {
+                                    self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, InitializationExample.getAppParametersDataSource() failed, then stopConnecting() failed due to: \(err)")
+                                }
+                                return
                             }
 
                             self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, calling MCCastingPlayer.continueConnecting()")
@@ -99,6 +109,14 @@ class MCConnectionExampleViewModel: ObservableObject {
                             } else {
                                 self.connectionStatus = "Continue Connecting to Casting Player failed with: \(String(describing: errContinue)) \n\nRoute back and try again."
                                 self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, MCCastingPlayer.continueConnecting() failed due to: \(errContinue)")
+                                // Since continueConnecting() failed, Attempt to cancel the connection attempt with
+                                // the CastingPlayer/Commissioner.
+                                let err = selectedCastingPlayer?.stopConnecting()
+                                if err == nil {
+                                    self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, MCCastingPlayer.continueConnecting() failed, then stopConnecting() succeeded")
+                                } else {
+                                    self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, MCCastingPlayer.continueConnecting() failed, then stopConnecting() failed due to: \(err)")
+                                }
                             }
                         }, cancelConnecting: {
                             self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, Connection attempt cancelled by the user, calling MCCastingPlayer.stopConnecting()")

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleViewModel.swift
@@ -67,8 +67,8 @@ class MCConnectionExampleViewModel: ObservableObject {
                     self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, calling getTopMostViewController()")
                     if let topViewController = self.getTopMostViewController() {
                         self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, calling displayPasscodeInputDialog()")
-                        self.displayPasscodeInputDialog(on: topViewController, continueConnecting: { passcode in
-                            self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, Continuing to connect with user entered MCCastingPlayer/Commissioner-Generated passcode: \(passcode)")
+                        self.displayPasscodeInputDialog(on: topViewController, continueConnecting: { userEnteredPasscode in
+                            self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, Continuing to connect with user entered MCCastingPlayer/Commissioner-Generated passcode: \(userEnteredPasscode)")
 
                             // Update the CommissionableData in the client defined MCAppParametersDataSource with the user
                             // entered CastingPlayer/Commissioner-Generated setup passcode. This is mandatory for the
@@ -79,14 +79,14 @@ class MCConnectionExampleViewModel: ObservableObject {
                             self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback calling MCInitializationExample.getAppParametersDataSource()")
                             if let dataSource = initializationExample.getAppParametersDataSource() {
                                 let newCommissionableData = MCCommissionableData(
-                                    passcode: UInt32(passcode) ?? 0,
+                                    passcode: UInt32(userEnteredPasscode) ?? 0,
                                     discriminator: 0,
                                     spake2pIterationCount: 1000,
                                     spake2pVerifier: nil,
                                     spake2pSalt: nil
                                 )
                                 dataSource.update(newCommissionableData)
-                                self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, Updated MCAppParametersDataSource instance with new MCCommissionableData.")
+                                self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, Updated MCAppParametersDataSource instance with new MCCommissionableData.")
                             } else {
                                 self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, InitializationExample.getAppParametersDataSource() failed")
                                 self.connectionStatus = "Failed to update the MCAppParametersDataSource with the user entered passcode: \n\nRoute back and try again."
@@ -95,7 +95,7 @@ class MCConnectionExampleViewModel: ObservableObject {
                             self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, calling MCCastingPlayer.continueConnecting()")
                             let errContinue = selectedCastingPlayer?.continueConnecting()
                             if errContinue == nil {
-                                self.connectionStatus = "Continuing to connect with user entered passcode: \(passcode)"
+                                self.connectionStatus = "Continuing to connect with user entered passcode: \(userEnteredPasscode)"
                             } else {
                                 self.connectionStatus = "Continue Connecting to Casting Player failed with: \(String(describing: errContinue)) \n\nRoute back and try again."
                                 self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, MCCastingPlayer.continueConnecting() failed due to: \(errContinue)")

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -455,17 +455,17 @@ CHIP_ERROR CommandHandler(int argc, char ** argv)
             return PrintAllCommands();
         }
         char * eptr;
-        uint32_t passcode = (uint32_t) strtol(argv[1], &eptr, 10);
+        uint32_t userEnteredPasscode = (uint32_t) strtol(argv[1], &eptr, 10);
         if (gAwaitingCommissionerPasscodeInput)
         {
-            ChipLogProgress(AppServer, "CommandHandler() setcommissionerpasscode user entered passcode: %d", passcode);
+            ChipLogProgress(AppServer, "CommandHandler() setcommissionerpasscode user-entered passcode: %d", userEnteredPasscode);
             gAwaitingCommissionerPasscodeInput = false;
 
             // Per connectedhomeip/examples/platform/linux/LinuxCommissionableDataProvider.h: We don't support overriding the
-            // passcode post-init (it is deprecated!). Therefore we need to initiate a new provider with the user entered
+            // passcode post-init (it is deprecated!). Therefore we need to initiate a new provider with the user-entered
             // Commissioner-generated passcode, and then update the CastigApp's AppParameters to update the commissioning session's
             // passcode.
-            LinuxDeviceOptions::GetInstance().payload.setUpPINCode = passcode;
+            LinuxDeviceOptions::GetInstance().payload.setUpPINCode = userEnteredPasscode;
             LinuxCommissionableDataProvider gCommissionableDataProvider;
             CHIP_ERROR err = CHIP_NO_ERROR;
             err            = InitCommissionableDataProvider(gCommissionableDataProvider, LinuxDeviceOptions::GetInstance());


### PR DESCRIPTION
Linux, Android and iOS tv-casting-app example app, updated APIs.md with the new Matter v1.3 Matter Casting User Directed Commissioning (UDC) feature Commissioner-Generated Passcode feature commissioning flow APIs.

**Change summary**

1.	Updated the connectedhomeip/examples/tv-casting-app/APIs.md with instructions and example code on how to use the new CastingPlayer / Commissioner-Generated passcode feature APIs.
2.	Updated connectedhomeip/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/IdentificationDeclarationOptions.java and connectedhomeip/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/support/TargetAppInfo.java to make the fields private. 
3.	Updated some fields for clarity in linux/simple-app-helper.cpp,  ConnectionExampleFragment.java and MCConnectionExampleViewModel.swift

**Testing**

Verified and tested locally with the Linux, Android and iOS tv-casting-app example mobile apps, and the Linux tv-app (CastingPlayer). Able to build and commission with the example apps.

