### PR TITLE
[Python] Only auto re-subscribe after initial subscription

### DIFF
--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -145,18 +145,20 @@ public:
 
     void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override
     {
+        // Only enable auto resubscribe if the subscription is established successfully.
+        mAutoResubscribeNeeded = mAutoResubscribe;
         gOnSubscriptionEstablishedCallback(mAppContext, aSubscriptionId);
     }
 
     CHIP_ERROR OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override
     {
-        if (mAutoResubscribe)
+        if (mAutoResubscribeNeeded)
         {
             ReturnErrorOnFailure(ReadClient::Callback::OnResubscriptionNeeded(apReadClient, aTerminationCause));
         }
         gOnResubscriptionAttemptedCallback(mAppContext, ToPyChipError(aTerminationCause),
                                            apReadClient->ComputeTimeTillNextSubscription());
-        if (mAutoResubscribe)
+        if (mAutoResubscribeNeeded)
         {
             return CHIP_NO_ERROR;
         }
@@ -242,7 +244,8 @@ private:
     PyObject * mAppContext;
 
     std::unique_ptr<ReadClient> mReadClient;
-    bool mAutoResubscribe = true;
+    bool mAutoResubscribe       = true;
+    bool mAutoResubscribeNeeded = false;
 };
 
 extern "C" {


### PR DESCRIPTION
The subscription logic waits for the first successful subscription before the Read() call is being returned (the future is awaited which is only released on handleSubscriptionEstablished). If the first subscription attempt fails (e.g. because the CASE session doesn't establish) the Read() never returns, not with an error but also not with a subscription transaction. And since the Python side has no access to the SubscriptionTransaction object at this point yet, there is also no way to stop this subscription attempt.

With this change, we only resubscribe if the initial subscription was successful. This changes semantics slightly, but really allows the caller to decide if it wants to continue try to establish the subscription.

