### PR TITLE
RPC builds for fabric-admin: suppress compile warning, add RemoveSynchronizationDevice RPC call

### DIFF
--- a/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
+++ b/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
@@ -40,7 +40,10 @@ namespace {
 constexpr char kInteractiveModePrompt[]          = ">>> ";
 constexpr char kInteractiveModeHistoryFileName[] = "chip_tool_history";
 constexpr char kInteractiveModeStopCommand[]     = "quit()";
-constexpr uint16_t kRetryIntervalS               = 5;
+
+#if defined(PW_RPC_ENABLED)
+constexpr uint16_t kRetryIntervalS = 5;
+#endif
 
 // File pointer for the log file
 FILE * sLogFile = nullptr;

--- a/examples/fabric-admin/commands/pairing/PairingCommand.cpp
+++ b/examples/fabric-admin/commands/pairing/PairingCommand.cpp
@@ -543,7 +543,9 @@ void PairingCommand::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
         // print to console
         fprintf(stderr, "Device with Node ID: 0x%lx has been successfully removed.\n", nodeId);
 
-        // TODO: (#33973) Add RPC method RemoveSynchronizedDevice
+#if defined(PW_RPC_ENABLED)
+        RemoveSynchronizedDevice(nodeId);
+#endif
     }
     else
     {


### PR DESCRIPTION
1. Suppress warning when RPC is disabled when cross-compile for arm64
2. Enable RemoveSynchronizationDevice

