### PR TITLE
Link all unit tests with string adapters for CHIP_ERROR

### DIFF
--- a/src/access/tests/BUILD.gn
+++ b/src/access/tests/BUILD.gn
@@ -25,6 +25,7 @@ chip_test_suite("tests") {
   cflags = [ "-Wconversion" ]
   public_deps = [
     "${chip_root}/src/access",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support:test_utils",
     "${dir_pw_unit_test}",
   ]

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -19,9 +19,10 @@
 #include "access/AccessControl.h"
 #include "access/examples/ExampleAccessControlDelegate.h"
 
-#include <lib/core/CHIPCore.h>
+#include <pw_unit_test/framework.h>
 
-#include <gtest/gtest.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 
 namespace chip {
 namespace Access {

--- a/src/app/cluster-building-blocks/tests/BUILD.gn
+++ b/src/app/cluster-building-blocks/tests/BUILD.gn
@@ -24,6 +24,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/app/cluster-building-blocks",
     "${chip_root}/src/app/data-model:nullable",
     "${chip_root}/src/lib/core:error",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support/tests:pw-test-macros",
     "${chip_root}/src/system",
   ]

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -22,9 +22,10 @@
 
 #include <app/data-model/Nullable.h>
 #include <lib/core/CHIPError.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <system/SystemClock.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 using namespace chip;
 using namespace chip::app;

--- a/src/app/codegen-data-model/tests/TestCodegenModelViaMocks.cpp
+++ b/src/app/codegen-data-model/tests/TestCodegenModelViaMocks.cpp
@@ -14,6 +14,11 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#include <vector>
+
+#include <pw_unit_test/framework.h>
+
 #include "app/ConcreteCommandPath.h"
 #include <app/codegen-data-model/CodegenDataModel.h>
 
@@ -53,9 +58,6 @@
 #include <lib/core/TLVTypes.h>
 #include <lib/core/TLVWriter.h>
 #include <lib/support/Span.h>
-
-#include <gtest/gtest.h>
-#include <vector>
 
 using namespace chip;
 using namespace chip::Test;

--- a/src/app/data-model-interface/tests/BUILD.gn
+++ b/src/app/data-model-interface/tests/BUILD.gn
@@ -21,5 +21,8 @@ chip_test_suite("tests") {
 
   cflags = [ "-Wconversion" ]
 
-  public_deps = [ "${chip_root}/src/app/data-model-interface" ]
+  public_deps = [
+    "${chip_root}/src/app/data-model-interface",
+    "${chip_root}/src/lib/core:string-builder-adapters",
+  ]
 }

--- a/src/app/data-model-interface/tests/TestEventEmitting.cpp
+++ b/src/app/data-model-interface/tests/TestEventEmitting.cpp
@@ -19,9 +19,10 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model-interface/EventsGenerator.h>
 #include <app/data-model/Decode.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 namespace {
 

--- a/src/app/icd/server/tests/BUILD.gn
+++ b/src/app/icd/server/tests/BUILD.gn
@@ -31,6 +31,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/app/icd/server:manager",
     "${chip_root}/src/app/icd/server:monitoring-table",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support:test_utils",
     "${chip_root}/src/lib/support:testing",
     "${chip_root}/src/messaging/tests:helpers",

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -15,6 +15,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 #include <pw_unit_test/framework.h>
 
 #include <app/SubscriptionsInfoProvider.h>
@@ -29,6 +30,7 @@
 #include <lib/address_resolve/AddressResolve.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/NodeId.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/TimeUtils.h>
 #include <messaging/tests/MessagingContext.h>

--- a/src/app/icd/server/tests/TestICDMonitoringTable.cpp
+++ b/src/app/icd/server/tests/TestICDMonitoringTable.cpp
@@ -15,12 +15,14 @@
  *    limitations under the License.
  */
 
+#include <pw_unit_test/framework.h>
+
 #include <app/icd/server/ICDMonitoringTable.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <crypto/DefaultSessionKeystore.h>
-#include <gtest/gtest.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/ClusterEnums.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 

--- a/src/app/tests/TestAclEvent.cpp
+++ b/src/app/tests/TestAclEvent.cpp
@@ -18,7 +18,6 @@
 
 #include <type_traits>
 
-#include <app/tests/test-interaction-model-api.h>
 #include <pw_unit_test/framework.h>
 
 #include <access/AccessControl.h>
@@ -27,11 +26,13 @@
 #include <app/MessageDef/EventDataIB.h>
 #include <app/reporting/tests/MockReportScheduler.h>
 #include <app/tests/AppTestContext.h>
+#include <app/tests/test-interaction-model-api.h>
 #include <app/util/basic-types.h>
 #include <app/util/mock/Constants.h>
 #include <app/util/mock/Functions.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/core/TLV.h>
 #include <lib/core/TLVDebug.h>
 #include <lib/core/TLVUtilities.h>

--- a/src/app/tests/TestFailSafeContext.cpp
+++ b/src/app/tests/TestFailSafeContext.cpp
@@ -31,6 +31,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <app/FailSafeContext.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>

--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -24,6 +24,8 @@
 
 #include <cinttypes>
 
+#include <pw_unit_test/framework.h>
+
 #include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/Engine.h>
@@ -31,13 +33,13 @@
 #include <app/tests/AppTestContext.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/core/TLV.h>
 #include <lib/core/TLVDebug.h>
 #include <lib/core/TLVUtilities.h>
 #include <lib/support/tests/ExtraPwTestMacros.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/Flags.h>
-#include <pw_unit_test/framework.h>
 
 namespace chip {
 

--- a/src/ble/tests/BUILD.gn
+++ b/src/ble/tests/BUILD.gn
@@ -31,6 +31,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/ble",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/platform",
   ]
 }

--- a/src/ble/tests/TestBleErrorStr.cpp
+++ b/src/ble/tests/TestBleErrorStr.cpp
@@ -28,12 +28,12 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <pw_unit_test/framework.h>
+
 #include <lib/core/ErrorStr.h>
 
 #define _CHIP_BLE_BLE_H
 #include <ble/BleError.h>
-
-#include <gtest/gtest.h>
 
 using namespace chip;
 

--- a/src/ble/tests/TestBleLayer.cpp
+++ b/src/ble/tests/TestBleLayer.cpp
@@ -21,9 +21,10 @@
 #include <type_traits>
 #include <utility>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPError.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/Span.h>
 #include <lib/support/TypeTraits.h>

--- a/src/ble/tests/TestBleUUID.cpp
+++ b/src/ble/tests/TestBleUUID.cpp
@@ -27,7 +27,7 @@
 #define _CHIP_BLE_BLE_H
 #include <ble/BleUUID.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 using namespace chip;
 using namespace chip::Ble;

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -20,14 +20,15 @@
 #include <cstdint>
 #include <numeric>
 
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #define _CHIP_BLE_BLE_H
 #include <ble/BleLayer.h>
 #include <ble/BtpEngine.h>
-
-#include <gtest/gtest.h>
 
 using namespace chip;
 using namespace chip::Ble;

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -39,6 +39,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/app/common:cluster-objects",
     "${chip_root}/src/app/tests:helpers",
     "${chip_root}/src/controller",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support:test_utils",
     "${chip_root}/src/messaging/tests:helpers",
     "${chip_root}/src/transport/raw/tests:helpers",

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -16,9 +16,10 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <controller/CHIPCommissionableNodeController.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMemString.h>
 
 using namespace chip;

--- a/src/controller/tests/TestEventCaching.cpp
+++ b/src/controller/tests/TestEventCaching.cpp
@@ -16,6 +16,8 @@
  *    limitations under the License.
  */
 
+#include <pw_unit_test/framework.h>
+
 #include "app-common/zap-generated/ids/Attributes.h"
 #include "app-common/zap-generated/ids/Clusters.h"
 #include "app/ClusterStateCache.h"
@@ -32,6 +34,7 @@
 #include <app/util/attribute-storage.h>
 #include <controller/InvokeInteraction.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/TimeUtils.h>
 #include <lib/support/UnitTestUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -38,6 +38,7 @@
 #include <controller/InvokeInteraction.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPCounter.h>
 #include <lib/support/TimeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/controller/tests/TestEventNumberCaching.cpp
+++ b/src/controller/tests/TestEventNumberCaching.cpp
@@ -31,6 +31,7 @@
 #include <app/util/attribute-storage.h>
 #include <controller/InvokeInteraction.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/TimeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -41,6 +41,7 @@
 #include <app/util/endpoint-config-api.h>
 #include <controller/InvokeInteraction.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/TimeUtils.h>
 #include <lib/support/UnitTestUtils.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -35,6 +35,7 @@
 #include <controller/InvokeInteraction.h>
 #include <controller/ReadInteraction.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -19,6 +19,8 @@
 #include <memory>
 #include <utility>
 
+#include <pw_unit_test/framework.h>
+
 #include "app-common/zap-generated/ids/Attributes.h"
 #include "app-common/zap-generated/ids/Clusters.h"
 #include "app/ConcreteAttributePath.h"
@@ -35,6 +37,7 @@
 #include <app/util/attribute-storage.h>
 #include <controller/InvokeInteraction.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;

--- a/src/credentials/tests/BUILD.gn
+++ b/src/credentials/tests/BUILD.gn
@@ -69,6 +69,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/credentials",
     "${chip_root}/src/credentials:default_attestation_verifier",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support:testing",
   ]
 }

