### PR TITLE
[DRYERCTRL] Align description with spec

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -2731,8 +2731,8 @@ cluster OvenMode = 73 {
   command ChangeToMode(ChangeToModeRequest): ChangeToModeResponse = 0;
 }
 
-/** This cluster supports remotely monitoring and controling the different typs of
-            functionality available to a drying device, such as a laundry dryer. */
+/** This cluster provides a way to access options associated with the operation of
+            a laundry dryer device type. */
 cluster LaundryDryerControls = 74 {
   revision 1;
 

--- a/src/app/zap-templates/zcl/data-model/chip/laundry-dryer-controls-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/laundry-dryer-controls-cluster.xml
@@ -33,7 +33,8 @@ limitations under the License.
         <define>LAUNDRY_DRYER_CONTROLS_CLUSTER</define>
         <client init="false" tick="false">true</client>
         <server init="false" tick="false">true</server>
-        <description>This cluster provides a way to access options associated with the operation of a laundry dryer device type.</description>
+        <description>This cluster provides a way to access options associated with the operation of
+            a laundry dryer device type.</description>
 
         <globalAttribute side="either" code="0xFFFD" value="1" />
 

--- a/src/app/zap-templates/zcl/data-model/chip/laundry-dryer-controls-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/laundry-dryer-controls-cluster.xml
@@ -33,8 +33,7 @@ limitations under the License.
         <define>LAUNDRY_DRYER_CONTROLS_CLUSTER</define>
         <client init="false" tick="false">true</client>
         <server init="false" tick="false">true</server>
-        <description>This cluster supports remotely monitoring and controling the different typs of
-            functionality available to a drying device, such as a laundry dryer.</description>
+        <description>This cluster provides a way to access options associated with the operation of a laundry dryer device type.</description>
 
         <globalAttribute side="either" code="0xFFFD" value="1" />
 

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -2933,8 +2933,8 @@ cluster OvenMode = 73 {
   command ChangeToMode(ChangeToModeRequest): ChangeToModeResponse = 0;
 }
 
-/** This cluster supports remotely monitoring and controling the different typs of
-            functionality available to a drying device, such as a laundry dryer. */
+/** This cluster provides a way to access options associated with the operation of
+            a laundry dryer device type. */
 cluster LaundryDryerControls = 74 {
   revision 1;
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -4936,8 +4936,8 @@ MTR_PROVISIONALLY_AVAILABLE
 /**
  * Cluster Laundry Dryer Controls
  *
- * This cluster supports remotely monitoring and controling the different typs of
-            functionality available to a drying device, such as a laundry dryer.
+ * This cluster provides a way to access options associated with the operation of
+            a laundry dryer device type.
  */
 MTR_PROVISIONALLY_AVAILABLE
 @interface MTRBaseClusterLaundryDryerControls : MTRGenericBaseCluster

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -2301,8 +2301,8 @@ MTR_PROVISIONALLY_AVAILABLE
 
 /**
  * Cluster Laundry Dryer Controls
- *    This cluster supports remotely monitoring and controling the different typs of
-            functionality available to a drying device, such as a laundry dryer.
+ *    This cluster provides a way to access options associated with the operation of
+            a laundry dryer device type.
  */
 MTR_PROVISIONALLY_AVAILABLE
 @interface MTRClusterLaundryDryerControls : MTRGenericCluster


### PR DESCRIPTION
This PR aligns the cluster description with the spec.

Fixes #34217 