### PR TITLE
Make tv casting tests use multithreading.

### DIFF
--- a/examples/tv-app/linux/args.gni
+++ b/examples/tv-app/linux/args.gni
@@ -31,6 +31,8 @@ chip_enable_additional_data_advertising = true
 chip_enable_rotating_device_id = true
 
 matter_enable_tracing_support = true
+matter_log_json_payload_hex = true
+matter_log_json_payload_decode_full = true
 
 # Thread devices do not support WakeOnLan because their mac address is >48bit
 chip_enable_openthread = false

--- a/examples/tv-casting-app/linux/args.gni
+++ b/examples/tv-casting-app/linux/args.gni
@@ -35,3 +35,5 @@ chip_max_discovered_ip_addresses = 20
 enable_rtti = true
 
 matter_enable_tracing_support = true
+matter_log_json_payload_hex = true
+matter_log_json_payload_decode_full = true

--- a/scripts/tests/linux/log_line_processing.py
+++ b/scripts/tests/linux/log_line_processing.py
@@ -66,15 +66,15 @@ class ProcessOutputCapture:
             while not self.done:
                 changes = out_wait.poll(0.1)
                 if changes:
-                    l = self.process.stdout.readline()
-                    f.write(l)
-                    self.output_lines.put(l)
+                    out_line = self.process.stdout.readline()
+                    f.write(out_line)
+                    self.output_lines.put(out_line)
 
                 changes = err_wait.poll(0)
                 if changes:
-                    l = self.process.stderr.readline()
-                    if l:
-                        f.write(f"!!STDERR!! : {l}")
+                    err_line = self.process.stderr.readline()
+                    if err_line:
+                        f.write(f"!!STDERR!! : {err_line}")
 
     def __enter__(self):
         self.done = False
@@ -102,8 +102,8 @@ class ProcessOutputCapture:
             # When we fail because of an exception, report the entire log content
             logging.error(f"-------- START: LOG DUMP FOR {self.command!r} -----")
             with open(self.output_path, "rt") as f:
-                for l in f.readlines():
-                    logging.error(l.strip())
+                for output_line in f.readlines():
+                    logging.error(output_line.strip())
             logging.error(f"-------- END:   LOG DUMP FOR {self.command!r} -----")
 
     def next_output_line(self, timeout_sec=None):

--- a/scripts/tests/linux/log_line_processing.py
+++ b/scripts/tests/linux/log_line_processing.py
@@ -108,7 +108,10 @@ class ProcessOutputCapture:
 
     def next_output_line(self, timeout_sec=None):
         """Fetch an item from the output queue, potentially wit h a timeout."""
-        return self.output_lines.get(timeout=timeout_sec)
+        try:
+            return self.output_lines.get(timeout=timeout_sec)
+        except Empty:
+            return None
 
     def send_to_program(self, what):
         """Sends the given string to the program.

--- a/scripts/tests/linux/log_line_processing.py
+++ b/scripts/tests/linux/log_line_processing.py
@@ -118,5 +118,5 @@ class ProcessOutputCapture:
 
         NOTE: remember to append a `\n` for terminal applications
         """
-        self.process.stdin.write(what)
+        self.process.stdin.write(input_cmd)
         self.process.stdin.flush()

--- a/scripts/tests/linux/log_line_processing.py
+++ b/scripts/tests/linux/log_line_processing.py
@@ -113,8 +113,8 @@ class ProcessOutputCapture:
         except queue.Empty:
             return None
 
