### PR TITLE
Build ESP32 QEMU from correct ESP branch

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-61 : Update env variable in vscode image
+62 : Fix ESP32 qemu build

--- a/integrations/docker/images/stage-3/chip-build-esp32-qemu/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-esp32-qemu/Dockerfile
@@ -13,7 +13,7 @@ RUN set -x \
 WORKDIR /opt/espressif/qemu
 # Setup QEMU emulator for ESP32 platform
 RUN set -x \
-    && git clone --depth 1 -b v9.0.0 https://github.com/espressif/qemu.git ../qemu-src \
+    && git clone --depth 1 -b esp-develop-9.0.0-20240606 https://github.com/espressif/qemu.git ../qemu-src \
     && ../qemu-src/configure --target-list=xtensa-softmmu --enable-debug --disable-strip --disable-user --disable-capstone --disable-vnc --disable-sdl --disable-gtk \
     && make -j$(nproc) \
     && : # last line

--- a/src/test_driver/esp32/run_qemu_image.py
+++ b/src/test_driver/esp32/run_qemu_image.py
@@ -150,6 +150,7 @@ def main(log_level, no_log_timestamps, image, file_image_list, qemu, verbose):
             # make sure output is visible in stdout
             print("========== TEST OUTPUT BEGIN ============")
             print(output)
+            print(status.stderr.decode('ascii'))
             print("========== TEST OUTPUT END   ============")
             raise
 


### PR DESCRIPTION
### Problem

QEMU for ESP32 is not built from ESP branch (there is no support for ESP32)

### Changes

- use proper tag for QEMU with ESP32 suport
- print `stderr` in case of QEMU run failure (it might contain useful message)

### Testing

Now QEMU shows ESP32 as supported machine:
```
root@08a88e74bea0:/opt/espressif/qemu# ./qemu-system-xtensa -machine help
Supported machines are:
esp32                Espressif ESP32 machine
esp32s3              Espressif ESP32S3 machine
kc705                kc705 EVB (dc232b)
kc705-nommu          kc705 noMMU EVB (de212)
lx200                lx200 EVB (dc232b)
lx200-nommu          lx200 noMMU EVB (de212)
lx60                 lx60 EVB (dc232b)
lx60-nommu           lx60 noMMU EVB (de212)
ml605                ml605 EVB (dc232b)
ml605-nommu          ml605 noMMU EVB (de212)
none                 empty machine
sim                  sim machine (dc232b) (default)
virt                 virt machine (dc232b)
```