### PR TITLE
Revert "Darwin: Prohibit static initializers in Matter.framework"

### DIFF
--- a/src/app/AttributeAccessInterfaceCache.h
+++ b/src/app/AttributeAccessInterfaceCache.h
@@ -48,7 +48,7 @@ public:
         kDefinitelyUsed
     };
 
-    constexpr AttributeAccessInterfaceCache() = default;
+    AttributeAccessInterfaceCache() { Invalidate(); }
 
     /**
      * @brief Invalidate the whole cache. Must be called every time list of AAI registrations changes.
@@ -106,8 +106,6 @@ public:
 private:
     struct AttributeAccessCacheEntry
     {
-        constexpr AttributeAccessCacheEntry() = default;
-
         EndpointId endpointId               = kInvalidEndpointId;
         ClusterId clusterId                 = kInvalidClusterId;
         AttributeAccessInterface * accessor = nullptr;
@@ -139,8 +137,8 @@ private:
         return &mCacheSlots[0];
     }
 
-    AttributeAccessCacheEntry mCacheSlots[1] = {};
-    AttributeAccessCacheEntry mLastUnusedEntry{};
+    AttributeAccessCacheEntry mCacheSlots[1];
+    AttributeAccessCacheEntry mLastUnusedEntry;
 };
 
 } // namespace app

--- a/src/app/EventLoggingTypes.h
+++ b/src/app/EventLoggingTypes.h
@@ -100,7 +100,7 @@ struct Timestamp
         kSystem = 0,
         kEpoch
     };
-    constexpr Timestamp() = default;
+    Timestamp() {}
     Timestamp(Type aType, uint64_t aValue) : mType(aType), mValue(aValue) {}
     Timestamp(System::Clock::Timestamp aValue) : mType(Type::kSystem), mValue(aValue.count()) {}
     static Timestamp Epoch(System::Clock::Timestamp aValue)

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -32,7 +32,7 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-EventManagement EventManagement::sInstance;
+static EventManagement sInstance;
 
 /**
  * @brief

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -73,7 +73,7 @@ namespace app {
 inline constexpr const uint32_t kEventManagementProfile = 0x1;
 inline constexpr const uint32_t kFabricIndexTag         = 0x1;
 inline constexpr size_t kMaxEventSizeReserve            = 512;
-inline constexpr uint16_t kRequiredEventField =
+constexpr uint16_t kRequiredEventField =
     (1 << to_underlying(EventDataIB::Tag::kPriority)) | (1 << to_underlying(EventDataIB::Tag::kPath));
 
 /**
@@ -388,9 +388,6 @@ public:
     void SetScheduledEventInfo(EventNumber & aEventNumber, uint32_t & aInitialWrittenEventBytes) const;
 
 private:
-    constexpr EventManagement() = default;
-    static EventManagement sInstance;
-
     /**
      * @brief
      *  Internal structure for traversing events.
@@ -558,9 +555,9 @@ private:
     MonotonicallyIncreasingCounter<EventNumber> * mpEventNumberCounter = nullptr;
 
     EventNumber mLastEventNumber = 0; ///< Last event Number vended
-    Timestamp mLastEventTimestamp{};  ///< The timestamp of the last event in this buffer
+    Timestamp mLastEventTimestamp;    ///< The timestamp of the last event in this buffer
 
-    System::Clock::Milliseconds64 mMonotonicStartupTime{};
+    System::Clock::Milliseconds64 mMonotonicStartupTime;
 };
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -27,7 +27,6 @@
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/endpoint-config-api.h>
-#include <lib/core/Global.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -206,9 +205,7 @@ CHIP_ERROR DescriptorAttrAccess::ReadClusterRevision(EndpointId endpoint, Attrib
     return aEncoder.Encode(kClusterRevision);
 }
 
-namespace {
-Global<DescriptorAttrAccess> gAttrAccess;
-}
+DescriptorAttrAccess gAttrAccess;
 
 CHIP_ERROR DescriptorAttrAccess::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
 {
@@ -247,5 +244,5 @@ CHIP_ERROR DescriptorAttrAccess::Read(const ConcreteReadAttributePath & aPath, A
 
 void MatterDescriptorPluginServerInitCallback()
 {
-    registerAttributeAccessOverride(&gAttrAccess.get());
+    registerAttributeAccessOverride(&gAttrAccess);
 }

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -2497,7 +2497,6 @@
 					"-Wl,-unexported_symbol,\"__Unwind_*\"",
 					"-Wl,-unexported_symbol,\"_unw_*\"",
 					"-Wl,-hidden-lCHIP",
-					"-Wl,-no_inits",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
 					"-framework",
@@ -2516,7 +2515,6 @@
 					"-Wl,-unexported_symbol,\"__Unwind_*\"",
 					"-Wl,-unexported_symbol,\"_unw_*\"",
 					"-Wl,-hidden-lCHIP",
-					"-Wl,-no_inits",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.csa.matter;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -49,8 +49,6 @@
 #include <platform/ThreadStackManager.h>
 #endif
 
-#include <optional>
-
 // TODO : may be we can make it configurable
 #define BLE_ADVERTISEMENT_VERSION 0
 
@@ -58,9 +56,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-namespace {
-std::optional<System::Clock::Seconds32> gFirmwareBuildChipEpochTime;
-}
+static Optional<System::Clock::Seconds32> sFirmwareBuildChipEpochTime;
 
 #if CHIP_USE_TRANSITIONAL_COMMISSIONABLE_DATA_PROVIDER
 
@@ -292,9 +288,9 @@ template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetFirmwareBuildChipEpochTime(System::Clock::Seconds32 & chipEpochTime)
 {
     // If the setter was called and we have a value in memory, return this.
-    if (gFirmwareBuildChipEpochTime.has_value())
+    if (sFirmwareBuildChipEpochTime.HasValue())
     {
-        chipEpochTime = gFirmwareBuildChipEpochTime.value();
+        chipEpochTime = sFirmwareBuildChipEpochTime.Value();
         return CHIP_NO_ERROR;
     }
 #ifdef CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME_MATTER_EPOCH_S
@@ -327,7 +323,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::SetFirmwareBuildChipEpo
     //
     // Implementations that can't use the hard-coded time for whatever reason
     // should set this at each init.
-    gFirmwareBuildChipEpochTime = chipEpochTime;
+    sFirmwareBuildChipEpochTime.SetValue(chipEpochTime);
     return CHIP_NO_ERROR;
 }
 

--- a/src/lib/support/IntrusiveList.h
+++ b/src/lib/support/IntrusiveList.h
@@ -84,7 +84,7 @@ enum class IntrusiveMode
 class IntrusiveListNodePrivateBase
 {
 public:
-    constexpr IntrusiveListNodePrivateBase() : mPrev(nullptr), mNext(nullptr) {}
+    IntrusiveListNodePrivateBase() : mPrev(nullptr), mNext(nullptr) {}
     ~IntrusiveListNodePrivateBase() { VerifyOrDie(!IsInList()); }
 
     // Note: The copy construct/assignment is not provided because the list node state is not copyable.
@@ -98,7 +98,7 @@ public:
 
 private:
     friend class IntrusiveListBase;
-    constexpr IntrusiveListNodePrivateBase(IntrusiveListNodePrivateBase * prev, IntrusiveListNodePrivateBase * next) :
+    IntrusiveListNodePrivateBase(IntrusiveListNodePrivateBase * prev, IntrusiveListNodePrivateBase * next) :
         mPrev(prev), mNext(next)
     {}
 
@@ -284,7 +284,7 @@ protected:
     //   ^                                           |
     //    \------------------------------------------/
     //
-    constexpr IntrusiveListBase() : mNode(&mNode, &mNode) {}
+    IntrusiveListBase() : mNode(&mNode, &mNode) {}
     ~IntrusiveListBase()
     {
         VerifyOrDie(Empty());
@@ -399,7 +399,7 @@ template <typename T, IntrusiveMode Mode = IntrusiveMode::Strict, typename Hook 
 class IntrusiveList : public IntrusiveListBase
 {
 public:
-    constexpr IntrusiveList() : IntrusiveListBase() {}
+    IntrusiveList() : IntrusiveListBase() {}
 
     IntrusiveList(IntrusiveList &&)             = default;
     IntrusiveList & operator=(IntrusiveList &&) = default;

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -191,9 +191,8 @@ inline constexpr System::Clock::Milliseconds32 kDefaultActiveTime = System::Cloc
  */
 struct ReliableMessageProtocolConfig
 {
-    constexpr ReliableMessageProtocolConfig(System::Clock::Milliseconds32 idleInterval,
-                                            System::Clock::Milliseconds32 activeInterval,
-                                            System::Clock::Milliseconds16 activeThreshold = kDefaultActiveTime) :
+    ReliableMessageProtocolConfig(System::Clock::Milliseconds32 idleInterval, System::Clock::Milliseconds32 activeInterval,
+                                  System::Clock::Milliseconds16 activeThreshold = kDefaultActiveTime) :
         mIdleRetransTimeout(idleInterval),
         mActiveRetransTimeout(activeInterval), mActiveThresholdTime(activeThreshold)
     {}

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -26,7 +26,6 @@
 #include <platform/Darwin/ConfigurationManagerImpl.h>
 
 #include <lib/core/CHIPVendorIdentifiers.hpp>
-#include <lib/core/Global.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/Darwin/DiagnosticDataProviderImpl.h>
@@ -139,13 +138,10 @@ exit:
 }
 #endif // TARGET_OS_OSX
 