-    def send_to_program(self, what):
-        """Sends the given string to the program.
+    def send_to_program(self, input_cmd):
+        """Sends the given input command string to the program.
 
         NOTE: remember to append a `\n` for terminal applications
         """

--- a/scripts/tests/linux/log_line_processing.py
+++ b/scripts/tests/linux/log_line_processing.py
@@ -30,7 +30,7 @@ class ProcessOutputCapture:
         the process stdout)
       - provides read timeouts for incoming data
 
-    Use as part of a resource mangement block like:
+    Use as part of a resource management block like:
 
     with ProcessOutputCapture("test.sh", "logs.txt") as p:
        p.send_to_program("input\n")

--- a/scripts/tests/linux/log_line_processing.py
+++ b/scripts/tests/linux/log_line_processing.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import queue
+import select
+import subprocess
+import threading
+from typing import List
+
+
+class ProcessOutputCapture:
+    """
+    Captures stdout from a process and redirects such stdout to a given file.
+
+    The capture serves several purposes as opposed to just reading stdout:
+      - as data is received, it will get written to a separate file
+      - data is accumulated in memory for later processing (does not starve/block
+        the process stdout)
+      - provides read timeouts for incoming data
+
+    Use as part of a resource mangement block like:
+
+    with ProcessOutputCapture("test.sh", "logs.txt") as p:
+       p.send_to_program("input\n")
+
+       while True:
+           l = p.next_output_line(timeout_sec = 1)
+           if not l:
+               break
+    """
+
+    def __init__(self, command: List[str], output_path: str):
+        # in/out/err are pipes
+        self.command = command
+        self.output_path = output_path
+        self.output_lines = queue.Queue()
+        self.process = None
+        self.io_thread = None
+        self.done = False
+
+    def _io_thread(self):
+        """Reads process lines and writes them to an output file.
+
+        It also sends the output lines to `self.output_lines` for later
+        reading
+        """
+        out_wait = select.poll()
+        out_wait.register(self.process.stdout, select.POLLIN)
+
+        err_wait = select.poll()
+        err_wait.register(self.process.stderr, select.POLLIN)
+
+        with open(self.output_path, "wt") as f:
+            while not self.done:
+                changes = out_wait.poll(0.1)
+                if changes:
+                    l = self.process.stdout.readline()
+                    f.write(l)
+                    self.output_lines.put(l)
+
+                changes = err_wait.poll(0)
+                if changes:
+                    l = self.process.stderr.readline()
+                    if l:
+                        f.write(f"!!STDERR!! : {l}")
+
+    def __enter__(self):
+        self.done = False
+        self.process = subprocess.Popen(
+            self.command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.io_thread = threading.Thread(target=self._io_thread)
+        self.io_thread.start()
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        self.done = True
+        if self.process:
+            self.process.terminate()
+            self.process.wait()
+
+        if self.io_thread:
+            self.io_thread.join()
+
+        if exception_value:
+            # When we fail because of an exception, report the entire log content
+            logging.error(f"-------- START: LOG DUMP FOR {self.command!r} -----")
+            with open(self.output_path, "rt") as f:
+                for l in f.readlines():
+                    logging.error(l.strip())
+            logging.error(f"-------- END:   LOG DUMP FOR {self.command!r} -----")
+
+    def next_output_line(self, timeout_sec=None):
+        """Fetch an item from the output queue, potentially wit h a timeout."""
+        return self.output_lines.get(timeout=timeout_sec)
+
+    def send_to_program(self, what):
+        """Sends the given string to the program.
+
+        NOTE: remember to append a `\n` for terminal applications
+        """
+        self.process.stdin.write(what)
+        self.process.stdin.flush()

--- a/scripts/tests/linux/log_line_processing.py
+++ b/scripts/tests/linux/log_line_processing.py
@@ -73,8 +73,7 @@ class ProcessOutputCapture:
                 changes = err_wait.poll(0)
                 if changes:
                     err_line = self.process.stderr.readline()
-                    if err_line:
-                        f.write(f"!!STDERR!! : {err_line}")
+                    f.write(f"!!STDERR!! : {err_line}")
 
     def __enter__(self):
         self.done = False

--- a/scripts/tests/linux/log_line_processing.py
+++ b/scripts/tests/linux/log_line_processing.py
@@ -110,7 +110,7 @@ class ProcessOutputCapture:
         """Fetch an item from the output queue, potentially wit h a timeout."""
         try:
             return self.output_lines.get(timeout=timeout_sec)
-        except Empty:
+        except queue.Empty:
             return None
 
     def send_to_program(self, what):

--- a/scripts/tests/linux/log_line_processing.py
+++ b/scripts/tests/linux/log_line_processing.py
@@ -107,7 +107,7 @@ class ProcessOutputCapture:
             logging.error(f"-------- END:   LOG DUMP FOR {self.command!r} -----")
 
     def next_output_line(self, timeout_sec=None):
-        """Fetch an item from the output queue, potentially wit h a timeout."""
+        """Fetch an item from the output queue, potentially with a timeout."""
         try:
             return self.output_lines.get(timeout=timeout_sec)
         except queue.Empty:

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -198,8 +198,7 @@ def send_input_cmd_to_subprocess(
     app_name = test_sequence_step.app.value
 
     input_cmd = test_sequence_step.input_cmd
-    app_subprocess.process.stdin.write(input_cmd)
-    app_subprocess.process.stdin.flush()
+    app_subprocess.send_to_program(input_cmd)
 
     input_cmd = input_cmd.rstrip("\n")
     logging.info(

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -173,7 +173,7 @@ def parse_output_msg_in_subprocess(
                 # successful completion
                 return
 
-    raise TestStepException("Unespected exit", test_sequence_name, test_sequence_step)
+    raise TestStepException("Unexpected exit", test_sequence_name, test_sequence_step)
 
 
 def send_input_cmd_to_subprocess(

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -22,9 +22,11 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import List, TextIO, Tuple
+from dataclasses import dataclass
+from typing import List, Optional
 
 import click
+from linux.log_line_processing import ProcessOutputCapture
 from linux.tv_casting_test_sequence_utils import App, Sequence, Step
 from linux.tv_casting_test_sequences import START_APP, STOP_APP
 
@@ -35,108 +37,99 @@ It runs a series of test sequences that check for expected output lines from the
 a deterministic order. If these lines are not found, it indicates an issue with the casting experience.
 """
 
