### PR TITLE
[ESP32] Initialize LwIP stack when initializing CHIP stack

### DIFF
--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -48,7 +48,7 @@ namespace chip {
 namespace DeviceLayer {
 
 namespace Internal {
-extern CHIP_ERROR InitLwIPCoreLock(void);
+extern CHIP_ERROR InitLwIPCoreLock();
 }
 
 PlatformManagerImpl PlatformManagerImpl::sInstance;
@@ -60,20 +60,25 @@ static int app_entropy_source(void * data, unsigned char * output, size_t len, s
     return 0;
 }
 
-CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
+CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 {
     // Arrange for CHIP-encapsulated ESP32 errors to be translated to text
     Internal::ESP32Utils::RegisterESP32ErrorFormatter();
     // Make sure the LwIP core lock has been initialized
     ReturnErrorOnFailure(Internal::InitLwIPCoreLock());
+
+    // Initialize TCP/IP network interface, which internally initializes LwIP stack. We have to
+    // call this before the usage of PacketBufferHandle::New() because in case of LwIP-based pool
+    // allocator, the LwIP pool allocator uses the LwIP stack.
+    esp_err_t err = esp_netif_init();
+    VerifyOrReturnError(err == ESP_OK, Internal::ESP32Utils::MapError(err));
+
     // Arrange for the ESP event loop to deliver events into the CHIP Device layer.
-    esp_err_t err = esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent, NULL);
-    if (err != ESP_OK)
-    {
-        return Internal::ESP32Utils::MapError(err);
-    }
+    err = esp_event_handler_register(IP_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent, nullptr);
+    VerifyOrReturnError(err == ESP_OK, Internal::ESP32Utils::MapError(err));
+
     mStartTime = System::SystemClock().GetMonotonicTimestamp();
-    ReturnErrorOnFailure(chip::Crypto::add_entropy_source(app_entropy_source, NULL, 16));
+    ReturnErrorOnFailure(chip::Crypto::add_entropy_source(app_entropy_source, nullptr, 16));
 
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.
@@ -108,6 +113,7 @@ void PlatformManagerImpl::_Shutdown()
     Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
 
     esp_event_handler_unregister(IP_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent);
+    esp_netif_deinit();
 }
 
 void PlatformManagerImpl::HandleESPSystemEvent(void * arg, esp_event_base_t eventBase, int32_t eventId, void * eventData)

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -324,7 +324,6 @@ TEST_F_FROM_FIXTURE(TestSystemPacketBuffer, CheckNew)
         }
     }
 
-#if 0 // TODO: Fix this check on ESP32 (issue #34145)
 #if CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL || CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL
     // Use the rest of the buffer space
     std::vector<PacketBufferHandle> allocate_all_the_things;
@@ -339,7 +338,6 @@ TEST_F_FROM_FIXTURE(TestSystemPacketBuffer, CheckNew)
         allocate_all_the_things.push_back(std::move(buffer));
     }
 #endif // CHIP_SYSTEM_PACKETBUFFER_FROM_LWIP_POOL || CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_POOL
-#endif
 }
 
 /**


### PR DESCRIPTION
### Problem

When allocating `PacketBufferHandle::New(0, 0)` in a loop (somewhere around 150th iteration), ESP32 crashes.

### Changes

Use `esp_netif_init()` in CHIP stack initialization in order to initialize LwIP stack. The LwIP stack needs to be initialized before the usage of `PacketBufferHandle::New()` in case of LwIP-based pool allocator, because the LwIP pool allocator uses the LwIP stack.

Fixes #34145

### Testing

CI will verify potential breaks.