### PR TITLE
Revert "[ESP32] Remove SupportedModes implementation of ModeSelect from nvs and use all-clusters-apps common implementation"

### DIFF
--- a/docs/guides/esp32/providers.md
+++ b/docs/guides/esp32/providers.md
@@ -15,6 +15,8 @@ Below are the providers that have been implemented:
 -   [Device Info Provider](https://github.com/project-chip/connectedhomeip/blob/master/src/platform/ESP32/ESP32DeviceInfoProvider.h#L31)
     This provider provides fixed labels, supported calendar types, and supported
     locales from the factory partition.
+-   [Supported Modes](https://github.com/project-chip/connectedhomeip/blob/master/examples/platform/esp32/mode-support/static-supported-modes-manager.h#L28)
+    This provider offers the supported modes for the mode-select cluster.
 
 More information can be found in the [factory data guide](factory_data.md).
 

--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/ota"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/common"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/shell_extension"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/mode-support"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/icd/server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/util"
@@ -104,6 +105,8 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/clusters/electrical-power-measurement-server"
 )
 
+
+set(EXCLUDE_SRCS "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp")
 
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -41,6 +41,7 @@
 #include <common/Esp32ThreadInit.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <examples/platform/esp32/mode-support/static-supported-modes-manager.h>
 #include <platform/ESP32/ESP32Utils.h>
 #include <static-supported-temperature-levels.h>
 
@@ -121,6 +122,13 @@ static void InitServer(intptr_t context)
 #if CONFIG_DEVICE_TYPE_M5STACK
     SetupPretendDevices();
 #endif
+    CHIP_ERROR err =
+        app::Clusters::ModeSelect::StaticSupportedModesManager::getStaticSupportedModesManagerInstance().InitEndpointArray(
+            FIXED_ENDPOINT_COUNT);
+    if (err != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "Failed to initialize endpoint array for supported-modes, err:%" CHIP_ERROR_FORMAT, err.Format());
+    }
 
     app::Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
 }

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -1,0 +1,223 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "static-supported-modes-manager.h"
+#include <platform/ESP32/ESP32Config.h>
+
+using namespace chip;
+using namespace chip::app::Clusters;
+using namespace chip::DeviceLayer::Internal;
+using namespace chip::app::Clusters::ModeSelect;
+using chip::Protocols::InteractionModel::Status;
+
+using ModeOptionStructType = Structs::ModeOptionStruct::Type;
+using SemanticTag          = Structs::SemanticTagStruct::Type;
+
+template <typename T>
+using List = app::DataModel::List<T>;
+
+SupportedModesManager::ModeOptionsProvider * StaticSupportedModesManager::epModeOptionsProviderList = nullptr;
+
+const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
+
+int StaticSupportedModesManager::mSize = 0;
+
+CHIP_ERROR StaticSupportedModesManager::InitEndpointArray(int size)
+{
+    if (epModeOptionsProviderList != nullptr)
+    {
+        ChipLogError(Zcl, "Cannot allocate epModeOptionsProviderList");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+    mSize                     = size;
+    epModeOptionsProviderList = new SupportedModesManager::ModeOptionsProvider[mSize];
+    if (epModeOptionsProviderList == nullptr)
+    {
+        ChipLogError(Zcl, "Failed to allocate memory to epModeOptionsProviderList");
+        return CHIP_ERROR_NO_MEMORY;
+    }
+    for (int i = 0; i < mSize; i++)
+    {
+        epModeOptionsProviderList[i] = ModeOptionsProvider();
+    }
+    return CHIP_NO_ERROR;
+}
+
+SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeOptionsProvider(EndpointId endpointId) const
+{
+    if (epModeOptionsProviderList[endpointId].begin() != nullptr && epModeOptionsProviderList[endpointId].end() != nullptr)
+    {
+        return ModeOptionsProvider(epModeOptionsProviderList[endpointId].begin(), epModeOptionsProviderList[endpointId].end());
+    }
+
+    ModeOptionStructType * modeOptionStructList = nullptr;
+    SemanticTag * semanticTags                  = nullptr;
+
+    char keyBuf[ESP32Config::kMaxConfigKeyNameLength];
+    uint32_t supportedModeCount = 0;
+
+    VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesCount(keyBuf, sizeof(keyBuf), endpointId) == CHIP_NO_ERROR,
+                        ModeOptionsProvider(nullptr, nullptr));
+    ESP32Config::Key countKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+    VerifyOrReturnValue(ESP32Config::ReadConfigValue(countKey, supportedModeCount) == CHIP_NO_ERROR,
+                        ModeOptionsProvider(nullptr, nullptr));
+
+    modeOptionStructList = new ModeOptionStructType[supportedModeCount];
+    if (modeOptionStructList == nullptr)
+    {
+        return ModeOptionsProvider(nullptr, nullptr);
+    }
+
+    epModeOptionsProviderList[endpointId] = ModeOptionsProvider(modeOptionStructList, modeOptionStructList + supportedModeCount);
+
+    for (int index = 0; index < supportedModeCount; index++)
+    {
+        Structs::ModeOptionStruct::Type option;
+        uint32_t supportedModeMode = 0;
+        uint32_t semanticTagCount  = 0;
+        size_t outLen              = 0;
+
+        memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
+        VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesLabel(keyBuf, sizeof(keyBuf), endpointId, index) ==
+                                CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
+        ESP32Config::Key labelKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+        VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, nullptr, 0, outLen) == CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
+
+        char * modeLabel = new char[outLen + 1];
+        if (modeLabel == nullptr)
+        {
+            CleanUp(endpointId);
+            return ModeOptionsProvider(nullptr, nullptr);
+        }
+
+        VerifyOrReturnValue(ESP32Config::ReadConfigValueStr(labelKey, modeLabel, outLen + 1, outLen) == CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
+
+        memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
+        VerifyOrReturnValue(ESP32Config::KeyAllocator::SupportedModesValue(keyBuf, sizeof(keyBuf), endpointId, index) ==
+                                CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
+        ESP32Config::Key modeKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+        VerifyOrReturnValue(ESP32Config::ReadConfigValue(labelKey, supportedModeMode) == CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
+
+        memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
+        VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagsCount(keyBuf, sizeof(keyBuf), endpointId, index) ==
+                                CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
+        ESP32Config::Key stCountKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+        VerifyOrReturnValue(ESP32Config::ReadConfigValue(stCountKey, semanticTagCount) == CHIP_NO_ERROR,
+                            ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
+
+        semanticTags = new SemanticTag[semanticTagCount];
+        if (semanticTags == nullptr)
+        {
+            CleanUp(endpointId);
+            return ModeOptionsProvider(nullptr, nullptr);
+        }
+        for (auto stIndex = 0; stIndex < semanticTagCount; stIndex++)
+        {
+
+            uint32_t semanticTagValue   = 0;
+            uint32_t semanticTagMfgCode = 0;
+            SemanticTag tag;
+
+            memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
+            VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagValue(keyBuf, sizeof(keyBuf), endpointId, index, stIndex) ==
+                                    CHIP_NO_ERROR,
+                                ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
+            ESP32Config::Key stValueKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+            VerifyOrReturnValue(ESP32Config::ReadConfigValue(stValueKey, semanticTagValue) == CHIP_NO_ERROR,
+                                ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
+
+            memset(keyBuf, 0, sizeof(char) * ESP32Config::kMaxConfigKeyNameLength);
+            VerifyOrReturnValue(ESP32Config::KeyAllocator::SemanticTagMfgCode(keyBuf, sizeof(keyBuf), endpointId, index, stIndex) ==
+                                    CHIP_NO_ERROR,
+                                ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
+            ESP32Config::Key stMfgCodeKey(ESP32Config::kConfigNamespace_ChipFactory, keyBuf);
+            VerifyOrReturnValue(ESP32Config::ReadConfigValue(stMfgCodeKey, semanticTagMfgCode) == CHIP_NO_ERROR,
+                                ModeOptionsProvider(nullptr, nullptr), CleanUp(endpointId));
+
+            tag.value             = static_cast<uint16_t>(semanticTagValue);
+            tag.mfgCode           = static_cast<chip::VendorId>(semanticTagMfgCode);
+            semanticTags[stIndex] = tag;
+        }
+
+        option.label        = chip::CharSpan::fromCharString(modeLabel);
+        option.mode         = static_cast<uint8_t>(supportedModeMode);
+        option.semanticTags = DataModel::List<const SemanticTag>(semanticTags, semanticTagCount);
+
+        modeOptionStructList[index] = option;
+    }
+
+    return ModeOptionsProvider(modeOptionStructList, modeOptionStructList + supportedModeCount);
+}
+
+Status StaticSupportedModesManager::getModeOptionByMode(unsigned short endpointId, unsigned char mode,
+                                                        const ModeOptionStructType ** dataPtr) const
+{
+    auto modeOptionsProvider = this->getModeOptionsProvider(endpointId);
+    if (modeOptionsProvider.begin() == nullptr)
+    {
+        return Status::UnsupportedCluster;
+    }
+    auto * begin = modeOptionsProvider.begin();
+    auto * end   = modeOptionsProvider.end();
+
+    for (auto * it = begin; it != end; ++it)
+    {
+        auto & modeOption = *it;
+        if (modeOption.mode == mode)
+        {
+            *dataPtr = &modeOption;
+            return Status::Success;
+        }
+    }
+    ChipLogProgress(Zcl, "Cannot find the mode %u", mode);
+    return Status::InvalidCommand;
+}
+
+const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()
+{
+    return &StaticSupportedModesManager::getStaticSupportedModesManagerInstance();
+}
+
+void StaticSupportedModesManager::FreeSupportedModes(EndpointId endpointId) const
+{
+    if (epModeOptionsProviderList[endpointId].begin() != nullptr)
+    {
+        auto * begin = epModeOptionsProviderList[endpointId].begin();
+        auto * end   = epModeOptionsProviderList[endpointId].end();
+        for (auto * it = begin; it != end; ++it)
+        {
+            auto & modeOption = *it;
+            delete[] modeOption.label.data();
+            delete[] modeOption.semanticTags.data();
+        }
+        delete[] begin;
+    }
+    epModeOptionsProviderList[endpointId] = ModeOptionsProvider();
+}
+
+void StaticSupportedModesManager::CleanUp(EndpointId endpointId) const
+{
+    ChipLogError(Zcl, "Supported mode data is in incorrect format");
+    FreeSupportedModes(endpointId);
+}

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -1,0 +1,80 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/mode-select-server/supported-modes-manager.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ModeSelect {
+
+class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::SupportedModesManager
+{
+private:
+    using ModeOptionStructType = Structs::ModeOptionStruct::Type;
+    using SemanticTag          = Structs::SemanticTagStruct::Type;
+    static int mSize;
+
+    static ModeOptionsProvider * epModeOptionsProviderList;
+
+    void FreeSupportedModes(EndpointId endpointId) const;
+
+    static const StaticSupportedModesManager instance;
+
+public:
+    // InitEndpointArray should be called only once in the application. Memory allocated to the
+    // epModeOptionsProviderList will be needed for the lifetime of the program, so it's never deallocated.
+    static CHIP_ERROR InitEndpointArray(int size);
+
+    // DeInitEndpointArray should be called only when application need to reallocate memory of
+    // epModeOptionsProviderList ( Eg. Bridges ).
+    static void DeInitEndpointArray()
+    {
+        delete[] epModeOptionsProviderList;
+        epModeOptionsProviderList = nullptr;
+        mSize                     = 0;
+    }
+
+    SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;
+
+    Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
+                                                            const ModeOptionStructType ** dataPtr) const override;
+
+    void CleanUp(EndpointId endpointId) const;
+
+    StaticSupportedModesManager() {}
+
+    ~StaticSupportedModesManager()
+    {
+        for (int i = 0; i < mSize; i++)
+        {
+            FreeSupportedModes(i);
+        }
+    }
+
+    static inline const StaticSupportedModesManager & getStaticSupportedModesManagerInstance() { return instance; }
+};
+
+const SupportedModesManager * getSupportedModesManager();
+
+} // namespace ModeSelect
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -159,6 +159,39 @@ def ishex(s):
     except ValueError:
         return False
 
+# get_supported_modes_dict() converts the list of strings to per endpoint dictionaries.
+# example with semantic tags
+# input  : ['0/label1/1/"1\0x8000, 2\0x8000" 1/label2/1/"1\0x8000, 2\0x8000"']
+# output : {'1': [{'Label': 'label1', 'Mode': 0, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}, {'Label': 'label2', 'Mode': 1, 'Semantic_Tag': [{'value': 1, 'mfgCode': 32768}, {'value': 2, 'mfgCode': 32768}]}]}
+
+# example without semantic tags
+# input  : ['0/label1/1 1/label2/1']
+# output : {'1': [{'Label': 'label1', 'Mode': 0, 'Semantic_Tag': []}, {'Label': 'label2', 'Mode': 1, 'Semantic_Tag': []}]}
+
+
+def get_supported_modes_dict(supported_modes):
+    output_dict = {}
+
+    for mode_str in supported_modes:
+        mode_label_strs = mode_str.split('/')
+        mode = mode_label_strs[0]
+        label = mode_label_strs[1]
+        ep = mode_label_strs[2]
+
+        semantic_tags = ''
+        if (len(mode_label_strs) == 4):
+            semantic_tag_strs = mode_label_strs[3].split(', ')
+            semantic_tags = [{"value": int(v.split('\\')[0]), "mfgCode": int(v.split('\\')[1], 16)} for v in semantic_tag_strs]
+
+        mode_dict = {"Label": label, "Mode": int(mode), "Semantic_Tag": semantic_tags}
+
+        if ep in output_dict:
+            output_dict[ep].append(mode_dict)
+        else:
+            output_dict[ep] = [mode_dict]
+
+    return output_dict
+
 
 def check_str_range(s, min_len, max_len, name):
     if s and ((len(s) < min_len) or (len(s) > max_len)):
@@ -268,6 +301,60 @@ def populate_factory_data(args, spake2p_params):
         FACTORY_DATA['hardware-ver']['value'] = args.hw_ver
     if args.hw_ver_str:
         FACTORY_DATA['hw-ver-str']['value'] = args.hw_ver_str
+
+    # SupportedModes are stored as multiple entries
+    #  - sm-sz/<ep>                 : number of supported modes for the endpoint
+    #  - sm-label/<ep>/<index>      : supported modes label key for the endpoint and index
+    #  - sm-mode/<ep>/<index>       : supported modes mode key for the endpoint and index
+    #  - sm-st-sz/<ep>/<index>      : supported modes SemanticTag key for the endpoint and index
+    #  - st-v/<ep>/<index>/<ind>    : semantic tag value key for the endpoint and index and ind
+    #  - st-mfg/<ep>/<index>/<ind>  : semantic tag mfg code key for the endpoint and index and ind
+    if (args.supported_modes is not None):
+        dictionary = get_supported_modes_dict(args.supported_modes)
+        for ep in dictionary.keys():
+            _sz = {
+                'type': 'data',
+                'encoding': 'u32',
+                'value': len(dictionary[ep])
+            }
+            FACTORY_DATA.update({'sm-sz/{:x}'.format(int(ep)): _sz})
+            for i in range(len(dictionary[ep])):
+                item = dictionary[ep][i]
+                _label = {
+                    'type': 'data',
+                    'encoding': 'string',
+                    'value': item["Label"]
+                }
+                _mode = {
+                    'type': 'data',
+                    'encoding': 'u32',
+                    'value': item["Mode"]
+                }
+                _st_sz = {
+                    'type': 'data',
+                    'encoding': 'u32',
+                    'value': len(item["Semantic_Tag"])
+                }
+                FACTORY_DATA.update({'sm-label/{:x}/{:x}'.format(int(ep), i): _label})
+                FACTORY_DATA.update({'sm-mode/{:x}/{:x}'.format(int(ep), i): _mode})
+                FACTORY_DATA.update({'sm-st-sz/{:x}/{:x}'.format(int(ep), i): _st_sz})
+
+                for j in range(len(item["Semantic_Tag"])):
+                    entry = item["Semantic_Tag"][j]
+
+                    _value = {
+                        'type': 'data',
+                        'encoding': 'u32',
+                        'value': entry["value"]
+                    }
+                    _mfg_code = {
+                        'type': 'data',
+                        'encoding': 'u32',
+                        'value': entry["mfgCode"]
+                    }
+
+                    FACTORY_DATA.update({'st-v/{:x}/{:x}/{:x}'.format(int(ep), i, j): _value})
+                    FACTORY_DATA.update({'st-mfg/{:x}/{:x}/{:x}'.format(int(ep), i, j): _mfg_code})
 
 
 def gen_raw_ec_keypair_from_der(key_file, pubkey_raw_file, privkey_raw_file):
@@ -381,6 +468,9 @@ def get_args():
                         help=('128-bit unique identifier for generating rotating device identifier, '
                               'provide 32-byte hex string, e.g. "1234567890abcdef1234567890abcdef"'))
 
+    parser.add_argument('--supported-modes', type=str, nargs='+', required=False,
+                        help='List of supported modes, eg: mode1/label1/ep/"tagValue1\\mfgCode, tagValue2\\mfgCode"  mode2/label2/ep/"tagValue1\\mfgCode, tagValue2\\mfgCode"  mode3/label3/ep/"tagValue1\\mfgCode, tagValue2\\mfgCode"')
+
     parser.add_argument('-s', '--size', type=any_base_int, default=0x6000,
                         help='The size of the partition.bin, default: 0x6000')
     parser.add_argument('--target', default='esp32',
@@ -419,8 +509,7 @@ def set_up_factory_data(args):
 def generate_factory_partiton_binary(args):
     generate_nvs_csv(args.output_dir, FACTORY_PARTITION_CSV)
     if args.generate_bin:
-        csv_file = os.path.join(args.output_dir, FACTORY_PARTITION_CSV)
-        generate_nvs_bin(args.encrypt, args.size, csv_file, FACTORY_PARTITION_BIN, args.output_dir)
+        generate_nvs_bin(args.encrypt, args.size, FACTORY_PARTITION_CSV, FACTORY_PARTITION_BIN, args.output_dir)
         print_flashing_help(args.encrypt, args.output_dir, FACTORY_PARTITION_BIN)
     clean_up()
 


### PR DESCRIPTION
Reverts project-chip/connectedhomeip#34044

- Reason for revert

Actually, we thought of using common implementation and planned to remove this fixed attributes from the factory partition because of while OTA, we cannot update these attributes as factory partition can’t be change in OTA. in #34044

But later we thought of supporting this fixed attributes in the factory partition for backward compatibility along with SDKs common implementation which has static data.