### PR TITLE
Update `ember-compatibility-functions` to always return error codes instead of directly encoding them as success.

### DIFF
--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -455,14 +455,8 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
         uint8_t dataLength = gEmberAttributeIOBufferSpan[0];
         if (dataLength == 0xFF)
         {
-            if (isNullable)
-            {
-                ReturnErrorOnFailure(writer->PutNull(tag));
-            }
-            else
-            {
-                return CHIP_ERROR_INCORRECT_STATE;
-            }
+            VerifyOrReturnError(isNullable, CHIP_ERROR_INCORRECT_STATE);
+            ReturnErrorOnFailure(writer->PutNull(tag));
         }
         else
         {
@@ -477,14 +471,8 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
         memcpy(&dataLength, gEmberAttributeIOBufferSpan.data(), sizeof(dataLength));
         if (dataLength == 0xFFFF)
         {
-            if (isNullable)
-            {
-                ReturnErrorOnFailure(writer->PutNull(tag));
-            }
-            else
-            {
-                return CHIP_ERROR_INCORRECT_STATE;
-            }
+            VerifyOrReturnError(isNullable, CHIP_ERROR_INCORRECT_STATE);
+            ReturnErrorOnFailure(writer->PutNull(tag));
         }
         else
         {
@@ -498,14 +486,8 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
         uint8_t dataLength   = gEmberAttributeIOBufferSpan[0];
         if (dataLength == 0xFF)
         {
-            if (isNullable)
-            {
-                ReturnErrorOnFailure(writer->PutNull(tag));
-            }
-            else
-            {
-                return CHIP_ERROR_INCORRECT_STATE;
-            }
+            VerifyOrReturnError(isNullable, CHIP_ERROR_INCORRECT_STATE);
+            ReturnErrorOnFailure(writer->PutNull(tag));
         }
         else
         {
@@ -519,14 +501,8 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
         memcpy(&dataLength, gEmberAttributeIOBufferSpan.data(), sizeof(dataLength));
         if (dataLength == 0xFFFF)
         {
-            if (isNullable)
-            {
-                ReturnErrorOnFailure(writer->PutNull(tag));
-            }
-            else
-            {
-                return CHIP_ERROR_INCORRECT_STATE;
-            }
+            VerifyOrReturnError(isNullable, CHIP_ERROR_INCORRECT_STATE);
+            ReturnErrorOnFailure(writer->PutNull(tag));
         }
         else
         {

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -515,7 +515,8 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
         return CHIP_IM_GLOBAL_STATUS(Failure);
     }
 
-    // If we got this far, write succeeded. Encode the success by terminating the write
+    // If we got this far, placing the data to be read in the output TLVWriter succeeded.
+    // Try to terminate our attribute report to signal success.
     ReturnErrorOnFailure(attributeDataIBBuilder.EndOfAttributeDataIB());
     return attributeReport.EndOfAttributeReportIB();
 }

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -292,7 +292,7 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
 
     if (attributeCluster == nullptr && attributeMetadata == nullptr)
     {
-        return CHIP_IM_GLOBAL_STATUS_VALUE(UnsupportedAttributeStatus(aPath));
+        return CHIP_ERROR_IM_GLOBAL_STATUS_VALUE(UnsupportedAttributeStatus(aPath));
     }
 
     // Check access control. A failed check will disallow the operation, and may or may not generate an attribute report
@@ -564,7 +564,7 @@ CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, b
         return SendSuccessStatus(attributeReport, attributeDataIBBuilder);
     }
 
-    return CHIP_IM_GLOBAL_STATUS_VALUE(status);
+    return CHIP_ERROR_IM_GLOBAL_STATUS_VALUE(status);
 }
 
 namespace {


### PR DESCRIPTION
This lets the read implementation in `Engine.cpp` do the work of encoding failures and doing rollback/restore.

Without this, the logic was duplicated in ember-compatibility-functions which results in extra complexity and flash usage.


For reference, https://github.com/project-chip/connectedhomeip/blob/master/src/app/reporting/Engine.cpp#L205 has logic for handling errors and generally it has to accept them because it has special handling for out of space.