### PR TITLE
[ESP32] Fixed the check to set the certificatio declaration using api in FactoryDataProviderImpl. 

### DIFF
--- a/src/platform/ESP32/ESP32FactoryDataProvider.cpp
+++ b/src/platform/ESP32/ESP32FactoryDataProvider.cpp
@@ -98,11 +98,15 @@ CHIP_ERROR ESP32FactoryDataProvider::GetSpake2pVerifier(MutableByteSpan & verifi
 
 CHIP_ERROR ESP32FactoryDataProvider::GetCertificationDeclaration(MutableByteSpan & outBuffer)
 {
+#ifdef CONFIG_ENABLE_SET_CERT_DECLARATION_API
+    return CopySpanToMutableSpan(mCD, outBuffer);
+#else
     size_t certSize;
     ReturnErrorOnFailure(
         ESP32Config::ReadConfigValueBin(ESP32Config::kConfigKey_CertDeclaration, outBuffer.data(), outBuffer.size(), certSize));
     outBuffer.reduce_size(certSize);
     return CHIP_NO_ERROR;
+#endif // CONFIG_ENABLE_SET_CERT_DECLARATION_API
 }
 
 CHIP_ERROR ESP32FactoryDataProvider::GetFirmwareInformation(MutableByteSpan & out_firmware_info_buffer)
@@ -123,15 +127,11 @@ CHIP_ERROR ESP32FactoryDataProvider::GetDeviceAttestationCert(MutableByteSpan & 
 
 CHIP_ERROR ESP32FactoryDataProvider::GetProductAttestationIntermediateCert(MutableByteSpan & outBuffer)
 {
-#ifdef CONFIG_ENABLE_SET_CERT_DECLARATION_API
-    return CopySpanToMutableSpan(mCD, outBuffer);
-#else
     size_t certSize;
     ReturnErrorOnFailure(
         ESP32Config::ReadConfigValueBin(ESP32Config::kConfigKey_PAICert, outBuffer.data(), outBuffer.size(), certSize));
     outBuffer.reduce_size(certSize);
     return CHIP_NO_ERROR;
-#endif // CONFIG_ENABLE_SET_CERT_DECLARATION_API
 }
 
 CHIP_ERROR ESP32FactoryDataProvider::SignWithDeviceAttestationKey(const ByteSpan & messageToSign, MutableByteSpan & outSignBuffer)


### PR DESCRIPTION
**Problem**
- The option `CONFIG_SET_CERT_DECLARATION_API` is used for setting the certification declaration through API.
- There was a regression in FactoryDataProviderImpl as this check was present in `GetProductAttestationIntermediateCert` instead of `GetCertificationDeclaration`.

**Change Overview**
- Fixed the check and added it to GetCertificationDeclaration api .



