### PR TITLE
Fix: drop poll timer to avoid crash after TransferFacilitator object destruction

### DIFF
--- a/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
@@ -174,7 +174,6 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         {
             ChipLogError(BDX, "onTransferComplete Callback not set");
         }
-        mStopPolling = true; // Stop polling the TransferSession only after receiving BlockAckEOF
         Reset();
         break;
     case TransferSession::OutputEventType::kStatusReceived:
@@ -228,7 +227,7 @@ void BdxOtaSender::Reset()
 {
     mFabricIndex.ClearValue();
     mNodeId.ClearValue();
-    mTransfer.Reset();
+    ResetTransfer();
     if (mExchangeCtx != nullptr)
     {
         mExchangeCtx->Close();

--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
@@ -180,7 +180,6 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         break;
     case TransferSession::OutputEventType::kAckEOFReceived:
         ChipLogDetail(BDX, "Transfer completed, got AckEOF");
-        mStopPolling = true; // Stop polling the TransferSession only after receiving BlockAckEOF
         Reset();
         break;
     case TransferSession::OutputEventType::kStatusReceived:
@@ -212,7 +211,7 @@ void BdxOtaSender::Reset()
 {
     mFabricIndex.ClearValue();
     mNodeId.ClearValue();
-    Responder::ResetTransfer();
+    ResetTransfer();
     if (mExchangeCtx != nullptr)
     {
         mExchangeCtx->Close();

--- a/src/protocols/bdx/TransferFacilitator.h
+++ b/src/protocols/bdx/TransferFacilitator.h
@@ -45,7 +45,12 @@ class TransferFacilitator : public Messaging::ExchangeDelegate, public Messaging
 {
 public:
     TransferFacilitator() : mExchangeCtx(nullptr), mSystemLayer(nullptr), mPollFreq(kDefaultPollFreq) {}
-    ~TransferFacilitator() override = default;
+    ~TransferFacilitator() override;
+
+    /**
+     * Calls reset on the TransferSession object and stops the poll timer.
+     */
+    void ResetTransfer();
 
 private:
     //// UnsolicitedMessageHandler Implementation ////
@@ -96,7 +101,6 @@ protected:
     System::Clock::Timeout mPollFreq;
     static constexpr System::Clock::Timeout kDefaultPollFreq    = System::Clock::Milliseconds32(500);
     static constexpr System::Clock::Timeout kImmediatePollDelay = System::Clock::Milliseconds32(1);
-    bool mStopPolling                                           = false;
 };
 
 /**
@@ -121,11 +125,6 @@ public:
     CHIP_ERROR PrepareForTransfer(System::Layer * layer, TransferRole role, BitFlags<TransferControlFlags> xferControlOpts,
                                   uint16_t maxBlockSize, System::Clock::Timeout timeout,
                                   System::Clock::Timeout pollFreq = TransferFacilitator::kDefaultPollFreq);
-
-    /**
-     * Calls reset on the TransferSession object and stops the poll timer.
-     */
-    void ResetTransfer();
 };
 
 /**
@@ -150,10 +149,6 @@ public:
     CHIP_ERROR InitiateTransfer(System::Layer * layer, TransferRole role, const TransferSession::TransferInitData & initData,
                                 System::Clock::Timeout timeout,
                                 System::Clock::Timeout pollFreq = TransferFacilitator::kDefaultPollFreq);
-    /**
-     * Calls reset on the TransferSession object and stops the poll timer.
-     */
-    void ResetTransfer();
 };
 
 } // namespace bdx


### PR DESCRIPTION
We should drop timer on destruction or process will crash trying to access [mTransfer](https://github.com/project-chip/connectedhomeip/blob/master/src/protocols/bdx/TransferFacilitator.cpp#L77) property of destroyed object.
