### PR TITLE
Disentangle data model tests by moving fixtures into their own file

### DIFF
--- a/src/app/util/mock/Constants.h
+++ b/src/app/util/mock/Constants.h
@@ -51,11 +51,22 @@ constexpr EventId MockEventId(const uint16_t & id)
     return (0xFFF1'0000 | id);
 }
 
+// Cluster Revision value returned by mock clusters
 extern const uint16_t mockClusterRevision;
+
+// Feature Map value returned by mock clusters
 extern const uint32_t mockFeatureMap;
+
+// Scalar value returned by mock clusters for MockAttributeId(1)
 extern const bool mockAttribute1;
+
+// Scalar value returned by mock clusters for MockAttributeId(2)
 extern const int16_t mockAttribute2;
+
+// Scalar value returned by mock clusters for MockAttributeId(3)
 extern const uint64_t mockAttribute3;
+
+// MockAttributeId(4) returns a list of octstr with this value
 extern const uint8_t mockAttribute4[256];
 
 } // namespace Test

--- a/src/app/util/mock/Constants.h
+++ b/src/app/util/mock/Constants.h
@@ -50,5 +50,13 @@ constexpr EventId MockEventId(const uint16_t & id)
 {
     return (0xFFF1'0000 | id);
 }
+
+extern const uint16_t mockClusterRevision;
+extern const uint32_t mockFeatureMap;
+extern const bool mockAttribute1;
+extern const int16_t mockAttribute2;
+extern const uint64_t mockAttribute3;
+extern const uint8_t mockAttribute4[256];
+
 } // namespace Test
 } // namespace chip

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -113,12 +113,17 @@ const MockNodeConfig & GetMockNodeConfig()
     return (mockConfig != nullptr) ? *mockConfig : DefaultMockNodeConfig();
 }
 