+
+@dataclass
+class RunningProcesses:
+    tv_casting: ProcessOutputCapture = None
+    tv_app: ProcessOutputCapture = None
+
+
 # Configure logging format.
-logging.basicConfig(level=logging.INFO, format='%(levelname)s - %(message)s')
+logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
 
 # File names of logs for the Linux tv-casting-app and the Linux tv-app.
-LINUX_TV_APP_LOGS = 'Linux-tv-app-logs.txt'
-LINUX_TV_CASTING_APP_LOGS = 'Linux-tv-casting-app-logs.txt'
+LINUX_TV_APP_LOGS = "Linux-tv-app-logs.txt"
+LINUX_TV_CASTING_APP_LOGS = "Linux-tv-casting-app-logs.txt"
 
 
-class ProcessManager:
-    """A context manager for managing subprocesses.
+class TestStepException(Exception):
+    """Thrown when a test fails, contains information about the test step that faied"""
 
-    This class provides a context manager for safely starting and stopping a subprocess.
-    """
+    def __init__(self, message, sequence_name: str, step: Optional[Step]):
+        super().__init__(message)
+        self.sequence_name = sequence_name
+        self.step = step
 
-    def __init__(self, command: List[str], stdin, stdout, stderr):
-        self.command = command
-        self.stdin = stdin
-        self.stdout = stdout
-        self.stderr = stderr
-
-    def __enter__(self):
-        self.process = subprocess.Popen(self.command, stdin=self.stdin, stdout=self.stdout, stderr=self.stderr, text=True)
-        return self.process
-
-    def __exit__(self, exception_type, exception_value, traceback):
-        self.process.terminate()
-        self.process.wait()
+        logging.error("EXCEPTION at %s/%r: %s", sequence_name, step, message)
 
 
 def remove_cached_files(cached_file_pattern: str):
     """Remove any cached files that match the provided pattern."""
 
-    cached_files = glob.glob(cached_file_pattern)  # Returns a list of paths that match the pattern.
+    cached_files = glob.glob(
+        cached_file_pattern
+    )  # Returns a list of paths that match the pattern.
 
     for cached_file in cached_files:
         try:
             os.remove(cached_file)
         except OSError as e:
-            logging.error(f'Failed to remove cached file `{cached_file}` with error: `{e.strerror}`')
+            logging.error(
+                f"Failed to remove cached file `{cached_file}` with error: `{e.strerror}`"
+            )
             raise  # Re-raise the OSError to propagate it up.
 
 
-def dump_temporary_logs_to_console(log_file_path: str):
-    """Dump log file to the console; log file will be removed once the function exits."""
-    """Write the entire content of `log_file_path` to the console."""
-    print(f'\nDumping logs from: {log_file_path}')
-
-    with open(log_file_path, 'r') as file:
-        for line in file:
-            print(line.rstrip())
-
-
-def handle_casting_failure(test_sequence_name: str, log_file_paths: List[str]):
-    """Log failure of validation of test sequence as error, dump log files to console, exit on error."""
-    logging.error(f'{test_sequence_name} - Validation of test sequence failed.')
-
-    for log_file_path in log_file_paths:
-        try:
-            dump_temporary_logs_to_console(log_file_path)
-        except Exception as e:
-            logging.exception(f'{test_sequence_name} - Failed to dump {log_file_path}: {e}')
-
-    sys.exit(1)
-
-
-def stop_app(test_sequence_name: str, app_name: str, app: subprocess.Popen) -> bool:
+def stop_app(test_sequence_name: str, app_name: str, app: ProcessOutputCapture):
     """Stop the given `app` subprocess."""
 
