### PR TITLE
External sdk support

### DIFF
--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -43,6 +43,8 @@ declare_args() {
   #
   # see https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
   chip_enable_thread_safety_checks = is_clang
+
+  chip_external_sdk_target = ""
 }
 
 if (chip_project_config_include_dirs == [] &&
@@ -196,6 +198,9 @@ source_set("system_config_header") {
       }
       if (chip_device_platform == "bl702l") {
         public_deps += [ "${bouffalolab_iot_sdk_build_root}/bl702l:bl_iot_sdk" ]
+      }
+      if (chip_external_sdk_target != "") {
+        public_deps += [ "${chip_external_sdk_target}" ]
       }
 
       # Add platform here as needed.

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -214,6 +214,9 @@ source_set("system_config_header") {
 
   if(chip_platform_sdk_target != "") {
     public_deps += [ chip_platform_sdk_target ]
+
+  if (chip_device_platform == "mt793x") {
+    public_deps += [ "${mt793x_sdk_build_root}:mt793x_sdk" ]
   }
 }
 

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -44,13 +44,51 @@ declare_args() {
   # see https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
   chip_enable_thread_safety_checks = is_clang
 
-  chip_external_sdk_target = ""
+  # SDK target for the platform
+  # If left blank the SDK target will be determined by the device platform
+  chip_platform_sdk_target = ""
 }
 
 if (chip_project_config_include_dirs == [] &&
     chip_project_config_include == "<CHIPProjectConfig.h>" &&
     chip_system_project_config_include == "<SystemProjectConfig.h>") {
   chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
+}
+
+if(chip_platform_sdk_target == "")
+{
+  if (target_cpu != "esp32") {
+    if (chip_system_config_use_lwip) {
+      chip_platform_sdk_target = "${lwip_root}:lwip"
+    } else {
+      if (chip_device_platform == "efr32") {
+        chip_platform_sdk_target = "${efr32_sdk_build_root}:efr32_sdk"
+      }
+      if (chip_device_platform == "qpg") {
+        chip_platform_sdk_target = "${qpg_sdk_build_root}:qpg_sdk"
+      }
+      if (chip_device_platform == "nxp") {
+        chip_platform_sdk_target = "${nxp_sdk_build_root}:nxp_sdk"
+      }
+      if (chip_device_platform == "cyw30739") {
+        chip_platform_sdk_target = "${cyw30739_sdk_build_root}:cyw30739_sdk"
+      }
+      if (chip_device_platform == "stm32") {
+        chip_platform_sdk_target = "${stm32_sdk_build_root}:stm32_sdk"
+      }
+      if (chip_device_platform == "bl702") {
+        chip_platform_sdk_target = "${bouffalolab_iot_sdk_build_root}/bl702:bl_iot_sdk"
+      }
+      if (chip_device_platform == "bl702l") {
+        chip_platform_sdk_target = "${bouffalolab_iot_sdk_build_root}/bl702l:bl_iot_sdk"
+      }
+      if (chip_device_platform == "mt793x") {
+        chip_platform_sdk_target = "${mt793x_sdk_build_root}:mt793x_sdk"
+      }
+
+      # Add platform here as needed.
+    }
+  }
 }
 
 if (chip_device_platform == "cc13x4_26x4") {
@@ -174,41 +212,8 @@ source_set("system_config_header") {
 
   public_deps = []
 
-  if (target_cpu != "esp32") {
-    if (chip_system_config_use_lwip) {
-      public_deps += [ "${lwip_root}:lwip" ]
-    } else {
-      if (chip_device_platform == "efr32") {
-        public_deps += [ "${efr32_sdk_build_root}:efr32_sdk" ]
-      }
-      if (chip_device_platform == "qpg") {
-        public_deps += [ "${qpg_sdk_build_root}:qpg_sdk" ]
-      }
-      if (chip_device_platform == "nxp") {
-        public_deps += [ "${nxp_sdk_build_root}:nxp_sdk" ]
-      }
-      if (chip_device_platform == "cyw30739") {
-        public_deps += [ "${cyw30739_sdk_build_root}:cyw30739_sdk" ]
-      }
-      if (chip_device_platform == "stm32") {
-        public_deps += [ "${stm32_sdk_build_root}:stm32_sdk" ]
-      }
-      if (chip_device_platform == "bl702") {
-        public_deps += [ "${bouffalolab_iot_sdk_build_root}/bl702:bl_iot_sdk" ]
-      }
-      if (chip_device_platform == "bl702l") {
-        public_deps += [ "${bouffalolab_iot_sdk_build_root}/bl702l:bl_iot_sdk" ]
-      }
-      if (chip_external_sdk_target != "") {
-        public_deps += [ "${chip_external_sdk_target}" ]
-      }
-
-      # Add platform here as needed.
-    }
-  }
-
-  if (chip_device_platform == "mt793x") {
-    public_deps += [ "${mt793x_sdk_build_root}:mt793x_sdk" ]
+  if(chip_platform_sdk_target != "") {
+    public_deps += [ chip_platform_sdk_target ]
   }
 }
 

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -214,9 +214,6 @@ source_set("system_config_header") {
 
   if(chip_platform_sdk_target != "") {
     public_deps += [ chip_platform_sdk_target ]
-
-  if (chip_device_platform == "mt793x") {
-    public_deps += [ "${mt793x_sdk_build_root}:mt793x_sdk" ]
   }
 }
 

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -44,51 +44,13 @@ declare_args() {
   # see https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
   chip_enable_thread_safety_checks = is_clang
 
-  # SDK target for the platform
-  # If left blank the SDK target will be determined by the device platform
-  chip_platform_sdk_target = ""
+  chip_external_sdk_target = ""
 }
 
 if (chip_project_config_include_dirs == [] &&
     chip_project_config_include == "<CHIPProjectConfig.h>" &&
     chip_system_project_config_include == "<SystemProjectConfig.h>") {
   chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
-}
-
-if(chip_platform_sdk_target == "")
-{
-  if (target_cpu != "esp32") {
-    if (chip_system_config_use_lwip) {
-      chip_platform_sdk_target = "${lwip_root}:lwip"
-    } else {
-      if (chip_device_platform == "efr32") {
-        chip_platform_sdk_target = "${efr32_sdk_build_root}:efr32_sdk"
-      }
-      if (chip_device_platform == "qpg") {
-        chip_platform_sdk_target = "${qpg_sdk_build_root}:qpg_sdk"
-      }
-      if (chip_device_platform == "nxp") {
-        chip_platform_sdk_target = "${nxp_sdk_build_root}:nxp_sdk"
-      }
-      if (chip_device_platform == "cyw30739") {
-        chip_platform_sdk_target = "${cyw30739_sdk_build_root}:cyw30739_sdk"
-      }
-      if (chip_device_platform == "stm32") {
-        chip_platform_sdk_target = "${stm32_sdk_build_root}:stm32_sdk"
-      }
-      if (chip_device_platform == "bl702") {
-        chip_platform_sdk_target = "${bouffalolab_iot_sdk_build_root}/bl702:bl_iot_sdk"
-      }
-      if (chip_device_platform == "bl702l") {
-        chip_platform_sdk_target = "${bouffalolab_iot_sdk_build_root}/bl702l:bl_iot_sdk"
-      }
-      if (chip_device_platform == "mt793x") {
-        chip_platform_sdk_target = "${mt793x_sdk_build_root}:mt793x_sdk"
-      }
-
-      # Add platform here as needed.
-    }
-  }
 }
 
 if (chip_device_platform == "cc13x4_26x4") {
@@ -212,8 +174,41 @@ source_set("system_config_header") {
 
   public_deps = []
 
-  if(chip_platform_sdk_target != "") {
-    public_deps += [ chip_platform_sdk_target ]
+  if (target_cpu != "esp32") {
+    if (chip_system_config_use_lwip) {
+      public_deps += [ "${lwip_root}:lwip" ]
+    } else {
+      if (chip_device_platform == "efr32") {
+        public_deps += [ "${efr32_sdk_build_root}:efr32_sdk" ]
+      }
+      if (chip_device_platform == "qpg") {
+        public_deps += [ "${qpg_sdk_build_root}:qpg_sdk" ]
+      }
+      if (chip_device_platform == "nxp") {
+        public_deps += [ "${nxp_sdk_build_root}:nxp_sdk" ]
+      }
+      if (chip_device_platform == "cyw30739") {
+        public_deps += [ "${cyw30739_sdk_build_root}:cyw30739_sdk" ]
+      }
+      if (chip_device_platform == "stm32") {
+        public_deps += [ "${stm32_sdk_build_root}:stm32_sdk" ]
+      }
+      if (chip_device_platform == "bl702") {
+        public_deps += [ "${bouffalolab_iot_sdk_build_root}/bl702:bl_iot_sdk" ]
+      }
+      if (chip_device_platform == "bl702l") {
+        public_deps += [ "${bouffalolab_iot_sdk_build_root}/bl702l:bl_iot_sdk" ]
+      }
+      if (chip_external_sdk_target != "") {
+        public_deps += [ "${chip_external_sdk_target}" ]
+      }
+
+      # Add platform here as needed.
+    }
+  }
+
+  if (chip_device_platform == "mt793x") {
+    public_deps += [ "${mt793x_sdk_build_root}:mt793x_sdk" ]
   }
 }
 


### PR DESCRIPTION
Added a way to depend on an external SDK to allow an external platforms to provide dependencies to the matter libraries the same way as platforms currently included within the source tree
