### PR TITLE
chip-repl runner: support missing features needed to yaml tests

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -226,50 +226,17 @@ def _GetChipReplUnsupportedTests() -> Set[str]:
     return {
         "Test_AddNewFabricFromExistingFabric.yaml",     # chip-repl does not support GetCommissionerRootCertificate and IssueNocChain command
         "Test_TC_OPCREDS_3_7.yaml",         # chip-repl does not support GetCommissionerRootCertificate and IssueNocChain command
-        "TestEqualities.yaml",              # chip-repl does not support pseudo-cluster commands that return a value
         "TestExampleCluster.yaml",          # chip-repl does not load custom pseudo clusters
         "TestAttributesById.yaml",           # chip-repl does not support AnyCommands (06/06/2023)
         "TestCommandsById.yaml",             # chip-repl does not support AnyCommands (06/06/2023)
         "TestEventsById.yaml",               # chip-repl does not support AnyCommands (06/06/2023)
         "TestReadNoneSubscribeNone.yaml",    # chip-repl does not support AnyCommands (07/27/2023)
-        "Test_TC_DRLK_2_8.yaml",   # Test fails only in chip-repl: Refer--> https://github.com/project-chip/connectedhomeip/pull/27011#issuecomment-1593339855
-        "Test_TC_ACE_1_6.yaml",    # Test fails only in chip-repl: Refer--> https://github.com/project-chip/connectedhomeip/pull/27910#issuecomment-1632485584
         "Test_TC_IDM_1_2.yaml",              # chip-repl does not support AnyCommands (19/07/2023)
-        "TestGroupKeyManagementCluster.yaml",  # chip-repl does not support EqualityCommands (2023-08-04)
         "TestIcdManagementCluster.yaml",   # TODO(#30430): add ICD registration support in chip-repl
         "Test_TC_ICDM_3_4.yaml",           # chip-repl does not support ICD registration
-        "Test_TC_S_2_2.yaml",              # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_MOD_3_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_MOD_3_2.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_MOD_3_3.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_MOD_3_4.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_BRBINFO_2_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_DGGEN_2_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_DGGEN_2_3.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_LWM_3_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_LWM_3_2.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_LWM_3_3.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_OTCCM_3_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_OTCCM_3_2.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_OTCCM_3_3.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_G_2_4.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_RVCRUNM_3_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_RVCCLEANM_3_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_TCCM_3_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_TCCM_3_2.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_TCCM_3_3.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_TCTL_2_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
         # chip-repl and chip-tool disagree on what the YAML here should look like: https://github.com/project-chip/connectedhomeip/issues/29110
         "TestClusterMultiFabric.yaml",
-        "Test_TC_ACL_2_5.yaml",            # chip-repl does not support LastReceivedEventNumber : https://github.com/project-chip/connectedhomeip/issues/28884
-        "Test_TC_ACL_2_6.yaml",            # chip-repl does not support LastReceivedEventNumber : https://github.com/project-chip/connectedhomeip/issues/28884
-        "Test_TC_RVCCLEANM_3_3.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_BINFO_2_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
         "TestDiagnosticLogs.yaml",          # chip-repl does not implement a BDXTransferServerDelegate
-        "Test_TC_EEVSEM_2_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_EEVSEM_3_1.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_EEVSEM_3_2.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
-        "Test_TC_EEVSEM_3_3.yaml",            # chip-repl does not support EqualityCommands pseudo-cluster
         "TestDiagnosticLogsDownloadCommand.yaml",  # chip-repl does not implement the bdx download command
     }
 

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -31,14 +31,11 @@ from chip.clusters.Attribute import (AttributeStatus, EventReadResult, Subscript
 from chip.exceptions import ChipStackError
 from chip.yaml.data_model_lookup import DataModelLookup
 from chip.yaml.errors import ActionCreationError, UnexpectedActionCreationError
-from matter_yamltests.pseudo_clusters.clusters.delay_commands import DelayCommands
-from matter_yamltests.pseudo_clusters.clusters.log_commands import LogCommands
-from matter_yamltests.pseudo_clusters.clusters.system_commands import SystemCommands
-from matter_yamltests.pseudo_clusters.pseudo_clusters import PseudoClusters
+from matter_yamltests.pseudo_clusters.pseudo_clusters import get_default_pseudo_clusters
 
 from .data_model_lookup import PreDefinedDataModelLookup
 
-_PSEUDO_CLUSTERS = PseudoClusters([DelayCommands(), LogCommands(), SystemCommands()])
+_PSEUDO_CLUSTERS = get_default_pseudo_clusters()
 logger = logging.getLogger('YamlParser')
 
 
@@ -129,8 +126,8 @@ class DefaultPseudoCluster(BaseAction):
             raise ActionCreationError(f'Default cluster {test_step.cluster} {test_step.command}, not supported')
 
     async def run_action(self, dev_ctrl: ChipDeviceController) -> _ActionResult:
-        _ = await _PSEUDO_CLUSTERS.execute(self._test_step)
-        return _ActionResult(status=_ActionStatus.SUCCESS, response=None)
+        response = await _PSEUDO_CLUSTERS.execute(self._test_step)
+        return _ActionResult(status=_ActionStatus.SUCCESS, response=response[0])
 
 
 class InvokeAction(BaseAction):
@@ -884,8 +881,12 @@ class ReplTestRunner:
         response = result.response
 
         decoded_response = {}
+        if isinstance(response, dict):
+            return response
+
         if isinstance(response, chip.interaction_model.InteractionModelError):
             decoded_response['error'] = stringcase.snakecase(response.status.name).upper()
+            decoded_response['clusterError'] = response.clusterStatus
             return decoded_response
 
         if isinstance(response, chip.interaction_model.Status):
@@ -939,12 +940,13 @@ class ReplTestRunner:
                 cluster_id = event.Header.ClusterId
                 cluster_name = self._test_spec_definition.get_cluster_name(cluster_id)
                 event_id = event.Header.EventId
+                event_number = event.Header.EventNumber
                 event_name = self._test_spec_definition.get_event_name(cluster_id, event_id)
                 event_definition = self._test_spec_definition.get_event_by_name(cluster_name, event_name)
                 is_fabric_scoped = bool(event_definition.is_fabric_sensitive)
                 decoded_event = Converter.from_data_model_to_test_definition(
                     self._test_spec_definition, cluster_name, event_definition.fields, event.Data, is_fabric_scoped)
-                decoded_response.append({'value': decoded_event})
+                decoded_response.append({'value': decoded_event, 'eventNumber': event_number})
             return decoded_response
 
         if isinstance(response, ChipStackError):


### PR DESCRIPTION
* Add support to capture and use eventNumber parameter from read event response (needed for e.g. ACL-2.6)
* Add support for current implemented pseudo cluster - most crucial EqualityCommands (needed for e.g. DGGEN-2.3)
* Add possibility to gather cluster-specific error in InteractionDataModelError (needed for e.g. DRLK-2.8)

Fix: 
* https://github.com/project-chip/connectedhomeip/issues/34029
* https://github.com/project-chip/connectedhomeip/issues/34028
* Some aspects of https://github.com/project-chip/connectedhomeip/issues/28884



