### PR TITLE
Remove including RvcOperationalState in operational-state-delegate-impl

### DIFF
--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -173,6 +173,16 @@ public:
     {}
 };
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+class PairWiFiPAF : public PairingCommand
+{
+public:
+    PairWiFiPAF(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("wifi-paf", PairingMode::WiFiPAF, PairingNetworkType::WiFi, credsIssuerConfig)
+    {}
+};
+#endif
+
 class PairAlreadyDiscovered : public PairingCommand
 {
 public:
@@ -234,6 +244,9 @@ void registerCommandsPairing(Commands & commands, CredentialIssuerCommands * cre
         make_unique<PairBleWiFi>(credsIssuerConfig),
         make_unique<PairBleThread>(credsIssuerConfig),
         make_unique<PairSoftAP>(credsIssuerConfig),
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        make_unique<PairWiFiPAF>(credsIssuerConfig),
+#endif
         make_unique<PairAlreadyDiscovered>(credsIssuerConfig),
         make_unique<PairAlreadyDiscoveredByIndex>(credsIssuerConfig),
         make_unique<PairAlreadyDiscoveredByIndexWithWiFi>(credsIssuerConfig),

--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -178,7 +178,7 @@ class PairWiFiPAF : public PairingCommand
 {
 public:
     PairWiFiPAF(CredentialIssuerCommands * credsIssuerConfig) :
-        PairingCommand("wifi-paf", PairingMode::WiFiPAF, PairingNetworkType::WiFi, credsIssuerConfig)
+        PairingCommand("wifipaf-wifi", PairingMode::WiFiPAF, PairingNetworkType::WiFi, credsIssuerConfig)
     {}
 };
 #endif

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -80,6 +80,11 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
     case PairingMode::SoftAP:
         err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort, mRemoteAddr.interfaceId));
         break;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    case PairingMode::WiFiPAF:
+        err = Pair(remoteId, PeerAddress::WiFiPAF());
+        break;
+#endif
     case PairingMode::AlreadyDiscovered:
         err = Pair(remoteId, PeerAddress::UDP(mRemoteAddr.address, mRemotePort, mRemoteAddr.interfaceId));
         break;

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -82,7 +82,7 @@ CHIP_ERROR PairingCommand::RunInternal(NodeId remoteId)
         break;
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     case PairingMode::WiFiPAF:
-        err = Pair(remoteId, PeerAddress::WiFiPAF());
+        err = Pair(remoteId, PeerAddress::WiFiPAF(remoteId));
         break;
 #endif
     case PairingMode::AlreadyDiscovered:

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -33,6 +33,9 @@ enum class PairingMode
     CodePaseOnly,
     Ble,
     SoftAP,
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    WiFiPAF,
+#endif
     AlreadyDiscovered,
     AlreadyDiscoveredByIndex,
     AlreadyDiscoveredByIndexWithCode,
@@ -117,6 +120,13 @@ public:
             AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
             AddArgument("pase-only", 0, 1, &mPaseOnly);
             break;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        case PairingMode::WiFiPAF:
+            AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
+            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
+            AddArgument("discriminator", 0, 4096, &mDiscriminator);
+            break;
+#endif
         case PairingMode::AlreadyDiscovered:
             AddArgument("skip-commissioning-complete", 0, 1, &mSkipCommissioningComplete);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -108,6 +108,14 @@ CHIP_ERROR SetupPayloadParseCommand::Print(chip::SetupPayload payload)
                     }
                     humanFlags.Add("On IP network");
                 }
+                if (payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kWiFiPAF))
+                {
+                    if (!humanFlags.Empty())
+                    {
+                        humanFlags.Add(", ");
+                    }
+                    humanFlags.Add("WIFIPAF");
+                }
             }
             else
             {

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR SetupPayloadParseCommand::Print(chip::SetupPayload payload)
                     {
                         humanFlags.Add(", ");
                     }
-                    humanFlags.Add("WIFIPAF");
+                    humanFlags.Add("Wi-Fi PAF");
                 }
             }
             else

--- a/examples/laundry-washer-app/nxp/common/main/operational-state-delegate-impl.cpp
+++ b/examples/laundry-washer-app/nxp/common/main/operational-state-delegate-impl.cpp
@@ -21,7 +21,6 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::OperationalState;
-using namespace chip::app::Clusters::RvcOperationalState;
 
 CHIP_ERROR GenericOperationalStateDelegateImpl::GetOperationalStateAtIndex(size_t index, GenericOperationalState & operationalState)
 {

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -360,6 +360,8 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
     CHIP_ERROR err = CHIP_NO_ERROR;
 #if CONFIG_NETWORK_LAYER_BLE
     RendezvousInformationFlags rendezvousFlags = RendezvousInformationFlag::kBLE;
+#elif CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    RendezvousInformationFlags rendezvousFlags = RendezvousInformationFlag::kWiFiPAF;
 #else  // CONFIG_NETWORK_LAYER_BLE
     RendezvousInformationFlag rendezvousFlags = RendezvousInformationFlag::kOnNetwork;
 #endif // CONFIG_NETWORK_LAYER_BLE
@@ -465,6 +467,17 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
         }
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    ChipLogProgress(NotSpecified, "WiFi-PAF: initialzing");
+    if (LinuxDeviceOptions::GetInstance().mWiFi)
+    {
+        if (EnsureWiFiIsStarted())
+        {
+            ChipLogProgress(NotSpecified, "Wi-Fi Management started");
+            DeviceLayer::ConnectivityMgr().SetWiFiPAFAdvertisingEnabled(LinuxDeviceOptions::GetInstance().mWiFiPAF);
+        }
+    }
+#endif
 
 #if CHIP_ENABLE_OPENTHREAD
     if (LinuxDeviceOptions::GetInstance().mThread)

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -360,14 +360,15 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
     CHIP_ERROR err = CHIP_NO_ERROR;
 #if CONFIG_NETWORK_LAYER_BLE
     RendezvousInformationFlags rendezvousFlags = RendezvousInformationFlag::kBLE;
-#elif CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    RendezvousInformationFlags rendezvousFlags = RendezvousInformationFlag::kWiFiPAF;
 #else  // CONFIG_NETWORK_LAYER_BLE
     RendezvousInformationFlag rendezvousFlags = RendezvousInformationFlag::kOnNetwork;
 #endif // CONFIG_NETWORK_LAYER_BLE
 
 #ifdef CONFIG_RENDEZVOUS_MODE
     rendezvousFlags = static_cast<RendezvousInformationFlags>(CONFIG_RENDEZVOUS_MODE);
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    rendezvousFlags.Set(RendezvousInformationFlag::kWiFiPAF);
 #endif
 
     err = Platform::MemoryInit();

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -361,7 +361,7 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
 #if CONFIG_NETWORK_LAYER_BLE
     RendezvousInformationFlags rendezvousFlags = RendezvousInformationFlag::kBLE;
 #else  // CONFIG_NETWORK_LAYER_BLE
-    RendezvousInformationFlag rendezvousFlags = RendezvousInformationFlag::kOnNetwork;
+    RendezvousInformationFlags rendezvousFlags = RendezvousInformationFlag::kOnNetwork;
 #endif // CONFIG_NETWORK_LAYER_BLE
 
 #ifdef CONFIG_RENDEZVOUS_MODE

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -106,6 +106,9 @@ enum
 #if CHIP_WITH_NLFAULTINJECTION
     kDeviceOption_FaultInjection,
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    kDeviceOption_WiFi_PAF = 0x1028,
+#endif
 };
 
 constexpr unsigned kAppUsageLength = 64;
@@ -117,6 +120,9 @@ OptionDef sDeviceOptionDefs[] = {
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     { "wifi", kNoArgument, kDeviceOption_WiFi },
     { "wifi-supports-5g", kNoArgument, kDeviceOption_WiFiSupports5g },
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    { "wifi-paf", kNoArgument, kDeviceOption_WiFi_PAF },
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 #if CHIP_ENABLE_OPENTHREAD
     { "thread", kNoArgument, kDeviceOption_Thread },
@@ -189,6 +195,11 @@ const char * sDeviceOptionHelp =
     "  --wifi-supports-5g\n"
     "       Indicate that local Wi-Fi hardware should report 5GHz support.\n"
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+#if (CHIP_DEVICE_CONFIG_ENABLE_WIFI && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF)
+    "\n"
+    "  --wifi-paf\n"
+    "       Enable Wi-Fi PAF via wpa_supplicant.\n"
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 #if CHIP_ENABLE_OPENTHREAD
     "\n"
     "  --thread\n"
@@ -587,6 +598,12 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
             PrintArgError("%s: Invalid fault injection specification\n", aProgram);
             retval = false;
         }
+        break;
+    }
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    case kDeviceOption_WiFi_PAF: {
+        LinuxDeviceOptions::GetInstance().mWiFiPAF = true;
         break;
     }
 #endif

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -107,7 +107,7 @@ enum
     kDeviceOption_FaultInjection,
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    kDeviceOption_WiFi_PAF = 0x1028,
+    kDeviceOption_WiFi_PAF,
 #endif
 };
 

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -121,7 +121,7 @@ OptionDef sDeviceOptionDefs[] = {
     { "wifi", kNoArgument, kDeviceOption_WiFi },
     { "wifi-supports-5g", kNoArgument, kDeviceOption_WiFiSupports5g },
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    { "wifi-paf", kNoArgument, kDeviceOption_WiFi_PAF },
+    { "wifipaf", kNoArgument, kDeviceOption_WiFi_PAF },
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 #if CHIP_ENABLE_OPENTHREAD
@@ -195,11 +195,11 @@ const char * sDeviceOptionHelp =
     "  --wifi-supports-5g\n"
     "       Indicate that local Wi-Fi hardware should report 5GHz support.\n"
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-#if (CHIP_DEVICE_CONFIG_ENABLE_WIFI && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF)
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     "\n"
-    "  --wifi-paf\n"
+    "  --wifipaf\n"
     "       Enable Wi-Fi PAF via wpa_supplicant.\n"
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 #if CHIP_ENABLE_OPENTHREAD
     "\n"
     "  --thread\n"

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -50,7 +50,7 @@ struct LinuxDeviceOptions
     bool mWiFi                 = false;
     bool mThread               = false;
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    bool mWiFiPAF              = false;
+    bool mWiFiPAF = false;
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE || CHIP_DEVICE_ENABLE_PORT_PARAMS
     uint16_t securedDevicePort         = CHIP_PORT;

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -49,6 +49,9 @@ struct LinuxDeviceOptions
     bool wifiSupports5g        = false;
     bool mWiFi                 = false;
     bool mThread               = false;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    bool mWiFiPAF              = false;
+#endif
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE || CHIP_DEVICE_ENABLE_PORT_PARAMS
     uint16_t securedDevicePort         = CHIP_PORT;
     uint16_t unsecuredCommissionerPort = CHIP_UDC_PORT;

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -72,6 +72,9 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
         // If in NonConcurrentConnection, this will already have been completed
         mServer->GetBleLayerObject()->CloseAllBleConnections();
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        DeviceLayer::ConnectivityMgr().SetWiFiPAFAdvertisingEnabled(false);
+#endif
     }
     else if (event->Type == DeviceLayer::DeviceEventType::kFailSafeTimerExpired)
     {

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -216,7 +216,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
                                .SetListenPort(mOperationalServicePort)
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-                           ,
+                               ,
                            Transport::WiFiPAFListenParameters(DeviceLayer::ConnectivityMgr().GetWiFiPAF())
 #endif
     );

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -56,6 +56,10 @@
 #include <system/TLVPacketBufferBackingStore.h>
 #include <transport/SessionManager.h>
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#include <transport/raw/WiFiPAF.h>
+#endif
+
 #if defined(CHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT) || defined(CHIP_SUPPORT_ENABLE_STORAGE_LOAD_TEST_AUDIT)
 #include <lib/support/PersistentStorageAudit.h>
 #endif // defined(CHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT) || defined(CHIP_SUPPORT_ENABLE_STORAGE_LOAD_TEST_AUDIT)
@@ -210,6 +214,10 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
                            TcpListenParameters(DeviceLayer::TCPEndPointManager())
                                .SetAddressType(IPAddressType::kIPv6)
                                .SetListenPort(mOperationalServicePort)
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+                           ,
+                           Transport::WiFiPAFListenParameters(DeviceLayer::ConnectivityMgr().GetWiFiPAF())
 #endif
     );
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -65,6 +65,9 @@
 #if CONFIG_NETWORK_LAYER_BLE
 #include <transport/raw/BLE.h>
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#include <transport/raw/WiFiPAF.h>
+#endif
 #include <app/TimerDelegates.h>
 #include <app/reporting/ReportSchedulerImpl.h>
 #include <transport/raw/UDP.h>
@@ -99,6 +102,10 @@ using ServerTransportMgr = chip::TransportMgr<chip::Transport::UDP
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
                                               ,
                                               chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+                                              ,
