### PR TITLE
[Infineon] Update CYW30739 README files and setup requirements.

### DIFF
--- a/examples/light-switch-app/infineon/cyw30739/README.md
+++ b/examples/light-switch-app/infineon/cyw30739/README.md
@@ -12,7 +12,7 @@ An example showing the use of Matter on the Infineon CYW30739 platform.
     -   [Installing ModusToolbox™ Software](#installing-modustoolbox-software)
         -   [ModusToolbox™ tools package](#modustoolbox-tools-package)
             -   [Note for WSL (Windows Subsystem for Linux)](#note-for-wsl-windows-subsystem-for-linux)
-        -   [Checkout Submodules](#checkout-submodules)
+        -   [Checkout Submodules and Bootstrap](#checkout-submodules-and-bootstrap)
     -   [Building](#building)
     -   [Factory Data](#factory-data)
         -   [Commissionable Data](#commissionable-data)
@@ -65,7 +65,7 @@ If you are using WSL, please ensure you have installed the ModusToolbox™
 Software for Linux. Running Windows tools directly from the WSL command line
 would cause path resolution failure in the build process.
 
-### Checkout Submodules
+### Checkout Submodules and Bootstrap
 
 Before building the example, check out the Matter repository and sync submodules
 using the following command:
@@ -73,6 +73,7 @@ using the following command:
 ```bash
 $ cd ~/connectedhomeip
 $ scripts/checkout_submodules.py --platform infineon
+$ bash scripts/bootstrap.sh -p all,infineon
 ```
 
 ## Building

--- a/examples/lighting-app/infineon/cyw30739/README.md
+++ b/examples/lighting-app/infineon/cyw30739/README.md
@@ -12,7 +12,7 @@ An example showing the use of Matter on the Infineon CYW30739 platform.
     -   [Installing ModusToolbox™ Software](#installing-modustoolbox-software)
         -   [ModusToolbox™ tools package](#modustoolbox-tools-package)
             -   [Note for WSL (Windows Subsystem for Linux)](#note-for-wsl-windows-subsystem-for-linux)
-        -   [Checkout Submodules](#checkout-submodules)
+        -   [Checkout Submodules and Bootstrap](#checkout-submodules-and-bootstrap)
     -   [Building](#building)
     -   [Factory Data](#factory-data)
         -   [Commissionable Data](#commissionable-data)
@@ -65,7 +65,7 @@ If you are using WSL, please ensure you have installed the ModusToolbox™
 Software for Linux. Running Windows tools directly from the WSL command line
 would cause path resolution failure in the build process.
 
-### Checkout Submodules
+### Checkout Submodules and Bootstrap
 
 Before building the example, check out the Matter repository and sync submodules
 using the following command:
@@ -73,6 +73,7 @@ using the following command:
 ```bash
 $ cd ~/connectedhomeip
 $ scripts/checkout_submodules.py --platform infineon
+$ bash scripts/bootstrap.sh -p all,infineon
 ```
 
 ## Building

--- a/examples/lock-app/infineon/cyw30739/README.md
+++ b/examples/lock-app/infineon/cyw30739/README.md
@@ -12,7 +12,7 @@ An example showing the use of Matter on the Infineon CYW30739 platform.
     -   [Installing ModusToolbox™ Software](#installing-modustoolbox-software)
         -   [ModusToolbox™ tools package](#modustoolbox-tools-package)
             -   [Note for WSL (Windows Subsystem for Linux)](#note-for-wsl-windows-subsystem-for-linux)
-        -   [Checkout Submodules](#checkout-submodules)
+        -   [Checkout Submodules and Bootstrap](#checkout-submodules-and-bootstrap)
     -   [Building](#building)
     -   [Factory Data](#factory-data)
         -   [Commissionable Data](#commissionable-data)
@@ -65,7 +65,7 @@ If you are using WSL, please ensure you have installed the ModusToolbox™
 Software for Linux. Running Windows tools directly from the WSL command line
 would cause path resolution failure in the build process.
 
-### Checkout Submodules
+### Checkout Submodules and Bootstrap
 
 Before building the example, check out the Matter repository and sync submodules
 using the following command:
@@ -73,6 +73,7 @@ using the following command:
 ```bash
 $ cd ~/connectedhomeip
 $ scripts/checkout_submodules.py --platform infineon
+$ bash scripts/bootstrap.sh -p all,infineon
 ```
 
 ## Building

--- a/examples/thermostat/infineon/cyw30739/README.md
+++ b/examples/thermostat/infineon/cyw30739/README.md
@@ -12,7 +12,7 @@ An example showing the use of Matter on the Infineon CYW30739 platform.
     -   [Installing ModusToolbox™ Software](#installing-modustoolbox-software)
         -   [ModusToolbox™ tools package](#modustoolbox-tools-package)
             -   [Note for WSL (Windows Subsystem for Linux)](#note-for-wsl-windows-subsystem-for-linux)
-        -   [Checkout Submodules](#checkout-submodules)
+        -   [Checkout Submodules and Bootstrap](#checkout-submodules-and-bootstrap)
     -   [Building](#building)
     -   [Factory Data](#factory-data)
         -   [Commissionable Data](#commissionable-data)
@@ -65,7 +65,7 @@ If you are using WSL, please ensure you have installed the ModusToolbox™
 Software for Linux. Running Windows tools directly from the WSL command line
 would cause path resolution failure in the build process.
 
-### Checkout Submodules
+### Checkout Submodules and Bootstrap
 
 Before building the example, check out the Matter repository and sync submodules
 using the following command:
@@ -73,6 +73,7 @@ using the following command:
 ```bash
 $ cd ~/connectedhomeip
 $ scripts/checkout_submodules.py --platform infineon
+$ bash scripts/bootstrap.sh -p all,infineon
 ```
 
 ## Building

--- a/scripts/setup/requirements.infineon.txt
+++ b/scripts/setup/requirements.infineon.txt
@@ -1,2 +1,4 @@
+ecdsa
+intelhex
 leb128
 zcbor


### PR DESCRIPTION
#### Problem
* Missing bootstrap instruction in CYW30739 README files.
* Some dependencies in Infineon Python setup requirements need to be included.

#### Change overview
* Update CYW30739 README files.
* Add ecdsa and intelhex to Infineon Python setup requirements.

#### Testing
* chip-tool pairing