### PR TITLE
Fix handle cleanup in CommandHandler.

### DIFF
--- a/src/app/CommandHandlerImpl.cpp
+++ b/src/app/CommandHandlerImpl.cpp
@@ -323,6 +323,7 @@ void CommandHandlerImpl::InvalidateHandles()
     {
         handle->Invalidate();
     }
+    mpHandleList.Clear();
 }
 
 void CommandHandlerImpl::IncrementHoldOff(Handle * apHandle)


### PR DESCRIPTION
When a CommandHandler went away, it invalidated its handles, but did not remove them from the list.  This would cause it to fail a fatal assert when the non-empty list was destroyed.

The fix is to clear the list once we have invalidated all the handles, since we no longer need to track them once they have been invalidated.