--- a/src/credentials/tests/TestCertificationDeclaration.cpp
+++ b/src/credentials/tests/TestCertificationDeclaration.cpp
@@ -25,13 +25,14 @@
 #include <inttypes.h>
 #include <stddef.h>
 
+#include <pw_unit_test/framework.h>
+
 #include <credentials/CHIPCert.h>
 #include <credentials/CertificationDeclaration.h>
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/Span.h>
-
-#include <gtest/gtest.h>
 
 using namespace chip;
 using namespace chip::ASN1;

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -24,17 +24,18 @@
  *
  */
 
+#include <pw_unit_test/framework.h>
+
 #include <credentials/CHIPCert.h>
 #include <credentials/examples/LastKnownGoodTimeCertificateValidityPolicyExample.h>
 #include <credentials/examples/StrictCertificateValidityPolicyExample.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/ErrorStr.h>
 #include <lib/core/PeerId.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/core/TLV.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-
-#include <gtest/gtest.h>
 
 #include "CHIPCert_error_test_vectors.h"
 #include "CHIPCert_test_vectors.h"

--- a/src/credentials/tests/TestCommissionerDUTVectors.cpp
+++ b/src/credentials/tests/TestCommissionerDUTVectors.cpp
@@ -15,6 +15,9 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#include <pw_unit_test/framework.h>
+
 #include <crypto/CHIPCryptoPAL.h>
 
 #include <app/tests/suites/credentials/TestHarnessDACProvider.h>
@@ -27,10 +30,9 @@
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
 #include <lib/core/CHIPError.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/Span.h>
-
-#include <gtest/gtest.h>
 
 #include <dirent.h>
 #include <stdio.h>

--- a/src/credentials/tests/TestDeviceAttestationConstruction.cpp
+++ b/src/credentials/tests/TestDeviceAttestationConstruction.cpp
@@ -15,16 +15,19 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#include <cstdio>
+
+#include <pw_unit_test/framework.h>
+
 #include <credentials/DeviceAttestationConstructor.h>
 #include <credentials/DeviceAttestationVendorReserved.h>
 #include <lib/core/CHIPError.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/core/TLV.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/Span.h>
-
-#include <cstdio>
-#include <gtest/gtest.h>
 
 using namespace chip;
 using namespace chip::Credentials;

--- a/src/credentials/tests/TestDeviceAttestationCredentials.cpp
+++ b/src/credentials/tests/TestDeviceAttestationCredentials.cpp
@@ -15,6 +15,9 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#include <pw_unit_test/framework.h>
+
 #include <crypto/CHIPCryptoPAL.h>
 
 #include <credentials/CHIPCert.h>
@@ -28,10 +31,9 @@
 #include <credentials/examples/ExamplePAI.h>
 
 #include <lib/core/CHIPError.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/Span.h>
-
-#include <gtest/gtest.h>
 
 #include "CHIPAttCert_test_vectors.h"
 

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -22,9 +22,12 @@
  */
 
 #include <errno.h>
-#include <gtest/gtest.h>
+#include <stdarg.h>
+
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 
 #include <credentials/FabricTable.h>
 
@@ -40,8 +43,6 @@
 #include <platform/ConfigurationManager.h>
 
 #include <lib/support/BytesToHex.h>
-
-#include <stdarg.h>
 
 using namespace chip;
 using namespace chip::Credentials;

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -16,17 +16,20 @@
  *    limitations under the License.
  */
 
-#include <credentials/GroupDataProviderImpl.h>
-#include <crypto/DefaultSessionKeystore.h>
-#include <gtest/gtest.h>
-#include <lib/core/TLV.h>
-#include <lib/support/CHIPMem.h>
-#include <lib/support/TestPersistentStorageDelegate.h>
-#include <platform/KeyValueStoreManager.h>
 #include <set>
 #include <string.h>
 #include <tuple>
 #include <utility>
+
+#include <pw_unit_test/framework.h>
+
+#include <credentials/GroupDataProviderImpl.h>
+#include <crypto/DefaultSessionKeystore.h>
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/core/TLV.h>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+#include <platform/KeyValueStoreManager.h>
 
 using namespace chip::Credentials;
 using GroupInfo      = GroupDataProvider::GroupInfo;

--- a/src/credentials/tests/TestPersistentStorageOpCertStore.cpp
+++ b/src/credentials/tests/TestPersistentStorageOpCertStore.cpp
@@ -18,8 +18,10 @@
 
 #include <inttypes.h>
 
+#include <pw_unit_test/framework.h>
+
 #include <credentials/PersistentStorageOpCertStore.h>
-#include <gtest/gtest.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>

--- a/src/crypto/tests/BUILD.gn
+++ b/src/crypto/tests/BUILD.gn
@@ -68,6 +68,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/credentials/tests:cert_test_vectors",
     "${chip_root}/src/crypto",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support:testing",
     "${chip_root}/src/platform",
   ]

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -35,10 +35,12 @@
 #include "SPAKE2P_POINT_VALID_test_vectors.h"
 #include "SPAKE2P_RFC_test_vectors.h"
 
+#include <pw_unit_test/framework.h>
+
 #include <crypto/CHIPCryptoPAL.h>
 #include <crypto/DefaultSessionKeystore.h>
-#include <gtest/gtest.h>
 #include <lib/core/CHIPError.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
 

--- a/src/crypto/tests/TestGroupOperationalCredentials.cpp
+++ b/src/crypto/tests/TestGroupOperationalCredentials.cpp
@@ -18,11 +18,12 @@
 
 #include <inttypes.h>
 
+#include <pw_unit_test/framework.h>
+
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
-
-#include <gtest/gtest.h>
 
 using namespace chip;
 using namespace chip::Crypto;

--- a/src/crypto/tests/TestPSAOpKeyStore.cpp
+++ b/src/crypto/tests/TestPSAOpKeyStore.cpp
@@ -18,15 +18,16 @@
 
 #include <inttypes.h>
 
+#include <pw_unit_test/framework.h>
+
 #include <crypto/PSAOperationalKeystore.h>
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/Span.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
-
-#include <gtest/gtest.h>
 
 using namespace chip;
 using namespace chip::Crypto;

--- a/src/crypto/tests/TestPersistentStorageOpKeyStore.cpp
+++ b/src/crypto/tests/TestPersistentStorageOpKeyStore.cpp
@@ -17,17 +17,17 @@
  */
 
 #include <inttypes.h>
+#include <string>
+
+#include <pw_unit_test/framework.h>
 
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/Span.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
-
-#include <gtest/gtest.h>
-
-#include <string>
 
 using namespace chip;
 using namespace chip::Crypto;

--- a/src/crypto/tests/TestSessionKeystore.cpp
+++ b/src/crypto/tests/TestSessionKeystore.cpp
@@ -18,14 +18,15 @@
 
 #include "AES_CCM_128_test_vectors.h"
 
