### PR TITLE
[Python] Adjust logging levels in Python controller

### DIFF
--- a/src/controller/python/chip/CertificateAuthority.py
+++ b/src/controller/python/chip/CertificateAuthority.py
@@ -28,6 +28,8 @@ from chip import ChipStack, FabricAdmin
 from chip.native import PyChipError
 from chip.storage import PersistentStorage
 
+LOGGER = logging.getLogger(__name__)
+
 
 class CertificateAuthority:
     '''  This represents an operational Root Certificate Authority (CA) with a root key key pair with associated
@@ -64,7 +66,7 @@ class CertificateAuthority:
                 persistentStorage:  An optional reference to a PersistentStorage object. If one is provided, it will pick that over
                                     the default PersistentStorage object retrieved from the chipStack.
         '''
-        self.logger().warning(f"New CertificateAuthority at index {caIndex}")
+        LOGGER.info(f"New CertificateAuthority at index {caIndex}")
 
         self._chipStack = chipStack
         self._caIndex = caIndex
@@ -105,7 +107,7 @@ class CertificateAuthority:
         if (not (self._isActive)):
             raise RuntimeError("Object isn't active")
 
-        self.logger().warning("Loading fabric admins from storage...")
+        LOGGER.info("Loading fabric admins from storage...")
 
         caList = self._persistentStorage.GetReplKey(key='caList')
         if (str(self._caIndex) not in caList):
@@ -244,7 +246,7 @@ class CertificateAuthorityManager:
         if (not (self._isActive)):
             raise RuntimeError("Object is not active")
 
-        self.logger().warning("Loading certificate authorities from storage...")
+        LOGGER.info("Loading certificate authorities from storage...")
 
         #
         # Persist details to storage (read modify write).

--- a/src/controller/python/chip/FabricAdmin.py
+++ b/src/controller/python/chip/FabricAdmin.py
@@ -25,6 +25,8 @@ from chip import CertificateAuthority, ChipDeviceCtrl
 from chip.crypto import p256keypair
 from chip.native import GetLibraryHandle
 
+LOGGER = logging.getLogger(__name__)
+
 
 class FabricAdmin:
     ''' Administers a fabric associated with a unique FabricID under a given CertificateAuthority
@@ -33,10 +35,6 @@ class FabricAdmin:
     @classmethod
     def _Handle(cls):
         return GetLibraryHandle()
-
-    @classmethod
-    def logger(cls):
-        return logging.getLogger('FabricAdmin')
 
     def __init__(self, certificateAuthority: CertificateAuthority.CertificateAuthority, vendorId: int, fabricId: int = 1):
         ''' Initializes the object.
@@ -60,7 +58,7 @@ class FabricAdmin:
         self._fabricId = fabricId
         self._certificateAuthority = certificateAuthority
 
-        self.logger().warning(f"New FabricAdmin: FabricId: 0x{self._fabricId:016X}, VendorId = 0x{self.vendorId:04X}")
+        LOGGER.info(f"New FabricAdmin: FabricId: 0x{self._fabricId:016X}, VendorId = 0x{self.vendorId:04X}")
 
         self._isActive = True
         self._activeControllers = []
@@ -94,7 +92,7 @@ class FabricAdmin:
             if (nodeId in nodeIdList):
                 raise RuntimeError(f"Provided NodeId {nodeId} collides with an existing controller instance!")
 
