### PR TITLE
bumping mypy python package version to 1.10.1 in venv

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -128,7 +128,7 @@ mobly==1.12.1
     # via -r requirements.all.txt
 msgpack==1.0.4
     # via cachecontrol
-mypy==0.971
+mypy==1.10.1
     # via -r requirements.all.txt
 mypy-extensions==1.0.0
     # via mypy

--- a/scripts/setup/requirements.all.txt
+++ b/scripts/setup/requirements.all.txt
@@ -38,7 +38,7 @@ appdirs
 coloredlogs
 watchdog
 build==0.8.0
-mypy==0.971
+mypy==1.10.1
 mypy-protobuf==3.5.0
 protobuf==4.24.4
 types-protobuf==4.24.0.2
@@ -50,4 +50,3 @@ colorama
 
 # update tornado for pw_watch
 tornado
-


### PR DESCRIPTION
- bumping mypy python package version to 1.10.1 in venv from 0.971 to 1.10.1 
- this was done because there have been many changes in the versions as well as improvements and to make sure that mypy fixing activities will be inline with latest version.

- this was discussed in #34415 