### PR TITLE
Log the peer ID when logging operational IP lookup results.

### DIFF
--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -47,13 +47,16 @@ void NodeLookupHandle::LookupResult(const ResolveResult & result)
     char addr_string[Transport::PeerAddress::kMaxToStringSize];
     result.address.ToString(addr_string);
 
+    const PeerId peerId = GetRequest().GetPeerId();
     if (success)
     {
-        ChipLogProgress(Discovery, "%s: new best score: %u", addr_string, to_underlying(score));
+        ChipLogProgress(Discovery, "%s: new best score: %u (for " ChipLogFormatPeerId ")", addr_string, to_underlying(score),
+                        ChipLogValuePeerId(peerId));
     }
     else
     {
-        ChipLogProgress(Discovery, "%s: score has not improved: %u", addr_string, to_underlying(score));
+        ChipLogProgress(Discovery, "%s: score has not improved: %u (for " ChipLogFormatPeerId ")", addr_string,
+                        to_underlying(score), ChipLogValuePeerId(peerId));
     }
 #endif
 }


### PR DESCRIPTION
This allows correlating IP results with the peer ID we were resolving.
