### PR TITLE
[Silabs] [917SoC] Fixing sleepy with non LCD build fix

### DIFF
--- a/src/platform/silabs/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.cpp
@@ -164,15 +164,9 @@ void KeyValueStoreManagerImpl::ScheduleKeyMapSave(void)
         During commissioning, the key map will be modified multiples times subsequently.
         Commit the key map in nvm once it as stabilized.
     */
-#if SLI_SI91X_MCU_INTERFACE && CHIP_CONFIG_ENABLE_ICD_SERVER
-    // TODO: Remove this when RTC timer is added MATTER-2705
-    SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_KvsStringKeyMap, reinterpret_cast<const uint8_t *>(mKvsKeyMap),
-                                      sizeof(mKvsKeyMap));
-#else
     SystemLayer().StartTimer(
         std::chrono::duration_cast<System::Clock::Timeout>(System::Clock::Seconds32(SILABS_KVS_SAVE_DELAY_SECONDS)),
         KeyValueStoreManagerImpl::OnScheduledKeyMapSave, NULL);
-#endif // defined(SLI_SI91X_MCU_INTERFACE) && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size,

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -291,6 +291,14 @@ template("siwx917_sdk") {
     if (invoker.enable_dic) {
       _include_dirs += [ "${chip_root}/third_party/silabs/mqtt/stack" ]
     }
+
+    if (chip_enable_icd_server || !disable_lcd) {
+      defines += [
+        "SL_SLEEP_TIMER=1",
+        "SI91X_SYSRTC_COUNT=1",
+      ]
+    }
+
     if (!disable_lcd) {
       defines += [
         "CONFIG_ENABLE_UART",
@@ -310,12 +318,6 @@ template("siwx917_sdk") {
       ]
     }
 
-    if (chip_enable_icd_server || !disable_lcd) {
-      defines += [
-        "SL_SLEEP_TIMER=1",
-        "SI91X_SYSRTC_COUNT=1",
-      ]
-    }
     if (chip_enable_icd_server) {
       defines += [
         "SL_ICD_ENABLED=1",
@@ -759,6 +761,14 @@ template("siwx917_sdk") {
       ]
     }
 
+    if (chip_enable_icd_server || !disable_lcd) {
+      sources += [
+        "${efr32_sdk_root}/platform/service/sleeptimer/src/sl_sleeptimer.c",
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_sysrtc.c",
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/sleeptimer/src/sl_sleeptimer_hal_si91x_sysrtc.c",
+      ]
+    }
+
     if (!disable_lcd) {
       sources += [
         "${efr32_sdk_root}/platform/middleware/glib/dmd/display/dmd_memlcd.c",
@@ -791,14 +801,6 @@ template("siwx917_sdk") {
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/power_manager/src/sli_si91x_power_manager_wakeup_init.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_time_period.c",
         "${wifi_sdk_root}/third_party/silicon_labs/freertos/src/sl_si91x_low_power_tickless_mode.c",
-      ]
-    }
-
-    if (chip_enable_icd_server || !disable_lcd) {
-      sources += [
-        "${efr32_sdk_root}/platform/service/sleeptimer/src/sl_sleeptimer.c",
-        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_sysrtc.c",
-        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/sleeptimer/src/sl_sleeptimer_hal_si91x_sysrtc.c",
       ]
     }
 

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -797,8 +797,8 @@ template("siwx917_sdk") {
     if (chip_enable_icd_server || !disable_lcd) {
       sources += [
         "${efr32_sdk_root}/platform/service/sleeptimer/src/sl_sleeptimer.c",
-        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/sleeptimer/src/sl_sleeptimer_hal_si91x_sysrtc.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_sysrtc.c",
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/sleeptimer/src/sl_sleeptimer_hal_si91x_sysrtc.c",
       ]
     }
 

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -297,8 +297,6 @@ template("siwx917_sdk") {
         "SYSCALLS_WRITE",
         "SPI_MULTI_SLAVE",
         "SL_ULP_TIMER",
-        "SL_SLEEP_TIMER=1",
-        "SI91X_SYSRTC_COUNT=1",
       ]
     }
 
@@ -312,6 +310,12 @@ template("siwx917_sdk") {
       ]
     }
 
+    if (chip_enable_icd_server || !disable_lcd) {
+      defines += [
+        "SL_SLEEP_TIMER=1",
+        "SI91X_SYSRTC_COUNT=1",
+      ]
+    }
     if (chip_enable_icd_server) {
       defines += [
         "SL_ICD_ENABLED=1",
@@ -322,8 +326,6 @@ template("siwx917_sdk") {
         "SL_SI91X_NPSS_GPIO_BTN_HANDLER=1",
         "SL_SI91X_POWER_MANAGER_UC_AVAILABLE=1",
         "SL_SI91X_TICKLESS_MODE=1",
-        "SL_SLEEP_TIMER=1",
-        "SI91X_SYSRTC_COUNT=1",
       ]
 
       if (si91x_alarm_based_periodic_wakeup) {
@@ -771,13 +773,10 @@ template("siwx917_sdk") {
         "${efr32_sdk_root}/platform/middleware/glib/glib/glib_polygon.c",
         "${efr32_sdk_root}/platform/middleware/glib/glib/glib_rectangle.c",
         "${efr32_sdk_root}/platform/middleware/glib/glib/glib_string.c",
-        "${efr32_sdk_root}/platform/service/sleeptimer/src/sl_sleeptimer.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/cmsis_driver/SPI.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/memlcd/src/memlcd_917/sl_memlcd_spi.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/memlcd/src/sl_memlcd.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/memlcd/src/sl_memlcd_display.c",
-        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_sysrtc.c",
-        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/sleeptimer/src/sl_sleeptimer_hal_si91x_sysrtc.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_ulp_timer.c",
       ]
     }
@@ -792,6 +791,11 @@ template("siwx917_sdk") {
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/power_manager/src/sli_si91x_power_manager_wakeup_init.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_time_period.c",
         "${wifi_sdk_root}/third_party/silicon_labs/freertos/src/sl_si91x_low_power_tickless_mode.c",
+      ]
+    }
+
+    if (chip_enable_icd_server || !disable_lcd) {
+      sources += [
         "${efr32_sdk_root}/platform/service/sleeptimer/src/sl_sleeptimer.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/sleeptimer/src/sl_sleeptimer_hal_si91x_sysrtc.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_sysrtc.c",

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -294,11 +294,11 @@ template("siwx917_sdk") {
     if (!disable_lcd) {
       defines += [
         "CONFIG_ENABLE_UART",
-        "SI91X_SYSRTC_COUNT=1",
         "SYSCALLS_WRITE",
         "SPI_MULTI_SLAVE",
         "SL_ULP_TIMER",
-        "SL_SLEEP_TIMER",
+        "SL_SLEEP_TIMER=1",
+        "SI91X_SYSRTC_COUNT=1",
       ]
     }
 
@@ -322,6 +322,8 @@ template("siwx917_sdk") {
         "SL_SI91X_NPSS_GPIO_BTN_HANDLER=1",
         "SL_SI91X_POWER_MANAGER_UC_AVAILABLE=1",
         "SL_SI91X_TICKLESS_MODE=1",
+        "SL_SLEEP_TIMER=1",
+        "SI91X_SYSRTC_COUNT=1",
       ]
 
       if (si91x_alarm_based_periodic_wakeup) {
@@ -790,6 +792,9 @@ template("siwx917_sdk") {
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/power_manager/src/sli_si91x_power_manager_wakeup_init.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_time_period.c",
         "${wifi_sdk_root}/third_party/silicon_labs/freertos/src/sl_si91x_low_power_tickless_mode.c",
+        "${efr32_sdk_root}/platform/service/sleeptimer/src/sl_sleeptimer.c",
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/sleeptimer/src/sl_sleeptimer_hal_si91x_sysrtc.c",
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/rsi_sysrtc.c",
       ]
     }
 


### PR DESCRIPTION
917SoC Sleepy needs sleeptimer and lcd also needs sleeptimer so merging them together

Fixes the build with icd enabled and lcd disabled case

- removing the nvm direct write from the KVS since tickless is implemented now