### PR TITLE
Fix callback creation

### DIFF
--- a/src/lib/core/tests/TestCHIPCallback.cpp
+++ b/src/lib/core/tests/TestCHIPCallback.cpp
@@ -201,7 +201,7 @@ TEST_F(TestCHIPCallback, NotifierTest)
 {
     int n = 1;
     Callback<Notifier::NotifyFn> cb(reinterpret_cast<Notifier::NotifyFn>(increment_by), &n);
-    Callback<Notifier::NotifyFn> cancelcb(reinterpret_cast<Notifier::NotifyFn>(canceler), cb.Cancel());
+    Callback<Notifier::NotifyFn> cancelcb([](void * call, int) { canceler(reinterpret_cast<Cancelable *>(call)); }, cb.Cancel());
 
     // safe to call anytime
     cb.Cancel();


### PR DESCRIPTION
## Problem 
There is an error during building unit tests on latest images (61), the error can be found in related PR: #33979

``` log
FAILED: obj/src/lib/core/tests/libCoreTests.TestCHIPCallback.cpp.o
clang++ -MMD -MF obj/src/lib/core/tests/libCoreTests.TestCHIPCallback.cpp.o.d -Wconversion -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwin
d-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Werror -Wextra -Wshadow -Wunreachable-code -Wvla -Wformat -Wformat-nonliteral -Wformat-security -Wundef -Wimplicit-fall
through -Wheader-hygiene -Wshorten-64-to-32 -Wformat-type-confusion -Wthread-safety -Wno-deprecated-declarations -Wno-missing-field-initializers -Wno-unknown-warning-option
-Wno-unused-parameter -fdiagnostics-color -fno-strict-aliasing -fmacro-prefix-map=../../= -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include
/gio-unix-2.0 -I/usr/include/libmount -I/usr/include/blkid -std=gnu++17 -fno-rtti -Wnon-virtual-dtor -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS=1 -DCHIP_HAVE_CONFIG_H=1 -DPW
_UNIT_TEST_CONFIG_MEMORY_POOL_SIZE=16384 -DPW_SPAN_ENABLE_ASSERTS=false -I../../src/include -I../../src -Igen/include -I../../config/standalone -I../../zzz_generated/app-com
mon -I../../third_party/nlassert/repo/include -I../../third_party/nlio/repo/include -I../../third_party/nlfaultinjection/include -I../../third_party/inipp/repo/inipp -I../..
/third_party/pigweed/repo/pw_unit_test/public -I../../third_party/pigweed/repo/pw_unit_test/light_public_overrides -I../../third_party/pigweed/repo/pw_unit_test/public_overr
ides -I../../third_party/pigweed/repo/pw_polyfill/public -I../../third_party/pigweed/repo/pw_bytes/public -I../../third_party/pigweed/repo/third_party/fuchsia/repo/sdk/lib/s
tdcompat/include -I../../third_party/pigweed/repo/pw_containers/public -I../../third_party/pigweed/repo/pw_preprocessor/public -I../../third_party/pigweed/repo/pw_span/publi
c -I../../third_party/pigweed/repo/pw_status/public -I../../third_party/pigweed/repo/pw_assert/public -I../../third_party/pigweed/repo/pw_assert/assert_compatibility_public_
overrides -I../../third_party/pigweed/repo/pw_assert_log/check_backend_public_overrides -I../../third_party/pigweed/repo/pw_assert_log/public -I../../third_party/pigweed/rep
o/pw_log/public -I../../third_party/pigweed/repo/pw_log_basic/public_overrides -I../../third_party/pigweed/repo/pw_log_basic/public -I../../third_party/pigweed/repo/pw_strin
g/public -I../../third_party/pigweed/repo/pw_result/public -c ../../src/lib/core/tests/TestCHIPCallback.cpp -o obj/src/lib/core/tests/libCoreTests.TestCHIPCallback.cpp.o
../../src/lib/core/tests/TestCHIPCallback.cpp:204:74: error: reinterpret_cast from 'void *' to 'Cancelable' is not allowed
  204 |     Callback<Notifier::NotifyFn> cancelcb([](void * val, int) { canceler(reinterpret_cast<Cancelable>(val)) }, cb.Cancel());
      |                                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

## Changes 

Change creation of `Callback`, use lambda expression to skip one of required argument of passed callback function. The `static void canceler(Cancelable * ca)` is also used in other places so I can't change signature of this function. 
