### PR TITLE
TC-TSTAT-2.2: update test to match new constraint

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_TSTAT_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_2_2.yaml
@@ -1701,7 +1701,7 @@ tests:
       attribute: "MinSetpointDeadBand"
       PICS: TSTAT.S.F05 && TSTAT.S.M.MinSetpointDeadBandWritable
       arguments:
-          value: 30
+          value: 128
       response:
           error: CONSTRAINT_ERROR
 


### PR DESCRIPTION
Constraint was changed in
https://github.com/project-chip/connectedhomeip/pull/34474/files test was not updated.
