### PR TITLE
Added python testing for secondary network interface

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -500,6 +500,7 @@ jobs:
                   scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_ACE_1_5.py'
                   scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_AccessChecker.py'
                   scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_CGEN_2_4.py'
+                  scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_CNET_1_4.py'
                   scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_DA_1_2.py'
                   scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_DA_1_5.py'
                   scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_DA_1_7.py'

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -17,6 +17,10 @@
 
 import logging
 
+import chip.clusters as Clusters
+from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
@@ -24,9 +28,6 @@ import logging
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 
-import chip.clusters as Clusters
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_CNET_1_4(MatterBaseTest):

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -58,12 +58,9 @@ class TC_CNET_1_4(MatterBaseTest):
         # Commissioning is already done
         self.step(1)
 
-        cnet = Clusters.NetworkCommissioning
-        afeam = cnet.Attributes.FeatureMap
-
         self.step(2)
         # Read FeatureMap attribute with wildcard endpoint
-        feature_map_results = await self.default_controller.ReadAttribute(self.dut_node_id, [(afeam)], fabricFiltered=True)
+        feature_map_results = await self.default_controller.ReadAttribute(self.dut_node_id, [(Clusters.NetworkCommissioning.Attributes.FeatureMap)], fabricFiltered=True)
 
         NumNetworkCommissioning = len(feature_map_results)
         if NumNetworkCommissioning == 0:

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -40,7 +40,7 @@ kSecondaryNetworkInterfaceDeviceTypeId = 0x0019
 class TC_CNET_1_4(MatterBaseTest):
     def steps_TC_CNET_1_4(self):
         return [TestStep(1, "TH is commissioned", is_commissioning=True),
-                TestStep(2, 'TH performs a wildcard read of the FeatureMap attribute on Network Commissioning clusters across all endpoints, and save the response as `NetworkCommissioningResponse`'),
+                TestStep(2, 'TH performs a wildcard read of the FeatureMap attribute on Network Commissioning clusters across all endpoints, and saves the response as `NetworkCommissioningResponse`'),
                 TestStep(3, 'If `NetworkCommissioningResponse` does not contain any entries for Network Commissioning cluster, skip remaining steps and end test case'),
                 TestStep(4, 'If `NetworkCommissioningResponse` contains only a single entry for Network Commissioning cluster on Endpoint 0, skip remaining steps and end test case. Verify `NetworkCommissioningResponse` contains an entry for Network Commissioning cluster on Endpoint 0'),
                 TestStep(5, 'TH reads from the DUT the Descriptor Cluster DeviceTypeList attribute on each endpoint from the `NetworkCommissioningResponse` (except for Endpoint 0), verify that the Secondary Network Interface device type id (0x0019) is listed in the DeviceTypeList'),

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -60,8 +60,8 @@ class TC_CNET_1_4(MatterBaseTest):
         # Read FeatureMap attribute with wildcard endpoint
         feature_map_results = await self.default_controller.ReadAttribute(self.dut_node_id, [(afeam)], fabricFiltered=True)
 
-        NetworkNum = len(feature_map_results)
-        if NetworkNum == 0:
+        NumNetworkCommissioning = len(feature_map_results)
+        if NumNetworkCommissioning == 0:
             logging.info('No endpoint has Network Commissioning Cluster, skipping remaining steps')
             self.skip_all_remaining_steps(3)
             return
@@ -74,7 +74,7 @@ class TC_CNET_1_4(MatterBaseTest):
         if 49 not in server_list:
             asserts.assert_true(False, "There is no Network Commissioning Cluster on endpoint 0")
 
-        if NetworkNum == 1:
+        if NumNetworkCommissioning == 1:
             logging.info('Only endpoint 0 has Network Commissioning Cluster, skipping remaining steps')
             self.skip_all_remaining_steps(4)
             return

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -1,0 +1,98 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import logging
+
+# test-runner-runs: run1
+# test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
+# test-runner-run/run1/factoryreset: True
+# test-runner-run/run1/quiet: True
+# test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+# test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+
+import chip.clusters as Clusters
+from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+
+
+class TC_CNET_1_4(MatterBaseTest):
+    def steps_TC_CNET_1_4(self):
+        return [TestStep("precondition", "TH is commissioned", is_commissioning=True),
+                TestStep(1, 'TH performs a wildcard read of Network Commissioning clusters across all endpoints, and save the number of Network Commissioning clusters as `NetworkNum` for future use. If `NetworkNum` is 0, skip the remaining steps in this test case'),
+                TestStep(2, 'TH reads from the DUT the Descriptor Cluster DeviceTypeList attribute on each endpoint that hosts a Network Commissioning cluster, verify that the device types include the value 0x0016 (Root Node) or 0x0019 (Secondary Network Interface)'),
+                TestStep(3, 'TH reads from the DUT the General Commissioning Cluster SupportsConcurrentConnection attribute if NetworkNum is greater than 1, verify that it is true')]
+
+    def def_TC_CNET_1_4(self):
+        return '[TC-CNET-1.4] Verification for Secondary Network Interface [DUT-Server]'
+
+    def pics_TC_CNET_1_4(self):
+        return ['CNET.S']
+
+    # Override default timeout.
+    @property
+    def default_timeout(self) -> int:
+        return 200
+
+    @async_test_body
+    async def test_TC_CNET_1_4(self):
+        # Commissioning is already done
+        self.step("precondition")
+
+        cnet = Clusters.NetworkCommissioning
+        afeam = cnet.Attributes.FeatureMap
+
+        self.step(1)
+        # Read FeatureMap attribute with wildcard endpoint
+        feature_map_results = await self.default_controller.ReadAttribute(self.dut_node_id, [(afeam)], fabricFiltered=True)
+
+        NetworkNum = len(feature_map_results)
+        if NetworkNum == 0:
+            logging.info('No endpoint has Network Commissioning Cluster, skipping remaining steps')
+            self.skip_all_remaining_steps(2)
+            return
+
+        endpoints = []
+        for endpoint, data in feature_map_results.items():
+            endpoints.append(endpoint)
+        logging.info(f"Network Commissioning Cluster on endpoints: {endpoints}")
+
+        self.step(2)
+        cdesc = Clusters.Descriptor
+        adevt = cdesc.Attributes.DeviceTypeList
+
+        for endpoint in endpoints:
+            device_type_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=adevt, endpoint=endpoint)
+            logging.info(f"Device tyep list: {device_type_list}")
+            # Root Node device id: 0x16, Secondary Network Interface device id: 0x19
+            required_device_types = {22, 25}
+            found_device_types = {device.deviceType for device in device_type_list}
+            asserts.assert_true(required_device_types.intersection(found_device_types),
+                                "Network Commissioning Cluster is not on Root Node or Secondary Network Interface")
+
+        if NetworkNum == 1:
+            logging.info('Only one endpoint has Network Commissioning Cluster, skipping remaining steps')
+            self.skip_all_remaining_steps(3)
+            return
+
+        self.step(3)
+        cgen = Clusters.GeneralCommissioning
+        ascc = cgen.Attributes.SupportsConcurrentConnection
+        concurrent_connection = await self.read_single_attribute_check_success(cluster=cgen, attribute=ascc)
+        asserts.assert_true(concurrent_connection, "The device does not support concurrent connection commissioning")
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -41,9 +41,9 @@ class TC_CNET_1_4(MatterBaseTest):
     def steps_TC_CNET_1_4(self):
         return [TestStep(1, "TH is commissioned", is_commissioning=True),
                 TestStep(2, 'TH performs a wildcard read of Network Commissioning clusters across all endpoints, and save the number of Network Commissioning clusters as `NumNetworkCommissioning` for future use. If `NumNetworkCommissioning` is 0, skip the remaining steps in this test case'),
-                TestStep(3, 'TH checks whether endpoint 0 is contained in the previous response to determine whether there is a Network Commissioning cluster on endpoint 0'),
+                TestStep(3, 'TH verifies that Endpoint 0 exists in the returned data. If `NumNetworkCommissioning` is 1, skip the remaining steps'),
                 TestStep(4, 'TH reads from the DUT the Descriptor Cluster DeviceTypeList attribute on each endpoint (except for Endpoint 0) that hosts a Network Commissioning cluster, verify that the Secondary Network Interface device type id (0x0019) is listed in the DeviceTypeList'),
-                TestStep(5, 'TH reads from the DUT the General Commissioning Cluster SupportsConcurrentConnection attribute if NumNetworkCommissioning is greater than 1, verify that it is true')]
+                TestStep(5, 'TH reads from the DUT the General Commissioning Cluster SupportsConcurrentConnection attribute, verify that it is true')]
 
     def def_TC_CNET_1_4(self):
         return '[TC-CNET-1.4] Verification for Secondary Network Interface [DUT-Server]'

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -94,5 +94,6 @@ class TC_CNET_1_4(MatterBaseTest):
         concurrent_connection = await self.read_single_attribute_check_success(cluster=cgen, attribute=ascc)
         asserts.assert_true(concurrent_connection, "The device does not support concurrent connection commissioning")
 
