### PR TITLE
Reduce codesize for door locks a bit.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -3918,14 +3918,6 @@ void DoorLockServer::setAliroReaderConfigCommandHandler(CommandHandler * command
     EndpointId endpointID = commandPath.mEndpointId;
     ChipLogProgress(Zcl, "[SetAliroReaderConfig] Incoming command [endpointId=%d]", endpointID);
 
-    // If Aliro Provisioning feature is not supported, return UNSUPPORTED_COMMAND.
-    if (!SupportsAliroProvisioning(endpointID))
-    {
-        ChipLogProgress(Zcl, "[SetAliroReaderConfig] Aliro Provisioning is not supported [endpointId=%d]", endpointID);
-        commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
-        return;
-    }
-
     Delegate * delegate = GetDelegate(endpointID);
     if (!delegate)
     {
@@ -3988,10 +3980,7 @@ void DoorLockServer::setAliroReaderConfigCommandHandler(CommandHandler * command
         // Various attributes changed; mark them dirty.
         MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroReaderVerificationKey::Id);
         MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroReaderGroupIdentifier::Id);
-        if (supportsAliroBLEUWB)
-        {
-            MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroGroupResolvingKey::Id);
-        }
+        MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroGroupResolvingKey::Id);
     }
     sendClusterResponse(commandObj, commandPath, ClusterStatusCode(StatusIB(err).mStatus));
 }
@@ -4038,10 +4027,7 @@ void DoorLockServer::clearAliroReaderConfigCommandHandler(CommandHandler * comma
         // Various attributes changed; mark them dirty.
         MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroReaderVerificationKey::Id);
         MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroReaderGroupIdentifier::Id);
-        if (SupportsAliroBLEUWB(endpointID))
-        {
-            MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroGroupResolvingKey::Id);
-        }
+        MatterReportingAttributeChangeCallback(endpointID, Clusters::DoorLock::Id, AliroGroupResolvingKey::Id);
     }
     sendClusterResponse(commandObj, commandPath, ClusterStatusCode(StatusIB(err).mStatus));
 }
@@ -4203,8 +4189,7 @@ void DoorLockServer::DoorLockOnAutoRelockCallback(System::Layer *, void * callba
     }
 }
 
-CHIP_ERROR DoorLockServer::ReadAliroExpeditedTransactionSupportedProtocolVersions(const ConcreteReadAttributePath & aPath,
-                                                                                  AttributeValueEncoder & aEncoder,
+CHIP_ERROR DoorLockServer::ReadAliroExpeditedTransactionSupportedProtocolVersions(AttributeValueEncoder & aEncoder,
                                                                                   Delegate * delegate)
 {
     VerifyOrReturnValue(delegate != nullptr, aEncoder.EncodeEmptyList());
@@ -4225,8 +4210,7 @@ CHIP_ERROR DoorLockServer::ReadAliroExpeditedTransactionSupportedProtocolVersion
     });
 }
 
-CHIP_ERROR DoorLockServer::ReadAliroSupportedBLEUWBProtocolVersions(const ConcreteReadAttributePath & aPath,
-                                                                    AttributeValueEncoder & aEncoder, Delegate * delegate)
+CHIP_ERROR DoorLockServer::ReadAliroSupportedBLEUWBProtocolVersions(AttributeValueEncoder & aEncoder, Delegate * delegate)
 {
     VerifyOrReturnValue(delegate != nullptr, aEncoder.EncodeEmptyList());
 
@@ -4296,7 +4280,7 @@ CHIP_ERROR DoorLockServer::Read(const ConcreteReadAttributePath & aPath, Attribu
                                           AttributeNullabilityType::kNotNullable);
     }
     case AliroExpeditedTransactionSupportedProtocolVersions::Id: {
-        return ReadAliroExpeditedTransactionSupportedProtocolVersions(aPath, aEncoder, delegate);
+        return ReadAliroExpeditedTransactionSupportedProtocolVersions(aEncoder, delegate);
     }
     case AliroGroupResolvingKey::Id: {
         uint8_t buffer[kAliroGroupResolvingKeySize];
@@ -4305,7 +4289,7 @@ CHIP_ERROR DoorLockServer::Read(const ConcreteReadAttributePath & aPath, Attribu
                                           AttributeNullabilityType::kNullable);
     }
     case AliroSupportedBLEUWBProtocolVersions::Id: {
-        return ReadAliroSupportedBLEUWBProtocolVersions(aPath, aEncoder, delegate);
+        return ReadAliroSupportedBLEUWBProtocolVersions(aEncoder, delegate);
     }
     case AliroBLEAdvertisingVersion::Id: {
         uint8_t bleAdvertisingVersion = delegate->GetAliroBLEAdvertisingVersion();

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -576,29 +576,25 @@ private:
     /**
      * @brief Reads AliroExpeditedTransactionSupportedProtocolVersions attribute for door lock
      *
-     * @param aPath         attribute path.
      * @param aEncoder      attribute value encoder.
      * @param delegate      door lock cluster delegate that will provide the value
      *
      * @return CHIP_NO_ERROR  on success
      * @return CHIP_ERROR     if attribute read failed
      */
-    CHIP_ERROR ReadAliroExpeditedTransactionSupportedProtocolVersions(const chip::app::ConcreteReadAttributePath & aPath,
-                                                                      chip::app::AttributeValueEncoder & aEncoder,
+    CHIP_ERROR ReadAliroExpeditedTransactionSupportedProtocolVersions(chip::app::AttributeValueEncoder & aEncoder,
                                                                       chip::app::Clusters::DoorLock::Delegate * delegate);
 
     /**
      * @brief Reads AliroSupportedBLEUWBProtocolVersions attribute for door lock
      *
-     * @param aPath         attribute path.
      * @param aEncoder      attribute value encoder.
      * @param delegate      door lock cluster delegate that will provide the value
      *
      * @return CHIP_NO_ERROR  on success
      * @return CHIP_ERROR     if attribute read failed
      */
-    CHIP_ERROR ReadAliroSupportedBLEUWBProtocolVersions(const chip::app::ConcreteReadAttributePath & aPath,
-                                                        chip::app::AttributeValueEncoder & aEncoder,
+    CHIP_ERROR ReadAliroSupportedBLEUWBProtocolVersions(chip::app::AttributeValueEncoder & aEncoder,
                                                         chip::app::Clusters::DoorLock::Delegate * delegate);
 
     /**


### PR DESCRIPTION
* There is no need for SupportsAliroProvisioning checks in Aliro command handlers.  If we got into that code, that means that we recognized the command ID on the relevant endpoint's Door Lock cluster, and if we passed cert that means that we had the right feature map bit set too.

* There is no reason to do conditional MatterReportingAttributeChangeCallback for the AliroGroupResolvingKey attribute.  If we don't support the attribute, the call will just be a no-op.

* There's no reason to pass attribute paths to methods that do not use them.
