### PR TITLE
Introduce a building block usable for all Q attributes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,14 +26,14 @@ on:
         run-codeql:
           required: false
           type: boolean
-    
+
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
-    
+
 jobs:
     build_linux_gcc_debug:
         name: Build on Linux (gcc_debug)
@@ -210,7 +210,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "./scripts/run-clang-tidy-on-compile-commands.py \
                        --compile-database out/sanitizers/compile_commands.json \
-                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|-ReadImpl|-InvokeSubscribeImpl|CodegenDataModel_Write' \
+                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|-ReadImpl|-InvokeSubscribeImpl|CodegenDataModel_Write|QuieterReporting' \
                        check \
                     "
             - name: Clean output
@@ -243,7 +243,7 @@ jobs:
               run: |
                   rm -rf ./zzz_pregenerated
                   mv scripts/codegen.py.renamed scripts/codegen.py
-                  mv scripts/tools/zap/generate.py.renamed scripts/tools/zap/generate.py 
+                  mv scripts/tools/zap/generate.py.renamed scripts/tools/zap/generate.py
             - name: Run fake linux tests with build_examples
               run: |
                   ./scripts/run_in_build_env.sh \
@@ -253,7 +253,7 @@ jobs:
               uses: ./.github/actions/perform-codeql-analysis
               with:
                 language: cpp
-        
+
             - name: Uploading core files
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}
@@ -445,7 +445,7 @@ jobs:
               uses: ./.github/actions/perform-codeql-analysis
               with:
                 language: cpp