+
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -33,12 +33,15 @@ import chip.clusters as Clusters
 from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 
+kRootEndpointId = 0
+kSecondaryNetworkInterfaceDeviceTypeId = 0x0019
+
 
 class TC_CNET_1_4(MatterBaseTest):
     def steps_TC_CNET_1_4(self):
         return [TestStep(1, "TH is commissioned", is_commissioning=True),
                 TestStep(2, 'TH performs a wildcard read of Network Commissioning clusters across all endpoints, and save the number of Network Commissioning clusters as `NumNetworkCommissioning` for future use. If `NumNetworkCommissioning` is 0, skip the remaining steps in this test case'),
-                TestStep(3, 'TH reads from the DUT the Descriptor Cluster DeviceTypeList attribute from Endpoint 0, verify that the Network Commissioning cluster id (0x0031) is listed in the ServerList'),
+                TestStep(3, 'TH checks whether endpoint 0 is contained in the response of the previous response to determine whether there is a Network Commissioning cluster on endpoint 0'),
                 TestStep(4, 'TH reads from the DUT the Descriptor Cluster DeviceTypeList attribute on each endpoint (except for Endpoint 0) that hosts a Network Commissioning cluster, verify that the Secondary Network Interface device type id (0x0019) is listed in the DeviceTypeList'),
                 TestStep(5, 'TH reads from the DUT the General Commissioning Cluster SupportsConcurrentConnection attribute if NumNetworkCommissioning is greater than 1, verify that it is true')]
 
