### PR TITLE
[nrfconnect] Fixed paths used to create flash bundle

### DIFF
--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -239,6 +239,6 @@ west build --cmake-only -d {outdir} -b {board} --sysbuild {sourcedir}{build_flag
     def bundle_outputs(self):
         if self.app == NrfApp.UNIT_TESTS:
             return
-        with open(os.path.join(self.output_dir, self.app.FlashBundleName())) as f:
+        with open(os.path.join(self.output_dir, 'nrfconnect', self.app.FlashBundleName())) as f:
             for line in filter(None, [x.strip() for x in f.readlines()]):
-                yield BuilderOutput(os.path.join(self.output_dir, line), line)
+                yield BuilderOutput(os.path.join(self.output_dir, 'nrfconnect', line), line)


### PR DESCRIPTION
Added nrfconnect directory in path used to copy bundle outputs.