-        
+
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
             # TODO https://github.com/project-chip/connectedhomeip/issues/1512
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -430,7 +430,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "./scripts/run-clang-tidy-on-compile-commands.py \
                        --compile-database out/default/compile_commands.json \
-                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|CodegenDataModel_Write' \
+                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|CodegenDataModel_Write|QuieterReporting' \
                        check \
                     "
             - name: Uploading diagnostic logs

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -51,6 +51,7 @@ if (chip_build_tests) {
     deps = []
     tests = [
       "${chip_root}/src/app/data-model/tests",
+      "${chip_root}/src/app/cluster-building-blocks/tests",
       "${chip_root}/src/app/data-model-interface/tests",
       "${chip_root}/src/access/tests",
       "${chip_root}/src/crypto/tests",

--- a/src/app/cluster-building-blocks/BUILD.gn
+++ b/src/app/cluster-building-blocks/BUILD.gn
@@ -19,6 +19,6 @@ source_set("cluster-building-blocks") {
   public_deps = [
     "${chip_root}/src/app/data-model:nullable",
     "${chip_root}/src/system",
-    "${chip_root}src//lib/support:support",
+    "${chip_root}/src/lib/support:support",
   ]
 }

--- a/src/app/cluster-building-blocks/BUILD.gn
+++ b/src/app/cluster-building-blocks/BUILD.gn
@@ -18,7 +18,7 @@ source_set("cluster-building-blocks") {
 
   public_deps = [
     "${chip_root}/src/app/data-model:nullable",
-    "${chip_root}/src/system",
     "${chip_root}/src/lib/support:support",
+    "${chip_root}/src/system",
   ]
 }

--- a/src/app/cluster-building-blocks/BUILD.gn
+++ b/src/app/cluster-building-blocks/BUILD.gn
@@ -1,0 +1,24 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import("//build_overrides/chip.gni")
+
+source_set("cluster-building-blocks") {
+  sources = [ "QuieterReporting.h" ]
+
+  public_deps = [
+    "${chip_root}/src/app/data-model:nullable",
+    "${chip_root}/src/system",
+    "${chip_root}src//lib/support:support",
+  ]
+}

--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -85,9 +85,7 @@ template <typename T>
 class QuieterReportingAttribute
 {
 public:
-    explicit QuieterReportingAttribute(const Nullable<T> & initialValue) :
-        mValue(initialValue), mLastDirtyValue(initialValue)
-    {}
+    explicit QuieterReportingAttribute(const Nullable<T> & initialValue) : mValue(initialValue), mLastDirtyValue(initialValue) {}
 
     using SufficientChangePredicate =
         std::function<bool(Timestamp /* previousDirtyTime */, Timestamp /* now */, const Nullable<T> & /* previousDirtyValue */,

--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -19,8 +19,8 @@
 #pragma once
 
 #include <functional>
-#include <type_traits>
 #include <stdbool.h>
+#include <type_traits>
 
 #include <app/data-model/Nullable.h>
 #include <lib/support/BitFlags.h>
@@ -43,7 +43,6 @@ namespace detail {
 using Timestamp = System::Clock::Milliseconds64;
 template <typename T>
 using Nullable = DataModel::Nullable<T>;
-
 
 /**
  * This class helps track reporting state of an attribute to properly keep track of whether
@@ -120,12 +119,12 @@ public:
         // New (`now`) timestamp passed in `SetValue()`.
         Timestamp nowTimestamp;
         // Value last marked as dirty.
-        const Nullable<T>& lastDirtyValue;
+        const Nullable<T> & lastDirtyValue;
         // New value passed in `SetValue()`, to compare against lastDirtyValue for sufficient change if needed.
-        const Nullable<T>& newValue;
+        const Nullable<T> & newValue;
     };
 
-    using SufficientChangePredicate = std::function<bool(const SufficientChangePredicateCandidate&)>;
+    using SufficientChangePredicate = std::function<bool(const SufficientChangePredicateCandidate &)>;
 
     /**
      * @brief Factory to generate a functor for "attribute was last reported" at least `minimumDurationMillis` ago.
@@ -136,8 +135,9 @@ public:
     static SufficientChangePredicate
     GetPredicateForSufficientTimeSinceLastDirty(System::Clock::Milliseconds64 minimumDurationMillis)
     {
-        return [minimumDurationMillis](const SufficientChangePredicateCandidate& candidate) -> bool {
-            return (candidate.lastDirtyValue != candidate.newValue) && ((candidate.nowTimestamp - candidate.lastDirtyTimestamp) >= minimumDurationMillis);
+        return [minimumDurationMillis](const SufficientChangePredicateCandidate & candidate) -> bool {
+            return (candidate.lastDirtyValue != candidate.newValue) &&
+                ((candidate.nowTimestamp - candidate.lastDirtyTimestamp) >= minimumDurationMillis);
         };
     }
 
@@ -199,10 +199,10 @@ public:
         mIsDirty = mIsDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnIncrement) && isIncrement);
 
         SufficientChangePredicateCandidate candidate{
-          mLastDirtyTimestampMillis, // lastDirtyTimestamp
-          now, // nowTimestamp
-          mLastDirtyValue, // lastDirtyValue
-          newValue // newValue
+            mLastDirtyTimestampMillis, // lastDirtyTimestamp
+            now,                       // nowTimestamp
+            mLastDirtyValue,           // lastDirtyValue
+            newValue                   // newValue
         };
         mIsDirty = mIsDirty || changedPredicate(candidate);
 
@@ -225,7 +225,7 @@ public:
      */
     void SetValue(const chip::app::DataModel::Nullable<T> & newValue, Timestamp now)
     {
-        SetValue(newValue, now, [](const SufficientChangePredicateCandidate&) -> bool { return false; });
+        SetValue(newValue, now, [](const SufficientChangePredicateCandidate &) -> bool { return false; });
     }
 
 protected:

--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -28,13 +28,6 @@
 namespace chip {
 namespace app {
 
-// - If it has changed due to a change in the CurrentPhase or OperationalState attributes, or
-// - When it changes from 0 to any other value and vice versa, or
-// - When it changes from null to any other value and vice versa, or
-// - When it increases, or
-// - When there is any increase or decrease in the estimated time remaining that was due to progressing insight of the server's control logic, or
-// - When it changes at a rate significantly different from one unit per second.
-
 enum class QuieterReportingPolicyEnum
 {
     kMarkDirtyOnChangeToFromZero = (1u << 0),
@@ -74,6 +67,15 @@ using Nullable = chip::app::DataModel::Nullable<T>;
  * - Call `GetThenResetDirtyState()`. If it returns true, mark the attribute dirty, with the
  *   method most suitable at the call site (e.g. `MatterReportingAttributeChangeCallback` call
  *   or similar methods).
+ *
+ * Example of situations that require dirty, which are possible to support with this class:
+ *
+ * - If attribute has changed due to a change in the X or Y attributes, or
+ * - When it changes from 0 to any other value and vice versa, or
+ * - When it changes from null to any other value and vice versa, or
+ * - When it increases, or
+ * - When there is any increase or decrease in the estimated time remaining that was due to progressing insight of the server's control logic, or
+ * - When it changes at a rate significantly different from one unit per second.
  *
  * @tparam T - the type of underlying numerical value that will be held by the class.
  */

--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -1,0 +1,194 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <stdbool.h>
+
+#include <lib/support/BitFlags.h>
+#include <app/data-model/Nullable.h>
+#include <system/SystemClock.h>
+
+namespace chip {
+namespace app {
+
+// - If it has changed due to a change in the CurrentPhase or OperationalState attributes, or
+// - When it changes from 0 to any other value and vice versa, or
+// - When it changes from null to any other value and vice versa, or
+// - When it increases, or
+// - When there is any increase or decrease in the estimated time remaining that was due to progressing insight of the server's control logic, or
+// - When it changes at a rate significantly different from one unit per second.
+
+enum class QuieterReportingPolicyEnum
+{
+    kMarkDirtyOnChangeToFromZero = (1u << 0),
+    kMarkDirtyOnDecrement = (1u << 1),
+    kMarkDirtyOnIncrement = (1u << 2),
+};
+
+using QuieterReportingPolicyFlags = ::chip::BitFlags<QuieterReportingPolicyEnum>;
+
+namespace detail {
+
+using Timestamp = chip::System::Clock::Milliseconds64;
+template <typename T>
+using Nullable = chip::app::DataModel::Nullable<T>;
+
+/**
+ * This class helps track reporting state of an attribute to properly keep track of whether
+ * it needs to be marked as dirty or not for purposes of reporting using Q quality.
+ *
+ * The class can be configured via `SetPolicy` to have some/all of the common reasons
+ * for reporting (e.g. increment only, decrement only, change to/from zero).
+ *
+ * Changes of null to non-null or non-null to null are always considered dirty.
+ *
+ * It is possible to force mark the attribute as dirty (see `ForceMarkAsDirty`) such as
+ * for conditions like "When there is any increase or decrease in the estimated time
+ * remaining that was due to progressing insight of the server's control logic".
+ *
+ * Usage is simple:
+ *
+ * - Call `SetValue()` with the new value and current monotonic system timestamp
+ *   - There is an overload with a `SufficientChangePredicate` which will apply externally
+ *     provided checks between old/new value and time last marked dirty to allow for complex
+ *     rules like marking dirty less than once per second, etc.
+ * - *Maybe* call `ForceMarkAsDirty()` in some choice situations (e.g. know for sure it's
+ *    an important update, like at the edge of an operational state change).
+ * - Call `GetThenResetDirtyState()`. If it returns true, mark the attribute dirty, with the
+ *   method most suitable at the call site (e.g. `MatterReportingAttributeChangeCallback` call
+ *   or similar methods).
+ *
+ * @tparam T - the type of underlying numerical value that will be held by the class.
+ */
+template <typename T>
+class QuieterReportingAttribute
+{
+  public:
+    explicit QuieterReportingAttribute(const chip::app::DataModel::Nullable<T>& initialValue) : mValue(initialValue), mLastDirtyValue(initialValue) {}
+
+    using SufficientChangePredicate = std::function<bool(Timestamp /* previousDirtyTime */, Timestamp /* now */, const Nullable<T> & /* previousDirtyValue */, const Nullable<T> & /* newValue */)>;
+
+    /**
+     * @brief Factory to generate a functor for "attribute was last reported" at least `minimumDurationMillis` ago.
+     *
+     * @param minimumDurationMillis - number of millis needed since last marked as dirty before we mark dirty again.
+     * @return a functor usable for the `changedPredicate` arg of `SetValue()`
+     */
+    static SufficientChangePredicate GetPredicateForSufficientTimeSinceLastDirty(chip::System::Clock::Milliseconds64 minimumDurationMillis)
+    {
+      return [minimumDurationMillis](Timestamp previousDirtyTime, Timestamp now, const Nullable<T> &oldDirtyValue, const Nullable<T> &newValue) -> bool {
+        return (oldDirtyValue != newValue) && ((now - previousDirtyTime) >= minimumDurationMillis);
+      };
+    }
+
+    chip::app::DataModel::Nullable<T> value() const { return mValue; }
+    QuieterReportingPolicyFlags policy() const { return mPolicyFlags; }
+
+    void SetPolicy(QuieterReportingPolicyFlags policyFlags) { mPolicyFlags = policyFlags; }
+
+    /**
+     * When this returns true, attribute should be marked for reporting. Auto-resets to false after call.
+     */
+    bool GetThenResetDirtyState()
+    {
+        bool wasDirty = mIsDirty;
+        mIsDirty = false;
+        return wasDirty;
+    }
+
+    /**
+     * Force marking this attribute as dirty, with the `now` timestamp given as the reference point.
+     *
+     * WARNING: Only call `ForceMarkAsDirty` after a `SetValue` call.
+     */
+    void ForceMarkAsDirty(Timestamp now)
+    {
+        mIsDirty = true;
+        mLastDirtyTimestampMillis = now;
+        mLastDirtyValue = mValue;
+    }
+
+    /**
+     * Set the updated value of the attribute, computing whether it needs to be reported according to `changedPredicate` and policies.
+     *
+     * - Any change of nullability between `newValue` and the old value will be considered dirty.
+     * - The policies from `QuieterReportingPolicyEnum` and set via `SetPolicy()` are self-explanatory by name.
+     * - The changedPredicate will be called with last dirty <timestamp, value> and new <timestamp value> and may override
+     *   the dirty state altogether when it returns true. Use sparingly and default to a functor returning false.
+     *
+     * Internal recording will be done about last dirty value and last dirty timestamp based on the policies having applied.
+     *
+     * @param newValue - new value to set for the attribute
+     * @param now - system monotonic timestamp at the time of the call
+     * @param changedPredicate - functor to possibly override dirty state
+     */
+    void SetValue(const chip::app::DataModel::Nullable<T>& newValue, Timestamp now, SufficientChangePredicate changedPredicate)
+    {
+        bool isChangeOfNull = newValue.IsNull() ^ mValue.IsNull();
+        bool areBothValuesNonNull = !newValue.IsNull() && !mValue.IsNull();
+
+        bool changeToFromZero = areBothValuesNonNull && (*newValue == 0 || *mValue == 0);
+        bool isIncrement = areBothValuesNonNull && (*newValue > *mValue);
+        bool isDecrement = areBothValuesNonNull && (*newValue < *mValue);
+
+        bool wasDirty = mIsDirty;
+
+        mIsDirty = mIsDirty || isChangeOfNull;
+        mIsDirty = mIsDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero) && changeToFromZero);
+        mIsDirty = mIsDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnDecrement) && isDecrement);
+        mIsDirty = mIsDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnIncrement) && isIncrement);
+        mIsDirty = mIsDirty || changedPredicate(mLastDirtyTimestampMillis, now, mLastDirtyValue, newValue);
+
+        mValue = newValue;
+
+        if (!wasDirty && mIsDirty)
+        {
+            mLastDirtyValue = newValue;
+            mLastDirtyTimestampMillis = now;
+        }
+    }
+
+    /**
+     * Same as the other `SetValue`, but assumes a changedPredicate that never overrides to dirty.
+     *
+     * This is the easy/common case.
+     *
+     * @param newValue - new value to set for the attribute
+     * @param now - system monotonic timestamp at the time of the call
+     */
+    void SetValue(const chip::app::DataModel::Nullable<T>& newValue, Timestamp now)
+    {
+        SetValue(newValue, now, [](Timestamp, Timestamp, const Nullable<T> &, const Nullable<T> &) -> bool { return false; });
+    }
+
+  protected:
+    chip::app::DataModel::Nullable<T> mValue;
+    chip::app::DataModel::Nullable<T> mLastDirtyValue;
+    bool mIsDirty = false;
+    QuieterReportingPolicyFlags mPolicyFlags{0};
+    chip::System::Clock::Milliseconds64 mLastDirtyTimestampMillis{};
+};
+
+} // namespace detail
+
+using detail::QuieterReportingAttribute;
+
+} // namespace app
+} // namespace chip

--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -39,7 +39,7 @@ enum class QuieterReportingPolicyEnum
 enum class AttributeDirtyState
 {
     kNoReportNeeded = 0,
-    kMustReport = 1,
+    kMustReport     = 1,
 };
 
 using QuieterReportingPolicyFlags = BitFlags<QuieterReportingPolicyEnum>;
@@ -169,9 +169,11 @@ public:
      * @param newValue - new value to set for the attribute
      * @param now - system monotonic timestamp at the time of the call
      * @param changedPredicate - functor to possibly override dirty state
-     * @return AttributeDirtyState::kMustReport if attribute must be marked dirty right away, or AttributeDirtyState::kNoReportNeeded otherwise.
+     * @return AttributeDirtyState::kMustReport if attribute must be marked dirty right away, or
+     * AttributeDirtyState::kNoReportNeeded otherwise.
      */
-    AttributeDirtyState SetValue(const chip::app::DataModel::Nullable<T> & newValue, Timestamp now, SufficientChangePredicate changedPredicate)
+    AttributeDirtyState SetValue(const chip::app::DataModel::Nullable<T> & newValue, Timestamp now,
+                                 SufficientChangePredicate changedPredicate)
     {
         bool isChangeOfNull       = newValue.IsNull() ^ mValue.IsNull();
         bool areBothValuesNonNull = !newValue.IsNull() && !mValue.IsNull();
@@ -181,7 +183,8 @@ public:
         bool isDecrement      = areBothValuesNonNull && (*newValue < *mValue);
 
         bool isNewlyDirty = isChangeOfNull;
-        isNewlyDirty = isNewlyDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero) && changeToFromZero);
+        isNewlyDirty =
+            isNewlyDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero) && changeToFromZero);
         isNewlyDirty = isNewlyDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnDecrement) && isDecrement);
         isNewlyDirty = isNewlyDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnIncrement) && isIncrement);
 