@@ -61,7 +64,6 @@ class TC_CNET_1_4(MatterBaseTest):
         self.step(2)
         # Read FeatureMap attribute with wildcard endpoint
         feature_map_results = await self.default_controller.ReadAttribute(self.dut_node_id, [(Clusters.NetworkCommissioning.Attributes.FeatureMap)], fabricFiltered=True)
-
         NumNetworkCommissioning = len(feature_map_results)
         if NumNetworkCommissioning == 0:
             logging.info('No endpoint has Network Commissioning Cluster, skipping remaining steps')
@@ -69,9 +71,10 @@ class TC_CNET_1_4(MatterBaseTest):
             return
 
         self.step(3)
-        cdesc = Clusters.Descriptor
-        server_list = await self.read_single_attribute_check_success(cluster=cdesc, attribute=cdesc.Attributes.ServerList, endpoint=0)
-        if 49 not in server_list:
+        endpoints = []
+        for endpoint, _ in feature_map_results.items():
+            endpoints.append(endpoint)
+        if kRootEndpointId not in endpoints:
             asserts.assert_true(False, "There is no Network Commissioning Cluster on endpoint 0")
 
         if NumNetworkCommissioning == 1:
@@ -80,20 +83,19 @@ class TC_CNET_1_4(MatterBaseTest):
             return
 
         self.step(4)
-        adevt = cdesc.Attributes.DeviceTypeList
-        for endpoint, _ in feature_map_results.items():
-            if endpoint == 0:
+        for endpoint in endpoints:
+            if endpoint == kRootEndpointId:
                 continue
-            device_type_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=adevt, endpoint=endpoint)
-            required_device_types = {25}
+            device_type_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor,
+                                                                              attribute=Clusters.Descriptor.Attributes.DeviceTypeList, endpoint=endpoint)
+            required_device_types = { kSecondaryNetworkInterfaceDeviceTypeId }
             found_device_types = {device.deviceType for device in device_type_list}
             asserts.assert_true(required_device_types.intersection(found_device_types),
                                 "Network Commissioning Cluster is not on Root Node or Secondary Network Interface")
 
         self.step(5)