-uint16_t mockClusterRevision = 1;
-uint32_t mockFeatureMap      = 0x1234;
-bool mockAttribute1          = true;
-int16_t mockAttribute2       = 42;
-uint64_t mockAttribute3      = 0xdeadbeef0000cafe;
-uint8_t mockAttribute4[256]  = {
+} // namespace
+
+namespace chip {
+namespace Test {
+
+const uint16_t mockClusterRevision = 1;
+const uint32_t mockFeatureMap      = 0x1234;
+const bool mockAttribute1          = true;
+const int16_t mockAttribute2       = 42;
+const uint64_t mockAttribute3      = 0xdeadbeef0000cafe;
+const uint8_t mockAttribute4[256]  = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf,
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf,
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf,
@@ -129,7 +134,8 @@ uint8_t mockAttribute4[256]  = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf,
 };
 
-} // namespace
+} // namespace Test
+} // namespace chip
 
 uint16_t emberAfEndpointCount()
 {

--- a/src/controller/tests/data_model/BUILD.gn
+++ b/src/controller/tests/data_model/BUILD.gn
@@ -22,11 +22,19 @@ import("${chip_root}/src/platform/device.gni")
 chip_test_suite("data_model") {
   output_name = "libDataModelTests"
 
+  sources = [
+    "DataModelFixtures.cpp",
+    "DataModelFixtures.h",
+  ]
+
+  test_sources = []
   if (chip_device_platform != "mbed" && chip_device_platform != "efr32" &&
       chip_device_platform != "esp32" && chip_device_platform != "fake") {
-    test_sources = [ "TestCommands.cpp" ]
-    test_sources += [ "TestWrite.cpp" ]
-    test_sources += [ "TestRead.cpp" ]
+    test_sources += [
+      "TestCommands.cpp",
+      "TestRead.cpp",
+      "TestWrite.cpp",
+    ]
   }
 
   public_deps = [

--- a/src/controller/tests/data_model/DataModelFixtures.cpp
+++ b/src/controller/tests/data_model/DataModelFixtures.cpp
@@ -1,0 +1,467 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "DataModelFixtures.h"
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/AttributeValueDecoder.h>
+#include <app/InteractionModelEngine.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::DataModelTests;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::UnitTesting;
+using namespace chip::Protocols;
+
+namespace chip {
+namespace app {
+
+namespace DataModelTests {
+
+ReadResponseDirective gReadResponseDirective       = ReadResponseDirective::kSendDataResponse;
+WriteResponseDirective gWriteResponseDirective     = WriteResponseDirective::kSendAttributeSuccess;
+CommandResponseDirective gCommandResponseDirective = CommandResponseDirective::kSendSuccessStatusCode;
+
+uint16_t gInt16uTotalReadCount = 0;
+bool gIsLitIcd                 = false;
+CommandHandler::Handle gAsyncCommandHandle;
+
+} // namespace DataModelTests
+
+CHIP_ERROR ReadSingleClusterData(const Access::SubjectDescriptor & aSubjectDescriptor, bool aIsFabricFiltered,
+                                 const ConcreteReadAttributePath & aPath, AttributeReportIBs::Builder & aAttributeReports,
+                                 AttributeEncodeState * apEncoderState)
+{
+    if (aPath.mEndpointId >= chip::Test::kMockEndpointMin)
+    {
+        return chip::Test::ReadSingleMockClusterData(aSubjectDescriptor.fabricIndex, aPath, aAttributeReports, apEncoderState);
+    }
+
+    if (gReadResponseDirective == ReadResponseDirective::kSendManyDataResponses ||
+        gReadResponseDirective == ReadResponseDirective::kSendManyDataResponsesWrongPath)
+    {
+        if (aPath.mClusterId != Clusters::UnitTesting::Id || aPath.mAttributeId != Clusters::UnitTesting::Attributes::Boolean::Id)
+        {
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+
+        for (size_t i = 0; i < 4; ++i)
+        {
+            ConcreteAttributePath path(aPath);
+            // Use an incorrect attribute id for some of the responses.
+            path.mAttributeId = static_cast<AttributeId>(
+                path.mAttributeId + (i / 2) + (gReadResponseDirective == ReadResponseDirective::kSendManyDataResponsesWrongPath));
+            AttributeEncodeState state(apEncoderState);
+            AttributeValueEncoder valueEncoder(aAttributeReports, aSubjectDescriptor, path, kDataVersion, aIsFabricFiltered, state);
+            ReturnErrorOnFailure(valueEncoder.Encode(true));
+        }
+
+        return CHIP_NO_ERROR;
+    }
+
+    if (gReadResponseDirective == ReadResponseDirective::kSendDataResponse)
+    {
+        if (aPath.mClusterId == app::Clusters::UnitTesting::Id &&
+            aPath.mAttributeId == app::Clusters::UnitTesting::Attributes::ListFabricScoped::Id)
+        {
+            AttributeEncodeState state(apEncoderState);
+            AttributeValueEncoder valueEncoder(aAttributeReports, aSubjectDescriptor, aPath, kDataVersion, aIsFabricFiltered,
+                                               state);
+
+            return valueEncoder.EncodeList([aSubjectDescriptor](const auto & encoder) -> CHIP_ERROR {
+                app::Clusters::UnitTesting::Structs::TestFabricScoped::Type val;
+                val.fabricIndex = aSubjectDescriptor.fabricIndex;
+                ReturnErrorOnFailure(encoder.Encode(val));
+                val.fabricIndex = (val.fabricIndex == 1) ? 2 : 1;
+                ReturnErrorOnFailure(encoder.Encode(val));
+                return CHIP_NO_ERROR;
+            });
+        }
+        if (aPath.mClusterId == app::Clusters::UnitTesting::Id &&
+            aPath.mAttributeId == app::Clusters::UnitTesting::Attributes::Int16u::Id)
+        {
+            AttributeEncodeState state(apEncoderState);
+            AttributeValueEncoder valueEncoder(aAttributeReports, aSubjectDescriptor, aPath, kDataVersion, aIsFabricFiltered,
+                                               state);
+
+            return valueEncoder.Encode(++gInt16uTotalReadCount);
+        }
+        if (aPath.mClusterId == kPerpetualClusterId ||
+            (aPath.mClusterId == app::Clusters::UnitTesting::Id && aPath.mAttributeId == kPerpetualAttributeid))
+        {
+            AttributeEncodeState state;
+            AttributeValueEncoder valueEncoder(aAttributeReports, aSubjectDescriptor, aPath, kDataVersion, aIsFabricFiltered,
+                                               state);
+
+            CHIP_ERROR err = valueEncoder.EncodeList([](const auto & encoder) -> CHIP_ERROR {
+                encoder.Encode(static_cast<uint8_t>(1));
+                return CHIP_ERROR_NO_MEMORY;
+            });
+
+            if (err != CHIP_NO_ERROR)
+            {
+                // If the err is not CHIP_NO_ERROR, means the encoding was aborted, then the valueEncoder may save its state.
+                // The state is used by list chunking feature for now.
+                if (apEncoderState != nullptr)
+                {
+                    *apEncoderState = valueEncoder.GetState();
+                }
+                return err;
+            }
+        }
+        if (aPath.mClusterId == app::Clusters::IcdManagement::Id &&
+            aPath.mAttributeId == app::Clusters::IcdManagement::Attributes::OperatingMode::Id)
+        {
+            AttributeEncodeState state(apEncoderState);
+            AttributeValueEncoder valueEncoder(aAttributeReports, aSubjectDescriptor, aPath, kDataVersion, aIsFabricFiltered,
+                                               state);
+
+            return valueEncoder.Encode(gIsLitIcd ? Clusters::IcdManagement::OperatingModeEnum::kLit
+                                                 : Clusters::IcdManagement::OperatingModeEnum::kSit);
+        }
+
+        AttributeReportIB::Builder & attributeReport = aAttributeReports.CreateAttributeReport();
+        ReturnErrorOnFailure(aAttributeReports.GetError());
+        AttributeDataIB::Builder & attributeData = attributeReport.CreateAttributeData();
+        ReturnErrorOnFailure(attributeReport.GetError());
+        Clusters::UnitTesting::Attributes::ListStructOctetString::TypeInfo::Type value;
+        Clusters::UnitTesting::Structs::TestListStructOctet::Type valueBuf[4];
+
+        value = valueBuf;
+
+        uint8_t i = 0;
+        for (auto & item : valueBuf)
+        {
+            item.member1 = i;
+            i++;
+        }
+
+        attributeData.DataVersion(kDataVersion);
+        ReturnErrorOnFailure(attributeData.GetError());
+        AttributePathIB::Builder & attributePath = attributeData.CreatePath();
+        attributePath.Endpoint(aPath.mEndpointId).Cluster(aPath.mClusterId).Attribute(aPath.mAttributeId).EndOfAttributePathIB();
+        ReturnErrorOnFailure(attributePath.GetError());
+
+        ReturnErrorOnFailure(DataModel::Encode(*(attributeData.GetWriter()), TLV::ContextTag(AttributeDataIB::Tag::kData), value));
+        ReturnErrorOnFailure(attributeData.EndOfAttributeDataIB());
+        return attributeReport.EndOfAttributeReportIB();
+    }
+
+    for (size_t i = 0; i < (gReadResponseDirective == ReadResponseDirective::kSendTwoDataErrors ? 2 : 1); ++i)
+    {
+        AttributeReportIB::Builder & attributeReport = aAttributeReports.CreateAttributeReport();
+        ReturnErrorOnFailure(aAttributeReports.GetError());
+        AttributeStatusIB::Builder & attributeStatus = attributeReport.CreateAttributeStatus();
+        AttributePathIB::Builder & attributePath     = attributeStatus.CreatePath();
+        attributePath.Endpoint(aPath.mEndpointId).Cluster(aPath.mClusterId).Attribute(aPath.mAttributeId).EndOfAttributePathIB();
+        ReturnErrorOnFailure(attributePath.GetError());
+
+        StatusIB::Builder & errorStatus = attributeStatus.CreateErrorStatus();
+        ReturnErrorOnFailure(attributeStatus.GetError());
+        errorStatus.EncodeStatusIB(StatusIB(Protocols::InteractionModel::Status::Busy));
+        attributeStatus.EndOfAttributeStatusIB();
+        ReturnErrorOnFailure(attributeStatus.GetError());
+        ReturnErrorOnFailure(attributeReport.EndOfAttributeReportIB());
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+bool IsClusterDataVersionEqual(const app::ConcreteClusterPath & aConcreteClusterPath, DataVersion aRequiredVersion)
+{
+    if (aRequiredVersion == kDataVersion)
+    {
+        return true;
+    }
+    if (Test::GetVersion() == aRequiredVersion)
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint)
+{
+    return false;
+}
+
+bool ConcreteAttributePathExists(const ConcreteAttributePath & aPath)
+{
+    return true;
+}
+
+Protocols::InteractionModel::Status CheckEventSupportStatus(const ConcreteEventPath & aPath)
+{
+    return Protocols::InteractionModel::Status::Success;
+}
+
+const EmberAfAttributeMetadata * GetAttributeMetadata(const ConcreteAttributePath & aConcreteClusterPath)
+{
+    // Note: This test does not make use of the real attribute metadata.
+    static EmberAfAttributeMetadata stub = { .defaultValue = EmberAfDefaultOrMinMaxAttributeValue(uint32_t(0)) };
+    return &stub;
+}
+
+CHIP_ERROR WriteSingleClusterData(const Access::SubjectDescriptor & aSubjectDescriptor, const ConcreteDataAttributePath & aPath,
+                                  TLV::TLVReader & aReader, WriteHandler * aWriteHandler)
+{
+    static ListIndex listStructOctetStringElementCount = 0;
+
+    if (aPath.mDataVersion.HasValue() && aPath.mDataVersion.Value() == kRejectedDataVersion)
+    {
+        return aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::DataVersionMismatch);
+    }
+
+    if (aPath.mClusterId == Clusters::UnitTesting::Id &&
+        aPath.mAttributeId == Attributes::ListStructOctetString::TypeInfo::GetAttributeId())
+    {
+        if (gWriteResponseDirective == WriteResponseDirective::kSendAttributeSuccess)
+        {
+            if (!aPath.IsListOperation() || aPath.mListOp == ConcreteDataAttributePath::ListOperation::ReplaceAll)
+            {
+
+                Attributes::ListStructOctetString::TypeInfo::DecodableType value;
+
+                ReturnErrorOnFailure(DataModel::Decode(aReader, value));
+
+                auto iter                         = value.begin();
+                listStructOctetStringElementCount = 0;
+                while (iter.Next())
+                {
+                    auto & item = iter.GetValue();
+
+                    VerifyOrReturnError(item.member1 == listStructOctetStringElementCount, CHIP_ERROR_INVALID_ARGUMENT);
+                    listStructOctetStringElementCount++;
+                }
+
+                aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::Success);
+            }
+            else if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::AppendItem)
+            {
+                Structs::TestListStructOctet::DecodableType item;
+                ReturnErrorOnFailure(DataModel::Decode(aReader, item));
+                VerifyOrReturnError(item.member1 == listStructOctetStringElementCount, CHIP_ERROR_INVALID_ARGUMENT);
+                listStructOctetStringElementCount++;
+
+                aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::Success);
+            }
+            else
+            {
+                return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+            }
+        }
+        else
+        {
+            aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::Failure);
+        }
+
+        return CHIP_NO_ERROR;
+    }
+    if (aPath.mClusterId == Clusters::UnitTesting::Id && aPath.mAttributeId == Attributes::ListFabricScoped::Id)
+    {
+        // Mock a invalid SubjectDescriptor
+        AttributeValueDecoder decoder(aReader, Access::SubjectDescriptor());
+        if (!aPath.IsListOperation() || aPath.mListOp == ConcreteDataAttributePath::ListOperation::ReplaceAll)
+        {
+            Attributes::ListFabricScoped::TypeInfo::DecodableType value;
+
+            ReturnErrorOnFailure(decoder.Decode(value));
+
+            auto iter = value.begin();
+            while (iter.Next())
+            {
+                auto & item = iter.GetValue();
+                (void) item;
+            }
+
+            aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::Success);
+        }
+        else if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::AppendItem)
+        {
+            Structs::TestFabricScoped::DecodableType item;
+            ReturnErrorOnFailure(decoder.Decode(item));
+
+            aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::Success);
+        }
+        else
+        {
+            return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    // Boolean attribute of unit testing cluster triggers "multiple errors" case.
+    if (aPath.mClusterId == Clusters::UnitTesting::Id && aPath.mAttributeId == Attributes::Boolean::TypeInfo::GetAttributeId())
+    {
+        InteractionModel::ClusterStatusCode status{ Protocols::InteractionModel::Status::InvalidValue };
+
+        if (gWriteResponseDirective == WriteResponseDirective::kSendMultipleSuccess)
+        {
+            status = InteractionModel::Status::Success;
+        }
+        else if (gWriteResponseDirective == WriteResponseDirective::kSendMultipleErrors)
+        {
+            status = InteractionModel::Status::Failure;
+        }
+        else
+        {
+            VerifyOrDie(false);
+        }
+
+        for (size_t i = 0; i < 4; ++i)
+        {
+            aWriteHandler->AddStatus(aPath, status);
+        }
+
+        return CHIP_NO_ERROR;
+    }
+
+    if (aPath.mClusterId == Clusters::UnitTesting::Id && aPath.mAttributeId == Attributes::Int8u::TypeInfo::GetAttributeId())
+    {
+        InteractionModel::ClusterStatusCode status{ Protocols::InteractionModel::Status::InvalidValue };
+        if (gWriteResponseDirective == WriteResponseDirective::kSendClusterSpecificSuccess)
+        {
+            status = InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(kExampleClusterSpecificSuccess);
+        }
+        else if (gWriteResponseDirective == WriteResponseDirective::kSendClusterSpecificFailure)
+        {
+            status = InteractionModel::ClusterStatusCode::ClusterSpecificFailure(kExampleClusterSpecificFailure);
+        }
+        else
+        {
+            VerifyOrDie(false);
+        }
+
+        aWriteHandler->AddStatus(aPath, status);
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,
+                                  CommandHandler * apCommandObj)
+{
+    ChipLogDetail(Controller, "Received Cluster Command: Endpoint=%x Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI,
+                  aCommandPath.mEndpointId, ChipLogValueMEI(aCommandPath.mClusterId), ChipLogValueMEI(aCommandPath.mCommandId));
+
+    if (aCommandPath.mClusterId == Clusters::UnitTesting::Id &&
+        aCommandPath.mCommandId == Clusters::UnitTesting::Commands::TestSimpleArgumentRequest::Type::GetCommandId())
+    {
+        Clusters::UnitTesting::Commands::TestSimpleArgumentRequest::DecodableType dataRequest;
+
+        if (DataModel::Decode(aReader, dataRequest) != CHIP_NO_ERROR)
+        {
+            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure, "Unable to decode the request");
+            return;
+        }
+
+        if (gCommandResponseDirective == CommandResponseDirective::kSendDataResponse)
+        {
+            Clusters::UnitTesting::Commands::TestStructArrayArgumentResponse::Type dataResponse;
+            Clusters::UnitTesting::Structs::NestedStructList::Type nestedStructList[4];
+
+            uint8_t i = 0;
+            for (auto & item : nestedStructList)
+            {
+                item.a   = i;
+                item.b   = false;
+                item.c.a = i;
+                item.c.b = true;
+                i++;
+            }
+
+            dataResponse.arg1 = nestedStructList;
+            dataResponse.arg6 = true;
+
+            apCommandObj->AddResponse(aCommandPath, dataResponse);
+        }
+        else if (gCommandResponseDirective == CommandResponseDirective::kSendSuccessStatusCode)
+        {
+            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Success);
+        }
+        else if (gCommandResponseDirective == CommandResponseDirective::kSendMultipleSuccessStatusCodes)
+        {
+            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Success,
+                                    "No error but testing status success case");
+
+            // TODO: Right now all but the first AddStatus call fail, so this
+            // test is not really testing what it should.
+            for (size_t i = 0; i < 3; ++i)
+            {
+                (void) apCommandObj->FallibleAddStatus(aCommandPath, Protocols::InteractionModel::Status::Success,
+                                                       "No error but testing status success case");
+            }
+            // And one failure on the end.
+            (void) apCommandObj->FallibleAddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure);
+        }
+        else if (gCommandResponseDirective == CommandResponseDirective::kSendError)
+        {
+            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure);
+        }
+        else if (gCommandResponseDirective == CommandResponseDirective::kSendMultipleErrors)
+        {
+            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure);
+
+            // TODO: Right now all but the first AddStatus call fail, so this
+            // test is not really testing what it should.
+            for (size_t i = 0; i < 3; ++i)
+            {
+                (void) apCommandObj->FallibleAddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure);
+            }
+        }
+        else if (gCommandResponseDirective == CommandResponseDirective::kSendSuccessStatusCodeWithClusterStatus)
+        {
+            apCommandObj->AddStatus(
+                aCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(kTestSuccessClusterStatus));
+        }
+        else if (gCommandResponseDirective == CommandResponseDirective::kSendErrorWithClusterStatus)
+        {
+            apCommandObj->AddStatus(
+                aCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(kTestFailureClusterStatus));
+        }
+        else if (gCommandResponseDirective == CommandResponseDirective::kAsync)
+        {
+            gAsyncCommandHandle = apCommandObj;
+        }
+    }
+}
+
+InteractionModel::Status ServerClusterCommandExists(const ConcreteCommandPath & aCommandPath)
+{
+    // Mock cluster catalog, only support commands on one cluster on one endpoint.
+    using InteractionModel::Status;
+
+    if (aCommandPath.mEndpointId != kTestEndpointId)
+    {
+        return Status::UnsupportedEndpoint;
+    }
+
+    if (aCommandPath.mClusterId != Clusters::UnitTesting::Id)
+    {
+        return Status::UnsupportedCluster;
+    }
+
+    return Status::Success;
+}
+
+} // namespace app
+} // namespace chip

