### PR TITLE
[VALCC] Fixed assert_less_equal to match test plan and spec in VALCC-2.1

### DIFF
--- a/src/python_testing/TC_VALCC_2_1.py
+++ b/src/python_testing/TC_VALCC_2_1.py
@@ -159,7 +159,7 @@ class TC_VALCC_2_1(MatterBaseTest):
         if attributes.ValveFault.attribute_id in attribute_list:
             valve_fault_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.ValveFault)
 
-            asserts.assert_less_equal(valve_fault_dut, 0b00000111, "ValveFault is not in valid range")
+            asserts.assert_less_equal(valve_fault_dut, 0b00111111, "ValveFault is not in valid range")
         else:
             logging.info("Test step skipped")
 


### PR DESCRIPTION
It was noticed that the assert_less_equal for ValveFault in VALCC-2.1 used the wrong bitmap for compare and only allowed for bit 2..0 to be set, while the spec has defined 5..0 and the test plan states is it allowed to be in the range of 0 to 63.