-        cgen = Clusters.GeneralCommissioning
-        ascc = cgen.Attributes.SupportsConcurrentConnection
-        concurrent_connection = await self.read_single_attribute_check_success(cluster=cgen, attribute=ascc)
+        concurrent_connection = await self.read_single_attribute_check_success(cluster=Clusters.GeneralCommissioning,
+                                                                               attribute=Clusters.GeneralCommissioning.Attributes.SupportsConcurrentConnection)
         asserts.assert_true(concurrent_connection, "The device does not support concurrent connection commissioning")
 
 

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -15,18 +15,23 @@
 #    limitations under the License.
 #
 
-import logging
-
-import chip.clusters as Clusters
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
+
+import logging
+
+import chip.clusters as Clusters
+from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
 
 
 class TC_CNET_1_4(MatterBaseTest):

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -73,9 +73,7 @@ class TC_CNET_1_4(MatterBaseTest):
 
         self.step(3)
         cdesc = Clusters.Descriptor
-        aser = cdesc.Attributes.ServerList
-
-        server_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=aser, endpoint=0)
+        server_list = await self.read_single_attribute_check_success(cluster=cdesc, attribute=cdesc.Attributes.ServerList, endpoint=0)
         if 49 not in server_list:
             asserts.assert_true(False, "There is no Network Commissioning Cluster on endpoint 0")
 

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -29,13 +29,13 @@ from mobly import asserts
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 
 
-
 class TC_CNET_1_4(MatterBaseTest):
     def steps_TC_CNET_1_4(self):
-        return [TestStep("precondition", "TH is commissioned", is_commissioning=True),
-                TestStep(1, 'TH performs a wildcard read of Network Commissioning clusters across all endpoints, and save the number of Network Commissioning clusters as `NetworkNum` for future use. If `NetworkNum` is 0, skip the remaining steps in this test case'),
-                TestStep(2, 'TH reads from the DUT the Descriptor Cluster DeviceTypeList attribute on each endpoint that hosts a Network Commissioning cluster, verify that the device types include the value 0x0016 (Root Node) or 0x0019 (Secondary Network Interface)'),
-                TestStep(3, 'TH reads from the DUT the General Commissioning Cluster SupportsConcurrentConnection attribute if NetworkNum is greater than 1, verify that it is true')]
+        return [TestStep(1, "TH is commissioned", is_commissioning=True),
+                TestStep(2, 'TH performs a wildcard read of Network Commissioning clusters across all endpoints, and save the number of Network Commissioning clusters as `NumNetworkCommissioning` for future use. If `NumNetworkCommissioning` is 0, skip the remaining steps in this test case'),
+                TestStep(3, 'TH reads from the DUT the Descriptor Cluster DeviceTypeList attribute from Endpoint 0, verify that the Network Commissioning cluster id (0x0031) is listed in the ServerList'),
+                TestStep(4, 'TH reads from the DUT the Descriptor Cluster DeviceTypeList attribute on each endpoint (except for Endpoint 0) that hosts a Network Commissioning cluster, verify that the Secondary Network Interface device type id (0x0019) is listed in the DeviceTypeList'),
+                TestStep(5, 'TH reads from the DUT the General Commissioning Cluster SupportsConcurrentConnection attribute if NumNetworkCommissioning is greater than 1, verify that it is true')]
 
     def def_TC_CNET_1_4(self):
         return '[TC-CNET-1.4] Verification for Secondary Network Interface [DUT-Server]'
@@ -51,45 +51,46 @@ class TC_CNET_1_4(MatterBaseTest):
     @async_test_body
     async def test_TC_CNET_1_4(self):
         # Commissioning is already done
-        self.step("precondition")
+        self.step(1)
 
         cnet = Clusters.NetworkCommissioning
         afeam = cnet.Attributes.FeatureMap
 
-        self.step(1)
+        self.step(2)
         # Read FeatureMap attribute with wildcard endpoint
         feature_map_results = await self.default_controller.ReadAttribute(self.dut_node_id, [(afeam)], fabricFiltered=True)
 
         NetworkNum = len(feature_map_results)
         if NetworkNum == 0:
             logging.info('No endpoint has Network Commissioning Cluster, skipping remaining steps')
