### PR TITLE
Attempt to reduce CI failures in Energy Reporting test cases

### DIFF
--- a/src/python_testing/TC_EEM_2_2.py
+++ b/src/python_testing/TC_EEM_2_2.py
@@ -48,7 +48,7 @@ class TC_EEM_2_2(MatterBaseTest, EnergyReportingBaseTestHelper):
             TestStep("4", "Wait 3 seconds"),
             TestStep("4a", "TH reads from the DUT the CumulativeEnergyImported attribute",
                      "Verify the read is successful and note the value read."),
-            TestStep("5", "Wait 3 seconds"),
+            TestStep("5", "Wait 5 seconds"),
             TestStep("5a", "TH reads from the DUT the CumulativeEnergyImported attribute",
                      "Verify the read is successful and that the value is greater than the value measured in step 4a."),
             TestStep("6", "TH sends TestEventTrigger command to General Diagnostics Cluster on Endpoint 0 with EnableKey field set to PIXIT.EEM.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to PIXIT.EEM.TEST_EVENT_TRIGGER for Stop Fake Readings Test Event."),
@@ -75,7 +75,7 @@ class TC_EEM_2_2(MatterBaseTest, EnergyReportingBaseTestHelper):
         cumulative_energy_imported = await self.read_eem_attribute_expect_success("CumulativeEnergyImported")
 
         self.step("5")
-        time.sleep(3)
+        time.sleep(5)
 
         self.step("5a")
         cumulative_energy_imported_2 = await self.read_eem_attribute_expect_success("CumulativeEnergyImported")

--- a/src/python_testing/TC_EEM_2_3.py
+++ b/src/python_testing/TC_EEM_2_3.py
@@ -48,7 +48,7 @@ class TC_EEM_2_3(MatterBaseTest, EnergyReportingBaseTestHelper):
             TestStep("4", "Wait 6 seconds"),
             TestStep("4a", "TH reads from the DUT the CumulativeEnergyExported attribute",
                      "Verify the read is successful and note the value read."),
-            TestStep("5", "Wait 6 seconds"),
+            TestStep("5", "Wait 11 seconds"),
             TestStep("5a", "TH reads from the DUT the CumulativeEnergyExported attribute",
                      "Verify the read is successful and that the value is greater than the value measured in step 4a."),
             TestStep("6", "TH sends TestEventTrigger command to General Diagnostics Cluster on Endpoint 0 with EnableKey field set to PIXIT.EEM.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to PIXIT.EEM.TEST_EVENT_TRIGGER for Stop Fake Readings Test Event."),
@@ -75,7 +75,7 @@ class TC_EEM_2_3(MatterBaseTest, EnergyReportingBaseTestHelper):
         cumulative_energy_exported = await self.read_eem_attribute_expect_success("CumulativeEnergyExported")
 
         self.step("5")
-        time.sleep(6)
+        time.sleep(11)
 
         self.step("5a")
         cumulative_energy_exported_2 = await self.read_eem_attribute_expect_success("CumulativeEnergyExported")

--- a/src/python_testing/TC_EEM_2_4.py
+++ b/src/python_testing/TC_EEM_2_4.py
@@ -48,7 +48,7 @@ class TC_EEM_2_4(MatterBaseTest, EnergyReportingBaseTestHelper):
             TestStep("4", "Wait 3 seconds"),
             TestStep("4a", "TH reads from the DUT the PeriodicEnergyImported attribute",
                      "Verify the read is successful and note the value read."),
-            TestStep("5", "Wait 3 seconds"),
+            TestStep("5", "Wait 5 seconds"),
             TestStep("5a", "TH reads from the DUT the PeriodicEnergyImported attribute",
                      "Verify the read is successful and that the value read has to be different from value measure in step 4a."),
             TestStep("6", "TH sends TestEventTrigger command to General Diagnostics Cluster on Endpoint 0 with EnableKey field set to PIXIT.EEM.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to PIXIT.EEM.TEST_EVENT_TRIGGER for Stop Fake Readings Test Event."),