+                                              chip::Transport::WiFiPAFBase
 #endif
                                               >;
 

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -586,8 +586,13 @@ CHIP_ERROR AutoCommissioner::StartCommissioning(DeviceCommissioner * commissione
     mCommissioner            = commissioner;
     mCommissioneeDeviceProxy = proxy;
     mNeedsNetworkSetup =
-        mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
-        Transport::Type::kBle;
+        (mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
+        Transport::Type::kBle)
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        || (mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
+        Transport::Type::kWiFiPAF)
+#endif
+        ;
     CHIP_ERROR err               = CHIP_NO_ERROR;
     CommissioningStage nextStage = GetNextCommissioningStage(CommissioningStage::kSecurePairing, err);
     mCommissioner->PerformCommissioningStep(mCommissioneeDeviceProxy, nextStage, mParams, this, GetEndpoint(nextStage),

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -587,10 +587,10 @@ CHIP_ERROR AutoCommissioner::StartCommissioning(DeviceCommissioner * commissione
     mCommissioneeDeviceProxy = proxy;
     mNeedsNetworkSetup =
         (mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
-        Transport::Type::kBle)
+         Transport::Type::kBle)
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
         || (mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
-        Transport::Type::kWiFiPAF)
+            Transport::Type::kWiFiPAF)
 #endif
         ;
     CHIP_ERROR err               = CHIP_NO_ERROR;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -586,7 +586,8 @@ CHIP_ERROR AutoCommissioner::StartCommissioning(DeviceCommissioner * commissione
     mCommissioner            = commissioner;
     mCommissioneeDeviceProxy = proxy;
 
-    auto transportType = mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType();
+    auto transportType =
+        mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType();
     mNeedsNetworkSetup = (transportType == Transport::Type::kBle);
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     mNeedsNetworkSetup = mNeedsNetworkSetup || (transportType == Transport::Type::kWiFiPAF);

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -591,8 +591,9 @@ CHIP_ERROR AutoCommissioner::StartCommissioning(DeviceCommissioner * commissione
     CHIP_ERROR err               = CHIP_NO_ERROR;
     CommissioningStage nextStage = GetNextCommissioningStage(CommissioningStage::kSecurePairing, err);
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    mNeedsNetworkSetup = mNeedsNetworkSetup || (mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
-            Transport::Type::kWiFiPAF);
+    mNeedsNetworkSetup = mNeedsNetworkSetup ||
+        (mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
+         Transport::Type::kWiFiPAF);
 #endif
     mCommissioner->PerformCommissioningStep(mCommissioneeDeviceProxy, nextStage, mParams, this, GetEndpoint(nextStage),
                                             GetCommandTimeout(mCommissioneeDeviceProxy, nextStage));

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -585,16 +585,15 @@ CHIP_ERROR AutoCommissioner::StartCommissioning(DeviceCommissioner * commissione
     mStopCommissioning       = false;
     mCommissioner            = commissioner;
     mCommissioneeDeviceProxy = proxy;
-    mNeedsNetworkSetup =
-        (mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
-         Transport::Type::kBle);
+
+    auto transportType = mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType();
+    mNeedsNetworkSetup = (transportType == Transport::Type::kBle);
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    mNeedsNetworkSetup = mNeedsNetworkSetup || (transportType == Transport::Type::kWiFiPAF);
+#endif
     CHIP_ERROR err               = CHIP_NO_ERROR;
     CommissioningStage nextStage = GetNextCommissioningStage(CommissioningStage::kSecurePairing, err);
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    mNeedsNetworkSetup = mNeedsNetworkSetup ||
-        (mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
-         Transport::Type::kWiFiPAF);
-#endif
+
     mCommissioner->PerformCommissioningStep(mCommissioneeDeviceProxy, nextStage, mParams, this, GetEndpoint(nextStage),
                                             GetCommandTimeout(mCommissioneeDeviceProxy, nextStage));
     return CHIP_NO_ERROR;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -587,14 +587,13 @@ CHIP_ERROR AutoCommissioner::StartCommissioning(DeviceCommissioner * commissione
     mCommissioneeDeviceProxy = proxy;
     mNeedsNetworkSetup =
         (mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
-         Transport::Type::kBle)
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-        || (mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
-            Transport::Type::kWiFiPAF)
-#endif
-        ;
+         Transport::Type::kBle);
     CHIP_ERROR err               = CHIP_NO_ERROR;
     CommissioningStage nextStage = GetNextCommissioningStage(CommissioningStage::kSecurePairing, err);
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    mNeedsNetworkSetup = mNeedsNetworkSetup || (mCommissioneeDeviceProxy->GetSecureSession().Value()->AsSecureSession()->GetPeerAddress().GetTransportType() ==
+            Transport::Type::kWiFiPAF);
+#endif
     mCommissioner->PerformCommissioningStep(mCommissioneeDeviceProxy, nextStage, mParams, this, GetEndpoint(nextStage),
                                             GetCommandTimeout(mCommissioneeDeviceProxy, nextStage));
     return CHIP_NO_ERROR;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -69,7 +69,6 @@
 #include <transport/raw/WiFiPAF.h>
 #endif
 
-
 #include <errno.h>
 #include <inttypes.h>
 #include <memory>
@@ -817,7 +816,8 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     if (params.GetPeerAddress().GetTransportType() == Transport::Type::kWiFiPAF)
     {
-        if (DeviceLayer::ConnectivityMgr().GetWiFiPAF()->GetWiFiPAFState() != Transport::WiFiPAFBase::State::kConnected) {
+        if (DeviceLayer::ConnectivityMgr().GetWiFiPAF()->GetWiFiPAFState() != Transport::WiFiPAFBase::State::kConnected)
+        {
             ChipLogProgress(Controller, "WiFi-PAF: Subscribing the NAN-USD devices");
             static constexpr useconds_t kWiFiStartCheckTimeUsec = WIFI_START_CHECK_TIME_USEC;
             static constexpr uint8_t kWiFiStartCheckAttempts    = WIFI_START_CHECK_ATTEMPTS;
@@ -833,15 +833,12 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
                     usleep(kWiFiStartCheckTimeUsec);
                 }
             }
-            if (!DeviceLayer::ConnectivityMgrImpl().IsWiFiManagementStarted()) {
+            if (!DeviceLayer::ConnectivityMgrImpl().IsWiFiManagementStarted())
+            {
                 ChipLogError(NotSpecified, "Wi-Fi Management taking too long to start - device configuration will be reset.");
             }
             mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = params;
-            DeviceLayer::ConnectivityMgr().WiFiPAFConnect(
-                this,
-                OnWiFiPAFSubscribeComplete,
-                OnWiFiPAFSubscribeError
-                );
+            DeviceLayer::ConnectivityMgr().WiFiPAFConnect(this, OnWiFiPAFSubscribeComplete, OnWiFiPAFSubscribeError);
             ExitNow(CHIP_NO_ERROR);
         }
         ChipLogProgress(Controller, "WiFi-PAF: Request to subscrib the NAN-USD device complete");
@@ -924,7 +921,7 @@ void DeviceCommissioner::OnWiFiPAFSubscribeComplete(void * appState)
     if (nullptr != device && device->GetDeviceTransportType() == Transport::Type::kWiFiPAF)
     {
         auto remoteId = device->GetDeviceId();
-        auto params = self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF;
+        auto params   = self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF;
 
         self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = RendezvousParameters();
         self->ReleaseCommissioneeDevice(device);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -735,7 +735,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     else if (params.GetPeerAddress().GetTransportType() == Transport::Type::kWiFiPAF)
     {
-        peerAddress = Transport::PeerAddress::WiFiPAF();
+        peerAddress = Transport::PeerAddress::WiFiPAF(remoteDeviceId);
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -825,7 +825,8 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
                 ExitNow(CHIP_ERROR_INTERNAL);
             }
             mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = params;
-            DeviceLayer::ConnectivityMgr().WiFiPAFConnect(params.GetSetupDiscriminator().value(), this, OnWiFiPAFSubscribeComplete, OnWiFiPAFSubscribeError);
+            DeviceLayer::ConnectivityMgr().WiFiPAFConnect(params.GetSetupDiscriminator().value(), this, OnWiFiPAFSubscribeComplete,
+                                                          OnWiFiPAFSubscribeError);
             ExitNow(CHIP_NO_ERROR);
         }
     }
@@ -922,7 +923,8 @@ void DeviceCommissioner::OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err
 
     if (nullptr != device && device->GetDeviceTransportType() == Transport::Type::kWiFiPAF)
     {
-        ChipLogError(Controller, "WiFi-PAF: Subscription Error, id = %lu, err = %" CHIP_ERROR_FORMAT, device->GetDeviceId(), err.Format());
+        ChipLogError(Controller, "WiFi-PAF: Subscription Error, id = %lu, err = %" CHIP_ERROR_FORMAT, device->GetDeviceId(),
+                     err.Format());
         self->ReleaseCommissioneeDevice(device);
         self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = RendezvousParameters();
         if (self->mPairingDelegate != nullptr)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -819,29 +819,15 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
         if (DeviceLayer::ConnectivityMgr().GetWiFiPAF()->GetWiFiPAFState() != Transport::WiFiPAFBase::State::kConnected)
         {
             ChipLogProgress(Controller, "WiFi-PAF: Subscribing the NAN-USD devices");
-            static constexpr useconds_t kWiFiStartCheckTimeUsec = WIFI_START_CHECK_TIME_USEC;
-            static constexpr uint8_t kWiFiStartCheckAttempts    = WIFI_START_CHECK_ATTEMPTS;
-
-            DeviceLayer::ConnectivityMgrImpl().StartWiFiManagement();
-            {
-                for (int cnt = 0; cnt < kWiFiStartCheckAttempts; cnt++)
-                {
-                    if (DeviceLayer::ConnectivityMgrImpl().IsWiFiManagementStarted())
-                    {
-                        break;
-                    }
-                    usleep(kWiFiStartCheckTimeUsec);
-                }
-            }
             if (!DeviceLayer::ConnectivityMgrImpl().IsWiFiManagementStarted())
             {
-                ChipLogError(NotSpecified, "Wi-Fi Management taking too long to start - device configuration will be reset.");
+                ChipLogError(Controller, "Wi-Fi Management should have be started now.");
+                ExitNow(CHIP_ERROR_INTERNAL);
             }
             mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = params;
-            DeviceLayer::ConnectivityMgr().WiFiPAFConnect(this, OnWiFiPAFSubscribeComplete, OnWiFiPAFSubscribeError);
+            DeviceLayer::ConnectivityMgr().WiFiPAFConnect(params.GetSetupDiscriminator().value(), this, OnWiFiPAFSubscribeComplete, OnWiFiPAFSubscribeError);
             ExitNow(CHIP_NO_ERROR);
         }
-        ChipLogProgress(Controller, "WiFi-PAF: Request to subscribe the NAN-USD device complete");
     }
 #endif
     session = mSystemState->SessionMgr()->CreateUnauthenticatedSession(params.GetPeerAddress(), params.GetMRPConfig());
@@ -917,16 +903,14 @@ void DeviceCommissioner::OnWiFiPAFSubscribeComplete(void * appState)
     auto self   = static_cast<DeviceCommissioner *>(appState);
     auto device = self->mDeviceInPASEEstablishment;
 
-    ChipLogProgress(Controller, "WiFi-PAF: Subscription Completed!");
     if (nullptr != device && device->GetDeviceTransportType() == Transport::Type::kWiFiPAF)
     {
+        ChipLogProgress(Controller, "WiFi-PAF: Subscription Completed, dev_id = %lu", device->GetDeviceId());
         auto remoteId = device->GetDeviceId();
         auto params   = self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF;
 
         self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = RendezvousParameters();
         self->ReleaseCommissioneeDevice(device);
-        DeviceLayer::ConnectivityMgr().GetWiFiPAF()->SetWiFiPAFState(Transport::WiFiPAFBase::State::kConnected);
-        chip::DeviceLayer::StackLock stackLock;
         LogErrorOnFailure(self->EstablishPASEConnection(remoteId, params));
     }
 }
@@ -936,9 +920,9 @@ void DeviceCommissioner::OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err
     auto self   = static_cast<DeviceCommissioner *>(appState);
     auto device = self->mDeviceInPASEEstablishment;
 
-    ChipLogProgress(Controller, "WiFi-PAF: Subscription Error!");
     if (nullptr != device && device->GetDeviceTransportType() == Transport::Type::kWiFiPAF)
     {
+        ChipLogError(Controller, "WiFi-PAF: Subscription Error, id = %lu, err = %" CHIP_ERROR_FORMAT, device->GetDeviceId(), err.Format());
         self->ReleaseCommissioneeDevice(device);
         self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = RendezvousParameters();
         if (self->mPairingDelegate != nullptr)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -841,7 +841,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
             DeviceLayer::ConnectivityMgr().WiFiPAFConnect(this, OnWiFiPAFSubscribeComplete, OnWiFiPAFSubscribeError);
             ExitNow(CHIP_NO_ERROR);
         }
-        ChipLogProgress(Controller, "WiFi-PAF: Request to subscrib the NAN-USD device complete");
+        ChipLogProgress(Controller, "WiFi-PAF: Request to subscribe the NAN-USD device complete");
     }
 #endif
     session = mSystemState->SessionMgr()->CreateUnauthenticatedSession(params.GetPeerAddress(), params.GetMRPConfig());

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -845,6 +845,11 @@ private:
     static void OnDiscoveredDeviceOverBleError(void * appState, CHIP_ERROR err);
     RendezvousParameters mRendezvousParametersForDeviceDiscoveredOverBle;
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    static void OnWiFiPAFSubscribeComplete(void * appState);
+    static void OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err);
+    RendezvousParameters mRendezvousParametersForDeviceDiscoveredOverWiFiPAF;
+#endif
 
     CHIP_ERROR LoadKeyId(PersistentStorageDelegate * delegate, uint16_t & out);
 

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -141,6 +141,9 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
 #else
     stateParams.bleLayer = params.bleLayer;
 #endif // CONFIG_DEVICE_LAYER
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    stateParams.wifipaf_layer = params.wifipaf_layer;
+#endif
     VerifyOrReturnError(stateParams.bleLayer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 #endif
 
@@ -167,6 +170,10 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
                                                         Transport::TcpListenParameters(stateParams.tcpEndPointManager)
                                                             .SetAddressType(IPAddressType::kIPv6)
                                                             .SetListenPort(params.listenPort)
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+                                                            ,
+                                                        Transport::WiFiPAFListenParameters()
 #endif
                                                             ));
 

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -145,6 +145,9 @@ struct FactoryInitParams
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * bleLayer = nullptr;
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    Transport::WiFiPAFLayer * wifipaf_layer = nullptr;
+#endif
 
     //
     // Controls enabling server cluster interactions on a controller. This in turn

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -52,10 +52,17 @@
 #include <ble/Ble.h>
 #include <transport/raw/BLE.h>
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#include <transport/raw/WiFiPAF.h>
+#endif
 
 namespace chip {
 
 inline constexpr size_t kMaxDeviceTransportBlePendingPackets = 1;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+inline constexpr size_t kMaxDeviceTransportWiFiPAFPendingPackets = 1;
+#endif
+
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
 inline constexpr size_t kMaxDeviceTransportTcpActiveConnectionCount = CHIP_CONFIG_MAX_ACTIVE_TCP_CONNECTIONS;
@@ -77,6 +84,10 @@ using DeviceTransportMgr =
                  ,
                  Transport::TCP<kMaxDeviceTransportTcpActiveConnectionCount, kMaxDeviceTransportTcpPendingPackets>
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+                 ,
+                 Transport::WiFiPAF<kMaxDeviceTransportWiFiPAFPendingPackets> /* WiFiPAF */
+#endif
                  >;
 
 namespace Controller {
@@ -93,6 +104,9 @@ struct DeviceControllerSystemStateParams
     FabricTable * fabricTable                                     = nullptr;
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * bleLayer = nullptr;
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    Transport::WiFiPAFLayer	*wifipaf_layer = nullptr;
 #endif
     Credentials::GroupDataProvider * groupDataProvider = nullptr;
     Crypto::SessionKeystore * sessionKeystore          = nullptr;

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -63,7 +63,6 @@ inline constexpr size_t kMaxDeviceTransportBlePendingPackets = 1;
 inline constexpr size_t kMaxDeviceTransportWiFiPAFPendingPackets = 1;
 #endif
 
-
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
 inline constexpr size_t kMaxDeviceTransportTcpActiveConnectionCount = CHIP_CONFIG_MAX_ACTIVE_TCP_CONNECTIONS;
 
@@ -106,7 +105,7 @@ struct DeviceControllerSystemStateParams
     Ble::BleLayer * bleLayer = nullptr;
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    Transport::WiFiPAFLayer	*wifipaf_layer = nullptr;
+    Transport::WiFiPAFLayer * wifipaf_layer = nullptr;
 #endif
     Credentials::GroupDataProvider * groupDataProvider = nullptr;
     Crypto::SessionKeystore * sessionKeystore          = nullptr;

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -129,6 +129,17 @@ CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
             }
             VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
         }
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kWiFiPAF))
+        {
+            ChipLogProgress(Controller, "WiFi-PAF: has RendezvousInformationFlag::kWiFiPAF");
+            if (CHIP_NO_ERROR == (err = StartDiscoverOverWiFiPAF(payload)))
+            {
+                isRunning = true;
+            }
+            VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
+        }
+#endif
     }
 
     // We always want to search on network because any node that has already been commissioned will use on-network regardless of the