+#include <pw_unit_test/framework.h>
+
 #include <crypto/CHIPCryptoPAL.h>
 #include <crypto/DefaultSessionKeystore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/Span.h>
-
-#include <gtest/gtest.h>
 
 #if CHIP_CRYPTO_PSA
 #include <psa/crypto.h>

--- a/src/inet/tests/BUILD.gn
+++ b/src/inet/tests/BUILD.gn
@@ -71,6 +71,7 @@ if (chip_build_tests) {
       ":helpers",
       "${chip_root}/src/inet",
       "${chip_root}/src/lib/core",
+      "${chip_root}/src/lib/core:string-builder-adapters",
     ]
     test_sources = [
       "TestBasicPacketFilters.cpp",

--- a/src/inet/tests/TestBasicPacketFilters.cpp
+++ b/src/inet/tests/TestBasicPacketFilters.cpp
@@ -18,11 +18,12 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <inet/BasicPacketFilters.h>
 #include <inet/IPPacketInfo.h>
 #include <inet/InetInterface.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>

--- a/src/inet/tests/TestInetAddress.cpp
+++ b/src/inet/tests/TestInetAddress.cpp
@@ -26,10 +26,11 @@
 
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <inet/IPAddress.h>
 #include <lib/core/CHIPConfig.h>
+#include <lib/core/StringBuilderAdapters.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #include <inet/arpa-inet-compatibility.h>

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -29,11 +29,12 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <CHIPVersion.h>
 #include <inet/IPPrefix.h>
 #include <inet/InetError.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPArgParser.hpp>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>

--- a/src/inet/tests/TestInetErrorStr.cpp
+++ b/src/inet/tests/TestInetErrorStr.cpp
@@ -28,10 +28,11 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <inet/InetError.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 
 using namespace chip;

--- a/src/lib/address_resolve/tests/BUILD.gn
+++ b/src/lib/address_resolve/tests/BUILD.gn
@@ -28,6 +28,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/lib/address_resolve",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/protocols",
   ]
 }

--- a/src/lib/address_resolve/tests/TestAddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/tests/TestAddressResolve_DefaultImpl.cpp
@@ -13,9 +13,11 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <gtest/gtest.h>
+
+#include <pw_unit_test/framework.h>
 
 #include <lib/address_resolve/AddressResolve_DefaultImpl.h>
+#include <lib/core/StringBuilderAdapters.h>
 
 using namespace chip;
 using namespace chip::AddressResolve;

--- a/src/lib/asn1/tests/BUILD.gn
+++ b/src/lib/asn1/tests/BUILD.gn
@@ -25,6 +25,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/lib/asn1",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/platform",
   ]
 

--- a/src/lib/asn1/tests/TestASN1.cpp
+++ b/src/lib/asn1/tests/TestASN1.cpp
@@ -24,14 +24,16 @@
  *      decode interfaces.
  *
  */
-#include <gtest/gtest.h>
 
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
+#include <pw_unit_test/framework.h>
+
 #include <lib/asn1/ASN1.h>
 #include <lib/asn1/ASN1Macros.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/core/TLV.h>
 
 using namespace chip;

--- a/src/lib/core/tests/BUILD.gn
+++ b/src/lib/core/tests/BUILD.gn
@@ -43,6 +43,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/core:vectortlv",
     "${chip_root}/src/lib/support:test_utils",
     "${chip_root}/src/platform",

--- a/src/lib/core/tests/TestCATValues.cpp
+++ b/src/lib/core/tests/TestCATValues.cpp
@@ -16,9 +16,10 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/CASEAuthTag.h>
+#include <lib/core/StringBuilderAdapters.h>
 
 using namespace chip;
 

--- a/src/lib/core/tests/TestCHIPCallback.cpp
+++ b/src/lib/core/tests/TestCHIPCallback.cpp
@@ -21,9 +21,11 @@
  *      This file implements a test for  CHIP Callback
  *
  */
-#include <gtest/gtest.h>
+
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPCallback.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 

--- a/src/lib/core/tests/TestCHIPError.cpp
+++ b/src/lib/core/tests/TestCHIPError.cpp
@@ -18,9 +18,9 @@
 
 #include <string>
 
-#include <lib/core/CHIPError.h>
+#include <pw_unit_test/framework.h>
 
