### PR TITLE
Add reviewers-nxp as company-reviewers in the SDK

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -173,6 +173,14 @@ groups:
             teams: [reviewers-nordic]
         reviews:
             request: 10
+    shared-reviewers-nxp:
+        type: optional
+        conditions:
+            - files.include('*')
+        reviewers:
+            teams: [reviewers-nxp]
+        reviews:
+            request: 10
     shared-reviewers-samsung:
         type: optional
         conditions:


### PR DESCRIPTION
This updates pullapprove rules to allow reviewers-nxp to review code (and the group gets auto-added to the reviewer list).