@@ -75,7 +75,7 @@ class TC_EEM_2_4(MatterBaseTest, EnergyReportingBaseTestHelper):
         periodic_energy_imported = await self.read_eem_attribute_expect_success("PeriodicEnergyImported")
 
         self.step("5")
-        time.sleep(3)
+        time.sleep(5)
 
         self.step("5a")
         periodic_energy_imported_2 = await self.read_eem_attribute_expect_success("PeriodicEnergyImported")

--- a/src/python_testing/TC_EEM_2_5.py
+++ b/src/python_testing/TC_EEM_2_5.py
@@ -48,7 +48,7 @@ class TC_EEM_2_5(MatterBaseTest, EnergyReportingBaseTestHelper):
             TestStep("4", "Wait 6 seconds"),
             TestStep("4a", "TH reads from the DUT the PeriodicEnergyExported attribute",
                      "Verify the read is successful and note the value read."),
-            TestStep("5", "Wait 6 seconds"),
+            TestStep("5", "Wait 11 seconds"),
             TestStep("5a", "TH reads from the DUT the PeriodicEnergyExported attribute",
                      "Verify the read is successful and that the value read has to be different from value measure in step 4a."),
             TestStep("6", "TH sends TestEventTrigger command to General Diagnostics Cluster on Endpoint 0 with EnableKey field set to PIXIT.EEM.TEST_EVENT_TRIGGER_KEY and EventTrigger field set to PIXIT.EEM.TEST_EVENT_TRIGGER for Stop Fake Readings Test Event."),
@@ -75,7 +75,7 @@ class TC_EEM_2_5(MatterBaseTest, EnergyReportingBaseTestHelper):
         periodic_energy_exported = await self.read_eem_attribute_expect_success("PeriodicEnergyExported")
 
         self.step("5")
-        time.sleep(6)
+        time.sleep(11)
 
         self.step("5a")
         periodic_energy_exported_2 = await self.read_eem_attribute_expect_success("PeriodicEnergyExported")

--- a/src/python_testing/TC_EPM_2_2.py
+++ b/src/python_testing/TC_EPM_2_2.py
@@ -56,7 +56,7 @@ class TC_EPM_2_2(MatterBaseTest, EnergyReportingBaseTestHelper):
                      "Verify the read is successful and that the value is between 3'848 and 4'848 mA. Note the value read."),
             TestStep("4c", "TH reads from the DUT the Voltage attribute",
                      "Verify the read is successful and that the value is between 229'000 and 231'000 mV. Note the value read."),
-            TestStep("5", "Wait 3 seconds"),
+            TestStep("5", "Wait 5 seconds"),
             TestStep("5a", "TH reads from the DUT the ActivePower attribute",
                      "Verify the read is successful, that the value is between '980'000 and 1'020'000 mW, and the value is different from the value read in step 4a."),
             TestStep("5b", "TH reads from the DUT the ActiveCurrent attribute",
@@ -100,8 +100,8 @@ class TC_EPM_2_2(MatterBaseTest, EnergyReportingBaseTestHelper):
             voltage = await self.check_epm_attribute_in_range("Voltage", 229000, 231000)
 
         self.step("5")
-        # After 3 seconds...
-        time.sleep(3)
+        # After 5 seconds...
+        time.sleep(5)
 
         self.step("5a")
         # Active power is Mandatory


### PR DESCRIPTION
Over the last few months there seems to have been more and more CI failures caused by
the tests in EEM and EPM when checking for 2 values to be different.

There are 2 test event triggers (one generates readings every 2s, one generates them every 5s).

The idea of the tests was to trigger the fake readings, and then wait the repeat period +1s which should have been ample time for a CPU to handle any jitter.

Observations seem to be that the CI platform VMs can starve the processors for >300ms, so a couple of these starvations could push the test to fail.

In an attempt to prove if this is the root cause, then we have proposed doubling the wait time to be 2 x repeat_period + 1s.

i.e. where we had a wait 3s -> wait 5s (for 2s updates)
i.e. where we had a wait 6s -> wait 11s (for 5s updates).

This impacts several scripts in EEM and EPM clusters.
[Test cases will need to be updated separately IF this seems to be a solution - see Test Plan issue https://github.com/CHIP-Specifications/chip-test-plans/issues/4284]