### PR TITLE
Add a mandatory fence to CI tests config and improve Python testing docs

### DIFF
--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -27,7 +27,7 @@ Python tests located in src/python_testing
 -   All test classes inherit from `MatterBaseTest` in
     [matter_testing_support.py](https://github.com/project-chip/connectedhomeip/blob/master/src/python_testing/matter_testing_support.py)
     -   Support for commissioning using the python controller
-    -   Sefault controller (`self.default_controller`) of type `ChipDeviceCtrl`
+    -   Default controller (`self.default_controller`) of type `ChipDeviceCtrl`
     -   `MatterBaseTest` inherits from the Mobly BaseTestClass
 -   Test method(s) (start with test\_) and are all run automatically
     -   To run in the test harness, the test method name must be `test_TC_PICSCODE_#_#`

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -30,7 +30,8 @@ Python tests located in src/python_testing
     -   Default controller (`self.default_controller`) of type `ChipDeviceCtrl`
     -   `MatterBaseTest` inherits from the Mobly BaseTestClass
 -   Test method(s) (start with test\_) and are all run automatically
-    -   To run in the test harness, the test method name must be `test_TC_PICSCODE_#_#`
+    -   To run in the test harness, the test method name must be
+        `test_TC_PICSCODE_#_#`
         -   More information about integration with the test harness can be
             found in [Test Harness helpers](#test-harness-helpers) section
     -   Any tests that use async method (read / write / commands) should be
@@ -79,8 +80,8 @@ default_matter_test_main()
 
 ---
 
-In this test, `asserts.assert_equal` is used to fail the test on equality assertion failure
-(throws an exception).
+In this test, `asserts.assert_equal` is used to fail the test on equality
+assertion failure (throws an exception).
 
 Because the test requires the use of the async method
 `read_single_attribute_check_success`, the test is decorated with the
@@ -223,13 +224,13 @@ has a set of objects that map ID to the code generated object.
 `chip.clusters.ClusterObjects.ALL_CLUSTERS`
 
 -   `dict[int, Cluster]` - maps cluster ID to Cluster class
-    - `cluster = chip.clusters.ClusterObjects.ALL_CLUSTERS[cluster_id]`
+    -   `cluster = chip.clusters.ClusterObjects.ALL_CLUSTERS[cluster_id]`
 
 `chip.clusters.ClusterObjects.ALL_ATTRIBUTES`
 
--   `dict[int, dict[int, ClusterAttributeDescriptor]]` - maps cluster ID to a dict
-    of attribute ID to attribute class
-    - `attr = chip.clusters.ClusterObjects.ALL_ATTRIBUTES[cluster_id][attribute_id]`
+-   `dict[int, dict[int, ClusterAttributeDescriptor]]` - maps cluster ID to a
+    dict of attribute ID to attribute class
+    -   `attr = chip.clusters.ClusterObjects.ALL_ATTRIBUTES[cluster_id][attribute_id]`
 
 `chip.clusters.ClusterObjects.ALL_ACCEPTED_COMMANDS/ALL_GENERATED_COMMANDS`
 
@@ -280,7 +281,8 @@ Multi-path
 ### [ReadEvent](./ChipDeviceCtrlAPI.md#readevent)
 
 -   Convenience wrapper for `Read`
--   Similar to `ReadAttribute`, but the tuple includes urgency as the last argument
+-   Similar to `ReadAttribute`, but the tuple includes urgency as the last
+    argument
 
 Example:
 
@@ -294,9 +296,9 @@ Clusters.TimeSynchronization.Events.MissingTrustedTimeSource, urgent)])
 ### Subscriptions
 
 Subscriptions are handled in the `Read` / `ReadAttribute` / `ReadEvent` APIs. To
-initiate a subscription, set the `reportInterval` tuple argument to set the floor and
-ceiling. The `keepSubscriptions` and `autoResubscribe` arguments also apply to
-subscriptions.
+initiate a subscription, set the `reportInterval` tuple argument to set the
+floor and ceiling. The `keepSubscriptions` and `autoResubscribe` arguments also
+apply to subscriptions.
 
 Subscription return `ClusterAttribute.SubscriptionTransaction`. This can be used
 to set callbacks. The object is returned after the priming data read is
@@ -410,11 +412,12 @@ reference.
         with the test description
 -   Top-level PICS:
     -   To guard your test on a top level PICS, define a method called
-        `pics_<YourTestMethodName>` to send back a list of PICS. If this method is
-        omitted, the test will be run for every endpoint on every device.
+        `pics_<YourTestMethodName>` to send back a list of PICS. If this method
+        is omitted, the test will be run for every endpoint on every device.
 -   Overriding the default timeout:
-    -   If the test is exceptionally long running, define a property getter method
-        `default_timeout` to adjust the timeout. The default is 90 seconds.
+    -   If the test is exceptionally long running, define a property getter
+        method `default_timeout` to adjust the timeout. The default is 90
+        seconds.
 
 Deferred failures: For some tests, it makes sense to perform the entire test
 before failing and collect all the errors so the developers can address all the
@@ -427,8 +430,8 @@ For such tests, use the ProblemNotice format and the convenience methods:
 -   `self.record_error`
 -   `self.record_warning`
 
-These methods keep track of the problems, and will print them at the end of
-the test. The test will not be failed until an assert is called.
+These methods keep track of the problems, and will print them at the end of the
+test. The test will not be failed until an assert is called.
 
 A good example of this type of test can be found in the device basic composition
 tests, where all the test steps are independent and performed on a single read.
@@ -440,15 +443,16 @@ See
 -   Use `--help` to get a full list
 -   `--storage-path`
     -   Used to set a local storage file path for persisted data to avoid
-        clashing files. It is suggested to always provide this argument.
-        Default value is `admin_storage.json` in current directory.
+        clashing files. It is suggested to always provide this argument. Default
+        value is `admin_storage.json` in current directory.
 -   `--commissioning-method`
     -   Need to re-commission to python controller as chip-tool and python
         commissioner do not share a credentials
 -   `--discriminator`, `--passcode`, `--qr-code`, `--manual-code`
 -   `--tests` to select tests
 -   `--PICS`
--   `--int-arg`, `--bool-arg`, `--float-arg`, `--string-arg`, `--json-arg`, `--hex-arg`
+-   `--int-arg`, `--bool-arg`, `--float-arg`, `--string-arg`, `--json-arg`,
+    `--hex-arg`
     -   Specify as key:value ex --bool-arg pixit_name:False
     -   Used for custom arguments to scripts (PIXITs)
 
@@ -524,8 +528,8 @@ or
 bootstrap.sh should be used for for the first setup, activate.sh may be used for
 subsequent setups as it is faster.
 
-Next build the python wheels and create / activate a venv (called `pyenv` here, but
-any name may be used)
+Next build the python wheels and create / activate a venv (called `pyenv` here,
+but any name may be used)
 
 ```
 ./scripts/build_python.sh -i pyenv
@@ -596,7 +600,8 @@ Below is the format of the structured environment definition comments:
 # === END CI TEST ARGUMENTS ===
 ```
 
