### PR TITLE
make zap_regen_all auto-trigger a buildenv bootstrap/activate when run if not already activated

### DIFF
--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -503,7 +503,7 @@ def main():
     #    - scripts/codegen.py uses click (can be in current pyenv, but guaranteed in bootstrap)
     #    - formatting is using bootstrapped clang-format
     # Figure out if bootstrapped. For now assume `PW_ROOT` is such a marker in the environment
-    if not "PW_ROOT" in os.environ:
+    if "PW_ROOT" not in os.environ:
         logging.error("Script MUST be run in a bootstrapped environment.")
 
         # using the `--no-rerun-in-env` to avoid recursive infinite calls

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -520,7 +520,6 @@ def main():
             os.execv(launcher, [launcher, shlex.join(what_to_run)])
         sys.exit(1)
 
-
     checkPythonVersion()
     os.chdir(CHIP_ROOT_DIR)
     args = setupArgumentsParser()

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -513,10 +513,6 @@ def main():
 
             what_to_run = sys.argv + ['--no-rerun-in-env']
             launcher = os.path.join(CHIP_ROOT_DIR, 'scripts', 'run_in_build_env.sh')
-
-            logging.error("ARGV:    %r", sys.argv)
-            logging.error("Running: %r", shlex.join(what_to_run))
-
             os.execv(launcher, [launcher, shlex.join(what_to_run)])
         sys.exit(1)
 


### PR DESCRIPTION
We seem to always need to run this script in a bootstrapped environment. Make it auto-do so.