### PR TITLE
Fix more random Darwin test failures due to timing dependency.

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRSwiftDeviceTests.swift
+++ b/src/darwin/Framework/CHIPTests/MTRSwiftDeviceTests.swift
@@ -92,6 +92,14 @@ class MTRSwiftDeviceTestDelegate : NSObject, MTRDeviceDelegate {
       return 2; // seconds
     }
 
+    @objc func unitTestSuppressTimeBasedReachabilityChanges(_ device : MTRDevice) -> Bool
+    {
+      // Allowing time-based reachability changes just makes the tests
+      // non-deterministic and can lead to random failures.  Suppress them
+      // unconditionally for now.  If we ever add tests that try to exercise that
+      // codepath, we can make this configurable.
+      return true;
+    }
 }
 
 class MTRSwiftDeviceTests : XCTestCase {


### PR DESCRIPTION
The fix in https://github.com/project-chip/connectedhomeip/pull/33761 only fixed the Objective-C version of the test.  The Swift version would still fail if it took longer than 10s to set up a subscription.
