### PR TITLE
Make RPC call synchronous in Fabric Sync

### DIFF
--- a/examples/fabric-admin/rpc/RpcClient.h
+++ b/examples/fabric-admin/rpc/RpcClient.h
@@ -41,7 +41,7 @@ CHIP_ERROR InitRpcClient(uint16_t rpcServerPort);
  *
  * @param nodeId The Node ID of the device to be added.
  * @return CHIP_ERROR An error code indicating the success or failure of the operation.
- * - CHIP_NO_ERROR: The RPC command was successfully sent.
+ * - CHIP_NO_ERROR: The RPC command was successfully processed.
  * - CHIP_ERROR_BUSY: Another operation is currently in progress.
  * - CHIP_ERROR_INTERNAL: An internal error occurred while activating the RPC call.
  */
@@ -56,7 +56,7 @@ CHIP_ERROR AddSynchronizedDevice(chip::NodeId nodeId);
  *
  * @param nodeId The Node ID of the device to be removed.
  * @return CHIP_ERROR An error code indicating the success or failure of the operation.
- * - CHIP_NO_ERROR: The RPC command was successfully sent.
+ * - CHIP_NO_ERROR: The RPC command was successfully processed.
  * - CHIP_ERROR_BUSY: Another operation is currently in progress.
  * - CHIP_ERROR_INTERNAL: An internal error occurred while activating the RPC call.
  */

--- a/examples/fabric-bridge-app/linux/include/RpcClient.h
+++ b/examples/fabric-bridge-app/linux/include/RpcClient.h
@@ -37,7 +37,7 @@ CHIP_ERROR InitRpcClient(uint16_t rpcServerPort);
  *
  * @param nodeId The identifier of the node for which the commissioning window should be opened.
  * @return CHIP_ERROR An error code indicating the success or failure of the operation.
- * - CHIP_NO_ERROR: The RPC command was successfully sent.
+ * - CHIP_NO_ERROR: The RPC command was successfully processed.
  * - CHIP_ERROR_BUSY: Another commissioning window is currently in progress.
  * - CHIP_ERROR_INTERNAL: An internal error occurred.
  */


### PR DESCRIPTION
We need to make all RPC call synchronous in Fabric Sync to grantee the correct sequence of Fabric Sync.

I have explored all possible options to make an RPC call synchronous but found that busy-waiting is the most reliable option so far.

A better option would be to use the pw client synchronous call wrappers, but they are quite expensive and not available in the current nanopb integration in the CHIP project.

Fixes #33784