@@ -242,6 +253,19 @@ CHIP_ERROR SetUpCodePairer::StopConnectOverSoftAP()
     mWaitingForDiscovery[kSoftAPTransport] = false;
     return CHIP_NO_ERROR;
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+CHIP_ERROR SetUpCodePairer::StartDiscoverOverWiFiPAF(SetupPayload & payload)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR SetUpCodePairer::StopConnectOverWiFiPAF()
+{
+    mWaitingForDiscovery[kWiFiPAF] = false;
+    return CHIP_NO_ERROR;
+}
+#endif
 
 bool SetUpCodePairer::ConnectToDiscoveredDevice()
 {

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -260,7 +260,7 @@ CHIP_ERROR SetUpCodePairer::StartDiscoverOverWiFiPAF(SetupPayload & payload)
     VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
     mWaitingForDiscovery[kWiFiPAFTransport] = true;
     CHIP_ERROR err = DeviceLayer::ConnectivityMgr().WiFiPAFConnect(payload.discriminator, this, OnWiFiPAFSubscribeComplete,
-                                                          OnWiFiPAFSubscribeError);
+                                                                   OnWiFiPAFSubscribeError);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Commissioning discovery over WiFiPAF failed, err = %" CHIP_ERROR_FORMAT, err.Format());
@@ -376,7 +376,7 @@ void SetUpCodePairer::OnDiscoveredDeviceOverWifiPAF()
     ChipLogProgress(Controller, "Discovered device to be commissioned over WiFiPAF, RemoteId: %lu", mRemoteId);
 
     mWaitingForDiscovery[kWiFiPAFTransport] = false;
-    auto param = SetUpCodePairerParameters();
+    auto param                              = SetUpCodePairerParameters();
     param.SetPeerAddress(Transport::PeerAddress(Transport::Type::kWiFiPAF, mRemoteId));
     mDiscoveredParameters.emplace_front(param);
     ConnectToDiscoveredDevice();
@@ -399,7 +399,6 @@ void SetUpCodePairer::OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err)
     static_cast<SetUpCodePairer *>(appState)->OnWifiPAFDiscoveryError(err);
 }
 #endif
-
 
 bool SetUpCodePairer::IdIsPresent(uint16_t vendorOrProductID)
 {

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -378,7 +378,7 @@ void SetUpCodePairer::OnDiscoveredDeviceOverWifiPAF()
     mWaitingForDiscovery[kWiFiPAFTransport] = false;
     auto param                              = SetUpCodePairerParameters();
     param.SetPeerAddress(Transport::PeerAddress(Transport::Type::kWiFiPAF, mRemoteId));
-    mDiscoveredParameters.emplace_front(param);
+    mDiscoveredParameters.emplace_back(param);
     ConnectToDiscoveredDevice();
 }
 

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -262,7 +262,7 @@ CHIP_ERROR SetUpCodePairer::StartDiscoverOverWiFiPAF(SetupPayload & payload)
 
 CHIP_ERROR SetUpCodePairer::StopConnectOverWiFiPAF()
 {
-    mWaitingForDiscovery[kWiFiPAF] = false;
+    mWaitingForDiscovery[kWiFiPAFTransport] = false;
     return CHIP_NO_ERROR;
 }
 #endif

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -386,7 +386,6 @@ void SetUpCodePairer::OnWifiPAFDiscoveryError(CHIP_ERROR err)
 {
     ChipLogError(Controller, "Commissioning discovery over WiFiPAF failed: %" CHIP_ERROR_FORMAT, err.Format());
     mWaitingForDiscovery[kWiFiPAFTransport] = false;
-    LogErrorOnFailure(err);
 }
 
 void SetUpCodePairer::OnWiFiPAFSubscribeComplete(void * appState)

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -129,7 +129,6 @@ CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
             }
             VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
         }
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
         if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kWiFiPAF))
         {
             ChipLogProgress(Controller, "WiFi-PAF: has RendezvousInformationFlag::kWiFiPAF");
@@ -139,7 +138,6 @@ CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
             }
             VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
         }
-#endif
     }
 
     // We always want to search on network because any node that has already been commissioned will use on-network regardless of the
@@ -254,7 +252,6 @@ CHIP_ERROR SetUpCodePairer::StopConnectOverSoftAP()
     return CHIP_NO_ERROR;
 }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 CHIP_ERROR SetUpCodePairer::StartDiscoverOverWiFiPAF(SetupPayload & payload)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
@@ -265,7 +262,6 @@ CHIP_ERROR SetUpCodePairer::StopConnectOverWiFiPAF()
     mWaitingForDiscovery[kWiFiPAFTransport] = false;
     return CHIP_NO_ERROR;
 }
-#endif
 
 bool SetUpCodePairer::ConnectToDiscoveredDevice()
 {

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -112,8 +112,8 @@ private:
     CHIP_ERROR StartDiscoverOverSoftAP(SetupPayload & payload);
     CHIP_ERROR StopConnectOverSoftAP();
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-	CHIP_ERROR StartDiscoverOverWiFiPAF(SetupPayload & payload);
-	CHIP_ERROR StopConnectOverWiFiPAF();
+    CHIP_ERROR StartDiscoverOverWiFiPAF(SetupPayload & payload);
+    CHIP_ERROR StopConnectOverWiFiPAF();
 #endif
 
     // Returns whether we have kicked off a new connection attempt.

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -111,6 +111,10 @@ private:
     CHIP_ERROR StopConnectOverIP();
     CHIP_ERROR StartDiscoverOverSoftAP(SetupPayload & payload);
     CHIP_ERROR StopConnectOverSoftAP();
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+	CHIP_ERROR StartDiscoverOverWiFiPAF(SetupPayload & payload);
+	CHIP_ERROR StopConnectOverWiFiPAF();
+#endif
 
     // Returns whether we have kicked off a new connection attempt.
     bool ConnectToDiscoveredDevice();
@@ -150,6 +154,9 @@ private:
         kBLETransport = 0,
         kIPTransport,
         kSoftAPTransport,
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        kWiFiPAF,
+#endif
         kTransportTypeCount,
     };
 

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -154,9 +154,7 @@ private:
         kBLETransport = 0,
         kIPTransport,
         kSoftAPTransport,
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-        kWiFiPAF,
-#endif
+        kWiFiPAFTransport,
         kTransportTypeCount,
     };
 

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -111,10 +111,8 @@ private:
     CHIP_ERROR StopConnectOverIP();
     CHIP_ERROR StartDiscoverOverSoftAP(SetupPayload & payload);
     CHIP_ERROR StopConnectOverSoftAP();
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     CHIP_ERROR StartDiscoverOverWiFiPAF(SetupPayload & payload);
     CHIP_ERROR StopConnectOverWiFiPAF();
-#endif
 
     // Returns whether we have kicked off a new connection attempt.
     bool ConnectToDiscoveredDevice();

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -168,6 +168,12 @@ private:
     static void OnDiscoveredDeviceOverBleSuccess(void * appState, BLE_CONNECTION_OBJECT connObj);
     static void OnDiscoveredDeviceOverBleError(void * appState, CHIP_ERROR err);
 #endif // CONFIG_NETWORK_LAYER_BLE
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    void OnDiscoveredDeviceOverWifiPAF();
+    void OnWifiPAFDiscoveryError(CHIP_ERROR err);
+    static void OnWiFiPAFSubscribeComplete(void * appState);
+    static void OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err);
+#endif
 
     bool NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData & nodeData) const;
     static bool IdIsPresent(uint16_t vendorOrProductID);

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -425,6 +425,16 @@
 #define CHIP_DEVICE_CONFIG_WIFI_STATION_IF_NAME "wlan0"
 #endif
 
