### PR TITLE
Remove global RPC call handler for each RPC call

### DIFF
--- a/examples/fabric-admin/rpc/RpcClient.cpp
+++ b/examples/fabric-admin/rpc/RpcClient.cpp
@@ -49,7 +49,7 @@ std::condition_variable responseCv;
 bool responseReceived    = false;
 CHIP_ERROR responseError = CHIP_NO_ERROR;
 
-// By passing the call object to WaitForResponse to keep RPC call alive until it completes or timeout.
+// By passing the `call` parameter into WaitForResponse we are explicitly trying to insure the caller takes into consideration that the lifetime of the `call` object when calling WaitForResponse
 template <typename CallType>
 CHIP_ERROR WaitForResponse(CallType & call)
 {

--- a/examples/fabric-admin/rpc/RpcClient.cpp
+++ b/examples/fabric-admin/rpc/RpcClient.cpp
@@ -49,7 +49,8 @@ std::condition_variable responseCv;
 bool responseReceived    = false;
 CHIP_ERROR responseError = CHIP_NO_ERROR;
 
-// By passing the `call` parameter into WaitForResponse we are explicitly trying to insure the caller takes into consideration that the lifetime of the `call` object when calling WaitForResponse
+// By passing the `call` parameter into WaitForResponse we are explicitly trying to insure the caller takes into consideration that
+// the lifetime of the `call` object when calling WaitForResponse
 template <typename CallType>
 CHIP_ERROR WaitForResponse(CallType & call)
 {

--- a/examples/fabric-bridge-app/linux/RpcClient.cpp
+++ b/examples/fabric-bridge-app/linux/RpcClient.cpp
@@ -49,7 +49,8 @@ std::condition_variable responseCv;
 bool responseReceived    = false;
 CHIP_ERROR responseError = CHIP_NO_ERROR;
 
-// By passing the call object to WaitForResponse to keep RPC call alive until it completes or timeout.
+// By passing the `call` parameter into WaitForResponse we are explicitly trying to insure the caller takes into consideration that
+// the lifetime of the `call` object when calling WaitForResponse
 template <typename CallType>
 CHIP_ERROR WaitForResponse(CallType & call)
 {

--- a/examples/fabric-bridge-app/linux/RpcClient.cpp
+++ b/examples/fabric-bridge-app/linux/RpcClient.cpp
@@ -43,13 +43,13 @@ constexpr uint32_t kDefaultChannelId = 1;
 
 // Fabric Admin Client
 rpc::pw_rpc::nanopb::FabricAdmin::Client fabricAdminClient(rpc::client::GetDefaultRpcClient(), kDefaultChannelId);
-pw::rpc::NanopbUnaryReceiver<::chip_rpc_OperationStatus> openCommissioningWindowCall;
 
 std::mutex responseMutex;
 std::condition_variable responseCv;
 bool responseReceived    = false;
 CHIP_ERROR responseError = CHIP_NO_ERROR;
 
+// By passing the call object to WaitForResponse to keep RPC call alive until it completes or timeout.
 template <typename CallType>
 CHIP_ERROR WaitForResponse(CallType & call)
 {
@@ -98,23 +98,18 @@ CHIP_ERROR OpenCommissioningWindow(NodeId nodeId)
 {
     ChipLogProgress(NotSpecified, "OpenCommissioningWindow with Node Id 0x:" ChipLogFormatX64, ChipLogValueX64(nodeId));
 
-    if (openCommissioningWindowCall.active())
-    {
-        ChipLogError(NotSpecified, "OpenCommissioningWindow is in progress\n");
-        return CHIP_ERROR_BUSY;
-    }
-
     chip_rpc_DeviceInfo device;
     device.node_id = nodeId;
 
-    // The RPC will remain active as long as `openCommissioningWindowCall` is alive.
-    openCommissioningWindowCall = fabricAdminClient.OpenCommissioningWindow(device, OnOpenCommissioningWindowCompleted);
+    // The RPC call is kept alive until it completes. When a response is received, it will be logged by the handler
+    // function and the call will complete.
+    auto call = fabricAdminClient.OpenCommissioningWindow(device, OnOpenCommissioningWindowCompleted);
 
-    if (!openCommissioningWindowCall.active())
+    if (!call.active())
     {
         // The RPC call was not sent. This could occur due to, for example, an invalid channel ID. Handle if necessary.
         return CHIP_ERROR_INTERNAL;
     }
 
-    return WaitForResponse(openCommissioningWindowCall);
+    return WaitForResponse(call);
 }


### PR DESCRIPTION
Currently, we use global RPC call handler for each RPC call, this is used to keep the RPC call object alive until the RPC call complete.

By adding the synchronous WaitForResponse function, which uses a parameterized template to accept the call object, the function ensures that it waits for the specific RPC call to complete. This design allows the function to handle different types of RPC calls uniformly.