-NOTE: The `=== BEGIN CI TEST ARGUMENTS ===` and `=== END CI TEST ARGUMENTS ===` markers must be present.
+NOTE: The `=== BEGIN CI TEST ARGUMENTS ===` and `=== END CI TEST ARGUMENTS ===`
+markers must be present.
 
 ### Description of Parameters
 
@@ -612,26 +617,26 @@ NOTE: The `=== BEGIN CI TEST ARGUMENTS ===` and `=== END CI TEST ARGUMENTS ===` 
 
         -   Example: `${TYPE_OF_APP}`
 
--   `test-runner-run/<run_identifier>/factoryreset`: Determines whether a factory
-    reset should be performed before the test.
+-   `test-runner-run/<run_identifier>/factoryreset`: Determines whether a
+    factory reset should be performed before the test.
 
     -   Example: `True`
 
--   `test-runner-run/<run_identifier>/quiet`: Sets the verbosity level of the test
-    run. When set to True, the test run will be quieter.
+-   `test-runner-run/<run_identifier>/quiet`: Sets the verbosity level of the
+    test run. When set to True, the test run will be quieter.
 
     -   Example: `True`
 
 -   `test-runner-run/<run_identifier>/app-args`: Specifies the arguments to be
     passed to the application during the test.
 
-    -   Example: `--discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json`
+    -   Example:
+        `--discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json`
 
--   `test-runner-run/<run_identifier>/script-args`: Specifies the arguments to be
-    passed to the test script.
-    -   Example: `--storage-path admin_storage.json --commissioning-method
-        on-network --discriminator 1234 --passcode 20202021 --trace-to
-        json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto`
+-   `test-runner-run/<run_identifier>/script-args`: Specifies the arguments to
+    be passed to the test script.
+    -   Example:
+        `--storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto`
 
 This structured format ensures that all necessary configurations are clearly
 defined and easily understood, allowing for consistent and reliable test

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -24,33 +24,38 @@ Python tests located in src/python_testing
         essential to define arguments at the top of the test script. This
         section should include various parameters and their respective values,
         which will guide the test runner on how to execute the tests.