+/**
+ * CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+ *
+ * Name of the WiFi PAF/DNAN-USD
+ */
+#ifndef CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#define CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF 0
+#endif
+
+
 // -------------------- WiFi AP Configuration --------------------
 
 /**

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -434,7 +434,6 @@
 #define CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF 0
 #endif
 
-
 // -------------------- WiFi AP Configuration --------------------
 
 /**

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -428,7 +428,7 @@
 /**
  * CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
  *
- * Name of the WiFiPAF commission function
+ * Enable support for the WiFiPAF commissioning function
  */
 #ifndef CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 #define CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF 0

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -428,7 +428,7 @@
 /**
  * CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
  *
- * Enable support for the WiFiPAF commissioning function
+ * Enable support for commissioning using Wi-Fi Public Action Frame as the transport.
  */
 #ifndef CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 #define CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF 0

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -428,7 +428,7 @@
 /**
  * CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
  *
- * Name of the WiFi PAF/DNAN-USD
+ * Name of the WiFiPAF commission function
  */
 #ifndef CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 #define CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF 0

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -276,7 +276,10 @@ enum InternalEventTypes
      * This event should populate CHIPoBLEConnectionError structure.
      */
     kCHIPoBLEConnectionError,
-    kCHIPoBLENotifyConfirm
+    kCHIPoBLENotifyConfirm,
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    kCHIPoWiFiPAFWriteReceived,
+#endif
 };
 
 static_assert(kEventTypeNotSet == 0, "kEventTypeNotSet must be defined as 0");
@@ -486,6 +489,12 @@ struct ChipDeviceEvent final
         {
             BLE_CONNECTION_OBJECT ConId;
         } CHIPoBLENotifyConfirm;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+		struct
+        {
+            chip::System::PacketBuffer * Data;
+        } CHIPoWiFiPAFWriteReceived;
+#endif
         struct
         {
             bool RoleChanged : 1;

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -490,7 +490,7 @@ struct ChipDeviceEvent final
             BLE_CONNECTION_OBJECT ConId;
         } CHIPoBLENotifyConfirm;
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-		struct
+        struct
         {
             chip::System::PacketBuffer * Data;
         } CHIPoWiFiPAFWriteReceived;

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -277,9 +277,8 @@ enum InternalEventTypes
      */
     kCHIPoBLEConnectionError,
     kCHIPoBLENotifyConfirm,
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     kCHIPoWiFiPAFWriteReceived,
-#endif
+    kCHIPoWiFiPAFConnected,
 };
 
 static_assert(kEventTypeNotSet == 0, "kEventTypeNotSet must be defined as 0");

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -35,6 +35,9 @@
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
 #include <inet/TCPEndPoint.h>
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#include <transport/raw/WiFiPAF.h>
+#endif
 
 namespace chip {
 
@@ -171,6 +174,18 @@ public:
     bool IsWiFiStationProvisioned();
     void ClearWiFiStationProvision();
     CHIP_ERROR GetAndLogWiFiStatsCounters();
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    CHIP_ERROR SetWiFiPAFAdvertisingEnabled(bool val);
+
+    typedef void (*OnConnectionCompleteFunct)(void * appState);
+    typedef void (*OnConnectionErrorFunct)(void * appState, CHIP_ERROR err);
+    CHIP_ERROR WiFiPAFConnect(void * appState,
+                                        OnConnectionCompleteFunct onSuccess,
+                                        OnConnectionErrorFunct onError);
+    CHIP_ERROR WiFiPAFSend(chip::System::PacketBufferHandle && msgBuf);
+	Transport::WiFiPAFBase * GetWiFiPAF();
+	void SetWiFiPAF(Transport::WiFiPAFBase * pmWiFiPAF);
+#endif
 
     // WiFi AP methods
     WiFiAPMode GetWiFiAPMode();
@@ -407,6 +422,26 @@ inline CHIP_ERROR ConnectivityManager::GetAndLogWiFiStatsCounters()
     return static_cast<ImplClass *>(this)->_GetAndLogWiFiStatsCounters();
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+inline CHIP_ERROR ConnectivityManager::SetWiFiPAFAdvertisingEnabled(bool val)
+{
+    return static_cast<ImplClass *>(this)->_SetWiFiPAFAdvertisingEnabled(val);
+}
+
+inline CHIP_ERROR ConnectivityManager::WiFiPAFConnect(
+                                        void * appState,
+                                        OnConnectionCompleteFunct onSuccess,
+                                        OnConnectionErrorFunct onError)
+{
+    return static_cast<ImplClass *>(this)->_WiFiPAFConnect(appState, onSuccess, onError);
+}
+
+inline CHIP_ERROR ConnectivityManager::WiFiPAFSend(chip::System::PacketBufferHandle && msgBuf)
+{
+    return static_cast<ImplClass *>(this)->_WiFiPAFSend(std::move(msgBuf));
+}
+#endif
+
 inline bool ConnectivityManager::IsThreadEnabled()
 {
     return static_cast<ImplClass *>(this)->_IsThreadEnabled();
@@ -450,6 +485,18 @@ inline void ConnectivityManager::ResetThreadNetworkDiagnosticsCounts()
 {
     static_cast<ImplClass *>(this)->_ResetThreadNetworkDiagnosticsCounts();
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+inline Transport::WiFiPAFBase * ConnectivityManager::GetWiFiPAF()
+{
+    return static_cast<ImplClass *>(this)->_GetWiFiPAF();
+}
+
+inline void ConnectivityManager::SetWiFiPAF(Transport::WiFiPAFBase * pWiFiPAF)
+{
+    return static_cast<ImplClass *>(this)->_SetWiFiPAF(pWiFiPAF);
+}
+#endif
 
 inline Ble::BleLayer * ConnectivityManager::GetBleLayer()
 {

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -179,12 +179,10 @@ public:
 
     typedef void (*OnConnectionCompleteFunct)(void * appState);
     typedef void (*OnConnectionErrorFunct)(void * appState, CHIP_ERROR err);
-    CHIP_ERROR WiFiPAFConnect(void * appState,
-                                        OnConnectionCompleteFunct onSuccess,
-                                        OnConnectionErrorFunct onError);
+    CHIP_ERROR WiFiPAFConnect(void * appState, OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError);
     CHIP_ERROR WiFiPAFSend(chip::System::PacketBufferHandle && msgBuf);
-	Transport::WiFiPAFBase * GetWiFiPAF();
-	void SetWiFiPAF(Transport::WiFiPAFBase * pmWiFiPAF);
+    Transport::WiFiPAFBase * GetWiFiPAF();
+    void SetWiFiPAF(Transport::WiFiPAFBase * pmWiFiPAF);
 #endif
 
     // WiFi AP methods
@@ -428,10 +426,8 @@ inline CHIP_ERROR ConnectivityManager::SetWiFiPAFAdvertisingEnabled(bool val)
     return static_cast<ImplClass *>(this)->_SetWiFiPAFAdvertisingEnabled(val);
 }
 
-inline CHIP_ERROR ConnectivityManager::WiFiPAFConnect(
-                                        void * appState,
-                                        OnConnectionCompleteFunct onSuccess,
-                                        OnConnectionErrorFunct onError)
+inline CHIP_ERROR ConnectivityManager::WiFiPAFConnect(void * appState, OnConnectionCompleteFunct onSuccess,
+                                                      OnConnectionErrorFunct onError)
 {
     return static_cast<ImplClass *>(this)->_WiFiPAFConnect(appState, onSuccess, onError);
 }

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -180,7 +180,7 @@ public:
     typedef void (*OnConnectionCompleteFunct)(void * appState);
     typedef void (*OnConnectionErrorFunct)(void * appState, CHIP_ERROR err);
     CHIP_ERROR WiFiPAFConnect(void * appState, OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError);
-    CHIP_ERROR WiFiPAFSend(chip::System::PacketBufferHandle && msgBuf);
+    CHIP_ERROR WiFiPAFSend(System::PacketBufferHandle && msgBuf);
     Transport::WiFiPAFBase * GetWiFiPAF();
     void SetWiFiPAF(Transport::WiFiPAFBase * pmWiFiPAF);
 #endif

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -174,12 +174,12 @@ public:
     bool IsWiFiStationProvisioned();
     void ClearWiFiStationProvision();
     CHIP_ERROR GetAndLogWiFiStatsCounters();
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     CHIP_ERROR SetWiFiPAFAdvertisingEnabled(bool val);
 
     typedef void (*OnConnectionCompleteFunct)(void * appState);
     typedef void (*OnConnectionErrorFunct)(void * appState, CHIP_ERROR err);
-    CHIP_ERROR WiFiPAFConnect(void * appState, OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError);
+    CHIP_ERROR WiFiPAFConnect(const SetupDiscriminator & connDiscriminator, void * appState, OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError);
     CHIP_ERROR WiFiPAFSend(System::PacketBufferHandle && msgBuf);
     Transport::WiFiPAFBase * GetWiFiPAF();
     void SetWiFiPAF(Transport::WiFiPAFBase * pmWiFiPAF);
@@ -420,16 +420,16 @@ inline CHIP_ERROR ConnectivityManager::GetAndLogWiFiStatsCounters()
     return static_cast<ImplClass *>(this)->_GetAndLogWiFiStatsCounters();
 }
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA && CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 inline CHIP_ERROR ConnectivityManager::SetWiFiPAFAdvertisingEnabled(bool val)
 {
     return static_cast<ImplClass *>(this)->_SetWiFiPAFAdvertisingEnabled(val);
 }
 
-inline CHIP_ERROR ConnectivityManager::WiFiPAFConnect(void * appState, OnConnectionCompleteFunct onSuccess,
+inline CHIP_ERROR ConnectivityManager::WiFiPAFConnect(const SetupDiscriminator & connDiscriminator, void * appState, OnConnectionCompleteFunct onSuccess,
                                                       OnConnectionErrorFunct onError)
 {
-    return static_cast<ImplClass *>(this)->_WiFiPAFConnect(appState, onSuccess, onError);
+    return static_cast<ImplClass *>(this)->_WiFiPAFConnect(connDiscriminator, appState, onSuccess, onError);
 }
 
 inline CHIP_ERROR ConnectivityManager::WiFiPAFSend(chip::System::PacketBufferHandle && msgBuf)

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -179,7 +179,8 @@ public:
 
     typedef void (*OnConnectionCompleteFunct)(void * appState);
     typedef void (*OnConnectionErrorFunct)(void * appState, CHIP_ERROR err);
-    CHIP_ERROR WiFiPAFConnect(const SetupDiscriminator & connDiscriminator, void * appState, OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError);
+    CHIP_ERROR WiFiPAFConnect(const SetupDiscriminator & connDiscriminator, void * appState, OnConnectionCompleteFunct onSuccess,
+                              OnConnectionErrorFunct onError);
     CHIP_ERROR WiFiPAFSend(System::PacketBufferHandle && msgBuf);
     Transport::WiFiPAFBase * GetWiFiPAF();
     void SetWiFiPAF(Transport::WiFiPAFBase * pmWiFiPAF);
@@ -426,8 +427,8 @@ inline CHIP_ERROR ConnectivityManager::SetWiFiPAFAdvertisingEnabled(bool val)
     return static_cast<ImplClass *>(this)->_SetWiFiPAFAdvertisingEnabled(val);
 }
 
-inline CHIP_ERROR ConnectivityManager::WiFiPAFConnect(const SetupDiscriminator & connDiscriminator, void * appState, OnConnectionCompleteFunct onSuccess,
-                                                      OnConnectionErrorFunct onError)
+inline CHIP_ERROR ConnectivityManager::WiFiPAFConnect(const SetupDiscriminator & connDiscriminator, void * appState,
+                                                      OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError)
 {
     return static_cast<ImplClass *>(this)->_WiFiPAFConnect(connDiscriminator, appState, onSuccess, onError);
 }

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -77,6 +77,9 @@ public:
     bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    CHIP_ERROR _SetWiFiPAFAdvertisingEnabled(bool val);
+#endif
 // TODO ICD rework: ambiguous declaration of _SetPollingInterval when thread and wifi are both build together
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && !CHIP_DEVICE_CONFIG_ENABLE_THREAD
     CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);

--- a/src/lib/shell/commands/OnboardingCodes.cpp
+++ b/src/lib/shell/commands/OnboardingCodes.cpp
@@ -128,6 +128,13 @@ static CHIP_ERROR RendezvousStringToFlag(char * str, chip::RendezvousInformation
         *aRendezvousFlags = chip::RendezvousInformationFlag::kOnNetwork;
         return CHIP_NO_ERROR;
     }
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    if (strcmp(str, "wifipaf") == 0)
+    {
+        *aRendezvousFlags = chip::RendezvousInformationFlag::kWiFiPAF;
+        return CHIP_NO_ERROR;
+    }
+#endif
     return CHIP_ERROR_INVALID_ARGUMENT;
 }
 

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -140,6 +140,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       "CHIP_USE_TRANSITIONAL_COMMISSIONABLE_DATA_PROVIDER=${chip_use_transitional_commissionable_data_provider}",
       "CHIP_USE_TRANSITIONAL_DEVICE_INSTANCE_INFO_PROVIDER=${chip_use_transitional_device_instance_info_provider}",
       "CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG=${chip_device_config_enable_dynamic_mrp_config}",
