### PR TITLE
[logging] Add chip_device_platform == "none" to default target assert

### DIFF
--- a/src/platform/logging/BUILD.gn
+++ b/src/platform/logging/BUILD.gn
@@ -79,7 +79,7 @@ source_set("default") {
     } else {
       assert(
           chip_device_platform == "fake" || chip_device_platform == "android" ||
-          chip_device_platform == "external")
+          chip_device_platform == "external" || chip_device_platform == "none")
     }
   }
 }


### PR DESCRIPTION
On Windows, chip_device_platform is set to none during bootstrap. This assert would fail, consequently bootstrap would fail, without adding this check.