-    app.terminate()
-    app_exit_code = app.wait()
+    app.process.terminate()
+    app_exit_code = app.process.wait()
 
-    if app.poll() is None:
-        logging.error(f'{test_sequence_name}: Failed to stop running {app_name}. Process is still running.')
-    else:
-        if app_exit_code < 0:
-            signal_number = -app_exit_code
-            if signal_number == signal.SIGTERM.value:
-                logging.info(f'{test_sequence_name}: {app_name} stopped by {signal_number} (SIGTERM) signal.')
-                return True
-            else:
-                logging.error(
-                    f'{test_sequence_name}: {app_name} stopped by signal {signal_number} instead of {signal.SIGTERM.value} (SIGTERM).')
-        else:
-            logging.error(f'{test_sequence_name}: {app_name} exited with unexpected exit code {app_exit_code}.')
+    if app.process.poll() is None:
+        raise TestStepException(
+            f"{test_sequence_name}: Failed to stop running {app_name}. Process is still running.",
+            test_sequence_name,
+            None,
+        )
 
-    return False
+    if app_exit_code >= 0:
+        raise TestStepException(
+            f"{test_sequence_name}: {app_name} exited with unexpected exit code {app_exit_code}.",
+            test_sequence_name,
+            None,
+        )
+
+    signal_number = -app_exit_code
+    if signal_number != signal.SIGTERM.value:
+        raise TestStepException(
+            f"{test_sequence_name}: {app_name} stopped by signal {signal_number} instead of {signal.SIGTERM.value} (SIGTERM).",
+            test_sequence_name,
+            None,
+        )
+
+    logging.info(
+        f"{test_sequence_name}: {app_name} stopped by {signal_number} (SIGTERM) signal."
+    )
 
 
 def parse_output_msg_in_subprocess(
-    tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
-    tv_app_info: Tuple[subprocess.Popen, TextIO],
-    log_paths: List[str],
-    test_sequence_name: str,
-    test_sequence_step: Step
-) -> bool:
+    processes: RunningProcesses, test_sequence_name: str, test_sequence_step: Step
+):
     """Parse the output of a given `app` subprocess and validate its output against the expected `output_msg` in the given `Step`."""
 
     if not test_sequence_step.output_msg:
-        logging.error(f'{test_sequence_name} - No output message provided in the test sequence step.')
-        return False
+        raise TestStepException(
+            f"{test_sequence_name} - No output message provided in the test sequence step.",
+            test_sequence_name,
+            test_sequence_step,
+        )
 
-    app_subprocess, app_log_file = (tv_casting_app_info if test_sequence_step.app == App.TV_CASTING_APP else tv_app_info)
+    app_subprocess = (
+        processes.tv_casting
+        if test_sequence_step.app == App.TV_CASTING_APP
+        else processes.tv_app
+    )
 
     start_wait_time = time.time()
     msg_block = []