+      "CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF=${chip_device_config_enable_wifipaf}",
     ]
 
     if (chip_device_platform == "linux" || chip_device_platform == "darwin" ||

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -19,6 +19,7 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <platform/CommissionableDataProvider.h>
+#include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/DeviceControlServer.h>
 #include <platform/DiagnosticDataProvider.h>
@@ -64,6 +65,9 @@
 #include <credentials/CHIPCert.h>
 #include <platform/GLibTypeDeleter.h>
 #include <platform/internal/GenericConnectivityManagerImpl_WiFi.ipp>
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#include <transport/raw/WiFiPAF.h>
+#endif
 #endif
 
 using namespace ::chip;
@@ -152,6 +156,15 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_OnPlatformEvent(event);
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    switch (event->Type)
+    {
+        case DeviceEventType::kCHIPoWiFiPAFWriteReceived:
+            ChipLogProgress(DeviceLayer, "WiFi-PAF: kCHIPoWiFiPAFWriteReceived");
+            _GetWiFiPAF()->OnWiFiPAFMessageReceived(System::PacketBufferHandle::Adopt(event->CHIPoWiFiPAFWriteReceived.Data));
+            break;
+    }
+#endif //CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
@@ -797,6 +810,83 @@ bool ConnectivityManagerImpl::IsWiFiManagementStarted()
     return ret;
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+const char srv_name[]="_matterc._udp";
+/*
+    NAN-USD Service Protocol Type: ref: Table 58 of Wi-Fi Aware Specificaiton
+*/
+#define MAX_PAF_PUBLISH_SSI_BUFLEN        128
+#define MAX_PAF_TX_SSI_BUFLEN        2048
+#define NAN_SRV_PROTO_MATTER        3
+#define NAM_PUBLISH_PERIOD        300u
+#define NAN_PUBLISH_SSI_TAG        "ssi="
+
+#pragma pack(push, 1)
+struct PAFPublishSSI
+{
+    uint8_t    DevOpCode;
+    uint16_t   DevInfo;
+    uint16_t   ProductId;
+    uint16_t   VendorId;
+};
+#pragma pack(pop)
+
+CHIP_ERROR ConnectivityManagerImpl::_SetWiFiPAFAdvertisingEnabled(bool val)
+{
+    CHIP_ERROR  ret;
+    GAutoPtr<GError> err;
+    gchar args[MAX_PAF_PUBLISH_SSI_BUFLEN];
+    gint publish_id;
+
+    snprintf(args, sizeof(args), "service_name=%s srv_proto_type=%u ttl=%u ",
+        srv_name, NAN_SRV_PROTO_MATTER, NAM_PUBLISH_PERIOD);
+
+    struct PAFPublishSSI PafPublish_ssi;
+    VerifyOrReturnError((strlen(args) + strlen(NAN_PUBLISH_SSI_TAG) + (sizeof(struct PAFPublishSSI)*2) < MAX_PAF_PUBLISH_SSI_BUFLEN),
+        CHIP_ERROR_BUFFER_TOO_SMALL);
+    PafPublish_ssi.DevOpCode = 0;
+    VerifyOrDie(DeviceLayer::GetCommissionableDataProvider()->GetSetupDiscriminator(PafPublish_ssi.DevInfo) == CHIP_NO_ERROR);
+    if (DeviceLayer::GetDeviceInstanceInfoProvider()->GetProductId(PafPublish_ssi.ProductId) != CHIP_NO_ERROR)
+    {
+        PafPublish_ssi.ProductId = 0;
+    }
+    if (DeviceLayer::GetDeviceInstanceInfoProvider()->GetVendorId(PafPublish_ssi.VendorId) != CHIP_NO_ERROR)
+    {
+        PafPublish_ssi.VendorId = 0;
+    }
+    strcat(args, NAN_PUBLISH_SSI_TAG);
+    ret = chip::Encoding::BytesToUppercaseHexString((uint8_t*)&PafPublish_ssi, sizeof(PafPublish_ssi), &args[strlen(args)],
+        MAX_PAF_PUBLISH_SSI_BUFLEN-strlen(args));
+    VerifyOrReturnError(ret == CHIP_NO_ERROR, ret);
+    ChipLogProgress(DeviceLayer, "WiFi-PAF: SetWiFiPAFAdvertisingEnabled(%d)", val);
+    wpa_fi_w1_wpa_supplicant1_interface_call_nanpublish_sync(mWpaSupplicant.iface,
+        args,
+        &publish_id,
+        nullptr,
+        &err.GetReceiver());
+    ChipLogProgress(DeviceLayer, "WiFi-PAF: publish_id: %d ! ", publish_id);
+
+    g_signal_connect(
+        mWpaSupplicant.iface, "nan-receive",
+        G_CALLBACK(+[](WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * obj, ConnectivityManagerImpl * self) {
+            return self->OnNanReceive(obj);
+        }),
+        this);
+    return CHIP_NO_ERROR;
+}
+
+Transport::WiFiPAFBase * ConnectivityManagerImpl::_GetWiFiPAF()
+{
+    return pmWiFiPAF;
+}
+
+void ConnectivityManagerImpl::_SetWiFiPAF(Transport::WiFiPAFBase * pWiFiPAF)
+{
+    pmWiFiPAF = pWiFiPAF;
+    return;
+}
+#endif
+
 void ConnectivityManagerImpl::StartNonConcurrentWiFiManagement()
 {
     StartWiFiManagement();
@@ -1226,6 +1316,179 @@ CHIP_ERROR ConnectivityManagerImpl::ConnectWiFiNetworkWithPDCAsync(
     return _ConnectWiFiNetworkAsync(args, connectCallback);
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+/*
+    NAN-USD Service Protocol Type: ref: Table 58 of Wi-Fi Aware Specificaiton
+*/
+#define MAX_PAF_SUBSCRIBE_SSI_BUFLEN        128
+#define NAN_SRV_PROTO_MATTER        3
+#define NAM_SUBSCRIBE_PERIOD        30u
+void ConnectivityManagerImpl::OnDiscoveryResult(gboolean success, GVariant * discov_info)
+{
+    ChipLogProgress(Controller, "WiFi-PAF: OnDiscoveryResult, %d", success);
+
+    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+    if (g_variant_n_children(discov_info) == 0)
+    {
+        return;
+    }
+
+    GAutoPtr<GVariant> dataValue(g_variant_lookup_value(discov_info, "discov_info", G_VARIANT_TYPE_BYTESTRING));
+    size_t bufferLen;
+    auto buffer = g_variant_get_fixed_array(dataValue.get(), &bufferLen, sizeof(uint8_t));
+
+    if (((struct wpa_dbus_discov_info*)buffer)->subscribe_id == mpaf_info.subscribe_id)
+    {
+        return;
+    }
+    memcpy(&mpaf_info, buffer, sizeof(struct wpa_dbus_discov_info));
+    ChipLogProgress(DeviceLayer, "WiFi-PAF: subscribe_id: %u", mpaf_info.subscribe_id);
+    ChipLogProgress(DeviceLayer, "WiFi-PAF: peer_publish_id: %u", mpaf_info.peer_publish_id);
+    ChipLogProgress(DeviceLayer, "WiFi-PAF: peer_addr: [%02x:%02x:%02x:%02x:%02x:%02x]",
+          mpaf_info.peer_addr[0], mpaf_info.peer_addr[1], mpaf_info.peer_addr[2],
+          mpaf_info.peer_addr[3], mpaf_info.peer_addr[4], mpaf_info.peer_addr[5]);
+    if (mOnPafSubscribeComplete != nullptr)
+    {
+        mOnPafSubscribeComplete(mAppState);
+    }
+
+    return;
+}
+
+void ConnectivityManagerImpl::OnNanReceive(GVariant * obj)
+{
+    ChipLogProgress(Controller, "WiFi-PAF: OnNanReceive");
+
+    if (g_variant_n_children(obj) == 0)
+    {
+        return;
+    }
+    {
+    GAutoPtr<GVariant> dataValue(g_variant_lookup_value(obj, "nanrx_info", G_VARIANT_TYPE_BYTESTRING));
+    size_t bufferLen;
+    auto buffer = g_variant_get_fixed_array(dataValue.get(), &bufferLen, sizeof(uint8_t));
+
+    memcpy(&mpaf_nanrx_info, buffer, sizeof(struct wpa_dbus_nanrx_info));
+    mpaf_info.subscribe_id = mpaf_nanrx_info.id;
+    mpaf_info.peer_publish_id = mpaf_nanrx_info.peer_id;
+    memcpy(mpaf_info.peer_addr, mpaf_nanrx_info.peer_addr, 6);
+    }
+    if (mpaf_nanrx_info.ssi_len > 0) {
+        GAutoPtr<GVariant> dataValue(g_variant_lookup_value(obj, "ssi", G_VARIANT_TYPE_BYTESTRING));
+        size_t bufferLen;
+        System::PacketBufferHandle buf;
+        auto rxbuf = g_variant_get_fixed_array(dataValue.get(), &bufferLen, sizeof(uint8_t));
+        ChipLogProgress(DeviceLayer, "WiFi-PAF: wpa_supplicant:nan-rx: [buflen: %lu], preparing rxbuf", bufferLen);
+        buf = System::PacketBufferHandle::NewWithData(rxbuf, bufferLen);
+
+        // Post an event to the Chip queue to deliver the data into the Chip stack.
+        {
+            ChipDeviceEvent event;
+            event.Type = DeviceEventType::kCHIPoWiFiPAFWriteReceived;
+            event.CHIPoWiFiPAFWriteReceived.Data  = std::move(buf).UnsafeRelease();
+            PlatformMgr().PostEventOrDie(&event);
+        }
+    } else {
+        ChipLogProgress(DeviceLayer, "WiFi-PAF: Skip, ssi length = %u", mpaf_nanrx_info.ssi_len);
+    }
+
+    return;
+}
+
+
+CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFConnect(void *appState,
+                                        OnConnectionCompleteFunct onSuccess,
+                                        OnConnectionErrorFunct onError)
+{
+    ChipLogProgress(Controller, "WiFi-PAF: Try to subscribe the NAN-USD devices");
+    gchar args[MAX_PAF_SUBSCRIBE_SSI_BUFLEN];
+    snprintf(args, sizeof(args), "service_name=%s srv_proto_type=%u ttl=%u ",
+        srv_name, NAN_SRV_PROTO_MATTER, NAM_SUBSCRIBE_PERIOD);
+    mAppState = appState;
+    GAutoPtr<GError> err;
+
+    wpa_fi_w1_wpa_supplicant1_interface_call_nansubscribe(mWpaSupplicant.iface,
+        args,
+        nullptr,
+        reinterpret_cast<GAsyncReadyCallback>(
+                +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) {
+                    return ;
+                }),
+        &err.GetReceiver());
+    mOnPafSubscribeComplete = onSuccess;
+    g_signal_connect(
+            mWpaSupplicant.iface, "discovery-result",
+            G_CALLBACK(+[](WpaFiW1Wpa_supplicant1Interface * proxy, gboolean success, GVariant * obj, ConnectivityManagerImpl * self) {
+                return self->OnDiscoveryResult(success, obj);
+            }),
+            this);
+
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSend(System::PacketBufferHandle && msgBuf)
+{
+    ChipLogProgress(Controller, "WiFi-PAF: sending PAF Follow-up packets, (%lu)", msgBuf->DataLength());
+    CHIP_ERROR ret = CHIP_NO_ERROR;
+
+    if (msgBuf.IsNull()) {
+        ChipLogError(Controller, "WiFi-PAF: Invalid Packet (%lu)", msgBuf->DataLength());
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    // Ensure outgoing message fits in a single contiguous packet buffer, as currently required by the
+    // message fragmentation and reassembly engine.
+    if (msgBuf->HasChainedBuffer())
+    {
+        msgBuf->CompactHead();
+
+        if (msgBuf->HasChainedBuffer())
+        {
+            ret = CHIP_ERROR_OUTBOUND_MESSAGE_TOO_BIG;
+            ChipLogError(Controller, "WiFi-PAF: Outbound message too big (%lu), skip temporally", msgBuf->DataLength());
+            return ret;
+        }
+    }
+
+    // ================================================================================================================
+    //  Send the packets
+    GAutoPtr<GError> err;
+    gchar args[MAX_PAF_TX_SSI_BUFLEN];
+
+    snprintf(args, sizeof(args), "handle=%u req_instance_id=%u address=%02x:%02x:%02x:%02x:%02x:%02x ssi=",
+        mpaf_info.subscribe_id, mpaf_info.peer_publish_id,
+        mpaf_info.peer_addr[0], mpaf_info.peer_addr[1], mpaf_info.peer_addr[2],
+        mpaf_info.peer_addr[3], mpaf_info.peer_addr[4], mpaf_info.peer_addr[5]);
+
+    ChipLogProgress(Controller, "===> %s(), (%lu, %u)", __FUNCTION__,
+            (strlen(args) + msgBuf->DataLength()),
+            MAX_PAF_TX_SSI_BUFLEN)
+    VerifyOrReturnError((strlen(args) + msgBuf->DataLength() < MAX_PAF_TX_SSI_BUFLEN),
+        CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    ret = chip::Encoding::BytesToUppercaseHexString(msgBuf->Start(), msgBuf->DataLength(), &args[strlen(args)],
+        MAX_PAF_TX_SSI_BUFLEN-strlen(args));
+    VerifyOrReturnError(ret == CHIP_NO_ERROR, ret);
+    ChipLogProgress(DeviceLayer, "WiFi-PAF: ssi: [%s]", args);
+
+    wpa_fi_w1_wpa_supplicant1_interface_call_nantransmit_sync(mWpaSupplicant.iface,
+        args,
+        nullptr,
+        &err.GetReceiver());
+
+    g_signal_connect(
+            mWpaSupplicant.iface, "nan-receive",
+            G_CALLBACK(+[](WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * obj, ConnectivityManagerImpl * self) {
+                return self->OnNanReceive(obj);
+            }),
+            this);
+
+    ChipLogProgress(Controller, "WiFi-PAF: Outbound message (%lu) done", msgBuf->DataLength());
+    return ret;
+}
+
+#endif //CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 
 void ConnectivityManagerImpl::_ConnectWiFiNetworkAsyncCallback(GObject * sourceObject, GAsyncResult * res)
 {
@@ -1471,7 +1734,7 @@ CHIP_ERROR ConnectivityManagerImpl::GetConfiguredNetwork(NetworkCommissioning::N
     const gchar * networkPath = wpa_fi_w1_wpa_supplicant1_interface_get_current_network(mWpaSupplicant.iface);
 
     // wpa_supplicant DBus API: if network path of current network is "/", means no networks is currently selected.
-    if (strcmp(networkPath, "/") == 0)
+    if ((networkPath==nullptr) || (strcmp(networkPath, "/") == 0))
     {
         return CHIP_ERROR_KEY_NOT_FOUND;
     }

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -862,7 +862,7 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFPublish()
     }
     strcat(args, NAN_PUBLISH_SSI_TAG);
     ret = Encoding::BytesToUppercaseHexString((uint8_t *) &PafPublish_ssi, sizeof(PafPublish_ssi), &args[strlen(args)],
-                                                    MAX_PAF_PUBLISH_SSI_BUFLEN - strlen(args));
+                                              MAX_PAF_PUBLISH_SSI_BUFLEN - strlen(args));
     VerifyOrReturnError(ret == CHIP_NO_ERROR, ret);
     ChipLogProgress(DeviceLayer, "WiFi-PAF: publish: [%s]", args);
     wpa_fi_w1_wpa_supplicant1_interface_call_nanpublish_sync(mWpaSupplicant.iface, args, &publish_id, nullptr, &err.GetReceiver());
@@ -887,12 +887,14 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFCancelPublish()
     return CHIP_NO_ERROR;
 }
 
-
 CHIP_ERROR ConnectivityManagerImpl::_SetWiFiPAFAdvertisingEnabled(bool val)
 {
-    if (val == true) {
+    if (val == true)
+    {
         return _WiFiPAFPublish();
-    } else {
+    }
+    else
+    {
         return _WiFiPAFCancelPublish();
     }
 }
@@ -1355,7 +1357,8 @@ void ConnectivityManagerImpl::OnDiscoveryResult(gboolean success, GVariant * dis
         return;
     }
 
-    if (success == true) {
+    if (success == true)
+    {
         GAutoPtr<GVariant> dataValue(g_variant_lookup_value(discov_info, "discov_info", G_VARIANT_TYPE_BYTESTRING));
         size_t bufferLen;
         auto buffer = g_variant_get_fixed_array(dataValue.get(), &bufferLen, sizeof(uint8_t));
@@ -1374,7 +1377,9 @@ void ConnectivityManagerImpl::OnDiscoveryResult(gboolean success, GVariant * dis
         ChipDeviceEvent event;
         event.Type = DeviceEventType::kCHIPoWiFiPAFConnected;
         PlatformMgr().PostEventOrDie(&event);
-    } else {
+    }
+    else
+    {
         GetWiFiPAF()->SetWiFiPAFState(Transport::WiFiPAFBase::State::kInitialized);
         if (mOnPafSubscribeError != nullptr)
         {
@@ -1421,8 +1426,8 @@ void ConnectivityManagerImpl::OnNanReceive(GVariant * obj)
     return;
 }
 
-CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFConnect(const SetupDiscriminator & connDiscriminator, void * appState, OnConnectionCompleteFunct onSuccess,
-                                                    OnConnectionErrorFunct onError)
+CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFConnect(const SetupDiscriminator & connDiscriminator, void * appState,
+                                                    OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError)
 {
     ChipLogProgress(Controller, "WiFi-PAF: Try to subscribe the NAN-USD devices");
     gchar args[MAX_PAF_SUBSCRIBE_SSI_BUFLEN];
@@ -1434,9 +1439,9 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFConnect(const SetupDiscriminator & c
     VerifyOrReturnError(
         (strlen(args) + strlen(NAN_PUBLISH_SSI_TAG) + (sizeof(struct PAFPublishSSI) * 2) < MAX_PAF_PUBLISH_SSI_BUFLEN),
         CHIP_ERROR_BUFFER_TOO_SMALL);
-    mAppState = appState;
+    mAppState                = appState;
     PafPublish_ssi.DevOpCode = 0;
-    PafPublish_ssi.DevInfo = connDiscriminator.GetLongValue();
+    PafPublish_ssi.DevInfo   = connDiscriminator.GetLongValue();
     if (DeviceLayer::GetDeviceInstanceInfoProvider()->GetProductId(PafPublish_ssi.ProductId) != CHIP_NO_ERROR)
     {
         PafPublish_ssi.ProductId = 0;
@@ -1447,7 +1452,7 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFConnect(const SetupDiscriminator & c
     }
     strcat(args, NAN_PUBLISH_SSI_TAG);
     ret = Encoding::BytesToUppercaseHexString((uint8_t *) &PafPublish_ssi, sizeof(PafPublish_ssi), &args[strlen(args)],
-                                                    MAX_PAF_PUBLISH_SSI_BUFLEN - strlen(args));
+                                              MAX_PAF_PUBLISH_SSI_BUFLEN - strlen(args));
     VerifyOrReturnError(ret == CHIP_NO_ERROR, ret);
     ChipLogProgress(DeviceLayer, "WiFi-PAF: subscribe: [%s]", args);
 
@@ -1457,7 +1462,7 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFConnect(const SetupDiscriminator & c
             +[](GObject * sourceObject_, GAsyncResult * res_, ConnectivityManagerImpl * self) { return; }),
         &err.GetReceiver());
     mOnPafSubscribeComplete = onSuccess;
-    mOnPafSubscribeError = onError;
+    mOnPafSubscribeError    = onError;
     g_signal_connect(mWpaSupplicant.iface, "discovery-result",
                      G_CALLBACK(+[](WpaFiW1Wpa_supplicant1Interface * proxy, gboolean success, GVariant * obj,
                                     ConnectivityManagerImpl * self) { return self->OnDiscoveryResult(success, obj); }),

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -141,15 +141,13 @@ public:
                                               NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-	CHIP_ERROR _WiFiPAFConnect(void * appState,
-										  OnConnectionCompleteFunct onSuccess,
-										  OnConnectionErrorFunct onError);
+    CHIP_ERROR _WiFiPAFConnect(void * appState, OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError);
     void OnDiscoveryResult(gboolean success, GVariant * obj);
-	void OnNanReceive(GVariant * obj);
+    void OnNanReceive(GVariant * obj);
 
-	CHIP_ERROR _WiFiPAFSend(chip::System::PacketBufferHandle && msgBuf);
-	Transport::WiFiPAFBase * _GetWiFiPAF();
-	void _SetWiFiPAF(Transport::WiFiPAFBase * pWiFiPAF);
+    CHIP_ERROR _WiFiPAFSend(chip::System::PacketBufferHandle && msgBuf);
+    Transport::WiFiPAFBase * _GetWiFiPAF();
+    void _SetWiFiPAF(Transport::WiFiPAFBase * pWiFiPAF);
 #endif
 
     void PostNetworkConnect();
@@ -230,23 +228,25 @@ private:
     void _OnWpaInterfaceProxyReady(GObject * sourceObject, GAsyncResult * res);
     void _OnWpaBssProxyReady(GObject * sourceObject, GAsyncResult * res);
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-	struct wpa_dbus_discov_info {
-		uint32_t subscribe_id;
-		uint32_t peer_publish_id;
-		uint8_t peer_addr[6];
-	};
-	struct wpa_dbus_discov_info mpaf_info;
-	struct wpa_dbus_nanrx_info {
-		uint32_t id;
-		uint32_t peer_id;
-		uint8_t peer_addr[6];
-		uint32_t ssi_len;
-	};
-	struct wpa_dbus_nanrx_info mpaf_nanrx_info;
+    struct wpa_dbus_discov_info
+    {
+        uint32_t subscribe_id;
+        uint32_t peer_publish_id;
+        uint8_t peer_addr[6];
+    };
+    struct wpa_dbus_discov_info mpaf_info;
+    struct wpa_dbus_nanrx_info
+    {
+        uint32_t id;
+        uint32_t peer_id;
+        uint8_t peer_addr[6];
+        uint32_t ssi_len;
+    };
+    struct wpa_dbus_nanrx_info mpaf_nanrx_info;
 
     OnConnectionCompleteFunct mOnPafSubscribeComplete;
     Transport::WiFiPAFBase * pmWiFiPAF;
-	void * mAppState;
+    void * mAppState;
     CHIP_ERROR _SetWiFiPAFAdvertisingEnabled(bool val);
 #endif
 

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -141,7 +141,8 @@ public:
                                               NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    CHIP_ERROR _WiFiPAFConnect(const SetupDiscriminator & connDiscriminator, void * appState, OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError);
+    CHIP_ERROR _WiFiPAFConnect(const SetupDiscriminator & connDiscriminator, void * appState, OnConnectionCompleteFunct onSuccess,
+                               OnConnectionErrorFunct onError);
     void OnDiscoveryResult(gboolean success, GVariant * obj);
     void OnNanReceive(GVariant * obj);
 
@@ -245,12 +246,12 @@ private:
     struct wpa_dbus_nanrx_info mpaf_nanrx_info;
 
     OnConnectionCompleteFunct mOnPafSubscribeComplete;
-	OnConnectionErrorFunct mOnPafSubscribeError;
+    OnConnectionErrorFunct mOnPafSubscribeError;
     Transport::WiFiPAFBase * pmWiFiPAF;
     void * mAppState;
     CHIP_ERROR _SetWiFiPAFAdvertisingEnabled(bool val);
-	CHIP_ERROR _WiFiPAFPublish();
-	CHIP_ERROR _WiFiPAFCancelPublish();
+    CHIP_ERROR _WiFiPAFPublish();
+    CHIP_ERROR _WiFiPAFCancelPublish();
 #endif
 
     bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -141,7 +141,7 @@ public:
                                               NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_PDC
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    CHIP_ERROR _WiFiPAFConnect(void * appState, OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError);
+    CHIP_ERROR _WiFiPAFConnect(const SetupDiscriminator & connDiscriminator, void * appState, OnConnectionCompleteFunct onSuccess, OnConnectionErrorFunct onError);
     void OnDiscoveryResult(gboolean success, GVariant * obj);
     void OnNanReceive(GVariant * obj);
 
@@ -245,9 +245,12 @@ private:
     struct wpa_dbus_nanrx_info mpaf_nanrx_info;
 
     OnConnectionCompleteFunct mOnPafSubscribeComplete;
+	OnConnectionErrorFunct mOnPafSubscribeError;
     Transport::WiFiPAFBase * pmWiFiPAF;
     void * mAppState;
     CHIP_ERROR _SetWiFiPAFAdvertisingEnabled(bool val);
+	CHIP_ERROR _WiFiPAFPublish();
+	CHIP_ERROR _WiFiPAFCancelPublish();
 #endif
 
     bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);

--- a/src/platform/Linux/dbus/wpa/DBusWpaInterface.xml
+++ b/src/platform/Linux/dbus/wpa/DBusWpaInterface.xml
@@ -56,6 +56,16 @@
         <method name="AutoScan">
             <arg name="arg" type="s" direction="in" />
         </method>
+        <method name="NANPublish">
+            <arg name="nan_args" type="s" direction="in" />
+	    <arg name="publish_id" type="i" direction="out" />
+        </method>
+        <method name="NANSubscribe">
+            <arg name="nan_args" type="s" direction="in" />
+        </method>
+        <method name="NANTransmit">
+            <arg name="nan_args" type="s" direction="in" />
+        </method>
         <method name="TDLSDiscover">
             <arg name="peer_address" type="s" direction="in" />
         </method>
@@ -91,6 +101,13 @@
         <method name="AbortScan" />
         <signal name="ScanDone">
             <arg name="success" type="b" />
+        </signal>
+        <signal name="DiscoveryResult">
+            <arg name="result" type="b" />
+            <arg name="discov_info" type="a{sv}" />
+        </signal>
+        <signal name="NanReceive">
+            <arg name="nanrx" type="a{sv}" />
         </signal>
         <signal name="BSSAdded">
             <arg name="path" type="o" />

--- a/src/platform/Linux/dbus/wpa/DBusWpaInterface.xml
+++ b/src/platform/Linux/dbus/wpa/DBusWpaInterface.xml
@@ -58,9 +58,15 @@
         </method>
         <method name="NANPublish">
             <arg name="nan_args" type="s" direction="in" />
-	    <arg name="publish_id" type="i" direction="out" />
+	        <arg name="publish_id" type="i" direction="out" />
+        </method>
+        <method name="NANCancelPublish">
+            <arg name="nan_args" type="s" direction="in" />
         </method>
         <method name="NANSubscribe">
+            <arg name="nan_args" type="s" direction="in" />
+        </method>
+        <method name="NANCancelSubscribe">
             <arg name="nan_args" type="s" direction="in" />
         </method>
         <method name="NANTransmit">

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -23,6 +23,9 @@ declare_args() {
 
   # Substitute fake platform when building with chip_device_platform=auto.
   chip_fake_platform = false
+
+  # Include wifi-paf to commission the device or not
+  chip_device_config_enable_wifipaf = false
 }
 
 if (chip_device_platform == "auto") {

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -62,7 +62,7 @@ bool PayloadContents::isValidQRCodePayload(ValidationMode mode) const
     if (mode == ValidationMode::kProduce)
     {
         chip::RendezvousInformationFlags valid(RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kOnNetwork,
-                                               RendezvousInformationFlag::kSoftAP);
+                                               RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kWiFiPAF);
         VerifyOrReturnValue(rendezvousInformation.Value().HasOnly(valid), false);
     }
 

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -64,9 +64,10 @@ bool PayloadContents::isValidQRCodePayload(ValidationMode mode) const
         chip::RendezvousInformationFlags valid(RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kOnNetwork,
                                                RendezvousInformationFlag::kSoftAP
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-                                               , RendezvousInformationFlag::kWiFiPAF
+                                               ,
+                                               RendezvousInformationFlag::kWiFiPAF
 #endif
-                                               );
+        );
         VerifyOrReturnValue(rendezvousInformation.Value().HasOnly(valid), false);
     }
 

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -62,7 +62,11 @@ bool PayloadContents::isValidQRCodePayload(ValidationMode mode) const
     if (mode == ValidationMode::kProduce)
     {
         chip::RendezvousInformationFlags valid(RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kOnNetwork,
-                                               RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kWiFiPAF);
+                                               RendezvousInformationFlag::kSoftAP
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+                                               , RendezvousInformationFlag::kWiFiPAF
+#endif
+                                               );
         VerifyOrReturnValue(rendezvousInformation.Value().HasOnly(valid), false);
     }
 

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -62,11 +62,8 @@ bool PayloadContents::isValidQRCodePayload(ValidationMode mode) const
     if (mode == ValidationMode::kProduce)
     {
         chip::RendezvousInformationFlags valid(RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kOnNetwork,
-                                               RendezvousInformationFlag::kSoftAP
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-                                               ,
+                                               RendezvousInformationFlag::kSoftAP ,
                                                RendezvousInformationFlag::kWiFiPAF
-#endif
         );
         VerifyOrReturnValue(rendezvousInformation.Value().HasOnly(valid), false);
     }

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -62,9 +62,7 @@ bool PayloadContents::isValidQRCodePayload(ValidationMode mode) const
     if (mode == ValidationMode::kProduce)
     {
         chip::RendezvousInformationFlags valid(RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kOnNetwork,
-                                               RendezvousInformationFlag::kSoftAP ,
-                                               RendezvousInformationFlag::kWiFiPAF
-        );
+                                               RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kWiFiPAF);
         VerifyOrReturnValue(rendezvousInformation.Value().HasOnly(valid), false);
     }
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -101,7 +101,9 @@ enum class RendezvousInformationFlag : uint8_t
     kSoftAP    = 1 << 0, ///< Device supports Wi-Fi softAP
     kBLE       = 1 << 1, ///< Device supports BLE
     kOnNetwork = 1 << 2, ///< Device supports Setup on network
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     kWiFiPAF   = 1 << 3, ///< Device supports Wi-Fi Public Action Frame for discovery
+#endif
 };
 using RendezvousInformationFlags = chip::BitFlags<RendezvousInformationFlag, uint8_t>;
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -101,6 +101,7 @@ enum class RendezvousInformationFlag : uint8_t
     kSoftAP    = 1 << 0, ///< Device supports Wi-Fi softAP
     kBLE       = 1 << 1, ///< Device supports BLE
     kOnNetwork = 1 << 2, ///< Device supports Setup on network
+    kWiFiPAF   = 1 << 3, ///< Device supports Wi-Fi Public Action Frame for discovery
 };
 using RendezvousInformationFlags = chip::BitFlags<RendezvousInformationFlag, uint8_t>;
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -102,7 +102,7 @@ enum class RendezvousInformationFlag : uint8_t
     kBLE       = 1 << 1, ///< Device supports BLE
     kOnNetwork = 1 << 2, ///< Device supports Setup on network
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    kWiFiPAF   = 1 << 3, ///< Device supports Wi-Fi Public Action Frame for discovery
+    kWiFiPAF = 1 << 3, ///< Device supports Wi-Fi Public Action Frame for discovery
 #endif
 };
 using RendezvousInformationFlags = chip::BitFlags<RendezvousInformationFlag, uint8_t>;

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -101,7 +101,7 @@ enum class RendezvousInformationFlag : uint8_t
     kSoftAP    = 1 << 0, ///< Device supports Wi-Fi softAP
     kBLE       = 1 << 1, ///< Device supports BLE
     kOnNetwork = 1 << 2, ///< Device supports Setup on network
-    kWiFiPAF = 1 << 3, ///< Device supports Wi-Fi Public Action Frame for discovery
+    kWiFiPAF   = 1 << 3, ///< Device supports Wi-Fi Public Action Frame for discovery
 };
 using RendezvousInformationFlags = chip::BitFlags<RendezvousInformationFlag, uint8_t>;
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -101,9 +101,7 @@ enum class RendezvousInformationFlag : uint8_t
     kSoftAP    = 1 << 0, ///< Device supports Wi-Fi softAP
     kBLE       = 1 << 1, ///< Device supports BLE
     kOnNetwork = 1 << 2, ///< Device supports Setup on network
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     kWiFiPAF = 1 << 3, ///< Device supports Wi-Fi Public Action Frame for discovery
-#endif
 };
 using RendezvousInformationFlags = chip::BitFlags<RendezvousInformationFlag, uint8_t>;
 

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -303,9 +303,10 @@ TEST(TestQRCode, TestSetupPayloadVerify)
     EXPECT_EQ(test_payload.isValidQRCodePayload(), false);
 
     // test invalid rendezvousInformation
