### PR TITLE
Move chip-build-doxygen to version 65

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -81,7 +81,7 @@ jobs:
 
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/project-chip/chip-build-doxygen:54
+            image: ghcr.io/project-chip/chip-build-doxygen:65
 
         if: github.actor != 'restyled-io[bot]'
 


### PR DESCRIPTION
Updates the dockerimage to latest for chip-build-doxygen.

Change assumed safe, however if there are errors I will fix them.