### PR TITLE
Fixed broken link

### DIFF
--- a/docs/getting_started/SDKBasics.md
+++ b/docs/getting_started/SDKBasics.md
@@ -58,7 +58,7 @@ logic is handled in the run-time installed interface layers.
 -   examples
     -   [examples/chip-tool](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool) -
         main controller example
-    -   [examples/all-clusters-app](https://github.com/project-chip/connectedhomeip/blob/master/examples/all-cluster-app) -
+    -   [examples/all-clusters-app](https://github.com/project-chip/connectedhomeip/blob/master/examples/all-clusters-app) -
         QA app
     -   [examples/\<others\>](https://github.com/project-chip/connectedhomeip/blob/master/examples) -
         Specific Device examples


### PR DESCRIPTION
link to examples/all-clusters-app was broken. Now it points to the correct location again
