### PR TITLE
VS Code Python Formatting 

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -21,7 +21,9 @@
         "vadimcn.vscode-lldb",
         "xaver.clang-format",
         "yuichinukiyama.vscode-preview-server",
-        "yzhang.markdown-all-in-one"
+        "yzhang.markdown-all-in-one",
+        "ms-python.autopep8",
+        "ms-python.isort"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -192,5 +192,5 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
     },
-    "autopep8.args": ["--in-place", "--max-line-length", "132"]
+    "autopep8.args": ["--max-line-length", "132"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -192,5 +192,5 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
     },
-    "python.formatting.provider": "none"
+    "autopep8.args": ["--in-place", "--max-line-length", "132"]
 }


### PR DESCRIPTION
- Adding python formatting settings (enforcing maxline length to 132) for autopep8 (python formatter) to be inline with restyled settings (#32384)
- Adding `autopep8` and `isort` as recommended extensions when installing a new VSCode workspace (since `isort` is also part of restyled settings #24148)