@@ -211,7 +214,8 @@ public:
      *
      * @param newValue - new value to set for the attribute
      * @param now - system monotonic timestamp at the time of the call
-     * @return AttributeDirtyState::kMustReport if attribute must be marked dirty right away, or AttributeDirtyState::kNoReportNeeded otherwise.
+     * @return AttributeDirtyState::kMustReport if attribute must be marked dirty right away, or
+     * AttributeDirtyState::kNoReportNeeded otherwise.
      */
     AttributeDirtyState SetValue(const chip::app::DataModel::Nullable<T> & newValue, Timestamp now)
     {

--- a/src/app/cluster-building-blocks/tests/BUILD.gn
+++ b/src/app/cluster-building-blocks/tests/BUILD.gn
@@ -1,0 +1,30 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "libAppClusterBuildingBlockTests"
+
+  test_sources = [ "TestQuieterReporting.cpp" ]
+
+  public_deps = [
+    "${chip_root}/src/app/cluster-building-blocks",
+    "${chip_root}/src/app/data-model:nullable",
+    "${chip_root}/src/lib/core:error",
+    "${chip_root}/src/lib/support/tests:pw-test-macros",
+    "${chip_root}/src/system",
+  ]
+}

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -1,0 +1,306 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/cluster-building-blocks/QuieterReporting.h>
+
+#include <limits.h>
+
+#include <app/data-model/Nullable.h>
+#include <lib/core/CHIPError.h>
+#include <system/SystemClock.h>
+
+#include <gtest/gtest.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::DataModel;
+using namespace chip::System::Clock;
+using namespace chip::System::Clock::Literals;
+
+class FakeClock
+{
+  public:
+    FakeClock() = default;
+
+    Timestamp Advance(Milliseconds64 numMillis)
+    {
+        mCurrentTimestamp += numMillis;
+        return mCurrentTimestamp;
+    }
+
+    void SetMonotonic(Timestamp now)
+    {
+        mCurrentTimestamp = now;
+    }
+
+    Timestamp now() const
+    {
+      return mCurrentTimestamp;
+    }
+
+  private:
+    Timestamp mCurrentTimestamp{};
+};
+
+TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
+{
+    FakeClock fakeClock;
+    fakeClock.SetMonotonic(100_ms);
+
+    QuieterReportingAttribute<int> attribute{MakeNullable<int>(10)};
+    // Always start not dirty (because first sub priming always just read value anyway).
+    ASSERT_FALSE(attribute.GetThenResetDirtyState());
+
+    EXPECT_FALSE(attribute.value().IsNull());
+    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{});
+
+    auto now = fakeClock.now();
+
+    attribute.SetPolicy(QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero});
+    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero});
+
+    // 10 --> 11, expect not marked dirty yet.
+    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    // 11 --> 0, expect marked dirty.
+    attribute.SetValue(0, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // 0 --> 11, expect marked dirty.
+    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // 11 --> 12, expect not marked dirty.
+    attribute.SetValue(12, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    // Reset policy, expect 12 --> 0 does not mark dirty due to no longer having the policy that causes it.
+    attribute.SetPolicy(QuieterReportingPolicyFlags{});
+    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{});
+
+    attribute.SetValue(0, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+}
+
+TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
+{
+    FakeClock fakeClock;
+    fakeClock.SetMonotonic(100_ms);
+
+    QuieterReportingAttribute<int> attribute{MakeNullable<int>(10)};
+
+    // Always start not dirty (because first sub priming always just read value anyway).
+    ASSERT_FALSE(attribute.GetThenResetDirtyState());
+    ASSERT_EQ(*attribute.value(), 10);
+
+    auto now = fakeClock.now();
+
+    attribute.SetPolicy(QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnIncrement});
+    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnIncrement});
+
+    // 10 --> 9, expect not marked dirty yet.
+    attribute.SetValue(9, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 9);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    // 9 --> 10, expect marked dirty.
+    attribute.SetValue(10, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // 10 --> 11, expect marked dirty.
+    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // 11 --> 11, expect marked not dirty.
+    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    // 11 --> null, expect marked dirty (null change always marks dirty)
+    attribute.SetValue(NullNullable, now);
+    EXPECT_TRUE(attribute.value().IsNull());
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // null --> null, not dirty (no change)
+    attribute.SetValue(NullNullable, now);
+    EXPECT_TRUE(attribute.value().IsNull());
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    // null --> 11, expect marked dirty (null change always marks dirty).
+    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // Reset policy, expect 11 --> 12 does not mark dirty due to no longer having the policy that causes it.
+    attribute.SetPolicy(QuieterReportingPolicyFlags{});
+    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{});
+
+    attribute.SetValue(12, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+}
+
+TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
+{
+    FakeClock fakeClock;
+    fakeClock.SetMonotonic(100_ms);
+
+    QuieterReportingAttribute<int> attribute{MakeNullable<int>(9)};
+
+    // Always start not dirty (because first sub priming always just read value anyway).
+    ASSERT_FALSE(attribute.GetThenResetDirtyState());
+    ASSERT_EQ(*attribute.value(), 9);
+
+    auto now = fakeClock.now();
+
+    attribute.SetPolicy(QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnDecrement});
+    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnDecrement});
+
+    // 9 --> 10, expect not marked dirty yet.
+    attribute.SetValue(10, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    // 10 --> 9, expect marked dirty.
+    attribute.SetValue(9, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 9);
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // 9 --> 8, expect marked dirty.
+    attribute.SetValue(8, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 8);
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // Second call in a row always false.
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    // 8 --> 8, expect not marked dirty.
+    attribute.SetValue(8, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 8);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    // 8 --> null, expect marked dirty (null change always marks dirty)
+    attribute.SetValue(NullNullable, now);
+    EXPECT_TRUE(attribute.value().IsNull());
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // null --> null, not dirty (no change)
+    attribute.SetValue(NullNullable, now);
+    EXPECT_TRUE(attribute.value().IsNull());
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    // null --> 11, expect marked dirty (null change always marks dirty).
+    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // Reset policy, expect 11 --> 10 does not mark dirty due to no longer having the policy that causes it.
+    attribute.SetPolicy(QuieterReportingPolicyFlags{});
+    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{});
+
+    attribute.SetValue(10, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+}
+
+TEST(TestQuieterReporting, SufficientChangePredicateWorks)
+{
+    FakeClock fakeClock;
+    fakeClock.SetMonotonic(100_ms);
+
+    QuieterReportingAttribute<int> attribute{MakeNullable<int>(9)};
+
+    // Always start not dirty (because first sub priming always just read value anyway).
+    ASSERT_FALSE(attribute.GetThenResetDirtyState());
+    ASSERT_EQ(*attribute.value(), 9);
+
+    auto now = fakeClock.now();
+
+    attribute.SetValue(10, now);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    attribute.ForceMarkAsDirty(now);
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    auto predicate = attribute.GetPredicateForSufficientTimeSinceLastDirty(1000_ms);
+
+    now = fakeClock.Advance(100_ms);
+
+    // Last dirty value is 10. This won't mark dirty again due to predicate mismatch.
+    attribute.SetValue(11, now, predicate);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    now = fakeClock.Advance(900_ms);
+    // Last dirty value is 10 still. This will mark dirty because both enough time has passed
+    // and value is different from the last dirty value.
+    attribute.SetValue(11, now, predicate);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // Last dirty value is 11. Since there has not been a value change, no amount of time will
+    // mark dirty.
+    now = fakeClock.Advance(1000_ms);
+    attribute.SetValue(11, now, predicate);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    now = fakeClock.Advance(1000_ms);
+    attribute.SetValue(11, now, predicate);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    // Change the value to a value that marks dirty.
+    now = fakeClock.Advance(1_ms);
+    attribute.SetValue(11, now, predicate);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // Wait a small delay and change again. Will not mark dirty due to too little time.
+    now = fakeClock.Advance(1_ms);
+    attribute.SetValue(12, now, predicate);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    now = fakeClock.Advance(1_ms);
+    attribute.SetValue(13, now, predicate);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 13);
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+
+    // Change to a value that marks dirty no matter what (e.g. null). Should be dirty even
+    // before delay.
+    now = fakeClock.Advance(1_ms);
+    attribute.SetValue(NullNullable, now, predicate);
+    EXPECT_TRUE(attribute.value().IsNull());
+    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+
+    // Null --> Null should not lead to dirty.
+    now = fakeClock.Advance(1000_ms);
+    attribute.SetValue(NullNullable, now, predicate);
+    EXPECT_TRUE(attribute.value().IsNull());
+    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+}

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -65,8 +65,8 @@ TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
 
     auto now = fakeClock.now();
 
