### PR TITLE
[ColorControl]Add Quiet reporting to the CurrentHue, CurrentSaturation, EnhancedCur…   

### DIFF
--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -113,7 +113,7 @@ class QuieterReportingAttribute
 public:
     explicit QuieterReportingAttribute(const Nullable<T> & initialValue) : mValue(initialValue), mLastDirtyValue(initialValue) {}
     // constructor that works with arrays of QuieterReportingAttribute
-    explicit QuieterReportingAttribute() : mValue(Nullable<T>(0)), mLastDirtyValue(Nullable<T>(0)) {}
+    explicit QuieterReportingAttribute() : mValue(DataModel::NullNullable), mLastDirtyValue(DataModel::NullNullable) {}
 
     struct SufficientChangePredicateCandidate
     {

--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -112,6 +112,8 @@ class QuieterReportingAttribute
 {
 public:
     explicit QuieterReportingAttribute(const Nullable<T> & initialValue) : mValue(initialValue), mLastDirtyValue(initialValue) {}
+    // constructor that works with arrays of QuieterReportingAttribute
+    explicit QuieterReportingAttribute() : mValue(Nullable<T>(0)), mLastDirtyValue(Nullable<T>(0)) {}
 
     struct SufficientChangePredicateCandidate
     {

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -30,6 +30,7 @@
 #endif
 
 using namespace chip;
+using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ColorControl;
 using chip::Protocols::InteractionModel::Status;
@@ -1058,9 +1059,10 @@ void ColorControlServer::startColorLoop(EndpointId endpoint, uint8_t startFromSt
     colorHueTransitionState->stepsRemaining = static_cast<uint16_t>(time * TRANSITION_STEPS_PER_1S);
     colorHueTransitionState->stepsTotal     = static_cast<uint16_t>(time * TRANSITION_STEPS_PER_1S);
     colorHueTransitionState->timeRemaining  = MAX_INT16U_VALUE;
+    colorHueTransitionState->transitionTime = MAX_INT16U_VALUE;
     colorHueTransitionState->endpoint       = endpoint;
 
-    Attributes::RemainingTime::Set(endpoint, MAX_INT16U_VALUE);
+    SetQuietReportRemainingTime(endpoint, MAX_INT16U_VALUE);
 
     scheduleTimerCallbackMs(configureHSVEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
 }
@@ -1111,7 +1113,7 @@ void ColorControlServer::SetHSVRemainingTime(chip::EndpointId endpoint)
     // When the hue transition is loop, RemainingTime stays at MAX_INT16
     if (hueTransitionState->repeat == false)
     {
-        Attributes::RemainingTime::Set(endpoint, max(hueTransitionState->timeRemaining, saturationTransitionState->timeRemaining));
+        SetQuietReportRemainingTime(endpoint, max(hueTransitionState->timeRemaining, saturationTransitionState->timeRemaining));
     }
 }
 
@@ -1303,6 +1305,7 @@ Status ColorControlServer::moveToSaturation(uint8_t saturation, uint16_t transit
     colorSaturationTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
     colorSaturationTransitionState->stepsTotal     = colorSaturationTransitionState->stepsRemaining;
     colorSaturationTransitionState->timeRemaining  = transitionTime;
+    colorSaturationTransitionState->transitionTime = transitionTime;
     colorSaturationTransitionState->endpoint       = endpoint;
     colorSaturationTransitionState->lowLimit       = MIN_SATURATION_VALUE;
     colorSaturationTransitionState->highLimit      = MAX_SATURATION_VALUE;
@@ -1334,7 +1337,7 @@ Status ColorControlServer::moveToHueAndSaturation(uint16_t hue, uint8_t saturati
     uint16_t halfWay    = isEnhanced ? HALF_MAX_UINT16T : HALF_MAX_UINT8T;
     bool moveUp;
 
-    uint16_t epIndex = getEndpointIndex(endpoint);
+    uint16_t epIndex                                         = getEndpointIndex(endpoint);
     Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionStateByIndex(epIndex);
     ColorHueTransitionState * colorHueTransitionState        = getColorHueTransitionStateByIndex(epIndex);
 
@@ -1382,6 +1385,7 @@ Status ColorControlServer::moveToHueAndSaturation(uint16_t hue, uint8_t saturati
     colorHueTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
     colorHueTransitionState->stepsTotal     = colorHueTransitionState->stepsRemaining;
     colorHueTransitionState->timeRemaining  = transitionTime;
+    colorHueTransitionState->transitionTime = transitionTime;
     colorHueTransitionState->endpoint       = endpoint;
     colorHueTransitionState->repeat         = false;
 
@@ -1390,6 +1394,7 @@ Status ColorControlServer::moveToHueAndSaturation(uint16_t hue, uint8_t saturati
     colorSaturationTransitionState->stepsRemaining = colorHueTransitionState->stepsRemaining;
     colorSaturationTransitionState->stepsTotal     = colorHueTransitionState->stepsRemaining;
     colorSaturationTransitionState->timeRemaining  = transitionTime;
+    colorSaturationTransitionState->transitionTime = transitionTime;
     colorSaturationTransitionState->endpoint       = endpoint;
     colorSaturationTransitionState->lowLimit       = MIN_SATURATION_VALUE;
     colorSaturationTransitionState->highLimit      = MAX_SATURATION_VALUE;
@@ -1420,10 +1425,10 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
                                         bool isEnhanced)
 {
     MATTER_TRACE_SCOPE("moveHue", "ColorControl");
-    EndpointId endpoint                               = commandPath.mEndpointId;
-    Status status                                     = Status::Success;
+    EndpointId endpoint = commandPath.mEndpointId;
+    Status status       = Status::Success;
 
-    uint16_t epIndex = getEndpointIndex(endpoint);
+    uint16_t epIndex                                  = getEndpointIndex(endpoint);
     ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionStateByIndex(epIndex);
 
     VerifyOrExit(colorHueTransitionState != nullptr, status = Status::UnsupportedEndpoint);
@@ -1496,11 +1501,12 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
     colorHueTransitionState->stepsRemaining = TRANSITION_STEPS_PER_1S;
     colorHueTransitionState->stepsTotal     = TRANSITION_STEPS_PER_1S;
     colorHueTransitionState->timeRemaining  = MAX_INT16U_VALUE;
+    colorHueTransitionState->transitionTime = MAX_INT16U_VALUE;
     colorHueTransitionState->endpoint       = endpoint;
     colorHueTransitionState->repeat         = true;
 
     // hue movement can last forever. Indicate this with a remaining time of maxint
-    Attributes::RemainingTime::Set(endpoint, MAX_INT16U_VALUE);
+    SetQuietReportRemainingTime(endpoint, MAX_INT16U_VALUE);
 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureHSVEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
@@ -1629,6 +1635,7 @@ bool ColorControlServer::moveToHueCommand(app::CommandHandler * commandObj, cons
     colorHueTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
     colorHueTransitionState->stepsTotal     = colorHueTransitionState->stepsRemaining;
     colorHueTransitionState->timeRemaining  = transitionTime;
+    colorHueTransitionState->transitionTime = transitionTime;
     colorHueTransitionState->endpoint       = endpoint;
     colorHueTransitionState->up             = (direction == HueDirection::kUp);
     colorHueTransitionState->repeat         = false;
@@ -1771,6 +1778,7 @@ bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const 
     colorHueTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
     colorHueTransitionState->stepsTotal     = colorHueTransitionState->stepsRemaining;
     colorHueTransitionState->timeRemaining  = transitionTime;
+    colorHueTransitionState->transitionTime = transitionTime;
     colorHueTransitionState->endpoint       = endpoint;
     colorHueTransitionState->repeat         = false;
 
@@ -1795,7 +1803,7 @@ bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj,
     EndpointId endpoint    = commandPath.mEndpointId;
     Status status          = Status::Success;
 
-    uint16_t epIndex = getEndpointIndex(endpoint);
+    uint16_t epIndex                                         = getEndpointIndex(endpoint);
     Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionStateByIndex(epIndex);
     VerifyOrExit(colorSaturationTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
@@ -1847,6 +1855,7 @@ bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj,
     colorSaturationTransitionState->stepsRemaining = transitionTime;
     colorSaturationTransitionState->stepsTotal     = transitionTime;
     colorSaturationTransitionState->timeRemaining  = transitionTime;
+    colorSaturationTransitionState->transitionTime = transitionTime;
     colorSaturationTransitionState->endpoint       = endpoint;
     colorSaturationTransitionState->lowLimit       = MIN_SATURATION_VALUE;
     colorSaturationTransitionState->highLimit      = MAX_SATURATION_VALUE;
@@ -1945,6 +1954,7 @@ bool ColorControlServer::stepSaturationCommand(app::CommandHandler * commandObj,
     colorSaturationTransitionState->stepsRemaining = max<uint8_t>(transitionTime, 1);
     colorSaturationTransitionState->stepsTotal     = colorSaturationTransitionState->stepsRemaining;
     colorSaturationTransitionState->timeRemaining  = transitionTime;
+    colorSaturationTransitionState->transitionTime = transitionTime;
     colorSaturationTransitionState->endpoint       = endpoint;
     colorSaturationTransitionState->lowLimit       = MIN_SATURATION_VALUE;
     colorSaturationTransitionState->highLimit      = MAX_SATURATION_VALUE;
@@ -1975,7 +1985,8 @@ bool ColorControlServer::colorLoopCommand(app::CommandHandler * commandObj, cons
     uint8_t isColorLoopActive = 0;
     uint8_t deactiveColorLoop = 0;
 
-    ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionState(endpoint);
+    uint16_t epIndex                                  = getEndpointIndex(endpoint);
+    ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionStateByIndex(epIndex);
     VerifyOrExit(colorHueTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // Validate the action and direction parameters of the command
@@ -2060,7 +2071,9 @@ bool ColorControlServer::colorLoopCommand(app::CommandHandler * commandObj, cons
 
                 uint16_t storedEnhancedHue = 0;
                 Attributes::ColorLoopStoredEnhancedHue::Get(endpoint, &storedEnhancedHue);
-                Attributes::EnhancedCurrentHue::Set(endpoint, storedEnhancedHue);
+                MarkAttributeDirty markDirty =
+                    SetQuietReportAttribute(quietEnhancedHue[epIndex], storedEnhancedHue, true /*isStartOrEndOfTransition*/, 0);
+                Attributes::EnhancedCurrentHue::Set(endpoint, quietEnhancedHue[epIndex].value().Value(), markDirty);
             }
             else
             {
@@ -2093,13 +2106,17 @@ exit:
 void ColorControlServer::updateHueSatCommand(EndpointId endpoint)
 {
     MATTER_TRACE_SCOPE("updateHueSat", "ColorControl");
-    uint16_t epIndex = getEndpointIndex(endpoint);
+    uint16_t epIndex                                         = getEndpointIndex(endpoint);
     ColorHueTransitionState * colorHueTransitionState        = getColorHueTransitionStateByIndex(epIndex);
     Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionStateByIndex(epIndex);
 
     uint8_t previousHue          = colorHueTransitionState->currentHue;
     uint16_t previousSaturation  = colorSaturationTransitionState->currentValue;
     uint16_t previousEnhancedhue = colorHueTransitionState->currentEnhancedHue;
+
+    bool isHueTansitionStart = (colorHueTransitionState->stepsRemaining == colorHueTransitionState->stepsTotal);
+    bool isSaturationTransitionStart =
+        (colorSaturationTransitionState->stepsRemaining == colorSaturationTransitionState->stepsTotal);
 
     bool isHueTansitionDone         = computeNewHueValue(colorHueTransitionState);
     bool isSaturationTransitionDone = computeNewColor16uValue(colorSaturationTransitionState);
@@ -2115,31 +2132,42 @@ void ColorControlServer::updateHueSatCommand(EndpointId endpoint)
         scheduleTimerCallbackMs(configureHSVEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
     }
 
+    uint8_t currentHue;
+    MarkAttributeDirty markDirty;
     if (colorHueTransitionState->isEnhancedHue)
     {
+        markDirty = SetQuietReportAttribute(quietEnhancedHue[epIndex], colorHueTransitionState->currentEnhancedHue,
+                                            (isHueTansitionStart || isHueTansitionDone), colorHueTransitionState->transitionTime);
+        Attributes::EnhancedCurrentHue::Set(endpoint, quietEnhancedHue[epIndex].value().Value(), markDirty);
+        currentHue = static_cast<uint8_t>(colorHueTransitionState->currentEnhancedHue >> 8);
+
         if (previousEnhancedhue != colorHueTransitionState->currentEnhancedHue)
         {
-            Attributes::EnhancedCurrentHue::Set(endpoint, colorHueTransitionState->currentEnhancedHue);
-            Attributes::CurrentHue::Set(endpoint, static_cast<uint8_t>(colorHueTransitionState->currentEnhancedHue >> 8));
-
             ChipLogProgress(Zcl, "Enhanced Hue %d endpoint %d", colorHueTransitionState->currentEnhancedHue, endpoint);
         }
     }
     else
     {
+        currentHue = colorHueTransitionState->currentHue;
         if (previousHue != colorHueTransitionState->currentHue)
         {
-            Attributes::CurrentHue::Set(colorHueTransitionState->endpoint, colorHueTransitionState->currentHue);
             ChipLogProgress(Zcl, "Hue %d endpoint %d", colorHueTransitionState->currentHue, endpoint);
         }
     }
 
+    markDirty = SetQuietReportAttribute(quietHue[epIndex], currentHue, (isHueTansitionStart || isHueTansitionDone),
+                                        colorHueTransitionState->transitionTime);
+    Attributes::CurrentHue::Set(endpoint, quietHue[epIndex].value().Value(), markDirty);
+
     if (previousSaturation != colorSaturationTransitionState->currentValue)
     {
-        Attributes::CurrentSaturation::Set(colorSaturationTransitionState->endpoint,
-                                           (uint8_t) colorSaturationTransitionState->currentValue);
         ChipLogProgress(Zcl, "Saturation %d endpoint %d", colorSaturationTransitionState->currentValue, endpoint);
     }
+
+    markDirty = SetQuietReportAttribute(quietSaturation[epIndex], colorSaturationTransitionState->currentValue,
+                                        (isSaturationTransitionStart || isSaturationTransitionDone),
+                                        colorSaturationTransitionState->transitionTime);
+    Attributes::CurrentSaturation::Set(endpoint, quietSaturation[epIndex].value().Value(), markDirty);
 
     computePwmFromHsv(endpoint);
 }
@@ -2254,7 +2282,7 @@ EmberEventControl * ColorControlServer::configureXYEventControl(EndpointId endpo
  */
 Status ColorControlServer::moveToColor(uint16_t colorX, uint16_t colorY, uint16_t transitionTime, EndpointId endpoint)
 {
-    uint16_t epIndex = getEndpointIndex(endpoint);
+    uint16_t epIndex                                = getEndpointIndex(endpoint);
     Color16uTransitionState * colorXTransitionState = getXTransitionStateByIndex(epIndex);
     Color16uTransitionState * colorYTransitionState = getYTransitionStateByIndex(epIndex);
 
@@ -2274,6 +2302,7 @@ Status ColorControlServer::moveToColor(uint16_t colorX, uint16_t colorY, uint16_
     colorXTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
     colorXTransitionState->stepsTotal     = colorXTransitionState->stepsRemaining;
     colorXTransitionState->timeRemaining  = transitionTime;
+    colorXTransitionState->transitionTime = transitionTime;
     colorXTransitionState->endpoint       = endpoint;
     colorXTransitionState->lowLimit       = MIN_CIE_XY_VALUE;
     colorXTransitionState->highLimit      = MAX_CIE_XY_VALUE;
@@ -2284,11 +2313,12 @@ Status ColorControlServer::moveToColor(uint16_t colorX, uint16_t colorY, uint16_
     colorYTransitionState->stepsRemaining = colorXTransitionState->stepsRemaining;
     colorYTransitionState->stepsTotal     = colorXTransitionState->stepsRemaining;
     colorYTransitionState->timeRemaining  = transitionTime;
+    colorYTransitionState->transitionTime = transitionTime;
     colorYTransitionState->endpoint       = endpoint;
     colorYTransitionState->lowLimit       = MIN_CIE_XY_VALUE;
     colorYTransitionState->highLimit      = MAX_CIE_XY_VALUE;
 
-    Attributes::RemainingTime::Set(endpoint, transitionTime);
+    SetQuietReportRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureXYEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
@@ -2323,7 +2353,7 @@ bool ColorControlServer::moveColorCommand(app::CommandHandler * commandObj, cons
     EndpointId endpoint     = commandPath.mEndpointId;
     Status status           = Status::Success;
 
-    uint16_t epIndex = getEndpointIndex(endpoint);
+    uint16_t epIndex                                = getEndpointIndex(endpoint);
     Color16uTransitionState * colorXTransitionState = getXTransitionStateByIndex(epIndex);
     Color16uTransitionState * colorYTransitionState = getYTransitionStateByIndex(epIndex);
 
@@ -2369,6 +2399,7 @@ bool ColorControlServer::moveColorCommand(app::CommandHandler * commandObj, cons
     colorXTransitionState->stepsRemaining = transitionTimeX;
     colorXTransitionState->stepsTotal     = transitionTimeX;
     colorXTransitionState->timeRemaining  = transitionTimeX;
+    colorXTransitionState->transitionTime = transitionTimeX;
     colorXTransitionState->endpoint       = endpoint;
     colorXTransitionState->lowLimit       = MIN_CIE_XY_VALUE;
     colorXTransitionState->highLimit      = MAX_CIE_XY_VALUE;
@@ -2389,18 +2420,12 @@ bool ColorControlServer::moveColorCommand(app::CommandHandler * commandObj, cons
     colorYTransitionState->stepsRemaining = transitionTimeY;
     colorYTransitionState->stepsTotal     = transitionTimeY;
     colorYTransitionState->timeRemaining  = transitionTimeY;
+    colorYTransitionState->transitionTime = transitionTimeY;
     colorYTransitionState->endpoint       = endpoint;
     colorYTransitionState->lowLimit       = MIN_CIE_XY_VALUE;
     colorYTransitionState->highLimit      = MAX_CIE_XY_VALUE;
 
-    if (transitionTimeX < transitionTimeY)
-    {
-        Attributes::RemainingTime::Set(endpoint, transitionTimeX);
-    }
-    else
-    {
-        Attributes::RemainingTime::Set(endpoint, transitionTimeY);
-    }
+    SetQuietReportRemainingTime(endpoint, max(transitionTimeX, transitionTimeY));
 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureXYEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
@@ -2426,7 +2451,7 @@ bool ColorControlServer::stepColorCommand(app::CommandHandler * commandObj, cons
 
     Status status = Status::Success;
 
-    uint16_t epIndex = getEndpointIndex(endpoint);
+    uint16_t epIndex                                = getEndpointIndex(endpoint);
     Color16uTransitionState * colorXTransitionState = getXTransitionStateByIndex(epIndex);
     Color16uTransitionState * colorYTransitionState = getYTransitionStateByIndex(epIndex);
 
@@ -2464,6 +2489,7 @@ bool ColorControlServer::stepColorCommand(app::CommandHandler * commandObj, cons
     colorXTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
     colorXTransitionState->stepsTotal     = colorXTransitionState->stepsRemaining;
     colorXTransitionState->timeRemaining  = transitionTime;
+    colorXTransitionState->transitionTime = transitionTime;
     colorXTransitionState->endpoint       = endpoint;
     colorXTransitionState->lowLimit       = MIN_CIE_XY_VALUE;
     colorXTransitionState->highLimit      = MAX_CIE_XY_VALUE;
@@ -2474,11 +2500,12 @@ bool ColorControlServer::stepColorCommand(app::CommandHandler * commandObj, cons
     colorYTransitionState->stepsRemaining = colorXTransitionState->stepsRemaining;
     colorYTransitionState->stepsTotal     = colorXTransitionState->stepsRemaining;
     colorYTransitionState->timeRemaining  = transitionTime;
+    colorYTransitionState->transitionTime = transitionTime;
     colorYTransitionState->endpoint       = endpoint;
     colorYTransitionState->lowLimit       = MIN_CIE_XY_VALUE;
     colorYTransitionState->highLimit      = MAX_CIE_XY_VALUE;
 
-    Attributes::RemainingTime::Set(endpoint, transitionTime);
+    SetQuietReportRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureXYEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
@@ -2495,16 +2522,15 @@ exit:
  */
 void ColorControlServer::updateXYCommand(EndpointId endpoint)
 {
-    uint16_t epIndex = getEndpointIndex(endpoint);
+    uint16_t epIndex                                = getEndpointIndex(endpoint);
     Color16uTransitionState * colorXTransitionState = getXTransitionStateByIndex(epIndex);
     Color16uTransitionState * colorYTransitionState = getYTransitionStateByIndex(epIndex);
-    bool isXTransitionDone, isYTransitionDone;
 
     // compute new values for X and Y.
-    isXTransitionDone = computeNewColor16uValue(colorXTransitionState);
-    isYTransitionDone = computeNewColor16uValue(colorYTransitionState);
+    bool isXTransitionDone = computeNewColor16uValue(colorXTransitionState);
+    bool isYTransitionDone = computeNewColor16uValue(colorYTransitionState);
 
-    Attributes::RemainingTime::Set(endpoint, max(colorXTransitionState->timeRemaining, colorYTransitionState->timeRemaining));
+    SetQuietReportRemainingTime(endpoint, max(colorXTransitionState->timeRemaining, colorYTransitionState->timeRemaining));
 
     if (isXTransitionDone && isYTransitionDone)
     {
@@ -2515,9 +2541,18 @@ void ColorControlServer::updateXYCommand(EndpointId endpoint)
         scheduleTimerCallbackMs(configureXYEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
     }
 
-    // update the attributes
-    Attributes::CurrentX::Set(endpoint, colorXTransitionState->currentValue);
-    Attributes::CurrentY::Set(endpoint, colorYTransitionState->currentValue);
+    bool isXTransitionStart = (colorXTransitionState->stepsRemaining == colorXTransitionState->stepsTotal);
+    bool isYTransitionStart = (colorYTransitionState->stepsRemaining == colorYTransitionState->stepsTotal);
+
+    MarkAttributeDirty markXDirty =
+        SetQuietReportAttribute(quietColorX[epIndex], colorXTransitionState->currentValue,
+                                (isXTransitionStart || isXTransitionDone), colorXTransitionState->transitionTime);
+    MarkAttributeDirty markYDirty =
+        SetQuietReportAttribute(quietColorY[epIndex], colorYTransitionState->currentValue,
+                                (isYTransitionStart || isYTransitionDone), colorYTransitionState->transitionTime);
+
+    Attributes::CurrentX::Set(endpoint, quietColorX[epIndex].value().Value(), markXDirty);
+    Attributes::CurrentY::Set(endpoint, quietColorY[epIndex].value().Value(), markYDirty);
 
     ChipLogProgress(Zcl, "Color X %d Color Y %d", colorXTransitionState->currentValue, colorYTransitionState->currentValue);
 
@@ -2600,6 +2635,7 @@ Status ColorControlServer::moveToColorTemp(EndpointId aEndpoint, uint16_t colorT
     colorTempTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
     colorTempTransitionState->stepsTotal     = colorTempTransitionState->stepsRemaining;
     colorTempTransitionState->timeRemaining  = transitionTime;
+    colorTempTransitionState->transitionTime = transitionTime;
     colorTempTransitionState->endpoint       = endpoint;
     colorTempTransitionState->lowLimit       = temperatureMin;
     colorTempTransitionState->highLimit      = temperatureMax;
@@ -2729,7 +2765,7 @@ void ColorControlServer::updateTempCommand(EndpointId endpoint)
         }
     }
 
-    Attributes::RemainingTime::Set(endpoint, colorTempTransitionState->timeRemaining);
+    SetQuietReportRemainingTime(endpoint, colorTempTransitionState->timeRemaining);
 
     if (isColorTempTransitionDone)
     {
@@ -2851,11 +2887,12 @@ bool ColorControlServer::moveColorTempCommand(app::CommandHandler * commandObj, 
     colorTempTransitionState->stepsRemaining = transitionTime;
     colorTempTransitionState->stepsTotal     = transitionTime;
     colorTempTransitionState->timeRemaining  = transitionTime;
+    colorTempTransitionState->transitionTime = transitionTime;
     colorTempTransitionState->endpoint       = endpoint;
     colorTempTransitionState->lowLimit       = colorTemperatureMinimum;
     colorTempTransitionState->highLimit      = colorTemperatureMaximum;
 
-    Attributes::RemainingTime::Set(endpoint, transitionTime);
+    SetQuietReportRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureTempEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
@@ -2968,11 +3005,12 @@ bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, 
     colorTempTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
     colorTempTransitionState->stepsTotal     = colorTempTransitionState->stepsRemaining;
     colorTempTransitionState->timeRemaining  = transitionTime;
+    colorTempTransitionState->transitionTime = transitionTime;
     colorTempTransitionState->endpoint       = endpoint;
     colorTempTransitionState->lowLimit       = colorTemperatureMinimum;
     colorTempTransitionState->highLimit      = colorTemperatureMaximum;
 
-    Attributes::RemainingTime::Set(endpoint, transitionTime);
+    SetQuietReportRemainingTime(endpoint, transitionTime);
 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureTempEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
@@ -3064,6 +3102,89 @@ void ColorControlServer::levelControlColorTempChangeCommand(EndpointId endpoint)
 }
 
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_TEMP
+
+/*
+ * @brief
+ * Utility function used to update a color control attribute which has the quiet reporting quality.
+ * matching the following report conditions:
+ * - At most once per second, or
+ * - At the start of the movement/transition, or
+ * - At the end of the movement/transition, or
+ * - When it changes from null to any other value and vice versa. (Implicit to the QuieterReportingAttribute class)
+ *
+ * The QuietReportAttribute class is updated with the new value and when the report conditions are met,
+ * this function will return MarkAttributeDirty::kIfChanged.
+ * It is expected that the user will use this return value to trigger a reporting mechanism for the attribute with the new value
+ * (Which was updated in the quietReporter)
+ *
+ * @param quietReporter: The QuieterReportingAttribute<TYPE> object for the attribute to update.
+ * @param newValue: Value to update the attribute with
+ * @param isStartOrEndOfTransition: Boolean that indicatse whether the update is occurring at the start or end of a level transition
+ * @return MarkAttributeDirty::kIfChanged when the attribute must be maredk dirty and be reported. MarkAttributeDirty::kNo when it
+ * when it no report is needed.
+ */
+template <typename Q, typename V>
+MarkAttributeDirty ColorControlServer::SetQuietReportAttribute(QuieterReportingAttribute<Q> & quietReporter, V newValue,
+                                                               bool isStartOrEndOfTransition, uint16_t transitionTime)
+{
+    AttributeDirtyState dirtyState;
+    auto now = System::SystemClock().GetMonotonicTimestamp();
+
+    if (isStartOrEndOfTransition)
+    {
+        // At the start or end of the movement/transition we must report
+        auto predicate = [](const typename QuieterReportingAttribute<Q>::SufficientChangePredicateCandidate &) -> bool {
+            return true;
+        };
+        dirtyState = quietReporter.SetValue(newValue, now, predicate);
+    }
+    else
+    {
+        // During transitions, reports should be at most once per second
+
+        // For "infinite" transition, default reports interval to 10s (100 1/10ths of a second )
+        if (transitionTime == MAX_INT16U_VALUE)
+        {
+            transitionTime = 100;
+        }
+
+        // Opt for the longest interval between reports, 1s or (transitionTime / 4).
+        // Since transitionTime is in 1/10th of a second, convert it to ms (x 100), thus * 100/4 -> * 25
+        System::Clock::Milliseconds64 reportInterval = System::Clock::Milliseconds64(std::max(1000, transitionTime * 25));
+        auto predicate                               = quietReporter.GetPredicateForSufficientTimeSinceLastDirty(reportInterval);
+        dirtyState                                   = quietReporter.SetValue(newValue, now, predicate);
+    }
+
+    return (dirtyState == AttributeDirtyState::kMustReport) ? MarkAttributeDirty::kIfChanged : MarkAttributeDirty::kNo;
+}
+
+/*
+ * @brief
+ * Function used to set the remaining time based on quiet reporting conditions.
+ * It will update the attribute storage and report the attribute if it is determined dirty.
+ * The condition on which the attribute must be reported are defined by the set QuieterReportingPolicyFlags
+ * of the quietRemainingTime object and the implicit conditions of the QuieterReportingAttribute class
+ *
+ * @param endpoint: Endpoint of the RemainingTime attribute to set
+ * @param newRemainingTime: Value to update the RemainingTime attribute with
+ * @return Success in setting the attribute value or the IM error code for the failure.
+ */
+Status ColorControlServer::SetQuietReportRemainingTime(EndpointId endpoint, uint16_t newRemainingTime)
+{
+    uint16_t epIndex = getEndpointIndex(endpoint);
+    auto markDirty   = MarkAttributeDirty::kNo;
+    auto now         = System::SystemClock().GetMonotonicTimestamp();
+    // Establish the quiet report condition for the RemainingTime Attribute
+    // The quiet report is by the previously set policies :
+    // - kMarkDirtyOnChangeToFromZero : When the value changes from 0 to any other value and vice versa, or
+    // - kMarkDirtyOnIncrement : When the value increases.
+    if (quietRemainingTime[epIndex].SetValue(newRemainingTime, now) == AttributeDirtyState::kMustReport)
+    {
+        markDirty = MarkAttributeDirty::kIfChanged;
+    }
+
+    return Attributes::RemainingTime::Set(endpoint, quietRemainingTime[epIndex].value().Value(), markDirty);
+}
 
 /**********************************************************
  * Callbacks Implementation

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -295,27 +295,17 @@ private:
     ColorHueTransitionState colorHueTransitionStates[kColorControlClusterServerMaxEndpointCount];
     Color16uTransitionState colorSatTransitionStates[kColorControlClusterServerMaxEndpointCount];
 
-    chip::app::QuieterReportingAttribute<uint8_t> quietHue[kColorControlClusterServerMaxEndpointCount]{
-        chip::app::QuieterReportingAttribute<uint8_t>(0)
-    };
-    chip::app::QuieterReportingAttribute<uint8_t> quietSaturation[kColorControlClusterServerMaxEndpointCount]{
-        chip::app::QuieterReportingAttribute<uint8_t>(0)
-    };
-    chip::app::QuieterReportingAttribute<uint16_t> quietEnhancedHue[kColorControlClusterServerMaxEndpointCount]{
-        chip::app::QuieterReportingAttribute<uint16_t>(0)
-    };
+    chip::app::QuieterReportingAttribute<uint8_t> quietHue[kColorControlClusterServerMaxEndpointCount];
+    chip::app::QuieterReportingAttribute<uint8_t> quietSaturation[kColorControlClusterServerMaxEndpointCount];
+    chip::app::QuieterReportingAttribute<uint16_t> quietEnhancedHue[kColorControlClusterServerMaxEndpointCount];
 #endif
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_XY
     Color16uTransitionState colorXtransitionStates[kColorControlClusterServerMaxEndpointCount];
     Color16uTransitionState colorYtransitionStates[kColorControlClusterServerMaxEndpointCount];
 
-    chip::app::QuieterReportingAttribute<uint16_t> quietColorX[kColorControlClusterServerMaxEndpointCount]{
-        chip::app::QuieterReportingAttribute<uint16_t>(0)
-    };
-    chip::app::QuieterReportingAttribute<uint16_t> quietColorY[kColorControlClusterServerMaxEndpointCount]{
-        chip::app::QuieterReportingAttribute<uint16_t>(0)
-    };
+    chip::app::QuieterReportingAttribute<uint16_t> quietColorX[kColorControlClusterServerMaxEndpointCount];
+    chip::app::QuieterReportingAttribute<uint16_t> quietColorY[kColorControlClusterServerMaxEndpointCount];
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_XY
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_TEMP
@@ -323,9 +313,7 @@ private:
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_TEMP
 
     EmberEventControl eventControls[kColorControlClusterServerMaxEndpointCount];
-    chip::app::QuieterReportingAttribute<uint16_t> quietRemainingTime[kColorControlClusterServerMaxEndpointCount]{
-        chip::app::QuieterReportingAttribute<uint16_t>(0)
-    };
+    chip::app::QuieterReportingAttribute<uint16_t> quietRemainingTime[kColorControlClusterServerMaxEndpointCount];
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
     friend class DefaultColorControlSceneHandler;

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -20,6 +20,8 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
+#include <app/cluster-building-blocks/QuieterReporting.h>
+#include <app/data-model/Nullable.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/basic-types.h>
@@ -199,7 +201,37 @@ private:
      * Functions Definitions
      *********************************************************/
 
-    ColorControlServer() {}
+    ColorControlServer()
+    {
+        // #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
+        //         quietHue = new chip::app::QuieterReportingAttribute<uint8_t>[kColorControlClusterServerMaxEndpointCount]
+        //         {
+        //             chip::app::QuieterReportingAttribute<uint8_t>(0)
+        //         };
+        //         quietSaturation = new
+        //         chip::app::QuieterReportingAttribute<uint8_t>[kColorControlClusterServerMaxEndpointCount] {
+        //             chip::app::QuieterReportingAttribute<uint8_t>(0)
+        //         };
+        //         quietEnhancedHue = new
+        //         chip::app::QuieterReportingAttribute<uint16_t>[kColorControlClusterServerMaxEndpointCount] {
+        //             chip::app::QuieterReportingAttribute<uint16_t>(0)
+        //         };
+        // #endif
+        // #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_XY
+        //         quietColorX = new
+        //         chip::app::QuieterReportingAttribute<uint16_t>[kColorControlClusterServerMaxEndpointCount] {
+        //             chip::app::QuieterReportingAttribute<uint16_t>(0)
+        //         };
+        //         quietColorY = new
+        //         chip::app::QuieterReportingAttribute<uint16_t>[kColorControlClusterServerMaxEndpointCount] {
+        //             chip::app::QuieterReportingAttribute<uint16_t>(0)
+        //         };
+        // #endif
+        //         quietRemainingTime =
+        //             new chip::app::QuieterReportingAttribute<uint16_t>[kColorControlClusterServerMaxEndpointCount] {
+        //                 chip::app::QuieterReportingAttribute<uint16_t>(0)
+        //             };
+    }
     bool shouldExecuteIfOff(chip::EndpointId endpoint, uint8_t optionMask, uint8_t optionOverride);
     void handleModeSwitch(chip::EndpointId endpoint, uint8_t newColorMode);
     uint16_t computeTransitionTimeFromStateAndRate(Color16uTransitionState * p, uint16_t rate);
@@ -213,6 +245,7 @@ private:
     static void timerCallback(chip::System::Layer *, void * callbackContext);
     void scheduleTimerCallbackMs(EmberEventControl * control, uint32_t delayMs);
     void cancelEndpointTimerCallback(EmberEventControl * control);
+    uint16_t getEndpointIndex(chip::EndpointId);
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
     chip::Protocols::InteractionModel::Status moveToSaturation(uint8_t saturation, uint16_t transitionTime,
@@ -221,6 +254,8 @@ private:
                                                                      bool isEnhanced, chip::EndpointId endpoint);
     ColorHueTransitionState * getColorHueTransitionState(chip::EndpointId endpoint);
     Color16uTransitionState * getSaturationTransitionState(chip::EndpointId endpoint);
+    ColorHueTransitionState * getColorHueTransitionStateByIndex(uint16_t index);
+    Color16uTransitionState * getSaturationTransitionStateByIndex(uint16_t index);
     uint8_t getSaturation(chip::EndpointId endpoint);
     uint8_t addHue(uint8_t hue1, uint8_t hue2);
     uint8_t subtractHue(uint8_t hue1, uint8_t hue2);
@@ -241,12 +276,15 @@ private:
                                                           chip::EndpointId endpoint);
     Color16uTransitionState * getXTransitionState(chip::EndpointId endpoint);
     Color16uTransitionState * getYTransitionState(chip::EndpointId endpoint);
+    Color16uTransitionState * getXTransitionStateByIndex(uint16_t index);
+    Color16uTransitionState * getYTransitionStateByIndex(uint16_t index);
     uint16_t findNewColorValueFromStep(uint16_t oldValue, int16_t step);
     EmberEventControl * configureXYEventControl(chip::EndpointId);
 #endif // #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_XY
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_TEMP
     Color16uTransitionState * getTempTransitionState(chip::EndpointId endpoint);
+    Color16uTransitionState * getTempTransitionStateByIndex(uint16_t index);
     chip::Protocols::InteractionModel::Status moveToColorTemp(chip::EndpointId aEndpoint, uint16_t colorTemperature,
                                                               uint16_t transitionTime);
     uint16_t getTemperatureCoupleToLevelMin(chip::EndpointId endpoint);
@@ -264,11 +302,26 @@ private:
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
     ColorHueTransitionState colorHueTransitionStates[kColorControlClusterServerMaxEndpointCount];
     Color16uTransitionState colorSatTransitionStates[kColorControlClusterServerMaxEndpointCount];
+
+    chip::app::QuieterReportingAttribute<uint8_t> quietHue[kColorControlClusterServerMaxEndpointCount]{
+        chip::app::QuieterReportingAttribute<uint8_t>(0)
+    };
+    chip::app::QuieterReportingAttribute<uint8_t> quietSaturation[kColorControlClusterServerMaxEndpointCount]{
+        chip::app::QuieterReportingAttribute<uint8_t>(0)
+    };
+    chip::app::QuieterReportingAttribute<uint16_t> quietEnhancedHue[kColorControlClusterServerMaxEndpointCount]{
+        chip::app::QuieterReportingAttribute<uint16_t>(0)
+    };
 #endif
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_XY
     Color16uTransitionState colorXtransitionStates[kColorControlClusterServerMaxEndpointCount];
     Color16uTransitionState colorYtransitionStates[kColorControlClusterServerMaxEndpointCount];
+
+    chip::app::QuieterReportingAttribute<uint16_t> quietColorX[kColorControlClusterServerMaxEndpointCount]{
+        chip::app::QuieterReportingAttribute<uint16_t>(0)};
+    chip::app::QuieterReportingAttribute<uint16_t> quietColorY[kColorControlClusterServerMaxEndpointCount]{
+        chip::app::QuieterReportingAttribute<uint16_t>(0)};
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_XY
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_TEMP
@@ -276,6 +329,8 @@ private:
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_TEMP
 
     EmberEventControl eventControls[kColorControlClusterServerMaxEndpointCount];
+    chip::app::QuieterReportingAttribute<uint16_t> quietRemainingTime[kColorControlClusterServerMaxEndpointCount]{
+        chip::app::QuieterReportingAttribute<uint16_t>(0)};
 
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
     friend class DefaultColorControlSceneHandler;


### PR DESCRIPTION
…rentHue, CurrentX, CurrentY and RemainingTime attributes of the color control cluster server implementation

CurrentHue, CurrentSaturation, EnhancedCurrentHue, CurrentX and CurrentY attributes are reported on at most every second, but usually 4 times throughout the transition or at transition start and end 

RemainingTime is reported on value increase, or when it changes from or to 0

fixes #33863

Tests:

Existing Color control cert tests.
Manual test by subscribing to the attributes