### PR TITLE
[nrfconnect] Updated nRF Connect SDK version in Docker to 2.7.0

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-64 : [NXP] Add `--break-system-packages` to pip install
+65 : [nrfconnect] Update nRF Connect SDK version.

--- a/integrations/docker/images/stage-2/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nrf-platform/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION=1
 FROM ghcr.io/project-chip/chip-build:${VERSION} as build
 LABEL org.opencontainers.image.source https://github.com/project-chip/connectedhomeip
 # Compatible Nordic Connect SDK revision.
-ARG NCS_REVISION=v2.6.0
+ARG NCS_REVISION=v2.7.0
 
 # Requirements to clone SDKs in temporary container
 RUN set -x \


### PR DESCRIPTION
Regular update of nRF Connect SDK to 2.7.0 version.


