### PR TITLE
OnOffServer: ignore StartUpOnOff value after reboot due to OTA

### DIFF
--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -98,7 +98,8 @@ bool IsKnownEnumValue(EnumType value)
     return (EnsureKnownEnumValue(value) != EnumType::kUnknownEnumValue);
 }
 
-BootReasonType GetBootReason() {
+BootReasonType GetBootReason()
+{
     BootReasonType bootReason = BootReasonType::kUnspecified;
 
     CHIP_ERROR error = DeviceLayer::GetDiagnosticDataProvider().GetBootReason(bootReason);
@@ -561,8 +562,9 @@ Status OnOffServer::getOnOffValueForStartUp(chip::EndpointId endpoint, bool & on
     }
 
     bool currentOnOff = false;
-    status = Attributes::OnOff::Get(endpoint, &currentOnOff);
-    if (status != Status::Success) {
+    status            = Attributes::OnOff::Get(endpoint, &currentOnOff);
+    if (status != Status::Success)
+    {
         return status;
     }
 

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -45,12 +45,15 @@
 #endif                                                               // MATTER_DM_PLUGIN_MODE_BASE
 
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/DiagnosticDataProvider.h>
 #include <platform/PlatformManager.h>
 
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::OnOff;
 using chip::Protocols::InteractionModel::Status;
+
+using BootReasonType = GeneralDiagnostics::BootReasonEnum;
 
 namespace {
 
@@ -93,6 +96,21 @@ template <typename EnumType>
 bool IsKnownEnumValue(EnumType value)
 {
     return (EnsureKnownEnumValue(value) != EnumType::kUnknownEnumValue);
+}
+
+BootReasonType GetBootReason() {
+    BootReasonType bootReason = BootReasonType::kUnspecified;
+
+    CHIP_ERROR error = DeviceLayer::GetDiagnosticDataProvider().GetBootReason(bootReason);
+    if (error != CHIP_NO_ERROR)
+    {
+        ChipLogError(Zcl, "Unable to retrieve boot reason: %" CHIP_ERROR_FORMAT, error.Format());
+        bootReason = BootReasonType::kUnspecified;
+    }
+
+    ChipLogProgress(Zcl, "Boot reason: %u", to_underlying(bootReason));
+
+    return bootReason;
 }
 
 } // namespace
@@ -537,35 +555,40 @@ Status OnOffServer::getOnOffValueForStartUp(chip::EndpointId endpoint, bool & on
 {
     app::DataModel::Nullable<OnOff::StartUpOnOffEnum> startUpOnOff;
     Status status = Attributes::StartUpOnOff::Get(endpoint, startUpOnOff);
-    if (status == Status::Success)
+    if (status != Status::Success)
     {
-        // Initialise updated value to 0
-        bool updatedOnOff = false;
-        status            = Attributes::OnOff::Get(endpoint, &updatedOnOff);
-        if (status == Status::Success)
-        {
-            if (!startUpOnOff.IsNull())
-            {
-                switch (startUpOnOff.Value())
-                {
-                case OnOff::StartUpOnOffEnum::kOff:
-                    updatedOnOff = false; // Off
-                    break;
-                case OnOff::StartUpOnOffEnum::kOn:
-                    updatedOnOff = true; // On
-                    break;
-                case OnOff::StartUpOnOffEnum::kToggle:
-                    updatedOnOff = !updatedOnOff;
-                    break;
-                default:
-                    // All other values 0x03- 0xFE are reserved - no action.
-                    break;
-                }
-            }
-            onOffValueForStartUp = updatedOnOff;
-        }
+        return status;
     }
-    return status;
+
+    bool currentOnOff = false;
+    status = Attributes::OnOff::Get(endpoint, &currentOnOff);
+    if (status != Status::Success) {
+        return status;
+    }
+
+    if (startUpOnOff.IsNull() || GetBootReason() == BootReasonType::kSoftwareUpdateCompleted)
+    {
+        onOffValueForStartUp = currentOnOff;
+        return Status::Success;
+    }
+
+    switch (startUpOnOff.Value())
+    {
+    case OnOff::StartUpOnOffEnum::kOff:
+        onOffValueForStartUp = false; // Off
+        break;
+    case OnOff::StartUpOnOffEnum::kOn:
+        onOffValueForStartUp = true; // On
+        break;
+    case OnOff::StartUpOnOffEnum::kToggle:
+        onOffValueForStartUp = !currentOnOff;
+        break;
+    default:
+        // All other values 0x03- 0xFE are reserved - no action.
+        break;
+    }
+
+    return Status::Success;
 }
 
 bool OnOffServer::offCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath)

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -556,17 +556,11 @@ Status OnOffServer::getOnOffValueForStartUp(chip::EndpointId endpoint, bool & on
 {
     app::DataModel::Nullable<OnOff::StartUpOnOffEnum> startUpOnOff;
     Status status = Attributes::StartUpOnOff::Get(endpoint, startUpOnOff);
-    if (status != Status::Success)
-    {
-        return status;
-    }
+    VerifyOrReturnError(status == Status::Success, status);
 
     bool currentOnOff = false;
     status            = Attributes::OnOff::Get(endpoint, &currentOnOff);
-    if (status != Status::Success)
-    {
-        return status;
-    }
+    VerifyOrReturnError(status == Status::Success, status);
 
     if (startUpOnOff.IsNull() || GetBootReason() == BootReasonType::kSoftwareUpdateCompleted)
     {
@@ -587,6 +581,7 @@ Status OnOffServer::getOnOffValueForStartUp(chip::EndpointId endpoint, bool & on
         break;
     default:
         // All other values 0x03- 0xFE are reserved - no action.
+        onOffValueForStartUp = currentOnOff;
         break;
     }
 


### PR DESCRIPTION
From the specification:
> 1.5.6.6. StartUpOnOff Attribute
> This attribute SHALL define the desired startup behavior of a device when it is supplied with power and this state SHALL be reflected in the OnOff attribute. If the value is null, the OnOff attribute is set to its previous value. Otherwise, the behavior is defined in the table defining StartUpOnOf­fEnum.
> **_This behavior does not apply to reboots associated with OTA. After an OTA restart, the OnOff attribute SHALL return to its value prior to the restart_**.

Related PR:  https://github.com/project-chip/connectedhomeip/pull/21074