### PR TITLE
Replace chip-build-cirque version comment with a generic string

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -42,7 +42,7 @@ jobs:
         # need to run with privilege, which isn't supported by job.XXX.contaner
         #  https://github.com/actions/container-action/issues/2
         #         container:
-        #             image: ghcr.io/project-chip/chip-build-cirque:54
+        #             image: ghcr.io/project-chip/chip-build-cirque:<VERSION_HERE>
         #             volumes:
         #                 - "/tmp:/tmp"
         #                 - "/dev/pts:/dev/pts"


### PR DESCRIPTION
We seemed to keep updating this version string, however the version string does not currently matter: we use a cirque run.sh which uses `:latest` anyway (which is buggy, however this is what we have).

This just updates a comment, change should be a noop otherwise.