### PR TITLE
[nrfconnect] Fixed nrfconnect flashing after NCS 2.7.0 update

### DIFF
--- a/config/nrfconnect/app/flashing.cmake
+++ b/config/nrfconnect/app/flashing.cmake
@@ -40,9 +40,9 @@ add_custom_command(OUTPUT "${FLASHBUNDLE_FLASHER_PLATFORM}"
     VERBATIM)
 
 if (merged_hex_to_flash)
-  set(flashbundle_hex_to_copy "zephyr/${merged_hex_to_flash}")
+  set(flashbundle_hex_to_copy "${merged_hex_to_flash}")
 else()
-  set(flashbundle_hex_to_copy "zephyr/${KERNEL_HEX_NAME}")
+  set(flashbundle_hex_to_copy "../merged.hex")
 endif()
 
 add_custom_command(OUTPUT "${FLASHBUNDLE_FIRMWARE}"

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -224,16 +224,16 @@ west build --cmake-only -d {outdir} -b {board} --sysbuild {sourcedir}{build_flag
     def _bundle(self):
         logging.info(f'Generating flashbundle at {self.output_dir}')
 
-        self._Execute(['ninja', '-C', self.output_dir, 'flashing_script'],
+        self._Execute(['ninja', '-C', os.path.join(self.output_dir, 'nrfconnect'), 'flashing_script'],
                       title='Generating flashable files of ' + self.identifier)
 
     def build_outputs(self):
         yield BuilderOutput(
-            os.path.join(self.output_dir, 'zephyr', 'zephyr.elf'),
+            os.path.join(self.output_dir, 'nrfconnect', 'zephyr', 'zephyr.elf'),
             '%s.elf' % self.app.AppNamePrefix())
         if self.options.enable_link_map_file:
             yield BuilderOutput(
-                os.path.join(self.output_dir, 'zephyr', 'zephyr.map'),
+                os.path.join(self.output_dir, 'nrfconnect', 'zephyr', 'zephyr.map'),
                 '%s.map' % self.app.AppNamePrefix())
 
     def bundle_outputs(self):


### PR DESCRIPTION
The flashing script used by cloudbuild stopped to work after NCS update to 2.7.0, due to the path and files location changes.
