### PR TITLE
Add methods to clear data from the cluster state cache.

### DIFF
--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -649,6 +649,47 @@ exit:
 }
 
 template <bool CanEnableDataCaching>
+void ClusterStateCacheT<CanEnableDataCaching>::ClearAttributes(EndpointId endpointId)
+{
+    mCache.erase(endpointId);
+}
+
+template <bool CanEnableDataCaching>
+void ClusterStateCacheT<CanEnableDataCaching>::ClearAttributes(const ConcreteClusterPath & cluster)
+{
+    // Can't use GetEndpointState here, since that only handles const things.
+    auto endpointIter = mCache.find(cluster.mEndpointId);
+    if (endpointIter == mCache.end())
+    {
+        return;
+    }
+
+    auto & endpointState = endpointIter->second;
+    endpointState.erase(cluster.mClusterId);
+}
+
+template <bool CanEnableDataCaching>
+void ClusterStateCacheT<CanEnableDataCaching>::ClearAttribute(const ConcreteAttributePath & attribute)
+{
+    // Can't use GetClusterState here, since that only handles const things.
+    auto endpointIter = mCache.find(attribute.mEndpointId);
+    if (endpointIter == mCache.end())
+    {
+        return;
+    }
+
+    auto & endpointState = endpointIter->second;
+    auto clusterIter     = endpointState.find(attribute.mClusterId);
+    if (clusterIter == endpointState.end())
+    {
+        return;
+    }
+
+    auto & clusterState = clusterIter->second;
+    clusterState.mAttributes.erase(attribute.mAttributeId);
+}
+
+template <bool CanEnableDataCaching>
 CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::GetLastReportDataPath(ConcreteClusterPath & aPath)
 {
     if (mLastReportDataPath.IsValidConcreteClusterPath())

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -505,6 +505,22 @@ public:
     }
 
     /*
+     * Clear out all the attribute data and DataVersions stored for a given endpoint.
+     */
+    void ClearAttributes(EndpointId endpoint);
+
+    /*
+     * Clear out all the attribute data and the DataVersion stored for a given cluster.
+     */
+    void ClearAttributes(const ConcreteClusterPath & cluster);
+
+    /*
+     * Clear out the data (or size, if not storing data) stored for an
+     * attribute.
+     */
+    void ClearAttribute(const ConcreteAttributePath & attribute);
+
+    /*
      * Clear out the event data and status caches.
      *
      * By default, this will not clear out any internally tracked event counters, specifically:


### PR DESCRIPTION
This allows consumers to clear stale data when they detects PartsList/ServerList/AttributeList changes.