-namespace {
-AtomicGlobal<ConfigurationManagerImpl> gInstance;
-}
-
 ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 {
-    return gInstance.get();
+    static ConfigurationManagerImpl sInstance;
+    return sInstance;
 }
 
 CHIP_ERROR ConfigurationManagerImpl::Init()

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -34,7 +34,7 @@
 namespace chip {
 namespace DeviceLayer {
 
-inline constexpr int kCountryCodeLength = 2;
+static constexpr int kCountryCodeLength = 2;
 
 /**
  * Concrete implementation of the ConfigurationManager singleton object for the Darwin platform.

--- a/src/platform/Darwin/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/Darwin/DeviceInstanceInfoProviderImpl.cpp
@@ -18,7 +18,6 @@
 
 #include "DeviceInstanceInfoProviderImpl.h"
 
-#include <lib/core/Global.h>
 #include <platform/Darwin/PosixConfig.h>
 
 namespace chip {
@@ -32,15 +31,6 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetVendorId(uint16_t & vendorId)
 CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductId(uint16_t & productId)
 {
     return Internal::PosixConfig::ReadConfigValue(Internal::PosixConfig::kConfigKey_ProductId, productId);
-}
-
-namespace {
-AtomicGlobal<DeviceInstanceInfoProviderImpl> gInstance;
-} // namespace
-
-DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl()
-{
-    return gInstance.get();
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Darwin/DeviceInstanceInfoProviderImpl.h
+++ b/src/platform/Darwin/DeviceInstanceInfoProviderImpl.h
@@ -30,13 +30,15 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
 
-    DeviceInstanceInfoProviderImpl() : DeviceInstanceInfoProviderImpl(ConfigurationManagerImpl::GetDefaultInstance()) {}
     DeviceInstanceInfoProviderImpl(ConfigurationManagerImpl & configManager) :
         Internal::GenericDeviceInstanceInfoProvider<Internal::PosixConfig>(configManager)
     {}
 };
 
-DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl();
-
+inline DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl()
+{
+    static DeviceInstanceInfoProviderImpl sInstance(ConfigurationManagerImpl::GetDefaultInstance());
+    return sInstance;
+}
 } // namespace DeviceLayer
 } // namespace chip


### PR DESCRIPTION
Reverts project-chip/connectedhomeip#34168

This is causing crashes at mDNS discovery time for some reason.