### PR TITLE
Log message sizes in Msg RX/TX logs.

### DIFF
--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -215,16 +215,23 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
         }
     }
 
+    // Work around pigweed not allowing more than 14 format args in a log
+    // message when using tokenized logs.
+    char typeStr[4 + 1 + 2 + 1];
+    snprintf(typeStr, sizeof(typeStr), "%04X:%02X", payloadHeader.GetProtocolID().GetProtocolId(), payloadHeader.GetMessageType());
+
     //
     // Legend that can be used to decode this log line can be found in README.md
     //
-    ChipLogProgress(ExchangeManager,
-                    ">>> [E:" ChipLogFormatExchangeId " S:%u M:" ChipLogFormatMessageCounter
-                    "%s] (%s) Msg RX from %u:" ChipLogFormatX64 " [%04X] --- Type %04x:%02x (%s:%s)",
-                    ChipLogValueExchangeIdFromReceivedHeader(payloadHeader), session->SessionIdForLogging(),
-                    packetHeader.GetMessageCounter(), ackBuf, Transport::GetSessionTypeString(session), session->GetFabricIndex(),
-                    ChipLogValueX64(session->GetPeer().GetNodeId()), static_cast<uint16_t>(compressedFabricId),
-                    payloadHeader.GetProtocolID().GetProtocolId(), payloadHeader.GetMessageType(), protocolName, msgTypeName);
+    ChipLogProgress(
+        ExchangeManager,
+        ">>> [E:" ChipLogFormatExchangeId " S:%u M:" ChipLogFormatMessageCounter "%s] (%s) Msg RX from %u:" ChipLogFormatX64
+        " [%04X] --- Type %s (%s:%s) (B:%u)",
+        ChipLogValueExchangeIdFromReceivedHeader(payloadHeader), session->SessionIdForLogging(), packetHeader.GetMessageCounter(),
+        ackBuf, Transport::GetSessionTypeString(session), session->GetFabricIndex(),
+        ChipLogValueX64(session->GetPeer().GetNodeId()), static_cast<uint16_t>(compressedFabricId), typeStr, protocolName,
+        msgTypeName,
+        static_cast<unsigned>(msgBuf->TotalLength() + packetHeader.EncodeSizeBytes() + payloadHeader.EncodeSizeBytes()));
 #endif
 
     MessageFlags msgFlags;

--- a/src/messaging/README.md
+++ b/src/messaging/README.md
@@ -16,7 +16,7 @@ will be expanded are denoted with `$` .
 Unless specified, numerical values are represented in decimal notation.
 
 ```
-<<< [E:$exchange_id S:$session_id M:$msg_id (Ack: $ack_msg_id)] ($msg_category) Msg TX to $fabric_index:$destination [$compressed_fabric_id] [$peer_address] --- Type $protocol_id:$msg_type ($protocol_name:$msg_type_name)
+<<< [E:$exchange_id S:$session_id M:$msg_id (Ack: $ack_msg_id)] ($msg_category) Msg TX to $fabric_index:$destination [$compressed_fabric_id] [$peer_address] --- Type $protocol_id:$msg_type ($protocol_name:$msg_type_name) (B:$size)
 ```
 
 | Field                | Description                                                                                                                            |
@@ -34,6 +34,7 @@ Unless specified, numerical values are represented in decimal notation.
 | msg_type             | 8-bit message type ID (in hex)                                                                                                         |
 | protocol_name        | If available, a logical name for the protocol                                                                                          |
 | msg_type_name        | If available, a logical name for the message type                                                                                      |
+| size                 | Size, in bytes, of the message being transmitted. Includes the Matter payload header and packet header but not transport headers       |
 
 #### Examples:
 
@@ -65,7 +66,7 @@ will be expanded are denoted with `$` .
 Unless specified, numerical values are represented in decimal notation.
 
 ```
->>> [E:$exchange_id M: $msg_id (Ack: $ack_msg_id)] ($msg_category) Msg RX from $fabric_index:$source [$compressed_fabric_id] --- Type $protocol_id:$msg_type ($protocol_name:$msg_type_name)
+>>> [E:$exchange_id M: $msg_id (Ack: $ack_msg_id)] ($msg_category) Msg RX from $fabric_index:$source [$compressed_fabric_id] --- Type $protocol_id:$msg_type ($protocol_name:$msg_type_name) (B:$size)
 ```
 
 This has a similar legend to that for transmission except `$source` denotes the


### PR DESCRIPTION
The sizes logged include payload and packet headers, so the size of the entire Matter message.
