### PR TITLE
Use in k32w example dependencies from project

### DIFF
--- a/examples/lighting-app/nxp/k32w/k32w0/.gn
+++ b/examples/lighting-app/nxp/k32w/k32w0/.gn
@@ -27,7 +27,8 @@ default_args = {
   import("//args.gni")
 
   pw_build_PIP_CONSTRAINTS = [ "${chip_root}/scripts/setup/constraints.txt" ]
-  pw_build_PIP_REQUIREMENTS = [ "${chip_root}/scripts/setup/requirements.build.txt" ]
+  pw_build_PIP_REQUIREMENTS =
+      [ "${chip_root}/scripts/setup/requirements.build.txt" ]
 
   # Import default platform configs
   import("${chip_root}/src/platform/nxp/k32w/k32w0/args.gni")

--- a/examples/lighting-app/nxp/k32w/k32w0/.gn
+++ b/examples/lighting-app/nxp/k32w/k32w0/.gn
@@ -26,6 +26,9 @@ default_args = {
 
   import("//args.gni")
 
+  pw_build_PIP_CONSTRAINTS = [ "${chip_root}/scripts/setup/constraints.txt" ]
+  pw_build_PIP_REQUIREMENTS = [ "${chip_root}/scripts/setup/requirements.build.txt" ]
+
   # Import default platform configs
   import("${chip_root}/src/platform/nxp/k32w/k32w0/args.gni")
 }


### PR DESCRIPTION
## Problem 

Light-app example in created python-venv install default packages from pigweed repo. In #33979 is a problem with conflict of version of this packages on python3.12.

## Solution

I've added configuration of `pw_build_PIP_CONSTRAINTS` and  `pw_build_PIP_REQUIREMENTS` in light example. After my modification when building the example, dependencies are used from our project and not from pigweed.