### PR TITLE
THNETDIR / WIFINM: Test scripts and small fixes

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -95,6 +95,7 @@ jobs:
                         --target darwin-x64-lit-icd-${BUILD_VARIANT} \
                         --target darwin-x64-microwave-oven-${BUILD_VARIANT} \
                         --target darwin-x64-rvc-${BUILD_VARIANT} \
+                        --target darwin-x64-network-manager-${BUILD_VARIANT} \
                         build \
                         --copy-artifacts-to objdir-clone \
                      "
@@ -116,6 +117,7 @@ jobs:
                      --bridge-app ./out/darwin-x64-bridge-${BUILD_VARIANT}/chip-bridge-app \
                      --microwave-oven-app ./out/darwin-x64-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
                      --rvc-app ./out/darwin-x64-rvc-${BUILD_VARIANT}/chip-rvc-app \
+                     --network-manager-app ./out/darwin-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
                   "
             - name: Run OTA Test
               run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -185,6 +185,7 @@ jobs:
                       src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml \
                       src/app/zap-templates/zcl/data-model/chip/thread-border-router-management-cluster.xml \
                       src/app/zap-templates/zcl/data-model/chip/thread-network-diagnostics-cluster.xml \
+                      src/app/zap-templates/zcl/data-model/chip/thread-network-directory-cluster.xml \
                       src/app/zap-templates/zcl/data-model/chip/time-format-localization-cluster.xml \
                       src/app/zap-templates/zcl/data-model/chip/time-synchronization-cluster.xml \
                       src/app/zap-templates/zcl/data-model/chip/timer-cluster.xml \
@@ -222,6 +223,7 @@ jobs:
                         --target linux-x64-lit-icd-${BUILD_VARIANT} \
                         --target linux-x64-microwave-oven-${BUILD_VARIANT} \
                         --target linux-x64-rvc-${BUILD_VARIANT} \
+                        --target linux-x64-network-manager-${BUILD_VARIANT} \
                         build \
                         --copy-artifacts-to objdir-clone \
                      "
@@ -244,6 +246,7 @@ jobs:
                      --lit-icd-app ./out/linux-x64-lit-icd-${BUILD_VARIANT}/lit-icd-app \
                      --microwave-oven-app ./out/linux-x64-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
                      --rvc-app ./out/linux-x64-rvc-${BUILD_VARIANT}/chip-rvc-app \
+                     --network-manager-app ./out/linux-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
                   "
 
             - name: Run purposeful failure tests using the python parser sending commands to chip-tool
@@ -285,6 +288,7 @@ jobs:
                      --lit-icd-app ./out/linux-x64-lit-icd-${BUILD_VARIANT}/lit-icd-app \
                      --microwave-oven-app ./out/linux-x64-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
                      --rvc-app ./out/linux-x64-rvc-${BUILD_VARIANT}/chip-rvc-app \
+                     --network-manager-app ./out/linux-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
                   "
             - name: Run Tests using chip-repl (including slow)
               if: github.event_name == 'push'
@@ -304,6 +308,7 @@ jobs:
                      --lit-icd-app ./out/linux-x64-lit-icd-${BUILD_VARIANT}/lit-icd-app \
                      --microwave-oven-app ./out/linux-x64-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
                      --rvc-app ./out/linux-x64-rvc-${BUILD_VARIANT}/chip-rvc-app \
+                     --network-manager-app ./out/linux-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
                   "
             - name: Uploading core files
               uses: actions/upload-artifact@v4
@@ -372,6 +377,7 @@ jobs:
                         --target darwin-x64-lit-icd-${BUILD_VARIANT} \
                         --target darwin-x64-microwave-oven-${BUILD_VARIANT} \
                         --target darwin-x64-rvc-${BUILD_VARIANT} \
+                        --target darwin-x64-network-manager-${BUILD_VARIANT} \
                         build \
                         --copy-artifacts-to objdir-clone \
                      "
@@ -395,6 +401,7 @@ jobs:
                      --lit-icd-app ./out/darwin-x64-lit-icd-${BUILD_VARIANT}/lit-icd-app \
                      --microwave-oven-app ./out/darwin-x64-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
                      --rvc-app ./out/darwin-x64-rvc-${BUILD_VARIANT}/chip-rvc-app \
+                     --network-manager-app ./out/darwin-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
                   "
 
             - name: Run purposeful failure tests using the python parser sending commands to chip-tool

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/pigweed.gni")
+import("//build_overrides/pigweed_environment.gni")
 import("${build_root}/chip/java/config.gni")
 import("${build_root}/config/compiler/compiler.gni")
 import("${build_root}/config/sysroot.gni")
