### PR TITLE
Update `chip-build` image to 65

### DIFF
--- a/.github/actions/bootstrap-cache/action.yaml
+++ b/.github/actions/bootstrap-cache/action.yaml
@@ -11,7 +11,7 @@ runs:
         attempt_limit: 3
         attempt_delay: 2000
         with: |
-          key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**') }}
+          key: ${{ runner.os }}-env-${{ hashFiles('scripts/setup/*', 'third_party/pigweed/**', '/etc/lsb-release') }}
           path: |
               .environment
               build_overrides/pigweed_environment.gni

--- a/.github/workflows/bloat_check.yaml
+++ b/.github/workflows/bloat_check.yaml
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
 
         steps:
             - name: Checkout

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -344,7 +344,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:65
+            image: ghcr.io/project-chip/chip-build:54
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -138,7 +138,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -283,7 +283,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -344,7 +344,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -456,7 +456,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,7 +138,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:65
+            image: ghcr.io/project-chip/chip-build:54
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"
@@ -283,7 +283,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:65
+            image: ghcr.io/project-chip/chip-build:54
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -35,7 +35,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             options: --user root
 
         steps:

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-linux-tv-casting-app.yaml
+++ b/.github/workflows/examples-linux-tv-casting-app.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-mw320.yaml
+++ b/.github/workflows/examples-mw320.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-stm32.yaml
+++ b/.github/workflows/examples-stm32.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -33,7 +33,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
 
         steps:
             - name: Checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
 
@@ -445,7 +445,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=0 net.ipv6.conf.all.forwarding=0"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:65
+            image: ghcr.io/project-chip/chip-build:54
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
 

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -39,7 +39,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -30,7 +30,7 @@ jobs:
 
         runs-on: ubuntu-20.04
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
         defaults:
             run:
                 shell: sh

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -34,7 +34,7 @@ jobs:
 
         runs-on: ubuntu-20.04
         container:
-            image: ghcr.io/project-chip/chip-build:54
+            image: ghcr.io/project-chip/chip-build:65
         defaults:
             run:
                 shell: sh

--- a/scripts/setup/requirements.build.txt
+++ b/scripts/setup/requirements.build.txt
@@ -1,8 +1,9 @@
 # Minimal requirements for building stand-alone CHIP applications.
 #
 # The list of Python packages required to perform a minimal CHIP
-# application build should be kept as small as possible. Ideally,
-# core build scripts should depend only on the standard library.
+# application build should be kept as small as possible. 
+
+# Ideally, core build scripts should depend only on the standard library.
 
 # scripts/build
 click


### PR DESCRIPTION
This only updates chip-build and **not** all the other images.

Expect to gradually update images one by one and fix anything that breaks.
#34025 attempts a mass complete update, however it seems to show there is still individual work to do.

### Changes

- update several images to chip-build:65
- update the buildjet cache image hash to include lsb-release to make it image-dependent.

Several updates not done:
  - python compilation seems to fail due to package versions
  - `TestPurposefulFailureExtraReportingOnToggle` does not fail anymore on latest python, needs debugging why (since this is a intentional failure case, we do not log sufficient data on success to debug)