### PR TITLE
[nrfconnect] Updated documentation for all nrfconnect examples

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -402,6 +402,7 @@ DevKitM
 devtype
 df
 dfe
+DFILE
 dfu
 DgDxsfHx
 dhclient
@@ -1354,6 +1355,7 @@ SVR
 SWD
 SWU
 symlinks
+sysbuild
 sysconfdir
 SysConfig
 sysctl

--- a/examples/all-clusters-app/nrfconnect/README.md
+++ b/examples/all-clusters-app/nrfconnect/README.md
@@ -1,5 +1,21 @@
 # Matter nRF Connect All Clusters Example Application
 
+> **Note:** This example is intended only to perform smoke tests of a Matter
+> solution integrated with nRF Connect SDK platform. The example quality is not
+> production ready and it may contain minor bugs or use not optimal
+> configuration. It is not recommended to use this example as a basis for
+> creating a market ready product.
+>
+> For the production ready and optimized Matter samples, see
+> [nRF Connect SDK samples](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/matter.html).
+> The Matter samples in nRF Connect SDK use various additional software
+> components and provide multiple optional features that improve the developer
+> and user experience. To read more about it, see
+> [Matter support in nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html#ug-matter)
+> page. Using Matter samples from nRF Connect SDK allows you to get a full
+> Nordic technical support via [DevZone](https://devzone.nordicsemi.com/)
+> portal.
+
 The nRF All Clusters Example Application implements various ZCL clusters
 populated on three endpoints. You can use this example as a reference for
 creating your own application.
@@ -85,10 +101,10 @@ The example supports building and running on the following devices:
 
 | Hardware platform                                                                                 | Build target               | Platform image                                                                                                                                          |
 | ------------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)         | `nrf52840dk_nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details>        |
-| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)           | `nrf5340dk_nrf5340_cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>           |
-| [nRF52840 Dongle](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle) | `nrf52840dongle_nrf52840`  | <details><summary>nRF52840 Dongle</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_Dongle-medium.jpg" alt="nRF52840 Dongle"/></details> |
-| [nRF7002 DK](https://www.nordicsemi.com/Products/Development-hardware/nRF7002-DK)                 | `nrf7002dk_nrf5340_cpuapp` | <details><summary>nRF7002 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF7002-DK_Front-small.png" alt="nRF7002 DK"/></details>           |
+| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)         | `nrf52840dk/nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details>        |
+| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)           | `nrf5340dk/nrf5340/cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>           |
+| [nRF52840 Dongle](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle) | `nrf52840dongle/nrf52840`  | <details><summary>nRF52840 Dongle</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_Dongle-medium.jpg" alt="nRF52840 Dongle"/></details> |
+| [nRF7002 DK](https://www.nordicsemi.com/Products/Development-hardware/nRF7002-DK)                 | `nrf7002dk/nrf5340/cpuapp` | <details><summary>nRF7002 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF7002-DK_Front-small.png" alt="nRF7002 DK"/></details>           |
 
 <hr>
 
@@ -97,9 +113,9 @@ The example supports building and running on the following devices:
 The development kits for this sample offer the following IPv6 network support
 for Matter:
 
--   Matter over Thread is supported for `nrf52840dk_nrf52840` and
-    `nrf5340dk_nrf5340_cpuapp`.
--   Matter over Wi-Fi is supported for `nrf7002dk_nrf5340_cpuapp`.
+-   Matter over Thread is supported for `nrf52840dk/nrf52840` and
+    `nrf5340dk/nrf5340/cpuapp`.
+-   Matter over Wi-Fi is supported for `nrf7002dk/nrf5340/cpuapp`.
 
 ## Device UI
 
@@ -248,14 +264,15 @@ Complete the following steps to build the sample:
 
 2.  Run the following command to build the example, with _build-target_ replaced
     with the build target name of the Nordic Semiconductor's kit you own, for
-    example `nrf52840dk_nrf52840`:
+    example `nrf52840dk/nrf52840`:
 
-         $ west build -b build-target
+         $ west build -b build-target --sysbuild
 
     You only need to specify the build target on the first build. See
     [Requirements](#requirements) for the build target names of compatible kits.
 
-The output `zephyr.hex` file will be available in the `build/zephyr/` directory.
+The output `zephyr.hex` file will be available in the `build/nrfconnect/zephyr/`
+directory.
 
 ### Removing build artifacts
 
@@ -270,7 +287,7 @@ following command:
 To build the example with release configuration that disables the diagnostic
 features like logs and command-line interface, run the following command:
 
-    $ west build -b build-target -- -DCONF_FILE=prj_release.conf
+    $ west build -b build-target --sysbuild -- -DFILE_SUFFIX=release
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -281,9 +298,9 @@ Support for DFU using Matter OTA is disabled by default.
 
 To build the example with configuration that supports DFU, run the following
 command with _build-target_ replaced with the build target name of the Nordic
-Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
+Semiconductor kit you are using (for example `nrf52840dk/nrf52840`):
 
-    $ west build -b build-target -- -DCONF_FILE=prj_dfu.conf
+    $ west build -b build-target --sysbuild -- -DFILE_SUFFIX=dfu
 
 > **Note**:
 >
@@ -299,7 +316,7 @@ Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
 #### Changing bootloader configuration
 
 To change the default MCUboot configuration, edit the `prj.conf` file located in
-the `child_image/mcuboot` directory.
+the `sysbuild/mcuboot` directory.
 
 #### Changing flash memory settings
 
@@ -311,8 +328,9 @@ purposes. You can change these settings by defining
 This example uses this option to define using an external flash.
 
 To modify the flash settings of your board (that is, your _build-target_, for
-example `nrf52840dk_nrf52840`), edit the `pm_static_dfu.yml` file located in the
-`configuration/build-target/` directory.
+example `nrf52840dk/nrf52840`), edit the `pm_static_<build_target>.yml` file
+(for example `pm_static_nrf52840dk_nrf52840.yml`), located in the main
+application directory.
 
 <hr>
 
@@ -324,7 +342,7 @@ using the menuconfig utility.
 To open the menuconfig utility, run the following command from the example
 directory:
 
-    $ west build -b build-target -t menuconfig
+    $ west build -b build-target --sysbuild -t menuconfig
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.

--- a/examples/all-clusters-minimal-app/nrfconnect/README.md
+++ b/examples/all-clusters-minimal-app/nrfconnect/README.md
@@ -1,5 +1,21 @@
 # Matter nRF Connect All Clusters Example Application
 
+> **Note:** This example is intended only to perform smoke tests of a Matter
+> solution integrated with nRF Connect SDK platform. The example quality is not
+> production ready and it may contain minor bugs or use not optimal
+> configuration. It is not recommended to use this example as a basis for
+> creating a market ready product.
+>
+> For the production ready and optimized Matter samples, see
+> [nRF Connect SDK samples](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/matter.html).
+> The Matter samples in nRF Connect SDK use various additional software
+> components and provide multiple optional features that improve the developer
+> and user experience. To read more about it, see
+> [Matter support in nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html#ug-matter)
+> page. Using Matter samples from nRF Connect SDK allows you to get a full
+> Nordic technical support via [DevZone](https://devzone.nordicsemi.com/)
+> portal.
+
 The nRF All Clusters Example Application implements various ZCL clusters
 populated on three endpoints. You can use this example as a reference for
 creating your own application.
@@ -77,9 +93,9 @@ The example supports building and running on the following devices:
 
 | Hardware platform                                                                                 | Build target               | Platform image                                                                                                                                          |
 | ------------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)         | `nrf52840dk_nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details>        |
-| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)           | `nrf5340dk_nrf5340_cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>           |
-| [nRF52840 Dongle](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle) | `nrf52840dongle_nrf52840`  | <details><summary>nRF52840 Dongle</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_Dongle-medium.jpg" alt="nRF52840 Dongle"/></details> |
+| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)         | `nrf52840dk/nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details>        |
+| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)           | `nrf5340dk/nrf5340/cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>           |
+| [nRF52840 Dongle](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle) | `nrf52840dongle/nrf52840`  | <details><summary>nRF52840 Dongle</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_Dongle-medium.jpg" alt="nRF52840 Dongle"/></details> |
 
 <hr>
 
@@ -240,14 +256,15 @@ environment:
 
 2.  Run the following command to build the example, with _build-target_ replaced
     with the build target name of the Nordic Semiconductor's kit you own, for
-    example `nrf52840dk_nrf52840`:
+    example `nrf52840dk/nrf52840`:
 
-         $ west build -b build-target
+         $ west build -b build-target --sysbuild
 
     You only need to specify the build target on the first build. See
     [Requirements](#requirements) for the build target names of compatible kits.
 
-The output `zephyr.hex` file will be available in the `build/zephyr/` directory.
+The output `zephyr.hex` file will be available in the `build/nrfconnect/zephyr/`
+directory.
 
 ### Removing build artifacts
 
@@ -262,7 +279,7 @@ following command:
 To build the example with release configuration that disables the diagnostic
 features like logs and command-line interface, run the following command:
 
-    $ west build -b build-target -- -DCONF_FILE=prj_release.conf
+    $ west build -b build-target --sysbuild -- -DFILE_SUFFIX=release
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -273,9 +290,9 @@ Support for DFU using Matter OTA is disabled by default.
 
 To build the example with configuration that supports DFU, run the following
 command with _build-target_ replaced with the build target name of the Nordic
-Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
+Semiconductor kit you are using (for example `nrf52840dk/nrf52840`):
 
-    $ west build -b build-target -- -DCONF_FILE=prj_dfu.conf
+    $ west build -b build-target --sysbuild -- -DFILE_SUFFIX=dfu
 
 > **Note**:
 >
@@ -291,7 +308,7 @@ Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
 #### Changing bootloader configuration
 
 To change the default MCUboot configuration, edit the `prj.conf` file located in
-the `child_image/mcuboot` directory.
+the `sysbuild/mcuboot` directory.
 
 #### Changing flash memory settings
 
@@ -303,8 +320,9 @@ purposes. You can change these settings by defining
 This example uses this option to define using an external flash.
 
 To modify the flash settings of your board (that is, your _build-target_, for
-example `nrf52840dk_nrf52840`), edit the `pm_static_dfu.yml` file located in the
-`configuration/build-target/` directory.
+example `nrf52840dk/nrf52840`), edit the `pm_static_<build_target>.yml` file
+(for example `pm_static_nrf52840dk_nrf52840.yml`), located in the main
+application directory.
 
 <hr>
 
@@ -316,7 +334,7 @@ using the menuconfig utility.
 To open the menuconfig utility, run the following command from the example
 directory:
 
-    $ west build -b build-target -t menuconfig
+    $ west build -b build-target --sysbuild -t menuconfig
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.

--- a/examples/chef/nrfconnect/README.md
+++ b/examples/chef/nrfconnect/README.md
@@ -1,5 +1,21 @@
 # CHIP nRF Connect SDK Shell Application
 
+> **Note:** This example is intended only to perform smoke tests of a Matter
+> solution integrated with nRF Connect SDK platform. The example quality is not
+> production ready and it may contain minor bugs or use not optimal
+> configuration. It is not recommended to use this example as a basis for
+> creating a market ready product.
+>
+> For the production ready and optimized Matter samples, see
+> [nRF Connect SDK samples](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/matter.html).
+> The Matter samples in nRF Connect SDK use various additional software
+> components and provide multiple optional features that improve the developer
+> and user experience. To read more about it, see
+> [Matter support in nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html#ug-matter)
+> page. Using Matter samples from nRF Connect SDK allows you to get a full
+> Nordic technical support via [DevZone](https://devzone.nordicsemi.com/)
+> portal.
+
 A [chip-shell](../README.md) project for the Nordic nRF52840 and nRF5340
 development kits, built using the nRF Connect SDK.
 

--- a/examples/light-switch-app/nrfconnect/README.md
+++ b/examples/light-switch-app/nrfconnect/README.md
@@ -1,5 +1,21 @@
 # Matter nRF Connect Light Switch Example Application
 
+> **Note:** This example is intended only to perform smoke tests of a Matter
+> solution integrated with nRF Connect SDK platform. The example quality is not
+> production ready and it may contain minor bugs or use not optimal
+> configuration. It is not recommended to use this example as a basis for
+> creating a market ready product.
+>
+> For the production ready and optimized Matter samples, see
+> [nRF Connect SDK samples](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/matter.html).
+> The Matter samples in nRF Connect SDK use various additional software
+> components and provide multiple optional features that improve the developer
+> and user experience. To read more about it, see
+> [Matter support in nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html#ug-matter)
+> page. Using Matter samples from nRF Connect SDK allows you to get a full
+> Nordic technical support via [DevZone](https://devzone.nordicsemi.com/)
+> portal.
+
 The nRF Connect Light Switch Example demonstrates how to remotely control a
 lighting devices such as light bulbs or LEDs. The application should be used
 together with the
@@ -199,18 +215,18 @@ The example supports building and running on the following devices:
 
 | Hardware platform                                                                         | Build target               | Platform image                                                                                                                                   |
 | ----------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk_nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
-| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk_nrf5340_cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
-| [nRF7002 DK](https://www.nordicsemi.com/Products/Development-hardware/nRF7002-DK)         | `nrf7002dk_nrf5340_cpuapp` | <details><summary>nRF7002 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF7002-DK_Front-small.png" alt="nRF7002 DK"/></details>    |
+| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk/nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
+| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk/nrf5340/cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
+| [nRF7002 DK](https://www.nordicsemi.com/Products/Development-hardware/nRF7002-DK)         | `nrf7002dk/nrf5340/cpuapp` | <details><summary>nRF7002 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF7002-DK_Front-small.png" alt="nRF7002 DK"/></details>    |
 
 ### IPv6 network support
 
 The development kits for this sample offer the following IPv6 network support
 for Matter:
 
--   Matter over Thread is supported for `nrf52840dk_nrf52840` and
-    `nrf5340dk_nrf5340_cpuapp`.
--   Matter over Wi-Fi is supported for `nrf7002dk_nrf5340_cpuapp`.
+-   Matter over Thread is supported for `nrf52840dk/nrf52840` and
+    `nrf5340dk/nrf5340/cpuapp`.
+-   Matter over Wi-Fi is supported for `nrf7002dk/nrf5340/cpuapp`.
 
 ### Additional requirements for testing
 
@@ -341,9 +357,9 @@ connection to Nordic Semiconductor's kit.
 To enable the Matter CLI, you must compile the Light Switch Example application
 with the additional option **-DCONFIG_CHIP_LIB_SHELL=y**. Run the following
 command with _build-target_ replaced with the build target name of Nordic
-Semiconductor's kit you are using (for example, `nrf52840dk_nrf52840`):
+Semiconductor's kit you are using (for example, `nrf52840dk/nrf52840`):
 
-    west build -b build-target -- -DCONFIG_CHIP_LIB_SHELL=y
+    west build -b build-target --sysbuild -- -DCONFIG_CHIP_LIB_SHELL=y
 
 You can use the following commands to control a device that is programmed with
 the Light Switch Example application by using the Matter CLI:
@@ -441,14 +457,15 @@ Complete the following steps to build the sample:
 
 2.  Run the following command to build the example, with _build-target_ replaced
     with the build target name of the Nordic Semiconductor's kit you own, for
-    example `nrf52840dk_nrf52840`:
+    example `nrf52840dk/nrf52840`:
 
-         $ west build -b build-target
+         $ west build -b build-target --sysbuild
 
     You only need to specify the build target on the first build. See
     [Requirements](#requirements) for the build target names of compatible kits.
 
-The output `zephyr.hex` file will be available in the `build/zephyr/` directory.
+The output `zephyr.hex` file will be available in the `build/nrfconnect/zephyr/`
+directory.
 
 ### Removing build artifacts
 
@@ -463,7 +480,7 @@ following command:
 To build the example with release configuration that disables the diagnostic
 features like logs and command-line interface, run the following command:
 
-    $ west build -b build-target -- -DCONF_FILE=prj_release.conf
+    $ west build -b build-target --sysbuild -- -DFILE_SUFFIX=release
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -474,15 +491,9 @@ Support for DFU using Matter OTA is enabled by default.
 
 To enable DFU over Bluetooth LE, run the following command with _build-target_
 replaced with the build target name of the Nordic Semiconductor kit you are
-using (for example `nrf52840dk_nrf52840`):
+using (for example `nrf52840dk/nrf52840`):
 
-    $ west build -b build-target -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
-
-To completely disable support for both DFU methods, run the following command
-with _build-target_ replaced with the build target name of the Nordic
-Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
-
-    $ west build -b build-target -- -DCONF_FILE=prj_no_dfu.conf
+    $ west build -b build-target --sysbuild -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
 
 > **Note**:
 >
@@ -496,7 +507,7 @@ Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
 #### Changing bootloader configuration
 
 To change the default MCUboot configuration, edit the `prj.conf` file located in
-the `child_image/mcuboot` directory.
+the `sysbuild/mcuboot` directory.
 
 Make sure to keep the configuration consistent with changes made to the
 application configuration. This is necessary for the configuration to work, as
@@ -513,8 +524,9 @@ purposes. You can change these settings by defining
 This example uses this option to define using an external flash.
 
 To modify the flash settings of your board (that is, your _build-target_, for
-example `nrf52840dk_nrf52840`), edit the `pm_static_dfu.yml` file located in the
-`configuration/build-target/` directory.
+example `nrf52840dk/nrf52840`), edit the `pm_static_<build_target>.yml` file
+(for example `pm_static_nrf52840dk_nrf52840.yml`), located in the main
+application directory.
 
 <hr>
 
@@ -526,7 +538,7 @@ using the menuconfig utility.
 To open the menuconfig utility, run the following command from the example
 directory:
 
-    $ west build -b build-target -t menuconfig
+    $ west build -b build-target --sysbuild -t menuconfig
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -556,9 +568,6 @@ depending on the selected board:
     command-line shell.
 -   release -- Release version of the application - can be used to enable only
     the necessary application functionalities to optimize its performance.
--   no_dfu -- Debug version of the application without Device Firmware Upgrade
-    feature support - can be used only for the nRF52840 DK and nRF5340 DK, as
-    those platforms have DFU enabled by default.
 
 For more information, see the
 [Configuring nRF Connect SDK examples](../../../docs/guides/nrfconnect_examples_configuration.md)

--- a/examples/lighting-app/nrfconnect/README.md
+++ b/examples/lighting-app/nrfconnect/README.md
@@ -1,5 +1,21 @@
 # Matter nRF Connect Lighting Example Application
 
+> **Note:** This example is intended only to perform smoke tests of a Matter
+> solution integrated with nRF Connect SDK platform. The example quality is not
+> production ready and it may contain minor bugs or use not optimal
+> configuration. It is not recommended to use this example as a basis for
+> creating a market ready product.
+>
+> For the production ready and optimized Matter samples, see
+> [nRF Connect SDK samples](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/matter.html).
+> The Matter samples in nRF Connect SDK use various additional software
+> components and provide multiple optional features that improve the developer
+> and user experience. To read more about it, see
+> [Matter support in nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html#ug-matter)
+> page. Using Matter samples from nRF Connect SDK allows you to get a full
+> Nordic technical support via [DevZone](https://devzone.nordicsemi.com/)
+> portal.
+
 The nRF Connect Lighting Example demonstrates how to remotely control a white
 dimmable light bulb. It uses buttons to test changing the lighting and device
 states and LEDs to show the state of these changes. You can use this example as
@@ -153,10 +169,10 @@ The example supports building and running on the following devices:
 
 | Hardware platform                                                                                 | Build target               | Platform image                                                                                                                                          |
 | ------------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)         | `nrf52840dk_nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details>        |
-| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)           | `nrf5340dk_nrf5340_cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>           |
-| [nRF52840 Dongle](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle) | `nrf52840dongle_nrf52840`  | <details><summary>nRF52840 Dongle</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_Dongle-medium.jpg" alt="nRF52840 Dongle"/></details> |
-| [nRF7002 DK](https://www.nordicsemi.com/Products/Development-hardware/nRF7002-DK)                 | `nrf7002dk_nrf5340_cpuapp` | <details><summary>nRF7002 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF7002-DK_Front-small.png" alt="nRF7002 DK"/></details>           |
+| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)         | `nrf52840dk/nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details>        |
+| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)           | `nrf5340dk/nrf5340/cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>           |
+| [nRF52840 Dongle](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-Dongle) | `nrf52840dongle/nrf52840`  | <details><summary>nRF52840 Dongle</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_Dongle-medium.jpg" alt="nRF52840 Dongle"/></details> |
+| [nRF7002 DK](https://www.nordicsemi.com/Products/Development-hardware/nRF7002-DK)                 | `nrf7002dk/nrf5340/cpuapp` | <details><summary>nRF7002 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF7002-DK_Front-small.png" alt="nRF7002 DK"/></details>           |
 
 <hr>
 
@@ -165,9 +181,9 @@ The example supports building and running on the following devices:
 The development kits for this sample offer the following IPv6 network support
 for Matter:
 
--   Matter over Thread is supported for `nrf52840dk_nrf52840` and
-    `nrf5340dk_nrf5340_cpuapp`.
--   Matter over Wi-Fi is supported for `nrf7002dk_nrf5340_cpuapp`.
+-   Matter over Thread is supported for `nrf52840dk/nrf52840` and
+    `nrf5340dk/nrf5340/cpuapp`.
+-   Matter over Wi-Fi is supported for `nrf7002dk/nrf5340/cpuapp`.
 
 ## Device UI
 
@@ -339,16 +355,17 @@ Complete the following steps to build the sample:
 
 2.  Run the following command to build the example, with _build-target_ replaced
     with the build target name of the Nordic Semiconductor's kit you own, for
-    example `nrf52840dk_nrf52840`:
+    example `nrf52840dk/nrf52840`:
 
         ```
-        $ west build -b build-target
+        $ west build -b build-target --sysbuild
         ```
 
     You only need to specify the build target on the first build. See
     [Requirements](#requirements) for the build target names of compatible kits.
 
-The output `zephyr.hex` file will be available in the `build/zephyr/` directory.
+The output `zephyr.hex` file will be available in the `build/nrfconnect/zephyr/`
+directory.
 
 ### Removing build artifacts
 
@@ -366,7 +383,7 @@ To build the example with release configuration that disables the diagnostic
 features like logs and command-line interface, run the following command:
 
     ```
-    $ west build -b build-target -- -DCONF_FILE=prj_release.conf
+    $ west build -b build-target --sysbuild -- -DFILE_SUFFIX=release
     ```
 
 Remember to replace _build-target_ with the build target name of the Nordic
@@ -381,7 +398,7 @@ command with _build-target_ replaced with the build target name of the Nordic
 Semiconductor's kit you own:
 
     ```
-    $ west build -b build-target -- -DOVERLAY_CONFIG=rpc.overlay
+    $ west build -b build-target --sysbuild -- -DOVERLAY_CONFIG=rpc.overlay
     ```
 
 ### Building with Device Firmware Upgrade support
@@ -390,18 +407,10 @@ Support for DFU using Matter OTA is enabled by default.
 
 To enable DFU over Bluetooth LE, run the following command with _build-target_
 replaced with the build target name of the Nordic Semiconductor kit you are
-using (for example `nrf52840dk_nrf52840`):
+using (for example `nrf52840dk/nrf52840`):
 
     ```
-    $ west build -b build-target -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
-    ```
-
-To completely disable support for both DFU methods, run the following command
-with _build-target_ replaced with the build target name of the Nordic
-Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
-
-    ```
-    $ west build -b build-target -- -DCONF_FILE=prj_no_dfu.conf
+    $ west build -b build-target --sysbuild -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
     ```
 
 > **Note**:
@@ -419,7 +428,7 @@ Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
 #### Changing bootloader configuration
 
 To change the default MCUboot configuration, edit the `prj.conf` file located in
-the `child_image/mcuboot` directory.
+the `sysbuild/mcuboot` directory.
 
 Make sure to keep the configuration consistent with changes made to the
 application configuration. This is necessary for the configuration to work, as
@@ -436,8 +445,9 @@ purposes. You can change these settings by defining
 This example uses this option to define using an external flash.
 
 To modify the flash settings of your board (that is, your _build-target_, for
-example `nrf52840dk_nrf52840`), edit the `pm_static_dfu.yml` file located in the
-`configuration/build-target/` directory.
+example `nrf52840dk/nrf52840`), edit the `pm_static_<build_target>.yml` file
+(for example `pm_static_nrf52840dk_nrf52840.yml`), located in the main
+application directory.
 
 <hr>
 
@@ -450,7 +460,7 @@ To open the menuconfig utility, run the following command from the example
 directory:
 
     ```
-    $ west build -b build-target -t menuconfig
+    $ west build -b build-target --sysbuild -t menuconfig
     ```
 
 Remember to replace _build-target_ with the build target name of the Nordic
@@ -484,9 +494,6 @@ depending on the selected board:
     the necessary application functionalities to optimize its performance. It
     can be used only for the nRF52840 DK and nRF5340 DK, as those platforms have
     DFU enabled by default.
--   no_dfu -- Debug version of the application without Device Firmware Upgrade
-    feature support - can be used for the nRF52840 DK, nRF5340 DK and nRF52840
-    Dongle.
 
 For more information, see the
 [Configuring nRF Connect SDK examples](../../../docs/guides/nrfconnect_examples_configuration.md)

--- a/examples/lit-icd-app/nrfconnect/README.md
+++ b/examples/lit-icd-app/nrfconnect/README.md
@@ -1,5 +1,21 @@
 # Matter nRF Connect LIT ICD Example Application
 
+> **Note:** This example is intended only to perform smoke tests of a Matter
+> solution integrated with nRF Connect SDK platform. The example quality is not
+> production ready and it may contain minor bugs or use not optimal
+> configuration. It is not recommended to use this example as a basis for
+> creating a market ready product.
+>
+> For the production ready and optimized Matter samples, see
+> [nRF Connect SDK samples](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/matter.html).
+> The Matter samples in nRF Connect SDK use various additional software
+> components and provide multiple optional features that improve the developer
+> and user experience. To read more about it, see
+> [Matter support in nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html#ug-matter)
+> page. Using Matter samples from nRF Connect SDK allows you to get a full
+> Nordic technical support via [DevZone](https://devzone.nordicsemi.com/)
+> portal.
+
 The nRF Connect LIT ICD Example allows to test the device that utilizes Long
 Idle Time feature from the Intermittently Connected Device Management cluster.
 It uses buttons to change the device states and LEDs to show the state of these
@@ -115,8 +131,8 @@ The example supports building and running on the following devices:
 
 | Hardware platform                                                                         | Build target               | Platform image                                                                                                                                   |
 | ----------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk_nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
-| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk_nrf5340_cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
+| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk/nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
+| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk/nrf5340/cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
 
 <hr>
 
@@ -248,14 +264,15 @@ Complete the following steps to build the sample:
 
 2.  Run the following command to build the example, with _build-target_ replaced
     with the build target name of the Nordic Semiconductor's kit you own, for
-    example `nrf52840dk_nrf52840`:
+    example `nrf52840dk/nrf52840`:
 
-         $ west build -b build-target
+         $ west build -b build-target --sysbuild
 
     You only need to specify the build target on the first build. See
     [Requirements](#requirements) for the build target names of compatible kits.
 
-The output `zephyr.hex` file will be available in the `build/zephyr/` directory.
+The output `zephyr.hex` file will be available in the `build/nrfconnect/zephyr/`
+directory.
 
 ### Removing build artifacts
 
@@ -270,7 +287,7 @@ following command:
 To build the example with release configuration that disables the diagnostic
 features like logs and command-line interface, run the following command:
 
-    $ west build -b build-target -- -DCONF_FILE=prj_release.conf
+    $ west build -b build-target --sysbuild -- -DFILE_SUFFIX=release
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -278,12 +295,6 @@ Semiconductor's kit you own.
 ### Building with Device Firmware Upgrade support
 
 Support for DFU using Matter OTA is enabled by default.
-
-To completely disable support for DFU, run the following command with
-_build-target_ replaced with the build target name of the Nordic Semiconductor
-kit you are using (for example `nrf52840dk_nrf52840`):
-
-    $ west build -b build-target -- -DCONF_FILE=prj_no_dfu.conf
 
 > **Note**:
 >
@@ -297,7 +308,7 @@ kit you are using (for example `nrf52840dk_nrf52840`):
 #### Changing bootloader configuration
 
 To change the default MCUboot configuration, edit the `prj.conf` file located in
-the `child_image/mcuboot` directory.
+the `sysbuild/mcuboot` directory.
 
 Make sure to keep the configuration consistent with changes made to the
 application configuration. This is necessary for the configuration to work, as
@@ -314,8 +325,9 @@ purposes. You can change these settings by defining
 This example uses this option to define using an external flash.
 
 To modify the flash settings of your board (that is, your _build-target_, for
-example `nrf52840dk_nrf52840`), edit the `pm_static_dfu.yml` file located in the
-`configuration/build-target/` directory.
+example `nrf52840dk/nrf52840`), edit the `pm_static_<build_target>.yml` file
+(for example `pm_static_nrf52840dk_nrf52840.yml`), located in the main
+application directory.
 
 <hr>
 
@@ -327,7 +339,7 @@ using the menuconfig utility.
 To open the menuconfig utility, run the following command from the example
 directory:
 
-    $ west build -b build-target -t menuconfig
+    $ west build -b build-target --sysbuild -t menuconfig
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -357,8 +369,6 @@ depending on the selected board:
     command-line shell.
 -   release -- Release version of the application - can be used to enable only
     the necessary application functionalities to optimize its performance.
--   no_dfu -- Debug version of the application without Device Firmware Upgrade
-    feature support.
 
 For more information, see the
 [Configuring nRF Connect SDK examples](../../../docs/guides/nrfconnect_examples_configuration.md)

--- a/examples/lock-app/nrfconnect/README.md
+++ b/examples/lock-app/nrfconnect/README.md
@@ -1,5 +1,21 @@
 # Matter nRF Connect Lock Example Application
 
+> **Note:** This example is intended only to perform smoke tests of a Matter
+> solution integrated with nRF Connect SDK platform. The example quality is not
+> production ready and it may contain minor bugs or use not optimal
+> configuration. It is not recommended to use this example as a basis for
+> creating a market ready product.
+>
+> For the production ready and optimized Matter samples, see
+> [nRF Connect SDK samples](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/matter.html).
+> The Matter samples in nRF Connect SDK use various additional software
+> components and provide multiple optional features that improve the developer
+> and user experience. To read more about it, see
+> [Matter support in nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html#ug-matter)
+> page. Using Matter samples from nRF Connect SDK allows you to get a full
+> Nordic technical support via [DevZone](https://devzone.nordicsemi.com/)
+> portal.
+
 The nRF Connect Lock Example demonstrates how to remotely control a door lock
 device with one basic bolt. It uses buttons to test changing the lock and device
 states and LEDs to show the state of these changes. You can use this example as
@@ -148,9 +164,9 @@ The example supports building and running on the following devices:
 
 | Hardware platform                                                                         | Build target               | Platform image                                                                                                                                   |
 | ----------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk_nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
-| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk_nrf5340_cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
-| [nRF7002 DK](https://www.nordicsemi.com/Products/Development-hardware/nRF7002-DK)         | `nrf7002dk_nrf5340_cpuapp` | <details><summary>nRF7002 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF7002-DK_Front-small.png" alt="nRF7002 DK"/></details>    |
+| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk/nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
+| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk/nrf5340/cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
+| [nRF7002 DK](https://www.nordicsemi.com/Products/Development-hardware/nRF7002-DK)         | `nrf7002dk/nrf5340/cpuapp` | <details><summary>nRF7002 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF7002-DK_Front-small.png" alt="nRF7002 DK"/></details>    |
 
 <hr>
 
@@ -159,9 +175,9 @@ The example supports building and running on the following devices:
 The development kits for this sample offer the following IPv6 network support
 for Matter:
 
--   Matter over Thread is supported for `nrf52840dk_nrf52840` and
-    `nrf5340dk_nrf5340_cpuapp`.
--   Matter over Wi-Fi is supported for `nrf7002dk_nrf5340_cpuapp`.
+-   Matter over Thread is supported for `nrf52840dk/nrf52840` and
+    `nrf5340dk/nrf5340/cpuapp`.
+-   Matter over Wi-Fi is supported for `nrf7002dk/nrf5340/cpuapp`.
 
 ## Device UI
 
@@ -325,14 +341,15 @@ Complete the following steps to build the sample:
 
 2.  Run the following command to build the example, with _build-target_ replaced
     with the build target name of the Nordic Semiconductor's kit you own, for
-    example `nrf52840dk_nrf52840`:
+    example `nrf52840dk/nrf52840`:
 
-         $ west build -b build-target
+         $ west build -b build-target --sysbuild
 
     You only need to specify the build target on the first build. See
     [Requirements](#requirements) for the build target names of compatible kits.
 
-The output `zephyr.hex` file will be available in the `build/zephyr/` directory.
+The output `zephyr.hex` file will be available in the `build/nrfconnect/zephyr/`
+directory.
 
 ### Removing build artifacts
 
@@ -347,7 +364,7 @@ following command:
 To build the example with release configuration that disables the diagnostic
 features like logs and command-line interface, run the following command:
 
-    $ west build -b build-target -- -DCONF_FILE=prj_release.conf
+    $ west build -b build-target --sysbuild -- -DFILE_SUFFIX=release
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -358,15 +375,9 @@ Support for DFU using Matter OTA is enabled by default.
 
 To enable DFU over Bluetooth LE, run the following command with _build-target_
 replaced with the build target name of the Nordic Semiconductor kit you are
-using (for example `nrf52840dk_nrf52840`):
+using (for example `nrf52840dk/nrf52840`):
 
-    $ west build -b build-target -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
-
-To completely disable support for both DFU methods, run the following command
-with _build-target_ replaced with the build target name of the Nordic
-Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
-
-    $ west build -b build-target -- -DCONF_FILE=prj_no_dfu.conf
+    $ west build -b build-target --sysbuild -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
 
 > **Note**:
 >
@@ -380,7 +391,7 @@ Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
 #### Changing bootloader configuration
 
 To change the default MCUboot configuration, edit the `prj.conf` file located in
-the `child_image/mcuboot` directory.
+the `sysbuild/mcuboot` directory.
 
 Make sure to keep the configuration consistent with changes made to the
 application configuration. This is necessary for the configuration to work, as
@@ -397,8 +408,9 @@ purposes. You can change these settings by defining
 This example uses this option to define using an external flash.
 
 To modify the flash settings of your board (that is, your _build-target_, for
-example `nrf52840dk_nrf52840`), edit the `pm_static_dfu.yml` file located in the
-`configuration/build-target/` directory.
+example `nrf52840dk/nrf52840`), edit the `pm_static_<build_target>.yml` file
+(for example `pm_static_nrf52840dk_nrf52840.yml`), located in the main
+application directory.
 
 <hr>
 
@@ -410,7 +422,7 @@ using the menuconfig utility.
 To open the menuconfig utility, run the following command from the example
 directory:
 
-    $ west build -b build-target -t menuconfig
+    $ west build -b build-target --sysbuild -t menuconfig
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -440,9 +452,6 @@ depending on the selected board:
     command-line shell.
 -   release -- Release version of the application - can be used to enable only
     the necessary application functionalities to optimize its performance.
--   no_dfu -- Debug version of the application without Device Firmware Upgrade
-    feature support - can be used only for the nRF52840 DK and nRF5340 DK, as
-    those platforms have DFU enabled by default.
 
 For more information, see the
 [Configuring nRF Connect SDK examples](../../../docs/guides/nrfconnect_examples_configuration.md)

--- a/examples/pump-app/nrfconnect/README.md
+++ b/examples/pump-app/nrfconnect/README.md
@@ -1,5 +1,21 @@
 # Matter nRF Connect Pump Example Application
 
+> **Note:** This example is intended only to perform smoke tests of a Matter
+> solution integrated with nRF Connect SDK platform. The example quality is not
+> production ready and it may contain minor bugs or use not optimal
+> configuration. It is not recommended to use this example as a basis for
+> creating a market ready product.
+>
+> For the production ready and optimized Matter samples, see
+> [nRF Connect SDK samples](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/matter.html).
+> The Matter samples in nRF Connect SDK use various additional software
+> components and provide multiple optional features that improve the developer
+> and user experience. To read more about it, see
+> [Matter support in nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html#ug-matter)
+> page. Using Matter samples from nRF Connect SDK allows you to get a full
+> Nordic technical support via [DevZone](https://devzone.nordicsemi.com/)
+> portal.
+
 The nRF Connect Pump Example demonstrates how to remotely control a pump device
 with basic start/stop functionality. It uses buttons to test changing the pump
 state and device states and LEDs to show the state of these changes. This
@@ -139,8 +155,8 @@ The example supports building and running on the following devices:
 
 | Hardware platform                                                                         | Build target               | Platform image                                                                                                                                   |
 | ----------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk_nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
-| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk_nrf5340_cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
+| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk/nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
+| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk/nrf5340/cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
 
 <hr>
 
@@ -283,14 +299,15 @@ Complete the following steps to build the sample:
 
 2.  Run the following command to build the example, with _build-target_ replaced
     with the build target name of the Nordic Semiconductor's kit you own, for
-    example `nrf52840dk_nrf52840`:
+    example `nrf52840dk/nrf52840`:
 
-         $ west build -b build-target
+         $ west build -b build-target --sysbuild
 
     You only need to specify the build target on the first build. See
     [Requirements](#requirements) for the build target names of compatible kits.
 
-The output `zephyr.hex` file will be available in the `build/zephyr/` directory.
+The output `zephyr.hex` file will be available in the `build/nrfconnect/zephyr/`
+directory.
 
 ### Removing build artifacts
 
@@ -305,7 +322,7 @@ following command:
 To build the example with release configuration that disables the diagnostic
 features like logs and command-line interface, run the following command:
 
-    $ west build -b build-target -- -DCONF_FILE=prj_release.conf
+    $ west build -b build-target --sysbuild -- -DFILE_SUFFIX=release
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -316,15 +333,9 @@ Support for DFU using Matter OTA is enabled by default.
 
 To enable DFU over Bluetooth LE, run the following command with _build-target_
 replaced with the build target name of the Nordic Semiconductor kit you are
-using (for example `nrf52840dk_nrf52840`):
+using (for example `nrf52840dk/nrf52840`):
 
-    $ west build -b build-target -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
-
-To completely disable support for both DFU methods, run the following command
-with _build-target_ replaced with the build target name of the Nordic
-Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
-
-    $ west build -b build-target -- -DCONF_FILE=prj_no_dfu.conf
+    $ west build -b build-target --sysbuild -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
 
 > **Note**:
 >
@@ -341,7 +352,7 @@ Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
 #### Changing bootloader configuration
 
 To change the default MCUboot configuration, edit the `prj.conf` file located in
-the `child_image/mcuboot` directory.
+the `sysbuild/mcuboot` directory.
 
 Make sure to keep the configuration consistent with changes made to the
 application configuration. This is necessary for the configuration to work, as
@@ -358,8 +369,9 @@ purposes. You can change these settings by defining
 This example uses this option to define using an external flash.
 
 To modify the flash settings of your board (that is, your _build-target_, for
-example `nrf52840dk_nrf52840`), edit the `pm_static_dfu.yml` file located in the
-`configuration/build-target/` directory.
+example `nrf52840dk/nrf52840`), edit the `pm_static_<build_target>.yml` file
+(for example `pm_static_nrf52840dk_nrf52840.yml`), located in the main
+application directory.
 
 <hr>
 
@@ -371,7 +383,7 @@ using the menuconfig utility.
 To open the menuconfig utility, run the following command from the example
 directory:
 
-    $ west build -b build-target -t menuconfig
+    $ west build -b build-target --sysbuild -t menuconfig
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -401,9 +413,6 @@ depending on the selected board:
     command-line shell.
 -   release -- Release version of the application - can be used to enable only
     the necessary application functionalities to optimize its performance.
--   no_dfu -- Debug version of the application without Device Firmware Upgrade
-    feature support - can be used only for the nRF52840 DK and nRF5340 DK, as
-    those platforms have DFU enabled by default.
 
 For more information, see the
 [Configuring nRF Connect SDK examples](../../../docs/guides/nrfconnect_examples_configuration.md)

--- a/examples/pump-controller-app/nrfconnect/README.md
+++ b/examples/pump-controller-app/nrfconnect/README.md
@@ -1,5 +1,21 @@
 # Matter nRF Connect Pump Example Application
 
+> **Note:** This example is intended only to perform smoke tests of a Matter
+> solution integrated with nRF Connect SDK platform. The example quality is not
+> production ready and it may contain minor bugs or use not optimal
+> configuration. It is not recommended to use this example as a basis for
+> creating a market ready product.
+>
+> For the production ready and optimized Matter samples, see
+> [nRF Connect SDK samples](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/matter.html).
+> The Matter samples in nRF Connect SDK use various additional software
+> components and provide multiple optional features that improve the developer
+> and user experience. To read more about it, see
+> [Matter support in nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html#ug-matter)
+> page. Using Matter samples from nRF Connect SDK allows you to get a full
+> Nordic technical support via [DevZone](https://devzone.nordicsemi.com/)
+> portal.
+
 The nRF Connect Pump Controller Example demonstrates how to implement a pump
 controller client device with basic start/stop functionality. It uses buttons to
 test changing the pump state and device states and LEDs to show the state of
@@ -140,8 +156,8 @@ The example supports building and running on the following devices:
 
 | Hardware platform                                                                         | Build target               | Platform image                                                                                                                                   |
 | ----------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk_nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
-| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk_nrf5340_cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
+| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk/nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
+| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk/nrf5340/cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
 
 <hr>
 
@@ -283,14 +299,15 @@ Complete the following steps to build the sample:
 
 2.  Run the following command to build the example, with _build-target_ replaced
     with the build target name of the Nordic Semiconductor's kit you own, for
-    example `nrf52840dk_nrf52840`:
+    example `nrf52840dk/nrf52840`:
 
-         $ west build -b build-target
+         $ west build -b build-target --sysbuild
 
     You only need to specify the build target on the first build. See
     [Requirements](#requirements) for the build target names of compatible kits.
 
-The output `zephyr.hex` file will be available in the `build/zephyr/` directory.
+The output `zephyr.hex` file will be available in the `build/nrfconnect/zephyr/`
+directory.
 
 ### Removing build artifacts
 
@@ -305,7 +322,7 @@ following command:
 To build the example with release configuration that disables the diagnostic
 features like logs and command-line interface, run the following command:
 
-    $ west build -b build-target -- -DCONF_FILE=prj_release.conf
+    $ west build -b build-target --sysbuild -- -DFILE_SUFFIX=release
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -316,15 +333,9 @@ Support for DFU using Matter OTA is enabled by default.
 
 To enable DFU over Bluetooth LE, run the following command with _build-target_
 replaced with the build target name of the Nordic Semiconductor kit you are
-using (for example `nrf52840dk_nrf52840`):
+using (for example `nrf52840dk/nrf52840`):
 
-    $ west build -b build-target -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
-
-To completely disable support for both DFU methods, run the following command
-with _build-target_ replaced with the build target name of the Nordic
-Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
-
-    $ west build -b build-target -- -DCONF_FILE=prj_no_dfu.conf
+    $ west build -b build-target --sysbuild -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
 
 > **Note**:
 >
@@ -341,7 +352,7 @@ Semiconductor kit you are using (for example `nrf52840dk_nrf52840`):
 #### Changing bootloader configuration
 
 To change the default MCUboot configuration, edit the `prj.conf` file located in
-the `child_image/mcuboot` directory.
+the `sysbuild/mcuboot` directory.
 
 Make sure to keep the configuration consistent with changes made to the
 application configuration. This is necessary for the configuration to work, as
@@ -358,8 +369,9 @@ purposes. You can change these settings by defining
 This example uses this option to define using an external flash.
 
 To modify the flash settings of your board (that is, your _build-target_, for
-example `nrf52840dk_nrf52840`), edit the `pm_static_dfu.yml` file located in the
-`configuration/build-target/` directory.
+example `nrf52840dk/nrf52840`), edit the `pm_static_<build_target>.yml` file
+(for example `pm_static_nrf52840dk_nrf52840.yml`), located in the main
+application directory.
 
 <hr>
 
@@ -371,7 +383,7 @@ using the menuconfig utility.
 To open the menuconfig utility, run the following command from the example
 directory:
 
-    $ west build -b build-target -t menuconfig
+    $ west build -b build-target --sysbuild -t menuconfig
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -401,9 +413,6 @@ depending on the selected board:
     command-line shell.
 -   release -- Release version of the application - can be used to enable only
     the necessary application functionalities to optimize its performance.
--   no_dfu -- Debug version of the application without Device Firmware Upgrade
-    feature support - can be used only for the nRF52840 DK and nRF5340 DK, as
-    those platforms have DFU enabled by default.
 
 For more information, see the
 [Configuring nRF Connect SDK examples](../../../docs/guides/nrfconnect_examples_configuration.md)

--- a/examples/shell/nrfconnect/README.md
+++ b/examples/shell/nrfconnect/README.md
@@ -1,5 +1,21 @@
 # Matter nRF Connect SDK Shell Application
 
+> **Note:** This example is intended only to perform smoke tests of a Matter
+> solution integrated with nRF Connect SDK platform. The example quality is not
+> production ready and it may contain minor bugs or use not optimal
+> configuration. It is not recommended to use this example as a basis for
+> creating a market ready product.
+>
+> For the production ready and optimized Matter samples, see
+> [nRF Connect SDK samples](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/matter.html).
+> The Matter samples in nRF Connect SDK use various additional software
+> components and provide multiple optional features that improve the developer
+> and user experience. To read more about it, see
+> [Matter support in nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html#ug-matter)
+> page. Using Matter samples from nRF Connect SDK allows you to get a full
+> Nordic technical support via [DevZone](https://devzone.nordicsemi.com/)
+> portal.
+
 A [Matter shell](../README.md) project for the Nordic nRF52840 and nRF5340
 development kits, built using the nRF Connect SDK.
 

--- a/examples/window-app/nrfconnect/README.md
+++ b/examples/window-app/nrfconnect/README.md
@@ -1,5 +1,21 @@
 # Matter nRF Connect Window Covering Example Application
 
+> **Note:** This example is intended only to perform smoke tests of a Matter
+> solution integrated with nRF Connect SDK platform. The example quality is not
+> production ready and it may contain minor bugs or use not optimal
+> configuration. It is not recommended to use this example as a basis for
+> creating a market ready product.
+>
+> For the production ready and optimized Matter samples, see
+> [nRF Connect SDK samples](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/matter.html).
+> The Matter samples in nRF Connect SDK use various additional software
+> components and provide multiple optional features that improve the developer
+> and user experience. To read more about it, see
+> [Matter support in nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/index.html#ug-matter)
+> page. Using Matter samples from nRF Connect SDK allows you to get a full
+> Nordic technical support via [DevZone](https://devzone.nordicsemi.com/)
+> portal.
+
 The nRF Connect Window Covering Example demonstrates how to remotely control a
 window shutter device. It uses buttons to test changing cover position and
 device states and LEDs to show the state of these changes. You can use this
@@ -131,8 +147,8 @@ The example supports building and running on the following devices:
 
 | Hardware platform                                                                         | Build target               | Platform image                                                                                                                                   |
 | ----------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk_nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
-| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk_nrf5340_cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
+| [nRF52840 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK) | `nrf52840dk/nrf52840`      | <details><summary>nRF52840 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF52840_DK_info-medium.jpg" alt="nRF52840 DK"/></details> |
+| [nRF5340 DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF5340-DK)   | `nrf5340dk/nrf5340/cpuapp` | <details><summary>nRF5340 DK</summary><img src="../../platform/nrfconnect/doc/images/nRF5340_DK_info-medium.jpg" alt="nRF5340 DK"/></details>    |
 
 <hr>
 
@@ -299,14 +315,15 @@ Complete the following steps to build the sample:
 
 2.  Run the following command to build the example, with _build-target_ replaced
     with the build target name of the Nordic Semiconductor's kit you own, for
-    example `nrf52840dk_nrf52840`:
+    example `nrf52840dk/nrf52840`:
 
-         $ west build -b build-target
+         $ west build -b build-target --sysbuild
 
     You only need to specify the build target on the first build. See
     [Requirements](#requirements) for the build target names of compatible kits.
 
-The output `zephyr.hex` file will be available in the `build/zephyr/` directory.
+The output `zephyr.hex` file will be available in the `build/nrfconnect/zephyr/`
+directory.
 
 ### Removing build artifacts
 
@@ -321,7 +338,7 @@ following command:
 To build the example with release configuration that disables the diagnostic
 features like logs and command-line interface, run the following command:
 
-    $ west build -b build-target -- -DCONF_FILE=prj_release.conf
+    $ west build -b build-target --sysbuild -- -DFILE_SUFFIX=release
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -332,17 +349,11 @@ Support for DFU using Matter OTA is enabled by default.
 
 To enable DFU over Bluetooth LE, run the following command with _build-target_
 replaced with the build target name of the Nordic Semiconductor kit you are
-using (for example `nrf52840dk_nrf52840`):
+using (for example `nrf52840dk/nrf52840`):
 
     ```
-    $ west build -b build-target -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
+    $ west build -b build-target --sysbuild -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
     ```
-
-To completely disable support for DFU, run the following command with
-_build-target_ replaced with the build target name of the Nordic Semiconductor
-kit you are using (for example `nrf52840dk_nrf52840`):
-
-    $ west build -b build-target -- -DCONF_FILE=prj_no_dfu.conf
 
 > **Note**:
 >
@@ -356,7 +367,7 @@ kit you are using (for example `nrf52840dk_nrf52840`):
 #### Changing bootloader configuration
 
 To change the default MCUboot configuration, edit the `prj.conf` file located in
-the `child_image/mcuboot` directory.
+the `sysbuild/mcuboot` directory.
 
 Make sure to keep the configuration consistent with changes made to the
 application configuration. This is necessary for the configuration to work, as
@@ -373,8 +384,9 @@ purposes. You can change these settings by defining
 This example uses this option to define using an external flash.
 
 To modify the flash settings of your board (that is, your _build-target_, for
-example `nrf52840dk_nrf52840`), edit the `pm_static_dfu.yml` file located in the
-`configuration/build-target/` directory.
+example `nrf52840dk/nrf52840`), edit the `pm_static_<build_target>.yml` file
+(for example `pm_static_nrf52840dk_nrf52840.yml`), located in the main
+application directory.
 
 <hr>
 
@@ -386,7 +398,7 @@ using the menuconfig utility.
 To open the menuconfig utility, run the following command from the example
 directory:
 
-    $ west build -b build-target -t menuconfig
+    $ west build -b build-target --sysbuild -t menuconfig
 
 Remember to replace _build-target_ with the build target name of the Nordic
 Semiconductor's kit you own.
@@ -416,9 +428,6 @@ depending on the selected board:
     command-line shell.
 -   release &mdash; Release version of the application - can be used to enable
     only the necessary application functionalities to optimize its performance.
--   no_dfu &mdash; Debug version of the application without Device Firmware
-    Upgrade feature support - can be used only for the nRF52840 DK and nRF5340
-    DK, as those platforms have DFU enabled by default.
 
 For more information, see the
 [Configuring nRF Connect SDK examples](../../../docs/guides/nrfconnect_examples_configuration.md)


### PR DESCRIPTION
Updated docs for all nrfconnect examples to:
* be aligned with the most recent NCS 2.7.0 version
* mention that the examples are not production ready and redirect to the production ready NCS Matter samples


