### PR TITLE
Do not force STDIO output for Linux example apps

### DIFF
--- a/config/nuttx/chip-gn/BUILD.gn
+++ b/config/nuttx/chip-gn/BUILD.gn
@@ -44,6 +44,7 @@ static_library("nuttx") {
     public_deps += [
       "${chip_root}/examples/lighting-app/lighting-common",
       "${chip_root}/examples/lighting-app/lighting-common:lighting-manager",
+      "${chip_root}/src/platform/logging:default",
     ]
   }
 

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -109,7 +109,7 @@ static_library("chip-tool-utils") {
     "${chip_root}/src/app/tests/suites/commands/interaction_model",
     "${chip_root}/src/controller/data_model",
     "${chip_root}/src/credentials:file_attestation_trust_store",
-    "${chip_root}/src/lib",
+    "${chip_root}/src/lib:without-logging",
     "${chip_root}/src/lib/core:types",
     "${chip_root}/src/lib/support/jsontlv",
     "${chip_root}/src/platform",

--- a/examples/common/tracing/BUILD.gn
+++ b/examples/common/tracing/BUILD.gn
@@ -94,7 +94,7 @@ source_set("trace_handlers_decoder") {
   public_configs = [ ":default_config" ]
 
   deps = [
-    "${chip_root}/src/lib",
+    "${chip_root}/src/lib:without-logging",
     "${chip_root}/src/lib/core:types",
   ]
   public_deps = [ "${chip_root}/third_party/jsoncpp" ]
@@ -120,11 +120,10 @@ executable("chip-trace-decoder") {
 
   output_dir = root_out_dir
 
-  deps = [ "${chip_root}/src/platform/logging:stdio" ]
-
-  public_deps = [
-    "${chip_root}/src/lib",
+  deps = [
+    "${chip_root}/src/lib:without-logging",
     "${chip_root}/src/lib/core:types",
+    "${chip_root}/src/platform/logging:stdio",
     "${chip_root}/third_party/jsoncpp",
   ]
 

--- a/examples/fabric-admin/BUILD.gn
+++ b/examples/fabric-admin/BUILD.gn
@@ -100,7 +100,7 @@ static_library("fabric-admin-utils") {
     "${chip_root}/src/app/tests/suites/commands/interaction_model",
     "${chip_root}/src/controller/data_model",
     "${chip_root}/src/credentials:file_attestation_trust_store",
-    "${chip_root}/src/lib",
+    "${chip_root}/src/lib:without-logging",
     "${chip_root}/src/lib/core:types",
     "${chip_root}/src/lib/support/jsontlv",
     "${chip_root}/src/platform",

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -79,7 +79,6 @@ source_set("app-main") {
     ":energy-reporting-test-event-trigger",
     ":smco-test-event-trigger",
     "${chip_root}/src/lib",
-    "${chip_root}/src/platform/logging:stdio",
   ]
   deps = [
     ":ota-test-event-trigger",

--- a/src/test_driver/linux-cirque/helper/CHIPTestBase.py
+++ b/src/test_driver/linux-cirque/helper/CHIPTestBase.py
@@ -143,9 +143,9 @@ class CHIPVirtualHome:
         for device_id in devices:
             # Wait for otbr-agent and CHIP server start
             self.assertTrue(self.wait_for_device_output(
-                device_id, "Thread Border Router started on AIL", 10))
+                device_id, ["Thread Border Router started on AIL"], 10))
             self.assertTrue(self.wait_for_device_output(
-                device_id, "[SVR] Server Listening...", 15))
+                device_id, ["SVR", "Server Listening..."], 15))
             # Clear default Thread network commissioning data
             self.logger.info("Resetting thread network on {}".format(
                 self.get_device_pretty_id(device_id)))
@@ -211,7 +211,7 @@ class CHIPVirtualHome:
         self.logger.info("Running commands to form default Thread network")
         for device in self.thread_devices:
             self.wait_for_device_output(
-                device['id'], "Border router agent started.", 5)
+                device['id'], ["Border router agent started."], 5)
 
         otInitCommands = [
             "ot-ctl thread stop",
@@ -282,10 +282,10 @@ class CHIPVirtualHome:
     def get_device_log(self, device_id):
         return self.query_api('device_log', [self.home_id, device_id], binary=True)
 
-    def wait_for_device_output(self, device_id, pattern, timeout=1):
+    def wait_for_device_output(self, device_id, patterns, timeout=1):
         due = time.time() + timeout
         while True:
-            if self.sequenceMatch(self.get_device_log(device_id).decode(), [pattern, ]):
+            if self.sequenceMatch(self.get_device_log(device_id).decode(), patterns):
                 return True
             if time.time() < due:
                 time.sleep(1)


### PR DESCRIPTION
### Problem

Example apps should be designed as real applications. Hence, they should integrate with platform logger instead of logging to stdio.

### Changes

- remove forced logging type from examples/platform, so logging can be selected per-app if required
- update cirque test script, so it will work with stdio and platform logging

### Testing

CI will verify potential build breaks.