### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-65 : [nrfconnect] Update nRF Connect SDK version.
+66 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=ab81a585fca6a83b30e1f4e58a021113d6a3acb8
+ARG ZEPHYR_REVISION=ef7bfc2214602ecf237332b71e6a2bdd69205fbd
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**
- soc: riscv: telink_w91: ECC HW cryptography
- soc: riscv: telink_w91: Set IPC dispatcher common timeout
- soc: riscv: telink_w91: Simplify heartbeat procedure
- zephyr: drivers: spi: spi_b9x: Fixed wrong SPI mode selection
- samples: boards: tlsr9x: sock_simple: Update application
- telink: b92: adopt ble v4.0.3.0 and 4m flash support .
- boards: tlsr9118bdk40d: doc: index.rst: Update documentation
- boards: doc: index.rst: Update documentation
- telink: flash: fix flash and pwm driver.

Testing
Tested manually.

Steps:
- Build image
- Run docker
- Check if Telink examples able to be built successfully