### PR TITLE
Add checks for OffWithEffect command parameters contraints

### DIFF
--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -621,13 +621,13 @@ bool OnOffServer::offWithEffectCommand(app::CommandHandler * commandObj, const a
         // The following check validates that effectVariant value is valid in relation to the applicable enum type.
         // DelayedAllOffEffectVariantEnum or DyingLightEffectVariantEnum
         if (effectId == EffectIdentifierEnum::kDelayedAllOff &&
-            !isKnownEnumValue(static_cast<DelayedAllOffEffectVariantEnum>(effectVariant)))
+            !IsKnownEnumValue(static_cast<DelayedAllOffEffectVariantEnum>(effectVariant)))
         {
             // The server does not support the given variant, it SHALL use the default variant.
             effectVariant = to_underlying(DelayedAllOffEffectVariantEnum::kDelayedOffFastFade);
         }
         else if (effectId == EffectIdentifierEnum::kDyingLight &&
-                 !isKnownEnumValue(static_cast<DyingLightEffectVariantEnum>(effectVariant)))
+                 !IsKnownEnumValue(static_cast<DyingLightEffectVariantEnum>(effectVariant)))
         {
             // The server does not support the given variant, it SHALL use the default variant.
             effectVariant = to_underlying(DyingLightEffectVariantEnum::kDyingLightFadeOff);

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -92,7 +92,7 @@ void UpdateModeBaseCurrentModeToOnMode(EndpointId endpoint)
 template <typename EnumType>
 bool isKnownEnumValue(EnumType value)
 {
-    return (EnsureKnownEnumValue(value) == EnumType::kUnknownEnumValue) ? false : true;
+    return (EnsureKnownEnumValue(value) != EnumType::kUnknownEnumValue);
 }
 
 } // namespace

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -90,7 +90,7 @@ void UpdateModeBaseCurrentModeToOnMode(EndpointId endpoint)
 #endif // MATTER_DM_PLUGIN_MODE_BASE
 
 template <typename EnumType>
-bool isKnownEnumValue(EnumType value)
+bool IsKnownEnumValue(EnumType value)
 {
     return (EnsureKnownEnumValue(value) != EnumType::kUnknownEnumValue);
 }

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -615,7 +615,7 @@ bool OnOffServer::offWithEffectCommand(app::CommandHandler * commandObj, const a
     chip::EndpointId endpoint = commandPath.mEndpointId;
     Status status             = Status::Success;
 
-    if (isKnownEnumValue(effectId))
+    if (effectId != EffectIdentifierEnum::kUnknownEnumValue)
     {
         // Depending on effectId value, effectVariant enum type varies.
         // The following check validates that effectVariant value is valid in relation to the applicable enum type.

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -620,12 +620,17 @@ bool OnOffServer::offWithEffectCommand(app::CommandHandler * commandObj, const a
         // Depending on effectId value, effectVariant enum type varies.
         // The following check validates that effectVariant value is valid in relation to the applicable enum type.
         // DelayedAllOffEffectVariantEnum or DyingLightEffectVariantEnum
-        if ((effectId == EffectIdentifierEnum::kDelayedAllOff &&
-             !isKnownEnumValue(static_cast<DelayedAllOffEffectVariantEnum>(effectVariant))) ||
-            (effectId == EffectIdentifierEnum::kDyingLight &&
-             !isKnownEnumValue(static_cast<DyingLightEffectVariantEnum>(effectVariant))))
+        if (effectId == EffectIdentifierEnum::kDelayedAllOff &&
+            !isKnownEnumValue(static_cast<DelayedAllOffEffectVariantEnum>(effectVariant)))
         {
-            status = Status::ConstraintError;
+            // The server does not support the given variant, it SHALL use the default variant.
+            effectVariant = to_underlying(DelayedAllOffEffectVariantEnum::kDelayedOffFastFade);
+        }
+        else if (effectId == EffectIdentifierEnum::kDyingLight &&
+                 !isKnownEnumValue(static_cast<DyingLightEffectVariantEnum>(effectVariant)))
+        {
+            // The server does not support the given variant, it SHALL use the default variant.
+            effectVariant = to_underlying(DyingLightEffectVariantEnum::kDyingLightFadeOff);
         }
     }
     else


### PR DESCRIPTION
fixes #34214

It was possible to pass invalid enum values to the `OffWithEffect` command from the on-off cluster.

Add checks against the passed arguments in the command handler
- handle the `effectVariant` parameter range variation depending on the `effectId` parameter.


**Note the On-Off cluster test plan must be expanded to test invalid parameter handling.**

Manually tested with chip-tool and efr32 lighting-app.
**Invalid effectVariant when effectId is DelayedAllOff**
```
./chip-tool onoff off-with-effect 0 10 $NODE_ID 1
[1721319091.737648][24180:24182] CHIP:DMG: Received Command Response Status for Endpoint=1 Cluster=0x0000_0006 Command=0x0000_0040 Status=0x87
[1721319091.737713][24180:24182] CHIP:TOO: Error: IM Error 0x00000587: General error: 0x87 (CONSTRAINT_ERROR)
```

**Valid effectVariant when effectId is DelayedAllOff**
```
./chip-tool onoff off-with-effect 0 2 $NODE_ID 1
[1721319152.105680][24187:24189] CHIP:DMG: Received Command Response Status for Endpoint=1 Cluster=0x0000_0006 Command=0x0000_0040 Status=0x0
```

**Invalid effectId**
```
./chip-tool onoff off-with-effect 2 2 $NODE_ID 1
[1721319203.173323][24194:24196] CHIP:DMG: Received Command Response Status for Endpoint=1 Cluster=0x0000_0006 Command=0x0000_0040 Status=0x87
[1721319203.173389][24194:24196] CHIP:TOO: Error: IM Error 0x00000587: General error: 0x87 (CONSTRAINT_ERROR)
```

**Invalid effectVariant when effectId is DyingLight**
```
./chip-tool  onoff off-with-effect 1 2 $NODE_ID 1
[1721319220.474435][24200:24202] CHIP:DMG: Received Command Response Status for Endpoint=1 Cluster=0x0000_0006 Command=0x0000_0040 Status=0x87
[1721319220.474514][24200:24202] CHIP:TOO: Error: IM Error 0x00000587: General error: 0x87 (CONSTRAINT_ERROR)
```

**Valid effectVariant when effectId is DyingLight**
```
./chip-tool onoff off-with-effect 1 0 $NODE_ID 1
 Received Command Response Status for Endpoint=1 Cluster=0x0000_0006 Command=0x0000_0040 Status=0x0
```
