### PR TITLE
update more CI runs to version 65 (i.e. ubuntu 24.04)

### DIFF
--- a/.github/workflows/examples-asr.yaml
+++ b/.github/workflows/examples-asr.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-asr:54
+            image: ghcr.io/project-chip/chip-build-asr:65
             options: --user root
 
         steps:

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -40,7 +40,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build-efr32:56
+      image: ghcr.io/project-chip/chip-build-efr32:65
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
     steps:

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -42,7 +42,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-mbed-os:54
+            image: ghcr.io/project-chip/chip-build-mbed-os:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-nuttx.yaml
+++ b/.github/workflows/examples-nuttx.yaml
@@ -35,7 +35,7 @@ jobs:
     if: github.actor != 'restyled-io[bot]'
 
     container:
-      image: ghcr.io/project-chip/chip-build-nuttx:54
+      image: ghcr.io/project-chip/chip-build-nuttx:65
       volumes:
         - "/tmp/bloat_reports:/tmp/bloat_reports"
     steps:

--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-k32w:54
+            image: ghcr.io/project-chip/chip-build-k32w:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:
@@ -104,7 +104,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp-zephyr:64
+            image: ghcr.io/project-chip/chip-build-nxp-zephyr:65
 
         steps:
             - name: Checkout

--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-openiotsdk:54
+            image: ghcr.io/project-chip/chip-build-openiotsdk:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
             options: --privileged

--- a/.github/workflows/examples-rw61x.yaml
+++ b/.github/workflows/examples-rw61x.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-rw61x:54
+            image: ghcr.io/project-chip/chip-build-rw61x:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -38,7 +38,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-telink:57
+            image: ghcr.io/project-chip/chip-build-telink:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-tizen:54
+            image: ghcr.io/project-chip/chip-build-tizen:65
             options: --user root
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/.github/workflows/minimal-build.yaml
+++ b/.github/workflows/minimal-build.yaml
@@ -33,7 +33,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-minimal:54
+            image: ghcr.io/project-chip/chip-build-minimal:65
 
         steps:
             - name: Checkout
@@ -55,7 +55,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-minimal:54
+            image: ghcr.io/project-chip/chip-build-minimal:65
 
         steps:
             - name: Checkout


### PR DESCRIPTION
Updating images that seem to just pass out of the box, before we update the remaining images one by one (which need fixes, either pypi which would be the most complex or just individual platform fixes.

created this by looking at #34025 and seeing what passed out of the box.