### PR TITLE
Skip backwards compatibility on internal data (specifically internal clusters)

### DIFF
--- a/scripts/py_matter_idl/matter_idl/backwards_compatibility.py
+++ b/scripts/py_matter_idl/matter_idl/backwards_compatibility.py
@@ -54,9 +54,9 @@ def attribute_name(attribute: Attribute) -> str:
 
 def not_stable(maturity: ApiMaturity):
     """Determine if the given api maturity allows binary/api changes or not."""
-    # TODO: internal and deprecated not currently widely used,
-    #       so we enforce stability on them for now.
-    return maturity == ApiMaturity.PROVISIONAL
+    # NOTE: deprecated are not to be used, so we expect no changes. They were
+    #       probably "stable" at some point
+    return (maturity == ApiMaturity.PROVISIONAL) or (maturity == ApiMaturity.INTERNAL)
 
 
 class CompatibilityChecker:

--- a/scripts/py_matter_idl/matter_idl/test_backwards_compatibility.py
+++ b/scripts/py_matter_idl/matter_idl/test_backwards_compatibility.py
@@ -111,6 +111,13 @@ class TestCompatibilityChecks(unittest.TestCase):
             "provisional server cluster A = 16 { enum X : ENUM8 { A = 1; B = 3; } info event A = 2 { int16u x = 1;} }",
             Compatibility.ALL_OK)
 
+    def test_internal_cluster(self):
+        self.ValidateUpdate(
+            "Internal cluster changes are ok.",
+            "internal server cluster A = 16 { enum X : ENUM8 { A = 1; B = 2; } info event A = 1 { int8u x = 1;} }",
+            "internal server cluster A = 16 { enum X : ENUM8 { A = 1; B = 3; } info event A = 2 { int16u x = 1;} }",
+            Compatibility.ALL_OK)
+
     def test_clusters_enum_code(self):
         self.ValidateUpdate(
             "Adding an enum is ok. Also validates code formatting",


### PR DESCRIPTION
Internal clusters can be changed for any reason at any time, as they are generally for testing (UnitTesting and FaultInjection right now). Allow these to break API compatibility.