@@ -144,115 +137,107 @@ def parse_output_msg_in_subprocess(
     current_index = 0
     while current_index < len(test_sequence_step.output_msg):
         # Check if we exceeded the maximum wait time to parse for the output string(s).
-        if time.time() - start_wait_time > test_sequence_step.timeout_sec:
-            logging.error(
-                f'{test_sequence_name} - Did not find the expected output string(s) in the {test_sequence_step.app.value} subprocess within the timeout: {test_sequence_step.output_msg}')
-            return False
-
-        output_line = app_subprocess.stdout.readline()
+        max_wait_time = start_wait_time + test_sequence_step.timeout_sec - time.time()
+        if max_wait_time < 0:
+            raise TestStepException(
+                f"{test_sequence_name} - Did not find the expected output string(s) in the {test_sequence_step.app.value} subprocess within the timeout: {test_sequence_step.output_msg}",
+                test_sequence_name,
+                test_sequence_step,
+            )
+        output_line = app_subprocess.next_output_line(max_wait_time)
 
         if output_line:
-            app_log_file.write(output_line)
-            app_log_file.flush()
-
-            if (test_sequence_step.output_msg[current_index] in output_line):
-                msg_block.append(output_line.rstrip('\n'))
+            if test_sequence_step.output_msg[current_index] in output_line:
+                msg_block.append(output_line.rstrip("\n"))
                 current_index += 1
             elif msg_block:
-                msg_block.append(output_line.rstrip('\n'))
-                if (test_sequence_step.output_msg[0] in output_line):
+                msg_block.append(output_line.rstrip("\n"))
+                if test_sequence_step.output_msg[0] in output_line:
                     msg_block.clear()
-                    msg_block.append(output_line.rstrip('\n'))
+                    msg_block.append(output_line.rstrip("\n"))
                     current_index = 1
                 # Sanity check that `Discovered Commissioner #0` is the valid commissioner.
-                elif 'Discovered Commissioner #' in output_line:
-                    logging.error(f'{test_sequence_name} - The valid discovered commissioner should be `Discovered Commissioner #0`.')
-                    handle_casting_failure(test_sequence_name, log_paths)
+                elif "Discovered Commissioner #" in output_line:
+                    raise TestStepException(
+                        f"{test_sequence_name} - The valid discovered commissioner should be `Discovered Commissioner #0`.",
+                        test_sequence_name,
+                        test_sequence_step,
+                    )
 
             if current_index == len(test_sequence_step.output_msg):
-                logging.info(f'{test_sequence_name} - Found the expected output string(s) in the {test_sequence_step.app.value} subprocess:')
+                logging.info(
+                    f"{test_sequence_name} - Found the expected output string(s) in the {test_sequence_step.app.value} subprocess:"
+                )
                 for line in msg_block:
-                    logging.info(f'{test_sequence_name} - {line}')
+                    logging.info(f"{test_sequence_name} - {line}")
 
-                return True
+                # successful completion
+                return
+
+    raise TestStepException("Unespected exit", test_sequence_name, test_sequence_step)
 
 
 def send_input_cmd_to_subprocess(
-    tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
-    tv_app_info: Tuple[subprocess.Popen, TextIO],
+    processes: RunningProcesses,
     test_sequence_name: str,
-    test_sequence_step: Step
-) -> bool:
+    test_sequence_step: Step,
+):
     """Send a given input command (`input_cmd`) from the `Step` to its given `app` subprocess."""
 
     if not test_sequence_step.input_cmd:
-        logging.error(f'{test_sequence_name} - No input command provided in the test sequence step.')
-        return False
+        raise TestStepException(
+            f"{test_sequence_name} - No input command provided in the test sequence step.",
+            test_sequence_step,
+            test_sequence_step,
+        )
 
-    app_subprocess, app_log_file = (tv_casting_app_info if test_sequence_step.app == App.TV_CASTING_APP else tv_app_info)
+    app_subprocess = (
+        processes.tv_casting
+        if test_sequence_step.app == App.TV_CASTING_APP
+        else processes.tv_app
+    )
     app_name = test_sequence_step.app.value
 
     input_cmd = test_sequence_step.input_cmd
-    app_subprocess.stdin.write(input_cmd)
-    app_subprocess.stdin.flush()
+    app_subprocess.process.stdin.write(input_cmd)
+    app_subprocess.process.stdin.flush()
 
-    input_cmd = input_cmd.rstrip('\n')
-    logging.info(f'{test_sequence_name} - Sent `{input_cmd}` to the {app_name} subprocess.')
-
-    return True
-
-
-def handle_output_msg(
-    tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
-    tv_app_info: Tuple[subprocess.Popen, TextIO],
-    log_paths: List[str],
-    test_sequence_name: str,
-    test_sequence_step: Step
-):
-    """Handle the output message (`output_msg`) from a test sequence step."""
-
-    if not parse_output_msg_in_subprocess(tv_casting_app_info, tv_app_info, log_paths, test_sequence_name, test_sequence_step):
-        handle_casting_failure(test_sequence_name, log_paths)
+    input_cmd = input_cmd.rstrip("\n")
+    logging.info(
+        f"{test_sequence_name} - Sent `{input_cmd}` to the {app_name} subprocess."
+    )
 
 
 def handle_input_cmd(
-    tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
-    tv_app_info: Tuple[subprocess.Popen, TextIO],
-    log_paths: List[str],
-    test_sequence_name: str,
-    test_sequence_step: Step
+    processes: RunningProcesses, test_sequence_name: str, test_sequence_step: Step
 ):
     """Handle the input command (`input_cmd`) from a test sequence step."""
-
-    tv_casting_app_process, tv_casting_app_log_file = tv_casting_app_info
-    tv_app_process, tv_app_log_file = tv_app_info
-
     if test_sequence_step.input_cmd == STOP_APP:
         if test_sequence_step.app == App.TV_CASTING_APP:
-            # Stop the tv-casting-app subprocess.
-            if not stop_app(test_sequence_name, test_sequence_step.app.value, tv_casting_app_process):
-                handle_casting_failure(test_sequence_name, log_paths)
+            stop_app(
+                test_sequence_name, test_sequence_step.app.value, processes.tv_casting
+            )
         elif test_sequence_step.app == App.TV_APP:
-            # Stop the tv-app subprocess.
-            if not stop_app(test_sequence_name, test_sequence_step.app.value, tv_app_process):
-                handle_casting_failure(test_sequence_name, log_paths)
-    else:
-        if not send_input_cmd_to_subprocess(tv_casting_app_info, tv_app_info, test_sequence_name, test_sequence_step):
-            handle_casting_failure(test_sequence_name, log_paths)
+            stop_app(test_sequence_name, test_sequence_step.app.value, processes.tv_app)
+        else:
+            raise TestStepException(
+                "Unknown stop app", test_sequence_name, test_sequence_step
+            )
+        return
+
+    send_input_cmd_to_subprocess(processes, test_sequence_name, test_sequence_step)
 
 
 def run_test_sequence_steps(
     current_index: int,
     test_sequence_name: str,
     test_sequence_steps: List[Step],
-    tv_casting_app_info: Tuple[subprocess.Popen, TextIO],
-    tv_app_info: Tuple[subprocess.Popen, TextIO],
-    log_paths: List[str]
+    processes: RunningProcesses,
 ):
     """Run through the test steps from a test sequence starting from the current index and perform actions based on the presence of `output_msg` or `input_cmd`."""
 
     if test_sequence_steps is None:
-        logging.error('No test sequence steps provided.')
+        logging.error("No test sequence steps provided.")
 
     while current_index < len(test_sequence_steps):
         # Current step in the list of steps.