-    test_payload                       = payload;
-    RendezvousInformationFlags invalid = RendezvousInformationFlags(
-        RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kOnNetwork, RendezvousInformationFlag::kWiFiPAF);
+    test_payload = payload;
+    RendezvousInformationFlags invalid =
+        RendezvousInformationFlags(RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kSoftAP,
+                                   RendezvousInformationFlag::kOnNetwork, RendezvousInformationFlag::kWiFiPAF);
     invalid.SetRaw(static_cast<uint8_t>(invalid.Raw() + 1));
     test_payload.rendezvousInformation.SetValue(invalid);
     EXPECT_EQ(test_payload.isValidQRCodePayload(), false);

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -305,7 +305,7 @@ TEST(TestQRCode, TestSetupPayloadVerify)
     // test invalid rendezvousInformation
     test_payload                       = payload;
     RendezvousInformationFlags invalid = RendezvousInformationFlags(
-        RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kOnNetwork);
+        RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kOnNetwork, RendezvousInformationFlag::kWiFiPAF);
     invalid.SetRaw(static_cast<uint8_t>(invalid.Raw() + 1));
     test_payload.rendezvousInformation.SetValue(invalid);
     EXPECT_EQ(test_payload.isValidQRCodePayload(), false);

--- a/src/transport/raw/BUILD.gn
+++ b/src/transport/raw/BUILD.gn
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 import("${chip_root}/src/ble/ble.gni")
 import("${chip_root}/src/inet/inet.gni")