-#include <gtest/gtest.h>
+#include <lib/core/CHIPError.h>
 
 namespace chip {
 namespace {

--- a/src/lib/core/tests/TestCHIPErrorStr.cpp
+++ b/src/lib/core/tests/TestCHIPErrorStr.cpp
@@ -28,10 +28,11 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPError.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 
 using namespace chip;
 

--- a/src/lib/core/tests/TestGroupedCallbackList.cpp
+++ b/src/lib/core/tests/TestGroupedCallbackList.cpp
@@ -16,9 +16,10 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/GroupedCallbackList.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #include <unordered_map>

--- a/src/lib/core/tests/TestOTAImageHeader.cpp
+++ b/src/lib/core/tests/TestOTAImageHeader.cpp
@@ -16,9 +16,10 @@
  *    limitations under the License.
  */
 
-#include <lib/core/OTAImageHeader.h>
+#include <pw_unit_test/framework.h>
 
-#include <gtest/gtest.h>
+#include <lib/core/OTAImageHeader.h>
+#include <lib/core/StringBuilderAdapters.h>
 
 using namespace chip;
 

--- a/src/lib/core/tests/TestOptional.cpp
+++ b/src/lib/core/tests/TestOptional.cpp
@@ -28,10 +28,11 @@
 #include <cstdint>
 #include <cstring>
 
-#include <lib/core/Optional.h>
-#include <lib/support/Span.h>
+#include <pw_unit_test/framework.h>
 
-#include <gtest/gtest.h>
+#include <lib/core/Optional.h>
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/Span.h>
 
 using namespace chip;
 

--- a/src/lib/core/tests/TestReferenceCounted.cpp
+++ b/src/lib/core/tests/TestReferenceCounted.cpp
@@ -27,9 +27,10 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <lib/core/ReferenceCounted.h>
+#include <pw_unit_test/framework.h>
 
-#include <gtest/gtest.h>
+#include <lib/core/ReferenceCounted.h>
+#include <lib/core/StringBuilderAdapters.h>
 
 using namespace chip;
 

--- a/src/lib/core/tests/TestTLV.cpp
+++ b/src/lib/core/tests/TestTLV.cpp
@@ -23,21 +23,21 @@
  *
  */
 
-#include <gtest/gtest.h>
 #include <nlbyteorder.h>
 
+#include <pw_unit_test/framework.h>
+
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/core/TLV.h>
 #include <lib/core/TLVCircularBuffer.h>
 #include <lib/core/TLVData.h>
 #include <lib/core/TLVDebug.h>
 #include <lib/core/TLVUtilities.h>
-
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/Span.h>
-
 #include <lib/support/UnitTestUtils.h>
 #include <lib/support/logging/Constants.h>
 

--- a/src/lib/core/tests/TestTLVVectorWriter.cpp
+++ b/src/lib/core/tests/TestTLVVectorWriter.cpp
@@ -16,19 +16,19 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
-
-#include <lib/core/TLVVectorWriter.h>
-
 #include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
 
+#include <pw_unit_test/framework.h>
+
 #include <lib/core/CHIPError.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/core/TLVCommon.h>
 #include <lib/core/TLVTags.h>
+#include <lib/core/TLVVectorWriter.h>
 #include <lib/support/Span.h>
 #include <lib/support/UnitTestUtils.h>
 

--- a/src/lib/dnssd/minimal_mdns/core/tests/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/core/tests/BUILD.gn
@@ -41,6 +41,7 @@ chip_test_suite("tests") {
   public_deps = [
     ":support",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/dnssd/minimal_mdns/core",
   ]
 }

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestFlatAllocatedQName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestFlatAllocatedQName.cpp
@@ -14,8 +14,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <gtest/gtest.h>
 
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/core/FlatAllocatedQName.h>
 
 namespace {

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestHeapQName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestHeapQName.cpp
@@ -16,8 +16,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/core/HeapQName.h>
 #include <lib/dnssd/minimal_mdns/core/tests/QNameStrings.h>
 

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestQName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestQName.cpp
@@ -16,8 +16,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/core/QName.h>
 
 namespace {

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestRecordWriter.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestRecordWriter.cpp
@@ -16,8 +16,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/core/RecordWriter.h>
 
 namespace {

--- a/src/lib/dnssd/minimal_mdns/records/tests/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/records/tests/BUILD.gn
@@ -32,6 +32,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/dnssd/minimal_mdns/records",
   ]
 }

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecord.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecord.cpp
@@ -16,8 +16,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/records/ResourceRecord.h>
 
 namespace {

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordIP.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordIP.cpp
@@ -16,8 +16,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/records/IP.h>
 
 namespace {

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordPtr.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordPtr.cpp
@@ -15,8 +15,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/records/Ptr.h>
 
 namespace {

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordSrv.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordSrv.cpp
@@ -15,8 +15,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/records/Srv.h>
 
 namespace {

--- a/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordTxt.cpp
+++ b/src/lib/dnssd/minimal_mdns/records/tests/TestResourceRecordTxt.cpp
@@ -15,8 +15,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/records/Txt.h>
 
 namespace {

--- a/src/lib/dnssd/minimal_mdns/responders/tests/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/BUILD.gn
@@ -30,6 +30,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/dnssd/minimal_mdns",
     "${chip_root}/src/lib/dnssd/minimal_mdns:default_policy",
     "${chip_root}/src/lib/dnssd/minimal_mdns/responders",

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
@@ -18,10 +18,11 @@
 
 #include <vector>
 
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/AddressPolicy_DefaultImpl.h>
 #include <lib/support/CHIPMem.h>
-
-#include <gtest/gtest.h>
 
 namespace {
 

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
@@ -18,10 +18,11 @@
 
 #include <vector>
 
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/Parser.h>
 #include <lib/dnssd/minimal_mdns/RecordData.h>
-
-#include <gtest/gtest.h>
 
 namespace {
 

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestQueryResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestQueryResponder.cpp
@@ -18,9 +18,10 @@
 
 #include <vector>
 
-#include <lib/dnssd/minimal_mdns/records/Ptr.h>
+#include <pw_unit_test/framework.h>
 
-#include <gtest/gtest.h>
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/minimal_mdns/records/Ptr.h>
 
 namespace {
 

--- a/src/lib/dnssd/minimal_mdns/tests/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/tests/BUILD.gn
@@ -37,6 +37,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/dnssd",
     "${chip_root}/src/lib/dnssd/minimal_mdns",
     "${chip_root}/src/transport/raw/tests:helpers",

--- a/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
+++ b/src/lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h
@@ -22,6 +22,9 @@
 #include <string>
 #include <vector>
 
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/MinimalMdnsServer.h>
 #include <lib/dnssd/minimal_mdns/RecordData.h>
 #include <lib/dnssd/minimal_mdns/Server.h>
@@ -30,8 +33,6 @@
 #include <lib/dnssd/minimal_mdns/records/Txt.h>
 #include <lib/support/CHIPMemString.h>
 #include <system/SystemMutex.h>
-
-#include <gtest/gtest.h>
 
 namespace mdns {
 namespace Minimal {

--- a/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestAdvertiser.cpp
@@ -20,6 +20,9 @@
 #include <string>
 #include <utility>
 
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/Advertiser.h>
 #include <lib/dnssd/MinimalMdnsServer.h>
 #include <lib/dnssd/minimal_mdns/Query.h>
@@ -32,8 +35,6 @@
 
 #include <system/SystemPacketBuffer.h>
 #include <transport/raw/tests/NetworkTestHelpers.h>
-
-#include <gtest/gtest.h>
 
 namespace {
 

--- a/src/lib/dnssd/minimal_mdns/tests/TestMinimalMdnsAllocator.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestMinimalMdnsAllocator.cpp
@@ -16,8 +16,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/Advertiser_ImplMinimalMdnsAllocator.h>
 
 using namespace chip;

--- a/src/lib/dnssd/minimal_mdns/tests/TestQueryReplyFilter.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestQueryReplyFilter.cpp
@@ -14,8 +14,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <gtest/gtest.h>
 
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/QueryReplyFilter.h>
 
 namespace {

--- a/src/lib/dnssd/minimal_mdns/tests/TestRecordData.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestRecordData.cpp
@@ -14,12 +14,15 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 #include <lib/dnssd/minimal_mdns/RecordData.h>
 
 #include <string>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 
 namespace {
 

--- a/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
@@ -14,13 +14,15 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 #include <lib/dnssd/minimal_mdns/ResponseSender.h>
 
 #include <string>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/RecordData.h>
 #include <lib/dnssd/minimal_mdns/core/FlatAllocatedQName.h>
 #include <lib/dnssd/minimal_mdns/core/RecordWriter.h>
@@ -28,7 +30,6 @@
 #include <lib/dnssd/minimal_mdns/responders/Srv.h>
 #include <lib/dnssd/minimal_mdns/responders/Txt.h>
 #include <lib/dnssd/minimal_mdns/tests/CheckOnlyServer.h>
-
 #include <lib/support/CHIPMem.h>
 
 namespace {

--- a/src/lib/dnssd/platform/tests/BUILD.gn
+++ b/src/lib/dnssd/platform/tests/BUILD.gn
@@ -22,6 +22,9 @@ chip_test_suite("tests") {
   if (chip_device_platform == "fake") {
     test_sources = [ "TestPlatform.cpp" ]
 
-    public_deps = [ "${chip_root}/src/lib/dnssd" ]
+    public_deps = [
+      "${chip_root}/src/lib/core:string-builder-adapters",
+      "${chip_root}/src/lib/dnssd",
+    ]
   }
 }

--- a/src/lib/dnssd/platform/tests/TestPlatform.cpp
+++ b/src/lib/dnssd/platform/tests/TestPlatform.cpp
@@ -16,14 +16,14 @@
  *    limitations under the License.
  */
 
-#include <lib/core/PeerId.h>
-#include <lib/dnssd/Discovery_ImplPlatform.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/PeerId.h>
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/Discovery_ImplPlatform.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/fake/DnssdImpl.h>
-
-#include <gtest/gtest.h>
 
 #if CHIP_DEVICE_LAYER_TARGET_FAKE != 1
 #error "This test is designed for use only with the fake platform"

--- a/src/lib/dnssd/tests/BUILD.gn
+++ b/src/lib/dnssd/tests/BUILD.gn
@@ -25,7 +25,10 @@ chip_test_suite("tests") {
     "TestTxtFields.cpp",
   ]
 
-  public_deps = [ "${chip_root}/src/lib/dnssd" ]
+  public_deps = [
+    "${chip_root}/src/lib/core:string-builder-adapters",
+    "${chip_root}/src/lib/dnssd",
+  ]
 
   if (chip_mdns == "minimal") {
     test_sources += [

--- a/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
@@ -14,9 +14,11 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <lib/dnssd/ActiveResolveAttempts.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/ActiveResolveAttempts.h>
 
 namespace {
 

--- a/src/lib/dnssd/tests/TestIncrementalResolve.cpp
+++ b/src/lib/dnssd/tests/TestIncrementalResolve.cpp
@@ -20,6 +20,9 @@
 
 #include <string.h>
 
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/ServiceNaming.h>
 #include <lib/dnssd/minimal_mdns/core/tests/QNameStrings.h>
 #include <lib/dnssd/minimal_mdns/records/IP.h>
@@ -28,8 +31,6 @@
 #include <lib/dnssd/minimal_mdns/records/Srv.h>
 #include <lib/dnssd/minimal_mdns/records/Txt.h>
 #include <lib/support/ScopedBuffer.h>
-
-#include <gtest/gtest.h>
 
 using namespace chip;
 using namespace chip::Dnssd;

--- a/src/lib/dnssd/tests/TestServiceNaming.cpp
+++ b/src/lib/dnssd/tests/TestServiceNaming.cpp
@@ -20,7 +20,9 @@
 
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 
 using namespace chip;
 using namespace chip::Dnssd;

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -22,9 +22,10 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <lib/dnssd/Resolver.h>
+#include <pw_unit_test/framework.h>
 
-#include <gtest/gtest.h>
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/Resolver.h>
 
 using namespace chip;
 using namespace chip::Dnssd;

--- a/src/lib/format/tests/BUILD.gn
+++ b/src/lib/format/tests/BUILD.gn
@@ -36,6 +36,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/controller/data_model:cluster-tlv-metadata",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/format:flat-tree",
     "${chip_root}/src/lib/format:protocol-decoder",
     "${chip_root}/src/lib/format:protocol-tlv-metadata",

--- a/src/lib/format/tests/TestDecoding.cpp
+++ b/src/lib/format/tests/TestDecoding.cpp
@@ -14,14 +14,15 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/core/TLVWriter.h>
 #include <lib/format/protocol_decoder.h>
 #include <lib/support/StringBuilder.h>
-
 #include <tlv/meta/clusters_meta.h>
 #include <tlv/meta/protocols_meta.h>
-
-#include <gtest/gtest.h>
 
 #include "sample_data.h"
 

--- a/src/lib/format/tests/TestFlatTree.cpp
+++ b/src/lib/format/tests/TestFlatTree.cpp
@@ -14,15 +14,15 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <lib/format/FlatTree.h>
-
-#include <lib/core/TLVTags.h>
 
 #include <array>
-
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/core/TLVTags.h>
+#include <lib/format/FlatTree.h>
 
 namespace {
 

--- a/src/lib/format/tests/TestFlatTreePosition.cpp
+++ b/src/lib/format/tests/TestFlatTreePosition.cpp
@@ -14,17 +14,18 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <lib/format/FlatTree.h>
-#include <lib/format/FlatTreePosition.h>
-
-#include <lib/core/TLVTags.h>
 
 #include <array>
 #include <vector>
 
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/core/TLVTags.h>
+#include <lib/format/FlatTree.h>
+#include <lib/format/FlatTreePosition.h>
 
 namespace {
 

--- a/src/lib/shell/tests/BUILD.gn
+++ b/src/lib/shell/tests/BUILD.gn
@@ -29,6 +29,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/shell",
   ]
 }

--- a/src/lib/shell/tests/TestShellStreamerStdio.cpp
+++ b/src/lib/shell/tests/TestShellStreamerStdio.cpp
@@ -15,8 +15,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/shell/Engine.h>
 #include <lib/support/CodeUtils.h>
 

--- a/src/lib/shell/tests/TestShellTokenizeLine.cpp
+++ b/src/lib/shell/tests/TestShellTokenizeLine.cpp
@@ -15,8 +15,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 
 // Include entire C++ file to have access to functions-under-test

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -88,6 +88,7 @@ chip_test_suite("tests") {
   public_deps = [
     "${chip_root}/src/credentials",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support:static-support",
     "${chip_root}/src/lib/support:testing",
     "${chip_root}/src/lib/support/jsontlv",

--- a/src/lib/support/tests/TestBitMask.cpp
+++ b/src/lib/support/tests/TestBitMask.cpp
@@ -14,12 +14,16 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <gtest/gtest.h>
+
 #include <lib/support/BitMask.h>
 
 #include <algorithm>
 #include <cstring>
 #include <initializer_list>
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 
 using namespace chip;
 

--- a/src/lib/support/tests/TestBufferReader.cpp
+++ b/src/lib/support/tests/TestBufferReader.cpp
@@ -22,10 +22,12 @@
  *
  */
 
-#include <gtest/gtest.h>
-#include <lib/support/BufferReader.h>
-
 #include <type_traits>
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/BufferReader.h>
 
 using namespace chip;
 using namespace chip::Encoding::LittleEndian;

--- a/src/lib/support/tests/TestBufferWriter.cpp
+++ b/src/lib/support/tests/TestBufferWriter.cpp
@@ -14,9 +14,11 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <lib/support/BufferWriter.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/BufferWriter.h>
 
 namespace {
 

--- a/src/lib/support/tests/TestBytesCircularBuffer.cpp
+++ b/src/lib/support/tests/TestBytesCircularBuffer.cpp
@@ -23,8 +23,9 @@
 #include <string.h>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/BytesCircularBuffer.h>
 
 namespace {

--- a/src/lib/support/tests/TestBytesToHex.cpp
+++ b/src/lib/support/tests/TestBytesToHex.cpp
@@ -20,13 +20,15 @@
 #include <string>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/EnforceFormat.h>
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
+
 namespace {
 
 using namespace chip;

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -22,9 +22,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPArgParser.hpp>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPMemString.h>

--- a/src/lib/support/tests/TestCHIPCounter.cpp
+++ b/src/lib/support/tests/TestCHIPCounter.cpp
@@ -18,8 +18,9 @@
 
 #include <stdint.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPCounter.h>
 
 using namespace chip;

--- a/src/lib/support/tests/TestCHIPMem.cpp
+++ b/src/lib/support/tests/TestCHIPMem.cpp
@@ -29,8 +29,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 

--- a/src/lib/support/tests/TestCHIPMemString.cpp
+++ b/src/lib/support/tests/TestCHIPMemString.cpp
@@ -22,8 +22,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>

--- a/src/lib/support/tests/TestDefer.cpp
+++ b/src/lib/support/tests/TestDefer.cpp
@@ -20,7 +20,9 @@
 
 #include <memory>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 
 namespace {
 

--- a/src/lib/support/tests/TestErrorStr.cpp
+++ b/src/lib/support/tests/TestErrorStr.cpp
@@ -19,10 +19,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPCore.h>
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 
 using namespace chip;
 

--- a/src/lib/support/tests/TestFixedBufferAllocator.cpp
+++ b/src/lib/support/tests/TestFixedBufferAllocator.cpp
@@ -19,7 +19,10 @@
 #include <lib/support/FixedBufferAllocator.h>
 
 #include <cstring>
-#include <gtest/gtest.h>
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 
 using namespace chip;
 

--- a/src/lib/support/tests/TestFold.cpp
+++ b/src/lib/support/tests/TestFold.cpp
@@ -16,12 +16,15 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <lib/support/Fold.h>
-
 #include <algorithm>
 #include <cstring>
 #include <initializer_list>
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/Fold.h>
+
 using namespace chip;
 
 namespace {

--- a/src/lib/support/tests/TestIniEscaping.cpp
+++ b/src/lib/support/tests/TestIniEscaping.cpp
@@ -16,9 +16,12 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <lib/support/IniEscaping.h>
 #include <string>
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/IniEscaping.h>
 
 using namespace chip;
 using namespace chip::IniEscaping;

--- a/src/lib/support/tests/TestIntrusiveList.cpp
+++ b/src/lib/support/tests/TestIntrusiveList.cpp
@@ -18,8 +18,9 @@
 #include <ctime>
 #include <list>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/IntrusiveList.h>
 
 namespace {

--- a/src/lib/support/tests/TestJsonToTlv.cpp
+++ b/src/lib/support/tests/TestJsonToTlv.cpp
@@ -17,16 +17,18 @@
 
 #include <string>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/Decode.h>
 #include <app/data-model/Encode.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/core/TLVDebug.h>
 #include <lib/core/TLVReader.h>
 #include <lib/support/jsontlv/JsonToTlv.h>
 #include <lib/support/jsontlv/TextFormat.h>
 #include <lib/support/jsontlv/TlvToJson.h>
+
 namespace {
 
 using namespace chip::Encoding;

--- a/src/lib/support/tests/TestJsonToTlvToJson.cpp
+++ b/src/lib/support/tests/TestJsonToTlvToJson.cpp
@@ -18,11 +18,12 @@
 #include <stdio.h>
 #include <string>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/Decode.h>
 #include <app/data-model/Encode.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/jsontlv/JsonToTlv.h>
 #include <lib/support/jsontlv/TextFormat.h>
 #include <lib/support/jsontlv/TlvToJson.h>

--- a/src/lib/support/tests/TestPersistedCounter.cpp
+++ b/src/lib/support/tests/TestPersistedCounter.cpp
@@ -23,8 +23,10 @@
  *
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
 #include <lib/core/CHIPEncoding.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/PersistedCounter.h>
 #include <lib/support/TestPersistentStorageDelegate.h>

--- a/src/lib/support/tests/TestPool.cpp
+++ b/src/lib/support/tests/TestPool.cpp
@@ -25,11 +25,13 @@
 
 #include <set>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/Pool.h>
 #include <lib/support/PoolWrapper.h>
 #include <system/SystemConfig.h>
+
 namespace chip {
 
 template <class POOL>

--- a/src/lib/support/tests/TestPrivateHeap.cpp
+++ b/src/lib/support/tests/TestPrivateHeap.cpp
@@ -18,8 +18,9 @@
 
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/PrivateHeap.h>
 
 namespace {

--- a/src/lib/support/tests/TestSafeInt.cpp
+++ b/src/lib/support/tests/TestSafeInt.cpp
@@ -22,7 +22,9 @@
  *
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/SafeInt.h>
 
 using namespace chip;

--- a/src/lib/support/tests/TestSafeString.cpp
+++ b/src/lib/support/tests/TestSafeString.cpp
@@ -22,8 +22,9 @@
  *
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/SafeString.h>
 
 using namespace chip;

--- a/src/lib/support/tests/TestScoped.cpp
+++ b/src/lib/support/tests/TestScoped.cpp
@@ -18,8 +18,9 @@
 
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/Scoped.h>
 
 namespace {

--- a/src/lib/support/tests/TestScopedBuffer.cpp
+++ b/src/lib/support/tests/TestScopedBuffer.cpp
@@ -16,8 +16,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/ScopedBuffer.h>
 
 namespace {

--- a/src/lib/support/tests/TestSorting.cpp
+++ b/src/lib/support/tests/TestSorting.cpp
@@ -20,8 +20,9 @@
 #include <array>
 #include <stdio.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/SortUtils.h>
 #include <lib/support/Span.h>
 

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -24,8 +24,9 @@
 
 #include <array>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/Span.h>
 
 using namespace chip;

--- a/src/lib/support/tests/TestStateMachine.cpp
+++ b/src/lib/support/tests/TestStateMachine.cpp
@@ -16,8 +16,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/StateMachine.h>
 #include <lib/support/Variant.h>
 

--- a/src/lib/support/tests/TestStaticSupportSmartPtr.cpp
+++ b/src/lib/support/tests/TestStaticSupportSmartPtr.cpp
@@ -18,8 +18,9 @@
 
 #include <cstring>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/Scoped.h>
 #include <lib/support/static_support_smart_ptr.h>
 

--- a/src/lib/support/tests/TestStringBuilder.cpp
+++ b/src/lib/support/tests/TestStringBuilder.cpp
@@ -14,9 +14,11 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <lib/support/StringBuilder.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/StringBuilder.h>
 
 namespace {
 

--- a/src/lib/support/tests/TestStringSplitter.cpp
+++ b/src/lib/support/tests/TestStringSplitter.cpp
@@ -14,9 +14,12 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/StringSplitter.h>
 
-#include <gtest/gtest.h>
 namespace {
 
 using namespace chip;

--- a/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
+++ b/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
@@ -16,15 +16,16 @@
  *    limitations under the License.
  */
 
-#include <lib/core/CHIPError.h>
-#include <lib/support/TestPersistentStorageDelegate.h>
-
 #include <array>
 #include <cstring>
 #include <set>
 #include <string>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/CHIPError.h>
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
 
 using namespace chip;
 

--- a/src/lib/support/tests/TestThreadOperationalDataset.cpp
+++ b/src/lib/support/tests/TestThreadOperationalDataset.cpp
@@ -15,8 +15,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ThreadOperationalDataset.h>
 

--- a/src/lib/support/tests/TestTimeUtils.cpp
+++ b/src/lib/support/tests/TestTimeUtils.cpp
@@ -29,8 +29,9 @@
 #include <stdlib.h>
 #include <time.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/TimeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 

--- a/src/lib/support/tests/TestTlvJson.cpp
+++ b/src/lib/support/tests/TestTlvJson.cpp
@@ -15,11 +15,12 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/Decode.h>
 #include <app/data-model/Encode.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/jsontlv/TlvJson.h>
 #include <system/SystemPacketBuffer.h>
 #include <system/TLVPacketBufferBackingStore.h>

--- a/src/lib/support/tests/TestTlvToJson.cpp
+++ b/src/lib/support/tests/TestTlvToJson.cpp
@@ -17,11 +17,12 @@
 
 #include <string>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/Decode.h>
 #include <app/data-model/Encode.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/jsontlv/TextFormat.h>
 #include <lib/support/jsontlv/TlvToJson.h>
 #include <system/SystemPacketBuffer.h>

--- a/src/lib/support/tests/TestUtf8.cpp
+++ b/src/lib/support/tests/TestUtf8.cpp
@@ -17,10 +17,12 @@
  *    limitations under the License.
  */
 
-#include <lib/support/utf8.h>
-
 #include <functional>
-#include <gtest/gtest.h>
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/utf8.h>
 
 namespace {
 

--- a/src/lib/support/tests/TestVariant.cpp
+++ b/src/lib/support/tests/TestVariant.cpp
@@ -18,8 +18,9 @@
 
 #include <functional>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/Variant.h>
 
 namespace {

--- a/src/lib/support/tests/TestZclString.cpp
+++ b/src/lib/support/tests/TestZclString.cpp
@@ -26,8 +26,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>

--- a/src/messaging/tests/BUILD.gn
+++ b/src/messaging/tests/BUILD.gn
@@ -65,6 +65,7 @@ chip_test_suite("tests") {
     ":helpers",
     "${chip_root}/src/inet/tests:helpers",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/lib/support:test_utils",
     "${chip_root}/src/messaging",

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -16,6 +16,8 @@
  */
 #pragma once
 
+#include <pw_unit_test/framework.h>
+
 #include <credentials/PersistentStorageOpCertStore.h>
 #include <crypto/DefaultSessionKeystore.h>
 #include <crypto/PersistentStorageOperationalKeystore.h>
@@ -26,7 +28,6 @@
 #include <messaging/ExchangeMgr.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/PASESession.h>
-#include <pw_unit_test/framework.h>
 #include <system/SystemClock.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>

--- a/src/messaging/tests/TestAbortExchangesForFabric.cpp
+++ b/src/messaging/tests/TestAbortExchangesForFabric.cpp
@@ -24,6 +24,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <app/icd/server/ICDServerConfig.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/ReliableMessageProtocolConfig.h>

--- a/src/messaging/tests/TestExchange.cpp
+++ b/src/messaging/tests/TestExchange.cpp
@@ -20,6 +20,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <messaging/ExchangeContext.h>

--- a/src/messaging/tests/TestExchangeHolder.cpp
+++ b/src/messaging/tests/TestExchangeHolder.cpp
@@ -25,6 +25,7 @@
 
 #include "messaging/ExchangeDelegate.h"
 #include "system/SystemClock.h"
+#include <lib/core/StringBuilderAdapters.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeHolder.h>
 #include <messaging/ExchangeMgr.h>

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -26,6 +26,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <messaging/ExchangeContext.h>

--- a/src/messaging/tests/TestMessagingLayer.cpp
+++ b/src/messaging/tests/TestMessagingLayer.cpp
@@ -26,6 +26,7 @@
 #include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPFaultInjection.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -27,6 +27,7 @@
 
 #include <app/icd/server/ICDServerConfig.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <messaging/ReliableMessageContext.h>
 #include <messaging/ReliableMessageMgr.h>

--- a/src/platform/tests/BUILD.gn
+++ b/src/platform/tests/BUILD.gn
@@ -38,6 +38,7 @@ if (chip_device_platform != "none" && chip_device_platform != "fake") {
     }
 
     public_deps = [
+      "${chip_root}/src/lib/core:string-builder-adapters",
       "${chip_root}/src/lib/support",
       "${chip_root}/src/lib/support:test_utils",
       "${chip_root}/src/platform",

--- a/src/platform/tests/TestCHIPoBLEStackMgr.cpp
+++ b/src/platform/tests/TestCHIPoBLEStackMgr.cpp
@@ -16,14 +16,14 @@
  */
 
 #include "platform/internal/CHIPDeviceLayerInternal.h"
-#include <assert.h>
-#include <gtest/gtest.h>
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-#include <memory>
-
-#include "platform/PlatformManager.h"
-#include "platform/internal/BLEManager.h"
+#include <platform/PlatformManager.h>
+#include <platform/internal/BLEManager.h>
 
 void EventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t)
 {

--- a/src/platform/tests/TestCHIPoBLEStackMgrDriver.cpp
+++ b/src/platform/tests/TestCHIPoBLEStackMgrDriver.cpp
@@ -15,9 +15,11 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
-#include <platform/CHIPDeviceConfig.h>
 #include <stdlib.h>
+
+#include <pw_unit_test/framework.h>
+
+#include <platform/CHIPDeviceConfig.h>
 
 int main(int argc, char * argv[])
 {

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -28,10 +28,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-
 #include <platform/BuildTime.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DeviceInstanceInfoProvider.h>

--- a/src/platform/tests/TestConnectivityMgr.cpp
+++ b/src/platform/tests/TestConnectivityMgr.cpp
@@ -28,11 +28,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-
-#include <gtest/gtest.h>
-
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DiagnosticDataProvider.h>
 

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -17,12 +17,13 @@
 
 #include <atomic>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include "lib/dnssd/platform/Dnssd.h"
 #include "platform/CHIPDeviceLayer.h"
 #include "platform/ConnectivityManager.h"
 #include "platform/PlatformManager.h"
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/minimal_mdns/AddressPolicy.h>
 #include <lib/dnssd/minimal_mdns/AddressPolicy_DefaultImpl.h>
 #include <lib/dnssd/minimal_mdns/Parser.h>

--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -22,10 +22,10 @@
  *
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
-
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/KeyValueStoreManager.h>
 

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -30,7 +30,9 @@
 
 #include <atomic>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/UnitTestUtils.h>

--- a/src/platform/tests/TestPlatformTime.cpp
+++ b/src/platform/tests/TestPlatformTime.cpp
@@ -28,7 +28,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/UnitTestUtils.h>
 #include <system/SystemClock.h>

--- a/src/platform/tests/TestThreadStackMgr.cpp
+++ b/src/platform/tests/TestThreadStackMgr.cpp
@@ -18,7 +18,9 @@
 #include <assert.h>
 #include <memory>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ThreadOperationalDataset.h>
 

--- a/src/protocols/bdx/tests/BUILD.gn
+++ b/src/protocols/bdx/tests/BUILD.gn
@@ -28,6 +28,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/protocols/bdx",
   ]

--- a/src/protocols/bdx/tests/TestBdxMessages.cpp
+++ b/src/protocols/bdx/tests/TestBdxMessages.cpp
@@ -1,12 +1,12 @@
-#include <protocols/bdx/BdxMessages.h>
+#include <limits>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/BufferWriter.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-
-#include <limits>
+#include <protocols/bdx/BdxMessages.h>
 
 using namespace chip;
 using namespace chip::bdx;

--- a/src/protocols/bdx/tests/TestBdxTransferSession.cpp
+++ b/src/protocols/bdx/tests/TestBdxTransferSession.cpp
@@ -1,15 +1,15 @@
-#include <protocols/Protocols.h>
-#include <protocols/bdx/BdxMessages.h>
-#include <protocols/bdx/BdxTransferSession.h>
-
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BufferReader.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
+#include <protocols/Protocols.h>
+#include <protocols/bdx/BdxMessages.h>
+#include <protocols/bdx/BdxTransferSession.h>
 #include <protocols/secure_channel/Constants.h>
 #include <protocols/secure_channel/StatusReport.h>
 #include <system/SystemPacketBuffer.h>

--- a/src/protocols/bdx/tests/TestBdxUri.cpp
+++ b/src/protocols/bdx/tests/TestBdxUri.cpp
@@ -15,10 +15,13 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <protocols/bdx/BdxUri.h>
 
 #include <cstring>
-#include <gtest/gtest.h>
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <protocols/bdx/BdxUri.h>
 
 using namespace ::chip;
 

--- a/src/protocols/interaction_model/tests/BUILD.gn
+++ b/src/protocols/interaction_model/tests/BUILD.gn
@@ -24,6 +24,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/protocols/interaction_model",
   ]

--- a/src/protocols/interaction_model/tests/TestStatusCode.cpp
+++ b/src/protocols/interaction_model/tests/TestStatusCode.cpp
@@ -18,8 +18,10 @@
 
 #include <stdint.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
 #include <lib/core/Optional.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 using namespace ::chip;

--- a/src/protocols/secure_channel/tests/BUILD.gn
+++ b/src/protocols/secure_channel/tests/BUILD.gn
@@ -28,6 +28,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/credentials/tests:cert_test_vectors",
     "${chip_root}/src/crypto/tests:tests.lib",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/lib/support:test_utils",
     "${chip_root}/src/lib/support:testing",

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -21,6 +21,10 @@
  *      This file implements unit tests for the CASESession implementation.
  */
 
+#include <stdarg.h>
+
+#include <pw_unit_test/framework.h>
+
 #include <credentials/CHIPCert.h>
 #include <credentials/GroupDataProviderImpl.h>
 #include <credentials/PersistentStorageOpCertStore.h>
@@ -30,6 +34,7 @@
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/ScopedNodeId.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/ScopedBuffer.h>
@@ -38,8 +43,6 @@
 #include <messaging/tests/MessagingContext.h>
 #include <protocols/secure_channel/CASEServer.h>
 #include <protocols/secure_channel/CASESession.h>
-#include <pw_unit_test/framework.h>
-#include <stdarg.h>
 
 #include "credentials/tests/CHIPCert_test_vectors.h"
 

--- a/src/protocols/secure_channel/tests/TestCheckInCounter.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckInCounter.cpp
@@ -16,11 +16,14 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <stdint.h>
+
+#include <pw_unit_test/framework.h>
+
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <protocols/secure_channel/CheckInCounter.h>
-#include <stdint.h>
 
 using namespace chip;
 using namespace chip::Protocols::SecureChannel;

--- a/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
+++ b/src/protocols/secure_channel/tests/TestCheckinMsg.cpp
@@ -16,9 +16,11 @@
  *    limitations under the License.
  */
 
+#include <pw_unit_test/framework.h>
+
 #include <crypto/DefaultSessionKeystore.h>
 #include <crypto/RandUtils.h>
-#include <gtest/gtest.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/BufferWriter.h>
 #include <lib/support/CHIPMem.h>
 #include <protocols/Protocols.h>

--- a/src/protocols/secure_channel/tests/TestDefaultSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/tests/TestDefaultSessionResumptionStorage.cpp
@@ -15,7 +15,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 

--- a/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
+++ b/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
@@ -21,9 +21,14 @@
  *      This file implements unit tests for the MessageCounterManager implementation.
  */
 
-#include <lib/core/CHIPCore.h>
-#include <lib/support/CodeUtils.h>
+#include <errno.h>
 
+#include <nlbyteorder.h>
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
@@ -33,11 +38,6 @@
 #include <protocols/echo/Echo.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
-
-#include <nlbyteorder.h>
-#include <pw_unit_test/framework.h>
-
-#include <errno.h>
 
 namespace {
 

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -22,11 +22,13 @@
  */
 
 #include <errno.h>
+
 #include <pw_unit_test/framework.h>
 
 #include <app/icd/server/ICDServerConfig.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPSafeCasts.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/UnitTestUtils.h>

--- a/src/protocols/secure_channel/tests/TestPairingSession.cpp
+++ b/src/protocols/secure_channel/tests/TestPairingSession.cpp
@@ -22,14 +22,15 @@
  */
 
 #include <errno.h>
-#include <gtest/gtest.h>
+#include <stdarg.h>
+
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
-
 #include <messaging/ReliableMessageProtocolConfig.h>
 #include <protocols/secure_channel/PairingSession.h>
-#include <stdarg.h>
 #include <system/SystemClock.h>
 #include <system/TLVPacketBufferBackingStore.h>
 

--- a/src/protocols/secure_channel/tests/TestSimpleSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/tests/TestSimpleSessionResumptionStorage.cpp
@@ -15,8 +15,9 @@
  *    limitations under the License.
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <protocols/secure_channel/SimpleSessionResumptionStorage.h>
 

--- a/src/protocols/secure_channel/tests/TestStatusReport.cpp
+++ b/src/protocols/secure_channel/tests/TestStatusReport.cpp
@@ -16,16 +16,16 @@
  *    limitations under the License.
  */
 
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/BufferReader.h>
 #include <lib/support/BufferWriter.h>
 #include <lib/support/CHIPMem.h>
-
 #include <protocols/Protocols.h>
 #include <protocols/secure_channel/Constants.h>
 #include <protocols/secure_channel/StatusReport.h>
 #include <system/SystemPacketBuffer.h>
-
-#include <gtest/gtest.h>
 
 using namespace chip;
 using namespace chip::Protocols;

--- a/src/protocols/user_directed_commissioning/tests/BUILD.gn
+++ b/src/protocols/user_directed_commissioning/tests/BUILD.gn
@@ -22,6 +22,7 @@ chip_test_suite("tests") {
 
   public_deps = [
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/protocols",
   ]

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -1,8 +1,9 @@
 #include <protocols/user_directed_commissioning/UserDirectedCommissioning.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPSafeCasts.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/dnssd/TxtFields.h>
 #include <lib/support/BufferWriter.h>
 #include <lib/support/CHIPMem.h>

--- a/src/setup_payload/tests/TestAdditionalDataPayload.cpp
+++ b/src/setup_payload/tests/TestAdditionalDataPayload.cpp
@@ -26,7 +26,7 @@
 #include <memory>
 #include <stdio.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/BytesToHex.h>

--- a/src/tracing/tests/BUILD.gn
+++ b/src/tracing/tests/BUILD.gn
@@ -30,6 +30,7 @@ if (matter_enable_tracing_support &&
     ]
 
     public_deps = [
+      "${chip_root}/src/lib/core:string-builder-adapters",
       "${chip_root}/src/platform",
       "${chip_root}/src/tracing",
       "${chip_root}/src/tracing:macros",

--- a/src/tracing/tests/TestMetricEvents.cpp
+++ b/src/tracing/tests/TestMetricEvents.cpp
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 #include <pw_unit_test/framework.h>
 
 #include <lib/core/StringBuilderAdapters.h>

--- a/src/tracing/tests/TestTracing.cpp
+++ b/src/tracing/tests/TestTracing.cpp
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 #include <pw_unit_test/framework.h>
 
 #include <lib/core/StringBuilderAdapters.h>

--- a/src/transport/raw/tests/BUILD.gn
+++ b/src/transport/raw/tests/BUILD.gn
@@ -54,6 +54,7 @@ chip_test_suite("tests") {
     ":helpers",
     "${chip_root}/src/inet/tests:helpers",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/lib/support:test_utils",
     "${chip_root}/src/transport",

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -23,9 +23,10 @@
  *
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <protocols/Protocols.h>

--- a/src/transport/raw/tests/TestPeerAddress.cpp
+++ b/src/transport/raw/tests/TestPeerAddress.cpp
@@ -21,11 +21,12 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <inet/IPAddress.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/PeerId.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <transport/raw/PeerAddress.h>
 
 namespace {

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -28,11 +28,12 @@
 #include <string.h>
 #include <utility>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <crypto/RandUtils.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPEncoding.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/UnitTestUtils.h>

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -25,9 +25,10 @@
 
 #include <errno.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/UDP.h>

--- a/src/transport/retransmit/tests/BUILD.gn
+++ b/src/transport/retransmit/tests/BUILD.gn
@@ -25,5 +25,8 @@ chip_test_suite("tests") {
 
   test_sources = [ "TestCache.cpp" ]
 
-  public_deps = [ "${chip_root}/src/transport/retransmit" ]
+  public_deps = [
+    "${chip_root}/src/lib/core:string-builder-adapters",
+    "${chip_root}/src/transport/retransmit",
+  ]
 }

--- a/src/transport/retransmit/tests/TestCache.cpp
+++ b/src/transport/retransmit/tests/TestCache.cpp
@@ -14,10 +14,13 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <transport/retransmit/Cache.h>
 
 #include <bitset>
-#include <gtest/gtest.h>
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <transport/retransmit/Cache.h>
 
 // Helpers for simple payload management
 namespace {

--- a/src/transport/tests/BUILD.gn
+++ b/src/transport/tests/BUILD.gn
@@ -57,6 +57,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/credentials/tests:cert_test_vectors",
     "${chip_root}/src/inet/tests:helpers",
     "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/lib/support:testing",
     "${chip_root}/src/protocols",

--- a/src/transport/tests/TestCryptoContext.cpp
+++ b/src/transport/tests/TestCryptoContext.cpp
@@ -18,10 +18,11 @@
 
 #include <inttypes.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <transport/CryptoContext.h>
 

--- a/src/transport/tests/TestGroupMessageCounter.cpp
+++ b/src/transport/tests/TestGroupMessageCounter.cpp
@@ -22,8 +22,10 @@
  */
 
 #include <errno.h>
-#include <gtest/gtest.h>
 
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <transport/GroupPeerMessageCounter.h>

--- a/src/transport/tests/TestPeerConnections.cpp
+++ b/src/transport/tests/TestPeerConnections.cpp
@@ -23,9 +23,10 @@
  *
  */
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <lib/core/ErrorStr.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <transport/SecureSessionTable.h>
 

--- a/src/transport/tests/TestPeerMessageCounter.cpp
+++ b/src/transport/tests/TestPeerMessageCounter.cpp
@@ -24,8 +24,9 @@
 #include <errno.h>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
+#include <lib/core/StringBuilderAdapters.h>
 #include <transport/MessageCounter.h>
 #include <transport/PeerMessageCounter.h>
 

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -24,10 +24,11 @@
 #include <errno.h>
 #include <stdarg.h>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
 #include <crypto/DefaultSessionKeystore.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <transport/CryptoContext.h>
 

--- a/src/transport/tests/TestSecureSessionTable.cpp
+++ b/src/transport/tests/TestSecureSessionTable.cpp
@@ -24,11 +24,12 @@
 #include <errno.h>
 #include <vector>
 
-#include <gtest/gtest.h>
+#include <pw_unit_test/framework.h>
 
-#include "system/SystemClock.h"
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
+#include <system/SystemClock.h>
 #include <transport/SecureSessionTable.h>
 #include <transport/SessionHolder.h>
 

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -21,6 +21,10 @@
  *      This file implements unit tests for the SessionManager implementation.
  */
 
+#include <errno.h>
+
+#include <pw_unit_test/framework.h>
+
 #define CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API // Up here in case some other header
                                               // includes SessionManager.h indirectly
 
@@ -29,6 +33,7 @@
 #include <crypto/DefaultSessionKeystore.h>
 #include <crypto/PersistentStorageOperationalKeystore.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <protocols/Protocols.h>
@@ -38,10 +43,6 @@
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
 #include <transport/tests/LoopbackTransportManager.h>
-
-#include <gtest/gtest.h>
-
-#include <errno.h>
 
 #undef CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -21,6 +21,10 @@
  *      This file implements unit tests for the SessionManager implementation.
  */
 
+#include <errno.h>
+
+#include <pw_unit_test/framework.h>
+
 #define CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API // Up here in case some other header
                                               // includes SessionManager.h indirectly
 
@@ -29,16 +33,13 @@
 #include <crypto/DefaultSessionKeystore.h>
 #include <crypto/PersistentStorageOperationalKeystore.h>
 #include <lib/core/CHIPCore.h>
+#include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
 #include <transport/tests/LoopbackTransportManager.h>
-
-#include <pw_unit_test/framework.h>
-
-#include <errno.h>
 
 #undef CHIP_ENABLE_TEST_ENCRYPTED_BUFFER_API
 


### PR DESCRIPTION
### Problem

Checking for `CHIP_ERROR` does not show meaningful info.

### Changes

Use string adapter for `CHIP_ERROR` in all unit tests.

### Testing

CI will verify test failures.