### PR TITLE
[nrfconnect] Fix WiFiManager singleton implementation

### DIFF
--- a/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
+++ b/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
@@ -42,7 +42,7 @@ ConnectivityManager::WiFiStationMode ConnectivityManagerImplWiFi::_GetWiFiStatio
 {
     if (mStationMode != ConnectivityManager::WiFiStationMode::kWiFiStationMode_ApplicationControlled)
     {
-        mStationMode = (WiFiManager::StationStatus::DISABLED == WiFiManager().Instance().GetStationStatus())
+        mStationMode = (WiFiManager::StationStatus::DISABLED == WiFiManager::Instance().GetStationStatus())
             ? ConnectivityManager::WiFiStationMode::kWiFiStationMode_Disabled
             : ConnectivityManager::WiFiStationMode::kWiFiStationMode_Enabled;
     }
@@ -60,7 +60,7 @@ CHIP_ERROR ConnectivityManagerImplWiFi::_SetWiFiStationMode(ConnectivityManager:
 
 bool ConnectivityManagerImplWiFi::_IsWiFiStationEnabled(void)
 {
-    return (WiFiManager::StationStatus::DISABLED <= WiFiManager().Instance().GetStationStatus());
+    return (WiFiManager::StationStatus::DISABLED <= WiFiManager::Instance().GetStationStatus());
 }
 
 bool ConnectivityManagerImplWiFi::_IsWiFiStationApplicationControlled(void)
@@ -70,7 +70,7 @@ bool ConnectivityManagerImplWiFi::_IsWiFiStationApplicationControlled(void)
 
 bool ConnectivityManagerImplWiFi::_IsWiFiStationConnected(void)
 {
-    return (WiFiManager::StationStatus::CONNECTED == WiFiManager().Instance().GetStationStatus());
+    return (WiFiManager::StationStatus::CONNECTED == WiFiManager::Instance().GetStationStatus());
 }
 
 System::Clock::Timeout ConnectivityManagerImplWiFi::_GetWiFiStationReconnectInterval(void)
@@ -88,14 +88,14 @@ bool ConnectivityManagerImplWiFi::_IsWiFiStationProvisioned(void)
 {
     // from Matter perspective `provisioned` means that the supplicant has been provided
     // with SSID and password (doesn't matter if valid or not)
-    return (WiFiManager::StationStatus::CONNECTING <= WiFiManager().Instance().GetStationStatus());
+    return (WiFiManager::StationStatus::CONNECTING <= WiFiManager::Instance().GetStationStatus());
 }
 
 void ConnectivityManagerImplWiFi::_ClearWiFiStationProvision(void)
 {
     if (_IsWiFiStationProvisioned())
     {
-        if (CHIP_NO_ERROR != WiFiManager().Instance().ClearStationProvisioningData())
+        if (CHIP_NO_ERROR != WiFiManager::Instance().ClearStationProvisioningData())
         {
             ChipLogError(DeviceLayer, "Cannot clear WiFi station provisioning data");
         }
@@ -104,9 +104,9 @@ void ConnectivityManagerImplWiFi::_ClearWiFiStationProvision(void)
 
 bool ConnectivityManagerImplWiFi::_CanStartWiFiScan()
 {
-    return (WiFiManager::StationStatus::DISABLED != WiFiManager().Instance().GetStationStatus() &&
-            WiFiManager::StationStatus::SCANNING != WiFiManager().Instance().GetStationStatus() &&
-            WiFiManager::StationStatus::CONNECTING != WiFiManager().Instance().GetStationStatus());
+    return (WiFiManager::StationStatus::DISABLED != WiFiManager::Instance().GetStationStatus() &&
+            WiFiManager::StationStatus::SCANNING != WiFiManager::Instance().GetStationStatus() &&
+            WiFiManager::StationStatus::CONNECTING != WiFiManager::Instance().GetStationStatus());
 }
 
 void ConnectivityManagerImplWiFi::_OnWiFiStationProvisionChange()

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -88,6 +88,12 @@ private:
 class WiFiManager
 {
 public:
+    /* No copy, nor move. */
+    WiFiManager(const WiFiManager &)             = delete;
+    WiFiManager & operator=(const WiFiManager &) = delete;
+    WiFiManager(WiFiManager &&)                  = delete;
+    WiFiManager & operator=(WiFiManager &&)      = delete;
+
     using ScanDoneStatus     = decltype(wifi_status::status);
     using ScanResultCallback = void (*)(const NetworkCommissioning::WiFiScanResponse &);
     using ScanDoneCallback   = void (*)(const ScanDoneStatus &);
@@ -184,6 +190,9 @@ public:
 
 private:
     using NetEventHandler = void (*)(Platform::UniquePtr<uint8_t>, size_t);
+
+    WiFiManager()  = default;
+    ~WiFiManager() = default;
 
     struct ConnectionParams
     {


### PR DESCRIPTION
* Fixed the usage of WiFiManager::Instance()
* Fixed the WiFiManager's singleton by making c'tor and d'tor private
