### PR TITLE
Update to mobly-1.12.3 to avoid pip build errors

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -124,7 +124,7 @@ markupsafe==2.1.2
     # via jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mobly==1.12.1
+mobly==1.12.3
     # via -r requirements.all.txt
 msgpack==1.0.4
     # via cachecontrol


### PR DESCRIPTION
Mobly < 1.12.3 was using `setuptools.command.test` in setup.py which breaks installs of the most recent setuptools release.

See https://github.com/pypa/setuptools/issues/4519