--   All test classes inherit from MatterBaseTest in
+-   All test classes inherit from `MatterBaseTest` in
     [matter_testing_support.py](https://github.com/project-chip/connectedhomeip/blob/master/src/python_testing/matter_testing_support.py)
-    -   support for commissioning using the python controller
-    -   default controller (self.default_controller) of type ChipDeviceCtrl
-    -   MatterBaseTest inherits from the Mobly BaseTestClass
--   Test function(s) (start with test\_) and are all run automatically
-    -   To run in the test harness, the test name must be test_TC_PICSCODE\_#\_#
-        -   more information about integration with the test harness can be
+    -   Support for commissioning using the python controller
+    -   Sefault controller (`self.default_controller`) of type `ChipDeviceCtrl`
+    -   `MatterBaseTest` inherits from the Mobly BaseTestClass
+-   Test method(s) (start with test\_) and are all run automatically
+    -   To run in the test harness, the test method name must be `test_TC_PICSCODE_#_#`
+        -   More information about integration with the test harness can be
             found in [Test Harness helpers](#test-harness-helpers) section
-    -   any tests that use async function (read / write / commands) should be
+    -   Any tests that use async method (read / write / commands) should be
         decorated with the @async_test_body decorator
--   Use ChipDeviceCtrl to interact with the DUT
-    -   Controller API is in ChipDeviceCtrl.py (see API doc in file)
-    -   some support functions in matter_testing_support.py
+-   Use `ChipDeviceCtrl` to interact with the DUT
+    -   Controller API is in `ChipDeviceCtrl.py` (see API doc in file)
+    -   Some support methods in `matter_testing_support.py`
 -   Use Mobly assertions for failing tests
--   self.step() along with a steps\_ function to mark test plan steps for cert
+-   `self.step()` along with a `steps_*` method to mark test plan steps for cert
     tests
 
 ### A simple test
 
 ```
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 class TC_MYTEST_1_1(MatterBaseTest):
 
@@ -74,14 +79,14 @@ default_matter_test_main()
 
 ---
 
-In this test, asserts.assert_equal is used to fail the test on condition failure
+In this test, `asserts.assert_equal` is used to fail the test on equality assertion failure
 (throws an exception).
 
-Because the test requires the use of the async function
-read_single_attribute_check_success, the test is decorated with the
+Because the test requires the use of the async method
+`read_single_attribute_check_success`, the test is decorated with the
 `@async_test_body` decorator
 
-The default_matter_test_main() function is used to run the test on the command
+The `default_matter_test_main()` function is used to run the test on the command
 line. These two lines should appear verbatim at the bottom of every python test
 file.
 
@@ -106,12 +111,12 @@ always:
 Each `Clusters.<ClusterName>` will include the appropriate sub-classes (if
 defined for the cluster):
 
--   Enums
--   Bitmaps
--   Structs
--   Attributes
--   Commands
--   Events
+-   `Enums`
+-   `Bitmaps`
+-   `Structs`
+-   `Attributes`
+-   `Commands`
+-   `Events`
 
 ### Attributes
 
@@ -126,42 +131,41 @@ Each `Clusters.<ClusterName>.Attributes.<AttributeName>` class has:
 
 Example:
 
--   class - Clusters.OnOff.Attributes.OnTime
-    -   used for Read commands
--   instance - Clusters.OnOff.Attributes.OnTime(5)
-    -   sets the value to 5
-    -   pass the instance to write commands to write the value
+-   class - `Clusters.OnOff.Attributes.OnTime`
+    -   Used for Read commands
+-   instance - `Clusters.OnOff.Attributes.OnTime(5)`
+    -   Sets the value to `5`
+    -   Pass the instance to Write method to write the value
 
 ### Commands
 
-Commands derive from ClusterCommand
+Commands derive from `ClusterCommand`.
 
 Each `Clusters.<ClusterName>.Commands.<CommandName>` class has:
 
--   cluster_id
--   command_id
--   is_client
--   response_type (None for status response)
--   descriptor
+-   `cluster_id`
+-   `command_id`
+-   `is_client`
+-   `response_type` (None for status response)
+-   `descriptor`
 -   data members (if required)
 
 Example:
 
--   Clusters.OnOff.Commands.OnWithTimedOff(onOffControl=0, onTime=5,
-    offWaitTime=8)
--   Clusters.OnOff.Commands.OnWithTimedOff()
-    -   command with no fields
+-   `Clusters.OnOff.Commands.OnWithTimedOff(onOffControl=0, onTime=5, offWaitTime=8)`
+-   `Clusters.OnOff.Commands.OnWithTimedOff()`
+    -   Command with no fields
 
 ### Events
 
-Events derive from ClusterEvent
+Events derive from `ClusterEvent`.
 
 Each `Clusters.<ClusterName>.Events.<EventName>` class has:
 
--   cluster_id
--   event_id
--   descriptor
--   data members if required
+-   `cluster_id`
+-   `event_id`
+-   `descriptor`
+-   Other data members if required
 
 Example:
 
@@ -169,16 +173,16 @@ Example:
 
 ### Enums
 
-Enums derive from MatterIntEnum
+Enums derive from `MatterIntEnum`.
 
 Each `Clusters.<ClusterName>.Enum.<EnumName>` has
 
--   k<value>
--   kUnknownEnumValue (used for testing, do not transmit)
+-   `k<value>` constants
+-   `kUnknownEnumValue` (used for testing, do not transmit)
 
 Example:
 
--   Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kAdminister
+-   `Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kAdminister`
 
 ### Bitmaps
 
@@ -188,26 +192,28 @@ Each `Clusters.<ClusterName>.Bitmaps.<BitmapName>` has: - k<value>
 
 Special class:
 
--   class Feature(IntFlag) - contains the feature map bitmaps
+-   class `Feature(IntFlag)` - contains the feature map bitmaps
 
 Example:
 
--   Clusters.LaundryWasherControls.Bitmaps.Feature.kSpin
+-   `Clusters.LaundryWasherControls.Bitmaps.Feature.kSpin`
 
 ### Structs
 
-Structs derive from ClusterObject
+Structs derive from `ClusterObject`.
 
 Each `Clusters.<ClusterName>.Structs.<StructName>` has:
 
--   descriptor
--   data members
+-   A "descriptor"
+-   Data members
 
-Example
+Example:
 
--   Clusters.BasicInformation.Structs.ProductAppearanceStruct(
--   finish=Clusters.BasicInformation.Enums.ProductFinishEnum.kFabric,
--   primaryColor=Clusters.BasicInformation.Enums.ColorEnum.kBlack)
+```
+Clusters.BasicInformation.Structs.ProductAppearanceStruct(
+   finish=Clusters.BasicInformation.Enums.ProductFinishEnum.kFabric,
+   primaryColor=Clusters.BasicInformation.Enums.ColorEnum.kBlack)
+```
 
 ## Accessing Clusters and Cluster Elements by ID
 
@@ -216,14 +222,14 @@ has a set of objects that map ID to the code generated object.
 
 `chip.clusters.ClusterObjects.ALL_CLUSTERS`
 
--   dict[int, Cluster] - maps cluster ID to Cluster class
--   cluster = chip.clusters.ClusterObjects.ALL_CLUSTERS[cluster_id]
+-   `dict[int, Cluster]` - maps cluster ID to Cluster class
+    - `cluster = chip.clusters.ClusterObjects.ALL_CLUSTERS[cluster_id]`
 
 `chip.clusters.ClusterObjects.ALL_ATTRIBUTES`
 
--   dict[int, dict[int, ClusterAttributeDescriptor]] - maps cluster ID to a dict
+-   `dict[int, dict[int, ClusterAttributeDescriptor]]` - maps cluster ID to a dict
     of attribute ID to attribute class
--   attr = chip.clusters.ClusterObjects.ALL_ATTRIBUTES[cluster_id][attribute_id]
+    - `attr = chip.clusters.ClusterObjects.ALL_ATTRIBUTES[cluster_id][attribute_id]`
 
 `chip.clusters.ClusterObjects.ALL_ACCEPTED_COMMANDS/ALL_GENERATED_COMMANDS`
 
@@ -232,15 +238,15 @@ has a set of objects that map ID to the code generated object.
 
 ## ChipDeviceCtrl API
 
-The ChipDeviceCtrl API is implemented in
+The `ChipDeviceCtrl` API is implemented in
 [ChipDeviceCtrl.py](https://github.com/project-chip/connectedhomeip/blob/master/src/controller/python/chip/ChipDeviceCtrl.py).
 
-The ChipDeviceCtrl implements a python-based controller that can be used to
+The `ChipDeviceCtrl` implements a python-based controller that can be used to
 commission and control devices. The API is documented here in the
 [ChipDeviceCtrl API documentation](./ChipDeviceCtrlAPI.md)
 
 The API doc gives full descriptions of the APIs being used. The most commonly
-used functions are linked below
+used methods are linked below.
 
 ### [Read](./ChipDeviceCtrlAPI.md#read)
 
@@ -249,7 +255,7 @@ used functions are linked below
 
 ### [ReadAttribute](./ChipDeviceCtrlAPI.md#readattribute)
 
--   convenience wrapper for Read for attributes
+-   Convenience wrapper for Read for attributes
 
 Examples: Wildcard read (all clusters, all endpoints):
 
@@ -273,8 +279,8 @@ Multi-path
 
 ### [ReadEvent](./ChipDeviceCtrlAPI.md#readevent)
 
--   convenience wrapper for Read
--   Similar to ReadAttribute, but the tuple includes urgency as the last number
+-   Convenience wrapper for `Read`
+-   Similar to `ReadAttribute`, but the tuple includes urgency as the last argument
 
 Example:
 
@@ -287,9 +293,9 @@ Clusters.TimeSynchronization.Events.MissingTrustedTimeSource, urgent)])
 
 ### Subscriptions
 
-Subscriptions are handled in the Read / ReadAttribute / ReadEvent APIs. To
-initiate a subscription, set the `reportInterval` tuple to set the floor and
-ceiling. The `keepSubscriptions` and `autoResubscribe` parameters also apply to
+Subscriptions are handled in the `Read` / `ReadAttribute` / `ReadEvent` APIs. To
+initiate a subscription, set the `reportInterval` tuple argument to set the floor and
+ceiling. The `keepSubscriptions` and `autoResubscribe` arguments also apply to
 subscriptions.
 
 Subscription return `ClusterAttribute.SubscriptionTransaction`. This can be used
@@ -297,9 +303,9 @@ to set callbacks. The object is returned after the priming data read is
 complete, and the values there are used to populate the cache. The attribute
 callbacks are called on update.
 
--   SetAttributeUpdateCallback
+-   `SetAttributeUpdateCallback`
     -   Callable[[TypedAttributePath, SubscriptionTransaction], None]
--   SetEventUpdateCallback
+-   `SetEventUpdateCallback`
     -   Callable[[EventReadResult, SubscriptionTransaction], None]
 -   await changes in the main loop using a trigger mechanism from the callback.
 
@@ -337,7 +343,7 @@ asserts.assert_equal(ret[0].status, Status.Success, “write failed”)
 
 ### [SendCommand](./ChipDeviceCtrlAPI.md#sendcommand)
 
--   Instantiate the command with the values you need to populate
+-   Instantiate the command object with the values you need to populate
 -   If there is a non-status return, it’s returned from the command
 -   If there is a pure status return it will return nothing
 -   Raises InteractionModelError on failure
@@ -353,62 +359,62 @@ pai = await dev_ctrl.SendCommand(nodeid, 0, Clusters.OperationalCredentials.Comm
 -   Because we tend to do a lot of single read / single commands in tests, we
     added a couple of helpers in MatterBaseTest that use some of the default
     values
-    -   read_single_attribute_check_success
-    -   read_single_attribute_expect_error
-    -   send_single_cmd
--   step() function to mark step progress for the test harness
--   skip / skip_step / skip_remaining_steps functions for test harness
+    -   `read_single_attribute_check_success()`
+    -   `read_single_attribute_expect_error()`
+    -   `send_single_cmd()`
+-   `step()` method to mark step progress for the test harness
+-   `skip()` / `skip_step()` / `skip_remaining_steps()` methods for test harness
     integration
--   check_pics / pics_guard to handle pics
+-   `check_pics()` / `pics_guard()` to handle pics
 
 ## Mobly helpers
 
 The test system is based on Mobly, and the
 [matter_testing_support.py](https://github.com/project-chip/connectedhomeip/blob/master/src/python_testing/matter_testing_support.py)
-class provides some helpers for Mobly integration
+class provides some helpers for Mobly integration.
 
--   default_matter_test_main
-    -   Sets up commissioning and finds all tests, parses command arguments
+-   `default_matter_test_main`
+    -   Sets up commissioning and finds all tests, parses command-line arguments
 
 use as:
 
 ```
 if __name__ == "__main__":
-default_matter_test_main()
+    default_matter_test_main()
 ```
 
--   Mobly will run all functions starting with test\_ by default
-    -   use --tests command line argument to specify
--   Setup / teardown functions
-    -   setup_class / teardown_class
-    -   setup_test / teardown_test
-    -   Don’t forget to call the super() if you override these
+-   Mobly will run all methods starting with `test_` prefix by default
+    -   use `--tests` command line argument to specify exact name,s
+-   Setup and teardown methods
+    -   `setup_class` / `teardown_class`
+    -   `setup_test` / `teardown_test`
+    -   Don’t forget to call the `super()` if you override these
 
 ## Test harness helpers
 
-The python testing system also includes several functions for integrations with
+The python testing system also includes several methods for integrations with
 the test harness. To integrate with the test harness, you can define the
-following functions on your class to allow the test harness UI to properly work
+following methods on your class to allow the test harness UI to properly work
 through your tests.
 
-All of these functions are demonstrated in the
+All of these methods are demonstrated in the
 [hello_example.py](https://github.com/project-chip/connectedhomeip/blob/master/src/python_testing/hello_test.py)
 reference.
 
--   step enumeration
-    -   define a function called `steps_YourFunctionName` to allow the test
+-   Steps enumeration:
+    -   Define a method called `steps_<YourTestMethodName>` to allow the test
         harness to display the steps
-    -   use the self.step(`<stepnum>`) function to walk through the steps
--   test description
-    -   define a function called `desc_YourFunctionName` to send back a string
+    -   Use the `self.step(<stepnum>)` method to walk through the steps
+-   Test description:
+    -   Define a method called `desc_<YourTestMethodName>` to send back a string
         with the test description
--   top level PICS
-    -   To guard your test on a top level PICS, define a function called
-        `pics_YourFunctionName` to send back a list of pics. If this function is
+-   Top-level PICS:
+    -   To guard your test on a top level PICS, define a method called
+        `pics_<YourTestMethodName>` to send back a list of PICS. If this method is
         omitted, the test will be run for every endpoint on every device.
--   overriding the default timeout
-    -   if the test is exceptionally long running, define a property function
-        `default_timeout` to adjust the timeout. The default is 90 seconds
+-   Overriding the default timeout:
+    -   If the test is exceptionally long running, define a property getter method
+        `default_timeout` to adjust the timeout. The default is 90 seconds.
 
 Deferred failures: For some tests, it makes sense to perform the entire test
 before failing and collect all the errors so the developers can address all the
@@ -416,13 +422,13 @@ failures without needing to re-run the test multiple times. For example, tests
 that look at every attribute on the cluster and perform independent operations
 on them etc.
 
-For such tests, use the ProblemNotice format and the convenience functions:
+For such tests, use the ProblemNotice format and the convenience methods:
 
--   self.record_error
--   self.record_warning
+-   `self.record_error`
+-   `self.record_warning`
 
-These functions keep track of the problems, and will print them at the end of
-the test. The test will not be failed until the assert is called.
+These methods keep track of the problems, and will print them at the end of
+the test. The test will not be failed until an assert is called.
 
 A good example of this type of test can be found in the device basic composition
 tests, where all the test steps are independent and performed on a single read.
@@ -431,16 +437,20 @@ See
 
 ## Command line arguments
 
--   Use help to get a full list
--   --commissioning-method
-    -   need to re-commission to python controller as chip-tool and python
+-   Use `--help` to get a full list
+-   `--storage-path`
+    -   Used to set a local storage file path for persisted data to avoid
+        clashing files. It is suggested to always provide this argument.
+        Default value is `admin_storage.json` in current directory.
+-   `--commissioning-method`
+    -   Need to re-commission to python controller as chip-tool and python
         commissioner do not share a credentials
--   --discriminator, --passcode, --qr-code, --manual-code
--   --tests to select tests
--   --PICS
--   --int-arg, --bool-arg, --float-arg, --string-arg, --json-arg, --hex-arg
-    -   specify as key:value ex --bool-arg pixit_name:False
-    -   used for custom arguments to scripts (PIXITs)
+-   `--discriminator`, `--passcode`, `--qr-code`, `--manual-code`
+-   `--tests` to select tests
+-   `--PICS`
+-   `--int-arg`, `--bool-arg`, `--float-arg`, `--string-arg`, `--json-arg`, `--hex-arg`
+    -   Specify as key:value ex --bool-arg pixit_name:False
+    -   Used for custom arguments to scripts (PIXITs)
 
 ## PICS and PIXITS
 
@@ -454,7 +464,7 @@ See
         comments
 -   pixit_value = self.user_params.get("pixit_name", default)
 
-## Support functions
+## Support functionality
 
 To create a controller on a new fabric:
 
@@ -462,7 +472,7 @@ To create a controller on a new fabric:
 new_CA = self.certificate_authority_manager.NewCertificateAuthority()
 
 new_fabric_admin = new_certificate_authority.NewFabricAdmin(vendorId=0xFFF1,
-fabricId=self.matter_test_config.fabric_id + 1)
+    fabricId=self.matter_test_config.fabric_id + 1)
 
 TH2 = new_fabric_admin.NewController(nodeId=112233)
 ```
@@ -474,22 +484,22 @@ params = self.OpenCommissioningWindow(dev_ctrl=self.default_controller, node_id=
 ```
 
 To create a new controller on the SAME fabric, allocate a new controller from
-the fabric admin
+the fabric admin.
 
 Fabric admin for default controller:
 
 ```
-fa=self.certificate_authority_manager.activeCaList[0].adminList[0]
-second_ctrl = fa.new_fabric_admin.NewController(nodeId=node_id)
+  fa = self.certificate_authority_manager.activeCaList[0].adminList[0]
+  second_ctrl = fa.new_fabric_admin.NewController(nodeId=node_id)
 ```
 
-## other support functions
+## Other support utilities
 
--   basic_composition_support
+-   `basic_composition_support`
     -   wildcard read, whole device analysis
--   CommissioningFlowBlocks
+-   `CommissioningFlowBlocks`
     -   various commissioning support for core tests
--   spec_parsing_support
+-   `spec_parsing_support`
     -   parsing data model XML into python readable format
 
 # Running tests locally
@@ -514,12 +524,12 @@ or
 bootstrap.sh should be used for for the first setup, activate.sh may be used for
 subsequent setups as it is faster.
 
-Next build the python wheels and create / activate a venv (called `py` here, but
+Next build the python wheels and create / activate a venv (called `pyenv` here, but
 any name may be used)
 
 ```
-./scripts/build_python.sh -i py
-source py/bin/activate
+./scripts/build_python.sh -i pyenv
+source pyenv/bin/activate
 ```
 
 ## Running tests
@@ -539,11 +549,11 @@ python3 src/python_testing/TC_ACE_1_2.py --commissioning-method on-network --qr-
 ```
 
 Some tests require additional arguments (ex. PIXITs or configuration variables
-for the CI). These arguments can be passed as sets of key-value pairs using the
-`--<type>-arg` command line arguments. For example
+for the CI). These arguments can be passed as sets of key/value pairs using the
+`--<type>-arg:<value>` command line arguments. For example:
 
 ```
---int-arg PIXIT.ACE.APPENDPOINT:1 PIXIT.ACE.APPDEVTYPEID:0x0100 --string-arg PIXIT.ACE.APPCLUSTER:OnOff PIXIT.ACE.APPATTRIBUTE:OnOff
+--int-arg PIXIT.ACE.APPENDPOINT:1 --int-arg PIXIT.ACE.APPDEVTYPEID:0x0100 --string-arg PIXIT.ACE.APPCLUSTER:OnOff --string-arg PIXIT.ACE.APPATTRIBUTE:OnOff
 ```
 
 ## Local host app testing
@@ -555,67 +565,73 @@ example DUT on the host and includes factory reset support
 
 # Running tests in CI
 
--   add to .github/workflows/tests.yaml repl_tests_linux
--   don’t forget to set the PICS file to the ci-pics-values
--   if there are things in your test that will fail on CI (ex. test vendor
+-   Add test to the `repl_tests_linux` section of `.github/workflows/tests.yaml`
+-   Don’t forget to set the PICS file to the ci-pics-values
+-   If there are steps in your test that will fail on CI (e.g. test vendor
     checks), gate them on the PICS_SDK_CI_ONLY
-    -   is_ci = self.check_pics('PICS_SDK_CI_ONLY')
+    -   `is_ci = self.check_pics('PICS_SDK_CI_ONLY')`
 
 The CI test runner uses a structured environment setup that can be declared
 using structured comments at the top of the test file. To use this structured
-format, use the --load-from-env flag with the run_python_tests.py runner.
+format, use the `--load-from-env` flag with the `run_python_tests.py` runner.
 
 Ex:
 `scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_ICDM_2_1.py'`
 
 ## Defining the CI test arguments
 
-Below is the format:
+Below is the format of the structured environment definition comments:
 
 ```
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: <run_identifier>
 # test-runner-run/<run_identifier>/app: ${TYPE_OF_APP}
 # test-runner-run/<run_identifier>/factoryreset: <True|False>
 # test-runner-run/<run_identifier>/quiet: <True|False>
 # test-runner-run/<run_identifier>/app-args: <app_arguments>
 # test-runner-run/<run_identifier>/script-args: <script_arguments>
+# === END CI TEST ARGUMENTS ===
 ```
+
+NOTE: The `=== BEGIN CI TEST ARGUMENTS ===` and `=== END CI TEST ARGUMENTS ===` markers must be present.
 
 ### Description of Parameters
 
--   test-runner-runs: Specifies the identifier for the run. This can be any
+-   `test-runner-runs`: Specifies the identifier for the run. This can be any
     unique identifier.
 
-    -   Example: run1
+    -   Example: `run1`
 
--   test-runner-run/<run_identifier>/app: Indicates the application to be used
+-   `test-runner-run/<run_identifier>/app`: Indicates the application to be used
     in the test. Different app types as needed could be referenced from section
     [name: Generate an argument environment file ] of the file
     [.github/workflows/tests.yaml](https://github.com/project-chip/connectedhomeip/blob/master/.github/workflows/tests.yaml)
 
-        -   Example: \${TYPE_OF_APP}
+        -   Example: `${TYPE_OF_APP}`
 
--   test-runner-run/<run_identifier>/factoryreset: Determines whether a factory
+-   `test-runner-run/<run_identifier>/factoryreset`: Determines whether a factory
     reset should be performed before the test.
 
-    -   Example: True
+    -   Example: `True`
 
--   test-runner-run/<run_identifier>/quiet: Sets the verbosity level of the test
+-   `test-runner-run/<run_identifier>/quiet`: Sets the verbosity level of the test
     run. When set to True, the test run will be quieter.
 
-    -   Example: True
+    -   Example: `True`
 
--   test-runner-run/<run_identifier>/app-args: Specifies the arguments to be
+-   `test-runner-run/<run_identifier>/app-args`: Specifies the arguments to be
     passed to the application during the test.
 
-    -   Example: --discriminator 1234 --KVS kvs1 --trace-to
-        json:\${TRACE_APP}.json
+    -   Example: `--discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json`
 
--   test-runner-run/<run_identifier>/script-args: Specifies the arguments to be
+-   `test-runner-run/<run_identifier>/script-args`: Specifies the arguments to be
     passed to the test script.
-    -   Example: --storage-path admin_storage.json --commissioning-method
+    -   Example: `--storage-path admin_storage.json --commissioning-method
         on-network --discriminator 1234 --passcode 20202021 --trace-to
-        json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+        json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto`
 
 This structured format ensures that all necessary configurations are clearly
 defined and easily understood, allowing for consistent and reliable test

--- a/scripts/tests/py/metadata.py
+++ b/scripts/tests/py/metadata.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import re
-from dataclasses import dataclass
 import sys
+from dataclasses import dataclass
 from typing import Any, Dict, List
 
 import yaml

--- a/scripts/tests/py/metadata.py
+++ b/scripts/tests/py/metadata.py
@@ -83,7 +83,8 @@ def extract_runs_arg_lines(py_script_path: str) -> Dict[str, Dict[str, str]]:
     done_ci_args_section = False
 
     runs_def_ptrn = re.compile(r'^\s*#\s*test-runner-runs:\s*(?P<run_id>.*)$')
-    arg_def_ptrn = re.compile(r'^\s*#\s*test-runner-run/(?P<run_id>[a-zA-Z0-9_]+)/(?P<arg_name>[a-zA-Z0-9_\-]+):\s*(?P<arg_val>.*)$')
+    arg_def_ptrn = re.compile(
+        r'^\s*#\s*test-runner-run/(?P<run_id>[a-zA-Z0-9_]+)/(?P<arg_name>[a-zA-Z0-9_\-]+):\s*(?P<arg_val>.*)$')
 
     runs_arg_lines: Dict[str, Dict[str, str]] = {}
 

--- a/scripts/tests/py/metadata.py
+++ b/scripts/tests/py/metadata.py
@@ -15,9 +15,15 @@
 
 import re
 from dataclasses import dataclass
+import sys
 from typing import Any, Dict, List
 
 import yaml
+
+
+def bool_from_str(value: str) -> bool:
+    """Convert True/true/False/false strings to bool."""
+    return value.strip().lower() == "true"
 
 
 @dataclass
@@ -58,16 +64,58 @@ class Metadata:
             self.py_script_path = attr_dict["py_script_path"]
 
         if "factoryreset" in attr_dict:
-            self.factoryreset = bool(attr_dict["factoryreset"])
+            self.factoryreset = bool_from_str(attr_dict["factoryreset"])
 
         if "factoryreset_app_only" in attr_dict:
-            self.factoryreset_app_only = bool(attr_dict["factoryreset_app_only"])
+            self.factoryreset_app_only = bool_from_str(attr_dict["factoryreset_app_only"])
 
         if "script_gdb" in attr_dict:
-            self.script_gdb = bool(attr_dict["script_gdb"])
+            self.script_gdb = bool_from_str(attr_dict["script_gdb"])
 
         if "quiet" in attr_dict:
-            self.quiet = bool(attr_dict["quiet"])
+            self.quiet = bool_from_str(attr_dict["quiet"])
+
+
+def extract_runs_arg_lines(py_script_path: str) -> Dict[str, Dict[str, str]]:
+    """Extract the run arguments from the CI test arguments blocks."""
+
+    found_ci_args_section = False
+    done_ci_args_section = False
+
+    runs_def_ptrn = re.compile(r'^\s*#\s*test-runner-runs:\s*(?P<run_id>.*)$')
+    arg_def_ptrn = re.compile(r'^\s*#\s*test-runner-run/(?P<run_id>[a-zA-Z0-9_]+)/(?P<arg_name>[a-zA-Z0-9_\-]+):\s*(?P<arg_val>.*)$')
+
+    runs_arg_lines: Dict[str, Dict[str, str]] = {}
+
+    with open(py_script_path, 'r', encoding='utf8') as py_script:
+        for line_idx, line in enumerate(py_script.readlines()):
+            line = line.strip()
+            line_num = line_idx + 1
+
+            # Detect the single CI args section, to skip the lines otherwise.
+            if not done_ci_args_section and line.startswith("# === BEGIN CI TEST ARGUMENTS ==="):
+                found_ci_args_section = True
+            elif found_ci_args_section and line.startswith("# === END CI TEST ARGUMENTS ==="):
+                done_ci_args_section = True
+                found_ci_args_section = False
+
+            runs_match = runs_def_ptrn.match(line)
+            args_match = arg_def_ptrn.match(line)
+
+            if not found_ci_args_section and (runs_match or args_match):
+                print(f"WARNING: {py_script_path}:{line_num}: Found CI args outside of CI TEST ARGUMENTS block!", file=sys.stderr)
+                continue
+
+            if runs_match:
+                for run in runs_match.group("run_id").strip().split():
+                    runs_arg_lines[run] = {}
+                    runs_arg_lines[run]['run'] = run
+                    runs_arg_lines[run]['py_script_path'] = py_script_path
+
+            elif args_match:
+                runs_arg_lines[args_match.group("run_id")][args_match.group("arg_name")] = args_match.group("arg_val")
+
+    return runs_arg_lines
 
 
 class MetadataReader:
@@ -126,33 +174,15 @@ class MetadataReader:
          the run arguments associated with a particular run defined in
          the script file.
         """
-
-        runs_def_ptrn = re.compile(r'^\s*#\s*test-runner-runs:\s*(.*)$')
-        arg_def_ptrn = re.compile(r'^\s*#\s*test-runner-run/([a-zA-Z0-9_]+)/([a-zA-Z0-9_\-]+):\s*(.*)$')
-
-        runs_arg_lines: Dict[str, Dict[str, str]] = {}
         runs_metadata: List[Metadata] = []
-
-        with open(py_script_path, 'r', encoding='utf8') as py_script:
-            for line in py_script.readlines():
-                runs_match = runs_def_ptrn.match(line.strip())
-                args_match = arg_def_ptrn.match(line.strip())
-
-                if runs_match:
-                    for run in runs_match.group(1).strip().split():
-                        runs_arg_lines[run] = {}
-                        runs_arg_lines[run]['run'] = run
-                        runs_arg_lines[run]['py_script_path'] = py_script_path
-
-                elif args_match:
-                    runs_arg_lines[args_match.group(1)][args_match.group(2)] = args_match.group(3)
+        runs_arg_lines = extract_runs_arg_lines(py_script_path)
 
         for run, attr in runs_arg_lines.items():
             self.__resolve_env_vals__(attr)
 
             metadata = Metadata(
                 py_script_path=attr.get("py_script_path", ""),
-                run=attr.get("run", ""),
+                run=run,
                 app=attr.get("app", ""),
                 app_args=attr.get("app_args", ""),
                 script_args=attr.get("script_args", ""),

--- a/scripts/tests/py/test_metadata.py
+++ b/scripts/tests/py/test_metadata.py
@@ -21,13 +21,17 @@ from metadata import Metadata, MetadataReader
 
 class TestMetadataReader(unittest.TestCase):
 
-    test_file_content = ''' 
-    # test-runner-runs: run1 
+    test_file_content = '''
+    # === BEGIN CI TEST ARGUMENTS ===
+    # test-runner-runs: run1
     # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
     # test-runner-run/run1/app-args: --discriminator 1234 --trace-to json:${TRACE_APP}.json
     # test-runner-run/run1/script-args: --commissioning-method on-network --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
     # test-runner-run/run1/factoryreset: True
     # test-runner-run/run1/quiet: True
+    # === END CI TEST ARGUMENTS ===
+
+    # test-runner-run/run1/quiet: False
     '''
 
     env_file_content = '''

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -19,12 +19,17 @@
 
 # Commissioning test.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --log-level INFO -t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import asyncio
 import os

--- a/src/python_testing/TC_ACE_1_2.py
+++ b/src/python_testing/TC_ACE_1_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 import queue

--- a/src/python_testing/TC_ACE_1_3.py
+++ b/src/python_testing/TC_ACE_1_3.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_ACE_1_4.py
+++ b/src/python_testing/TC_ACE_1_4.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --int-arg PIXIT.ACE.APPENDPOINT:1 PIXIT.ACE.APPDEVTYPEID:0x0100 --string-arg PIXIT.ACE.APPCLUSTER:OnOff PIXIT.ACE.APPATTRIBUTE:OnOff --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import sys
 

--- a/src/python_testing/TC_ACE_1_5.py
+++ b/src/python_testing/TC_ACE_1_5.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_AccessChecker.py
+++ b/src/python_testing/TC_AccessChecker.py
@@ -1,9 +1,14 @@
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 from copy import deepcopy

--- a/src/python_testing/TC_CGEN_2_4.py
+++ b/src/python_testing/TC_CGEN_2_4.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 import random

--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import os
 import random

--- a/src/python_testing/TC_DA_1_5.py
+++ b/src/python_testing/TC_DA_1_5.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import random
 

--- a/src/python_testing/TC_DA_1_7.py
+++ b/src/python_testing/TC_DA_1_7.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --bool-arg allow_sdk_dac:true --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 from glob import glob

--- a/src/python_testing/TC_DGGEN_2_4.py
+++ b/src/python_testing/TC_DGGEN_2_4.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import asyncio
 import logging

--- a/src/python_testing/TC_DRLK_2_12.py
+++ b/src/python_testing/TC_DRLK_2_12.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_LOCK_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 from drlk_2_x_common import DRLK_COMMON
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_DRLK_2_2.py
+++ b/src/python_testing/TC_DRLK_2_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_LOCK_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 from drlk_2_x_common import DRLK_COMMON
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_DRLK_2_3.py
+++ b/src/python_testing/TC_DRLK_2_3.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_LOCK_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 from drlk_2_x_common import DRLK_COMMON
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --manual-code 10054912339 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 from dataclasses import dataclass

--- a/src/python_testing/TC_DeviceConformance.py
+++ b/src/python_testing/TC_DeviceConformance.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_LOCK_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --manual-code 10054912339 --bool-arg ignore_in_progress:True allow_provisional:True --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto --tests test_TC_IDM_10_2
+# === END CI TEST ARGUMENTS ===
 
 from typing import Callable
 

--- a/src/python_testing/TC_EEM_2_1.py
+++ b/src/python_testing/TC_EEM_2_1.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ENERGY_MANAGEMENT_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_EEM_2_2.py
+++ b/src/python_testing/TC_EEM_2_2.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ENERGY_MANAGEMENT_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import time
 

--- a/src/python_testing/TC_EEM_2_3.py
+++ b/src/python_testing/TC_EEM_2_3.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ENERGY_MANAGEMENT_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import time
 

--- a/src/python_testing/TC_EEM_2_4.py
+++ b/src/python_testing/TC_EEM_2_4.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ENERGY_MANAGEMENT_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import time
 

--- a/src/python_testing/TC_EEM_2_5.py
+++ b/src/python_testing/TC_EEM_2_5.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ENERGY_MANAGEMENT_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import time
 

--- a/src/python_testing/TC_EEVSE_2_2.py
+++ b/src/python_testing/TC_EEVSE_2_2.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ENERGY_MANAGEMENT_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 import time

--- a/src/python_testing/TC_EEVSE_2_4.py
+++ b/src/python_testing/TC_EEVSE_2_4.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ENERGY_MANAGEMENT_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 import time

--- a/src/python_testing/TC_EEVSE_2_5.py
+++ b/src/python_testing/TC_EEVSE_2_5.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ENERGY_MANAGEMENT_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_EPM_2_1.py
+++ b/src/python_testing/TC_EPM_2_1.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ENERGY_MANAGEMENT_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_EPM_2_2.py
+++ b/src/python_testing/TC_EPM_2_2.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ENERGY_MANAGEMENT_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 import time

--- a/src/python_testing/TC_FAN_3_1.py
+++ b/src/python_testing/TC_FAN_3_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 import time

--- a/src/python_testing/TC_FAN_3_2.py
+++ b/src/python_testing/TC_FAN_3_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 import time

--- a/src/python_testing/TC_FAN_3_3.py
+++ b/src/python_testing/TC_FAN_3_3.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_FAN_3_4.py
+++ b/src/python_testing/TC_FAN_3_4.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_FAN_3_5.py
+++ b/src/python_testing/TC_FAN_3_5.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 import time

--- a/src/python_testing/TC_ICDM_2_1.py
+++ b/src/python_testing/TC_ICDM_2_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${LIT_ICD_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 import re

--- a/src/python_testing/TC_ICDM_3_1.py
+++ b/src/python_testing/TC_ICDM_3_1.py
@@ -16,12 +16,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${LIT_ICD_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 import os

--- a/src/python_testing/TC_ICDManagementCluster.py
+++ b/src/python_testing/TC_ICDManagementCluster.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${LIT_ICD_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --hex-arg enableKey:000102030405060708090a0b0c0d0e0f --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import ctypes
 from enum import IntEnum

--- a/src/python_testing/TC_IDM_1_2.py
+++ b/src/python_testing/TC_IDM_1_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import inspect
 import logging

--- a/src/python_testing/TC_IDM_1_4.py
+++ b/src/python_testing/TC_IDM_1_4.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --hex-arg PIXIT.DGGEN.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_IDM_4_2.py
+++ b/src/python_testing/TC_IDM_4_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import copy
 import logging

--- a/src/python_testing/TC_MWOCTRL_2_1.py
+++ b/src/python_testing/TC_MWOCTRL_2_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_MICROWAVE_OVEN_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status

--- a/src/python_testing/TC_MWOCTRL_2_2.py
+++ b/src/python_testing/TC_MWOCTRL_2_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_MICROWAVE_OVEN_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_MWOCTRL_2_4.py
+++ b/src/python_testing/TC_MWOCTRL_2_4.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_MICROWAVE_OVEN_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_MWOM_1_2.py
+++ b/src/python_testing/TC_MWOM_1_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_MICROWAVE_OVEN_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_OPCREDS_3_1.py
+++ b/src/python_testing/TC_OPCREDS_3_1.py
@@ -14,12 +14,17 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 import copy
 import logging
 import random

--- a/src/python_testing/TC_OPCREDS_3_2.py
+++ b/src/python_testing/TC_OPCREDS_3_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import chip.clusters as Clusters
 from chip.tlv import TLVReader

--- a/src/python_testing/TC_OPSTATE_2_1.py
+++ b/src/python_testing/TC_OPSTATE_2_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --endpoint 1 --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import chip.clusters as Clusters
 from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_OPSTATE_2_2.py
+++ b/src/python_testing/TC_OPSTATE_2_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --endpoint 1 --int-arg PIXIT.WAITTIME.COUNTDOWN:5 --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import chip.clusters as Clusters
 from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_OPSTATE_2_3.py
+++ b/src/python_testing/TC_OPSTATE_2_3.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --endpoint 1 --int-arg PIXIT.WAITTIME.COUNTDOWN:5 --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 
 import chip.clusters as Clusters

--- a/src/python_testing/TC_OPSTATE_2_4.py
+++ b/src/python_testing/TC_OPSTATE_2_4.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --endpoint 1 --int-arg PIXIT.OPSTATE.ErrorEventGen:1 --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 
 import chip.clusters as Clusters

--- a/src/python_testing/TC_OPSTATE_2_5.py
+++ b/src/python_testing/TC_OPSTATE_2_5.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --endpoint 1 --int-arg PIXIT.WAITTIME.REBOOT:5 --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 
 import chip.clusters as Clusters

--- a/src/python_testing/TC_OVENOPSTATE_2_1.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --endpoint 1 --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 
 import chip.clusters as Clusters

--- a/src/python_testing/TC_OVENOPSTATE_2_2.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --endpoint 1 --int-arg PIXIT.WAITTIME.COUNTDOWN:5 --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import chip.clusters as Clusters
 from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_OVENOPSTATE_2_3.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_3.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --endpoint 1 --int-arg PIXIT.WAITTIME.COUNTDOWN:5 --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import chip.clusters as Clusters
 from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_OVENOPSTATE_2_4.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_4.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --endpoint 1 --int-arg PIXIT.OVENOPSTATE.ErrorEventGen:1 --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import chip.clusters as Clusters
 from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_OVENOPSTATE_2_5.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_5.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --endpoint 1 --int-arg PIXIT.WAITTIME.REBOOT:5 --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 
 import chip.clusters as Clusters

--- a/src/python_testing/TC_PWRTL_2_1.py
+++ b/src/python_testing/TC_PWRTL_2_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import asyncio
 import logging

--- a/src/python_testing/TC_RVCCLEANM_1_2.py
+++ b/src/python_testing/TC_RVCCLEANM_1_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_RVC_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_RVCCLEANM_2_1.py
+++ b/src/python_testing/TC_RVCCLEANM_2_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_RVC_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto --int-arg PIXIT.RVCCLEANM.MODE_CHANGE_FAIL:1 PIXIT.RVCCLEANM.MODE_CHANGE_OK:2
+# === END CI TEST ARGUMENTS ===
 
 import logging
 from time import sleep

--- a/src/python_testing/TC_RVCCLEANM_2_2.py
+++ b/src/python_testing/TC_RVCCLEANM_2_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_RVC_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 from time import sleep
 

--- a/src/python_testing/TC_RVCOPSTATE_2_1.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_RVC_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 from time import sleep

--- a/src/python_testing/TC_RVCOPSTATE_2_3.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_3.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_RVC_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 from time import sleep

--- a/src/python_testing/TC_RVCOPSTATE_2_4.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_4.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_RVC_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 from time import sleep

--- a/src/python_testing/TC_RVCRUNM_1_2.py
+++ b/src/python_testing/TC_RVCRUNM_1_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_RVC_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TC_RVCRUNM_2_1.py
+++ b/src/python_testing/TC_RVCRUNM_2_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_RVC_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto --int-arg PIXIT.RVCRUNM.MODE_CHANGE_OK:0 PIXIT.RVCRUNM.MODE_CHANGE_FAIL:2
+# === END CI TEST ARGUMENTS ===
 
 import logging
 from time import sleep

--- a/src/python_testing/TC_RVCRUNM_2_2.py
+++ b/src/python_testing/TC_RVCRUNM_2_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${CHIP_RVC_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto --int-arg PIXIT.RVCRUNM.MODE_A:1 PIXIT.RVCRUNM.MODE_B:2
+# === END CI TEST ARGUMENTS ===
 
 from time import sleep
 

--- a/src/python_testing/TC_SC_3_6.py
+++ b/src/python_testing/TC_SC_3_6.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 
 import asyncio

--- a/src/python_testing/TC_TIMESYNC_2_1.py
+++ b/src/python_testing/TC_TIMESYNC_2_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import ipaddress
 from datetime import timedelta

--- a/src/python_testing/TC_TIMESYNC_2_10.py
+++ b/src/python_testing/TC_TIMESYNC_2_10.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import queue
 import time

--- a/src/python_testing/TC_TIMESYNC_2_11.py
+++ b/src/python_testing/TC_TIMESYNC_2_11.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import queue
 import time

--- a/src/python_testing/TC_TIMESYNC_2_12.py
+++ b/src/python_testing/TC_TIMESYNC_2_12.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import queue
 import time

--- a/src/python_testing/TC_TIMESYNC_2_13.py
+++ b/src/python_testing/TC_TIMESYNC_2_13.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import queue
 import time

--- a/src/python_testing/TC_TIMESYNC_2_2.py
+++ b/src/python_testing/TC_TIMESYNC_2_2.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 from datetime import timedelta
 

--- a/src/python_testing/TC_TIMESYNC_2_4.py
+++ b/src/python_testing/TC_TIMESYNC_2_4.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import typing
 from datetime import timedelta

--- a/src/python_testing/TC_TIMESYNC_2_5.py
+++ b/src/python_testing/TC_TIMESYNC_2_5.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import typing
 

--- a/src/python_testing/TC_TIMESYNC_2_6.py
+++ b/src/python_testing/TC_TIMESYNC_2_6.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import typing
 

--- a/src/python_testing/TC_TIMESYNC_2_7.py
+++ b/src/python_testing/TC_TIMESYNC_2_7.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import time
 import typing

--- a/src/python_testing/TC_TIMESYNC_2_8.py
+++ b/src/python_testing/TC_TIMESYNC_2_8.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import time
 import typing

--- a/src/python_testing/TC_TIMESYNC_2_9.py
+++ b/src/python_testing/TC_TIMESYNC_2_9.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import typing
 from datetime import timedelta

--- a/src/python_testing/TC_TIMESYNC_3_1.py
+++ b/src/python_testing/TC_TIMESYNC_3_1.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import chip.clusters as Clusters
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_TestEventTrigger.py
+++ b/src/python_testing/TC_TestEventTrigger.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --enable-key 000102030405060708090a0b0c0d0e0f
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --bool-arg allow_sdk_dac:true --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TestBatchInvoke.py
+++ b/src/python_testing/TestBatchInvoke.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 

--- a/src/python_testing/TestGroupTableReports.py
+++ b/src/python_testing/TestGroupTableReports.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 import queue

--- a/src/python_testing/hello_test.py
+++ b/src/python_testing/hello_test.py
@@ -15,12 +15,17 @@
 #    limitations under the License.
 #
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs: run1
 # test-runner-run/run1/app: ${TYPE_OF_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
 
 import logging
 


### PR DESCRIPTION
- Fix bugs in metadata.py where bool args were incorrectly parse
- Introduce mandatory fence for the CI config
- Improve documentation for Python testing framework and examples involved