### PR TITLE
ESP32: Provision to place the app_main in other than main component

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -463,7 +463,11 @@ if (CONFIG_ENABLE_ENCRYPTED_OTA)
     list(APPEND chip_libraries $<TARGET_FILE:${esp_encrypted_img_lib}>)
 endif()
 
-idf_component_get_property(main_lib main COMPONENT_LIB)
+# Let user set EXECUTABLE_COMPONENT_NAME and defaults to main if not specified
+if (NOT EXECUTABLE_COMPONENT_NAME)
+  set(EXECUTABLE_COMPONENT_NAME "main")
+endif()
+idf_component_get_property(main_lib ${EXECUTABLE_COMPONENT_NAME} COMPONENT_LIB)
 list(APPEND chip_libraries $<TARGET_FILE:${main_lib}>)
 
 if (CONFIG_SEC_CERT_DAC_PROVIDER)

--- a/docs/guides/esp32/config_options.md
+++ b/docs/guides/esp32/config_options.md
@@ -11,3 +11,18 @@ Configure below options through `idf.py menuconfig` and build the app.
 CONFIG_DISABLE_IPV4=y
 CONFIG_LWIP_IPV4=n
 ```
+
+### Executable component not in "main" component
+
+The ESP-IDF framework allows renaming the main component, which can be useful if
+you want to place the app_main() function in a different component.
+
+For required changes in the executable component, please refer to the
+[esp-idf documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/build-system.html#renaming-main-component).
+
+If you're building applications that support Matter and want to place app_main()
+in a component other than main, use the following command:
+
+```
+idf.py -DEXECUTABLE_COMPONENT_NAME="your_component" build
+```


### PR DESCRIPTION
The ESP-IDF framework allows renaming the main component, which can be useful if
you want to place the app_main() function in a different component.

Adding changes required to support the same.

#### Tests
Tested renaming the main component in lighting-app/esp32.