### PR TITLE
Move chip-build-java to version 65

### DIFF
--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -42,7 +42,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-java:54
+            image: ghcr.io/project-chip/chip-build-java:65
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=0 net.ipv6.conf.all.forwarding=0"
 


### PR DESCRIPTION
Updates the dockerimage to latest for chip-build-java.

Change assumed safe, however if there are errors I will fix them.