--- a/src/controller/tests/data_model/DataModelFixtures.cpp
+++ b/src/controller/tests/data_model/DataModelFixtures.cpp
@@ -35,12 +35,13 @@ namespace app {
 
 namespace DataModelTests {
 
-ReadResponseDirective gReadResponseDirective       = ReadResponseDirective::kSendDataResponse;
-WriteResponseDirective gWriteResponseDirective     = WriteResponseDirective::kSendAttributeSuccess;
-CommandResponseDirective gCommandResponseDirective = CommandResponseDirective::kSendSuccessStatusCode;
+ScopedChangeOnly<ReadResponseDirective> gReadResponseDirective(ReadResponseDirective::kSendDataResponse);
+ScopedChangeOnly<WriteResponseDirective> gWriteResponseDirective(WriteResponseDirective::kSendAttributeSuccess);
+ScopedChangeOnly<CommandResponseDirective> gCommandResponseDirective(CommandResponseDirective::kSendSuccessStatusCode);
+
+ScopedChangeOnly<bool> gIsLitIcd(false);
 
 uint16_t gInt16uTotalReadCount = 0;
-bool gIsLitIcd                 = false;
 CommandHandler::Handle gAsyncCommandHandle;
 
 } // namespace DataModelTests

--- a/src/controller/tests/data_model/DataModelFixtures.h
+++ b/src/controller/tests/data_model/DataModelFixtures.h
@@ -16,11 +16,8 @@
  *    limitations under the License.
  */
 
-/**
- *  @file
- *  This module provides shared fixture implementations of global functions
- *  for data model tests as well as global variables to control them.
- */
+// This module provides shared fixture implementations of global functions
+// for data model tests as well as global variables to control them.
 
 #pragma once
 
@@ -28,6 +25,7 @@
 #include <app/util/mock/Constants.h>
 #include <app/util/mock/Functions.h>
 #include <lib/core/DataModelTypes.h>
+#include <lib/support/Scoped.h>
 
 namespace chip {
 namespace app {
@@ -48,6 +46,7 @@ constexpr uint8_t kExampleClusterSpecificFailure = 12u;
 constexpr ClusterStatus kTestSuccessClusterStatus = 1;
 constexpr ClusterStatus kTestFailureClusterStatus = 2;
 
+// Controls how the fixture responds to attribute reads
 enum class ReadResponseDirective
 {
     kSendDataResponse,
@@ -60,14 +59,16 @@ enum class ReadResponseDirective
     kSendTwoDataErrors, // Multiple errors, for a single concrete path,
                         // simulating a malicious server.
 };
-extern ReadResponseDirective gReadResponseDirective;
+extern ScopedChangeOnly<ReadResponseDirective> gReadResponseDirective;
 
 // Number of reads of Clusters::UnitTesting::Attributes::Int16u that we have observed.
 // Every read will increment this count by 1 and return the new value.
 extern uint16_t gInt16uTotalReadCount;
 
-extern bool gIsLitIcd;
+// Controls the ICD operating mode for the fixture
+extern ScopedChangeOnly<bool> gIsLitIcd;
 
+// Controls how the fixture responds to attribute writes
 enum class WriteResponseDirective
 {
     kSendAttributeSuccess,
@@ -77,8 +78,9 @@ enum class WriteResponseDirective
     kSendClusterSpecificSuccess,
     kSendClusterSpecificFailure,
 };
-extern WriteResponseDirective gWriteResponseDirective;
+extern ScopedChangeOnly<WriteResponseDirective> gWriteResponseDirective;
 
+// Controls how the fixture responds to commands
 enum class CommandResponseDirective
 {
     kSendDataResponse,
@@ -90,7 +92,9 @@ enum class CommandResponseDirective
     kSendErrorWithClusterStatus,
     kAsync,
 };
-extern CommandResponseDirective gCommandResponseDirective;
+extern ScopedChangeOnly<CommandResponseDirective> gCommandResponseDirective;
+
+// Populated with the command handle when gCommandResponseDirective == kAsync
 extern CommandHandler::Handle gAsyncCommandHandle;
 
 } // namespace DataModelTests

--- a/src/controller/tests/data_model/DataModelFixtures.h
+++ b/src/controller/tests/data_model/DataModelFixtures.h
@@ -1,0 +1,98 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *  @file
+ *  This module provides shared fixture implementations of global functions
+ *  for data model tests as well as global variables to control them.
+ */
+
+#pragma once
+
+#include <app/CommandHandler.h>
+#include <app/util/mock/Constants.h>
+#include <app/util/mock/Functions.h>
+#include <lib/core/DataModelTypes.h>
+
+namespace chip {
+namespace app {
+namespace DataModelTests {
+
+constexpr EndpointId kTestEndpointId = 1;
+
+constexpr ClusterId kPerpetualClusterId     = Test::MockClusterId(2);
+constexpr AttributeId kPerpetualAttributeid = Test::MockAttributeId(1);
+
+constexpr DataVersion kRejectedDataVersion = 1;
+constexpr DataVersion kAcceptedDataVersion = 5;
+constexpr DataVersion kDataVersion         = kAcceptedDataVersion;
+
+constexpr uint8_t kExampleClusterSpecificSuccess = 11u;
+constexpr uint8_t kExampleClusterSpecificFailure = 12u;
+
+constexpr ClusterStatus kTestSuccessClusterStatus = 1;
+constexpr ClusterStatus kTestFailureClusterStatus = 2;
+
+enum class ReadResponseDirective
+{
+    kSendDataResponse,
+    kSendManyDataResponses,          // Many data blocks, for a single concrete path
+                                     // read, simulating a malicious server.
+    kSendManyDataResponsesWrongPath, // Many data blocks, all using the wrong
+                                     // path, for a single concrete path
+                                     // read, simulating a malicious server.
+    kSendDataError,
+    kSendTwoDataErrors, // Multiple errors, for a single concrete path,
+                        // simulating a malicious server.
+};
+extern ReadResponseDirective gReadResponseDirective;
+
+// Number of reads of Clusters::UnitTesting::Attributes::Int16u that we have observed.
+// Every read will increment this count by 1 and return the new value.
+extern uint16_t gInt16uTotalReadCount;
+
+extern bool gIsLitIcd;
+
+enum class WriteResponseDirective
+{
+    kSendAttributeSuccess,
+    kSendAttributeError,
+    kSendMultipleSuccess,
+    kSendMultipleErrors,
+    kSendClusterSpecificSuccess,
+    kSendClusterSpecificFailure,
+};
+extern WriteResponseDirective gWriteResponseDirective;
+
+enum class CommandResponseDirective
+{
+    kSendDataResponse,
+    kSendSuccessStatusCode,
+    kSendMultipleSuccessStatusCodes,
+    kSendError,
+    kSendMultipleErrors,
+    kSendSuccessStatusCodeWithClusterStatus,
+    kSendErrorWithClusterStatus,
+    kAsync,
+};
+extern CommandResponseDirective gCommandResponseDirective;
+extern CommandHandler::Handle gAsyncCommandHandle;
+
+} // namespace DataModelTests
+} // namespace app
+} // namespace chip

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -125,7 +125,7 @@ TEST_F(TestCommands, TestDataResponse)
     // not safe to do so.
     auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) { onFailureWasCalled = true; };
 
-    gCommandResponseDirective = CommandResponseDirective::kSendDataResponse;
+    ScopedChange directive(gCommandResponseDirective, CommandResponseDirective::kSendDataResponse);
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
@@ -163,7 +163,7 @@ TEST_F(TestCommands, TestSuccessNoDataResponse)
     // not safe to do so.
     auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) { onFailureWasCalled = true; };
 
