### PR TITLE
Fix typo in cloudbuild target

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -75,7 +75,7 @@ steps:
               ./scripts/build/build_examples.py --enable-flashbundle
               --target efr32-brd4187c-light
               --target efr32-brd4187c-light-rpc
-              --target efr32-brd4187cbrd4187c-lock-openthread-mtd
+              --target efr32-brd4187c-lock-openthread-mtd
               --target efr32-brd4187c-lock-rpc-openthread-mtd
               --target efr32-brd4187c-unit-test
               build


### PR DESCRIPTION
#34019 has a typo of `brd4187cbrd4187c` instead of just `brd4187c`.