-    attribute.SetPolicy(QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero });
-    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero });
+    attribute.policy().Set(QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero);
+    EXPECT_TRUE(attribute.policy().HasOnly(QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero));
 
     // 10 --> 11, expect not marked dirty yet.
     attribute.SetValue(11, now);
@@ -89,8 +89,8 @@ TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
     EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // Reset policy, expect 12 --> 0 does not mark dirty due to no longer having the policy that causes it.
-    attribute.SetPolicy(QuieterReportingPolicyFlags{});
-    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{});
+    attribute.policy().ClearAll();
+    EXPECT_FALSE(attribute.policy().HasAny());
 
     attribute.SetValue(0, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
@@ -110,8 +110,8 @@ TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
 
     auto now = fakeClock.now();
 
-    attribute.SetPolicy(QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnIncrement });
-    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnIncrement });
+    attribute.policy().Set(QuieterReportingPolicyEnum::kMarkDirtyOnIncrement);
+    EXPECT_TRUE(attribute.policy().HasOnly(QuieterReportingPolicyEnum::kMarkDirtyOnIncrement));
 
     // 10 --> 9, expect not marked dirty yet.
     attribute.SetValue(9, now);
@@ -149,8 +149,8 @@ TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
     EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Reset policy, expect 11 --> 12 does not mark dirty due to no longer having the policy that causes it.
