### PR TITLE
Fix post-review comments on Q quality utils from #34266

### DIFF
--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -172,11 +172,10 @@ public:
      * @return AttributeDirtyState::kMustReport if attribute must be marked dirty right away, or
      * AttributeDirtyState::kNoReportNeeded otherwise.
      */
-    AttributeDirtyState SetValue(const DataModel::Nullable<T> & newValue, Timestamp now,
-                                 SufficientChangePredicate changedPredicate)
+    AttributeDirtyState SetValue(const DataModel::Nullable<T> & newValue, Timestamp now, SufficientChangePredicate changedPredicate)
     {
-        bool isChangeOfNull       = newValue.IsNull() != mValue.IsNull();
-        bool areBothValuesNonNull = !newValue.IsNull() && !mValue.IsNull();
+        bool isChangeOfNull         = newValue.IsNull() != mValue.IsNull();
+        bool areBothValuesNonNull   = !newValue.IsNull() && !mValue.IsNull();
         bool areBothValuesDifferent = areBothValuesNonNull && (newValue.Value() != mValue.Value());
 
         bool changeToFromZero = areBothValuesNonNull && areBothValuesDifferent && (newValue.Value() == 0 || mValue.Value() == 0);

--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -172,13 +172,14 @@ public:
      * @return AttributeDirtyState::kMustReport if attribute must be marked dirty right away, or
      * AttributeDirtyState::kNoReportNeeded otherwise.
      */
-    AttributeDirtyState SetValue(const chip::app::DataModel::Nullable<T> & newValue, Timestamp now,
+    AttributeDirtyState SetValue(const DataModel::Nullable<T> & newValue, Timestamp now,
                                  SufficientChangePredicate changedPredicate)
     {
-        bool isChangeOfNull       = newValue.IsNull() ^ mValue.IsNull();
+        bool isChangeOfNull       = newValue.IsNull() != mValue.IsNull();
         bool areBothValuesNonNull = !newValue.IsNull() && !mValue.IsNull();
+        bool areBothValuesDifferent = areBothValuesNonNull && (newValue.Value() != mValue.Value());
 
-        bool changeToFromZero = areBothValuesNonNull && (newValue.Value() == 0 || mValue.Value() == 0);
+        bool changeToFromZero = areBothValuesNonNull && areBothValuesDifferent && (newValue.Value() == 0 || mValue.Value() == 0);
         bool isIncrement      = areBothValuesNonNull && (newValue.Value() > mValue.Value());
         bool isDecrement      = areBothValuesNonNull && (newValue.Value() < mValue.Value());
 
@@ -217,20 +218,20 @@ public:
      * @return AttributeDirtyState::kMustReport if attribute must be marked dirty right away, or
      * AttributeDirtyState::kNoReportNeeded otherwise.
      */
-    AttributeDirtyState SetValue(const chip::app::DataModel::Nullable<T> & newValue, Timestamp now)
+    AttributeDirtyState SetValue(const DataModel::Nullable<T> & newValue, Timestamp now)
     {
         return SetValue(newValue, now, [](const SufficientChangePredicateCandidate &) -> bool { return false; });
     }
 
 protected:
     // Current value of the attribute.
-    chip::app::DataModel::Nullable<T> mValue;
+    DataModel::Nullable<T> mValue;
     // Last value that was marked as dirty (to use in comparisons for change, e.g. by SufficientChangePredicate).
-    chip::app::DataModel::Nullable<T> mLastDirtyValue;
+    DataModel::Nullable<T> mLastDirtyValue;
     // Enabled internal change detection policies.
     QuieterReportingPolicyFlags mPolicyFlags{ 0 };
     // Timestamp associated with the last time the attribute was marked dirty (to use in comparisons for change).
-    chip::System::Clock::Milliseconds64 mLastDirtyTimestampMillis{};
+    chip::System::Clock::Timestamp mLastDirtyTimestampMillis{};
 };
 
 } // namespace detail

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -252,7 +252,9 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 14);
 
     // Forcing dirty can NOT done with a force-true predicate.
-    decltype(attribute)::SufficientChangePredicate forceTruePredicate{[](const decltype(attribute)::SufficientChangePredicateCandidate &) -> bool { return true; }};
+    decltype(attribute)::SufficientChangePredicate forceTruePredicate{
+        [](const decltype(attribute)::SufficientChangePredicateCandidate &) -> bool { return true; }
+    };
     now = fakeClock.Advance(1_ms);
     EXPECT_EQ(attribute.SetValue(12, now, forceTruePredicate), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
@@ -267,6 +269,4 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     now = fakeClock.Advance(1000_ms);
     EXPECT_EQ(attribute.SetValue(NullNullable, now, predicate), AttributeDirtyState::kNoReportNeeded);
     EXPECT_TRUE(attribute.value().IsNull());
-
-
 }

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -213,9 +213,6 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     EXPECT_EQ(attribute.SetValue(10, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
 
-    // Forcing dirty can be done with a force-true predicate
-    EXPECT_EQ(attribute.SetValue(10, now, attribute.GetForceReportablePredicate()), AttributeDirtyState::kMustReport);
-
     auto predicate = attribute.GetPredicateForSufficientTimeSinceLastDirty(1000_ms);
 
     now = fakeClock.Advance(100_ms);
@@ -254,6 +251,12 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     EXPECT_EQ(attribute.SetValue(14, now, predicate), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 14);
 
+    // Forcing dirty can NOT done with a force-true predicate.
+    decltype(attribute)::SufficientChangePredicate forceTruePredicate{[](const decltype(attribute)::SufficientChangePredicateCandidate &) -> bool { return true; }};
+    now = fakeClock.Advance(1_ms);
+    EXPECT_EQ(attribute.SetValue(12, now, forceTruePredicate), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
+
     // Change to a value that marks dirty no matter what (e.g. null). Should be dirty even
     // before delay.
     now = fakeClock.Advance(1_ms);
@@ -264,4 +267,6 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     now = fakeClock.Advance(1000_ms);
     EXPECT_EQ(attribute.SetValue(NullNullable, now, predicate), AttributeDirtyState::kNoReportNeeded);
     EXPECT_TRUE(attribute.value().IsNull());
+
+
 }

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -74,6 +74,10 @@ TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
     EXPECT_EQ(attribute.SetValue(0, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
 
+    // 0 --> 0, expect NOT marked dirty.
+    EXPECT_EQ(attribute.SetValue(0, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
+
     // 0 --> 11, expect marked dirty.
     EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);


### PR DESCRIPTION
- PR #34266 had post review comments See: https://github.com/project-chip/connectedhomeip/pull/34266#pullrequestreview-2173994817
- Fix 0->0 case
- Introduce `Timestamp` more places where it makes sense
- Simplify some code lines

Fixes #34334

Testing done:

- Added unit test for 0->0
- Tests still pass
