### PR TITLE
Reset the state of DiscoveryImplPlatform to Uninitialized when ChipDnssdInit fails

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -419,7 +419,12 @@ CHIP_ERROR DiscoveryImplPlatform::InitImpl()
     VerifyOrReturnError(mState == State::kUninitialized, CHIP_NO_ERROR);
     mState = State::kInitializing;
 
-    ReturnErrorOnFailure(ChipDnssdInit(HandleDnssdInit, HandleDnssdError, this));
+    CHIP_ERROR err = ChipDnssdInit(HandleDnssdInit, HandleDnssdError, this);
+    if (err != CHIP_NO_ERROR)
+    {
+        mState = State::kUninitialized;
+        return err;
+    }
     UpdateCommissionableInstanceName();
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
If `HandleDnssdInit()` is not called with an error when `ChipDnssdInit()` fails, the state of DiscoveryImplPlatform will never be set to `State::kUninitialized` and the `InitImpl()` cannot be called again.
