### PR TITLE
[Silabs] Adds fix for Wi-Fi task loop, BLE task priority, BLE indication soft timer expiry

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -21,7 +21,7 @@
 
 #include "sl_status.h"
 #include <app/icd/server/ICDServerConfig.h>
-#include <support/logging/CHIPLogging.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 #include "FreeRTOS.h"
 #include "event_groups.h"

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -689,7 +689,7 @@ static sl_status_t wfx_rsi_do_join(void)
     status           = sl_wifi_connect(SL_WIFI_CLIENT_INTERFACE, &ap, timeout_ms);
     // sl_wifi_connect returns SL_STATUS_IN_PROGRESS if join is in progress
     // after the initial scan is done, the scan does not check for SSID
-    VerifyOrReturnError((status == SL_STATUS_OK || status == SL_STATUS_IN_PROGRESS), status);
+    ReturnErrorCodeIf((status == SL_STATUS_OK || status == SL_STATUS_IN_PROGRESS), status);
 
     // failure only happens when the firmware returns an error
     ChipLogError(DeviceLayer, "wfx_rsi_do_join: sl_wifi_connect failed: 0x%lx", status);

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -549,6 +549,7 @@ sl_status_t show_scan_results(sl_wifi_scan_result_t * scan_result)
     {
         memset(&cur_scan_result, 0, sizeof(wfx_wifi_scan_result_t));
         strncpy(cur_scan_result.ssid, (char *) &scan_result->scan_info[idx].ssid, WFX_MAX_SSID_LENGTH);
+        cur_scan_result[WFX_MAX_SSID_LENGTH] = '\0';
 
         // if user has provided ssid, then check if the current scan result ssid matches the user provided ssid
         if (wfx_rsi.scan_ssid != NULL && strcmp(wfx_rsi.scan_ssid, cur_scan_result.ssid) != CMP_SUCCESS)

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -657,10 +657,6 @@ static sl_status_t wfx_rsi_do_join(void)
         ChipLogError(DeviceLayer, "wfx_rsi_do_join: unknown security type.");
         return status;
     }
-
-    ChipLogDetail(DeviceLayer, "wfx_rsi_do_join: SSID: %s, SECURITY: %d(%d)", &wfx_rsi.sec.ssid[0], ap.security,
-                  wfx_rsi.sec.security);
-
     /*
      * Join the network
      */
@@ -690,7 +686,7 @@ static sl_status_t wfx_rsi_do_join(void)
     ap.credential_id    = id;
     memset(&ap.ssid.value, 0, (sizeof(ap.ssid.value) / sizeof(ap.ssid.value[0])));
     strncpy((char *) &ap.ssid.value[0], wfx_rsi.sec.ssid, WFX_MAX_SSID_LENGTH);