-    gCommandResponseDirective = CommandResponseDirective::kSendSuccessStatusCode;
+    ScopedChange directive(gCommandResponseDirective, CommandResponseDirective::kSendSuccessStatusCode);
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
@@ -201,7 +201,7 @@ TEST_F(TestCommands, TestMultipleSuccessNoDataResponses)
     // not safe to do so.
     auto onFailureCb = [&failureCalls](CHIP_ERROR aError) { ++failureCalls; };
 
-    gCommandResponseDirective = CommandResponseDirective::kSendMultipleSuccessStatusCodes;
+    ScopedChange directive(gCommandResponseDirective, CommandResponseDirective::kSendMultipleSuccessStatusCodes);
 
     Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                      onFailureCb);
@@ -240,7 +240,7 @@ TEST_F(TestCommands, TestAsyncResponse)
     // not safe to do so.
     auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) { onFailureWasCalled = true; };
 
-    gCommandResponseDirective = CommandResponseDirective::kAsync;
+    ScopedChange directive(gCommandResponseDirective, CommandResponseDirective::kAsync);
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
@@ -285,7 +285,7 @@ TEST_F(TestCommands, TestFailure)
         onFailureWasCalled = true;
     };
 
-    gCommandResponseDirective = CommandResponseDirective::kSendError;
+    ScopedChange directive(gCommandResponseDirective, CommandResponseDirective::kSendError);
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
@@ -323,7 +323,7 @@ TEST_F(TestCommands, TestMultipleFailures)
         ++failureCalls;
     };
 