+import("${chip_root}/src/platform/device.gni")
 
 static_library("raw") {
   output_name = "libRawTransport"
@@ -42,6 +43,12 @@ static_library("raw") {
     sources += [
       "BLE.cpp",
       "BLE.h",
+    ]
+  }
+  if (chip_device_config_enable_wifipaf) {
+    sources += [
+        "WiFiPAF.cpp",
+        "WiFiPAF.h",
     ]
   }
 

--- a/src/transport/raw/BUILD.gn
+++ b/src/transport/raw/BUILD.gn
@@ -47,8 +47,8 @@ static_library("raw") {
   }
   if (chip_device_config_enable_wifipaf) {
     sources += [
-        "WiFiPAF.cpp",
-        "WiFiPAF.h",
+      "WiFiPAF.cpp",
+      "WiFiPAF.h",
     ]
   }
 

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -53,7 +53,9 @@ enum class Type : uint8_t
     kUdp,
     kBle,
     kTcp,
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     kWiFiPAF,
+#endif
 };
 
 /**
@@ -168,9 +170,11 @@ public:
 #endif
                 snprintf(buf, bufSize, "TCP:[%s%s]:%d", ip_addr, interface, mPort);
             break;
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
         case Type::kWiFiPAF:
             snprintf(buf, bufSize, "WiFiPAF");
             break;
+#endif
         case Type::kBle:
             // Note that BLE does not currently use any specific address.
             snprintf(buf, bufSize, "BLE");
@@ -212,8 +216,9 @@ public:
     {
         return TCP(addr).SetPort(port).SetInterface(interface);
     }
-
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     static PeerAddress WiFiPAF() { return PeerAddress(Type::kWiFiPAF); }
+#endif
 
     static PeerAddress Multicast(chip::FabricId fabric, chip::GroupId group)
     {

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -53,6 +53,7 @@ enum class Type : uint8_t
     kUdp,
     kBle,
     kTcp,
+    kWiFiPAF,
 };
 
 /**
@@ -167,6 +168,9 @@ public:
 #endif
                 snprintf(buf, bufSize, "TCP:[%s%s]:%d", ip_addr, interface, mPort);
             break;
+        case Type::kWiFiPAF:
+            snprintf(buf, bufSize, "WiFiPAF");
+            break;
         case Type::kBle:
             // Note that BLE does not currently use any specific address.
             snprintf(buf, bufSize, "BLE");
@@ -208,6 +212,8 @@ public:
     {
         return TCP(addr).SetPort(port).SetInterface(interface);
     }
+
+    static PeerAddress WiFiPAF() { return PeerAddress(Type::kWiFiPAF); }
 
     static PeerAddress Multicast(chip::FabricId fabric, chip::GroupId group)
     {

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -246,7 +246,7 @@ private:
     Type mTransportType          = Type::kUndefined;
     uint16_t mPort               = CHIP_PORT; ///< Relevant for UDP data sending.
     Inet::InterfaceId mInterface = Inet::InterfaceId::Null();
-    NodeId mRemoteId = 0;
+    NodeId mRemoteId             = 0;
 };
 
 } // namespace Transport

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -65,6 +65,7 @@ public:
     PeerAddress() : mIPAddress(Inet::IPAddress::Any), mTransportType(Type::kUndefined) {}
     PeerAddress(const Inet::IPAddress & addr, Type type) : mIPAddress(addr), mTransportType(type) {}
     PeerAddress(Type type) : mTransportType(type) {}
+    PeerAddress(Type type, NodeId remoteId) : mTransportType(type), mRemoteId(remoteId) {}
 
     PeerAddress(PeerAddress &&)                  = default;
     PeerAddress(const PeerAddress &)             = default;
@@ -77,6 +78,8 @@ public:
         mIPAddress = addr;
         return *this;
     }
+
+    NodeId GetRemoteId() const { return mRemoteId; }
 
     Type GetTransportType() const { return mTransportType; }
     PeerAddress & SetTransportType(Type type)
@@ -213,7 +216,7 @@ public:
         return TCP(addr).SetPort(port).SetInterface(interface);
     }
 
-    static PeerAddress WiFiPAF() { return PeerAddress(Type::kWiFiPAF); }
+    static PeerAddress WiFiPAF(NodeId remoteId) { return PeerAddress(Type::kWiFiPAF); }
 
     static PeerAddress Multicast(chip::FabricId fabric, chip::GroupId group)
     {
@@ -243,6 +246,7 @@ private:
     Type mTransportType          = Type::kUndefined;
     uint16_t mPort               = CHIP_PORT; ///< Relevant for UDP data sending.
     Inet::InterfaceId mInterface = Inet::InterfaceId::Null();
+    NodeId mRemoteId = 0;
 };
 
 } // namespace Transport

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -172,7 +172,7 @@ public:
                 snprintf(buf, bufSize, "TCP:[%s%s]:%d", ip_addr, interface, mPort);
             break;
         case Type::kWiFiPAF:
-            snprintf(buf, bufSize, "WiFiPAF");
+            snprintf(buf, bufSize, "Wi-Fi PAF");
             break;
         case Type::kBle:
             // Note that BLE does not currently use any specific address.

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -53,9 +53,7 @@ enum class Type : uint8_t
     kUdp,
     kBle,
     kTcp,
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     kWiFiPAF,
-#endif
 };
 
 /**
@@ -170,11 +168,9 @@ public:
 #endif
                 snprintf(buf, bufSize, "TCP:[%s%s]:%d", ip_addr, interface, mPort);
             break;
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
         case Type::kWiFiPAF:
             snprintf(buf, bufSize, "WiFiPAF");
             break;
-#endif
         case Type::kBle:
             // Note that BLE does not currently use any specific address.
             snprintf(buf, bufSize, "BLE");
@@ -216,9 +212,8 @@ public:
     {
         return TCP(addr).SetPort(port).SetInterface(interface);
     }
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+
     static PeerAddress WiFiPAF() { return PeerAddress(Type::kWiFiPAF); }
-#endif
 
     static PeerAddress Multicast(chip::FabricId fabric, chip::GroupId group)
     {

--- a/src/transport/raw/WiFiPAF.cpp
+++ b/src/transport/raw/WiFiPAF.cpp
@@ -22,13 +22,13 @@
  *
  */
 
