### PR TITLE
Move chip-build-crosscompile to version 65

### DIFF
--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-crosscompile:54
+            image: ghcr.io/project-chip/chip-build-crosscompile:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 


### PR DESCRIPTION
Updates the dockerimage to latest for chip-build-java.

Change assumed safe, however if there are errors I will fix them.