### PR TITLE
ESP32: Fix data copy in BLE HandleRxNotify()

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -1749,10 +1749,12 @@ void BLEManagerImpl::DriveBLEState(intptr_t arg)
 #ifdef CONFIG_ENABLE_ESP32_BLE_CONTROLLER
 CHIP_ERROR BLEManagerImpl::HandleRXNotify(struct ble_gap_event * ble_event)
 {
-    uint8_t * data                 = OS_MBUF_DATA(ble_event->notify_rx.om, uint8_t *);
     size_t dataLen                 = OS_MBUF_PKTLEN(ble_event->notify_rx.om);
-    System::PacketBufferHandle buf = System::PacketBufferHandle::NewWithData(data, dataLen);
+    System::PacketBufferHandle buf = System::PacketBufferHandle::New(dataLen, 0);
     VerifyOrReturnError(!buf.IsNull(), CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(buf->AvailableDataLength() >= data_len, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+    ble_hs_mbuf_to_flat(ble_event->notify_rx.om, buf->Start(), data_len, NULL);
+    buf->SetDataLength(data_len);
 
     ChipLogDetail(DeviceLayer, "Indication received, conn = %d", ble_event->notify_rx.conn_handle);
 


### PR DESCRIPTION
The data copy in `BLEManagerImpl::HandleRXNotify(struct ble_gap_event * ble_event)` in not right for ESP32 platform. We should use `ble_hs_mbuf_to_flat()`.
