### PR TITLE
[examples] Fixed shell build for nrfconnect

### DIFF
--- a/examples/shell/nrfconnect/sysbuild.conf
+++ b/examples/shell/nrfconnect/sysbuild.conf
@@ -1,0 +1,18 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+SB_CONFIG_MATTER=y
+SB_CONFIG_MATTER_OTA=n


### PR DESCRIPTION
Shell example build for nrfconnect was broken due to missing sysbuild.conf file that enabled Matter.