-        self.logger().warning(
+        LOGGER.info(
             f"Allocating new controller with CaIndex: {self._certificateAuthority.caIndex}, "
             f"FabricId: 0x{self._fabricId:016X}, NodeId: 0x{nodeId:016X}, CatTags: {catTags}")
 

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -40,6 +40,8 @@ from rich.pretty import pprint
 
 from .ClusterObjects import Cluster, ClusterAttributeDescriptor, ClusterEvent
 
+LOGGER = logging.getLogger(__name__)
+
 
 @unique
 class EventTimestampType(Enum):
@@ -569,7 +571,7 @@ class SubscriptionTransaction:
 
     def Shutdown(self):
         if (self._isDone):
-            print("Subscription was already terminated previously!")
+            LOGGER.warning("Subscription 0x%08x was already terminated previously!", self.subscriptionId)
             return
 
         handle = chip.native.GetLibraryHandle()
@@ -675,7 +677,7 @@ class AsyncReadTransaction:
             self._changedPathSet.add(path)
 
         except Exception as ex:
-            logging.exception(ex)
+            LOGGER.exception(ex)
 
     def handleEventData(self, header: EventHeader, path: EventPath, data: bytes, status: int):
         try:
@@ -693,12 +695,12 @@ class AsyncReadTransaction:
                     try:
                         eventValue = eventType.FromTLV(data)
                     except Exception as ex:
-                        logging.error(
+                        LOGGER.error(
                             f"Error convering TLV to Cluster Object for path: Endpoint = {path.EndpointId}/"
                             f"Cluster = {path.ClusterId}/Event = {path.EventId}")
-                        logging.error(
+                        LOGGER.error(
                             f"Failed Cluster Object: {str(eventType)}")
-                        logging.error(ex)
+                        LOGGER.error(ex)
                         eventValue = ValueDecodeFailure(
                             tlvData, ex)
 
@@ -715,7 +717,7 @@ class AsyncReadTransaction:
                     eventResult, self._subscription_handler)
 
         except Exception as ex:
-            logging.exception(ex)
+            LOGGER.exception(ex)
 
     def handleError(self, chipError: PyChipError):
         self._resultError = chipError
@@ -726,7 +728,6 @@ class AsyncReadTransaction:
                 self, subscriptionId, self._devCtrl)
             self._future.set_result(self._subscription_handler)
         else:
-            logging.info("Re-subscription succeeded!")
             if self._subscription_handler._onResubscriptionSucceededCb is not None:
                 if (self._subscription_handler._onResubscriptionSucceededCb_isAsync):
                     self._event_loop.create_task(
@@ -761,7 +762,7 @@ class AsyncReadTransaction:
                     attribute_path = TypedAttributePath(Path=change)
                 except (KeyError, ValueError) as err:
                     # path could not be resolved into a TypedAttributePath
-                    logging.getLogger(__name__).exception(err)
+                    LOGGER.exception(err)
                     continue
                 self._subscription_handler.OnAttributeChangeCb(
                     attribute_path, self._subscription_handler)
@@ -816,7 +817,7 @@ class AsyncWriteTransaction:
             imStatus = chip.interaction_model.Status(status)
             self._resultData.append(AttributeWriteResult(Path=path, Status=imStatus))
         except ValueError as ex:
-            logging.exception(ex)
+            LOGGER.exception(ex)
 
     def handleError(self, chipError: PyChipError):
         self._resultError = chipError

--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -29,6 +29,8 @@ from typing import Dict
 import chip.exceptions
 import chip.native
 
+LOGGER = logging.getLogger(__name__)
+
 _SyncSetKeyValueCbFunct = CFUNCTYPE(
     None, py_object, c_char_p, POINTER(c_char),  c_uint16)
 _SyncGetKeyValueCbFunct = CFUNCTYPE(
@@ -91,9 +93,6 @@ class PersistentStorage:
 
         Object must be resident before the Matter stack starts up and last past its shutdown.
     '''
-    @classmethod
-    def logger(cls):
-        return logging.getLogger('PersistentStorage')
 
     def __init__(self, path: str = None, jsonData: Dict = None):
         ''' Initializes the object with either a path to a JSON file that contains the configuration OR
@@ -109,9 +108,9 @@ class PersistentStorage:
             raise ValueError("Can't provide both a valid path and jsonData")
 
         if (path is not None):
-            self.logger().warn(f"Initializing persistent storage from file: {path}")
+            LOGGER.info(f"Initializing persistent storage from file: {path}")
         else:
-            self.logger().warn("Initializing persistent storage from dict")
+            LOGGER.info("Initializing persistent storage from dict")
 
         self._handle = chip.native.GetLibraryHandle()
         self._isActive = True
@@ -125,24 +124,24 @@ class PersistentStorage:
                 self._file.seek(0)
 
                 if (size != 0):
-                    self.logger().warn(f"Loading configuration from {path}...")
+                    LOGGER.info(f"Loading configuration from {path}...")
                     self._jsonData = json.load(self._file)
                 else:
                     self._jsonData = {}
 
             except Exception as ex:
-                logging.error(ex)
-                logging.critical(f"Could not load configuration from {path} - resetting configuration...")
+                LOGGER.error(ex)
+                LOGGER.critical(f"Could not load configuration from {path} - resetting configuration...")
                 self._jsonData = {}
         else:
             self._jsonData = jsonData
 
         if ('sdk-config' not in self._jsonData):
-            logging.warn("No valid SDK configuration present - clearing out configuration")
+            LOGGER.warn("No valid SDK configuration present - clearing out configuration")
             self._jsonData['sdk-config'] = {}
 
         if ('repl-config' not in self._jsonData):
-            logging.warn("No valid REPL configuration present - clearing out configuration")
+            LOGGER.warn("No valid REPL configuration present - clearing out configuration")
             self._jsonData['repl-config'] = {}
 
         # Clear out the file so that calling 'Commit' will re-open the file at that time in write mode.
@@ -166,7 +165,6 @@ class PersistentStorage:
         ''' Commits the cached JSON configuration to file (if one was provided in the constructor).
             Otherwise, this is a no-op.
         '''
-        self.logger().info("Committing...")
 
         if (self._path is None):
             return
@@ -175,9 +173,8 @@ class PersistentStorage:
             try:
                 self._file = open(self._path, 'w')
             except Exception as ex:
-                logging.warn(
-                    f"Could not open {self._path} for writing configuration. Error:")
-                logging.warn(ex)
+                LOGGER.error(
+                    f"Could not open {self._path} for writing configuration. Error: {ex}")
                 return
 
         self._file.seek(0)
@@ -188,7 +185,7 @@ class PersistentStorage:
     def SetReplKey(self, key: str, value):
         ''' Set a REPL key to a specific value. Creates the key if one doesn't exist already.
         '''
-        self.logger().info(f"SetReplKey: {key} = {value}")
+        LOGGER.debug(f"SetReplKey: {key} = {value}")
 
         if (key is None or key == ''):
             raise ValueError("Invalid Key")
@@ -212,7 +209,7 @@ class PersistentStorage:
     def SetSdkKey(self, key: str, value: bytes):
         ''' Set an SDK key to a specific value. Creates the key if one doesn't exist already.
         '''
-        self.logger().info(f"SetSdkKey: {key} = {value}")
+        LOGGER.debug(f"SetSdkKey: {key} = {value}")
 
         if (key is None or key == ''):
             raise ValueError("Invalid Key")
@@ -236,7 +233,7 @@ class PersistentStorage:
     def DeleteSdkKey(self, key: str):
         ''' Deletes an SDK key if one exists.
         '''
-        self.logger().info(f"DeleteSdkKey: {key}")
+        LOGGER.debug(f"DeleteSdkKey: {key}")
 
         del (self._jsonData['sdk-config'][key])
         self.Commit()


### PR DESCRIPTION
Use global loggers per-module which is more Pythonic and avoids unnecessary logger instances. Also use the module name as the logger name consistently.

Avoid using the warning level for messages which are really only informational. Also lower the log level of storage messages to debug, as they are really not that important. Drop some unnecessary logs like on every storage commit.