-            self.skip_all_remaining_steps(2)
-            return
-
-        endpoints = []
-        for endpoint, data in feature_map_results.items():
-            endpoints.append(endpoint)
-        logging.info(f"Network Commissioning Cluster on endpoints: {endpoints}")
-
-        self.step(2)
-        cdesc = Clusters.Descriptor
-        adevt = cdesc.Attributes.DeviceTypeList
-
-        for endpoint in endpoints:
-            device_type_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=adevt, endpoint=endpoint)
-            logging.info(f"Device tyep list: {device_type_list}")
-            # Root Node device id: 0x16, Secondary Network Interface device id: 0x19
-            required_device_types = {22, 25}
-            found_device_types = {device.deviceType for device in device_type_list}
-            asserts.assert_true(required_device_types.intersection(found_device_types),
-                                "Network Commissioning Cluster is not on Root Node or Secondary Network Interface")
-
-        if NetworkNum == 1:
-            logging.info('Only one endpoint has Network Commissioning Cluster, skipping remaining steps')
             self.skip_all_remaining_steps(3)
             return
 
         self.step(3)
+        cdesc = Clusters.Descriptor
+        aser = cdesc.Attributes.ServerList
+
+        server_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=aser, endpoint=0)
+        if 49 not in server_list:
+            asserts.assert_true(False, "There is no Network Commissioning Cluster on endpoint 0")
+
+        if NetworkNum == 1:
+            logging.info('Only endpoint 0 has Network Commissioning Cluster, skipping remaining steps')
+            self.skip_all_remaining_steps(4)
+            return
+
+        self.step(4)
+        adevt = cdesc.Attributes.DeviceTypeList
+        for endpoint, _ in feature_map_results.items():
+            if endpoint == 0:
+                continue
+            device_type_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=adevt, endpoint=endpoint)
+            required_device_types = {25}
+            found_device_types = {device.deviceType for device in device_type_list}
+            asserts.assert_true(required_device_types.intersection(found_device_types),
+                                "Network Commissioning Cluster is not on Root Node or Secondary Network Interface")
+
+        self.step(5)
         cgen = Clusters.GeneralCommissioning
         ascc = cgen.Attributes.SupportsConcurrentConnection
         concurrent_connection = await self.read_single_attribute_check_success(cluster=cgen, attribute=ascc)

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -41,7 +41,7 @@ class TC_CNET_1_4(MatterBaseTest):
     def steps_TC_CNET_1_4(self):
         return [TestStep(1, "TH is commissioned", is_commissioning=True),
                 TestStep(2, 'TH performs a wildcard read of Network Commissioning clusters across all endpoints, and save the number of Network Commissioning clusters as `NumNetworkCommissioning` for future use. If `NumNetworkCommissioning` is 0, skip the remaining steps in this test case'),
-                TestStep(3, 'TH checks whether endpoint 0 is contained in the response of the previous response to determine whether there is a Network Commissioning cluster on endpoint 0'),
+                TestStep(3, 'TH checks whether endpoint 0 is contained in the previous response to determine whether there is a Network Commissioning cluster on endpoint 0'),
                 TestStep(4, 'TH reads from the DUT the Descriptor Cluster DeviceTypeList attribute on each endpoint (except for Endpoint 0) that hosts a Network Commissioning cluster, verify that the Secondary Network Interface device type id (0x0019) is listed in the DeviceTypeList'),
                 TestStep(5, 'TH reads from the DUT the General Commissioning Cluster SupportsConcurrentConnection attribute if NumNetworkCommissioning is greater than 1, verify that it is true')]
 
@@ -88,7 +88,7 @@ class TC_CNET_1_4(MatterBaseTest):
                 continue
             device_type_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor,
                                                                               attribute=Clusters.Descriptor.Attributes.DeviceTypeList, endpoint=endpoint)
-            required_device_types = { kSecondaryNetworkInterfaceDeviceTypeId }
+            required_device_types = {kSecondaryNetworkInterfaceDeviceTypeId}
             found_device_types = {device.deviceType for device in device_type_list}
             asserts.assert_true(required_device_types.intersection(found_device_types),
                                 "Network Commissioning Cluster is not on Root Node or Secondary Network Interface")


### PR DESCRIPTION
Added python test for secondary network interface, REF to test plan https://github.com/CHIP-Specifications/chip-test-plans/pull/4218.

