### PR TITLE
[Silabs] Additional Advertising fix and Rotating Unique ID fixes for the Wifi devices

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -106,6 +106,7 @@ extern "C" {
 #include <CHIPProjectConfig.h>
 
 #include <stdint.h>
+#include <stdio.h>
 
 #ifdef SLI_SI91X_MCU_INTERFACE
 #include "si91x_device.h"

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wlan_config.h
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wlan_config.h
@@ -19,8 +19,9 @@
 #define RSI_CONFIG_H
 
 #include "ble_config.h"
+#if SLI_SI91X_MCU_INTERFACE
 #include "rsi_wisemcu_hardware_setup.h"
-#include "rsi_wlan_defines.h"
+#endif // SLI_SI91X_MCU_INTERFACE
 #include "sl_wifi_device.h"
 
 //! Enable feature

--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -80,7 +80,7 @@ public:
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
 #if (SLI_SI91X_ENABLE_BLE || RSI_BLE_ENABLE)
-    static void HandleC3ReadRequest(void);
+    static void HandleC3ReadRequest(rsi_ble_read_req_t * rsi_ble_read_req);
 #else
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
     static void HandleC3ReadRequest(volatile sl_bt_msg_t * evt);

--- a/src/platform/silabs/CHIPDevicePlatformConfig.h
+++ b/src/platform/silabs/CHIPDevicePlatformConfig.h
@@ -69,6 +69,15 @@
 #define CHIP_DEVICE_CONFIG_ENABLE_TEST_SETUP_PARAMS 1
 #endif
 
+/**
+ * CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH
+ *
+ * Unique ID length in bytes. The value should be 16-bytes or longer.
+ */
+#ifndef CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH
+#define CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH 32
+#endif
+
 #if CHIP_DEVICE_CONFIG_ENABLE_TEST_SETUP_PARAMS
 /**
  *  @brief Fallback value for the basic information cluster's Vendor name attribute


### PR DESCRIPTION
- Include fixes for the 917 NCP
- Addition Advertisement fixes for the 91x ble devices
- Setting the `CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH` to 32