-    gCommandResponseDirective = CommandResponseDirective::kSendMultipleErrors;
+    ScopedChange directive(gCommandResponseDirective, CommandResponseDirective::kSendMultipleErrors);
 
     Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                      onFailureCb);
@@ -363,7 +363,7 @@ TEST_F(TestCommands, TestSuccessNoDataResponseWithClusterStatus)
     // not safe to do so.
     auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) { onFailureWasCalled = true; };
 
-    gCommandResponseDirective = CommandResponseDirective::kSendSuccessStatusCodeWithClusterStatus;
+    ScopedChange directive(gCommandResponseDirective, CommandResponseDirective::kSendSuccessStatusCodeWithClusterStatus);
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
@@ -402,7 +402,7 @@ TEST_F(TestCommands, TestFailureWithClusterStatus)
         onFailureWasCalled = true;
     };
 
-    gCommandResponseDirective = CommandResponseDirective::kSendErrorWithClusterStatus;
+    ScopedChange directive(gCommandResponseDirective, CommandResponseDirective::kSendErrorWithClusterStatus);
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -24,10 +24,12 @@
 
 #include <gtest/gtest.h>
 
-#include "app/data-model/NullObject.h"
+#include "DataModelFixtures.h"
+
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
+#include <app/data-model/NullObject.h>
 #include <app/tests/AppTestContext.h>
 #include <controller/InvokeInteraction.h>
 #include <lib/core/CHIPCore.h>
@@ -44,141 +46,8 @@ using TestContext = chip::Test::AppContext;
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
+using namespace chip::app::DataModelTests;
 using namespace chip::Protocols;
-
-namespace {
-chip::ClusterStatus kTestSuccessClusterStatus = 1;
-chip::ClusterStatus kTestFailureClusterStatus = 2;
-
-constexpr EndpointId kTestEndpointId = 1;
-
-enum ResponseDirective
-{
-    kSendDataResponse,
-    kSendSuccessStatusCode,
-    kSendMultipleSuccessStatusCodes,
-    kSendError,
-    kSendMultipleErrors,
-    kSendSuccessStatusCodeWithClusterStatus,
-    kSendErrorWithClusterStatus,
-    kAsync,
-};
-
-ResponseDirective responseDirective;
-CommandHandler::Handle asyncHandle;
-
-} // namespace
-
-namespace chip {
-namespace app {
-
-void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,
-                                  CommandHandler * apCommandObj)
-{
-    ChipLogDetail(Controller, "Received Cluster Command: Endpoint=%x Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI,
-                  aCommandPath.mEndpointId, ChipLogValueMEI(aCommandPath.mClusterId), ChipLogValueMEI(aCommandPath.mCommandId));
-
-    if (aCommandPath.mClusterId == Clusters::UnitTesting::Id &&
-        aCommandPath.mCommandId == Clusters::UnitTesting::Commands::TestSimpleArgumentRequest::Type::GetCommandId())
-    {
-        Clusters::UnitTesting::Commands::TestSimpleArgumentRequest::DecodableType dataRequest;
-
-        if (DataModel::Decode(aReader, dataRequest) != CHIP_NO_ERROR)
-        {
-            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure, "Unable to decode the request");
-            return;
-        }
-
-        if (responseDirective == kSendDataResponse)
-        {
-            Clusters::UnitTesting::Commands::TestStructArrayArgumentResponse::Type dataResponse;
-            Clusters::UnitTesting::Structs::NestedStructList::Type nestedStructList[4];
-
-            uint8_t i = 0;
-            for (auto & item : nestedStructList)
-            {
-                item.a   = i;
-                item.b   = false;
-                item.c.a = i;
-                item.c.b = true;
-                i++;
-            }
-
-            dataResponse.arg1 = nestedStructList;
-            dataResponse.arg6 = true;
-
-            apCommandObj->AddResponse(aCommandPath, dataResponse);
-        }
-        else if (responseDirective == kSendSuccessStatusCode)
-        {
-            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Success);
-        }
-        else if (responseDirective == kSendMultipleSuccessStatusCodes)
-        {
-            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Success,
-                                    "No error but testing status success case");
-
-            // TODO: Right now all but the first AddStatus call fail, so this
-            // test is not really testing what it should.
-            for (size_t i = 0; i < 3; ++i)
-            {
-                (void) apCommandObj->FallibleAddStatus(aCommandPath, Protocols::InteractionModel::Status::Success,
-                                                       "No error but testing status success case");
-            }
-            // And one failure on the end.
-            (void) apCommandObj->FallibleAddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure);
-        }
-        else if (responseDirective == kSendError)
-        {
-            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure);
-        }
-        else if (responseDirective == kSendMultipleErrors)
-        {
-            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure);
-
-            // TODO: Right now all but the first AddStatus call fail, so this
-            // test is not really testing what it should.
-            for (size_t i = 0; i < 3; ++i)
-            {
-                (void) apCommandObj->FallibleAddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure);
-            }
-        }
-        else if (responseDirective == kSendSuccessStatusCodeWithClusterStatus)
-        {
-            apCommandObj->AddStatus(
-                aCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(kTestSuccessClusterStatus));
-        }
-        else if (responseDirective == kSendErrorWithClusterStatus)
-        {
-            apCommandObj->AddStatus(
-                aCommandPath, Protocols::InteractionModel::ClusterStatusCode::ClusterSpecificFailure(kTestFailureClusterStatus));
-        }
-        else if (responseDirective == kAsync)
-        {
-            asyncHandle = apCommandObj;
-        }
-    }
-}
-
-InteractionModel::Status ServerClusterCommandExists(const ConcreteCommandPath & aCommandPath)
-{
-    // Mock cluster catalog, only support commands on one cluster on one endpoint.
-    using InteractionModel::Status;
-
-    if (aCommandPath.mEndpointId != kTestEndpointId)
-    {
-        return Status::UnsupportedEndpoint;
-    }
-
-    if (aCommandPath.mClusterId != Clusters::UnitTesting::Id)
-    {
-        return Status::UnsupportedCluster;
-    }
-
-    return Status::Success;
-}
-} // namespace app
-} // namespace chip
 
 namespace {
 
@@ -256,7 +125,7 @@ TEST_F(TestCommands, TestDataResponse)
     // not safe to do so.
     auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) { onFailureWasCalled = true; };
 
