### PR TITLE
Update Darwin availability annotations.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -9687,6 +9687,7 @@
       clusters:
           # Targeting 1.4
           - CommissionerControl
+          - EcosystemInformation
           - ServiceArea
           - ThreadBorderRouterManagement
           - ThreadNetworkDirectory
@@ -9699,16 +9700,33 @@
               - HoldTime
               - HoldTimeLimits
       commands:
+          BridgedDeviceBasicInformation:
+              # Targeting 1.4
+              - KeepActive
           UnitTesting:
               # Ideally none of UnitTesting would be exposed as public API, but
               # for now just start doing that for new additions to it.
               - StringEchoRequest
               - StringEchoResponse
       structs:
+          Globals:
+              # Test-only value
+              - TestGlobalStruct
           OccupancySensing:
               # Targeting 1.4
               - HoldTimeLimitsStruct
+      events:
+          BridgedDeviceBasicInformation:
+              # Targeting 1.4
+              - ActiveChanged
+      enums:
+          Globals:
+              # Test-only value
+              - TestGlobalEnum
       bitmaps:
+          BridgedDeviceBasicInformation:
+              # Targeting 1.4
+              - Feature
           OccupancySensing:
               # Targeting 1.4
               - Feature
@@ -9717,12 +9735,3 @@
               Feature:
                   # Targeting 1.4
                   - ActionSwitch
-  removed:
-      structs:
-          Globals:
-              # Don't enable TestGlobalStruct until the ZAP side is fixed to handle it properly
-              - TestGlobalStruct
-      enums:
-          Globals:
-              # Don't enable TestGlobalEnum until the ZAP side is fixed to handle it properly
-              - TestGlobalEnum

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -17124,6 +17124,12 @@ MTR_DEPRECATED("Please use MTRBaseClusterUnitTesting", ios(16.1, 16.4), macos(13
 @interface MTRBaseClusterTestCluster : MTRBaseClusterUnitTesting
 @end
 
+typedef NS_ENUM(uint8_t, MTRDataTypeTestGlobalEnum) {
+    MTRDataTypeTestGlobalEnumSomeValue MTR_PROVISIONALLY_AVAILABLE = 0x00,
+    MTRDataTypeTestGlobalEnumSomeOtherValue MTR_PROVISIONALLY_AVAILABLE = 0x01,
+    MTRDataTypeTestGlobalEnumFinalValue MTR_PROVISIONALLY_AVAILABLE = 0x02,
+} MTR_PROVISIONALLY_AVAILABLE;
+
 typedef NS_ENUM(uint8_t, MTRIdentifyEffectIdentifier) {
     MTRIdentifyEffectIdentifierBlink MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x00,
     MTRIdentifyEffectIdentifierBreathe MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x01,

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -19,6 +19,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+MTR_PROVISIONALLY_AVAILABLE
+@interface MTRDataTypeTestGlobalStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSString * _Nonnull name MTR_PROVISIONALLY_AVAILABLE;
+@property (nonatomic, copy) NSNumber * _Nullable myBitmap MTR_PROVISIONALLY_AVAILABLE;
+@property (nonatomic, copy) NSNumber * _Nullable myEnum MTR_PROVISIONALLY_AVAILABLE;
+@end
+
 MTR_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @interface MTRDescriptorClusterDeviceTypeStruct : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull deviceType MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -19,6 +19,39 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@implementation MTRDataTypeTestGlobalStruct
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _name = @"";
+
+        _myBitmap = nil;
+
+        _myEnum = nil;
+    }
+    return self;
+}
+
+- (id)copyWithZone:(NSZone * _Nullable)zone
+{
+    auto other = [[MTRDataTypeTestGlobalStruct alloc] init];
+
+    other.name = self.name;
+    other.myBitmap = self.myBitmap;
+    other.myEnum = self.myEnum;
+
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: name:%@; myBitmap:%@; myEnum:%@; >", NSStringFromClass([self class]), _name, _myBitmap, _myEnum];
+    return descriptionString;
+}
+
+@end
+
 @implementation MTRDescriptorClusterDeviceTypeStruct
 - (instancetype)init
 {


### PR DESCRIPTION
Marks a few things explicitly as provisional, and enables (as provisional) the global struct and enum we have for tests.


