### PR TITLE
[Silabs] Add support for  EFR32MG26 boards

### DIFF
--- a/examples/platform/silabs/ldscripts/efr32mg26.ld
+++ b/examples/platform/silabs/ldscripts/efr32mg26.ld
@@ -1,0 +1,245 @@
+/***************************************************************************//**
+ * GCC Linker script for Silicon Labs devices
+ *******************************************************************************
+ * # License
+ * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Zlib
+ *
+ * The licensor of this software is Silicon Laboratories Inc.
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ ******************************************************************************/
+
+ MEMORY
+ {
+   FLASH      (rx)  : ORIGIN = 0x8006000, LENGTH = 0x318000
+   RAM        (rwx) : ORIGIN = 0x20000000, LENGTH = 0x80000
+ }
+
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+
+  .vectors :
+  {
+    linker_vectors_begin = .;
+    KEEP(*(.vectors))
+    linker_vectors_end = .;
+
+    __Vectors_End = .;
+    __Vectors_Size = __Vectors_End - __Vectors;
+    __lma_ramfuncs_start__ = .;
+  } > FLASH
+
+  .stack (NOLOAD):
+  {
+    . = ALIGN(8);
+    __StackLimit = .;
+    KEEP(*(.stack*))
+    . = ALIGN(4);
+    __StackTop = .;
+    PROVIDE(__stack = __StackTop);
+  } > RAM
+
+
+  .noinit (NOLOAD):
+  {
+    *(.noinit*);
+  } > RAM
+
+  .bss :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    *(SORT_BY_ALIGNMENT(.bss*))
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+  } > RAM
+
+  text_application_ram :
+  {
+    . = ALIGN(4);
+    __vma_ramfuncs_start__ = .;
+    __text_application_ram_start__ = .;
+
+    *(text_application_ram)
+
+    . = ALIGN(4);
+    __vma_ramfuncs_end__ = .;
+    __text_application_ram_end__ = .;
+  } > RAM AT > FLASH
+
+  .rodata :
+  {
+    __lma_ramfuncs_end__ = .;
+    __rodata_start__ = .;
+    __rodata_end__ = .;
+  } > FLASH
+
+  .text :
+  {
+    linker_code_begin = .;
+    *(SORT_BY_ALIGNMENT(.text*))
+    *(SORT_BY_ALIGNMENT(text_*))
+    . = ALIGN(32);
+    linker_code_end = .;
+
+    KEEP(*(.init))
+    KEEP(*(.fini))
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+    *(.eh_frame*)
+  } > FLASH
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > FLASH
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > FLASH
+  __exidx_end = .;
+
+  .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+    /* Add each additional data section here */
+    /*
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+    */
+
+    __copy_table_end__ = .;
+  } > FLASH
+
+  .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    /* Add each additional bss section here */
+    /*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+    */
+
+    __zero_table_end__ = .;
+    __etext = .;
+  } > FLASH
+
+  .data :
+  {
+    . = ALIGN(4);
+    __data_start__ = .;
+    *(vtable)
+    *(SORT_BY_ALIGNMENT(.data*))
+    . = ALIGN(4);
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+  } > RAM AT > FLASH
+  .memory_manager_heap (NOLOAD):
+  {
+    . = ALIGN(8);
+    __HeapBase = .;
+    __end__ = .;
+    end = __end__;
+    _end = __end__;
+    KEEP(*(.memory_manager_heap*))
+    __HeapLimit = ORIGIN(RAM) + LENGTH(RAM);
+  } > RAM
+
+  __heap_size = __HeapLimit - __HeapBase;
+  __ram_end__ = 0x20000000 + 0x80000;
+  __main_flash_end__ = 0x8006000 + 0x318000;
+
+   /* This is where we handle flash storage blocks. We use dummy sections for finding the configured
+   * block sizes and then "place" them at the end of flash when the size is known. */
+  .internal_storage (DSECT) : {
+    KEEP(*(.internal_storage*))
+  } > FLASH
+
+
+  .nvm (DSECT) : {
+    KEEP(*(.simee*))
+  } > FLASH
+
+  __ramfuncs_start__ = __vma_ramfuncs_start__;
+  __ramfuncs_end__ = __vma_ramfuncs_end__;
+
+  linker_nvm_end = __main_flash_end__;
+  linker_nvm_begin = linker_nvm_end - SIZEOF(.nvm);
+  linker_storage_end = linker_nvm_begin;
+  __nvm3Base = linker_nvm_begin;
+
+  linker_storage_begin = linker_storage_end - SIZEOF(.internal_storage);
+  ASSERT((linker_storage_begin >= (__etext + SIZEOF(.data))), "FLASH memory overflowed !")
+
+
+  app_flash_end = 0x8006000 + 0x318000;
+  ASSERT( (linker_nvm_begin + SIZEOF(.nvm)) <= app_flash_end, "NVM3 is excessing the flash size !")
+}

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -138,6 +138,8 @@ template("efr32_sdk") {
   config("${sdk_target_name}_config") {
     include_dirs = []
     libs = []
+    defines = []
+
     if (defined(invoker.include_dirs)) {
       include_dirs += invoker.include_dirs
     }
@@ -267,6 +269,8 @@ template("efr32_sdk") {
       if (!chip_enable_ble_rs911x) {
         libs += [ "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg24_gcc_release.a" ]
       }
+
+      defines += [ "EFR32MG24" ]
     } else if (silabs_family == "mgm24") {
       _include_dirs += [
         "${efr32_sdk_root}/platform/Device/SiliconLabs/MGM24/Include",
@@ -289,6 +293,8 @@ template("efr32_sdk") {
         libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_config_mgm240sd22vna_gcc.a" ]
         defines += [ "SLI_RADIOAES_REQUIRES_MASKING=1" ]
       }
+
+      defines += [ "MGM24" ]
     } else if (silabs_family == "efr32mg26") {
       _include_dirs += [
         "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG26/Include",
@@ -300,6 +306,8 @@ template("efr32_sdk") {
         "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg26_gcc_release.a",
         "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg26_gcc_release.a",
       ]
+
+      defines += [ "EFR32MG26" ]
     }
 
     if (use_wf200) {
@@ -361,6 +369,29 @@ template("efr32_sdk") {
       }
     }
 
+    if (use_system_view) {
+      _include_dirs += [
+        "${efr32_sdk_root}/util/third_party/segger/systemview/SEGGER",
+        "${efr32_sdk_root}/util/third_party/segger/systemview/init/",
+        "${efr32_sdk_root}/util/third_party/segger/systemview/profiles/freertos_v10/",
+      ]
+
+      defines += [
+        "SL_CATALOG_SYSTEMVIEW_TRACE_PRESENT",
+        "SEGGER_SYSVIEW_RTT_BUFFER_SIZE=8192",
+      ]
+    }
+
+    if (use_wstk_leds) {
+      _include_dirs += [ "${efr32_sdk_root}/platform/driver/leddrv/inc" ]
+
+      defines += [ "ENABLE_WSTK_LEDS" ]
+    }
+
+    if (use_wstk_buttons) {
+      _include_dirs += [ "${efr32_sdk_root}/platform/driver/button/inc" ]
+    }
+
     if (invoker.enable_dic) {
       _include_dirs += [ "${chip_root}/third_party/silabs/mqtt/stack" ]
     }
@@ -370,7 +401,7 @@ template("efr32_sdk") {
     # the content of these, only when changing the filename itself.
     # To fix this, these files are also manually depended upon in the source set
     # declared in efr32_mbedtls_config further down this file.
-    defines = [
+    defines += [
       "MBEDTLS_CONFIG_FILE=\"efr32-chip-mbedtls-config.h\"",
       "MBEDTLS_PSA_CRYPTO_CONFIG_FILE=\"efr32-psa-crypto-config.h\"",
       "__STARTUP_CLEAR_BSS",
@@ -511,29 +542,6 @@ template("efr32_sdk") {
           defines += [ "LWIP_IPV6=0" ]
         }
       }
-    }
-
-    if (use_system_view) {
-      _include_dirs += [
-        "${efr32_sdk_root}/util/third_party/segger/systemview/SEGGER",
-        "${efr32_sdk_root}/util/third_party/segger/systemview/init/",
-        "${efr32_sdk_root}/util/third_party/segger/systemview/profiles/freertos_v10/",
-      ]
-
-      defines += [
-        "SL_CATALOG_SYSTEMVIEW_TRACE_PRESENT",
-        "SEGGER_SYSVIEW_RTT_BUFFER_SIZE=8192",
-      ]
-    }
-
-    if (use_wstk_leds) {
-      _include_dirs += [ "${efr32_sdk_root}/platform/driver/leddrv/inc" ]
-
-      defines += [ "ENABLE_WSTK_LEDS" ]
-    }
-
-    if (use_wstk_buttons) {
-      _include_dirs += [ "${efr32_sdk_root}/platform/driver/button/inc" ]
     }
 
     if (chip_enable_icd_server) {

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -81,8 +81,11 @@ declare_args() {
   # Multi-chip OTA
   chip_enable_multi_ota_requestor = false
 }
+
 examples_plat_dir = "${chip_root}/examples/platform/silabs/efr32"
 silabs_plat_efr32_wifi_dir = "${chip_root}/src/platform/silabs/efr32/wifi"
+is_series_2 = silabs_family == "mgm24" || silabs_family == "efr32mg24" ||
+              silabs_family == "efr32mg26"
 
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")
 
@@ -224,11 +227,6 @@ template("efr32_sdk") {
       # TODO this is for sl_openthread_features_config.h. should use generated one per board when sl_ot_abstraction is integrated
       "${sl_ot_libs_path}/config",
     ]
-
-    if (silabs_family == "efr32mg24") {
-      _include_dirs +=
-          [ "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG24/Include" ]
-    }
 
     if (use_SiWx917) {
       _include_dirs += [
@@ -527,20 +525,18 @@ template("efr32_sdk") {
       defines += [ "CHIP_CONFIG_SYNCHRONOUS_REPORTS_ENABLED=1" ]
     }
 
-    if (silabs_family == "efr32mg24") {
+    if (is_series_2) {
       _include_dirs += [
-        "${efr32_sdk_root}/platform/radio/rail_lib/chip/efr32/efr32xg2x",
-        "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/config",
-        "${efr32_sdk_root}/platform/service/device_init/config/s2/",
-        "${efr32_sdk_root}/platform/emdrv/spidrv/inc",
-        "${efr32_sdk_root}/platform/emdrv/spidrv/config",
         "${efr32_sdk_root}/platform/emdrv/dmadrv/inc/s2_signals",
+        "${efr32_sdk_root}/platform/driver/debug/inc/",
+        "${efr32_sdk_root}/platform/radio/rail_lib/chip/efr32/efr32xg2x",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/fem_util/",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/rail_util_rssi/",
+        "${efr32_sdk_root}/platform/service/device_init/config/s2/",
+        "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure",
       ]
 
       libs += [
-        "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg24_gcc_release.a",
         "${sdk_support_root}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a",
         "${sdk_support_root}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a",
       ]
@@ -548,38 +544,36 @@ template("efr32_sdk") {
       if (!chip_enable_ble_rs911x) {
         libs += [
           "${sdk_support_root}/protocol/bluetooth/bgcommon/lib/build/gcc/cortex-m33/bgcommon/release/libbgcommon.a",
-          "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg24_gcc_release.a",
           "${sdk_support_root}/protocol/bluetooth/build/gcc/cortex-m33/bt_host/release/libbt_host.a",
           "${sdk_support_root}/protocol/bluetooth/build/gcc/cortex-m33/bt_host/hal/release/libbt_hal_series2.a",
         ]
       }
+    }
 
-      defines += [
-        "EFR32MG24",
-        "EFR32_SERIES2_CONFIG4_MICRO",
+    if (silabs_family == "efr32mg24") {
+      _include_dirs += [
+        "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG24/Include",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/config",
+        "${efr32_sdk_root}/platform/emdrv/spidrv/inc",
+        "${efr32_sdk_root}/platform/emdrv/spidrv/config",
       ]
+
+      libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg24_gcc_release.a" ]
+
+      if (!chip_enable_ble_rs911x) {
+        libs += [ "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg24_gcc_release.a" ]
+      }
     } else if (silabs_family == "mgm24") {
       _include_dirs += [
         "${efr32_sdk_root}/platform/Device/SiliconLabs/MGM24/Include",
-        "${efr32_sdk_root}/platform/driver/debug/inc/",
-        "${efr32_sdk_root}/platform/radio/rail_lib/chip/efr32/efr32xg2x",
-        "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/fem_util/",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/rail_util_rssi/",
         "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24",
         "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/config",
-        "${efr32_sdk_root}/platform/service/device_init/config/s2/",
-        "${efr32_sdk_root}/platform/emdrv/dmadrv/inc/s2_signals",
       ]
 
       libs += [
-        "${sdk_support_root}/protocol/bluetooth/bgcommon/lib/build/gcc/cortex-m33/bgcommon/release/libbgcommon.a",
         "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg24_gcc_release.a",
-        "${sdk_support_root}/protocol/bluetooth/build/gcc/cortex-m33/bt_host/release/libbt_host.a",
-        "${sdk_support_root}/protocol/bluetooth/build/gcc/cortex-m33/bt_host/hal/release/libbt_hal_series2.a",
         "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_module_efr32xg24_gcc_release.a",
-        "${sdk_support_root}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a",
-        "${sdk_support_root}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a",
       ]
 
       if (silabs_mcu == "MGM240PB32VNA") {
@@ -592,10 +586,16 @@ template("efr32_sdk") {
         libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_config_mgm240sd22vna_gcc.a" ]
         defines += [ "SLI_RADIOAES_REQUIRES_MASKING=1" ]
       }
+    } else if (silabs_family == "efr32mg26") {
+      _include_dirs += [
+        "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG26/Include",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg26",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg26/config",
+      ]
 
-      defines += [
-        "MGM24",
-        "EFR32_SERIES2_CONFIG4_MICRO",
+      libs += [
+        "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg26_gcc_release.a",
+        "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg26_gcc_release.a",
       ]
     }
 
@@ -616,7 +616,7 @@ template("efr32_sdk") {
 
     cflags += [ "-Wno-shadow" ]
 
-    if (silabs_family == "efr32mg24" || silabs_family == "mgm24") {
+    if (is_series_2) {
       cflags += [ "-mcmse" ]
     }
 
@@ -930,7 +930,8 @@ template("efr32_sdk") {
       sources += [
         "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG24/Source/startup_efr32mg24.c",
         "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG24/Source/system_efr32mg24.c",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.c",
+        "${efr32_sdk_root}/platform/service/device_manager/clocks/sl_device_clock_efr32xg24.c",
+        "${efr32_sdk_root}/platform/service/device_manager/devices/sl_device_peripheral_hal_efr32xg24.c",
       ]
     } else if (silabs_family == "mgm24") {
       sources += [
@@ -938,11 +939,21 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform/Device/SiliconLabs/MGM24/Source/system_mgm24.c",
         "${efr32_sdk_root}/platform/radio/rail_lib/plugin/fem_util/sl_fem_util.c",
         "${efr32_sdk_root}/platform/radio/rail_lib/plugin/rail_util_rssi/sl_rail_util_rssi.c",
+        "${efr32_sdk_root}/platform/service/device_manager/clocks/sl_device_clock_efr32xg24.c",
+        "${efr32_sdk_root}/platform/service/device_manager/devices/sl_device_peripheral_hal_efr32xg24.c",
+      ]
+    } else if (silabs_family == "efr32mg26") {
+      sources += [
+        "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG26/Source/startup_efr32mg26.c",
+        "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG26/Source/system_efr32mg26.c",
+        "${efr32_sdk_root}/platform/service/device_manager/clocks/sl_device_clock_efr32xg26.c",
+        "${efr32_sdk_root}/platform/service/device_manager/devices/sl_device_peripheral_hal_efr32xg26.c",
       ]
     }
 
-    if (silabs_family == "mgm24" || silabs_family == "efr32mg24") {
+    if (is_series_2) {
       sources += [
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/pa_curves_efr32.c",
         "${efr32_sdk_root}/platform/radio/rail_lib/plugin/rail_util_sequencer/sl_rail_util_sequencer.c",
         "${efr32_sdk_root}/platform/security/sl_component/se_manager/src/sl_se_manager.c",
         "${efr32_sdk_root}/platform/security/sl_component/se_manager/src/sl_se_manager_attestation.c",
@@ -975,8 +986,6 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform/service/clock_manager/src/sl_clock_manager_hal_s2.c",
         "${efr32_sdk_root}/platform/service/clock_manager/src/sl_clock_manager_init_hal_s2.c",
         "${efr32_sdk_root}/platform/service/device_init/src/sl_device_init_dcdc_s2.c",
-        "${efr32_sdk_root}/platform/service/device_manager/clocks/sl_device_clock_efr32xg24.c",
-        "${efr32_sdk_root}/platform/service/device_manager/devices/sl_device_peripheral_hal_efr32xg24.c",
         "${efr32_sdk_root}/platform/service/hfxo_manager/src/sl_hfxo_manager_hal_s2.c",
         "${efr32_sdk_root}/platform/service/power_manager/src/sl_power_manager_hal_s2.c",
         "${efr32_sdk_root}/platform/service/sleeptimer/src/sl_sleeptimer_hal_sysrtc.c",

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -228,6 +228,90 @@ template("efr32_sdk") {
       "${sl_ot_libs_path}/config",
     ]
 
+    if (is_series_2) {
+      _include_dirs += [
+        "${efr32_sdk_root}/platform/emdrv/dmadrv/inc/s2_signals",
+        "${efr32_sdk_root}/platform/driver/debug/inc/",
+        "${efr32_sdk_root}/platform/radio/rail_lib/chip/efr32/efr32xg2x",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/fem_util/",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/rail_util_rssi/",
+        "${efr32_sdk_root}/platform/service/device_init/config/s2/",
+        "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure",
+      ]
+
+      libs += [
+        "${sdk_support_root}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a",
+        "${sdk_support_root}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a",
+      ]
+
+      if (!chip_enable_ble_rs911x) {
+        libs += [
+          "${sdk_support_root}/protocol/bluetooth/bgcommon/lib/build/gcc/cortex-m33/bgcommon/release/libbgcommon.a",
+          "${sdk_support_root}/protocol/bluetooth/build/gcc/cortex-m33/bt_host/release/libbt_host.a",
+          "${sdk_support_root}/protocol/bluetooth/build/gcc/cortex-m33/bt_host/hal/release/libbt_hal_series2.a",
+        ]
+      }
+    }
+
+    if (silabs_family == "efr32mg24") {
+      _include_dirs += [
+        "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG24/Include",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/config",
+        "${efr32_sdk_root}/platform/emdrv/spidrv/inc",
+        "${efr32_sdk_root}/platform/emdrv/spidrv/config",
+      ]
+
+      libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg24_gcc_release.a" ]
+
+      if (!chip_enable_ble_rs911x) {
+        libs += [ "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg24_gcc_release.a" ]
+      }
+    } else if (silabs_family == "mgm24") {
+      _include_dirs += [
+        "${efr32_sdk_root}/platform/Device/SiliconLabs/MGM24/Include",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/config",
+      ]
+
+      libs += [
+        "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg24_gcc_release.a",
+        "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_module_efr32xg24_gcc_release.a",
+      ]
+
+      if (silabs_mcu == "MGM240PB32VNA") {
+        libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_config_mgm240pb32vna_gcc.a" ]
+      } else if (silabs_mcu == "MGM240PB22VNA") {
+        libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_config_mgm240pb22vna_gcc.a" ]
+      } else if (silabs_mcu == "MGM240L022RNF") {
+        libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_config_mgm240l022rnf_gcc.a" ]
+      } else if (silabs_mcu == "MGM240SD22VNA") {
+        libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_config_mgm240sd22vna_gcc.a" ]
+        defines += [ "SLI_RADIOAES_REQUIRES_MASKING=1" ]
+      }
+    } else if (silabs_family == "efr32mg26") {
+      _include_dirs += [
+        "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG26/Include",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg26",
+        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg26/config",
+      ]
+
+      libs += [
+        "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg26_gcc_release.a",
+        "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg26_gcc_release.a",
+      ]
+    }
+
+    if (use_wf200) {
+      _include_dirs += [
+        "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver",
+        "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/bus",
+        "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/firmware",
+        "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/pds/brd8022a",
+        "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/secure_link",
+      ]
+    }
+
     if (use_SiWx917) {
       _include_dirs += [
         # si91x component
@@ -275,6 +359,10 @@ template("efr32_sdk") {
           "${wifi_sdk_root}/components/device/silabs/si91x/wireless/ble/inc",
         ]
       }
+    }
+
+    if (invoker.enable_dic) {
+      _include_dirs += [ "${chip_root}/third_party/silabs/mqtt/stack" ]
     }
 
     # Note that we're setting the mbedTLS and PSA configuration files through a
@@ -517,96 +605,8 @@ template("efr32_sdk") {
       ]
     }
 
-    if (invoker.enable_dic) {
-      _include_dirs += [ "${chip_root}/third_party/silabs/mqtt/stack" ]
-    }
-
     if (sl_use_subscription_synching) {
       defines += [ "CHIP_CONFIG_SYNCHRONOUS_REPORTS_ENABLED=1" ]
-    }
-
-    if (is_series_2) {
-      _include_dirs += [
-        "${efr32_sdk_root}/platform/emdrv/dmadrv/inc/s2_signals",
-        "${efr32_sdk_root}/platform/driver/debug/inc/",
-        "${efr32_sdk_root}/platform/radio/rail_lib/chip/efr32/efr32xg2x",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/fem_util/",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/rail_util_rssi/",
-        "${efr32_sdk_root}/platform/service/device_init/config/s2/",
-        "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure",
-      ]
-
-      libs += [
-        "${sdk_support_root}/platform/emdrv/nvm3/lib/libnvm3_CM33_gcc.a",
-        "${sdk_support_root}/protocol/openthread/libs/libsl_openthread_efr32mg2x_gcc.a",
-      ]
-
-      if (!chip_enable_ble_rs911x) {
-        libs += [
-          "${sdk_support_root}/protocol/bluetooth/bgcommon/lib/build/gcc/cortex-m33/bgcommon/release/libbgcommon.a",
-          "${sdk_support_root}/protocol/bluetooth/build/gcc/cortex-m33/bt_host/release/libbt_host.a",
-          "${sdk_support_root}/protocol/bluetooth/build/gcc/cortex-m33/bt_host/hal/release/libbt_hal_series2.a",
-        ]
-      }
-    }
-
-    if (silabs_family == "efr32mg24") {
-      _include_dirs += [
-        "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG24/Include",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/config",
-        "${efr32_sdk_root}/platform/emdrv/spidrv/inc",
-        "${efr32_sdk_root}/platform/emdrv/spidrv/config",
-      ]
-
-      libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg24_gcc_release.a" ]
-
-      if (!chip_enable_ble_rs911x) {
-        libs += [ "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg24_gcc_release.a" ]
-      }
-    } else if (silabs_family == "mgm24") {
-      _include_dirs += [
-        "${efr32_sdk_root}/platform/Device/SiliconLabs/MGM24/Include",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/config",
-      ]
-
-      libs += [
-        "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg24_gcc_release.a",
-        "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_module_efr32xg24_gcc_release.a",
-      ]
-
-      if (silabs_mcu == "MGM240PB32VNA") {
-        libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_config_mgm240pb32vna_gcc.a" ]
-      } else if (silabs_mcu == "MGM240PB22VNA") {
-        libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_config_mgm240pb22vna_gcc.a" ]
-      } else if (silabs_mcu == "MGM240L022RNF") {
-        libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_config_mgm240l022rnf_gcc.a" ]
-      } else if (silabs_mcu == "MGM240SD22VNA") {
-        libs += [ "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_config_mgm240sd22vna_gcc.a" ]
-        defines += [ "SLI_RADIOAES_REQUIRES_MASKING=1" ]
-      }
-    } else if (silabs_family == "efr32mg26") {
-      _include_dirs += [
-        "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG26/Include",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg26",
-        "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg26/config",
-      ]
-
-      libs += [
-        "${sdk_support_root}/protocol/bluetooth/bgstack/ll/lib/libbluetooth_controller_efr32xg26_gcc_release.a",
-        "${sdk_support_root}/platform/radio/rail_lib/autogen/librail_release/librail_multiprotocol_efr32xg26_gcc_release.a",
-      ]
-    }
-
-    if (use_wf200) {
-      _include_dirs += [
-        "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver",
-        "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/bus",
-        "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/firmware",
-        "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/pds/brd8022a",
-        "${efr32_sdk_root}/platform/radio/wifi/wfx_fmac_driver/secure_link",
-      ]
     }
 
     cflags = []

--- a/third_party/silabs/silabs_arm.gni
+++ b/third_party/silabs/silabs_arm.gni
@@ -20,7 +20,8 @@ if (silabs_family == "SiWx917-common") {
   arm_cpu = "cortex-m4"
   arm_float_abi = "softfp"
   arm_fpu = "fpv4-sp-d16"
-} else if (silabs_family == "efr32mg24" || silabs_family == "mgm24") {
+} else if (silabs_family == "efr32mg24" || silabs_family == "mgm24" ||
+           silabs_family == "efr32mg26") {
   arm_arch = "armv8-m.main+dsp"
   arm_abi = "aapcs"
   arm_cpu = "cortex-m33"

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -64,10 +64,13 @@ if (silabs_board == "") {
 
 assert(silabs_board != "", "silabs_board must be specified")
 
+# Si917 WIFI board ----------
 if (silabs_board == "BRD4338A") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
   wifi_soc = true
+
+  # EFR32 MG24 series ----------
 } else if (silabs_board == "BRD4186A" || silabs_board == "BRD4187A") {
   variant = string_replace(silabs_board, "A", "C")
   print(
@@ -95,6 +98,8 @@ if (silabs_board == "BRD4338A") {
   use_external_flash = false
   show_qr_code = false
   disable_lcd = true
+
+  # EFR32 MG24 Modules series ----------
 } else if (silabs_board == "BRD4316A") {
   silabs_family = "mgm24"
   silabs_mcu = "MGM240PB22VNA"
@@ -130,6 +135,24 @@ if (silabs_board == "BRD4338A") {
 } else if (silabs_board == "BRD4318A") {
   silabs_family = "mgm24"
   silabs_mcu = "MGM240SD22VNA"
+
+  # EFR32 MG26 series ----------
+} else if (silabs_board == "BRD4116A") {
+  silabs_family = "efr32mg26"
+  silabs_mcu = "EFR32MG26B410F3200IM48"
+} else if (silabs_board == "BRD4117A") {
+  silabs_family = "efr32mg26"
+  silabs_mcu = "EFR32MG26B420F3200IM48"
+} else if (silabs_board == "BRD4118A") {
+  silabs_family = "efr32mg26"
+  silabs_mcu = "EFR32MG26B510F3200IL136"
+} else if (silabs_board == "BRD2608A") {
+  silabs_family = "efr32mg26"
+  silabs_mcu = "EFR32MG26B510F3200IM68"
+
+  # ThunderBoards don't have a LCD,
+  show_qr_code = false
+  disable_lcd = true
 } else {
   assert(
       false,


### PR DESCRIPTION
This PR adds support for some EFR32MG26 boards which is a recent MCU of EFR32 series 2.
- The following boards are now supported: BRD4116A, BRD4117A BRD4118A, BRD2608A 
- Add linker script for this new mcu.
- link source and libs from simplicity sdk for those boards.
- Cleanup our silabs_sdk.gni for all series 2 family.


Test: 
Build apps for the new boards.
Manual commissioning and control validation with chip-tool