-    responseDirective = kSendDataResponse;
+    gCommandResponseDirective = CommandResponseDirective::kSendDataResponse;
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
@@ -294,7 +163,7 @@ TEST_F(TestCommands, TestSuccessNoDataResponse)
     // not safe to do so.
     auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) { onFailureWasCalled = true; };
 
-    responseDirective = kSendSuccessStatusCode;
+    gCommandResponseDirective = CommandResponseDirective::kSendSuccessStatusCode;
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
@@ -332,7 +201,7 @@ TEST_F(TestCommands, TestMultipleSuccessNoDataResponses)
     // not safe to do so.
     auto onFailureCb = [&failureCalls](CHIP_ERROR aError) { ++failureCalls; };
 
-    responseDirective = kSendMultipleSuccessStatusCodes;
+    gCommandResponseDirective = CommandResponseDirective::kSendMultipleSuccessStatusCodes;
 
     Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                      onFailureCb);
@@ -371,7 +240,7 @@ TEST_F(TestCommands, TestAsyncResponse)
     // not safe to do so.
     auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) { onFailureWasCalled = true; };
 
-    responseDirective = kAsync;
+    gCommandResponseDirective = CommandResponseDirective::kAsync;
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
@@ -381,12 +250,12 @@ TEST_F(TestCommands, TestAsyncResponse)
     EXPECT_TRUE(!onSuccessWasCalled && !onFailureWasCalled && !statusCheck);
     EXPECT_EQ(mpContext->GetExchangeManager().GetNumActiveExchanges(), 2u);
 
-    CommandHandler * commandHandle = asyncHandle.Get();
+    CommandHandler * commandHandle = gAsyncCommandHandle.Get();
     ASSERT_NE(commandHandle, nullptr);
 
     commandHandle->AddStatus(ConcreteCommandPath(kTestEndpointId, request.GetClusterId(), request.GetCommandId()),
                              Protocols::InteractionModel::Status::Success);
-    asyncHandle.Release();
+    gAsyncCommandHandle.Release();
 
     mpContext->DrainAndServiceIO();
 
@@ -416,7 +285,7 @@ TEST_F(TestCommands, TestFailure)
         onFailureWasCalled = true;
     };
 
-    responseDirective = kSendError;
+    gCommandResponseDirective = CommandResponseDirective::kSendError;
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
@@ -454,7 +323,7 @@ TEST_F(TestCommands, TestMultipleFailures)
         ++failureCalls;
     };
 
-    responseDirective = kSendMultipleErrors;
+    gCommandResponseDirective = CommandResponseDirective::kSendMultipleErrors;
 
     Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                      onFailureCb);
@@ -494,7 +363,7 @@ TEST_F(TestCommands, TestSuccessNoDataResponseWithClusterStatus)
     // not safe to do so.
     auto onFailureCb = [&onFailureWasCalled](CHIP_ERROR aError) { onFailureWasCalled = true; };
 
-    responseDirective = kSendSuccessStatusCodeWithClusterStatus;
+    gCommandResponseDirective = CommandResponseDirective::kSendSuccessStatusCodeWithClusterStatus;
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);
@@ -533,7 +402,7 @@ TEST_F(TestCommands, TestFailureWithClusterStatus)
         onFailureWasCalled = true;
     };
 
