### PR TITLE
Fix NXP Zephyr docker image.

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-63 : [NXP] Add docker image for Zephyr examples
+64 : [NXP] Add `--break-system-packages` to pip install

--- a/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
     && tar xvf zephyr-sdk-0.16.5_linux-x86_64_minimal.tar.xz \
     && rm -rf zephyr-sdk-0.16.5_linux-x86_64_minimal.tar.xz \
     && zephyr-sdk-0.16.5/setup.sh -t arm-zephyr-eabi \
-    && pip3 install -U --no-cache-dir west \
+    && pip3 install --break-system-packages -U --no-cache-dir west \
     && west init zephyrproject -m https://github.com/nxp-zephyr-ear/zephyr.git --mr zephyr_rw61x_v3.6_RFP \
     && cd zephyrproject/zephyr \
     && west update -o=--depth=1 -n \


### PR DESCRIPTION
Pip in newer ubunutu refuses system-wide installs. For now use a flag to allow breakage (even though separate virtualenv would be better)