-//#include <transport/raw/BLE.h>
+// #include <transport/raw/BLE.h>
 #include <transport/raw/WiFiPAF.h>
 
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <transport/raw/MessageHeader.h>
 #include <platform/ConnectivityManager.h>
+#include <transport/raw/MessageHeader.h>
 
 #include <inttypes.h>
 

--- a/src/transport/raw/WiFiPAF.cpp
+++ b/src/transport/raw/WiFiPAF.cpp
@@ -1,0 +1,96 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements the CHIP Connection object that maintains a BLE connection.
+ *
+ */
+
+//#include <transport/raw/BLE.h>
+#include <transport/raw/WiFiPAF.h>
+
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <transport/raw/MessageHeader.h>
+#include <platform/ConnectivityManager.h>
+
+#include <inttypes.h>
+
+using namespace chip::System;
+
+namespace chip {
+namespace Transport {
+
+WiFiPAFBase::~WiFiPAFBase()
+{
+    ClearState();
+}
+
+void WiFiPAFBase::ClearState()
+{
+    mState = State::kNotReady;
+}
+
+CHIP_ERROR WiFiPAFBase::Init(const WiFiPAFListenParameters & param)
+{
+    ChipLogDetail(Inet, "WiFiPAFBase::Init - setting/overriding transport");
+    VerifyOrReturnError(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
+    DeviceLayer::ConnectivityMgr().SetWiFiPAF(this);
+    mState = State::kInitialized;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WiFiPAFBase::SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf)
+{
+    ChipLogProgress(NotSpecified, "=====> WiFiPAFBase::SendMessage()");
+    ReturnErrorCodeIf(address.GetTransportType() != Type::kWiFiPAF, CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorCodeIf(mState == State::kNotReady, CHIP_ERROR_INCORRECT_STATE);
+
+    DeviceLayer::ConnectivityMgr().WiFiPAFSend(std::move(msgBuf));
+
+    ChipLogProgress(NotSpecified, "<===== WiFiPAFBase::SendMessage()");
+    return CHIP_NO_ERROR;
+}
+
+void WiFiPAFBase::OnWiFiPAFMessageReceived(System::PacketBufferHandle && buffer)
+{
+    HandleMessageReceived(Transport::PeerAddress(Transport::Type::kWiFiPAF), std::move(buffer));
+    return;
+}
+
+CHIP_ERROR WiFiPAFBase::SendAfterConnect(System::PacketBufferHandle && msg)
+{
+    CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
+
+    for (size_t i = 0; i < mPendingPacketsSize; i++)
+    {
+        if (mPendingPackets[i].IsNull())
+        {
+            mPendingPackets[i] = std::move(msg);
+            err                = CHIP_NO_ERROR;
+            break;
+        }
+    }
+
+    return err;
+}
+
+} // namespace Transport
+} // namespace chip

--- a/src/transport/raw/WiFiPAF.cpp
+++ b/src/transport/raw/WiFiPAF.cpp
@@ -22,12 +22,12 @@
  *
  */
 
-#include <transport/raw/WiFiPAF.h>
+#include <inttypes.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/ConnectivityManager.h>
 #include <transport/raw/MessageHeader.h>
-#include <inttypes.h>
+#include <transport/raw/WiFiPAF.h>
 
 using namespace chip::System;
 
@@ -51,7 +51,8 @@ CHIP_ERROR WiFiPAFBase::Init(const WiFiPAFListenParameters & param)
     DeviceLayer::ConnectivityMgr().SetWiFiPAF(this);
     mState = State::kInitialized;
 
-    if (!DeviceLayer::ConnectivityMgrImpl().IsWiFiManagementStarted()) {
+    if (!DeviceLayer::ConnectivityMgrImpl().IsWiFiManagementStarted())
+    {
         ChipLogError(Inet, "Wi-Fi Management has not started, do it now.");
         static constexpr useconds_t kWiFiStartCheckTimeUsec = WIFI_START_CHECK_TIME_USEC;
         static constexpr uint8_t kWiFiStartCheckAttempts    = WIFI_START_CHECK_ATTEMPTS;

--- a/src/transport/raw/WiFiPAF.h
+++ b/src/transport/raw/WiFiPAF.h
@@ -37,10 +37,9 @@ namespace Transport {
 class WiFiPAFLayer
 {
 public:
-	WiFiPAFLayer() = default;
+    WiFiPAFLayer() = default;
 };
 class WiFiPAFListenParameters;
-
 
 /**
  * Implements a transport using Wi-Fi-PAF
@@ -58,7 +57,7 @@ public:
         kInitialized = 1, /**< State after class is connected and ready. */
         kConnected   = 2, /**< Endpoint connected. */
     };
-    WiFiPAFBase()=default;
+    WiFiPAFBase() = default;
     WiFiPAFBase(System::PacketBufferHandle * packetBuffers, size_t packetBuffersSize) :
         mPendingPackets(packetBuffers), mPendingPacketsSize(packetBuffersSize)
     {}
@@ -75,18 +74,18 @@ public:
     {
         return (mState != State::kNotReady) && (address.GetTransportType() == Type::kWiFiPAF);
     }
-	void OnWiFiPAFMessageReceived(System::PacketBufferHandle && buffer);
-	void SetWiFiPAFState(State state) { mState = state; };
-	State GetWiFiPAFState() { return mState; };
+    void OnWiFiPAFMessageReceived(System::PacketBufferHandle && buffer);
+    void SetWiFiPAFState(State state) { mState = state; };
+    State GetWiFiPAFState() { return mState; };
 
 private:
     void ClearState();
-   /**
+    /**
      * Sends the specified message once a connection has been established.
      * @param msg - what buffer to send once a connection has been established.
      */
     CHIP_ERROR SendAfterConnect(System::PacketBufferHandle && msg);
-    State mState                    = State::kNotReady;
+    State mState = State::kNotReady;
 
     System::PacketBufferHandle * mPendingPackets;
     size_t mPendingPacketsSize;
@@ -102,16 +101,15 @@ private:
     System::PacketBufferHandle mPendingPackets[kPendingPacketSize];
 };
 
-
 /** Defines parameters for setting up the Wi-Fi PAF transport */
 class WiFiPAFListenParameters
 {
 public:
-	WiFiPAFListenParameters() = default;
-	explicit WiFiPAFListenParameters(WiFiPAFBase * layer) : mWiFiPAF(layer) {}
-private:
-	WiFiPAFBase * mWiFiPAF;
+    WiFiPAFListenParameters() = default;
+    explicit WiFiPAFListenParameters(WiFiPAFBase * layer) : mWiFiPAF(layer) {}
 
+private:
+    WiFiPAFBase * mWiFiPAF;
 };
 
 } // namespace Transport

--- a/src/transport/raw/WiFiPAF.h
+++ b/src/transport/raw/WiFiPAF.h
@@ -1,0 +1,118 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the CHIP Connection object that maintains a Wi-Fi PAF connection.
+ *
+ */
+
+#pragma once
+
+#include <utility>
+
+#include <lib/core/CHIPCore.h>
+#include <lib/support/DLLUtil.h>
+#include <system/SystemPacketBuffer.h>
+#include <transport/raw/Base.h>
+
+namespace chip {
+namespace Transport {
+
+class WiFiPAFLayer
+{
+public:
+	WiFiPAFLayer() = default;
+};
+class WiFiPAFListenParameters;
+
+
+/**
+ * Implements a transport using Wi-Fi-PAF
+ */
+class DLL_EXPORT WiFiPAFBase : public Base
+{
+public:
+    /**
+     *  The State of the Wi-Fi-PAF connection
+     *
+     */
+    enum class State
+    {
+        kNotReady    = 0, /**< State before initialization. */
+        kInitialized = 1, /**< State after class is connected and ready. */
+        kConnected   = 2, /**< Endpoint connected. */
+    };
+    WiFiPAFBase()=default;
+    WiFiPAFBase(System::PacketBufferHandle * packetBuffers, size_t packetBuffersSize) :
+        mPendingPackets(packetBuffers), mPendingPacketsSize(packetBuffersSize)
+    {}
+    ~WiFiPAFBase() override;
+
+    /**
+     * Initialize a Wi-Fi-PAF transport
+     *
+     * @param param        Wi-Fi-PAF configuration parameters for this transport
+     */
+    CHIP_ERROR Init(const WiFiPAFListenParameters & param);
+    CHIP_ERROR SendMessage(const Transport::PeerAddress & address, System::PacketBufferHandle && msgBuf) override;
+    bool CanSendToPeer(const Transport::PeerAddress & address) override
+    {
+        return (mState != State::kNotReady) && (address.GetTransportType() == Type::kWiFiPAF);
+    }
+	void OnWiFiPAFMessageReceived(System::PacketBufferHandle && buffer);
+	void SetWiFiPAFState(State state) { mState = state; };
+	State GetWiFiPAFState() { return mState; };
+
+private:
+    void ClearState();
+   /**
+     * Sends the specified message once a connection has been established.
+     * @param msg - what buffer to send once a connection has been established.
+     */
+    CHIP_ERROR SendAfterConnect(System::PacketBufferHandle && msg);
+    State mState                    = State::kNotReady;
+
+    System::PacketBufferHandle * mPendingPackets;
+    size_t mPendingPacketsSize;
+};
+
+template <size_t kPendingPacketSize>
+class WiFiPAF : public WiFiPAFBase
+{
+public:
+    WiFiPAF() : WiFiPAFBase(mPendingPackets, kPendingPacketSize) {}
+
+private:
+    System::PacketBufferHandle mPendingPackets[kPendingPacketSize];
+};
+
+
+/** Defines parameters for setting up the Wi-Fi PAF transport */
+class WiFiPAFListenParameters
+{
+public:
+	WiFiPAFListenParameters() = default;
+	explicit WiFiPAFListenParameters(WiFiPAFBase * layer) : mWiFiPAF(layer) {}
+private:
+	WiFiPAFBase * mWiFiPAF;
+
+};
+
+} // namespace Transport
+} // namespace chip

--- a/src/transport/raw/WiFiPAF.h
+++ b/src/transport/raw/WiFiPAF.h
@@ -18,14 +18,13 @@
 
 /**
  *    @file
- *      This file defines the CHIP Connection object that maintains a Wi-Fi PAF connection.
+ *      This file defines the Matter Connection object that maintains a Wi-Fi PAF connection.
  *
  */
 
 #pragma once
 
 #include <utility>
-
 #include <lib/core/CHIPCore.h>
 #include <lib/support/DLLUtil.h>
 #include <system/SystemPacketBuffer.h>

--- a/src/transport/raw/WiFiPAF.h
+++ b/src/transport/raw/WiFiPAF.h
@@ -24,11 +24,11 @@
 
 #pragma once
 
-#include <utility>
 #include <lib/core/CHIPCore.h>
 #include <lib/support/DLLUtil.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/raw/Base.h>
+#include <utility>
 
 namespace chip {
 namespace Transport {


### PR DESCRIPTION
 `Fixes #34298` to not include RvcOperationalState in operational-state-delegate-impl. 