@@ -260,18 +245,61 @@ def run_test_sequence_steps(
 
         # A test sequence step contains either an output_msg or input_cmd entry.
         if test_sequence_step.output_msg:
-            handle_output_msg(tv_casting_app_info, tv_app_info, log_paths, test_sequence_name, test_sequence_step)
+            parse_output_msg_in_subprocess(
+                processes,
+                test_sequence_name,
+                test_sequence_step,
+            )
         elif test_sequence_step.input_cmd:
-            handle_input_cmd(tv_casting_app_info, tv_app_info, log_paths, test_sequence_name, test_sequence_step)
+            handle_input_cmd(
+                processes,
+                test_sequence_name,
+                test_sequence_step,
+            )
 
         current_index += 1
 
 
+def cmd_execute_list(app_path):
+    """Returns the list suitable to pass to a ProcessOutputCapture/subprocess.run for execution."""
+    cmd = []
+
+    # On Unix-like systems, use stdbuf to disable stdout buffering.
+    # Configure command options to disable stdout buffering during tests.
+    if sys.platform == "darwin" or sys.platform == "linux":
+        cmd = ["stdbuf", "-o0", "-i0"]
+
+    cmd.append(app_path)
+
+    # Our applications support better debugging logs. Enable them
+    cmd.append("--trace-to")
+    cmd.append("json:log")
+
+    return cmd
+
+
 @click.command()
-@click.option('--tv-app-rel-path', type=str, default='out/tv-app/chip-tv-app', help='Path to the Linux tv-app executable.')
-@click.option('--tv-casting-app-rel-path', type=str, default='out/tv-casting-app/chip-tv-casting-app', help='Path to the Linux tv-casting-app executable.')
-@click.option('--commissioner-generated-passcode', type=bool, default=False, help='Enable the commissioner generated passcode test flow.')
-def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path, commissioner_generated_passcode):
+@click.option(
+    "--tv-app-rel-path",
+    type=str,
+    default="out/tv-app/chip-tv-app",
+    help="Path to the Linux tv-app executable.",
+)
+@click.option(
+    "--tv-casting-app-rel-path",
+    type=str,
+    default="out/tv-casting-app/chip-tv-casting-app",
+    help="Path to the Linux tv-casting-app executable.",
+)
+@click.option(
+    "--commissioner-generated-passcode",
+    type=bool,
+    default=False,
+    help="Enable the commissioner generated passcode test flow.",
+)
+def test_casting_fn(
+    tv_app_rel_path, tv_casting_app_rel_path, commissioner_generated_passcode
+):
     """Test if the casting experience between the Linux tv-casting-app and the Linux tv-app continues to work.
 
     By default, it uses the provided executable paths and the commissionee generated passcode flow as the test sequence.
@@ -295,82 +323,102 @@ def test_casting_fn(tv_app_rel_path, tv_casting_app_rel_path, commissioner_gener
     # Store the log files to a temporary directory.
     with tempfile.TemporaryDirectory() as temp_dir:
         linux_tv_app_log_path = os.path.join(temp_dir, LINUX_TV_APP_LOGS)
-        linux_tv_casting_app_log_path = os.path.join(temp_dir, LINUX_TV_CASTING_APP_LOGS)
+        linux_tv_casting_app_log_path = os.path.join(
+            temp_dir, LINUX_TV_CASTING_APP_LOGS
+        )
 
-        with open(linux_tv_app_log_path, 'w') as linux_tv_app_log_file, open(linux_tv_casting_app_log_path, 'w') as linux_tv_casting_app_log_file:
+        # Get all the test sequences.
+        test_sequences = Sequence.get_test_sequences()
 
-            # Get all the test sequences.
-            test_sequences = Sequence.get_test_sequences()
+        # Get the test sequence that we are interested in validating.
+        test_sequence_name = "commissionee_generated_passcode_test"
+        if commissioner_generated_passcode:
+            test_sequence_name = "commissioner_generated_passcode_test"
+        test_sequence = Sequence.get_test_sequence_by_name(
+            test_sequences, test_sequence_name
+        )
 
-            # Get the test sequence that we are interested in validating.
-            test_sequence_name = 'commissionee_generated_passcode_test'
-            if commissioner_generated_passcode:
-                test_sequence_name = 'commissioner_generated_passcode_test'
-            test_sequence = Sequence.get_test_sequence_by_name(test_sequences, test_sequence_name)
+        if not test_sequence:
+            raise TestStepException(
+                "No test sequence found by the test sequence name provided.",
+                test_sequence_name,
+                None,
+            )
 
-            if not test_sequence:
-                logging.error('No test sequence found by the test sequence name provided.')
-                handle_casting_failure(None, [])
+        # At this point, we have retrieved the test sequence of interest.
+        test_sequence_steps = test_sequence.steps
 
-            # At this point, we have retrieved the test sequence of interest.
-            test_sequence_steps = test_sequence.steps
+        current_index = 0
+        if test_sequence_steps[current_index].input_cmd != START_APP:
+            raise ValueError(
+                f"{test_sequence_name}: The first step in the test sequence must contain `START_APP` as `input_cmd` to indicate starting the tv-app."
+            )
+        elif test_sequence_steps[current_index].app != App.TV_APP:
+            raise ValueError(
+                f"{test_sequence_name}: The first step in the test sequence must be to start up the tv-app."
+            )
+        current_index += 1
 
-            # Configure command options to disable stdout buffering during tests.
-            disable_stdout_buffering_cmd = []
-            # On Unix-like systems, use stdbuf to disable stdout buffering.
-            if sys.platform == 'darwin' or sys.platform == 'linux':
-                disable_stdout_buffering_cmd = ['stdbuf', '-o0', '-i0']
-
-            current_index = 0
-            if test_sequence_steps[current_index].input_cmd != START_APP:
-                raise ValueError(
-                    f'{test_sequence_name}: The first step in the test sequence must contain `START_APP` as `input_cmd` to indicate starting the tv-app.')
-            elif test_sequence_steps[current_index].app != App.TV_APP:
-                raise ValueError(f'{test_sequence_name}: The first step in the test sequence must be to start up the tv-app.')
+        tv_app_abs_path = os.path.abspath(tv_app_rel_path)
+        # Run the Linux tv-app subprocess.
+        with ProcessOutputCapture(
+            cmd_execute_list(tv_app_abs_path), linux_tv_app_log_path
+        ) as tv_app_process:
+            # Verify that the tv-app is up and running.
+            parse_output_msg_in_subprocess(
+                RunningProcesses(tv_app=tv_app_process),
+                test_sequence_name,
+                test_sequence_steps[current_index],
+            )
             current_index += 1
 
-            tv_app_abs_path = os.path.abspath(tv_app_rel_path)
-            # Run the Linux tv-app subprocess.
-            with ProcessManager(disable_stdout_buffering_cmd + [tv_app_abs_path], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as tv_app_process:
-                tv_app_info = (tv_app_process, linux_tv_app_log_file)
+            if test_sequence_steps[current_index].input_cmd != START_APP:
+                raise ValueError(
+                    f"{test_sequence_name}: The third step in the test sequence must contain `START_APP` as `input_cmd` to indicate starting the tv-casting-app."
+                )
+            elif test_sequence_steps[current_index].app != App.TV_CASTING_APP:
+                raise ValueError(
+                    f"{test_sequence_name}: The third step in the test sequence must be to start up the tv-casting-app."
+                )
+            current_index += 1
 
-                # Verify that the tv-app is up and running.
-                handle_output_msg(None, tv_app_info, [linux_tv_app_log_path],
-                                  test_sequence_name, test_sequence_steps[current_index])
+            tv_casting_app_abs_path = os.path.abspath(tv_casting_app_rel_path)
+            # Run the Linux tv-casting-app subprocess.
+            with ProcessOutputCapture(
+                cmd_execute_list(tv_casting_app_abs_path), linux_tv_casting_app_log_path
+            ) as tv_casting_app_process:
+                log_paths = [linux_tv_app_log_path, linux_tv_casting_app_log_path]
+
+                processes = RunningProcesses(
+                    tv_casting=tv_casting_app_process, tv_app=tv_app_process
+                )
+
+                # Verify that the server initialization is completed in the tv-casting-app output.
+                parse_output_msg_in_subprocess(
+                    processes,
+                    test_sequence_name,
+                    test_sequence_steps[current_index],
+                )
                 current_index += 1
 
-                if test_sequence_steps[current_index].input_cmd != START_APP:
-                    raise ValueError(
-                        f'{test_sequence_name}: The third step in the test sequence must contain `START_APP` as `input_cmd` to indicate starting the tv-casting-app.')
-                elif test_sequence_steps[current_index].app != App.TV_CASTING_APP:
-                    raise ValueError(
-                        f'{test_sequence_name}: The third step in the test sequence must be to start up the tv-casting-app.')
-                current_index += 1
-
-                tv_casting_app_abs_path = os.path.abspath(tv_casting_app_rel_path)
-                # Run the Linux tv-casting-app subprocess.
-                with ProcessManager(disable_stdout_buffering_cmd + [tv_casting_app_abs_path], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as tv_casting_app_process:
-                    log_paths = [linux_tv_app_log_path, linux_tv_casting_app_log_path]
-                    tv_casting_app_info = (tv_casting_app_process, linux_tv_casting_app_log_file)
-
-                    # Verify that the server initialization is completed in the tv-casting-app output.
-                    handle_output_msg(tv_casting_app_info, tv_app_info, log_paths,
-                                      test_sequence_name, test_sequence_steps[current_index])
-                    current_index += 1
-
-                    run_test_sequence_steps(current_index, test_sequence_name, test_sequence_steps,
-                                            tv_casting_app_info, tv_app_info, log_paths)
+                run_test_sequence_steps(
+                    current_index,
+                    test_sequence_name,
+                    test_sequence_steps,
+                    processes,
+                )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     # Start with a clean slate by removing any previously cached entries.
     try:
-        cached_file_pattern = '/tmp/chip_*'
+        cached_file_pattern = "/tmp/chip_*"
         remove_cached_files(cached_file_pattern)
     except OSError:
         logging.error(
-            f'Error while removing cached files with file pattern: {cached_file_pattern}')
+            f"Error while removing cached files with file pattern: {cached_file_pattern}"
+        )
         sys.exit(1)
 
     # Test casting (discovery and commissioning) between the Linux tv-casting-app and the tv-app.

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -18,7 +18,6 @@ import glob
 import logging
 import os
 import signal
-import subprocess
 import sys
 import tempfile
 import time
@@ -387,8 +386,6 @@ def test_casting_fn(
             with ProcessOutputCapture(
                 cmd_execute_list(tv_casting_app_abs_path), linux_tv_casting_app_log_path
             ) as tv_casting_app_process:
-                log_paths = [linux_tv_app_log_path, linux_tv_casting_app_log_path]
-
                 processes = RunningProcesses(
                     tv_casting=tv_casting_app_process, tv_app=tv_app_process
                 )


### PR DESCRIPTION
TV casting tests had inline stdout reading as a single process, which caused several issues:
  - output reads were blocked while waiting for another process, potentially blocking the sending side for the "other" app, essentially deadlocking the chip main thread if the logging is blocking
  - timeouts were not properly working, since `readline` is blocking
  
Fixes #34443 and fixes #34444

### Changes

- create a new class for that does stdout i/o in a separate thread and timeouts that work
- move log reporting into exception handlers, so that a separate log path and exits are not needed
- move from a central `handle_failure` to exceptions
- enable json tracing for communication in the sample apps and during test runs (to see a clearer picture of packets that are sent/received during runs)

### Tested

tv_casting test still passes (and newly passes on my pr that had failures before)