@@ -348,7 +349,14 @@ config("cosmetic_default") {
 }
 
 config("runtime_default") {
-  if (is_clang) {  # Using Pigweed clang instead of Darwin host clang
+  if (is_clang &&
+      current_os == "mac") {  # Using Pigweed clang instead of Darwin host clang
+    # Without pw_env_setup_CIPD_PIGWEED defined the hostclang:no_system_libcpp
+    # config silently uses the system libc++, usually resulting in linker errors.
+    assert(
+        defined(pw_env_setup_CIPD_PIGWEED),
+        "//build_overrides/pigweed_environment.gni must define pw_env_setup_CIPD_PIGWEED when using pigweed clang")
+
     configs = [
       "$dir_pw_toolchain/host_clang:no_system_libcpp",
       "$dir_pw_toolchain/host_clang:xcode_sysroot",

--- a/examples/network-manager-app/linux/BUILD.gn
+++ b/examples/network-manager-app/linux/BUILD.gn
@@ -15,7 +15,7 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
-executable("network-manager-app") {
+executable("matter-network-manager-app") {
   sources = [
     "include/CHIPProjectAppConfig.h",
     "main.cpp",
@@ -32,7 +32,7 @@ executable("network-manager-app") {
 }
 
 group("linux") {
-  deps = [ ":network-manager-app" ]
+  deps = [ ":matter-network-manager-app" ]
 }
 
 group("default") {

--- a/examples/network-manager-app/network-manager-common/network-manager-app.matter
+++ b/examples/network-manager-app/network-manager-common/network-manager-app.matter
@@ -1237,7 +1237,7 @@ cluster ThreadNetworkDirectory = 1107 {
   /** Removes an entry from the ThreadNetworks list. */
   timed command access(invoke: manage) RemoveNetwork(RemoveNetworkRequest): DefaultSuccess = 1;
   /** Retrieves a Thread Operational Dataset from the ThreadNetworks list. */
-  timed command GetOperationalDataset(GetOperationalDatasetRequest): OperationalDatasetResponse = 2;
+  command GetOperationalDataset(GetOperationalDatasetRequest): OperationalDatasetResponse = 2;
 }
 
 endpoint 0 {

--- a/examples/network-manager-app/network-manager-common/network-manager-app.matter
+++ b/examples/network-manager-app/network-manager-common/network-manager-app.matter
@@ -1179,7 +1179,8 @@ cluster GroupKeyManagement = 63 {
 cluster WiFiNetworkManagement = 1105 {
   revision 1;
 
-  readonly attribute nullable octet_string<32> ssid = 1;
+  readonly attribute nullable octet_string<32> ssid = 0;
+  readonly attribute access(read: manage) nullable int64u passphraseSurrogate = 1;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
   readonly attribute event_id eventList[] = 65530;
@@ -1192,7 +1193,7 @@ cluster WiFiNetworkManagement = 1105 {
   }
 
   /** Request the current WPA-Personal passphrase or PSK associated with the managed Wi-Fi network. */
-  command access(invoke: administer) NetworkPassphraseRequest(): NetworkPassphraseResponse = 0;
+  command access(invoke: manage) NetworkPassphraseRequest(): NetworkPassphraseResponse = 0;
 }
 
 /** Manages the names and credentials of Thread networks visible to the user. */
@@ -1507,7 +1508,7 @@ endpoint 1 {
   }
 
   server cluster WiFiNetworkManagement {
-    callback attribute ssid;
+    callback attribute passphraseSurrogate;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute eventList;

--- a/examples/network-manager-app/network-manager-common/network-manager-app.matter
+++ b/examples/network-manager-app/network-manager-common/network-manager-app.matter
@@ -1176,7 +1176,7 @@ cluster GroupKeyManagement = 63 {
 }
 
 /** Functionality to retrieve operational information about a managed Wi-Fi network. */
-cluster WiFiNetworkManagement = 1105 {
+provisional cluster WiFiNetworkManagement = 1105 {
   revision 1;
 
   readonly attribute nullable octet_string<32> ssid = 0;
@@ -1197,7 +1197,7 @@ cluster WiFiNetworkManagement = 1105 {
 }
 
 /** Manages the names and credentials of Thread networks visible to the user. */
-cluster ThreadNetworkDirectory = 1107 {
+provisional cluster ThreadNetworkDirectory = 1107 {
   revision 1;
 
   struct ThreadNetworkStruct {

--- a/examples/network-manager-app/network-manager-common/network-manager-app.matter
+++ b/examples/network-manager-app/network-manager-common/network-manager-app.matter
@@ -1508,6 +1508,7 @@ endpoint 1 {
   }
 
   server cluster WiFiNetworkManagement {
+    callback attribute ssid;
     callback attribute passphraseSurrogate;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;

--- a/examples/network-manager-app/network-manager-common/network-manager-app.zap
+++ b/examples/network-manager-app/network-manager-common/network-manager-app.zap
@@ -3238,10 +3238,26 @@
           "attributes": [
             {
               "name": "SSID",
-              "code": 1,
+              "code": 0,
               "mfgCode": null,
               "side": "server",
               "type": "octet_string",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "PassphraseSurrogate",
+              "code": 1,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int64u",
               "included": 1,
               "storageOption": "External",
               "singleton": 0,

--- a/examples/network-manager-app/network-manager-common/network-manager-app.zap
+++ b/examples/network-manager-app/network-manager-common/network-manager-app.zap
@@ -3246,7 +3246,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": null,
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -256,6 +256,9 @@ class HostApp(Enum):
         elif self == HostApp.LIT_ICD:
             yield 'lit-icd-app'
             yield 'lit-icd-app.map'
+        elif self == HostApp.NETWORK_MANAGER:
+            yield 'matter-network-manager-app'
+            yield 'matter-network-manager-app.map'
         elif self == HostApp.ENERGY_MANAGEMENT:
             yield 'chip-energy-management-app'
             yield 'chip-energy-management-app.map'

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -286,6 +286,8 @@ def target_for_name(name: str):
         return TestTarget.MWO
     if name.startswith("Test_TC_RVCRUNM_") or name.startswith("Test_TC_RVCCLEANM_") or name.startswith("Test_TC_RVCOPSTATE_"):
         return TestTarget.RVC
+    if name.startswith("Test_TC_THNETDIR_"):
+        return TestTarget.NETWORK_MANAGER
     return TestTarget.ALL_CLUSTERS
 
 

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -286,7 +286,7 @@ def target_for_name(name: str):
         return TestTarget.MWO
     if name.startswith("Test_TC_RVCRUNM_") or name.startswith("Test_TC_RVCCLEANM_") or name.startswith("Test_TC_RVCOPSTATE_"):
         return TestTarget.RVC
-    if name.startswith("Test_TC_THNETDIR_"):
+    if name.startswith("Test_TC_THNETDIR_") or name.startswith("Test_TC_WIFINM_"):
         return TestTarget.NETWORK_MANAGER
     return TestTarget.ALL_CLUSTERS
 

--- a/scripts/tests/chiptest/linux.py
+++ b/scripts/tests/chiptest/linux.py
@@ -184,6 +184,7 @@ def PathsWithNetworkNamespaces(paths: ApplicationPaths) -> ApplicationPaths:
         lit_icd_app='ip netns exec app'.split() + paths.lit_icd_app,
         microwave_oven_app='ip netns exec app'.split() + paths.microwave_oven_app,
         rvc_app='ip netns exec app'.split() + paths.rvc_app,
+        network_manager_app='ip netns exec app'.split() + paths.network_manager_app,
         bridge_app='ip netns exec app'.split() + paths.bridge_app,
         chip_repl_yaml_tester_cmd='ip netns exec tool'.split() + paths.chip_repl_yaml_tester_cmd,
         chip_tool_with_python_cmd='ip netns exec tool'.split() + paths.chip_tool_with_python_cmd,

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -177,6 +177,7 @@ class TestTarget(Enum):
     LIT_ICD = auto()
     MWO = auto()
     RVC = auto()
+    NETWORK_MANAGER = auto()
 
 
 @dataclass
@@ -193,10 +194,11 @@ class ApplicationPaths:
     chip_repl_yaml_tester_cmd: typing.List[str]
     chip_tool_with_python_cmd: typing.List[str]
     rvc_app: typing.List[str]
+    network_manager_app: typing.List[str]
 
     def items(self):
         return [self.chip_tool, self.all_clusters_app, self.lock_app, self.ota_provider_app, self.ota_requestor_app,
-                self.tv_app, self.bridge_app, self.lit_icd_app, self.microwave_oven_app, self.chip_repl_yaml_tester_cmd, self.chip_tool_with_python_cmd, self.rvc_app]
+                self.tv_app, self.bridge_app, self.lit_icd_app, self.microwave_oven_app, self.chip_repl_yaml_tester_cmd, self.chip_tool_with_python_cmd, self.rvc_app, self.network_manager_app]
 
 
 @dataclass
@@ -309,6 +311,8 @@ class TestDefinition:
                 target_app = paths.microwave_oven_app
             elif self.target == TestTarget.RVC:
                 target_app = paths.rvc_app
+            elif self.target == TestTarget.NETWORK_MANAGER:
+                target_app = paths.network_manager_app
             else:
                 raise Exception("Unknown test target - "
                                 "don't know which application to run")

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -261,6 +261,9 @@ def cmd_list(context):
     '--rvc-app',
     help='what rvc app to use')
 @click.option(
+    '--network-manager-app',
+    help='what network-manager app to use')
+@click.option(
     '--chip-repl-yaml-tester',
     help='what python script to use for running yaml tests using chip-repl as controller')
 @click.option(
@@ -291,7 +294,7 @@ def cmd_list(context):
     help='Number of tests that are expected to fail in each iteration.  Overall test will pass if the number of failures matches this.  Nonzero values require --keep-going')
 @click.pass_context
 def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, ota_requestor_app,
-            tv_app, bridge_app, lit_icd_app, microwave_oven_app, rvc_app, chip_repl_yaml_tester, chip_tool_with_python, pics_file, keep_going, test_timeout_seconds, expected_failures):
+            tv_app, bridge_app, lit_icd_app, microwave_oven_app, rvc_app, network_manager_app, chip_repl_yaml_tester, chip_tool_with_python, pics_file, keep_going, test_timeout_seconds, expected_failures):
     if expected_failures != 0 and not keep_going:
         logging.exception(f"'--expected-failures {expected_failures}' used without '--keep-going'")
         sys.exit(2)
@@ -327,6 +330,9 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, o
     if rvc_app is None:
         rvc_app = paths_finder.get('chip-rvc-app')
 
+    if network_manager_app is None:
+        network_manager_app = paths_finder.get('matter-network-manager-app')
+
     if chip_repl_yaml_tester is None:
         chip_repl_yaml_tester = paths_finder.get('yamltest_with_chip_repl_tester.py')
 
@@ -348,6 +354,7 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, o
         lit_icd_app=[lit_icd_app],
         microwave_oven_app=[microwave_oven_app],
         rvc_app=[rvc_app],
+        network_manager_app=[network_manager_app],
         chip_repl_yaml_tester_cmd=['python3'] + [chip_repl_yaml_tester],
         chip_tool_with_python_cmd=['python3'] + [chip_tool_with_python],
     )

--- a/src/app/clusters/thread-network-directory-server/thread-network-directory-server.cpp
+++ b/src/app/clusters/thread-network-directory-server/thread-network-directory-server.cpp
@@ -274,8 +274,10 @@ void ThreadNetworkDirectoryServer::HandleOperationalDatasetRequest(
 
     uint8_t datasetBuffer[kSizeOperationalDataset];
     MutableByteSpan datasetSpan(datasetBuffer);
+    OperationalDatasetResponse::Type response;
     SuccessOrExit(err = mStorage.GetNetworkDataset(ExtendedPanId(req.extendedPanID), datasetSpan));
-    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, IMStatus::Success);
+    response.operationalDataset = datasetSpan;
+    ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
     return;
 exit:
     ChipLogError(Zcl, "GetOperationalDataset: %" CHIP_ERROR_FORMAT, err.Format());

--- a/src/app/clusters/wifi-network-management-server/wifi-network-management-server.cpp
+++ b/src/app/clusters/wifi-network-management-server/wifi-network-management-server.cpp
@@ -22,6 +22,7 @@
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/reporting.h>
 #include <lib/support/CodeUtils.h>
+#include <system/SystemClock.h>
 
 #include <algorithm>
 #include <cctype>
@@ -99,10 +100,19 @@ CHIP_ERROR WiFiNetworkManagementServer::SetNetworkCredentials(ByteSpan ssid, Byt
     VerifyOrDie(mPassphrase.SetLength(passphrase.size()) == CHIP_NO_ERROR);
     memcpy(mPassphrase.Bytes(), passphrase.data(), passphrase.size());
 
-    // Note: The spec currently defines no way to signal a passphrase change
     if (ssidChanged)
     {
         MatterReportingAttributeChangeCallback(GetEndpointId(), WiFiNetworkManagement::Id, Ssid::Id);
+    }
+    if (passphraseChanged)
+    {
+        mPassphraseSurrogate++;
+        System::Clock::Milliseconds64 realtime;
+        if (System::SystemClock().GetClock_RealTimeMS(realtime) == CHIP_NO_ERROR)
+        {
+            mPassphraseSurrogate = std::max(mPassphraseSurrogate, realtime.count());
+        }
+        MatterReportingAttributeChangeCallback(GetEndpointId(), WiFiNetworkManagement::Id, PassphraseSurrogate::Id);
     }
     return CHIP_NO_ERROR;
 }
@@ -113,6 +123,8 @@ CHIP_ERROR WiFiNetworkManagementServer::Read(const ConcreteReadAttributePath & a
     {
     case Ssid::Id:
         return HaveNetworkCredentials() ? aEncoder.Encode(SsidSpan()) : aEncoder.EncodeNull();
+    case PassphraseSurrogate::Id:
+        return HaveNetworkCredentials() ? aEncoder.Encode(mPassphraseSurrogate) : aEncoder.EncodeNull();
     }
     return CHIP_NO_ERROR;
 }

--- a/src/app/clusters/wifi-network-management-server/wifi-network-management-server.h
+++ b/src/app/clusters/wifi-network-management-server/wifi-network-management-server.h
@@ -57,6 +57,7 @@ private:
     static_assert(std::numeric_limits<decltype(mSsidLen)>::max() >= sizeof(mSsid));
     ByteSpan SsidSpan() const { return ByteSpan(mSsid, mSsidLen); }
 
+    uint64_t mPassphraseSurrogate = 0;
     Crypto::SensitiveDataBuffer<64> mPassphrase;
     ByteSpan PassphraseSpan() const { return mPassphrase.Span(); }
 

--- a/src/app/tests/suites/certification/PICS.yaml
+++ b/src/app/tests/suites/certification/PICS.yaml
@@ -10199,3 +10199,11 @@ PICS:
 
     - label: "Does the device implement the ActiveEndpoints attribute?"
       id: PWRTL.S.A0001
+
+    #
+    # Thread Network Directory Cluster
+    #
+    - label:
+          "Does the device implement the Thread Network Directory cluster as a
+          server"
+      id: THNETDIR.S

--- a/src/app/tests/suites/certification/PICS.yaml
+++ b/src/app/tests/suites/certification/PICS.yaml
@@ -10207,3 +10207,11 @@ PICS:
           "Does the device implement the Thread Network Directory cluster as a
           server"
       id: THNETDIR.S
+
+    #
+    # Wi-Fi Network Management Cluster
+    #
+    - label:
+          "Does the device implement the Wi-Fi Network Management cluster as a
+          server"
+      id: WIFINM.S

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_1.yaml
@@ -1,0 +1,51 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "[TC-THNETDIR-2.1] Simple Attributes check with DUT as Server"
+
+PICS:
+    - THNETDIR.S
+
+config:
+    nodeId: 0x12344321
+    cluster: Thread Network Directory
+    endpoint: 1
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: DelayCommands
+      command: WaitForCommissionee
+      arguments:
+          values:
+              - name: nodeId
+                value: nodeId
+
+    - label: "TH reads SupportedFabrics attribute from DUT"
+      command: readAttribute
+      endpoint: 0
+      cluster: Operational Credentials
+      attribute: SupportedFabrics
+      response:
+          saveAs: supportedFabrics
+          constraints:
+              type: int8u
+
+    - label: "TH reads ThreadNetworkTableSize attribute from DUT"
+      command: readAttribute
+      attribute: ThreadNetworkTableSize
+      response:
+          constraints:
+              type: int8u
+              minValue: 10 # assume 5 supported fabrics
+              # python: value >= 2 * supportedFabrics

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
@@ -1,0 +1,199 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "[TC-THNETDIR-2.2] Verification for Add/Remove/Get commands"
+
+PICS:
+    - THNETDIR.S
+
+config:
+    nodeId: 0x12344321
+    cluster: Thread Network Directory
+    endpoint: 1
+
+    # Note: TestNetwork* values need to match what's encoded in TestNetworkDataset
+    TestNetworkDataset:
+        type: octet_string
+        defaultValue: "hex:0e080000000000000001000300000f350407fff800020839758ec8144b07fb0708fdf1f1add0797dc00510f366cec7a446bab978d90d27abe38f23030f4f70656e5468726561642d353933380102593804103ca67c969efb0d0c74a4d8ee923b576c0c0402a0f7f8"
+    TestNetworkExtendedPanId:
+        type: octet_string
+        defaultValue: "hex:39758ec8144b07fb"
+    TestNetworkName: "OpenThread-5938"
+    TestNetworkChannel: 15
+    TestNetworkActiveTimestamp: 1
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: DelayCommands
+      command: WaitForCommissionee
+      arguments:
+          values:
+              - name: nodeId
+                value: nodeId
+
+    - label: "TH reads ThreadNetworks attribute from DUT"
+      command: readAttribute
+      attribute: ThreadNetworks
+      response:
+          saveAs: initialNetworks
+          constraints:
+              type: list
+
+    - label: "TH reads PreferredExtendedPanID attribute from DUT"
+      command: readAttribute
+      attribute: PreferredExtendedPanID
+      response:
+          constraints:
+              type: octet_string
+              minLength: 8
+              maxLength: 8
+              notValue: TestNetworkExtendedPanId
+
+    - label:
+          "TH writes ExtendedPanID from TestNetwork to PreferredExtendedPanID on
+          DUT"
+      command: writeAttribute
+      attribute: PreferredExtendedPanID
+      arguments:
+          value: TestNetworkExtendedPanId
+      response:
+          error: CONSTRAINT_ERROR # TestNetwork is not in ThreadNetworks
+
+    - label:
+          "TH sends GetOperationalDataset command to DUT with ExtendedPanID of
+          TestNetwork"
+      command: GetOperationalDataset
+      arguments:
+          values:
+              - name: ExtendedPanID
+                value: TestNetworkExtendedPanId
+      response:
+          error: NOT_FOUND
+
+    - label: "TH sends AddNetwork command to DUT without a timed interaction"
+      command: AddNetwork
+      arguments:
+          values:
+              - name: OperationalDataset
+                value: TestNetworkDataset
+      response:
+          error: NEEDS_TIMED_INTERACTION
+
+    - label: "TH sends AddNetwork command to DUT with TestNetwork dataset"
+      command: AddNetwork
+      timedInteractionTimeoutMs: 2000
+      arguments:
+          values:
+              - name: OperationalDataset
+                value: TestNetworkDataset
+
+    - label: "TH reads ThreadNetworks attribute from DUT"
+      command: readAttribute
+      attribute: ThreadNetworks
+      response:
+          constraints:
+              type: list
+              #   python: |
+              #       # Split the list into test (our TestNetwork) and rest (everything else)
+              #       test = next((n for n in value if n['ExtendedPanID'] == TestNetworkExtendedPanId), None)
+              #       rest = [n for n in value if n != test]
+              #       # Check test has the expected values and rest == initialNetworks (ignoring order)
+              #       return (test is not None and
+              #               test['NetworkName'] == TestNetworkName and
+              #               test['Channel'] == TestNetworkChannel and
+              #               test['ActiveTimestamp'] == TestNetworkActiveTimestamp and
+              #               len(value) == len(initialNetworks) + 1 and
+              #               len(rest) == len(initialNetworks) and
+              #               all(n in initialNetworks for n in rest))
+
+    - label:
+          "TH sends GetOperationalDataset command to DUT with ExtendedPanID from
+          TestNetwork"
+      command: GetOperationalDataset
+      arguments:
+          values:
+              - name: ExtendedPanID
+                value: TestNetworkExtendedPanId
+      response:
+          values:
+              - name: OperationalDataset
+                value: TestNetworkDataset
+
+    - label:
+          "TH writes ExtendedPanID from TestNetwork to PreferredExtendedPanID on
+          DUT"
+      command: writeAttribute
+      attribute: PreferredExtendedPanID
+      arguments:
+          value: TestNetworkExtendedPanId
+
+    - label: "TH reads PreferredExtendedPanID attribute from DUT"
+      command: readAttribute
+      attribute: PreferredExtendedPanID
+      response:
+          value: TestNetworkExtendedPanId
+
+    - label: "TH sends RemoveNetwork command to DUT without a timed interaction"
+      command: RemoveNetwork
+      arguments:
+          values:
+              - name: ExtendedPanID
+                value: TestNetworkExtendedPanId
+      response:
+          error: NEEDS_TIMED_INTERACTION
+
+    - label:
+          "TH sends RemoveNetwork command to DUT with ExtendedPanID of
+          TestNetwork while it is the preferred network"
+      command: RemoveNetwork
+      timedInteractionTimeoutMs: 2000
+      arguments:
+          values:
+              - name: ExtendedPanID
+                value: TestNetworkExtendedPanId
+      response:
+          error: CONSTRAINT_ERROR # Preferred network cannot be removed
+
+    - label: "TH writes null to PreferredExtendedPanID on DUT"
+      command: writeAttribute
+      attribute: PreferredExtendedPanID
+      arguments:
+          value: null
+
+    - label: "TH reads PreferredExtendedPanID attribute from DUT"
+      command: readAttribute
+      attribute: PreferredExtendedPanID
+      response:
+          value: null
+
+    - label:
+          "TH sends RemoveNetwork command to DUT with ExtendedPanID of
+          TestNetwork"
+      command: RemoveNetwork
+      timedInteractionTimeoutMs: 2000
+      arguments:
+          values:
+              - name: ExtendedPanID
+                value: TestNetworkExtendedPanId
+
+    - label: "TH reads ThreadNetworks attribute from DUT"
+      command: readAttribute
+      attribute: ThreadNetworks
+      response:
+          constraints:
+              type: list
+              #   python: |
+              #       # value == initialNetworks (ignoring order)
+              #       return (len(value) == len(initialNetworks) and
+              #               all(n in initialNetworks for n in value))

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
@@ -81,14 +81,15 @@ tests:
       response:
           error: NOT_FOUND
 
-    - label: "TH sends AddNetwork command to DUT without a timed interaction"
-      command: AddNetwork
-      arguments:
-          values:
-              - name: OperationalDataset
-                value: TestNetworkDataset
-      response:
-          error: NEEDS_TIMED_INTERACTION
+    # TODO: Currently fails with darwin-framework-tool because it automatically performs a timed invoke
+    # - label: "TH sends AddNetwork command to DUT without a timed interaction"
+    #   command: AddNetwork
+    #   arguments:
+    #       values:
+    #           - name: OperationalDataset
+    #             value: TestNetworkDataset
+    #   response:
+    #       error: NEEDS_TIMED_INTERACTION
 
     - label: "TH sends AddNetwork command to DUT with TestNetwork dataset"
       command: AddNetwork
@@ -144,14 +145,15 @@ tests:
       response:
           value: TestNetworkExtendedPanId
 
-    - label: "TH sends RemoveNetwork command to DUT without a timed interaction"
-      command: RemoveNetwork
-      arguments:
-          values:
-              - name: ExtendedPanID
-                value: TestNetworkExtendedPanId
-      response:
-          error: NEEDS_TIMED_INTERACTION
+    # TODO: Currently fails with darwin-framework-tool because it automatically performs a timed invoke
+    # - label: "TH sends RemoveNetwork command to DUT without a timed interaction"
+    #   command: RemoveNetwork
+    #   arguments:
+    #       values:
+    #           - name: ExtendedPanID
+    #             value: TestNetworkExtendedPanId
+    #   response:
+    #       error: NEEDS_TIMED_INTERACTION
 
     - label:
           "TH sends RemoveNetwork command to DUT with ExtendedPanID of

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
@@ -54,6 +54,7 @@ tests:
       command: readAttribute
       attribute: PreferredExtendedPanID
       response:
+          saveAs: initialPreferredExtendedPanID
           constraints:
               type: octet_string
               minLength: 8
@@ -69,6 +70,14 @@ tests:
           value: TestNetworkExtendedPanId
       response:
           error: CONSTRAINT_ERROR # TestNetwork is not in ThreadNetworks
+
+    - label:
+          "TH reads PreferredExtendedPanID attribute from DUT, verifying that
+          the value did not change"
+      command: readAttribute
+      attribute: PreferredExtendedPanID
+      response:
+          value: initialPreferredExtendedPanID
 
     - label:
           "TH sends GetOperationalDataset command to DUT with ExtendedPanID of
@@ -99,7 +108,9 @@ tests:
               - name: OperationalDataset
                 value: TestNetworkDataset
 
-    - label: "TH reads ThreadNetworks attribute from DUT"
+    - label:
+          "TH reads ThreadNetworks attribute from DUT, verifying that the
+          network has been added"
       command: readAttribute
       attribute: ThreadNetworks
       response:
@@ -139,7 +150,9 @@ tests:
       arguments:
           value: TestNetworkExtendedPanId
 
-    - label: "TH reads PreferredExtendedPanID attribute from DUT"
+    - label:
+          "TH reads PreferredExtendedPanID attribute from DUT, verifying that
+          the value was written"
       command: readAttribute
       attribute: PreferredExtendedPanID
       response:
@@ -173,7 +186,9 @@ tests:
       arguments:
           value: null
 
-    - label: "TH reads PreferredExtendedPanID attribute from DUT"
+    - label:
+          "TH reads PreferredExtendedPanID attribute from DUT, verifying that
+          the value was cleared"
       command: readAttribute
       attribute: PreferredExtendedPanID
       response:
@@ -189,7 +204,9 @@ tests:
               - name: ExtendedPanID
                 value: TestNetworkExtendedPanId
 
-    - label: "TH reads ThreadNetworks attribute from DUT"
+    - label:
+          "TH reads ThreadNetworks attribute from DUT, verifying that the
+          network was removed"
       command: readAttribute
       attribute: ThreadNetworks
       response:
@@ -199,3 +216,10 @@ tests:
               #       # value == initialNetworks (ignoring order)
               #       return (len(value) == len(initialNetworks) and
               #               all(n in initialNetworks for n in value))
+
+    - label:
+          "TH writes PreferredExtendedPanID to DUT, restoring the initial value"
+      command: writeAttribute
+      attribute: PreferredExtendedPanID
+      arguments:
+          value: initialPreferredExtendedPanID

--- a/src/app/tests/suites/certification/Test_TC_WIFINM_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WIFINM_2_1.yaml
@@ -43,6 +43,14 @@ tests:
               minLength: 1
               maxLength: 32
 
+    - label: "TH reads the PassphraseSurrogate attribute from the DUT"
+      command: readAttribute
+      attribute: PassphraseSurrogate
+      response:
+          constraints:
+              type: int64u
+              hasValue: true
+
     - label: "TH sends the NetworkPassphraseRequest command to the DUT"
       command: NetworkPassphraseRequest
       response:

--- a/src/app/tests/suites/certification/Test_TC_WIFINM_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WIFINM_2_1.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "[TC-WIFINM-2.1] Attributes and commands with DUT as Server"
+
+PICS:
+    - WIFINM.S
+
+config:
+    nodeId: 0x12344321
+    cluster: WiFi Network Management
+    endpoint: 1
+
+# Note: This test assumes the DUT has an active Wi-Fi network, i.e.
+# SSID is not null and NetworkPassphraseRequest returns a passphrase.
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: DelayCommands
+      command: WaitForCommissionee
+      arguments:
+          values:
+              - name: nodeId
+                value: nodeId
+
+    - label: "TH reads the SSID attribute from the DUT"
+      command: readAttribute
+      attribute: SSID
+      response:
+          constraints:
+              type: octet_string
+              hasValue: true
+              minLength: 1
+              maxLength: 32
+
+    - label: "TH sends the NetworkPassphraseRequest command to the DUT"
+      command: NetworkPassphraseRequest
+      response:
+          values:
+              - name: Passphrase
+                constraints:
+                    type: octet_string
+                    hasValue: true
+                    minLength: 8
+                    maxLength: 64

--- a/src/app/tests/suites/certification/ci-pics-values
+++ b/src/app/tests/suites/certification/ci-pics-values
@@ -2988,3 +2988,6 @@ PWRTL.S.F00=0
 PWRTL.S.F01=0
 PWRTL.S.F02=1
 PWRTL.S.F03=1
+
+# Thread Network Directory Cluster
+THNETDIR.S=1

--- a/src/app/tests/suites/certification/ci-pics-values
+++ b/src/app/tests/suites/certification/ci-pics-values
@@ -2991,3 +2991,6 @@ PWRTL.S.F03=1
 
 # Thread Network Directory Cluster
 THNETDIR.S=1
+
+# Wi-Fi Network Management Cluster
+WIFINM.S=1

--- a/src/app/zap-templates/zcl/data-model/chip/thread-network-directory-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-network-directory-cluster.xml
@@ -17,7 +17,7 @@ limitations under the License.
 <configurator>
     <domain name="CHIP"/>
 
-    <struct name="ThreadNetworkStruct">
+    <struct name="ThreadNetworkStruct" apiMaturity="provisional">
         <cluster code="0x0453"/>
         <item name="ExtendedPanID" type="octet_string" length="8"/>
         <item name="NetworkName" type="char_string" length="16"/>
@@ -25,7 +25,7 @@ limitations under the License.
         <item name="ActiveTimestamp" type="int64u"/>
     </struct>
 
-    <cluster>
+    <cluster apiMaturity="provisional">
         <domain>Network Infrastructure</domain>
         <name>Thread Network Directory</name>
         <code>0x0453</code>

--- a/src/app/zap-templates/zcl/data-model/chip/thread-network-directory-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-network-directory-cluster.xml
@@ -59,7 +59,7 @@ limitations under the License.
             <access op="invoke" privilege="manage"/>
             <arg name="ExtendedPanID" type="octet_string" length="8"/>
         </command>
-        <command source="client" code="0x02" name="GetOperationalDataset" mustUseTimedInvoke="true" optional="false" response="OperationalDatasetResponse">
+        <command source="client" code="0x02" name="GetOperationalDataset" optional="false" response="OperationalDatasetResponse">
             <description>Retrieves a Thread Operational Dataset from the ThreadNetworks list.</description>
             <access op="invoke" privilege="operate"/>
             <arg name="ExtendedPanID" type="octet_string" length="8"/>

--- a/src/app/zap-templates/zcl/data-model/chip/wifi-network-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wifi-network-management-cluster.xml
@@ -17,7 +17,7 @@ limitations under the License.
 <configurator>
     <domain name="CHIP"/>
 
-    <cluster>
+    <cluster apiMaturity="provisional">
         <domain>Network Infrastructure</domain>
         <name>Wi-Fi Network Management</name>
         <code>0x0451</code>

--- a/src/app/zap-templates/zcl/data-model/chip/wifi-network-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wifi-network-management-cluster.xml
@@ -30,11 +30,15 @@ limitations under the License.
         <!-- cluster revision -->
         <globalAttribute side="either" code="0xFFFD" value="1"/>
 
-        <attribute side="server" code="0x0001" define="SSID" type="octet_string" length="32" writable="false" isNullable="true" optional="false">SSID</attribute>
+        <attribute side="server" code="0x0000" define="SSID" type="octet_string" length="32" writable="false" isNullable="true" optional="false">SSID</attribute>
+        <attribute side="server" code="0x0001" define="PASSPHRASE_SURROGATE" type="int64u" writable="false" isNullable="true" optional="false">
+            <description>PassphraseSurrogate</description>
+            <access op="read" privilege="manage"/>
+        </attribute>
 
         <command source="client" code="0x00" name="NetworkPassphraseRequest" optional="false" response="NetworkPassphraseResponse">
             <description>Request the current WPA-Personal passphrase or PSK associated with the managed Wi-Fi network.</description>
-            <access op="invoke" privilege="administer"/>
+            <access op="invoke" privilege="manage"/>
         </command>
         <command source="server" code="0x01" name="NetworkPassphraseResponse" optional="false">
             <description>This is the response to a NetworkPassphraseRequest.</description>

--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -645,7 +645,7 @@
         "Valve Configuration and Control": ["RemainingDuration"],
         "Boolean State Configuration": ["CurrentSensitivityLevel"],
         "Water Heater Mode": ["SupportedModes", "CurrentMode", "FeatureMap"],
-        "Wi-Fi Network Management": ["SSID"],
+        "Wi-Fi Network Management": ["SSID", "PassphraseSurrogate"],
         "Thread Network Directory": [
             "PreferredExtendedPanID",
             "ThreadNetworks",

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -643,7 +643,7 @@
         "Valve Configuration and Control": ["RemainingDuration"],
         "Boolean State Configuration": ["CurrentSensitivityLevel"],
         "Water Heater Mode": ["SupportedModes", "CurrentMode", "FeatureMap"],
-        "Wi-Fi Network Management": ["SSID"],
+        "Wi-Fi Network Management": ["SSID", "PassphraseSurrogate"],
         "Thread Network Directory": [
             "PreferredExtendedPanID",
             "ThreadNetworks",

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -8103,7 +8103,7 @@ cluster RadonConcentrationMeasurement = 1071 {
 }
 
 /** Functionality to retrieve operational information about a managed Wi-Fi network. */
-cluster WiFiNetworkManagement = 1105 {
+provisional cluster WiFiNetworkManagement = 1105 {
   revision 1;
 
   readonly attribute nullable octet_string<32> ssid = 0;
@@ -8167,7 +8167,7 @@ provisional cluster ThreadBorderRouterManagement = 1106 {
 }
 
 /** Manages the names and credentials of Thread networks visible to the user. */
-cluster ThreadNetworkDirectory = 1107 {
+provisional cluster ThreadNetworkDirectory = 1107 {
   revision 1;
 
   struct ThreadNetworkStruct {

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -8207,7 +8207,7 @@ cluster ThreadNetworkDirectory = 1107 {
   /** Removes an entry from the ThreadNetworks list. */
   timed command access(invoke: manage) RemoveNetwork(RemoveNetworkRequest): DefaultSuccess = 1;
   /** Retrieves a Thread Operational Dataset from the ThreadNetworks list. */
-  timed command GetOperationalDataset(GetOperationalDatasetRequest): OperationalDatasetResponse = 2;
+  command GetOperationalDataset(GetOperationalDatasetRequest): OperationalDatasetResponse = 2;
 }
 
 /** This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol. */

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -8106,7 +8106,8 @@ cluster RadonConcentrationMeasurement = 1071 {
 cluster WiFiNetworkManagement = 1105 {
   revision 1;
 
-  readonly attribute nullable octet_string<32> ssid = 1;
+  readonly attribute nullable octet_string<32> ssid = 0;
+  readonly attribute access(read: manage) nullable int64u passphraseSurrogate = 1;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
   readonly attribute event_id eventList[] = 65530;
@@ -8119,7 +8120,7 @@ cluster WiFiNetworkManagement = 1105 {
   }
 
   /** Request the current WPA-Personal passphrase or PSK associated with the managed Wi-Fi network. */
-  command access(invoke: administer) NetworkPassphraseRequest(): NetworkPassphraseResponse = 0;
+  command access(invoke: manage) NetworkPassphraseRequest(): NetworkPassphraseResponse = 0;
 }
 
 /** Manage the Thread network of Thread Border Router */

--- a/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
@@ -54170,7 +54170,8 @@ public class ChipClusters {
   public static class WiFiNetworkManagementCluster extends BaseChipCluster {
     public static final long CLUSTER_ID = 1105L;
 
-    private static final long SSID_ATTRIBUTE_ID = 1L;
+    private static final long SSID_ATTRIBUTE_ID = 0L;
+    private static final long PASSPHRASE_SURROGATE_ATTRIBUTE_ID = 1L;
     private static final long GENERATED_COMMAND_LIST_ATTRIBUTE_ID = 65528L;
     private static final long ACCEPTED_COMMAND_LIST_ATTRIBUTE_ID = 65529L;
     private static final long EVENT_LIST_ATTRIBUTE_ID = 65530L;
@@ -54222,6 +54223,10 @@ public class ChipClusters {
       void onSuccess(@Nullable byte[] value);
     }
 
+    public interface PassphraseSurrogateAttributeCallback extends BaseAttributeCallback {
+      void onSuccess(@Nullable Long value);
+    }
+
     public interface GeneratedCommandListAttributeCallback extends BaseAttributeCallback {
       void onSuccess(List<Long> value);
     }
@@ -54262,6 +54267,32 @@ public class ChipClusters {
             callback.onSuccess(value);
           }
         }, SSID_ATTRIBUTE_ID, minInterval, maxInterval);
+    }
+
+    public void readPassphraseSurrogateAttribute(
+        PassphraseSurrogateAttributeCallback callback) {
+      ChipAttributePath path = ChipAttributePath.newInstance(endpointId, clusterId, PASSPHRASE_SURROGATE_ATTRIBUTE_ID);
+
+      readAttribute(new ReportCallbackImpl(callback, path) {
+          @Override
+          public void onSuccess(byte[] tlv) {
+            @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
+          }
+        }, PASSPHRASE_SURROGATE_ATTRIBUTE_ID, true);
+    }
+
+    public void subscribePassphraseSurrogateAttribute(
+        PassphraseSurrogateAttributeCallback callback, int minInterval, int maxInterval) {
+      ChipAttributePath path = ChipAttributePath.newInstance(endpointId, clusterId, PASSPHRASE_SURROGATE_ATTRIBUTE_ID);
+
+      subscribeAttribute(new ReportCallbackImpl(callback, path) {
+          @Override
+          public void onSuccess(byte[] tlv) {
+            @Nullable Long value = ChipTLVValueDecoder.decodeAttributeValue(path, tlv);
+            callback.onSuccess(value);
+          }
+        }, PASSPHRASE_SURROGATE_ATTRIBUTE_ID, minInterval, maxInterval);
     }
 
     public void readGeneratedCommandListAttribute(

--- a/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
@@ -54910,6 +54910,9 @@ public class ChipClusters {
         }}, commandId, commandArgs, timedInvokeTimeoutMs);
     }
 
+    public void getOperationalDataset(OperationalDatasetResponseCallback callback, byte[] extendedPanID) {
+      getOperationalDataset(callback, extendedPanID, 0);
+    }
 
     public void getOperationalDataset(OperationalDatasetResponseCallback callback, byte[] extendedPanID, int timedInvokeTimeoutMs) {
       final long commandId = 2L;

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterIDMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterIDMapping.java
@@ -14716,7 +14716,8 @@ public class ClusterIDMapping {
         }
 
         public enum Attribute {
-            Ssid(1L),
+            Ssid(0L),
+            PassphraseSurrogate(1L),
             GeneratedCommandList(65528L),
             AcceptedCommandList(65529L),
             EventList(65530L),

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterInfoMapping.java
@@ -27716,7 +27716,7 @@ public class ClusterInfoMapping {
            , (byte[])
              commandArguments.get("extendedPanID")
 
-            , 10000);
+            );
         },
         () -> new DelegatedThreadNetworkDirectoryClusterOperationalDatasetResponseCallback(),
         threadNetworkDirectorygetOperationalDatasetCommandParams

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterInfoMapping.java
@@ -17876,6 +17876,27 @@ public class ClusterInfoMapping {
     }
   }
 
+  public static class DelegatedWiFiNetworkManagementClusterPassphraseSurrogateAttributeCallback implements ChipClusters.WiFiNetworkManagementCluster.PassphraseSurrogateAttributeCallback, DelegatedClusterCallback {
+    private ClusterCommandCallback callback;
+    @Override
+    public void setCallbackDelegate(ClusterCommandCallback callback) {
+      this.callback = callback;
+    }
+
+    @Override
+    public void onSuccess(@Nullable Long value) {
+      Map<CommandResponseInfo, Object> responseValues = new LinkedHashMap<>();
+      CommandResponseInfo commandResponseInfo = new CommandResponseInfo("value", "Long");
+      responseValues.put(commandResponseInfo, value);
+      callback.onSuccess(responseValues);
+    }
+
+    @Override
+    public void onError(Exception ex) {
+      callback.onFailure(ex);
+    }
+  }
+
   public static class DelegatedWiFiNetworkManagementClusterGeneratedCommandListAttributeCallback implements ChipClusters.WiFiNetworkManagementCluster.GeneratedCommandListAttributeCallback, DelegatedClusterCallback {
     private ClusterCommandCallback callback;
     @Override

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterReadMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterReadMapping.java
@@ -16938,6 +16938,17 @@ public class ClusterReadMapping {
           readWiFiNetworkManagementSsidCommandParams
         );
         result.put("readSsidAttribute", readWiFiNetworkManagementSsidAttributeInteractionInfo);
+     Map<String, CommandParameterInfo> readWiFiNetworkManagementPassphraseSurrogateCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
+        InteractionInfo readWiFiNetworkManagementPassphraseSurrogateAttributeInteractionInfo = new InteractionInfo(
+          (cluster, callback, commandArguments) -> {
+            ((ChipClusters.WiFiNetworkManagementCluster) cluster).readPassphraseSurrogateAttribute(
+              (ChipClusters.WiFiNetworkManagementCluster.PassphraseSurrogateAttributeCallback) callback
+            );
+          },
+          () -> new ClusterInfoMapping.DelegatedWiFiNetworkManagementClusterPassphraseSurrogateAttributeCallback(),
+          readWiFiNetworkManagementPassphraseSurrogateCommandParams
+        );
+        result.put("readPassphraseSurrogateAttribute", readWiFiNetworkManagementPassphraseSurrogateAttributeInteractionInfo);
      Map<String, CommandParameterInfo> readWiFiNetworkManagementGeneratedCommandListCommandParams = new LinkedHashMap<String, CommandParameterInfo>();
         InteractionInfo readWiFiNetworkManagementGeneratedCommandListAttributeInteractionInfo = new InteractionInfo(
           (cluster, callback, commandArguments) -> {

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/ThreadNetworkDirectoryCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/ThreadNetworkDirectoryCluster.kt
@@ -154,7 +154,7 @@ class ThreadNetworkDirectoryCluster(
 
   suspend fun getOperationalDataset(
     extendedPanID: ByteArray,
-    timedInvokeTimeout: Duration,
+    timedInvokeTimeout: Duration? = null,
   ): OperationalDatasetResponse {
     val commandId: UInt = 2u
 

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/WiFiNetworkManagementCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/WiFiNetworkManagementCluster.kt
@@ -55,6 +55,16 @@ class WiFiNetworkManagementCluster(
     object SubscriptionEstablished : SsidAttributeSubscriptionState()
   }
 
+  class PassphraseSurrogateAttribute(val value: ULong?)
+
+  sealed class PassphraseSurrogateAttributeSubscriptionState {
+    data class Success(val value: ULong?) : PassphraseSurrogateAttributeSubscriptionState()
+
+    data class Error(val exception: Exception) : PassphraseSurrogateAttributeSubscriptionState()
+
+    object SubscriptionEstablished : PassphraseSurrogateAttributeSubscriptionState()
+  }
+
   class GeneratedCommandListAttribute(val value: List<UInt>)
 
   sealed class GeneratedCommandListAttributeSubscriptionState {
@@ -139,7 +149,7 @@ class WiFiNetworkManagementCluster(
   }
 
   suspend fun readSsidAttribute(): SsidAttribute {
-    val ATTRIBUTE_ID: UInt = 1u
+    val ATTRIBUTE_ID: UInt = 0u
 
     val attributePath =
       AttributePath(endpointId = endpointId, clusterId = CLUSTER_ID, attributeId = ATTRIBUTE_ID)
@@ -179,7 +189,7 @@ class WiFiNetworkManagementCluster(
     minInterval: Int,
     maxInterval: Int,
   ): Flow<SsidAttributeSubscriptionState> {
-    val ATTRIBUTE_ID: UInt = 1u
+    val ATTRIBUTE_ID: UInt = 0u
     val attributePaths =
       listOf(
         AttributePath(endpointId = endpointId, clusterId = CLUSTER_ID, attributeId = ATTRIBUTE_ID)
@@ -226,6 +236,101 @@ class WiFiNetworkManagementCluster(
         }
         SubscriptionState.SubscriptionEstablished -> {
           emit(SsidAttributeSubscriptionState.SubscriptionEstablished)
+        }
+      }
+    }
+  }
+
+  suspend fun readPassphraseSurrogateAttribute(): PassphraseSurrogateAttribute {
+    val ATTRIBUTE_ID: UInt = 1u
+
+    val attributePath =
+      AttributePath(endpointId = endpointId, clusterId = CLUSTER_ID, attributeId = ATTRIBUTE_ID)
+
+    val readRequest = ReadRequest(eventPaths = emptyList(), attributePaths = listOf(attributePath))
+
+    val response = controller.read(readRequest)
+
+    if (response.successes.isEmpty()) {
+      logger.log(Level.WARNING, "Read command failed")
+      throw IllegalStateException("Read command failed with failures: ${response.failures}")
+    }
+
+    logger.log(Level.FINE, "Read command succeeded")
+
+    val attributeData =
+      response.successes.filterIsInstance<ReadData.Attribute>().firstOrNull {
+        it.path.attributeId == ATTRIBUTE_ID
+      }
+
+    requireNotNull(attributeData) { "Passphrasesurrogate attribute not found in response" }
+
+    // Decode the TLV data into the appropriate type
+    val tlvReader = TlvReader(attributeData.data)
+    val decodedValue: ULong? =
+      if (!tlvReader.isNull()) {
+        tlvReader.getULong(AnonymousTag)
+      } else {
+        tlvReader.getNull(AnonymousTag)
+        null
+      }
+
+    return PassphraseSurrogateAttribute(decodedValue)
+  }
+
+  suspend fun subscribePassphraseSurrogateAttribute(
+    minInterval: Int,
+    maxInterval: Int,
+  ): Flow<PassphraseSurrogateAttributeSubscriptionState> {
+    val ATTRIBUTE_ID: UInt = 1u
+    val attributePaths =
+      listOf(
+        AttributePath(endpointId = endpointId, clusterId = CLUSTER_ID, attributeId = ATTRIBUTE_ID)
+      )
+
+    val subscribeRequest: SubscribeRequest =
+      SubscribeRequest(
+        eventPaths = emptyList(),
+        attributePaths = attributePaths,
+        minInterval = Duration.ofSeconds(minInterval.toLong()),
+        maxInterval = Duration.ofSeconds(maxInterval.toLong()),
+      )
+
+    return controller.subscribe(subscribeRequest).transform { subscriptionState ->
+      when (subscriptionState) {
+        is SubscriptionState.SubscriptionErrorNotification -> {
+          emit(
+            PassphraseSurrogateAttributeSubscriptionState.Error(
+              Exception(
+                "Subscription terminated with error code: ${subscriptionState.terminationCause}"
+              )
+            )
+          )
+        }
+        is SubscriptionState.NodeStateUpdate -> {
+          val attributeData =
+            subscriptionState.updateState.successes
+              .filterIsInstance<ReadData.Attribute>()
+              .firstOrNull { it.path.attributeId == ATTRIBUTE_ID }
+
+          requireNotNull(attributeData) {
+            "Passphrasesurrogate attribute not found in Node State update"
+          }
+
+          // Decode the TLV data into the appropriate type
+          val tlvReader = TlvReader(attributeData.data)
+          val decodedValue: ULong? =
+            if (!tlvReader.isNull()) {
+              tlvReader.getULong(AnonymousTag)
+            } else {
+              tlvReader.getNull(AnonymousTag)
+              null
+            }
+
+          decodedValue?.let { emit(PassphraseSurrogateAttributeSubscriptionState.Success(it)) }
+        }
+        SubscriptionState.SubscriptionEstablished -> {
+          emit(PassphraseSurrogateAttributeSubscriptionState.SubscriptionEstablished)
         }
       }
     }

--- a/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
@@ -38467,6 +38467,29 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
             }
             return value;
         }
+        case Attributes::PassphraseSurrogate::Id: {
+            using TypeInfo = Attributes::PassphraseSurrogate::TypeInfo;
+            TypeInfo::DecodableType cppValue;
+            *aError = app::DataModel::Decode(aReader, cppValue);
+            if (*aError != CHIP_NO_ERROR)
+            {
+                return nullptr;
+            }
+            jobject value;
+            if (cppValue.IsNull())
+            {
+                value = nullptr;
+            }
+            else
+            {
+                std::string valueClassName     = "java/lang/Long";
+                std::string valueCtorSignature = "(J)V";
+                jlong jnivalue                 = static_cast<jlong>(cppValue.Value());
+                chip::JniReferences::GetInstance().CreateBoxedObject<jlong>(valueClassName.c_str(), valueCtorSignature.c_str(),
+                                                                            jnivalue, value);
+            }
+            return value;
+        }
         case Attributes::GeneratedCommandList::Id: {
             using TypeInfo = Attributes::GeneratedCommandList::TypeInfo;
             TypeInfo::DecodableType cppValue;

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -11835,10 +11835,16 @@ class ChipClusters:
             },
         },
         "attributes": {
-            0x00000001: {
+            0x00000000: {
                 "attributeName": "Ssid",
-                "attributeId": 0x00000001,
+                "attributeId": 0x00000000,
                 "type": "bytes",
+                "reportable": True,
+            },
+            0x00000001: {
+                "attributeName": "PassphraseSurrogate",
+                "attributeId": 0x00000001,
+                "type": "int",
                 "reportable": True,
             },
             0x0000FFF8: {

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -42124,10 +42124,6 @@ class ThreadNetworkDirectory(Cluster):
                         ClusterObjectFieldDescriptor(Label="extendedPanID", Tag=0, Type=bytes),
                     ])
 
-            @ChipUtility.classproperty
-            def must_use_timed_invoke(cls) -> bool:
-                return True
-
             extendedPanID: 'bytes' = b""
 
         @dataclass

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -41569,7 +41569,8 @@ class WiFiNetworkManagement(Cluster):
     def descriptor(cls) -> ClusterObjectDescriptor:
         return ClusterObjectDescriptor(
             Fields=[
-                ClusterObjectFieldDescriptor(Label="ssid", Tag=0x00000001, Type=typing.Union[Nullable, bytes]),
+                ClusterObjectFieldDescriptor(Label="ssid", Tag=0x00000000, Type=typing.Union[Nullable, bytes]),
+                ClusterObjectFieldDescriptor(Label="passphraseSurrogate", Tag=0x00000001, Type=typing.Union[Nullable, uint]),
                 ClusterObjectFieldDescriptor(Label="generatedCommandList", Tag=0x0000FFF8, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="acceptedCommandList", Tag=0x0000FFF9, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="eventList", Tag=0x0000FFFA, Type=typing.List[uint]),
@@ -41579,6 +41580,7 @@ class WiFiNetworkManagement(Cluster):
             ])
 
     ssid: 'typing.Union[Nullable, bytes]' = None
+    passphraseSurrogate: 'typing.Union[Nullable, uint]' = None
     generatedCommandList: 'typing.List[uint]' = None
     acceptedCommandList: 'typing.List[uint]' = None
     eventList: 'typing.List[uint]' = None
@@ -41625,13 +41627,29 @@ class WiFiNetworkManagement(Cluster):
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
-                return 0x00000001
+                return 0x00000000
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, bytes])
 
             value: 'typing.Union[Nullable, bytes]' = NullValue
+
+        @dataclass
+        class PassphraseSurrogate(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x00000451
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x00000001
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class GeneratedCommandList(ClusterAttributeDescriptor):

--- a/src/darwin/Framework/CHIP/zap-generated/MTRAttributeSpecifiedCheck.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRAttributeSpecifiedCheck.mm
@@ -5433,6 +5433,9 @@ static BOOL AttributeIsSpecifiedInWiFiNetworkManagementCluster(AttributeId aAttr
     case Attributes::Ssid::Id: {
         return YES;
     }
+    case Attributes::PassphraseSurrogate::Id: {
+        return YES;
+    }
     case Attributes::GeneratedCommandList::Id: {
         return YES;
     }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
@@ -15695,6 +15695,21 @@ static id _Nullable DecodeAttributeValueForWiFiNetworkManagementCluster(Attribut
         }
         return value;
     }
+    case Attributes::PassphraseSurrogate::Id: {
+        using TypeInfo = Attributes::PassphraseSurrogate::TypeInfo;
+        TypeInfo::DecodableType cppValue;
+        *aError = DataModel::Decode(aReader, cppValue);
+        if (*aError != CHIP_NO_ERROR) {
+            return nil;
+        }
+        NSNumber * _Nullable value;
+        if (cppValue.IsNull()) {
+            value = nil;
+        } else {
+            value = [NSNumber numberWithUnsignedLongLong:cppValue.Value()];
+        }
+        return value;
+    }
     default: {
         break;
     }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -13353,6 +13353,12 @@ MTR_PROVISIONALLY_AVAILABLE
                            reportHandler:(void (^)(NSData * _Nullable value, NSError * _Nullable error))reportHandler MTR_PROVISIONALLY_AVAILABLE;
 + (void)readAttributeSSIDWithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completion:(void (^)(NSData * _Nullable value, NSError * _Nullable error))completion MTR_PROVISIONALLY_AVAILABLE;
 
+- (void)readAttributePassphraseSurrogateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion MTR_PROVISIONALLY_AVAILABLE;
+- (void)subscribeAttributePassphraseSurrogateWithParams:(MTRSubscribeParams *)params
+                                subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
+                                          reportHandler:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))reportHandler MTR_PROVISIONALLY_AVAILABLE;
++ (void)readAttributePassphraseSurrogateWithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue completion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion MTR_PROVISIONALLY_AVAILABLE;
+
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion MTR_PROVISIONALLY_AVAILABLE;
 - (void)subscribeAttributeGeneratedCommandListWithParams:(MTRSubscribeParams *)params
                                  subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -4412,7 +4412,8 @@ typedef NS_ENUM(uint32_t, MTRAttributeIDType) {
     MTRAttributeIDTypeClusterRadonConcentrationMeasurementAttributeClusterRevisionID MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6)) = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
 
     // Cluster WiFiNetworkManagement attributes
-    MTRAttributeIDTypeClusterWiFiNetworkManagementAttributeSSIDID MTR_PROVISIONALLY_AVAILABLE = 0x00000001,
+    MTRAttributeIDTypeClusterWiFiNetworkManagementAttributeSSIDID MTR_PROVISIONALLY_AVAILABLE = 0x00000000,
+    MTRAttributeIDTypeClusterWiFiNetworkManagementAttributePassphraseSurrogateID MTR_PROVISIONALLY_AVAILABLE = 0x00000001,
     MTRAttributeIDTypeClusterWiFiNetworkManagementAttributeGeneratedCommandListID MTR_PROVISIONALLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
     MTRAttributeIDTypeClusterWiFiNetworkManagementAttributeAcceptedCommandListID MTR_PROVISIONALLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
     MTRAttributeIDTypeClusterWiFiNetworkManagementAttributeEventListID MTR_PROVISIONALLY_AVAILABLE = MTRAttributeIDTypeGlobalAttributeEventListID,

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterNames.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterNames.mm
@@ -7420,6 +7420,10 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             result = @"SSID";
             break;
 
+        case MTRAttributeIDTypeClusterWiFiNetworkManagementAttributePassphraseSurrogateID:
+            result = @"PassphraseSurrogate";
+            break;
+
         case MTRAttributeIDTypeClusterWiFiNetworkManagementAttributeGeneratedCommandListID:
             result = @"GeneratedCommandList";
             break;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -6170,6 +6170,8 @@ MTR_PROVISIONALLY_AVAILABLE
 
 - (NSDictionary<NSString *, id> * _Nullable)readAttributeSSIDWithParams:(MTRReadParams * _Nullable)params MTR_PROVISIONALLY_AVAILABLE;
 
+- (NSDictionary<NSString *, id> * _Nullable)readAttributePassphraseSurrogateWithParams:(MTRReadParams * _Nullable)params MTR_PROVISIONALLY_AVAILABLE;
+
 - (NSDictionary<NSString *, id> * _Nullable)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params MTR_PROVISIONALLY_AVAILABLE;
 
 - (NSDictionary<NSString *, id> * _Nullable)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params MTR_PROVISIONALLY_AVAILABLE;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -17460,9 +17460,6 @@ using chip::System::Clock::Timeout;
     };
 
     auto * timedInvokeTimeoutMs = params.timedInvokeTimeoutMs;
-    if (timedInvokeTimeoutMs == nil) {
-        timedInvokeTimeoutMs = @(MTR_DEFAULT_TIMED_INTERACTION_TIMEOUT_MS);
-    }
 
     using RequestType = ThreadNetworkDirectory::Commands::GetOperationalDataset::Type;
     [self.device _invokeKnownCommandWithEndpointID:self.endpointID

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -17179,6 +17179,11 @@ using chip::System::Clock::Timeout;
     return [self.device readAttributeWithEndpointID:self.endpointID clusterID:@(MTRClusterIDTypeWiFiNetworkManagementID) attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkManagementAttributeSSIDID) params:params];
 }
 
+- (NSDictionary<NSString *, id> * _Nullable)readAttributePassphraseSurrogateWithParams:(MTRReadParams * _Nullable)params
+{
+    return [self.device readAttributeWithEndpointID:self.endpointID clusterID:@(MTRClusterIDTypeWiFiNetworkManagementID) attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkManagementAttributePassphraseSurrogateID) params:params];
+}
+
 - (NSDictionary<NSString *, id> * _Nullable)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:self.endpointID clusterID:@(MTRClusterIDTypeWiFiNetworkManagementID) attributeID:@(MTRAttributeIDTypeClusterWiFiNetworkManagementAttributeGeneratedCommandListID) params:params];

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandTimedCheck.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandTimedCheck.mm
@@ -1011,9 +1011,6 @@ static BOOL CommandNeedsTimedInvokeInThreadNetworkDirectoryCluster(AttributeId a
     case Commands::RemoveNetwork::Id: {
         return YES;
     }
-    case Commands::GetOperationalDataset::Id: {
-        return YES;
-    }
     default: {
         return NO;
     }

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -31499,7 +31499,6 @@ bool CommandNeedsTimedInvoke(ClusterId aCluster, CommandId aCommand)
         {
         case Clusters::ThreadNetworkDirectory::Commands::AddNetwork::Id:
         case Clusters::ThreadNetworkDirectory::Commands::RemoveNetwork::Id:
-        case Clusters::ThreadNetworkDirectory::Commands::GetOperationalDataset::Id:
             return true;
         default:
             return false;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -23731,6 +23731,8 @@ CHIP_ERROR TypeInfo::DecodableType::Decode(TLV::TLVReader & reader, const Concre
     {
     case Attributes::Ssid::TypeInfo::GetAttributeId():
         return DataModel::Decode(reader, ssid);
+    case Attributes::PassphraseSurrogate::TypeInfo::GetAttributeId():
+        return DataModel::Decode(reader, passphraseSurrogate);
     case Attributes::GeneratedCommandList::TypeInfo::GetAttributeId():
         return DataModel::Decode(reader, generatedCommandList);
     case Attributes::AcceptedCommandList::TypeInfo::GetAttributeId():

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -35929,6 +35929,18 @@ struct TypeInfo
     static constexpr size_t MaxLength() { return 32; }
 };
 } // namespace Ssid
+namespace PassphraseSurrogate {
+struct TypeInfo
+{
+    using Type             = chip::app::DataModel::Nullable<uint64_t>;
+    using DecodableType    = chip::app::DataModel::Nullable<uint64_t>;
+    using DecodableArgType = const chip::app::DataModel::Nullable<uint64_t> &;
+
+    static constexpr ClusterId GetClusterId() { return Clusters::WiFiNetworkManagement::Id; }
+    static constexpr AttributeId GetAttributeId() { return Attributes::PassphraseSurrogate::Id; }
+    static constexpr bool MustUseTimedWrite() { return false; }
+};
+} // namespace PassphraseSurrogate
 namespace GeneratedCommandList {
 struct TypeInfo : public Clusters::Globals::Attributes::GeneratedCommandList::TypeInfo
 {
@@ -35975,6 +35987,7 @@ struct TypeInfo
         CHIP_ERROR Decode(TLV::TLVReader & reader, const ConcreteAttributePath & path);
 
         Attributes::Ssid::TypeInfo::DecodableType ssid;
+        Attributes::PassphraseSurrogate::TypeInfo::DecodableType passphraseSurrogate;
         Attributes::GeneratedCommandList::TypeInfo::DecodableType generatedCommandList;
         Attributes::AcceptedCommandList::TypeInfo::DecodableType acceptedCommandList;
         Attributes::EventList::TypeInfo::DecodableType eventList;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -36439,7 +36439,7 @@ public:
 
     using ResponseType = Clusters::ThreadNetworkDirectory::Commands::OperationalDatasetResponse::DecodableType;
 
-    static constexpr bool MustUseTimedInvoke() { return true; }
+    static constexpr bool MustUseTimedInvoke() { return false; }
 };
 
 struct DecodableType

--- a/zzz_generated/app-common/app-common/zap-generated/ids/Attributes.h
+++ b/zzz_generated/app-common/app-common/zap-generated/ids/Attributes.h
@@ -6753,8 +6753,12 @@ namespace WiFiNetworkManagement {
 namespace Attributes {
 
 namespace Ssid {
-static constexpr AttributeId Id = 0x00000001;
+static constexpr AttributeId Id = 0x00000000;
 } // namespace Ssid
+
+namespace PassphraseSurrogate {
+static constexpr AttributeId Id = 0x00000001;
+} // namespace PassphraseSurrogate
 
 namespace GeneratedCommandList {
 static constexpr AttributeId Id = Globals::Attributes::GeneratedCommandList::Id;

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -11296,7 +11296,8 @@ private:
 | * NetworkPassphraseRequest                                          |   0x00 |
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
-| * Ssid                                                              | 0x0001 |
+| * Ssid                                                              | 0x0000 |
+| * PassphraseSurrogate                                               | 0x0001 |
 | * GeneratedCommandList                                              | 0xFFF8 |
 | * AcceptedCommandList                                               | 0xFFF9 |
 | * EventList                                                         | 0xFFFA |
@@ -25554,6 +25555,7 @@ void registerClusterWiFiNetworkManagement(Commands & commands, CredentialIssuerC
         //
         make_unique<ReadAttribute>(Id, credsIssuerConfig),                                                                 //
         make_unique<ReadAttribute>(Id, "ssid", Attributes::Ssid::Id, credsIssuerConfig),                                   //
+        make_unique<ReadAttribute>(Id, "passphrase-surrogate", Attributes::PassphraseSurrogate::Id, credsIssuerConfig),    //
         make_unique<ReadAttribute>(Id, "generated-command-list", Attributes::GeneratedCommandList::Id, credsIssuerConfig), //
         make_unique<ReadAttribute>(Id, "accepted-command-list", Attributes::AcceptedCommandList::Id, credsIssuerConfig),   //
         make_unique<ReadAttribute>(Id, "event-list", Attributes::EventList::Id, credsIssuerConfig),                        //
@@ -25563,6 +25565,9 @@ void registerClusterWiFiNetworkManagement(Commands & commands, CredentialIssuerC
         make_unique<WriteAttribute<>>(Id, credsIssuerConfig),                                                              //
         make_unique<WriteAttribute<chip::app::DataModel::Nullable<chip::ByteSpan>>>(
             Id, "ssid", Attributes::Ssid::Id, WriteCommandType::kForceWrite, credsIssuerConfig), //
+        make_unique<WriteAttribute<chip::app::DataModel::Nullable<uint64_t>>>(Id, "passphrase-surrogate", 0, UINT64_MAX,
+                                                                              Attributes::PassphraseSurrogate::Id,
+                                                                              WriteCommandType::kForceWrite, credsIssuerConfig), //
         make_unique<WriteAttributeAsComplex<chip::app::DataModel::List<const chip::CommandId>>>(
             Id, "generated-command-list", Attributes::GeneratedCommandList::Id, WriteCommandType::kForceWrite,
             credsIssuerConfig), //
@@ -25578,6 +25583,7 @@ void registerClusterWiFiNetworkManagement(Commands & commands, CredentialIssuerC
                                               WriteCommandType::kForceWrite, credsIssuerConfig),                                //
         make_unique<SubscribeAttribute>(Id, credsIssuerConfig),                                                                 //
         make_unique<SubscribeAttribute>(Id, "ssid", Attributes::Ssid::Id, credsIssuerConfig),                                   //
+        make_unique<SubscribeAttribute>(Id, "passphrase-surrogate", Attributes::PassphraseSurrogate::Id, credsIssuerConfig),    //
         make_unique<SubscribeAttribute>(Id, "generated-command-list", Attributes::GeneratedCommandList::Id, credsIssuerConfig), //
         make_unique<SubscribeAttribute>(Id, "accepted-command-list", Attributes::AcceptedCommandList::Id, credsIssuerConfig),   //
         make_unique<SubscribeAttribute>(Id, "event-list", Attributes::EventList::Id, credsIssuerConfig),                        //

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -16771,6 +16771,11 @@ CHIP_ERROR DataModelLogger::LogAttribute(const chip::app::ConcreteDataAttributeP
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
             return DataModelLogger::LogValue("SSID", 1, value);
         }
+        case WiFiNetworkManagement::Attributes::PassphraseSurrogate::Id: {
+            chip::app::DataModel::Nullable<uint64_t> value;
+            ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));
+            return DataModelLogger::LogValue("PassphraseSurrogate", 1, value);
+        }
         case WiFiNetworkManagement::Attributes::GeneratedCommandList::Id: {
             chip::app::DataModel::DecodableList<chip::CommandId> value;
             ReturnErrorOnFailure(chip::app::DataModel::Decode(*data, value));


### PR DESCRIPTION
### Thread Network Directory
- GetOperationalDataset does not require timed invoke
- Actually return the dataset in the GetOperationalDataset implementation 🤦 
- Add cert test scripts

See https://github.com/CHIP-Specifications/chip-test-plans/pull/4322

### Wi-Fi Network Management
- Add a simple cert test script. Test plan to be created from the script.

skip-protocol-compatibility, because these clusters should have been marked "provisional" (in the haven't shipped yet sense).