### PR TITLE
Fix leak in chip-tool when using "any" commands.

### DIFF
--- a/examples/chip-tool/commands/clusters/CustomArgument.h
+++ b/examples/chip-tool/commands/clusters/CustomArgument.h
@@ -230,13 +230,7 @@ private:
 class CustomArgument
 {
 public:
-    ~CustomArgument()
-    {
-        if (mData != nullptr)
-        {
-            chip::Platform::MemoryFree(mData);
-        }
-    }
+    ~CustomArgument() { Reset(); }
 
     CHIP_ERROR Parse(const char * label, const char * json)
     {
@@ -284,6 +278,15 @@ public:
         ReturnErrorOnFailure(reader.Next());
 
         return writer.CopyElement(tag, reader);
+    }
+
+    void Reset()
+    {
+        if (mData != nullptr)
+        {
+            chip::Platform::MemoryFree(mData);
+            mData = nullptr;
+        }
     }
 
     // We trust our consumers to do the encoding of our data correctly, so don't

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -1069,6 +1069,11 @@ void Command::ResetArguments()
                 auto vectorArgument = static_cast<std::vector<uint32_t> *>(arg.value);
                 vectorArgument->clear();
             }
+            else if (type == ArgumentType::Custom)
+            {
+                auto argument = static_cast<CustomArgument *>(arg.value);
+                argument->Reset();
+            }
             else if (type == ArgumentType::VectorCustom)
             {
                 auto vectorArgument = static_cast<std::vector<CustomArgument *> *>(arg.value);


### PR DESCRIPTION
We were not properly cleaning up the buffer in a CustomArgument when a command using it finished.

Addresses the main part of https://github.com/project-chip/connectedhomeip/issues/34221
