### PR TITLE
[ICD] Implement the support of the ICD Check-In BackOff

### DIFF
--- a/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.matter
+++ b/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.matter
@@ -1796,6 +1796,7 @@ endpoint 0 {
     ram      attribute userActiveModeTriggerHint default = 0x111D;
     ram      attribute userActiveModeTriggerInstruction default = "Restart the application";
     ram      attribute operatingMode default = 0;
+    callback attribute maximumCheckInBackOff;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute eventList;

--- a/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.zap
+++ b/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.zap
@@ -19,18 +19,18 @@
   "package": [
     {
       "pathRelativity": "relativeToZap",
-      "path": "../../../src/app/zap-templates/app-templates.json",
-      "type": "gen-templates-json",
-      "category": "matter",
-      "version": "chip-v1"
-    },
-    {
-      "pathRelativity": "relativeToZap",
       "path": "../../../src/app/zap-templates/zcl/zcl.json",
       "type": "zcl-properties",
       "category": "matter",
       "version": 1,
       "description": "Matter SDK ZCL data"
+    },
+    {
+      "pathRelativity": "relativeToZap",
+      "path": "../../../src/app/zap-templates/app-templates.json",
+      "type": "gen-templates-json",
+      "category": "matter",
+      "version": "chip-v1"
     }
   ],
   "endpointTypes": [
@@ -3547,6 +3547,22 @@
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "MaximumCheckInBackOff",
+              "code": 9,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int32u",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/src/app/clusters/icd-management-server/icd-management-server.cpp
+++ b/src/app/clusters/icd-management-server/icd-management-server.cpp
@@ -69,6 +69,7 @@ private:
     CHIP_ERROR ReadRegisteredClients(EndpointId endpoint, AttributeValueEncoder & encoder);
     CHIP_ERROR ReadICDCounter(EndpointId endpoint, AttributeValueEncoder & encoder);
     CHIP_ERROR ReadClientsSupportedPerFabric(EndpointId endpoint, AttributeValueEncoder & encoder);
+    CHIP_ERROR ReadMaximumCheckInBackOff(EndpointId endpoint, AttributeValueEncoder & encoder);
 
     PersistentStorageDelegate * mStorage           = nullptr;
     Crypto::SymmetricKeystore * mSymmetricKeystore = nullptr;
@@ -102,6 +103,10 @@ CHIP_ERROR IcdManagementAttributeAccess::Read(const ConcreteReadAttributePath & 
 
     case IcdManagement::Attributes::ClientsSupportedPerFabric::Id:
         return ReadClientsSupportedPerFabric(aPath.mEndpointId, aEncoder);
+
+    case IcdManagement::Attributes::MaximumCheckInBackOff::Id:
+        return ReadMaximumCheckInBackOff(aPath.mEndpointId, aEncoder);
+
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
     }
 
@@ -121,6 +126,11 @@ CHIP_ERROR IcdManagementAttributeAccess::ReadActiveModeDuration(EndpointId endpo
 CHIP_ERROR IcdManagementAttributeAccess::ReadActiveModeThreshold(EndpointId endpoint, AttributeValueEncoder & encoder)
 {
     return encoder.Encode(mICDConfigurationData->GetActiveModeThreshold().count());
+}
+
+CHIP_ERROR IcdManagementAttributeAccess::ReadMaximumCheckInBackOff(EndpointId endpoint, AttributeValueEncoder & encoder)
+{
+    return encoder.Encode(mICDConfigurationData->GetMaximumCheckInBackoff().count());
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP

--- a/src/app/clusters/icd-management-server/icd-management-server.cpp
+++ b/src/app/clusters/icd-management-server/icd-management-server.cpp
@@ -106,7 +106,6 @@ CHIP_ERROR IcdManagementAttributeAccess::Read(const ConcreteReadAttributePath & 
 
     case IcdManagement::Attributes::MaximumCheckInBackOff::Id:
         return ReadMaximumCheckInBackOff(aPath.mEndpointId, aEncoder);
-
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
     }
 
@@ -126,11 +125,6 @@ CHIP_ERROR IcdManagementAttributeAccess::ReadActiveModeDuration(EndpointId endpo
 CHIP_ERROR IcdManagementAttributeAccess::ReadActiveModeThreshold(EndpointId endpoint, AttributeValueEncoder & encoder)
 {
     return encoder.Encode(mICDConfigurationData->GetActiveModeThreshold().count());
-}
-
-CHIP_ERROR IcdManagementAttributeAccess::ReadMaximumCheckInBackOff(EndpointId endpoint, AttributeValueEncoder & encoder)
-{
-    return encoder.Encode(mICDConfigurationData->GetMaximumCheckInBackoff().count());
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
@@ -229,6 +223,11 @@ CHIP_ERROR IcdManagementAttributeAccess::ReadICDCounter(EndpointId endpoint, Att
 CHIP_ERROR IcdManagementAttributeAccess::ReadClientsSupportedPerFabric(EndpointId endpoint, AttributeValueEncoder & encoder)
 {
     return encoder.Encode(mICDConfigurationData->GetClientsSupportedPerFabric());
+}
+
+CHIP_ERROR IcdManagementAttributeAccess::ReadMaximumCheckInBackOff(EndpointId endpoint, AttributeValueEncoder & encoder)
+{
+    return encoder.Encode(mICDConfigurationData->GetMaximumCheckInBackoff().count());
 }
 
 /**

--- a/src/app/icd/server/BUILD.gn
+++ b/src/app/icd/server/BUILD.gn
@@ -66,6 +66,22 @@ source_set("notifier") {
   ]
 }
 
+source_set("check-in-back-off") {
+  sources = [ "ICDCheckInBackOffStrategy.h" ]
+
+  public_deps = [
+    ":monitoring-table",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+  ]
+}
+
+source_set("default-check-in-back-off") {
+  sources = [ "DefaultICDCheckInBackOffStrategy.h" ]
+
+  public_deps = [ ":check-in-back-off" ]
+}
+
 # ICD Manager source-set is broken out of the main source-set to enable unit tests
 # All sources and configurations used by the ICDManager need to go in this source-set
 source_set("manager") {
@@ -89,6 +105,7 @@ source_set("manager") {
 
   if (chip_enable_icd_checkin) {
     public_deps += [
+      ":check-in-back-off",
       ":monitoring-table",
       ":sender",
       "${chip_root}/src/app:app_config",

--- a/src/app/icd/server/BUILD.gn
+++ b/src/app/icd/server/BUILD.gn
@@ -93,6 +93,7 @@ source_set("manager") {
   deps = [ ":icd-server-config" ]
 
   public_deps = [
+    ":check-in-back-off",
     ":configuration-data",
     ":notifier",
     ":observer",
@@ -105,7 +106,6 @@ source_set("manager") {
 
   if (chip_enable_icd_checkin) {
     public_deps += [
-      ":check-in-back-off",
       ":monitoring-table",
       ":sender",
       "${chip_root}/src/app:app_config",

--- a/src/app/icd/server/DefaultICDCheckInBackOffStrategy.h
+++ b/src/app/icd/server/DefaultICDCheckInBackOffStrategy.h
@@ -40,13 +40,13 @@ public:
     /**
      * @brief Function checks if the entry is a permanent or ephemeral client.
      *        If the client is permanent, we should send a Check-In message.
-     *        If the cliet is ephemerakl, we should not send a Check-In message.
+     *        If the client is ephemeral, we should not send a Check-In message.
      *
-     * @param entry Entry for which we are deciding if we need to send a Check-In message or not.
+     * @param entry Entry for which we are deciding whether we need to send a Check-In message or not.
      * @return true If the client is permanent, return true.
      * @return false If the client is not permanent, ephemeral or invalid, return false.
      */
-    bool ShouldSendCheckInMessage(const ICDMonitoringEntry & entry)
+    bool ShouldSendCheckInMessage(const ICDMonitoringEntry & entry) override
     {
         return (entry.clientType == Clusters::IcdManagement::ClientTypeEnum::kPermanent);
     }
@@ -56,7 +56,7 @@ public:
      *        As such, we don't need to execute anything to force the maximum Check-In BackOff.
      *
      */
-    CHIP_ERROR ForceMaximumCheckInBackoff() { return CHIP_NO_ERROR; }
+    CHIP_ERROR ForceMaximumCheckInBackoff() override { return CHIP_NO_ERROR; }
 };
 
 } // namespace app

--- a/src/app/icd/server/DefaultICDCheckInBackOffStrategy.h
+++ b/src/app/icd/server/DefaultICDCheckInBackOffStrategy.h
@@ -1,0 +1,63 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/icd/server/ICDCheckInBackOffStrategy.h>
+#include <lib/core/ClusterEnums.h>
+
+namespace chip {
+namespace app {
+
+/**
+ * @brief Default ICD Check-In BackOff Strategy.
+ *        The default strategy is based on the two types of controllers
+ *        - kPermanent : Always send a Check-In message
+ *        - kEphemeral : Never send a Check-In message
+ *
+ *        This implementation represents a no back off strategy.
+ */
+class DefaultICDCheckInBackOffStrategy : public ICDCheckInBackOffStrategy
+{
+public:
+    DefaultICDCheckInBackOffStrategy()  = default;
+    ~DefaultICDCheckInBackOffStrategy() = default;
+
+    /**
+     * @brief Function checks if the entry is a permanent or ephemeral client.
+     *        If the client is permanent, we should send a Check-In message.
+     *        If the cliet is ephemerakl, we should not send a Check-In message.
+     *
+     * @param entry Entry for which we are deciding if we need to send a Check-In message or not.
+     * @return true If the client is permanent, return true.
+     * @return false If the client is not permanent, ephemeral or invalid, return false.
+     */
+    bool ShouldSendCheckInMessage(const ICDMonitoringEntry & entry)
+    {
+        return (entry.clientType == Clusters::IcdManagement::ClientTypeEnum::kPermanent);
+    }
+
+    /**
+     * @brief The default Check-In BackOff fundamentally implements a no back off strategy.
+     *        As such, we don't need to execute anything to force the maximum Check-In BackOff.
+     *
+     */
+    CHIP_ERROR ForceMaximumCheckInBackoff() { return CHIP_NO_ERROR; }
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/icd/server/ICDCheckInBackOffStrategy.h
+++ b/src/app/icd/server/ICDCheckInBackOffStrategy.h
@@ -35,14 +35,14 @@ public:
      * @brief Function is used by the ICDManager to determine if a Check-In message should be sent to the given entry based on the
      *        Check-In BackOff strategy.
      *
-     *        There are no  requirements on how the Check-In BackOff strategy should behave.
+     *        There are no requirements on how the Check-In BackOff strategy should behave.
      *        The only specified requirement is the maximum time between to Check-In message, MaximumCheckInBackOff.
      *        All strategies must respect this requirement.
      *
      * @param entry ICDMonitoringEntry for which we are about to send a Check-In message to.
      *
      * @return true   ICDCheckInBackOffStrategy determines that we SHOULD send a Check-In message to the given entry
-     * @return falseI CDCheckInBackOffStrategy determines that we SHOULD NOT send a Check-In message to the given entry
+     * @return false ICDCheckInBackOffStrategy determines that we SHOULD NOT send a Check-In message to the given entry
      */
     virtual bool ShouldSendCheckInMessage(const ICDMonitoringEntry & entry) = 0;
 

--- a/src/app/icd/server/ICDCheckInBackOffStrategy.h
+++ b/src/app/icd/server/ICDCheckInBackOffStrategy.h
@@ -1,0 +1,62 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/icd/server/ICDMonitoringTable.h>
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace app {
+
+/**
+ * @brief This class defines the necessary interface a ICD Check-In BackOff strategy needs to implment to be consummed by the
+ *        ICDManager class. The strategy is injected with the init server params when initializing the device Server class.
+ */
+class ICDCheckInBackOffStrategy
+{
+public:
+    virtual ~ICDCheckInBackOffStrategy() = default;
+
+    /**
+     * @brief Function is used by the ICDManager to determine if a Check-In message should be sent to the given entry based on the
+     *        Check-In BackOff strategy.
+     *
+     *        There are no  requirements on how the Check-In BackOff strategy should behave.
+     *        The only specified requirement is the maximum time between to Check-In message, MaximumCheckInBackOff.
+     *        All strategies must respect this requirement.
+     *
+     * @param entry ICDMonitoringEntry for which we are about to send a Check-In message to.
+     *
+     * @return true   ICDCheckInBackOffStrategy determines that we SHOULD send a Check-In message to the given entry
+     * @return falseI CDCheckInBackOffStrategy determines that we SHOULD NOT send a Check-In message to the given entry
+     */
+    virtual bool ShouldSendCheckInMessage(const ICDMonitoringEntry & entry) = 0;
+
+    /**
+     * @brief Function is used within the test event trigger to force the maximum BackOff state of the ICD Check-In BackOff
+     *        strategy. This enables to validate the strategy and to certify it respects the  MaximumCheckInBackOff interval during
+     *        certification.
+     *
+     *        Function sets the maxmimum BackOff state for all clients registered with the ICD
+     *
+     * @return CHIP_ERROR Any error returned during the forcing of the maximum BackOff state
+     */
+    virtual CHIP_ERROR ForceMaximumCheckInBackoff() = 0;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/icd/server/ICDConfigurationData.h
+++ b/src/app/icd/server/ICDConfigurationData.h
@@ -74,6 +74,8 @@ public:
 
     System::Clock::Milliseconds16 GetMinLitActiveModeThreshold() { return kMinLitActiveModeThreshold; }
 
+    System::Clock::Seconds32 GetMaximumCheckInBackoff() { return mMaximumCheckInBackOff; }
+
     /**
      * If ICD_ENFORCE_SIT_SLOW_POLL_LIMIT is set to 0, function will always return the configured Slow Polling interval
      * (CHIP_DEVICE_CONFIG_ICD_SLOW_POLL_INTERVAL).
@@ -149,6 +151,12 @@ private:
     static_assert((CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC) >= 1,
                   "Spec requires the minimum of supported clients per fabric be equal or greater to 1.");
     uint16_t mFabricClientsSupported = CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC;
+
+    static_assert((CHIP_CONFIG_ICD_MAXIMUM_CHECK_IN_BACKOFF_SEC) <= kMaxIdleModeDuration.count(),
+                  "Spec requires the MaximumCheckInBackOff to be equal or inferior to 64800s");
+    static_assert((CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC) <= (CHIP_CONFIG_ICD_MAXIMUM_CHECK_IN_BACKOFF_SEC),
+                  "Spec requires the MaximumCheckInBackOff to be equal or superior to the IdleModeDuration");
+    System::Clock::Seconds32 mMaximumCheckInBackOff = System::Clock::Seconds32(CHIP_CONFIG_ICD_MAXIMUM_CHECK_IN_BACKOFF_SEC);
 
     // SIT ICDs should have a SlowPollingThreshold shorter than or equal to 15s (spec 9.16.1.5)
     static constexpr System::Clock::Milliseconds32 kSITPollingThreshold = System::Clock::Milliseconds32(15000);

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -695,6 +695,7 @@ CHIP_ERROR ICDManager::HandleEventTrigger(uint64_t eventTrigger)
         break;
     case ICDTestEventTriggerEvent::kForceMaximumCheckInBackOffState:
         err = mICDCheckInBackOffStrategy->ForceMaximumCheckInBackoff();
+        break;
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
     default:
         err = CHIP_ERROR_INVALID_ARGUMENT;

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -21,6 +21,7 @@
 #include <app/AppConfig.h>
 #include <app/SubscriptionsInfoProvider.h>
 #include <app/TestEventTriggerDelegate.h>
+#include <app/icd/server/ICDCheckInBackOffStrategy.h>
 #include <app/icd/server/ICDConfigurationData.h>
 #include <app/icd/server/ICDNotifier.h>
 #include <app/icd/server/ICDStateObserver.h>
@@ -33,10 +34,9 @@
 #include <system/SystemClock.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
-#include <app/icd/server/ICDCheckInBackOffStrategy.h> // nogncheck
-#include <app/icd/server/ICDCheckInSender.h>          // nogncheck
-#include <app/icd/server/ICDMonitoringTable.h>        // nogncheck
-#endif                                                // CHIP_CONFIG_ENABLE_ICD_CIP
+#include <app/icd/server/ICDCheckInSender.h>   // nogncheck
+#include <app/icd/server/ICDMonitoringTable.h> // nogncheck
+#endif                                         // CHIP_CONFIG_ENABLE_ICD_CIP
 
 namespace chip {
 namespace Crypto {

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -115,9 +115,52 @@ public:
     ICDManager()  = default;
     ~ICDManager() = default;
 
-    void Init(PersistentStorageDelegate * storage, FabricTable * fabricTable, Crypto::SymmetricKeystore * symmetricKeyStore,
-              Messaging::ExchangeManager * exchangeManager, SubscriptionsInfoProvider * subInfoProvider,
-              ICDCheckInBackOffStrategy * strategy);
+    /*
+        Builder function to set all necessary members for the ICDManager class
+    */
+
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+    ICDManager & SetPersistentStorageDelegate(PersistentStorageDelegate * storage)
+    {
+        mStorage = storage;
+        return *this;
+    };
+
+    ICDManager & SetFabricTable(FabricTable * fabricTable)
+    {
+        mFabricTable = fabricTable;
+        return *this;
+    };
+
+    ICDManager & SetSymmetricKeyStore(Crypto::SymmetricKeystore * symmetricKeystore)
+    {
+        mSymmetricKeystore = symmetricKeystore;
+        return *this;
+    };
+
+    ICDManager & SetExchangeManager(Messaging::ExchangeManager * exchangeManager)
+    {
+        mExchangeManager = exchangeManager;
+        return *this;
+    };
+
+    ICDManager & SetSubscriptionsInfoProvider(SubscriptionsInfoProvider * subInfoProvider)
+    {
+        mSubInfoProvider = subInfoProvider;
+        return *this;
+    };
+
+    ICDManager & SetICDCheckInBackOffStrategy(ICDCheckInBackOffStrategy * strategy)
+    {
+        mICDCheckInBackOffStrategy = strategy;
+        return *this;
+    };
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
+
+    /**
+     * @brief Validates that the ICDManager has all the necessary members to function and initializes the class
+     */
+    void Init();
     void Shutdown();
 
     /**

--- a/src/app/icd/server/ICDManager.h
+++ b/src/app/icd/server/ICDManager.h
@@ -33,9 +33,10 @@
 #include <system/SystemClock.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
-#include <app/icd/server/ICDCheckInSender.h>   // nogncheck
-#include <app/icd/server/ICDMonitoringTable.h> // nogncheck
-#endif                                         // CHIP_CONFIG_ENABLE_ICD_CIP
+#include <app/icd/server/ICDCheckInBackOffStrategy.h> // nogncheck
+#include <app/icd/server/ICDCheckInSender.h>          // nogncheck
+#include <app/icd/server/ICDMonitoringTable.h>        // nogncheck
+#endif                                                // CHIP_CONFIG_ENABLE_ICD_CIP
 
 namespace chip {
 namespace Crypto {
@@ -115,7 +116,8 @@ public:
     ~ICDManager() = default;
 
     void Init(PersistentStorageDelegate * storage, FabricTable * fabricTable, Crypto::SymmetricKeystore * symmetricKeyStore,
-              Messaging::ExchangeManager * exchangeManager, SubscriptionsInfoProvider * subInfoProvider);
+              Messaging::ExchangeManager * exchangeManager, SubscriptionsInfoProvider * subInfoProvider,
+              ICDCheckInBackOffStrategy * strategy);
     void Shutdown();
 
     /**
@@ -318,11 +320,12 @@ private:
     bool mIsBootUpResumeSubscriptionExecuted = false;
 #endif // !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
-    PersistentStorageDelegate * mStorage           = nullptr;
-    FabricTable * mFabricTable                     = nullptr;
-    Messaging::ExchangeManager * mExchangeManager  = nullptr;
-    Crypto::SymmetricKeystore * mSymmetricKeystore = nullptr;
-    SubscriptionsInfoProvider * mSubInfoProvider   = nullptr;
+    PersistentStorageDelegate * mStorage                   = nullptr;
+    FabricTable * mFabricTable                             = nullptr;
+    Messaging::ExchangeManager * mExchangeManager          = nullptr;
+    Crypto::SymmetricKeystore * mSymmetricKeystore         = nullptr;
+    SubscriptionsInfoProvider * mSubInfoProvider           = nullptr;
+    ICDCheckInBackOffStrategy * mICDCheckInBackOffStrategy = nullptr;
     ObjectPool<ICDCheckInSender, (CHIP_CONFIG_ICD_CLIENTS_SUPPORTED_PER_FABRIC * CHIP_CONFIG_MAX_FABRICS)> mICDSenderPool;
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 

--- a/src/app/icd/server/tests/BUILD.gn
+++ b/src/app/icd/server/tests/BUILD.gn
@@ -22,6 +22,7 @@ chip_test_suite("tests") {
   output_name = "libICDServerTests"
 
   test_sources = [
+    "TestDefaultICDCheckInBackOffStrategy.cpp",
     "TestICDManager.cpp",
     "TestICDMonitoringTable.cpp",
   ]
@@ -29,6 +30,7 @@ chip_test_suite("tests") {
   sources = [ "ICDConfigurationDataTestAccess.h" ]
 
   public_deps = [
+    "${chip_root}/src/app/icd/server:default-check-in-back-off",
     "${chip_root}/src/app/icd/server:manager",
     "${chip_root}/src/app/icd/server:monitoring-table",
     "${chip_root}/src/lib/core:string-builder-adapters",

--- a/src/app/icd/server/tests/TestDefaultICDCheckInBackOffStrategy.cpp
+++ b/src/app/icd/server/tests/TestDefaultICDCheckInBackOffStrategy.cpp
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <app/icd/server/DefaultICDCheckInBackOffStrategy.h>
+#include <app/icd/server/ICDMonitoringTable.h>
+#include <crypto/DefaultSessionKeystore.h>
+#include <lib/core/ClusterEnums.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/core/NodeId.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters::IcdManagement;
+
+using TestSessionKeystoreImpl = Crypto::DefaultSessionKeystore;
+
+namespace {
+
+TEST(TestDefaultICDCheckInBackOffStrategy, TestShouldSendCheckInMessagePermanentClient)
+{
+    TestSessionKeystoreImpl keystore;
+    ICDMonitoringEntry entry(&keystore);
+
+    entry.clientType = ClientTypeEnum::kPermanent;
+
+    DefaultICDCheckInBackOffStrategy strategy;
+    EXPECT_TRUE(strategy.ShouldSendCheckInMessage(entry));
+}
+
+TEST(TestDefaultICDCheckInBackOffStrategy, TestShouldSendCheckInMessageEphemeralClient)
+{
+    TestSessionKeystoreImpl keystore;
+    ICDMonitoringEntry entry(&keystore);
+
+    entry.clientType = ClientTypeEnum::kEphemeral;
+
+    DefaultICDCheckInBackOffStrategy strategy;
+    EXPECT_FALSE(strategy.ShouldSendCheckInMessage(entry));
+}
+
+} // namespace

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -20,6 +20,7 @@
 
 #include <app/SubscriptionsInfoProvider.h>
 #include <app/TestEventTriggerDelegate.h>
+#include <app/icd/server/DefaultICDCheckInBackOffStrategy.h>
 #include <app/icd/server/ICDConfigurationData.h>
 #include <app/icd/server/ICDManager.h>
 #include <app/icd/server/ICDMonitoringTable.h>
@@ -197,7 +198,7 @@ public:
 
         mICDStateObserver.ResetAll();
         mICDManager.RegisterObserver(&mICDStateObserver);
-        mICDManager.Init(&testStorage, &GetFabricTable(), &mKeystore, &GetExchangeManager(), &mSubInfoProvider);
+        mICDManager.Init(&testStorage, &GetFabricTable(), &mKeystore, &GetExchangeManager(), &mSubInfoProvider, &mStrategy);
     }
 
     // Performs teardown for each individual test in the test suite
@@ -212,6 +213,7 @@ public:
     TestSubscriptionsInfoProvider mSubInfoProvider;
     TestPersistentStorageDelegate testStorage;
     TestICDStateObserver mICDStateObserver;
+    DefaultICDCheckInBackOffStrategy mStrategy;
 };
 
 TEST_F(TestICDManager, TestICDModeDurations)
@@ -568,7 +570,7 @@ TEST_F(TestICDManager, TestICDCounter)
 
     // Shut down and reinit ICDManager to increment counter
     mICDManager.Shutdown();
-    mICDManager.Init(&(testStorage), &GetFabricTable(), &(mKeystore), &GetExchangeManager(), &(mSubInfoProvider));
+    mICDManager.Init(&(testStorage), &GetFabricTable(), &(mKeystore), &GetExchangeManager(), &(mSubInfoProvider), &mStrategy);
     mICDManager.RegisterObserver(&(mICDStateObserver));
 
     EXPECT_EQ(counter + ICDConfigurationData::kICDCounterPersistenceIncrement,
@@ -973,7 +975,7 @@ TEST_F(TestICDManager, TestICDStateObserverOnICDModeChangeOnInit)
     // Shut down and reinit ICDManager - We should go to LIT mode since we have a registration
     mICDManager.Shutdown();
     mICDManager.RegisterObserver(&(mICDStateObserver));
-    mICDManager.Init(&testStorage, &GetFabricTable(), &mKeystore, &GetExchangeManager(), &mSubInfoProvider);
+    mICDManager.Init(&testStorage, &GetFabricTable(), &mKeystore, &GetExchangeManager(), &mSubInfoProvider, &mStrategy);
 
     // We have a registration, transition to LIT mode
     EXPECT_TRUE(mICDStateObserver.mOnICDModeChangeCalled);

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -199,13 +199,15 @@ public:
         mICDStateObserver.ResetAll();
         mICDManager.RegisterObserver(&mICDStateObserver);
 
+#if CHIP_CONFIG_ENABLE_ICD_CIP
         mICDManager.SetPersistentStorageDelegate(&testStorage)
             .SetFabricTable(&GetFabricTable())
             .SetSymmetricKeyStore(&mKeystore)
             .SetExchangeManager(&GetExchangeManager())
             .SetSubscriptionsInfoProvider(&mSubInfoProvider)
-            .SetICDCheckInBackOffStrategy(&mStrategy)
-            .Init();
+            .SetICDCheckInBackOffStrategy(&mStrategy);
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
+        mICDManager.Init();
     }
 
     // Performs teardown for each individual test in the test suite
@@ -577,13 +579,16 @@ TEST_F(TestICDManager, TestICDCounter)
 
     // Shut down and reinit ICDManager to increment counter
     mICDManager.Shutdown();
+#if CHIP_CONFIG_ENABLE_ICD_CIP
     mICDManager.SetPersistentStorageDelegate(&testStorage)
         .SetFabricTable(&GetFabricTable())
         .SetSymmetricKeyStore(&mKeystore)
         .SetExchangeManager(&GetExchangeManager())
         .SetSubscriptionsInfoProvider(&mSubInfoProvider)
-        .SetICDCheckInBackOffStrategy(&mStrategy)
-        .Init();
+        .SetICDCheckInBackOffStrategy(&mStrategy);
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
+    mICDManager.Init();
+
     mICDManager.RegisterObserver(&(mICDStateObserver));
 
     EXPECT_EQ(counter + ICDConfigurationData::kICDCounterPersistenceIncrement,
@@ -988,13 +993,15 @@ TEST_F(TestICDManager, TestICDStateObserverOnICDModeChangeOnInit)
     // Shut down and reinit ICDManager - We should go to LIT mode since we have a registration
     mICDManager.Shutdown();
     mICDManager.RegisterObserver(&(mICDStateObserver));
+#if CHIP_CONFIG_ENABLE_ICD_CIP
     mICDManager.SetPersistentStorageDelegate(&testStorage)
         .SetFabricTable(&GetFabricTable())
         .SetSymmetricKeyStore(&mKeystore)
         .SetExchangeManager(&GetExchangeManager())
         .SetSubscriptionsInfoProvider(&mSubInfoProvider)
-        .SetICDCheckInBackOffStrategy(&mStrategy)
-        .Init();
+        .SetICDCheckInBackOffStrategy(&mStrategy);
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
+    mICDManager.Init();
 
     // We have a registration, transition to LIT mode
     EXPECT_TRUE(mICDStateObserver.mOnICDModeChangeCalled);

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -198,7 +198,14 @@ public:
 
         mICDStateObserver.ResetAll();
         mICDManager.RegisterObserver(&mICDStateObserver);
-        mICDManager.Init(&testStorage, &GetFabricTable(), &mKeystore, &GetExchangeManager(), &mSubInfoProvider, &mStrategy);
+
+        mICDManager.SetPersistentStorageDelegate(&testStorage)
+            .SetFabricTable(&GetFabricTable())
+            .SetSymmetricKeyStore(&mKeystore)
+            .SetExchangeManager(&GetExchangeManager())
+            .SetSubscriptionsInfoProvider(&mSubInfoProvider)
+            .SetICDCheckInBackOffStrategy(&mStrategy)
+            .Init();
     }
 
     // Performs teardown for each individual test in the test suite
@@ -570,7 +577,13 @@ TEST_F(TestICDManager, TestICDCounter)
 
     // Shut down and reinit ICDManager to increment counter
     mICDManager.Shutdown();
-    mICDManager.Init(&(testStorage), &GetFabricTable(), &(mKeystore), &GetExchangeManager(), &(mSubInfoProvider), &mStrategy);
+    mICDManager.SetPersistentStorageDelegate(&testStorage)
+        .SetFabricTable(&GetFabricTable())
+        .SetSymmetricKeyStore(&mKeystore)
+        .SetExchangeManager(&GetExchangeManager())
+        .SetSubscriptionsInfoProvider(&mSubInfoProvider)
+        .SetICDCheckInBackOffStrategy(&mStrategy)
+        .Init();
     mICDManager.RegisterObserver(&(mICDStateObserver));
 
     EXPECT_EQ(counter + ICDConfigurationData::kICDCounterPersistenceIncrement,
@@ -975,7 +988,13 @@ TEST_F(TestICDManager, TestICDStateObserverOnICDModeChangeOnInit)
     // Shut down and reinit ICDManager - We should go to LIT mode since we have a registration
     mICDManager.Shutdown();
     mICDManager.RegisterObserver(&(mICDStateObserver));
-    mICDManager.Init(&testStorage, &GetFabricTable(), &mKeystore, &GetExchangeManager(), &mSubInfoProvider, &mStrategy);
+    mICDManager.SetPersistentStorageDelegate(&testStorage)
+        .SetFabricTable(&GetFabricTable())
+        .SetSymmetricKeyStore(&mKeystore)
+        .SetExchangeManager(&GetExchangeManager())
+        .SetSubscriptionsInfoProvider(&mSubInfoProvider)
+        .SetICDCheckInBackOffStrategy(&mStrategy)
+        .Init();
 
     // We have a registration, transition to LIT mode
     EXPECT_TRUE(mICDStateObserver.mOnICDModeChangeCalled);

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -72,5 +72,12 @@ static_library("server") {
 
   if (chip_enable_icd_server) {
     public_deps += [ "${chip_root}/src/app/icd/server:notifier" ]
+
+    if (chip_enable_icd_checkin) {
+      public_deps += [
+        "${chip_root}/src/app/icd/server:check-in-back-off",
+        "${chip_root}/src/app/icd/server:default-check-in-back-off",
+      ]
+    }
   }
 }

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -53,6 +53,7 @@ static_library("server") {
   public_deps = [
     "${chip_root}/src/app",
     "${chip_root}/src/app:test-event-trigger",
+    "${chip_root}/src/app/icd/server:check-in-back-off",
     "${chip_root}/src/app/icd/server:icd-server-config",
     "${chip_root}/src/app/icd/server:observer",
     "${chip_root}/src/lib/address_resolve",
@@ -74,10 +75,8 @@ static_library("server") {
     public_deps += [ "${chip_root}/src/app/icd/server:notifier" ]
 
     if (chip_enable_icd_checkin) {
-      public_deps += [
-        "${chip_root}/src/app/icd/server:check-in-back-off",
-        "${chip_root}/src/app/icd/server:default-check-in-back-off",
-      ]
+      public_deps +=
+          [ "${chip_root}/src/app/icd/server:default-check-in-back-off" ]
     }
   }
 }

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -359,8 +359,16 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     mICDManager.RegisterObserver(mReportScheduler);
     mICDManager.RegisterObserver(&app::DnssdServer::Instance());
 
-    mICDManager.Init(mDeviceStorage, &GetFabricTable(), mSessionKeystore, &mExchangeMgr,
-                     chip::app::InteractionModelEngine::GetInstance(), initParams.icdCheckInBackOffStrategy);
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+    mICDManager.SetPersistentStorageDelegate(mDeviceStorage)
+        .SetFabricTable(&GetFabricTable())
+        .SetSymmetricKeyStore(mSessionKeystore)
+        .SetExchangeManager(&mExchangeMgr)
+        .SetSubscriptionsInfoProvider(chip::app::InteractionModelEngine::GetInstance())
+        .SetICDCheckInBackOffStrategy(initParams.icdCheckInBackOffStrategy);
+
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
+    mICDManager.Init();
 
     // Register Test Event Trigger Handler
     if (mTestEventTriggerDelegate != nullptr)

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -360,7 +360,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     mICDManager.RegisterObserver(&app::DnssdServer::Instance());
 
     mICDManager.Init(mDeviceStorage, &GetFabricTable(), mSessionKeystore, &mExchangeMgr,
-                     chip::app::InteractionModelEngine::GetInstance());
+                     chip::app::InteractionModelEngine::GetInstance(), initParams.icdCheckInBackOffStrategy);
 
     // Register Test Event Trigger Handler
     if (mTestEventTriggerDelegate != nullptr)
@@ -769,5 +769,8 @@ app::SimpleSubscriptionResumptionStorage CommonCaseDeviceServerInitParams::sSubs
 #endif
 app::DefaultAclStorage CommonCaseDeviceServerInitParams::sAclStorage;
 Crypto::DefaultSessionKeystore CommonCaseDeviceServerInitParams::sSessionKeystore;
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+app::DefaultICDCheckInBackOffStrategy CommonCaseDeviceServerInitParams::sDefaultICDCheckInBackOffStrategy;
+#endif
 
 } // namespace chip

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -169,8 +169,8 @@ struct ServerInitParams
     Credentials::OperationalCertificateStore * opCertStore = nullptr;
     // Required, if not provided, the Server::Init() WILL fail.
     app::reporting::ReportScheduler * reportScheduler = nullptr;
-    // Optionnal. Support for the ICD Check-In BackOff strategy. Must be initialized before being provided.
-    // If the ICD Check-In protocol use-case is supported and no strategy is prprovided, server will use the default strategy.
+    // Optional. Support for the ICD Check-In BackOff strategy. Must be initialized before being provided.
+    // If the ICD Check-In protocol use-case is supported and no strategy is provided, server will use the default strategy.
     app::ICDCheckInBackOffStrategy * icdCheckInBackOffStrategy = nullptr;
 };
 

--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -278,7 +278,8 @@
             "ActiveModeThreshold",
             "RegisteredClients",
             "ICDCounter",
-            "ClientsSupportedPerFabric"
+            "ClientsSupportedPerFabric",
+            "MaximumCheckInBackOff"
         ],
         "Occupancy Sensing": ["HoldTimeLimits"],
         "Operational Credentials": [

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -276,7 +276,8 @@
             "ActiveModeThreshold",
             "RegisteredClients",
             "ICDCounter",
-            "ClientsSupportedPerFabric"
+            "ClientsSupportedPerFabric",
+            "MaximumCheckInBackOff"
         ],
         "Occupancy Sensing": ["HoldTimeLimits"],
         "Operational Credentials": [

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1625,6 +1625,15 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
+ * @def CHIP_CONFIG_ICD_MAXIMUM_CHECK_IN_BACKOFF
+ *
+ * @brief Default value for the ICD Management cluster MaximumCheckInBackoff attribute, in seconds
+ */
+#ifndef CHIP_CONFIG_ICD_MAXIMUM_CHECK_IN_BACKOFF_SEC
+#define CHIP_CONFIG_ICD_MAXIMUM_CHECK_IN_BACKOFF_SEC CHIP_CONFIG_ICD_IDLE_MODE_DURATION_SEC
+#endif
+
+/**
  *  @name Configuation for resuming subscriptions that timed out
  *
  *  @brief

--- a/src/python_testing/TC_ICDManagementCluster.py
+++ b/src/python_testing/TC_ICDManagementCluster.py
@@ -46,6 +46,7 @@ class ICDTestEventTriggerOperations(IntEnum):
     kRemoveActiveModeReq = 0x0046000000000002
     kInvalidateHalfCounterValues = 0x0046000000000003
     kInvalidateAllCounterValues = 0x0046000000000004
+    kForceMaximumCheckInBackOffState = 0x0046000000000005
 
 
 class TestICDManagementCluster(MatterBaseTest):
@@ -110,6 +111,15 @@ class TestICDManagementCluster(MatterBaseTest):
                 endpoint=kRootEndpointId,
                 payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kTestEventTriggerKey,
                                                                               eventTrigger=ICDTestEventTriggerOperations.kRemoveActiveModeReq)
+            )
+        )
+
+        asserts.assert_is_none(
+            await dev_ctrl.SendCommand(
+                self.dut_node_id,
+                endpoint=kRootEndpointId,
+                payload=Clusters.GeneralDiagnostics.Commands.TestEventTrigger(enableKey=kTestEventTriggerKey,
+                                                                              eventTrigger=ICDTestEventTriggerOperations.kForceMaximumCheckInBackOffState)
             )
         )
 

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -9397,52 +9397,6 @@ Protocols::InteractionModel::Status Set(chip::EndpointId endpoint, chip::app::Cl
 
 } // namespace OperatingMode
 
-namespace MaximumCheckInBackOff {
-
-Protocols::InteractionModel::Status Get(chip::EndpointId endpoint, uint32_t * value)
-{
-    using Traits = NumericAttributeTraits<uint32_t>;
-    Traits::StorageType temp;
-    uint8_t * readable = Traits::ToAttributeStoreRepresentation(temp);
-    Protocols::InteractionModel::Status status =
-        emberAfReadAttribute(endpoint, Clusters::IcdManagement::Id, Id, readable, sizeof(temp));
-    VerifyOrReturnError(Protocols::InteractionModel::Status::Success == status, status);
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, temp))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    *value = Traits::StorageToWorking(temp);
-    return status;
-}
-
-Protocols::InteractionModel::Status Set(chip::EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty)
-{
-    using Traits = NumericAttributeTraits<uint32_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::IcdManagement::Id, Id, writable, ZCL_INT32U_ATTRIBUTE_TYPE, markDirty);
-}
-
-Protocols::InteractionModel::Status Set(chip::EndpointId endpoint, uint32_t value)
-{
-    using Traits = NumericAttributeTraits<uint32_t>;
-    if (!Traits::CanRepresentValue(/* isNullable = */ false, value))
-    {
-        return Protocols::InteractionModel::Status::ConstraintError;
-    }
-    Traits::StorageType storageValue;
-    Traits::WorkingToStorage(value, storageValue);
-    uint8_t * writable = Traits::ToAttributeStoreRepresentation(storageValue);
-    return emberAfWriteAttribute(endpoint, Clusters::IcdManagement::Id, Id, writable, ZCL_INT32U_ATTRIBUTE_TYPE);
-}
-
-} // namespace MaximumCheckInBackOff
-
 namespace FeatureMap {
 
 Protocols::InteractionModel::Status Get(chip::EndpointId endpoint, uint32_t * value)

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -1506,12 +1506,6 @@ Protocols::InteractionModel::Status Set(chip::EndpointId endpoint, chip::app::Cl
                                         MarkAttributeDirty markDirty);
 } // namespace OperatingMode
 
-namespace MaximumCheckInBackOff {
-Protocols::InteractionModel::Status Get(chip::EndpointId endpoint, uint32_t * value); // int32u
-Protocols::InteractionModel::Status Set(chip::EndpointId endpoint, uint32_t value);
-Protocols::InteractionModel::Status Set(chip::EndpointId endpoint, uint32_t value, MarkAttributeDirty markDirty);
-} // namespace MaximumCheckInBackOff
-
 namespace FeatureMap {
 Protocols::InteractionModel::Status Get(chip::EndpointId endpoint, uint32_t * value); // bitmap32
 Protocols::InteractionModel::Status Set(chip::EndpointId endpoint, uint32_t value);


### PR DESCRIPTION
#### Description
PR implements the ICD Check-In BackOff strategy with the ICD server feature-set.
PR adds the framework to enable a platform to inject a strategy that will be leveraged by the ICDManager during server init.

- Add the MaximumCheckInBackOff attribute to the ICDM cluster.
- Adds an injectable Check-In BackOff strategy that is consummed by the ICDManager.
- Adds a Default Check-In BackOff that reproduces the current behavior

#### Note to reviewers
The goal of this PR is just to setup the structure were a strategy can be injected. It provides very little help to implement a given strategy for now. Having trackers for missed Check-In messages and other tools will be added in a follow up PR.

#### Tests
- Automated tests to validated regression
- Manual tests to validate the default strategy behavior since we still need to restructure the Check-In message sending.