### PR TITLE
Darwin: Avoid calling DnssdServer::StartServer() when not initialized

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -188,7 +188,7 @@ void DnssdServer::GetPrimaryOrFallbackMACAddress(chip::MutableByteSpan mac)
 /// Set MDNS operational advertisement
 CHIP_ERROR DnssdServer::AdvertiseOperational()
 {
-    VerifyOrDie(mFabricTable != nullptr);
+    VerifyOrReturnError(mFabricTable != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     for (const FabricInfo & fabricInfo : *mFabricTable)
     {

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -208,7 +208,7 @@ public:
             mGroupDataProvider != nullptr && mReportScheduler != nullptr && mTimerDelegate != nullptr &&
             mSessionKeystore != nullptr && mSessionResumptionStorage != nullptr && mBDXTransferServer != nullptr;
     };
-    bool IsShutDown() { return mHaveShutDown; }
+    bool IsShutDown() const { return mHaveShutDown; }
 
     System::Layer * SystemLayer() const { return mSystemLayer; };
     Inet::EndPointManager<Inet::TCPEndPoint> * TCPEndPointManager() const { return mTCPEndPointManager; };

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -889,11 +889,10 @@ MTR_DIRECT_MEMBERS
     // If we're not advertising, then there's no need to reset anything.
     VerifyOrReturn(_advertiseOperational);
 
-    // If there are no running controllers there will be no advertisements to reset.
-    {
-        std::lock_guard lock(_controllersLock);
-        VerifyOrReturn(_controllers.count > 0);
-    }
+    // Ensure the stack is running. We can't look at _controllers to determine this
+    // reliably because it gets updated early during controller startup from off-queue.
+    auto systemState = _controllerFactory->GetSystemState();
+    VerifyOrReturn(systemState != nullptr && !systemState->IsShutDown());
 
     // StartServer() is the only API we have for resetting DNS-SD advertising.
     // It sure would be nice if there were a "restart" that was a no-op if the


### PR DESCRIPTION
Look at the SystemState directly instead of relying on _controllers.
