### PR TITLE
Clear data from MTRDevice's ClusterStateCache when elements are removed.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -93,6 +93,11 @@ public:
 
     chip::app::BufferedReadCallback & GetBufferedCallback() { return mBufferedReadAdapter; }
 
+    // Accessor for the cluster state cache, so that stale data can be cleared
+    // from it as needed.  The returned pointer must not be held long-term,
+    // because it can dangle if this callback object is destroyed.
+    chip::app::ClusterStateCache * GetClusterStateCache() { return mClusterStateCache.get(); }
+
     // We need to exist to get a ReadClient, so can't take this as a constructor argument.
     void AdoptReadClient(std::unique_ptr<chip::app::ReadClient> aReadClient) { mReadClient = std::move(aReadClient); }
     void AdoptClusterStateCache(std::unique_ptr<chip::app::ClusterStateCache> aClusterStateCache)

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -22,6 +22,7 @@
 #include <app/BufferedReadCallback.h>
 #include <app/ClusterStateCache.h>
 #include <app/ConcreteAttributePath.h>
+#include <app/ConcreteClusterPath.h>
 #include <app/EventHeader.h>
 #include <app/MessageDef/StatusIB.h>
 #include <app/ReadClient.h>
@@ -93,10 +94,11 @@ public:
 
     chip::app::BufferedReadCallback & GetBufferedCallback() { return mBufferedReadAdapter; }
 
-    // Accessor for the cluster state cache, so that stale data can be cleared
-    // from it as needed.  The returned pointer must not be held long-term,
-    // because it can dangle if this callback object is destroyed.
-    chip::app::ClusterStateCache * GetClusterStateCache() { return mClusterStateCache.get(); }
+    // Methods to clear state from our cluster state cache.  Must be called on
+    // the Matter queue.
+    void ClearCachedAttributeState(chip::EndpointId aEndpoint);
+    void ClearCachedAttributeState(const chip::app::ConcreteClusterPath & aCluster);
+    void ClearCachedAttributeState(const chip::app::ConcreteAttributePath & aAttribute);
 
     // We need to exist to get a ReadClient, so can't take this as a constructor argument.
     void AdoptReadClient(std::unique_ptr<chip::app::ReadClient> aReadClient) { mReadClient = std::move(aReadClient); }

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.mm
@@ -201,3 +201,27 @@ void MTRBaseSubscriptionCallback::ReportError(CHIP_ERROR aError, bool aCancelSub
         });
     }
 }
+
+void MTRBaseSubscriptionCallback::ClearCachedAttributeState(EndpointId aEndpoint)
+{
+    assertChipStackLockedByCurrentThread();
+    if (mClusterStateCache) {
+        mClusterStateCache->ClearAttributes(aEndpoint);
+    }
+}
+
+void MTRBaseSubscriptionCallback::ClearCachedAttributeState(const ConcreteClusterPath & aCluster)
+{
+    assertChipStackLockedByCurrentThread();
+    if (mClusterStateCache) {
+        mClusterStateCache->ClearAttributes(aCluster);
+    }
+}
+
+void MTRBaseSubscriptionCallback::ClearCachedAttributeState(const ConcreteAttributePath & aAttribute)
+{
+    assertChipStackLockedByCurrentThread();
+    if (mClusterStateCache) {
+        mClusterStateCache->ClearAttribute(aAttribute);
+    }
+}


### PR DESCRIPTION
The idea is for that cache to store DataVersions and cluster data sizes, so on resubscribe we send the right data along.  But ClusterStateCache itself never removes anything, so if we detect that an endpoint or cluster or attribute has been removed, we need to explicitly remove the relevant bits from the cache.

Not doing that can lead to incorrect (so less efficient) DataVersion sorting for the case when an attribute was removed, of to unnecessary DataVersions being included in a subscribe (and potentially preventing useful ones from being included) when a cluster or endpoint was removed.