-    responseDirective = kSendErrorWithClusterStatus;
+    gCommandResponseDirective = CommandResponseDirective::kSendErrorWithClusterStatus;
 
     chip::Controller::InvokeCommandRequest(&mpContext->GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb,
                                            onFailureCb);

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -177,7 +177,7 @@ TEST_F(TestRead, TestReadAttributeResponse)
     auto sessionHandle      = mpContext->GetSessionBobToAlice();
     bool onSuccessCbInvoked = false, onFailureCbInvoked = false;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -217,8 +217,8 @@ TEST_F(TestRead, TestReadAttributeResponse)
 // `EXPECT_TRUE(version1.HasValue() && (version1.Value() == 0))`.
 TEST_F(TestRead, TestReadSubscribeAttributeResponseWithVersionOnlyCache)
 {
-    CHIP_ERROR err         = CHIP_NO_ERROR;
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     MockInteractionModelApp delegate;
     chip::app::ClusterStateCache cache(delegate, Optional<EventNumber>::Missing(), false /*cachedData*/);
@@ -289,8 +289,8 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithVersionOnlyCache)
 
 TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
 {
-    CHIP_ERROR err         = CHIP_NO_ERROR;
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     MockInteractionModelApp delegate;
     chip::app::ClusterStateCache cache(delegate);
@@ -1333,7 +1333,7 @@ TEST_F(TestRead, TestReadAttributeError)
     auto sessionHandle      = mpContext->GetSessionBobToAlice();
     bool onSuccessCbInvoked = false, onFailureCbInvoked = false;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataError;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataError);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -1364,7 +1364,7 @@ TEST_F(TestRead, TestReadAttributeTimeout)
     auto sessionHandle      = mpContext->GetSessionBobToAlice();
     bool onSuccessCbInvoked = false, onFailureCbInvoked = false;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataError;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataError);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -1623,7 +1623,7 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptions)
     uint32_t numSuccessCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -1691,7 +1691,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionAppRejection)
     uint32_t numFailureCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -1757,7 +1757,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest1)
     uint32_t numFailureCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -1832,7 +1832,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest2)
     uint32_t numFailureCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -1907,7 +1907,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest3)
     uint32_t numFailureCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -1984,7 +1984,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest4)
     uint32_t numFailureCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -2051,7 +2051,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest5)
     uint32_t numFailureCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -2126,7 +2126,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest6)
     uint32_t numFailureCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -2201,7 +2201,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest7)
     uint32_t numFailureCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -2277,7 +2277,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest8)
     uint32_t numFailureCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -2340,7 +2340,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest9)
     uint32_t numFailureCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -2491,11 +2491,10 @@ TEST_F(TestRead, TestSubscribe_DynamicLITSubscription)
     auto sessionHandle = mpContext->GetSessionBobToAlice();
 
     mpContext->SetMRPMode(chip::Test::MessagingContext::MRPMode::kResponsive);
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
+    ScopedChange isLitIcd(gIsLitIcd, false);
 
     {
-        gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
-        gIsLitIcd              = false;
-
         TestResubscriptionCallback callback;
         app::ReadClient readClient(app::InteractionModelEngine::GetInstance(), &mpContext->GetExchangeManager(), callback,
                                    app::ReadClient::InteractionType::Subscribe);
@@ -2568,7 +2567,7 @@ TEST_F(TestRead, TestSubscribe_DynamicLITSubscription)
 
         // Part 2. SIT -> LIT
 
-        gIsLitIcd = true;
+        isLitIcd = true;
         {
             app::AttributePathParams path;
             path.mEndpointId  = kRootEndpointId;
@@ -2596,8 +2595,6 @@ TEST_F(TestRead, TestSubscribe_DynamicLITSubscription)
 
     app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     EXPECT_EQ(mpContext->GetExchangeManager().GetNumActiveExchanges(), 0u);
-
-    gIsLitIcd = false;
 }
 
 /**
@@ -2732,7 +2729,7 @@ void TestRead::SubscribeThenReadHelper(TestContext * apCtx, size_t aSubscribeCou
     uint32_t numReadSuccessCalls = 0;
     uint32_t numReadFailureCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -2785,7 +2782,7 @@ void TestRead::MultipleReadHelperInternal(TestContext * apCtx, size_t aReadCount
 
     auto sessionHandle = apCtx->GetSessionBobToAlice();
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     uint16_t firstExpectedResponse = gInt16uTotalReadCount + 1;
 
@@ -2828,7 +2825,7 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptionsWithDataVersionFilter)
     uint32_t numSuccessCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -2889,7 +2886,7 @@ TEST_F(TestRead, TestReadHandlerResourceExhaustion_MultipleReads)
     uint32_t numSuccessCalls = 0;
     uint32_t numFailureCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -2940,7 +2937,7 @@ TEST_F(TestRead, TestReadFabricScopedWithoutFabricFilter)
     auto sessionHandle      = mpContext->GetSessionBobToAlice();
     bool onSuccessCbInvoked = false, onFailureCbInvoked = false;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -2985,7 +2982,7 @@ TEST_F(TestRead, TestReadFabricScopedWithFabricFilter)
     auto sessionHandle      = mpContext->GetSessionBobToAlice();
     bool onSuccessCbInvoked = false, onFailureCbInvoked = false;
 
-    gReadResponseDirective = ReadResponseDirective::kSendDataResponse;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -4543,7 +4540,7 @@ TEST_F(TestRead, TestReadAttribute_ManyDataValues)
     size_t successCalls = 0;
     size_t failureCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendManyDataResponses;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendManyDataResponses);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -4576,7 +4573,7 @@ TEST_F(TestRead, TestReadAttribute_ManyDataValuesWrongPath)
     size_t successCalls = 0;
     size_t failureCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendManyDataResponsesWrongPath;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendManyDataResponsesWrongPath);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -4609,7 +4606,7 @@ TEST_F(TestRead, TestReadAttribute_ManyErrors)
     size_t successCalls = 0;
     size_t failureCalls = 0;
 
-    gReadResponseDirective = ReadResponseDirective::kSendTwoDataErrors;
+    ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendTwoDataErrors);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.

--- a/src/controller/tests/data_model/TestWrite.cpp
+++ b/src/controller/tests/data_model/TestWrite.cpp
@@ -144,7 +144,7 @@ TEST_F(TestWrite, TestDataResponse)
         i++;
     }
 
-    gWriteResponseDirective = WriteResponseDirective::kSendAttributeSuccess;
+    ScopedChange directive(gWriteResponseDirective, WriteResponseDirective::kSendAttributeSuccess);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -182,7 +182,7 @@ TEST_F(TestWrite, TestDataResponseWithAcceptedDataVersion)
         i++;
     }
 
-    gWriteResponseDirective = WriteResponseDirective::kSendAttributeSuccess;
+    ScopedChange directive(gWriteResponseDirective, WriteResponseDirective::kSendAttributeSuccess);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -222,7 +222,7 @@ TEST_F(TestWrite, TestDataResponseWithRejectedDataVersion)
         i++;
     }
 
-    gWriteResponseDirective = WriteResponseDirective::kSendAttributeSuccess;
+    ScopedChange directive(gWriteResponseDirective, WriteResponseDirective::kSendAttributeSuccess);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -261,7 +261,7 @@ TEST_F(TestWrite, TestAttributeError)
         i++;
     }
 
-    gWriteResponseDirective = WriteResponseDirective::kSendAttributeError;
+    ScopedChange directive(gWriteResponseDirective, WriteResponseDirective::kSendAttributeError);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -327,7 +327,7 @@ TEST_F(TestWrite, TestMultipleSuccessResponses)
     size_t successCalls = 0;
     size_t failureCalls = 0;
 
-    gWriteResponseDirective = WriteResponseDirective::kSendMultipleSuccess;
+    ScopedChange directive(gWriteResponseDirective, WriteResponseDirective::kSendMultipleSuccess);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -354,7 +354,7 @@ TEST_F(TestWrite, TestMultipleFailureResponses)
     size_t successCalls = 0;
     size_t failureCalls = 0;
 
-    gWriteResponseDirective = WriteResponseDirective::kSendMultipleErrors;
+    ScopedChange directive(gWriteResponseDirective, WriteResponseDirective::kSendMultipleErrors);
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -381,7 +381,7 @@ TEST_F(TestWrite, TestWriteClusterSpecificStatuses)
 
     // Cluster-specific success code case
     {
-        gWriteResponseDirective = WriteResponseDirective::kSendClusterSpecificSuccess;
+        ScopedChange directive(gWriteResponseDirective, WriteResponseDirective::kSendClusterSpecificSuccess);
 
         this->ResetCallback();
         this->PrepareWriteCallback(
@@ -413,7 +413,7 @@ TEST_F(TestWrite, TestWriteClusterSpecificStatuses)
 
     // Cluster-specific failure code case
     {
-        gWriteResponseDirective = WriteResponseDirective::kSendClusterSpecificFailure;
+        ScopedChange directive(gWriteResponseDirective, WriteResponseDirective::kSendClusterSpecificFailure);
 
         this->ResetCallback();
         this->PrepareWriteCallback(

--- a/src/controller/tests/data_model/TestWrite.cpp
+++ b/src/controller/tests/data_model/TestWrite.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include "DataModelFixtures.h"
+
 #include "app-common/zap-generated/ids/Clusters.h"
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AttributeValueDecoder.h>
@@ -36,177 +38,10 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::UnitTesting;
+using namespace chip::app::DataModelTests;
 using namespace chip::Protocols;
 
 namespace {
-
-constexpr EndpointId kTestEndpointId       = 1;
-constexpr DataVersion kRejectedDataVersion = 1;
-constexpr DataVersion kAcceptedDataVersion = 5;
-
-constexpr uint8_t kExampleClusterSpecificSuccess = 11u;
-constexpr uint8_t kExampleClusterSpecificFailure = 12u;
-
-enum ResponseDirective
-{
-    kSendAttributeSuccess,
-    kSendAttributeError,
-    kSendMultipleSuccess,
-    kSendMultipleErrors,
-    kSendClusterSpecificSuccess,
-    kSendClusterSpecificFailure,
-};
-
-ResponseDirective gResponseDirective = kSendAttributeSuccess;
-
-} // namespace
-
-namespace chip {
-namespace app {
-
-const EmberAfAttributeMetadata * GetAttributeMetadata(const ConcreteAttributePath & aConcreteClusterPath)
-{
-    // Note: This test does not make use of the real attribute metadata.
-    static EmberAfAttributeMetadata stub = { .defaultValue = EmberAfDefaultOrMinMaxAttributeValue(uint32_t(0)) };
-    return &stub;
-}
-
-CHIP_ERROR WriteSingleClusterData(const Access::SubjectDescriptor & aSubjectDescriptor, const ConcreteDataAttributePath & aPath,
-                                  TLV::TLVReader & aReader, WriteHandler * aWriteHandler)
-{
-    static ListIndex listStructOctetStringElementCount = 0;
-
-    if (aPath.mDataVersion.HasValue() && aPath.mDataVersion.Value() == kRejectedDataVersion)
-    {
-        return aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::DataVersionMismatch);
-    }
-
-    if (aPath.mClusterId == Clusters::UnitTesting::Id &&
-        aPath.mAttributeId == Attributes::ListStructOctetString::TypeInfo::GetAttributeId())
-    {
-        if (gResponseDirective == kSendAttributeSuccess)
-        {
-            if (!aPath.IsListOperation() || aPath.mListOp == ConcreteDataAttributePath::ListOperation::ReplaceAll)
-            {
-
-                Attributes::ListStructOctetString::TypeInfo::DecodableType value;
-
-                ReturnErrorOnFailure(DataModel::Decode(aReader, value));
-
-                auto iter                         = value.begin();
-                listStructOctetStringElementCount = 0;
-                while (iter.Next())
-                {
-                    auto & item = iter.GetValue();
-
-                    VerifyOrReturnError(item.member1 == listStructOctetStringElementCount, CHIP_ERROR_INVALID_ARGUMENT);
-                    listStructOctetStringElementCount++;
-                }
-
-                aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::Success);
-            }
-            else if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::AppendItem)
-            {
-                Structs::TestListStructOctet::DecodableType item;
-                ReturnErrorOnFailure(DataModel::Decode(aReader, item));
-                VerifyOrReturnError(item.member1 == listStructOctetStringElementCount, CHIP_ERROR_INVALID_ARGUMENT);
-                listStructOctetStringElementCount++;
-
-                aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::Success);
-            }
-            else
-            {
-                return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-            }
-        }
-        else
-        {
-            aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::Failure);
-        }
-
-        return CHIP_NO_ERROR;
-    }
-    if (aPath.mClusterId == Clusters::UnitTesting::Id && aPath.mAttributeId == Attributes::ListFabricScoped::Id)
-    {
-        // Mock a invalid SubjectDescriptor
-        AttributeValueDecoder decoder(aReader, Access::SubjectDescriptor());
-        if (!aPath.IsListOperation() || aPath.mListOp == ConcreteDataAttributePath::ListOperation::ReplaceAll)
-        {
-            Attributes::ListFabricScoped::TypeInfo::DecodableType value;
-
-            ReturnErrorOnFailure(decoder.Decode(value));
-
-            auto iter = value.begin();
-            while (iter.Next())
-            {
-                auto & item = iter.GetValue();
-                (void) item;
-            }
-
-            aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::Success);
-        }
-        else if (aPath.mListOp == ConcreteDataAttributePath::ListOperation::AppendItem)
-        {
-            Structs::TestFabricScoped::DecodableType item;
-            ReturnErrorOnFailure(decoder.Decode(item));
-
-            aWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::Success);
-        }
-        else
-        {
-            return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-        }
-        return CHIP_NO_ERROR;
-    }
-
-    // Boolean attribute of unit testing cluster triggers "multiple errors" case.
-    if (aPath.mClusterId == Clusters::UnitTesting::Id && aPath.mAttributeId == Attributes::Boolean::TypeInfo::GetAttributeId())
-    {
-        InteractionModel::ClusterStatusCode status{ Protocols::InteractionModel::Status::InvalidValue };
-
-        if (gResponseDirective == kSendMultipleSuccess)
-        {
-            status = InteractionModel::Status::Success;
-        }
-        else if (gResponseDirective == kSendMultipleErrors)
-        {
-            status = InteractionModel::Status::Failure;
-        }
-        else
-        {
-            VerifyOrDie(false);
-        }
-
-        for (size_t i = 0; i < 4; ++i)
-        {
-            aWriteHandler->AddStatus(aPath, status);
-        }
-
-        return CHIP_NO_ERROR;
-    }
-
-    if (aPath.mClusterId == Clusters::UnitTesting::Id && aPath.mAttributeId == Attributes::Int8u::TypeInfo::GetAttributeId())
-    {
-        InteractionModel::ClusterStatusCode status{ Protocols::InteractionModel::Status::InvalidValue };
-        if (gResponseDirective == kSendClusterSpecificSuccess)
-        {
-            status = InteractionModel::ClusterStatusCode::ClusterSpecificSuccess(kExampleClusterSpecificSuccess);
-        }
-        else if (gResponseDirective == kSendClusterSpecificFailure)
-        {
-            status = InteractionModel::ClusterStatusCode::ClusterSpecificFailure(kExampleClusterSpecificFailure);
-        }
-        else
-        {
-            VerifyOrDie(false);
-        }
-
-        aWriteHandler->AddStatus(aPath, status);
-        return CHIP_NO_ERROR;
-    }
-
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
 
 class SingleWriteCallback : public WriteClient::Callback
 {
@@ -247,11 +82,6 @@ private:
     bool mPathWasReponded     = false;
     StatusIB mPathStatus;
 };
-
-} // namespace app
-} // namespace chip
-
-namespace {
 
 class TestWrite : public ::testing::Test
 {
@@ -314,7 +144,7 @@ TEST_F(TestWrite, TestDataResponse)
         i++;
     }
 
-    gResponseDirective = kSendAttributeSuccess;
+    gWriteResponseDirective = WriteResponseDirective::kSendAttributeSuccess;
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -352,7 +182,7 @@ TEST_F(TestWrite, TestDataResponseWithAcceptedDataVersion)
         i++;
     }
 
-    gResponseDirective = kSendAttributeSuccess;
+    gWriteResponseDirective = WriteResponseDirective::kSendAttributeSuccess;
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -392,7 +222,7 @@ TEST_F(TestWrite, TestDataResponseWithRejectedDataVersion)
         i++;
     }
 
-    gResponseDirective = kSendAttributeSuccess;
+    gWriteResponseDirective = WriteResponseDirective::kSendAttributeSuccess;
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -431,7 +261,7 @@ TEST_F(TestWrite, TestAttributeError)
         i++;
     }
 
-    gResponseDirective = kSendAttributeError;
+    gWriteResponseDirective = WriteResponseDirective::kSendAttributeError;
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -497,7 +327,7 @@ TEST_F(TestWrite, TestMultipleSuccessResponses)
     size_t successCalls = 0;
     size_t failureCalls = 0;
 
-    gResponseDirective = kSendMultipleSuccess;
+    gWriteResponseDirective = WriteResponseDirective::kSendMultipleSuccess;
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -524,7 +354,7 @@ TEST_F(TestWrite, TestMultipleFailureResponses)
     size_t successCalls = 0;
     size_t failureCalls = 0;
 
-    gResponseDirective = kSendMultipleErrors;
+    gWriteResponseDirective = WriteResponseDirective::kSendMultipleErrors;
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
@@ -551,7 +381,7 @@ TEST_F(TestWrite, TestWriteClusterSpecificStatuses)
 
     // Cluster-specific success code case
     {
-        gResponseDirective = kSendClusterSpecificSuccess;
+        gWriteResponseDirective = WriteResponseDirective::kSendClusterSpecificSuccess;
 
         this->ResetCallback();
         this->PrepareWriteCallback(
@@ -583,7 +413,7 @@ TEST_F(TestWrite, TestWriteClusterSpecificStatuses)
 
     // Cluster-specific failure code case
     {
-        gResponseDirective = kSendClusterSpecificFailure;
+        gWriteResponseDirective = WriteResponseDirective::kSendClusterSpecificFailure;
 
         this->ResetCallback();
         this->PrepareWriteCallback(


### PR DESCRIPTION
The data model tests all had linker dependencies on each other, which meant that running any of Test{Read,Write,Commands} would run the tests from all of them, because the global fixture function from that test was required.

This change moves all those fixture functions into DataModelFixtures.cpp. Also disambiguate the enum types and control variable names involved.
