### PR TITLE
[v1.2] Fix bootstrapping

### DIFF
--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -150,7 +150,19 @@ EOF
 # bootstrap or run_in_build_env.sh can be executed in a build env
 _ORIGINAL_PW_ENVIRONMENT_ROOT="$PW_ENVIRONMENT_ROOT"
 
+# pigweed does not seem to handle pwd involving symlinks very well.
+original_pwd=$PWD
+if hash realpath 2>/dev/null; then
+    realpwd="$(realpath "$PWD")"
+    if [ "$realpwd" != "$PWD" ]; then
+        echo "Warning: $PWD contains symlinks, using $realpwd instead"
+        cd "$realpwd"
+    fi
+fi
+
 _bootstrap_or_activate "$0"
+
+cd $original_pwd
 
 if [ "$_ACTION_TAKEN" = "bootstrap" ]; then
     # By default, install all extra pip dependencies even if slow. -p/--platform

--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -49,7 +49,7 @@ colorama==0.4.6
     #   west
 coloredlogs==15.0.1
     # via -r requirements.all.txt
-construct==2.10.54
+construct==2.10.70
     # via
     #   -r requirements.esp32.txt
     #   esp-coredump
@@ -208,7 +208,7 @@ python-socketio==4.6.1
     # via -r requirements.esp32.txt
 pytz==2022.7.1
     # via pandas
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   esptool
     #   idf-component-manager

--- a/scripts/setup/requirements.esp32.txt
+++ b/scripts/setup/requirements.esp32.txt
@@ -8,7 +8,7 @@ pygdbmi<=0.9.0.2
 reedsolo>=1.5.3,<=1.5.4
 bitstring>=3.1.6,<4
 ecdsa>=0.16.0
-construct==2.10.54
+construct==2.10.70
 python-socketio<5
 itsdangerous<2.1 ; python_version < "3.11"
 esp_idf_monitor==1.1.1


### PR DESCRIPTION
- Cherry picking #32945 to fix #31851
- Bump the pyyaml version to `6.0.1`
- Bump the construct version to `2.10.70`
<details>
  <summary>error due to pyyaml</summary>
  
    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> [54 lines of output]
        running egg_info
        writing lib/PyYAML.egg-info/PKG-INFO
        writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt
        writing top-level names to lib/PyYAML.egg-info/top_level.txt

</details>

<details>
    <summary> error due to construct </summary>

```
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/34/_563kfb57rj_9n2x3qc8ng5r0000gn/T/pip-install-upc5sc58/construct_47c6216bc9774546a3db803fd2414288/setup.py", line
 3, in <module>
          from construct.version import version_string
        File "/private/var/folders/34/_563kfb57rj_9n2x3qc8ng5r0000gn/T/pip-install-upc5sc58/construct_47c6216bc9774546a3db803fd2414288/construct/__ini
t__.py", line 22, in <module>
          from construct.core import *
        File "/private/var/folders/34/_563kfb57rj_9n2x3qc8ng5r0000gn/T/pip-install-upc5sc58/construct_47c6216bc9774546a3db803fd2414288/construct/core.
py", line 3, in <module>
          import struct, io, binascii, itertools, collections, pickle, sys, os, tempfile, hashlib, importlib, imp
      ModuleNotFoundError: No module named 'imp'
```

</details>