### PR TITLE
[Telink] Commissioning using WiFi.

### DIFF
--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -286,10 +286,10 @@ config NET_IPV6_NBR_CACHE
     default n
 
 config NET_MAX_CONN
-    default 1
+    default 1 if !WIFI
 
 config NET_MAX_CONTEXTS
-    default 1
+    default 1 if !WIFI
 
 config NET_CONFIG_INIT_TIMEOUT
     default 0


### PR DESCRIPTION
Change overview:
- Configure Zephyr to use WiFi
- Add changes in Telink WiFi platform to proceed commissioning

Changes touch only Telink platform.

Tested manually using chip-tool on lighting-app: commissioning and device controlling
```
./chip-tool pairing ble-wifi 1234 your_ssid your_passwd 20202021 3840
./chip-tool onoff on 1234 1
```
