### PR TITLE
Reduce codesize for door locks a bit more.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -3990,14 +3990,6 @@ void DoorLockServer::clearAliroReaderConfigCommandHandler(CommandHandler * comma
     EndpointId endpointID = commandPath.mEndpointId;
     ChipLogProgress(Zcl, "[ClearAliroReaderConfig] Incoming command [endpointId=%d]", endpointID);
 
-    // If Aliro Provisioning feature is not supported, return UNSUPPORTED_COMMAND.
-    if (!SupportsAliroProvisioning(endpointID))
-    {
-        ChipLogProgress(Zcl, "[ClearAliroReaderConfig] Aliro Provisioning is not supported [endpointId=%d]", endpointID);
-        commandObj->AddStatus(commandPath, Status::UnsupportedCommand);
-        return;
-    }
-
     Delegate * delegate = GetDelegate(endpointID);
     if (!delegate)
     {


### PR DESCRIPTION
There is no need for SupportsAliroProvisioning checks in Aliro command handlers. If we got into that code, that means that we recognized the command ID on the relevant endpoint's Door Lock cluster, and if we passed cert that means that we had the right feature map bit set too.
