### PR TITLE
move AttemptToGetTimeFromTrustedNode out of TIME_SYNC_ENABLE_TSC_FEATURE blocks

### DIFF
--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.h
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.h
@@ -124,8 +124,9 @@ public:
     void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override;
     void OnDone(ReadClient * apReadClient) override;
 
-    CHIP_ERROR AttemptToGetTimeFromTrustedNode();
 #endif
+
+    CHIP_ERROR AttemptToGetTimeFromTrustedNode();
 
     // Platform event handler functions
     void OnPlatformEventFn(const DeviceLayer::ChipDeviceEvent & event);


### PR DESCRIPTION
… since it is called out of TIME_SYNC_ENABLE_TSC_FEATURE blocks

AttemptToGetTimeFromTrustedNode() is called outside of TIME_SYNC_ENABLE_TSC_FEATURE blocks, so it should be declared outside of a TIME_SYNC_ENABLE_TSC_FEATURE. Otherwise, if the time sync client feature is turned off (time_sync_enable_tsc_feature = 0), we get a build error - error: 'AttemptToGetTimeFromTrustedNode' was not declared in this scope