-
+    ChipLogDetail(DeviceLayer, "wfx_rsi_do_join: SSID: %s, SECURITY: %d(%d)", ap.ssid.value, ap.security, wfx_rsi.sec.security);
     status = sl_wifi_connect(SL_WIFI_CLIENT_INTERFACE, &ap, timeout_ms);
     // sl_wifi_connect returns SL_STATUS_IN_PROGRESS if join is in progress
     // after the initial scan is done, the scan does not check for SSID

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -549,7 +549,6 @@ sl_status_t show_scan_results(sl_wifi_scan_result_t * scan_result)
     {
         memset(&cur_scan_result, 0, sizeof(wfx_wifi_scan_result_t));
         strncpy(cur_scan_result.ssid, (char *) &scan_result->scan_info[idx].ssid, WFX_MAX_SSID_LENGTH);
-        cur_scan_result[WFX_MAX_SSID_LENGTH] = '\0';
 
         // if user has provided ssid, then check if the current scan result ssid matches the user provided ssid
         if (wfx_rsi.scan_ssid != NULL && strcmp(wfx_rsi.scan_ssid, cur_scan_result.ssid) != CMP_SUCCESS)

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -246,7 +246,7 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
     {
         callback_status = *(sl_status_t *) result;
-        ChipLogError(DeviceLayer, "join_callback_handler: failed: 0x%x", callback_status);
+        ChipLogError(DeviceLayer, "join_callback_handler: failed: 0x%lx", static_cast<uint32_t>(callback_status));
         wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTED);
         wfx_retry_interval_handler(is_wifi_disconnection_event, wfx_rsi.join_retries++);
         if (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
@@ -329,14 +329,14 @@ int32_t wfx_rsi_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_
     status = rsi_bt_power_save_profile(sl_si91x_ble_state, 0);
     if (status != RSI_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: 0x%x", status);
+        ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: 0x%lx", static_cast<uint32_t>(status));
         return status;
     }
     sl_wifi_performance_profile_t wifi_profile = { .profile = sl_si91x_wifi_state };
     status                                     = sl_wifi_set_performance_profile(&wifi_profile);
     if (status != RSI_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile failed: 0x%x", status);
+        ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile failed: 0x%lx", static_cast<uint32_t>(status));
         return status;
     }
     if (sl_si91x_wifi_state == HIGH_PERFORMANCE)
@@ -413,7 +413,7 @@ static sl_status_t wfx_rsi_init(void)
     status = wfx_wifi_rsi_init();
     if (status != SL_STATUS_OK)
     {
-        ChipLogError(DeviceLayer, "wfx_rsi_init failed: 0x%x", status);
+        ChipLogError(DeviceLayer, "wfx_rsi_init failed: 0x%lx", static_cast<uint32_t>(status));
         return status;
     }
 #else // For SoC
@@ -422,7 +422,7 @@ static sl_status_t wfx_rsi_init(void)
     status              = sl_si91x_m4_ta_secure_handshake(SL_SI91X_ENABLE_XTAL, 1, &xtal_enable, 0, NULL);
     if (status != SL_STATUS_OK)
     {
-        ChipLogError(DeviceLayer, "sl_si91x_m4_ta_secure_handshake failed: 0x%x", status);
+        ChipLogError(DeviceLayer, "sl_si91x_m4_ta_secure_handshake failed: 0x%lx", static_cast<uint32_t>(status));
         return status;
     }
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER */
@@ -432,7 +432,7 @@ static sl_status_t wfx_rsi_init(void)
     status                             = sl_wifi_get_firmware_version(&version);
     if (status != SL_STATUS_OK)
     {
-        ChipLogError(DeviceLayer, "sl_wifi_get_firmware_version failed: 0x%x", status);
+        ChipLogError(DeviceLayer, "sl_wifi_get_firmware_version failed: 0x%lx", static_cast<uint32_t>(status));
         return status;
     }
     sl_print_firmware_version(&version);
@@ -440,7 +440,7 @@ static sl_status_t wfx_rsi_init(void)
     status = sl_wifi_get_mac_address(SL_WIFI_CLIENT_INTERFACE, (sl_mac_address_t *) &wfx_rsi.sta_mac.octet[0]);
     if (status != SL_STATUS_OK)
     {
-        ChipLogDetail(DeviceLayer, "sl_wifi_get_mac_address failed: 0x%x", status);
+        ChipLogDetail(DeviceLayer, "sl_wifi_get_mac_address failed: 0x%lx", static_cast<uint32_t>(status));
         return status;
     }
 
@@ -451,7 +451,7 @@ static sl_status_t wfx_rsi_init(void)
     status = sl_si91x_trng_entropy();
     if (status != SL_STATUS_OK)
     {
-        ChipLogError(DeviceLayer, "sl_si91x_trng_entropy failed: 0x%x", status);
+        ChipLogError(DeviceLayer, "sl_si91x_trng_entropy failed: 0x%lx", static_cast<uint32_t>(status));
         return status;
     }
 
@@ -459,7 +459,7 @@ static sl_status_t wfx_rsi_init(void)
     status = sl_si91x_trng_program_key((uint32_t *) trngKey, TRNG_KEY_SIZE);
     if (status != SL_STATUS_OK)
     {
-        ChipLogError(DeviceLayer, "sl_si91x_trng_program_key failed: 0x%x", status);
+        ChipLogError(DeviceLayer, "sl_si91x_trng_program_key failed: 0x%lx", static_cast<uint32_t>(status));
         return status;
     }
 #endif // SL_MBEDTLS_USE_TINYCRYPT
@@ -488,7 +488,7 @@ sl_status_t scan_callback_handler(sl_wifi_event_t event, sl_wifi_scan_result_t *
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
     {
         callback_status = *(sl_status_t *) scan_result;
-        ChipLogError(DeviceLayer, "scan_callback_handler: failed: 0x%x", callback_status);
+        ChipLogError(DeviceLayer, "scan_callback_handler: failed: 0x%lx", static_cast<uint32_t>(callback_status));
         scan_results_complete = true;
 #if WIFI_ENABLE_SECURITY_WPA3_TRANSITION
         wfx_rsi.sec.security = WFX_SEC_WPA3;
@@ -688,7 +688,7 @@ static sl_status_t wfx_rsi_do_join(void)
     ReturnErrorCodeIf((status == SL_STATUS_OK || status == SL_STATUS_IN_PROGRESS), status);
 
     // failure only happens when the firmware returns an error
-    ChipLogError(DeviceLayer, "wfx_rsi_do_join: sl_wifi_connect failed: 0x%x", status);
+    ChipLogError(DeviceLayer, "wfx_rsi_do_join: sl_wifi_connect failed: 0x%lx", static_cast<uint32_t>(status));
     VerifyOrReturnError((is_wifi_disconnection_event || wfx_rsi.join_retries <= MAX_JOIN_RETRIES_COUNT), status);
 
     wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED);
@@ -758,7 +758,7 @@ void WfxPostEvent(WfxEvent_t * event)
 
     if (status != osOK)
     {
-        ChipLogError(DeviceLayer, "WfxPostEvent: failed to post event: 0x%x", status);
+        ChipLogError(DeviceLayer, "WfxPostEvent: failed to post event: 0x%lx", static_cast<uint32_t>(status));
         // TODO: Handle error, requeue event depending on queue size or notify relevant task, Chipdie, etc.
     }
 }
@@ -836,7 +836,7 @@ void ProcessEvent(WfxEvent_t inEvent)
             if (SL_STATUS_OK != status)
             {
                 // TODO: Seems like Chipdie should be called here, the device should be initialized here
-                ChipLogError(DeviceLayer, "sl_wifi_set_advanced_scan_configuration failed: 0x%x", status);
+                ChipLogError(DeviceLayer, "sl_wifi_set_advanced_scan_configuration failed: 0x%lx", static_cast<uint32_t>(status));
                 return;
             }
 
@@ -899,7 +899,7 @@ void wfx_rsi_task(void * arg)
     WfxEvent_t wfxEvent;
     if (status != RSI_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "wfx_rsi_task: wfx_rsi_init failed: 0x%x", status);
+        ChipLogError(DeviceLayer, "wfx_rsi_task: wfx_rsi_init failed: 0x%lx", static_cast<uint32_t>(status));
         return;
     }
     wfx_lwip_start();
@@ -915,7 +915,7 @@ void wfx_rsi_task(void * arg)
         }
         else
         {
-            ChipLogError(DeviceLayer, "wfx_rsi_task: get event failed: 0x%x", status);
+            ChipLogError(DeviceLayer, "wfx_rsi_task: get event failed: 0x%lx", static_cast<uint32_t>(status));
         }
     }
 }

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -246,7 +246,7 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
     {
         callback_status = *(sl_status_t *) result;
-        ChipLogError(DeviceLayer, "join_callback_handler: failed: 0x%lx", callback_status);
+        ChipLogError(DeviceLayer, "join_callback_handler: failed: 0x%x", callback_status);
         wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTED);
         wfx_retry_interval_handler(is_wifi_disconnection_event, wfx_rsi.join_retries++);
         if (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
@@ -329,14 +329,14 @@ int32_t wfx_rsi_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_
     status = rsi_bt_power_save_profile(sl_si91x_ble_state, 0);
     if (status != RSI_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: 0x%lx", status);
+        ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: 0x%x", status);
         return status;
     }
     sl_wifi_performance_profile_t wifi_profile = { .profile = sl_si91x_wifi_state };
     status                                     = sl_wifi_set_performance_profile(&wifi_profile);
     if (status != RSI_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile failed: 0x%lx", status);
+        ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile failed: 0x%x", status);
         return status;
     }
     if (sl_si91x_wifi_state == HIGH_PERFORMANCE)
@@ -413,7 +413,7 @@ static sl_status_t wfx_rsi_init(void)
     status = wfx_wifi_rsi_init();
     if (status != SL_STATUS_OK)
     {
-        ChipLogError(DeviceLayer, "wfx_rsi_init failed: 0x%lx", status);
+        ChipLogError(DeviceLayer, "wfx_rsi_init failed: 0x%x", status);
         return status;
     }
 #else // For SoC
@@ -422,7 +422,7 @@ static sl_status_t wfx_rsi_init(void)
     status              = sl_si91x_m4_ta_secure_handshake(SL_SI91X_ENABLE_XTAL, 1, &xtal_enable, 0, NULL);
     if (status != SL_STATUS_OK)
     {
-        ChipLogError(DeviceLayer, "sl_si91x_m4_ta_secure_handshake failed: 0x%lx", status);
+        ChipLogError(DeviceLayer, "sl_si91x_m4_ta_secure_handshake failed: 0x%x", status);
         return status;
     }
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER */
@@ -432,7 +432,7 @@ static sl_status_t wfx_rsi_init(void)
     status                             = sl_wifi_get_firmware_version(&version);
     if (status != SL_STATUS_OK)
     {
-        ChipLogError(DeviceLayer, "sl_wifi_get_firmware_version failed: 0x%lx", status);
+        ChipLogError(DeviceLayer, "sl_wifi_get_firmware_version failed: 0x%x", status);
         return status;
     }
     sl_print_firmware_version(&version);
@@ -440,7 +440,7 @@ static sl_status_t wfx_rsi_init(void)
     status = sl_wifi_get_mac_address(SL_WIFI_CLIENT_INTERFACE, (sl_mac_address_t *) &wfx_rsi.sta_mac.octet[0]);
     if (status != SL_STATUS_OK)
     {
-        ChipLogDetail(DeviceLayer, "sl_wifi_get_mac_address failed: 0x%lx", status);
+        ChipLogDetail(DeviceLayer, "sl_wifi_get_mac_address failed: 0x%x", status);
         return status;
     }
 
@@ -451,7 +451,7 @@ static sl_status_t wfx_rsi_init(void)
     status = sl_si91x_trng_entropy();
     if (status != SL_STATUS_OK)
     {
-        ChipLogError(DeviceLayer, "sl_si91x_trng_entropy failed: 0x%lx", status);
+        ChipLogError(DeviceLayer, "sl_si91x_trng_entropy failed: 0x%x", status);
         return status;
     }
 
@@ -459,7 +459,7 @@ static sl_status_t wfx_rsi_init(void)
     status = sl_si91x_trng_program_key((uint32_t *) trngKey, TRNG_KEY_SIZE);
     if (status != SL_STATUS_OK)
     {
-        ChipLogError(DeviceLayer, "sl_si91x_trng_program_key failed: 0x%lx", status);
+        ChipLogError(DeviceLayer, "sl_si91x_trng_program_key failed: 0x%x", status);
         return status;
     }
 #endif // SL_MBEDTLS_USE_TINYCRYPT
@@ -488,7 +488,7 @@ sl_status_t scan_callback_handler(sl_wifi_event_t event, sl_wifi_scan_result_t *
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
     {
         callback_status = *(sl_status_t *) scan_result;
-        ChipLogError(DeviceLayer, "scan_callback_handler: failed: 0x%lx", callback_status);
+        ChipLogError(DeviceLayer, "scan_callback_handler: failed: 0x%x", callback_status);
         scan_results_complete = true;
 #if WIFI_ENABLE_SECURITY_WPA3_TRANSITION
         wfx_rsi.sec.security = WFX_SEC_WPA3;
@@ -688,7 +688,7 @@ static sl_status_t wfx_rsi_do_join(void)
     ReturnErrorCodeIf((status == SL_STATUS_OK || status == SL_STATUS_IN_PROGRESS), status);
 
     // failure only happens when the firmware returns an error
-    ChipLogError(DeviceLayer, "wfx_rsi_do_join: sl_wifi_connect failed: 0x%lx", status);
+    ChipLogError(DeviceLayer, "wfx_rsi_do_join: sl_wifi_connect failed: 0x%x", status);
     VerifyOrReturnError((is_wifi_disconnection_event || wfx_rsi.join_retries <= MAX_JOIN_RETRIES_COUNT), status);
 
     wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED);
@@ -758,7 +758,7 @@ void WfxPostEvent(WfxEvent_t * event)
 
     if (status != osOK)
     {
-        ChipLogError(DeviceLayer, "WfxPostEvent: failed to post event: 0x%lx", status);
+        ChipLogError(DeviceLayer, "WfxPostEvent: failed to post event: 0x%x", status);
         // TODO: Handle error, requeue event depending on queue size or notify relevant task, Chipdie, etc.
     }
 }
@@ -836,7 +836,7 @@ void ProcessEvent(WfxEvent_t inEvent)
             if (SL_STATUS_OK != status)
             {
                 // TODO: Seems like Chipdie should be called here, the device should be initialized here
-                ChipLogError(DeviceLayer, "sl_wifi_set_advanced_scan_configuration failed: 0x%lx", status);
+                ChipLogError(DeviceLayer, "sl_wifi_set_advanced_scan_configuration failed: 0x%x", status);
                 return;
             }
 
@@ -899,7 +899,7 @@ void wfx_rsi_task(void * arg)
     WfxEvent_t wfxEvent;
     if (status != RSI_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "wfx_rsi_task: wfx_rsi_init failed: 0x%lx", status);
+        ChipLogError(DeviceLayer, "wfx_rsi_task: wfx_rsi_init failed: 0x%x", status);
         return;
     }
     wfx_lwip_start();
@@ -915,7 +915,7 @@ void wfx_rsi_task(void * arg)
         }
         else
         {
-            ChipLogError(DeviceLayer, "wfx_rsi_task: get event failed: 0x%lx", status);
+            ChipLogError(DeviceLayer, "wfx_rsi_task: get event failed: 0x%x", status);
         }
     }
 }

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -677,7 +677,7 @@ static sl_status_t wfx_rsi_do_join(void)
     status = sl_wifi_set_advanced_client_configuration(SL_WIFI_CLIENT_INTERFACE, &client_config);
     VerifyOrReturnError(status == SL_STATUS_OK, status);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
-    VerifyOrReturnError(strlen(wfx_rsi.sec.passkey) > SL_WIFI_MAX_PSK_LENGTH, SL_STATUS_SI91X_INVALID_PSK_LENGTH);
+    VerifyOrReturnError(strlen(wfx_rsi.sec.passkey) <= SL_WIFI_MAX_PSK_LENGTH, SL_STATUS_SI91X_INVALID_PSK_LENGTH);
     sl_net_credential_id_t id = SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID;
     status                    = sl_net_set_credential(id, SL_NET_WIFI_PSK, &wfx_rsi.sec.passkey[0], strlen(wfx_rsi.sec.passkey));
     VerifyOrReturnError(status == SL_STATUS_OK, status);

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -694,9 +694,9 @@ static sl_status_t wfx_rsi_do_join(void)
     wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED);
     ChipLogProgress(DeviceLayer, "wfx_rsi_do_join: retry attempt %d", wfx_rsi.join_retries);
     wfx_retry_interval_handler(is_wifi_disconnection_event, wfx_rsi.join_retries);
+    wfx_rsi.join_retries++;
     event.eventType = WFX_EVT_STA_START_JOIN;
     WfxPostEvent(&event);