-    attribute.SetPolicy(QuieterReportingPolicyFlags{});
-    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{});
+    attribute.policy().ClearAll();
+    EXPECT_FALSE(attribute.policy().HasAny());
 
     attribute.SetValue(12, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
@@ -170,8 +170,8 @@ TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
 
     auto now = fakeClock.now();
 
-    attribute.SetPolicy(QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnDecrement });
-    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnDecrement });
+    attribute.policy().Set(QuieterReportingPolicyEnum::kMarkDirtyOnDecrement);
+    EXPECT_TRUE(attribute.policy().HasOnly(QuieterReportingPolicyEnum::kMarkDirtyOnDecrement));
 
     // 9 --> 10, expect not marked dirty yet.
     attribute.SetValue(10, now);
@@ -212,8 +212,8 @@ TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
     EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Reset policy, expect 11 --> 10 does not mark dirty due to no longer having the policy that causes it.
-    attribute.SetPolicy(QuieterReportingPolicyFlags{});
-    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{});
+    attribute.policy().ClearAll();
+    EXPECT_FALSE(attribute.policy().HasAny());
 
     attribute.SetValue(10, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -57,9 +57,6 @@ TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
     fakeClock.SetMonotonic(100_ms);
 
     QuieterReportingAttribute<int> attribute{ MakeNullable<int>(10) };
-    // Always start not dirty (because first sub priming always just read value anyway).
-    ASSERT_FALSE(attribute.WasJustMarkedDirty());
-
     EXPECT_FALSE(attribute.value().IsNull());
     EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{});
 
