### PR TITLE
[ESP32] Changes to shift the docker image version for chip-build to  65 in CI for ESP32.

### DIFF
--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -56,7 +56,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:54
+            image: ghcr.io/project-chip/chip-build-esp32:65
             options: --user root
 
         steps:

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:54
+            image: ghcr.io/project-chip/chip-build-esp32:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
@@ -126,7 +126,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:54
+            image: ghcr.io/project-chip/chip-build-esp32:65
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32-qemu:54
+            image: ghcr.io/project-chip/chip-build-esp32-qemu:65
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -32,7 +32,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-esp32:54
+            image: ghcr.io/project-chip/chip-build-esp32:65
 
         steps:
             - name: Checkout


### PR DESCRIPTION
**Change Overview**
- Changed the docker image version for chip-build and qemu to 65 in CI workflow for ESP32.
- These changes are for esp32 platform with reference to PR #34391.