-    wfx_rsi.join_retries++;
     return status;
 }
 

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -751,7 +751,9 @@ void HandleDHCPPolling()
      */
     if ((ip6_addr_ispreferred(netif_ip6_addr_state(sta_netif, 0))) && !hasNotifiedIPV6)
     {
-        ChipLogProgress(DeviceLayer, "SLAAC OK: linklocal addr: %s", ip6addr_ntoa(netif_ip6_addr(sta_netif, 0)));
+        char addrStr[40] = { 0 };
+        VerifyOrReturn(ip6addr_ntoa_r(netif_ip6_addr(sta_netif, 0), buf, sizeof(buf)) != NULL);
+        ChipLogProgress(DeviceLayer, "SLAAC OK: linklocal addr: %s", addrStr);
         wfx_ipv6_notify(GET_IPV6_SUCCESS);
         hasNotifiedIPV6 = true;
         event.eventType = WFX_EVT_STA_DHCP_DONE;

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -678,9 +678,10 @@ static sl_status_t wfx_rsi_do_join(void)
     status = sl_wifi_set_advanced_client_configuration(SL_WIFI_CLIENT_INTERFACE, &client_config);
     VerifyOrReturnError(status == SL_STATUS_OK, status);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
-    VerifyOrReturnError(strlen(wfx_rsi.sec.passkey) <= SL_WIFI_MAX_PSK_LENGTH, SL_STATUS_SI91X_INVALID_PSK_LENGTH);
+    size_t psk_length = strlen(wfx_rsi.sec.passkey);
+    VerifyOrReturnError(psk_length <= SL_WIFI_MAX_PSK_LENGTH, SL_STATUS_SI91X_INVALID_PSK_LENGTH);
     sl_net_credential_id_t id = SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID;
-    status                    = sl_net_set_credential(id, SL_NET_WIFI_PSK, &wfx_rsi.sec.passkey[0], strlen(wfx_rsi.sec.passkey));
+    status                    = sl_net_set_credential(id, SL_NET_WIFI_PSK, &wfx_rsi.sec.passkey[0], psk_length);
     VerifyOrReturnError(status == SL_STATUS_OK, status);
 
     uint32_t timeout_ms = 0;

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -261,7 +261,7 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
      * Join was complete - Do the DHCP
      */
     ChipLogDetail(DeviceLayer, "join_callback_handler: success");
-    memset(&temp_reset, 0, sizeof(wfx_wifi_scan_ext_t));
+    memset(&temp_reset, 0, sizeof(temp_reset));
 
     WfxEvent.eventType = WFX_EVT_STA_CONN;
     WfxPostEvent(&WfxEvent);
@@ -547,7 +547,7 @@ sl_status_t show_scan_results(sl_wifi_scan_result_t * scan_result)
     wfx_wifi_scan_result_t cur_scan_result;
     for (int idx = 0; idx < (int) scan_result->scan_count; idx++)
     {
-        memset(&cur_scan_result, 0, sizeof(wfx_wifi_scan_result_t));
+        memset(&cur_scan_result, 0, sizeof(cur_scan_result));
         strncpy(cur_scan_result.ssid, (char *) &scan_result->scan_info[idx].ssid, WFX_MAX_SSID_LENGTH);
 
         // if user has provided ssid, then check if the current scan result ssid matches the user provided ssid
@@ -603,7 +603,7 @@ static void wfx_rsi_save_ap_info() // translation
     sl_wifi_scan_configuration_t wifi_scan_configuration = default_wifi_scan_configuration;
 #endif
     sl_wifi_ssid_t ssid_arg;
-    memset(&ssid_arg, 0, sizeof(sl_wifi_ssid_t));
+    memset(&ssid_arg, 0, sizeof(ssid_arg));
     ssid_arg.length = strnlen(wfx_rsi.sec.ssid, WFX_MAX_SSID_LENGTH);
     strncpy((char *) &ssid_arg.value[0], wfx_rsi.sec.ssid, WFX_MAX_SSID_LENGTH);
     sl_wifi_set_scan_callback(scan_callback_handler, NULL);
@@ -630,7 +630,7 @@ static sl_status_t wfx_rsi_do_join(void)
     ReturnErrorCodeIf((wfx_rsi.dev_state & (WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED)), SL_STATUS_IN_PROGRESS);
     sl_status_t status = SL_STATUS_OK;
     sl_wifi_client_configuration_t ap;
-    memset(&ap, 0, sizeof(sl_wifi_client_configuration_t));
+    memset(&ap, 0, sizeof(ap));
     WfxEvent_t event;
     switch (wfx_rsi.sec.security)
     {
@@ -832,7 +832,7 @@ void ProcessEvent(WfxEvent_t inEvent)
         {
             ChipLogDetail(DeviceLayer, "WFX_EVT_SCAN");
             sl_wifi_scan_configuration_t wifi_scan_configuration;
-            memset(&wifi_scan_configuration, 0, sizeof(sl_wifi_scan_configuration_t));
+            memset(&wifi_scan_configuration, 0, sizeof(wifi_scan_configuration));
 
             // TODO: Add scan logic
             sl_wifi_advanced_scan_configuration_t advanced_scan_configuration = { 0 };

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -685,12 +685,12 @@ static sl_status_t wfx_rsi_do_join(void)
     VerifyOrReturnError(status == SL_STATUS_OK, status);
 
     uint32_t timeout_ms = 0;
-
-    ap.ssid.length = strnlen(wfx_rsi.sec.ssid, WFX_MAX_SSID_LENGTH);
+    ap.ssid.length      = strnlen(wfx_rsi.sec.ssid, WFX_MAX_SSID_LENGTH);
+    ap.encryption       = SL_WIFI_NO_ENCRYPTION;
+    ap.credential_id    = id;
     memcpy(ap.ssid.value, (int8_t *) &wfx_rsi.sec.ssid[0], ap.ssid.length);
-    ap.encryption    = SL_WIFI_NO_ENCRYPTION;
-    ap.credential_id = id;
-    status           = sl_wifi_connect(SL_WIFI_CLIENT_INTERFACE, &ap, timeout_ms);
+
+    status = sl_wifi_connect(SL_WIFI_CLIENT_INTERFACE, &ap, timeout_ms);
     // sl_wifi_connect returns SL_STATUS_IN_PROGRESS if join is in progress
     // after the initial scan is done, the scan does not check for SSID
     ReturnErrorCodeIf((status == SL_STATUS_OK || status == SL_STATUS_IN_PROGRESS), status);

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -686,7 +686,7 @@ static sl_status_t wfx_rsi_do_join(void)
 
     uint32_t timeout_ms = 0;
 
-    ap.ssid.length = strlen(wfx_rsi.sec.ssid);
+    ap.ssid.length = strnlen(wfx_rsi.sec.ssid, WFX_MAX_SSID_LENGTH);
     memcpy(ap.ssid.value, (int8_t *) &wfx_rsi.sec.ssid[0], ap.ssid.length);
     ap.encryption    = SL_WIFI_NO_ENCRYPTION;
     ap.credential_id = id;

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -21,6 +21,7 @@
 
 #include "sl_status.h"
 #include <app/icd/server/ICDServerConfig.h>
+#include <inet/IPAddress.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #include "FreeRTOS.h"
@@ -554,19 +555,16 @@ sl_status_t show_scan_results(sl_wifi_scan_result_t * scan_result)
         {
             continue;
         }
-
         cur_scan_result.security = static_cast<wfx_sec_t>(scan_result->scan_info[idx].security_mode);
         cur_scan_result.rssi     = (-1) * scan_result->scan_info[idx].rssi_val;
         memcpy(cur_scan_result.bssid, scan_result->scan_info[idx].bssid, BSSID_MAX_STR_LEN);
+        wfx_rsi.scan_cb(&cur_scan_result);
 
         // if user has not provided the ssid, then call the callback for each scan result
         if (wfx_rsi.scan_ssid == NULL)
         {
-            wfx_rsi.scan_cb(&cur_scan_result);
             continue;
         }
-
-        wfx_rsi.scan_cb(&cur_scan_result);
         break;
     }
 
@@ -751,8 +749,8 @@ void HandleDHCPPolling()
      */
     if ((ip6_addr_ispreferred(netif_ip6_addr_state(sta_netif, 0))) && !hasNotifiedIPV6)
     {
-        char addrStr[40] = { 0 };
-        VerifyOrReturn(ip6addr_ntoa_r(netif_ip6_addr(sta_netif, 0), buf, sizeof(buf)) != NULL);
+        char addrStr[chip::Inet::IPAddress::kMaxStringLength] = { 0 };
+        VerifyOrReturn(ip6addr_ntoa_r(netif_ip6_addr(sta_netif, 0), addrStr, sizeof(addrStr)) != NULL);
         ChipLogProgress(DeviceLayer, "SLAAC OK: linklocal addr: %s", addrStr);
         wfx_ipv6_notify(GET_IPV6_SUCCESS);
         hasNotifiedIPV6 = true;

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -671,11 +671,7 @@ static sl_status_t wfx_rsi_do_join(void)
     status = sl_wifi_set_advanced_client_configuration(SL_WIFI_CLIENT_INTERFACE, &client_config);
     VerifyOrReturnError(status == SL_STATUS_OK, status);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
-
-    sl_wifi_credential_t cred;
-    memset(&cred, 0, sizeof(sl_wifi_credential_t));
-    cred.type = SL_WIFI_PSK_CREDENTIAL;
-    memcpy(cred.psk.value, &wfx_rsi.sec.passkey[0], strlen(wfx_rsi.sec.passkey));
+    VerifyOrReturnError(strlen(wfx_rsi.sec.passkey) > SL_WIFI_MAX_PSK_LENGTH, SL_STATUS_SI91X_INVALID_PSK_LENGTH);
     sl_net_credential_id_t id = SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID;
     status                    = sl_net_set_credential(id, SL_NET_WIFI_PSK, &wfx_rsi.sec.passkey[0], strlen(wfx_rsi.sec.passkey));
     VerifyOrReturnError(status == SL_STATUS_OK, status);

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -19,9 +19,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "silabs_utils.h"
 #include "sl_status.h"
 #include <app/icd/server/ICDServerConfig.h>
+#include <support/logging/CHIPLogging.h>
 
 #include "FreeRTOS.h"
 #include "event_groups.h"
@@ -132,14 +132,14 @@ static void CancelDHCPTimer()
     // Check if timer started
     if (!osTimerIsRunning(sDHCPTimer))
     {
-        SILABS_LOG("CancelDHCPTimer: timer not running");
+        ChipLogDetail(DeviceLayer, "CancelDHCPTimer: timer not running");
         return;
     }
 
     status = osTimerStop(sDHCPTimer);
     if (status != osOK)
     {
-        SILABS_LOG("CancelDHCPTimer: failed to stop timer with status: %d", status);
+        ChipLogError(DeviceLayer, "CancelDHCPTimer: failed to stop timer: %d", status);
     }
 }
 
@@ -153,7 +153,7 @@ static void StartDHCPTimer(uint32_t timeout)
     status = osTimerStart(sDHCPTimer, pdMS_TO_TICKS(timeout));
     if (status != osOK)
     {
-        SILABS_LOG("StartDHCPTimer: failed to start timer with status: %d", status);
+        ChipLogError(DeviceLayer, "StartDHCPTimer: failed to start timer: %d", status);
     }
 }
 
@@ -246,7 +246,7 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
     {
         callback_status = *(sl_status_t *) result;
-        SILABS_LOG("join_callback_handler: failed: 0x%X", callback_status);
+        ChipLogError(DeviceLayer, "join_callback_handler: failed: 0x%lx", callback_status);
         wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTED);
         wfx_retry_interval_handler(is_wifi_disconnection_event, wfx_rsi.join_retries++);
         if (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
@@ -259,8 +259,8 @@ sl_status_t join_callback_handler(sl_wifi_event_t event, char * result, uint32_t
     /*
      * Join was complete - Do the DHCP
      */
+    ChipLogDetail(DeviceLayer, "join_callback_handler: success");
     memset(&temp_reset, 0, sizeof(wfx_wifi_scan_ext_t));
-    SILABS_LOG("join_callback_handler: success");
 
     WfxEvent.eventType = WFX_EVT_STA_CONN;
     WfxPostEvent(&WfxEvent);
@@ -329,14 +329,14 @@ int32_t wfx_rsi_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_
     status = rsi_bt_power_save_profile(sl_si91x_ble_state, 0);
     if (status != RSI_SUCCESS)
     {
-        SILABS_LOG("BT Powersave Config Failed, Error Code : 0x%lX", status);
+        ChipLogError(DeviceLayer, "rsi_bt_power_save_profile failed: 0x%lx", status);
         return status;
     }
     sl_wifi_performance_profile_t wifi_profile = { .profile = sl_si91x_wifi_state };
     status                                     = sl_wifi_set_performance_profile(&wifi_profile);
     if (status != RSI_SUCCESS)
     {
-        SILABS_LOG("Powersave Config Failed, Error Code : 0x%lX", status);
+        ChipLogError(DeviceLayer, "sl_wifi_set_performance_profile failed: 0x%lx", status);
         return status;
     }
     if (sl_si91x_wifi_state == HIGH_PERFORMANCE)
@@ -361,34 +361,23 @@ int32_t wfx_rsi_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_
  *****************************************************************************************/
 int32_t wfx_wifi_rsi_init(void)
 {
-    SILABS_LOG("wfx_wifi_rsi_init started");
+    ChipLogDetail(DeviceLayer, "wfx_wifi_rsi_init started");
     sl_status_t status;
     status = sl_wifi_init(&config, NULL, sl_wifi_default_event_handler);
-    if (status != SL_STATUS_OK)
-    {
-        return status;
-    }
+    VerifyOrReturnError(status == SL_STATUS_OK, status);
 
     // Create Sempaphore for scan
     sScanSemaphore = osSemaphoreNew(1, 0, NULL);
-    if (sScanSemaphore == NULL)
-    {
-        return SL_STATUS_ALLOCATION_FAILED;
-    }
+    VerifyOrReturnError(sScanSemaphore != NULL, SL_STATUS_ALLOCATION_FAILED);
+
     // Create the message queue
     sWifiEventQueue = osMessageQueueNew(WFX_QUEUE_SIZE, sizeof(WfxEvent_t), NULL);
-    if (sWifiEventQueue == NULL)
-    {
-        return SL_STATUS_ALLOCATION_FAILED;
-    }
+    VerifyOrReturnError(sWifiEventQueue != NULL, SL_STATUS_ALLOCATION_FAILED);
 
     // Create timer for DHCP polling
     // TODO: Use LWIP timer instead of creating a new one here
     sDHCPTimer = osTimerNew(DHCPTimerEventHandler, osTimerPeriodic, NULL, NULL);
-    if (sDHCPTimer == NULL)
-    {
-        return SL_STATUS_ALLOCATION_FAILED;
-    }
+    VerifyOrReturnError(sDHCPTimer != NULL, SL_STATUS_ALLOCATION_FAILED);
 
     return status;
 }
@@ -403,9 +392,9 @@ int32_t wfx_wifi_rsi_init(void)
  *****************************************************************************************/
 static void sl_print_firmware_version(sl_wifi_firmware_version_t * firmware_version)
 {
-    SILABS_LOG("Firmware version is: %x%x.%d.%d.%d.%d.%d.%d", firmware_version->chip_id, firmware_version->rom_id,
-               firmware_version->major, firmware_version->minor, firmware_version->security_version, firmware_version->patch_num,
-               firmware_version->customer_id, firmware_version->build_num);
+    ChipLogDetail(DeviceLayer, "Firmware version is: %x%x.%d.%d.%d.%d.%d.%d", firmware_version->chip_id, firmware_version->rom_id,
+                  firmware_version->major, firmware_version->minor, firmware_version->security_version, firmware_version->patch_num,
+                  firmware_version->customer_id, firmware_version->build_num);
 }
 
 /*************************************************************************************
@@ -424,7 +413,7 @@ static sl_status_t wfx_rsi_init(void)
     status = wfx_wifi_rsi_init();
     if (status != SL_STATUS_OK)
     {
-        SILABS_LOG("wfx_rsi_init failed %x", status);
+        ChipLogError(DeviceLayer, "wfx_rsi_init failed: 0x%lx", status);
         return status;
     }
 #else // For SoC
@@ -433,7 +422,7 @@ static sl_status_t wfx_rsi_init(void)
     status              = sl_si91x_m4_ta_secure_handshake(SL_SI91X_ENABLE_XTAL, 1, &xtal_enable, 0, NULL);
     if (status != SL_STATUS_OK)
     {
-        SILABS_LOG("Failed to bring m4_ta_secure_handshake: 0x%lx\r\n", status);
+        ChipLogError(DeviceLayer, "sl_si91x_m4_ta_secure_handshake failed: 0x%lx", status);
         return status;
     }
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER */
@@ -443,8 +432,7 @@ static sl_status_t wfx_rsi_init(void)
     status                             = sl_wifi_get_firmware_version(&version);
     if (status != SL_STATUS_OK)
     {
-        SILABS_LOG("Get fw version failed:");
-        sl_print_firmware_version(&version);
+        ChipLogError(DeviceLayer, "sl_wifi_get_firmware_version failed: 0x%lx", status);
         return status;
     }
     sl_print_firmware_version(&version);
@@ -452,7 +440,7 @@ static sl_status_t wfx_rsi_init(void)
     status = sl_wifi_get_mac_address(SL_WIFI_CLIENT_INTERFACE, (sl_mac_address_t *) &wfx_rsi.sta_mac.octet[0]);
     if (status != SL_STATUS_OK)
     {
-        SILABS_LOG("sl_wifi_get_mac_address failed: %x", status);
+        ChipLogDetail(DeviceLayer, "sl_wifi_get_mac_address failed: 0x%lx", status);
         return status;
     }
 
@@ -463,7 +451,7 @@ static sl_status_t wfx_rsi_init(void)
     status = sl_si91x_trng_entropy();
     if (status != SL_STATUS_OK)
     {
-        SILABS_LOG("TRNG Entropy Failed");
+        ChipLogError(DeviceLayer, "sl_si91x_trng_entropy failed: 0x%lx", status);
         return status;
     }
 
@@ -471,7 +459,7 @@ static sl_status_t wfx_rsi_init(void)
     status = sl_si91x_trng_program_key((uint32_t *) trngKey, TRNG_KEY_SIZE);
     if (status != SL_STATUS_OK)
     {
-        SILABS_LOG("TRNG Key Programming Failed");
+        ChipLogError(DeviceLayer, "sl_si91x_trng_program_key failed: 0x%lx", status);
         return status;
     }
 #endif // SL_MBEDTLS_USE_TINYCRYPT
@@ -492,7 +480,7 @@ static sl_status_t wfx_rsi_init(void)
  *****************************************************************************************/
 void wfx_show_err(char * msg)
 {
-    SILABS_LOG("wfx_show_err: message: %d", msg);
+    ChipLogError(DeviceLayer, "wfx_show_err: message: %s", msg);
 }
 
 sl_status_t scan_callback_handler(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_result, uint32_t result_length, void * arg)
@@ -500,12 +488,12 @@ sl_status_t scan_callback_handler(sl_wifi_event_t event, sl_wifi_scan_result_t *
     if (SL_WIFI_CHECK_IF_EVENT_FAILED(event))
     {
         callback_status = *(sl_status_t *) scan_result;
-        SILABS_LOG("scan_callback_handler: failed: 0x%X", callback_status);
+        ChipLogError(DeviceLayer, "scan_callback_handler: failed: 0x%lx", callback_status);
         scan_results_complete = true;
 #if WIFI_ENABLE_SECURITY_WPA3_TRANSITION
         wfx_rsi.sec.security = WFX_SEC_WPA3;
 #else
-        wfx_rsi.sec.security  = WFX_SEC_WPA2;
+        wfx_rsi.sec.security = WFX_SEC_WPA2;
 #endif /* WIFI_ENABLE_SECURITY_WPA3_TRANSITION */
 
         osSemaphoreRelease(sScanSemaphore);
@@ -536,7 +524,7 @@ sl_status_t scan_callback_handler(sl_wifi_event_t event, sl_wifi_scan_result_t *
     case SL_WIFI_WPA3:
         wfx_rsi.sec.security = WFX_SEC_WPA3;
 #else
-        wfx_rsi.sec.security  = WFX_SEC_WPA2;
+        wfx_rsi.sec.security = WFX_SEC_WPA2;
 #endif /* WIFI_ENABLE_SECURITY_WPA3_TRANSITION */
         break;
     default:
@@ -559,7 +547,7 @@ sl_status_t show_scan_results(sl_wifi_scan_result_t * scan_result)
         strcpy(&ap.ssid[0], (char *) &scan_result->scan_info[x].ssid);
         if (wfx_rsi.scan_ssid)
         {
-            SILABS_LOG("SCAN SSID: %s , ap scan: %s", wfx_rsi.scan_ssid, ap.ssid);
+            ChipLogDetail(DeviceLayer, "Scan SSID: %s , AP scan: %s", wfx_rsi.scan_ssid, ap.ssid);
             if (strcmp(wfx_rsi.scan_ssid, ap.ssid) == CMP_SUCCESS)
             {
                 ap.security = static_cast<wfx_sec_t>(scan_result->scan_info[x].security_mode);
@@ -605,7 +593,8 @@ sl_status_t bg_scan_callback_handler(sl_wifi_event_t event, sl_wifi_scan_result_
 static void wfx_rsi_save_ap_info() // translation
 {
     sl_status_t status = SL_STATUS_OK;
-#ifndef EXP_BOARD // TODO: this changes will be reverted back after the SDK team fix the scan API
+#ifndef EXP_BOARD
+    // TODO: this changes will be reverted back after the SDK team fix the scan API
     sl_wifi_scan_configuration_t wifi_scan_configuration = default_wifi_scan_configuration;
 #endif
     sl_wifi_ssid_t ssid_arg;
@@ -632,115 +621,86 @@ static void wfx_rsi_save_ap_info() // translation
  **********************************************************************************************/
 static sl_status_t wfx_rsi_do_join(void)
 {
-    sl_status_t status = SL_STATUS_OK;
-    sl_wifi_security_t connect_security_mode;
+    ReturnErrorCodeIf((wfx_rsi.dev_state & (WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED)), SL_STATUS_IN_PROGRESS);
+    sl_status_t status                = SL_STATUS_OK;
+    sl_wifi_client_configuration_t ap = { 0 };
     WfxEvent_t event;
     switch (wfx_rsi.sec.security)
     {
     case WFX_SEC_WEP:
-        connect_security_mode = SL_WIFI_WEP;
+        ap.security = SL_WIFI_WEP;
         break;
     case WFX_SEC_WPA:
-        connect_security_mode = SL_WIFI_WPA_WPA2_MIXED;
+        ap.security = SL_WIFI_WPA_WPA2_MIXED;
         break;
     case WFX_SEC_WPA2:
 #if WIFI_ENABLE_SECURITY_WPA3_TRANSITION
-        connect_security_mode = SL_WIFI_WPA3_TRANSITION;
+        ap.security = SL_WIFI_WPA3_TRANSITION;
         break;
     case WFX_SEC_WPA3:
-        connect_security_mode = SL_WIFI_WPA3_TRANSITION;
+        ap.security = SL_WIFI_WPA3_TRANSITION;
 #else
-        connect_security_mode = SL_WIFI_WPA_WPA2_MIXED;
+        ap.security          = SL_WIFI_WPA_WPA2_MIXED;
 #endif // WIFI_ENABLE_SECURITY_WPA3_TRANSITION
         break;
     case WFX_SEC_NONE:
-        connect_security_mode = SL_WIFI_OPEN;
+        ap.security = SL_WIFI_OPEN;
         break;
     default:
-        SILABS_LOG("error: unknown security type.");
+        ChipLogError(DeviceLayer, "wfx_rsi_do_join: unknown security type.");
         return status;
     }
 
-    if (wfx_rsi.dev_state & (WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED))
-    {
-        SILABS_LOG("%s: not joining - already in progress", __func__);
-    }
-    else
-    {
-        SILABS_LOG("%s: WLAN: connecting to %s, sec=%d", __func__, &wfx_rsi.sec.ssid[0], wfx_rsi.sec.security);
+    ChipLogDetail(DeviceLayer, "wfx_rsi_do_join: SSID: %s, SECURITY: %d(%d)", &wfx_rsi.sec.ssid[0], ap.security,
+                  wfx_rsi.sec.security);
 
-        /*
-         * Join the network
-         */
-        /* TODO - make the WFX_SECURITY_xxx - same as RSI_xxx
-         * Right now it's done by hand - we need something better
-         */
-        wfx_rsi.dev_state |= WFX_RSI_ST_STA_CONNECTING;
-
-        sl_wifi_set_join_callback(join_callback_handler, NULL);
+    /*
+     * Join the network
+     */
+    wfx_rsi.dev_state |= WFX_RSI_ST_STA_CONNECTING;
+    status = sl_wifi_set_join_callback(join_callback_handler, NULL);
+    VerifyOrReturnError(status == SL_STATUS_OK, status);
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-        // Setting the listen interval to 0 which will set it to DTIM interval
-        sl_wifi_listen_interval_t sleep_interval = { .listen_interval = 0 };
-        status                                   = sl_wifi_set_listen_interval(SL_WIFI_CLIENT_INTERFACE, sleep_interval);
+    // Setting the listen interval to 0 which will set it to DTIM interval
+    sl_wifi_listen_interval_t sleep_interval = { .listen_interval = 0 };
+    status                                   = sl_wifi_set_listen_interval(SL_WIFI_CLIENT_INTERFACE, sleep_interval);
+    VerifyOrReturnError(status == SL_STATUS_OK, status);
 
-        sl_wifi_advanced_client_configuration_t client_config = { .max_retry_attempts = 5 };
-        sl_wifi_set_advanced_client_configuration(SL_WIFI_CLIENT_INTERFACE, &client_config);
+    sl_wifi_advanced_client_configuration_t client_config = { .max_retry_attempts = 5 };
+    status = sl_wifi_set_advanced_client_configuration(SL_WIFI_CLIENT_INTERFACE, &client_config);
+    VerifyOrReturnError(status == SL_STATUS_OK, status);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
-        /* Try to connect Wifi with given Credentials
-         * untill there is a success or maximum number of tries allowed
-         */
 
-        /* Call rsi connect call with given ssid and password
-         * And check there is a success
-         */
-        sl_wifi_credential_t cred;
-        memset(&cred, 0, sizeof(sl_wifi_credential_t));
-        cred.type = SL_WIFI_PSK_CREDENTIAL;
-        memcpy(cred.psk.value, &wfx_rsi.sec.passkey[0], strlen(wfx_rsi.sec.passkey));
-        sl_net_credential_id_t id = SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID;
-        status = sl_net_set_credential(id, SL_NET_WIFI_PSK, &wfx_rsi.sec.passkey[0], strlen(wfx_rsi.sec.passkey));
-        if (SL_STATUS_OK != status)
-        {
-            SILABS_LOG("wfx_rsi_do_join: RSI callback register join failed with status: %02x", status);
-            return status;
-        }
+    sl_wifi_credential_t cred;
+    memset(&cred, 0, sizeof(sl_wifi_credential_t));
+    cred.type = SL_WIFI_PSK_CREDENTIAL;
+    memcpy(cred.psk.value, &wfx_rsi.sec.passkey[0], strlen(wfx_rsi.sec.passkey));
+    sl_net_credential_id_t id = SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID;
+    status                    = sl_net_set_credential(id, SL_NET_WIFI_PSK, &wfx_rsi.sec.passkey[0], strlen(wfx_rsi.sec.passkey));
+    VerifyOrReturnError(status == SL_STATUS_OK, status);
 
-        sl_wifi_client_configuration_t ap = { 0 };
-        uint32_t timeout_ms               = 0;
+    uint32_t timeout_ms = 0;
 
-        ap.ssid.length = strlen(wfx_rsi.sec.ssid);
-        memcpy(ap.ssid.value, (int8_t *) &wfx_rsi.sec.ssid[0], ap.ssid.length);
-        ap.security      = connect_security_mode;
-        ap.encryption    = SL_WIFI_NO_ENCRYPTION;
-        ap.credential_id = id;
-        if ((status = sl_wifi_connect(SL_WIFI_CLIENT_INTERFACE, &ap, timeout_ms)) == SL_STATUS_IN_PROGRESS)
-        {
-            callback_status = SL_STATUS_IN_PROGRESS;
-            while (callback_status == SL_STATUS_IN_PROGRESS)
-            {
-                osThreadYield();
-            }
-            status = callback_status;
-        }
-        else
-        {
-            if (is_wifi_disconnection_event || wfx_rsi.join_retries <= WFX_RSI_CONFIG_MAX_JOIN)
-            {
-                SILABS_LOG("wfx_rsi_do_join: Wifi connect failed with status: %x", status);
-                SILABS_LOG("wfx_rsi_do_join: starting JOIN to %s after %d tries\n", (char *) &wfx_rsi.sec.ssid[0],
-                           wfx_rsi.join_retries);
-                wfx_rsi.join_retries += 1;
-                wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED);
-                wfx_retry_interval_handler(is_wifi_disconnection_event, wfx_rsi.join_retries);
-                if (is_wifi_disconnection_event || wfx_rsi.join_retries <= MAX_JOIN_RETRIES_COUNT)
-                {
-                    event.eventType = WFX_EVT_STA_START_JOIN;
-                    WfxPostEvent(&event);
-                }
-            }
-        }
-    }
+    ap.ssid.length = strlen(wfx_rsi.sec.ssid);
+    memcpy(ap.ssid.value, (int8_t *) &wfx_rsi.sec.ssid[0], ap.ssid.length);
+    ap.encryption    = SL_WIFI_NO_ENCRYPTION;
+    ap.credential_id = id;
+    status           = sl_wifi_connect(SL_WIFI_CLIENT_INTERFACE, &ap, timeout_ms);
+    // sl_wifi_connect returns SL_STATUS_IN_PROGRESS if join is in progress
+    // after the initial scan is done, the scan does not check for SSID
+    VerifyOrReturnError((status == SL_STATUS_OK || status == SL_STATUS_IN_PROGRESS), status);
+
+    // failure only happens when the firmware returns an error
+    ChipLogError(DeviceLayer, "wfx_rsi_do_join: sl_wifi_connect failed: 0x%lx", status);
+    VerifyOrReturnError((is_wifi_disconnection_event || wfx_rsi.join_retries <= MAX_JOIN_RETRIES_COUNT), status);
+
+    wfx_rsi.dev_state &= ~(WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED);
+    ChipLogProgress(DeviceLayer, "wfx_rsi_do_join: retry attempt %d", wfx_rsi.join_retries);
+    wfx_retry_interval_handler(is_wifi_disconnection_event, wfx_rsi.join_retries);
+    event.eventType = WFX_EVT_STA_START_JOIN;
+    WfxPostEvent(&event);
+    wfx_rsi.join_retries++;
     return status;
 }
 
@@ -765,7 +725,7 @@ void HandleDHCPPolling()
     if (sta_netif == NULL)
     {
         // TODO: Notify the application that the interface is not set up or Chipdie here because we are in an unkonwn state
-        SILABS_LOG("HandleDHCPPolling: failed to get STA netif");
+        ChipLogError(DeviceLayer, "HandleDHCPPolling: failed to get STA netif");
         return;
     }
 #if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
@@ -787,6 +747,7 @@ void HandleDHCPPolling()
      */
     if ((ip6_addr_ispreferred(netif_ip6_addr_state(sta_netif, 0))) && !hasNotifiedIPV6)
     {
+        ChipLogProgress(DeviceLayer, "SLAAC OK: linklocal addr: %s", ip6addr_ntoa(netif_ip6_addr(sta_netif, 0)));
         wfx_ipv6_notify(GET_IPV6_SUCCESS);
         hasNotifiedIPV6 = true;
         event.eventType = WFX_EVT_STA_DHCP_DONE;
@@ -801,7 +762,7 @@ void WfxPostEvent(WfxEvent_t * event)
 
     if (status != osOK)
     {
-        SILABS_LOG("WfxPostEvent: failed to post event with status: %d", status);
+        ChipLogError(DeviceLayer, "WfxPostEvent: failed to post event: 0x%lx", status);
         // TODO: Handle error, requeue event depending on queue size or notify relevant task, Chipdie, etc.
     }
 }
@@ -829,7 +790,7 @@ void ProcessEvent(WfxEvent_t inEvent)
     switch (inEvent.eventType)
     {
     case WFX_EVT_STA_CONN:
-        SILABS_LOG("%s: starting LwIP STA", __func__);
+        ChipLogDetail(DeviceLayer, "WFX_EVT_STA_CONN");
         wfx_rsi.dev_state |= WFX_RSI_ST_STA_CONNECTED;
         ResetDHCPNotificationFlags();
         wfx_lwip_set_sta_link_up();
@@ -840,10 +801,10 @@ void ProcessEvent(WfxEvent_t inEvent)
         // is independant of IP connectivity.
         break;
     case WFX_EVT_STA_DISCONN:
+        ChipLogDetail(DeviceLayer, "WFX_EVT_STA_DISCONN");
         // TODO: This event is not being posted anywhere, seems to be a dead code or we are missing something
         wfx_rsi.dev_state &=
             ~(WFX_RSI_ST_STA_READY | WFX_RSI_ST_STA_CONNECTING | WFX_RSI_ST_STA_CONNECTED | WFX_RSI_ST_STA_DHCP_DONE);
-        SILABS_LOG("%s: disconnect notify", __func__);
         /* TODO: Implement disconnect notify */
         ResetDHCPNotificationFlags();
         wfx_lwip_set_sta_link_down(); // Internally dhcpclient_poll(netif) ->
@@ -863,7 +824,7 @@ void ProcessEvent(WfxEvent_t inEvent)
 #ifdef SL_WFX_CONFIG_SCAN
         if (!(wfx_rsi.dev_state & WFX_RSI_ST_SCANSTARTED))
         {
-            SILABS_LOG("%s: start SSID scan", __func__);
+            ChipLogDetail(DeviceLayer, "WFX_EVT_SCAN");
             sl_wifi_scan_configuration_t wifi_scan_configuration;
             memset(&wifi_scan_configuration, 0, sizeof(sl_wifi_scan_configuration_t));
 
@@ -879,7 +840,7 @@ void ProcessEvent(WfxEvent_t inEvent)
             if (SL_STATUS_OK != status)
             {
                 // TODO: Seems like Chipdie should be called here, the device should be initialized here
-                SILABS_LOG("Failed to set advanced scan configuration with status: %d", status);
+                ChipLogError(DeviceLayer, "sl_wifi_set_advanced_scan_configuration failed: 0x%lx", status);
                 return;
             }
 
@@ -942,13 +903,13 @@ void wfx_rsi_task(void * arg)
     WfxEvent_t wfxEvent;
     if (status != RSI_SUCCESS)
     {
-        SILABS_LOG("wfx_rsi_task: error: wfx_rsi_init with status: %02x", status);
+        ChipLogError(DeviceLayer, "wfx_rsi_task: wfx_rsi_init failed: 0x%lx", status);
         return;
     }
     wfx_lwip_start();
     wfx_started_notify();
 
-    SILABS_LOG("wfx_rsi_task: starting event loop");
+    ChipLogDetail(DeviceLayer, "wfx_rsi_task: starting event loop");
     for (;;)
     {
         status = osMessageQueueGet(sWifiEventQueue, &wfxEvent, NULL, osWaitForever);
@@ -958,8 +919,7 @@ void wfx_rsi_task(void * arg)
         }
         else
         {
-            // TODO: Everywhere in this file(and related) SILABS_LOG ---> Chiplog
-            SILABS_LOG("Failed to get event with status: %x", status);
+            ChipLogError(DeviceLayer, "wfx_rsi_task: get event failed: 0x%lx", status);
         }
     }
 }
@@ -982,8 +942,8 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     wfx_rsi.ip4_addr[1] = (ip >> 8) & HEX_VALUE_FF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & HEX_VALUE_FF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & HEX_VALUE_FF;
-    SILABS_LOG("%s: DHCP OK: IP=%d.%d.%d.%d", __func__, wfx_rsi.ip4_addr[0], wfx_rsi.ip4_addr[1], wfx_rsi.ip4_addr[2],
-               wfx_rsi.ip4_addr[3]);
+    ChipLogDetail(DeviceLayer, "DHCP OK: IP=%d.%d.%d.%d", wfx_rsi.ip4_addr[0], wfx_rsi.ip4_addr[1], wfx_rsi.ip4_addr[2],
+                  wfx_rsi.ip4_addr[3]);
     /* Notify the Connectivity Manager - via the app */
     wfx_rsi.dev_state |= WFX_RSI_ST_STA_DHCP_DONE;
     wfx_ip_changed_notify(IP_STATUS_SUCCESS);

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -142,7 +142,7 @@ int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap)
     uint8_t rssi;
     ap->security = wfx_rsi.sec.security;
     ap->chan     = wfx_rsi.ap_chan;
-    memcpy(&ap->bssid[0], &wfx_rsi.ap_mac.octet[0], BSSID_MAX_STR_LEN);
+    memcpy(&ap->bssid[0], &wfx_rsi.ap_mac.octet[0], BSSID_LEN);
     status = rsi_wlan_get(RSI_RSSI, &rssi, sizeof(rssi));
     if (status == RSI_SUCCESS)
     {
@@ -493,7 +493,7 @@ static void wfx_rsi_save_ap_info() // translation
     }
     wfx_rsi.sec.security = WFX_SEC_UNSPECIFIED;
     wfx_rsi.ap_chan      = rsp.scan_info->rf_channel;
-    memcpy(&wfx_rsi.ap_mac.octet[0], &rsp.scan_info->bssid[0], BSSID_MAX_STR_LEN);
+    memcpy(&wfx_rsi.ap_mac.octet[0], &rsp.scan_info->bssid[0], BSSID_LEN);
 
     switch (rsp.scan_info->security_mode)
     {
@@ -753,9 +753,9 @@ void ProcessEvent(WfxEvent_t inEvent)
                     strncpy(ap.ssid, (char *) scan->ssid, MIN(sizeof(ap.ssid), sizeof(scan->ssid)));
                     ap.security = scan->security_mode;
                     ap.rssi     = (-1) * scan->rssi_val;
-                    configASSERT(sizeof(ap.bssid) >= BSSID_MAX_STR_LEN);
-                    configASSERT(sizeof(scan->bssid) >= BSSID_MAX_STR_LEN);
-                    memcpy(ap.bssid, scan->bssid, BSSID_MAX_STR_LEN);
+                    configASSERT(sizeof(ap.bssid) >= BSSID_LEN);
+                    configASSERT(sizeof(scan->bssid) >= BSSID_LEN);
+                    memcpy(ap.bssid, scan->bssid, BSSID_LEN);
                     (*wfx_rsi.scan_cb)(&ap);
 
                     if (wfx_rsi.scan_ssid)

--- a/examples/platform/silabs/efr32/wf200/host_if.cpp
+++ b/examples/platform/silabs/efr32/wf200/host_if.cpp
@@ -335,7 +335,7 @@ static void sl_wfx_scan_result_callback(sl_wfx_scan_result_ind_body_t * scan_res
         }
         ap->scan.chan = scan_result->channel;
         ap->scan.rssi = scan_result->rcpi;
-        memcpy(&ap->scan.bssid[0], &scan_result->mac[0], BSSID_MAX_STR_LEN);
+        memcpy(&ap->scan.bssid[0], &scan_result->mac[0], BSSID_LEN);
         scan_count++;
     }
 }

--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -201,7 +201,7 @@ private:
 
 #if (SLI_SI91X_ENABLE_BLE || RSI_BLE_ENABLE)
 protected:
-    static void OnSendIndicationTimeout(TimerHandle_t xTimer);
+    static void OnSendIndicationTimeout(System::Layer * aLayer, void * appState);
 #endif
 };
 

--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -201,7 +201,7 @@ private:
 
 #if (SLI_SI91X_ENABLE_BLE || RSI_BLE_ENABLE)
 protected:
-    static void OnSendIndicationTimeout(System::Layer * aLayer, void * appState);
+    static void OnSendIndicationTimeout(TimerHandle_t xTimer);
 #endif
 };
 

--- a/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
+++ b/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
@@ -41,7 +41,10 @@
 #define SL_WFX_CONNECT_IND_ID (2)
 #define SL_WFX_DISCONNECT_IND_ID (3)
 #define SL_WFX_SCAN_COMPLETE_ID (4)
-#define WFX_RSI_SSID_SIZE (64)
+// MAX SSID LENGTH excluding NULL character
+#define WFX_MAX_SSID_LENGTH 32
+// MAX PASSKEY LENGTH including NULL character
+#define WFX_MAX_PASSKEY_LENGTH SL_WIFI_MAX_PSK_LENGTH
 
 /* Wi-Fi bitmask events - for the task */
 #define SL_WFX_CONNECT (1 << 1)
@@ -160,8 +163,8 @@ typedef enum
 
 typedef struct
 {
-    char ssid[32 + 1];
-    char passkey[64 + 1];
+    char ssid[WFX_MAX_SSID_LENGTH + 1];
+    char passkey[WFX_MAX_PASSKEY_LENGTH];
     wfx_sec_t security;
 } wfx_wifi_provision_t;
 
@@ -176,7 +179,7 @@ typedef enum
 
 typedef struct wfx_wifi_scan_result
 {
-    char ssid[32 + 1];
+    char ssid[WFX_MAX_SSID_LENGTH + 1];
     wfx_sec_t security;
     uint8_t bssid[6];
     uint8_t chan;

--- a/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
+++ b/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
@@ -181,7 +181,7 @@ typedef struct wfx_wifi_scan_result
 {
     char ssid[WFX_MAX_SSID_LENGTH + 1];
     wfx_sec_t security;
-    uint8_t bssid[6];
+    uint8_t bssid[BSSID_MAX_STR_LEN];
     uint8_t chan;
     int16_t rssi; /* I suspect this is in dBm - so signed */
 } wfx_wifi_scan_result_t;

--- a/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
+++ b/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
@@ -42,9 +42,9 @@
 #define SL_WFX_DISCONNECT_IND_ID (3)
 #define SL_WFX_SCAN_COMPLETE_ID (4)
 // MAX SSID LENGTH excluding NULL character
-#define WFX_MAX_SSID_LENGTH 32
+#define WFX_MAX_SSID_LENGTH (32)
 // MAX PASSKEY LENGTH including NULL character
-#define WFX_MAX_PASSKEY_LENGTH SL_WIFI_MAX_PSK_LENGTH
+#define WFX_MAX_PASSKEY_LENGTH (SL_WIFI_MAX_PSK_LENGTH)
 
 /* Wi-Fi bitmask events - for the task */
 #define SL_WFX_CONNECT (1 << 1)
@@ -70,7 +70,7 @@
 // WLAN related Macros
 #define ETH_FRAME (0)
 #define CMP_SUCCESS (0)
-#define BSSID_MAX_STR_LEN (6)
+#define BSSID_LEN (6)
 #define MAC_ADDRESS_FIRST_OCTET (6)
 #define AP_START_SUCCESS (0)
 #define BITS_TO_WAIT (0)
@@ -164,7 +164,7 @@ typedef enum
 typedef struct
 {
     char ssid[WFX_MAX_SSID_LENGTH + 1];
-    char passkey[WFX_MAX_PASSKEY_LENGTH];
+    char passkey[WFX_MAX_PASSKEY_LENGTH + 1];
     wfx_sec_t security;
 } wfx_wifi_provision_t;
 
@@ -181,7 +181,7 @@ typedef struct wfx_wifi_scan_result
 {
     char ssid[WFX_MAX_SSID_LENGTH + 1];
     wfx_sec_t security;
-    uint8_t bssid[BSSID_MAX_STR_LEN];
+    uint8_t bssid[BSSID_LEN];
     uint8_t chan;
     int16_t rssi; /* I suspect this is in dBm - so signed */
 } wfx_wifi_scan_result_t;

--- a/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
+++ b/src/platform/silabs/SiWx917/wifi/wfx_host_events.h
@@ -55,6 +55,7 @@
 #define WLAN_TASK_STACK_SIZE (1024)
 #define WLAN_TASK_PRIORITY (3)
 #define WLAN_DRIVER_TASK_PRIORITY (2)
+#define BLE_DRIVER_TASK_PRIORITY (2)
 #define MAX_JOIN_RETRIES_COUNT (5)
 
 // WLAN retry time intervals in milli seconds

--- a/src/platform/silabs/efr32/wifi/wfx_host_events.h
+++ b/src/platform/silabs/efr32/wifi/wfx_host_events.h
@@ -141,12 +141,12 @@ typedef struct __attribute__((__packed__)) sl_wfx_mib_req_s
 #define WLAN_TASK_STACK_SIZE 1024
 #define WLAN_TASK_PRIORITY 1
 #define WLAN_DRIVER_TASK_PRIORITY 1
+#define BLE_DRIVER_TASK_PRIORITY 1
 #define MAX_JOIN_RETRIES_COUNT 5
 
 #else /* WF200 */
 #define WLAN_TASK_STACK_SIZE 1024
 #define WLAN_TASK_PRIORITY 1
-#define BLE_TASK_PRIORITY 1
 #define MAX_JOIN_RETRIES_COUNT 5
 #endif
 

--- a/src/platform/silabs/efr32/wifi/wfx_host_events.h
+++ b/src/platform/silabs/efr32/wifi/wfx_host_events.h
@@ -114,7 +114,10 @@ typedef struct __attribute__((__packed__)) sl_wfx_mib_req_s
 #define SL_WFX_CONNECT_IND_ID 2
 #define SL_WFX_DISCONNECT_IND_ID 3
 #define SL_WFX_SCAN_COMPLETE_ID 4
-#define WFX_RSI_SSID_SIZE 64
+// MAX SSID LENGTH excluding NULL character
+#define WFX_MAX_SSID_LENGTH 32
+// MAX PASSKEY LENGTH including NULL character
+#define WFX_MAX_PASSKEY_LENGTH 64
 
 #endif /* WF200 */
 
@@ -254,8 +257,8 @@ typedef enum
 
 typedef struct
 {
-    char ssid[32 + 1];
-    char passkey[64 + 1];
+    char ssid[WFX_MAX_SSID_LENGTH + 1];
+    char passkey[WFX_MAX_PASSKEY_LENGTH];
     wfx_sec_t security;
 } wfx_wifi_provision_t;
 
@@ -270,7 +273,7 @@ typedef enum
 
 typedef struct wfx_wifi_scan_result
 {
-    char ssid[32 + 1];
+    char ssid[WFX_MAX_SSID_LENGTH + 1];
     wfx_sec_t security;
     uint8_t bssid[6];
     uint8_t chan;

--- a/src/platform/silabs/efr32/wifi/wfx_host_events.h
+++ b/src/platform/silabs/efr32/wifi/wfx_host_events.h
@@ -114,11 +114,6 @@ typedef struct __attribute__((__packed__)) sl_wfx_mib_req_s
 #define SL_WFX_CONNECT_IND_ID 2
 #define SL_WFX_DISCONNECT_IND_ID 3
 #define SL_WFX_SCAN_COMPLETE_ID 4
-// MAX SSID LENGTH excluding NULL character
-#define WFX_MAX_SSID_LENGTH 32
-// MAX PASSKEY LENGTH including NULL character
-#define WFX_MAX_PASSKEY_LENGTH 64
-
 #endif /* WF200 */
 
 /* LwIP includes. */
@@ -151,7 +146,12 @@ typedef struct __attribute__((__packed__)) sl_wfx_mib_req_s
 #define WLAN_TASK_STACK_SIZE 1024
 #define WLAN_TASK_PRIORITY 1
 #define MAX_JOIN_RETRIES_COUNT 5
-#endif
+#endif // RS911X_WIFI
+
+// MAX SSID LENGTH excluding NULL character
+#define WFX_MAX_SSID_LENGTH 32
+// MAX PASSKEY LENGTH including NULL character
+#define WFX_MAX_PASSKEY_LENGTH 64
 
 // WLAN retry time intervals in milli seconds
 #define WLAN_MAX_RETRY_TIMER_MS 30000

--- a/src/platform/silabs/efr32/wifi/wfx_host_events.h
+++ b/src/platform/silabs/efr32/wifi/wfx_host_events.h
@@ -275,7 +275,7 @@ typedef struct wfx_wifi_scan_result
 {
     char ssid[WFX_MAX_SSID_LENGTH + 1];
     wfx_sec_t security;
-    uint8_t bssid[6];
+    uint8_t bssid[BSSID_MAX_STR_LEN];
     uint8_t chan;
     int16_t rssi; /* I suspect this is in dBm - so signed */
 } wfx_wifi_scan_result_t;

--- a/src/platform/silabs/efr32/wifi/wfx_host_events.h
+++ b/src/platform/silabs/efr32/wifi/wfx_host_events.h
@@ -149,9 +149,9 @@ typedef struct __attribute__((__packed__)) sl_wfx_mib_req_s
 #endif // RS911X_WIFI
 
 // MAX SSID LENGTH excluding NULL character
-#define WFX_MAX_SSID_LENGTH 32
+#define WFX_MAX_SSID_LENGTH (32)
 // MAX PASSKEY LENGTH including NULL character
-#define WFX_MAX_PASSKEY_LENGTH 64
+#define WFX_MAX_PASSKEY_LENGTH (64)
 
 // WLAN retry time intervals in milli seconds
 #define WLAN_MAX_RETRY_TIMER_MS 30000
@@ -162,7 +162,7 @@ typedef struct __attribute__((__packed__)) sl_wfx_mib_req_s
 // WLAN related Macros
 #define ETH_FRAME 0
 #define CMP_SUCCESS 0
-#define BSSID_MAX_STR_LEN 6
+#define BSSID_LEN (6)
 #define MAC_ADDRESS_FIRST_OCTET 6
 #define AP_START_SUCCESS 0
 #define BITS_TO_WAIT 0
@@ -258,7 +258,7 @@ typedef enum
 typedef struct
 {
     char ssid[WFX_MAX_SSID_LENGTH + 1];
-    char passkey[WFX_MAX_PASSKEY_LENGTH];
+    char passkey[WFX_MAX_PASSKEY_LENGTH + 1];
     wfx_sec_t security;
 } wfx_wifi_provision_t;
 
@@ -275,7 +275,7 @@ typedef struct wfx_wifi_scan_result
 {
     char ssid[WFX_MAX_SSID_LENGTH + 1];
     wfx_sec_t security;
-    uint8_t bssid[BSSID_MAX_STR_LEN];
+    uint8_t bssid[BSSID_LEN];
     uint8_t chan;
     int16_t rssi; /* I suspect this is in dBm - so signed */
 } wfx_wifi_scan_result_t;

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -419,8 +419,6 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 
     case DeviceEventType::kCHIPoBLEIndicateConfirm: {
         ChipLogProgress(DeviceLayer, "_OnPlatformEvent kCHIPoBLEIndicateConfirm");
-        // stop the indication confirmation timer
-        DeviceLayer::SystemLayer().CancelTimer(OnSendIndicationTimeout, this);
         HandleIndicationConfirmation(event->CHIPoBLEIndicateConfirm.ConId, &CHIP_BLE_SVC_ID, &Ble::CHIP_BLE_CHAR_2_UUID);
     }
     break;
@@ -925,11 +923,11 @@ exit:
 
 void BLEManagerImpl::HandleTxConfirmationEvent(BLE_CONNECTION_OBJECT conId)
 {
-    ChipLogDetail(DeviceLayer, "HandleTxConfirmationEvent started");
+    // stop the indication confirmation timer
+    DeviceLayer::SystemLayer().CancelTimer(OnSendIndicationTimeout, this);
     ChipDeviceEvent event;
     event.Type                          = DeviceEventType::kCHIPoBLEIndicateConfirm;
     event.CHIPoBLEIndicateConfirm.ConId = conId;
-    ChipLogDetail(DeviceLayer, "HandleTxConfirmationEvent post kCHIPoBLEIndicateConfirm");
     PlatformMgr().PostEventOrDie(&event);
 }
 

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -253,7 +253,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
     sl_rs_ble_init_sem = osSemaphoreNew(1, 0, NULL);
     sl_ble_event_sem   = osSemaphoreNew(1, 0, NULL);
 
-    wfx_rsi.ble_task = xTaskCreateStatic((TaskFunction_t) sl_ble_event_handling_task, "rsi_ble", WFX_RSI_TASK_SZ, NULL, 1,
+    wfx_rsi.ble_task = xTaskCreateStatic((TaskFunction_t) sl_ble_event_handling_task, "rsi_ble", WFX_RSI_TASK_SZ, NULL, 2,
                                          wfxBLETaskStack, &rsiBLETaskStruct);
 
     if (wfx_rsi.ble_task == NULL)
@@ -419,7 +419,6 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 
     case DeviceEventType::kCHIPoBLEIndicateConfirm: {
         ChipLogProgress(DeviceLayer, "_OnPlatformEvent kCHIPoBLEIndicateConfirm");
-        DeviceLayer::SystemLayer().CancelTimer(OnSendIndicationTimeout, this);
         HandleIndicationConfirmation(event->CHIPoBLEIndicateConfirm.ConId, &CHIP_BLE_SVC_ID, &Ble::CHIP_BLE_CHAR_2_UUID);
     }
     break;
@@ -924,6 +923,8 @@ exit:
 
 void BLEManagerImpl::HandleTxConfirmationEvent(BLE_CONNECTION_OBJECT conId)
 {
+    // stop the indication confirmation timer
+    DeviceLayer::SystemLayer().CancelTimer(OnSendIndicationTimeout, this);
     ChipDeviceEvent event;
     event.Type                          = DeviceEventType::kCHIPoBLEIndicateConfirm;
     event.CHIPoBLEIndicateConfirm.ConId = conId;

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -253,8 +253,8 @@ CHIP_ERROR BLEManagerImpl::_Init()
     sl_rs_ble_init_sem = osSemaphoreNew(1, 0, NULL);
     sl_ble_event_sem   = osSemaphoreNew(1, 0, NULL);
 
-    wfx_rsi.ble_task = xTaskCreateStatic((TaskFunction_t) sl_ble_event_handling_task, "rsi_ble", WFX_RSI_TASK_SZ, NULL, 2,
-                                         wfxBLETaskStack, &rsiBLETaskStruct);
+    wfx_rsi.ble_task = xTaskCreateStatic((TaskFunction_t) sl_ble_event_handling_task, "rsi_ble", WFX_RSI_TASK_SZ, NULL,
+                                         BLE_DRIVER_TASK_PRIORITY, wfxBLETaskStack, &rsiBLETaskStruct);
 
     if (wfx_rsi.ble_task == NULL)
     {

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -237,6 +237,7 @@ namespace {
 #define BLE_CONFIG_MAX_CE_LENGTH (0xFFFF) // Leave to max value
 
 TimerHandle_t sbleAdvTimeoutTimer; // FreeRTOS sw timer.
+TimerHandle_t sbleIndicationTimeoutTimer;
 
 const uint8_t UUID_CHIPoBLEService[]      = { 0xFB, 0x34, 0x9B, 0x5F, 0x80, 0x00, 0x00, 0x80,
                                               0x00, 0x10, 0x00, 0x00, 0xF6, 0xFF, 0x00, 0x00 };
@@ -270,11 +271,17 @@ CHIP_ERROR BLEManagerImpl::_Init()
     mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Enabled;
 
     // Create FreeRTOS sw timer for BLE timeouts and interval change.
-    sbleAdvTimeoutTimer = xTimerCreate("BleAdvTimer",                              // Just a text name, not used by the RTOS kernel
-                                       pdMS_TO_TICKS(BLE_DEFAULT_TIMER_PERIOD_MS), // == default timer period
-                                       false,                                      // no timer reload (==one-shot)
-                                       (void *) this,                              // init timer id = ble obj context
-                                       BleAdvTimeoutHandler                        // timer callback handler
+    sbleAdvTimeoutTimer        = xTimerCreate("BleAdvTimer", // Just a text name, not used by the RTOS kernel
+                                              pdMS_TO_TICKS(BLE_DEFAULT_TIMER_PERIOD_MS), // == default timer period
+                                              false,                                      // no timer reload (==one-shot)
+                                              (void *) this,                              // init timer id = ble obj context
+                                              BleAdvTimeoutHandler                        // timer callback handler
+           );
+    sbleIndicationTimeoutTimer = xTimerCreate("BleIndicationTimer", // Just a text name, not used by the RTOS kernel
+                                              pdMS_TO_TICKS(BLE_SEND_INDICATION_TIMER_PERIOD_MS), // == default timer period
+                                              false,                                              // no timer reload (==one-shot)
+                                              (void *) this,                                      // init timer id = ble obj context
+                                              OnSendIndicationTimeout                             // timer callback handler
     );
 
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);
@@ -285,7 +292,7 @@ exit:
     return err;
 }
 
-void BLEManagerImpl::OnSendIndicationTimeout(System::Layer * aLayer, void * appState)
+void BLEManagerImpl::OnSendIndicationTimeout(TimerHandle_t xTimer)
 {
     // TODO: change the connection handle with the ble device ID
     uint8_t connHandle = 1;
@@ -475,8 +482,10 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
     }
 
     // start timer for the indication Confirmation Event
-    DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(BLE_SEND_INDICATION_TIMER_PERIOD_MS),
-                                          OnSendIndicationTimeout, this);
+    if (xTimerStart(sbleIndicationTimeoutTimer, pdMS_TO_TICKS(0)) == pdFAIL)
+    {
+        ChipLogError(DeviceLayer, "Failed to start indication timer");
+    }
     return true;
 }
 
@@ -924,7 +933,10 @@ exit:
 void BLEManagerImpl::HandleTxConfirmationEvent(BLE_CONNECTION_OBJECT conId)
 {
     // stop the indication confirmation timer
-    DeviceLayer::SystemLayer().CancelTimer(OnSendIndicationTimeout, this);
+    if (xTimerStop(sbleIndicationTimeoutTimer, pdMS_TO_TICKS(0)) == pdFAIL)
+    {
+        ChipLogError(DeviceLayer, "Failed to stop indication timer");
+    }
     ChipDeviceEvent event;
     event.Type                          = DeviceEventType::kCHIPoBLEIndicateConfirm;
     event.CHIPoBLEIndicateConfirm.ConId = conId;

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -419,6 +419,8 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 
     case DeviceEventType::kCHIPoBLEIndicateConfirm: {
         ChipLogProgress(DeviceLayer, "_OnPlatformEvent kCHIPoBLEIndicateConfirm");
+        // stop the indication confirmation timer
+        DeviceLayer::SystemLayer().CancelTimer(OnSendIndicationTimeout, this);
         HandleIndicationConfirmation(event->CHIPoBLEIndicateConfirm.ConId, &CHIP_BLE_SVC_ID, &Ble::CHIP_BLE_CHAR_2_UUID);
     }
     break;
@@ -923,11 +925,11 @@ exit:
 
 void BLEManagerImpl::HandleTxConfirmationEvent(BLE_CONNECTION_OBJECT conId)
 {
-    // stop the indication confirmation timer
-    DeviceLayer::SystemLayer().CancelTimer(OnSendIndicationTimeout, this);
+    ChipLogDetail(DeviceLayer, "HandleTxConfirmationEvent started");
     ChipDeviceEvent event;
     event.Type                          = DeviceEventType::kCHIPoBLEIndicateConfirm;
     event.CHIPoBLEIndicateConfirm.ConId = conId;
+    ChipLogDetail(DeviceLayer, "HandleTxConfirmationEvent post kCHIPoBLEIndicateConfirm");
     PlatformMgr().PostEventOrDie(&event);
 }
 

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -923,8 +923,10 @@ exit:
 
 void BLEManagerImpl::HandleTxConfirmationEvent(BLE_CONNECTION_OBJECT conId)
 {
+    DeviceLayer::PlatformMgr().LockChipStack();
     // stop the indication confirmation timer
     DeviceLayer::SystemLayer().CancelTimer(OnSendIndicationTimeout, this);
+    DeviceLayer::PlatformMgr().UnlockChipStack();
     ChipDeviceEvent event;
     event.Type                          = DeviceEventType::kCHIPoBLEIndicateConfirm;
     event.CHIPoBLEIndicateConfirm.ConId = conId;


### PR DESCRIPTION
**Description of Problem/Feature:**
- WiFi task was running in a while loop and invoking `osYeild` without a blocking call, causing lower priority task to be starved by the scheduler.
- This caused `CHIPOBLE_PROTOCOL_ABORT` error.

**Description of Fix/Solution:**
- Added a fix to increase priority of the BLE task.
- Removed the loop in the Wi-Fi connect flow.
- Aligned the BLE soft timer on SiWx917 with EFR32.
- Cleanup of the `SILABS_LOGS` and `VerifyOrReturnError`