@@ -69,32 +66,27 @@ TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
     EXPECT_TRUE(attribute.policy().HasOnly(QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero));
 
     // 10 --> 11, expect not marked dirty yet.
-    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 11 --> 0, expect marked dirty.
-    attribute.SetValue(0, now);
+    EXPECT_EQ(attribute.SetValue(0, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // 0 --> 11, expect marked dirty.
-    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // 11 --> 12, expect not marked dirty.
-    attribute.SetValue(12, now);
+    EXPECT_EQ(attribute.SetValue(12, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // Reset policy, expect 12 --> 0 does not mark dirty due to no longer having the policy that causes it.
     attribute.policy().ClearAll();
     EXPECT_FALSE(attribute.policy().HasAny());
 
-    attribute.SetValue(0, now);
+    EXPECT_EQ(attribute.SetValue(0, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 }
 
 TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
@@ -105,7 +97,6 @@ TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
     QuieterReportingAttribute<int> attribute{ MakeNullable<int>(10) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
-    ASSERT_FALSE(attribute.WasJustMarkedDirty());
     ASSERT_EQ(*attribute.value(), 10);
 
     auto now = fakeClock.now();
@@ -114,47 +105,39 @@ TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
     EXPECT_TRUE(attribute.policy().HasOnly(QuieterReportingPolicyEnum::kMarkDirtyOnIncrement));
 
     // 10 --> 9, expect not marked dirty yet.
-    attribute.SetValue(9, now);
+    EXPECT_EQ(attribute.SetValue(9, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 9);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 9 --> 10, expect marked dirty.
-    attribute.SetValue(10, now);
+    EXPECT_EQ(attribute.SetValue(10, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // 10 --> 11, expect marked dirty.
-    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // 11 --> 11, expect marked not dirty.
-    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 11 --> null, expect marked dirty (null change always marks dirty)
-    attribute.SetValue(NullNullable, now);
+    EXPECT_EQ(attribute.SetValue(NullNullable, now), AttributeDirtyState::kMustReport);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // null --> null, not dirty (no change)
-    attribute.SetValue(NullNullable, now);
+    EXPECT_EQ(attribute.SetValue(NullNullable, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // null --> 11, expect marked dirty (null change always marks dirty).
-    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Reset policy, expect 11 --> 12 does not mark dirty due to no longer having the policy that causes it.
     attribute.policy().ClearAll();
     EXPECT_FALSE(attribute.policy().HasAny());
 
-    attribute.SetValue(12, now);
+    EXPECT_EQ(attribute.SetValue(12, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 }
 
 TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
@@ -165,7 +148,6 @@ TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
     QuieterReportingAttribute<int> attribute{ MakeNullable<int>(9) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
-    ASSERT_FALSE(attribute.WasJustMarkedDirty());
     ASSERT_EQ(*attribute.value(), 9);
 
     auto now = fakeClock.now();
@@ -174,50 +156,41 @@ TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
     EXPECT_TRUE(attribute.policy().HasOnly(QuieterReportingPolicyEnum::kMarkDirtyOnDecrement));
 
     // 9 --> 10, expect not marked dirty yet.
-    attribute.SetValue(10, now);
+    EXPECT_EQ(attribute.SetValue(10, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 10 --> 9, expect marked dirty.
-    attribute.SetValue(9, now);
+    EXPECT_EQ(attribute.SetValue(9, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 9);
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // 9 --> 8, expect marked dirty.
-    attribute.SetValue(8, now);
+    EXPECT_EQ(attribute.SetValue(8, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 8);
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Second call in a row always false.
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 8 --> 8, expect not marked dirty.
-    attribute.SetValue(8, now);
+    EXPECT_EQ(attribute.SetValue(8, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 8);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 8 --> null, expect marked dirty (null change always marks dirty)
-    attribute.SetValue(NullNullable, now);
+    EXPECT_EQ(attribute.SetValue(NullNullable, now), AttributeDirtyState::kMustReport);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // null --> null, not dirty (no change)
-    attribute.SetValue(NullNullable, now);
+    EXPECT_EQ(attribute.SetValue(NullNullable, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // null --> 11, expect marked dirty (null change always marks dirty).
-    attribute.SetValue(11, now);
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Reset policy, expect 11 --> 10 does not mark dirty due to no longer having the policy that causes it.
     attribute.policy().ClearAll();
     EXPECT_FALSE(attribute.policy().HasAny());
 
-    attribute.SetValue(10, now);
+    EXPECT_EQ(attribute.SetValue(10, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 }
 
 TEST(TestQuieterReporting, SufficientChangePredicateWorks)
@@ -228,73 +201,62 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     QuieterReportingAttribute<int> attribute{ MakeNullable<int>(9) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
-    ASSERT_FALSE(attribute.WasJustMarkedDirty());
     ASSERT_EQ(*attribute.value(), 9);
 
     auto now = fakeClock.now();
 
-    attribute.SetValue(10, now);
+    EXPECT_EQ(attribute.SetValue(10, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
-    attribute.ForceDirty(now);
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
+    // Forcing dirty can be done with a force-true predicate
+    EXPECT_EQ(attribute.SetValue(10, now, attribute.GetForceReportablePredicate()), AttributeDirtyState::kMustReport);
 
     auto predicate = attribute.GetPredicateForSufficientTimeSinceLastDirty(1000_ms);
 
     now = fakeClock.Advance(100_ms);
 
     // Last dirty value is 10. This won't mark dirty again due to predicate mismatch.
-    attribute.SetValue(11, now, predicate);
+    EXPECT_EQ(attribute.SetValue(11, now, predicate), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     now = fakeClock.Advance(900_ms);
     // Last dirty value is 10 still. This will mark dirty because both enough time has passed
     // and value is different from the last dirty value.
-    attribute.SetValue(11, now, predicate);
+    EXPECT_EQ(attribute.SetValue(11, now, predicate), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Last dirty value is 11. Since there has not been a value change, no amount of time will
     // mark dirty.
     now = fakeClock.Advance(1000_ms);
-    attribute.SetValue(11, now, predicate);
+    EXPECT_EQ(attribute.SetValue(11, now, predicate), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     now = fakeClock.Advance(1000_ms);
-    attribute.SetValue(11, now, predicate);
+    EXPECT_EQ(attribute.SetValue(11, now, predicate), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // Change the value to a value that marks dirty.
     now = fakeClock.Advance(1_ms);
-    attribute.SetValue(12, now, predicate);
+    EXPECT_EQ(attribute.SetValue(12, now, predicate), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Wait a small delay and change again. Will not mark dirty due to too little time.
     now = fakeClock.Advance(1_ms);
-    attribute.SetValue(13, now, predicate);
+    EXPECT_EQ(attribute.SetValue(13, now, predicate), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 13);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     now = fakeClock.Advance(1_ms);
-    attribute.SetValue(14, now, predicate);
+    EXPECT_EQ(attribute.SetValue(14, now, predicate), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 14);
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // Change to a value that marks dirty no matter what (e.g. null). Should be dirty even
     // before delay.
     now = fakeClock.Advance(1_ms);
-    attribute.SetValue(NullNullable, now, predicate);
+    EXPECT_EQ(attribute.SetValue(NullNullable, now, predicate), AttributeDirtyState::kMustReport);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Null --> Null should not lead to dirty.
     now = fakeClock.Advance(1000_ms);
-    attribute.SetValue(NullNullable, now, predicate);
+    EXPECT_EQ(attribute.SetValue(NullNullable, now, predicate), AttributeDirtyState::kNoReportNeeded);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 }

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -58,7 +58,7 @@ TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
 
     QuieterReportingAttribute<int> attribute{ MakeNullable<int>(10) };
     // Always start not dirty (because first sub priming always just read value anyway).
-    ASSERT_FALSE(attribute.GetThenResetDirtyState());
+    ASSERT_FALSE(attribute.WasJustMarkedDirty());
 
     EXPECT_FALSE(attribute.value().IsNull());
     EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{});
@@ -71,22 +71,22 @@ TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
     // 10 --> 11, expect not marked dirty yet.
     attribute.SetValue(11, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 11 --> 0, expect marked dirty.
     attribute.SetValue(0, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // 0 --> 11, expect marked dirty.
     attribute.SetValue(11, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // 11 --> 12, expect not marked dirty.
     attribute.SetValue(12, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // Reset policy, expect 12 --> 0 does not mark dirty due to no longer having the policy that causes it.
     attribute.SetPolicy(QuieterReportingPolicyFlags{});
@@ -94,7 +94,7 @@ TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
 
     attribute.SetValue(0, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 }
 
 TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
@@ -105,7 +105,7 @@ TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
     QuieterReportingAttribute<int> attribute{ MakeNullable<int>(10) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
-    ASSERT_FALSE(attribute.GetThenResetDirtyState());
+    ASSERT_FALSE(attribute.WasJustMarkedDirty());
     ASSERT_EQ(*attribute.value(), 10);
 
     auto now = fakeClock.now();
@@ -116,37 +116,37 @@ TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
     // 10 --> 9, expect not marked dirty yet.
     attribute.SetValue(9, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 9);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 9 --> 10, expect marked dirty.
     attribute.SetValue(10, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // 10 --> 11, expect marked dirty.
     attribute.SetValue(11, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // 11 --> 11, expect marked not dirty.
     attribute.SetValue(11, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 11 --> null, expect marked dirty (null change always marks dirty)
     attribute.SetValue(NullNullable, now);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // null --> null, not dirty (no change)
     attribute.SetValue(NullNullable, now);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // null --> 11, expect marked dirty (null change always marks dirty).
     attribute.SetValue(11, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Reset policy, expect 11 --> 12 does not mark dirty due to no longer having the policy that causes it.
     attribute.SetPolicy(QuieterReportingPolicyFlags{});
@@ -154,7 +154,7 @@ TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
 
     attribute.SetValue(12, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 }
 
 TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
@@ -165,7 +165,7 @@ TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
     QuieterReportingAttribute<int> attribute{ MakeNullable<int>(9) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
-    ASSERT_FALSE(attribute.GetThenResetDirtyState());
+    ASSERT_FALSE(attribute.WasJustMarkedDirty());
     ASSERT_EQ(*attribute.value(), 9);
 
     auto now = fakeClock.now();
@@ -176,40 +176,40 @@ TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
     // 9 --> 10, expect not marked dirty yet.
     attribute.SetValue(10, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 10 --> 9, expect marked dirty.
     attribute.SetValue(9, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 9);
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // 9 --> 8, expect marked dirty.
     attribute.SetValue(8, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 8);
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Second call in a row always false.
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 8 --> 8, expect not marked dirty.
     attribute.SetValue(8, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 8);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // 8 --> null, expect marked dirty (null change always marks dirty)
     attribute.SetValue(NullNullable, now);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // null --> null, not dirty (no change)
     attribute.SetValue(NullNullable, now);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // null --> 11, expect marked dirty (null change always marks dirty).
     attribute.SetValue(11, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Reset policy, expect 11 --> 10 does not mark dirty due to no longer having the policy that causes it.
     attribute.SetPolicy(QuieterReportingPolicyFlags{});
@@ -217,7 +217,7 @@ TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
 
     attribute.SetValue(10, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 }
 
 TEST(TestQuieterReporting, SufficientChangePredicateWorks)
@@ -228,17 +228,17 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     QuieterReportingAttribute<int> attribute{ MakeNullable<int>(9) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
-    ASSERT_FALSE(attribute.GetThenResetDirtyState());
+    ASSERT_FALSE(attribute.WasJustMarkedDirty());
     ASSERT_EQ(*attribute.value(), 9);
 
     auto now = fakeClock.now();
 
     attribute.SetValue(10, now);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
-    attribute.ForceMarkAsDirty(now);
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    attribute.ForceDirty(now);
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     auto predicate = attribute.GetPredicateForSufficientTimeSinceLastDirty(1000_ms);
 
@@ -247,54 +247,54 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     // Last dirty value is 10. This won't mark dirty again due to predicate mismatch.
     attribute.SetValue(11, now, predicate);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     now = fakeClock.Advance(900_ms);
     // Last dirty value is 10 still. This will mark dirty because both enough time has passed
     // and value is different from the last dirty value.
     attribute.SetValue(11, now, predicate);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Last dirty value is 11. Since there has not been a value change, no amount of time will
     // mark dirty.
     now = fakeClock.Advance(1000_ms);
     attribute.SetValue(11, now, predicate);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     now = fakeClock.Advance(1000_ms);
     attribute.SetValue(11, now, predicate);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // Change the value to a value that marks dirty.
     now = fakeClock.Advance(1_ms);
-    attribute.SetValue(11, now, predicate);
-    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    attribute.SetValue(12, now, predicate);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Wait a small delay and change again. Will not mark dirty due to too little time.
     now = fakeClock.Advance(1_ms);
-    attribute.SetValue(12, now, predicate);
-    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
-
-    now = fakeClock.Advance(1_ms);
     attribute.SetValue(13, now, predicate);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 13);
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
+
+    now = fakeClock.Advance(1_ms);
+    attribute.SetValue(14, now, predicate);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 14);
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 
     // Change to a value that marks dirty no matter what (e.g. null). Should be dirty even
     // before delay.
     now = fakeClock.Advance(1_ms);
     attribute.SetValue(NullNullable, now, predicate);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_TRUE(attribute.GetThenResetDirtyState());
+    EXPECT_TRUE(attribute.WasJustMarkedDirty());
 
     // Null --> Null should not lead to dirty.
     now = fakeClock.Advance(1000_ms);
     attribute.SetValue(NullNullable, now, predicate);
     EXPECT_TRUE(attribute.value().IsNull());
-    EXPECT_FALSE(attribute.GetThenResetDirtyState());
+    EXPECT_FALSE(attribute.WasJustMarkedDirty());
 }

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -34,7 +34,7 @@ using namespace chip::System::Clock::Literals;
 
 class FakeClock
 {
-  public:
+public:
     FakeClock() = default;
 
     Timestamp Advance(Milliseconds64 numMillis)
@@ -43,17 +43,11 @@ class FakeClock
         return mCurrentTimestamp;
     }
 
-    void SetMonotonic(Timestamp now)
-    {
-        mCurrentTimestamp = now;
-    }
+    void SetMonotonic(Timestamp now) { mCurrentTimestamp = now; }
 
-    Timestamp now() const
-    {
-      return mCurrentTimestamp;
-    }
+    Timestamp now() const { return mCurrentTimestamp; }
 
-  private:
+private:
     Timestamp mCurrentTimestamp{};
 };
 
@@ -62,7 +56,7 @@ TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
     FakeClock fakeClock;
     fakeClock.SetMonotonic(100_ms);
 
-    QuieterReportingAttribute<int> attribute{MakeNullable<int>(10)};
+    QuieterReportingAttribute<int> attribute{ MakeNullable<int>(10) };
     // Always start not dirty (because first sub priming always just read value anyway).
     ASSERT_FALSE(attribute.GetThenResetDirtyState());
 
@@ -71,8 +65,8 @@ TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
 
     auto now = fakeClock.now();
 
-    attribute.SetPolicy(QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero});
-    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero});
+    attribute.SetPolicy(QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero });
+    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero });
 
     // 10 --> 11, expect not marked dirty yet.
     attribute.SetValue(11, now);
@@ -108,7 +102,7 @@ TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
     FakeClock fakeClock;
     fakeClock.SetMonotonic(100_ms);
 
-    QuieterReportingAttribute<int> attribute{MakeNullable<int>(10)};
+    QuieterReportingAttribute<int> attribute{ MakeNullable<int>(10) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
     ASSERT_FALSE(attribute.GetThenResetDirtyState());
@@ -116,8 +110,8 @@ TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
 
     auto now = fakeClock.now();
 
-    attribute.SetPolicy(QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnIncrement});
-    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnIncrement});
+    attribute.SetPolicy(QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnIncrement });
+    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnIncrement });
 
     // 10 --> 9, expect not marked dirty yet.
     attribute.SetValue(9, now);
@@ -168,7 +162,7 @@ TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
     FakeClock fakeClock;
     fakeClock.SetMonotonic(100_ms);
 
-    QuieterReportingAttribute<int> attribute{MakeNullable<int>(9)};
+    QuieterReportingAttribute<int> attribute{ MakeNullable<int>(9) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
     ASSERT_FALSE(attribute.GetThenResetDirtyState());
@@ -176,8 +170,8 @@ TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
 
     auto now = fakeClock.now();
 
-    attribute.SetPolicy(QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnDecrement});
-    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{QuieterReportingPolicyEnum::kMarkDirtyOnDecrement});
+    attribute.SetPolicy(QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnDecrement });
+    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{ QuieterReportingPolicyEnum::kMarkDirtyOnDecrement });
 
     // 9 --> 10, expect not marked dirty yet.
     attribute.SetValue(10, now);
@@ -231,7 +225,7 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     FakeClock fakeClock;
     fakeClock.SetMonotonic(100_ms);
 
-    QuieterReportingAttribute<int> attribute{MakeNullable<int>(9)};
+    QuieterReportingAttribute<int> attribute{ MakeNullable<int>(9) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
     ASSERT_FALSE(attribute.GetThenResetDirtyState());


### PR DESCRIPTION
- Q quality requires marking attributes as dirty for the purposes of reporting only when certain conditions arise.
- This PR introduces a building block attribute value wrapper compatible with any nullable or non-nullable numerical attribute, which allows applying the necessary policies, and all complex policies that currently exist in the Matter spec (e.g. any CountdownTime, CurrentLevel, etc).

Testing done:

- Added unit tests. Integration in existing clusters will follow in a different PR.
