### PR TITLE
[1.3 cherry-pick] Bump numpy/pandas to work with Python 3.12

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -134,7 +134,7 @@ mypy-extensions==1.0.0
     # via mypy
 mypy-protobuf==3.5.0
     # via -r requirements.all.txt
-numpy==1.24.2
+numpy==1.26.4
     # via pandas
 packaging==23.0
     # via
@@ -143,7 +143,7 @@ packaging==23.0
     #   ghapi
     #   idf-component-manager
     #   west
-pandas==1.5.3 ; platform_machine != "aarch64" and platform_machine != "arm64"
+pandas==2.1.4 ; platform_machine != "aarch64" and platform_machine != "arm64"
     # via -r requirements.memory.txt
 parso==0.8.3
     # via jedi


### PR DESCRIPTION
Partial cherry-pick of #33637.

When installing pip requirements for all fails on Python 3.12 with:
```
  File "/tmp/pip-build-env-o33g4it5/overlay/lib/python3.12/site-packages/pkg_resources/__init__.py", line 2172, in <module>
    register_finder(pkgutil.ImpImporter, find_on_path)
                    ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```

Bump numpy/pandas to make this work on v1.3 branch too.
