### PR TITLE
Add a SDK part of `IM Cluster Status Success` to CHIP_ERROR

### DIFF
--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -138,12 +138,16 @@ CHIP_ERROR StatusIB::ToChipError() const
 {
     if (mStatus == Status::Success)
     {
+        // NOTE: this explicitly does not return CHIP_IM_CLUSTER_STATUS_SUCCESS
+        //       even though those constants could be returned. This is to make
+        //       error handling easy/consistent (can verify against CHIP_NO_ERROR)
+        //
         return CHIP_NO_ERROR;
     }
 
     if (mClusterStatus.HasValue())
     {
-        return ChipError(ChipError::SdkPart::kIMClusterStatus, mClusterStatus.Value());
+        return ChipError(ChipError::SdkPart::kIMClusterStatusFailure, mClusterStatus.Value());
     }
 
     return ChipError(ChipError::SdkPart::kIMGlobalStatus, to_underlying(mStatus));
@@ -151,9 +155,18 @@ CHIP_ERROR StatusIB::ToChipError() const
 
 void StatusIB::InitFromChipError(CHIP_ERROR aError)
 {
-    if (aError.IsPart(ChipError::SdkPart::kIMClusterStatus))
+    if (aError.IsPart(ChipError::SdkPart::kIMClusterStatusFailure))
     {
+        // cluster statuses may be successes or failures. Figure it out ...
         mStatus        = Status::Failure;
+        mClusterStatus = MakeOptional(aError.GetSdkCode());
+        return;
+    }
+
+    if (aError.IsPart(ChipError::SdkPart::kIMClusterStatusSuccess))
+    {
+        // cluster statuses may be successes or failures. Figure it out ...
+        mStatus        = Status::Success;
         mClusterStatus = MakeOptional(aError.GetSdkCode());
         return;
     }

--- a/src/app/tests/TestStatusIB.cpp
+++ b/src/app/tests/TestStatusIB.cpp
@@ -101,6 +101,26 @@ TEST_F(TestStatusIB, TestStatusIBToFromChipError)
     }
 }
 
+TEST_F(TestStatusIB, TestChipErrorClusterSpecificErrorCodes)
+{
+    StatusIB status;
+    status.InitFromChipError(CHIP_IM_CLUSTER_STATUS_FAILURE(123));
+
+    EXPECT_TRUE(status.IsFailure());
+    ASSERT_TRUE(status.mClusterStatus.HasValue());
+    EXPECT_EQ(status.mClusterStatus.Value(), 123u);
+    EXPECT_EQ(status.mStatus, Status::Failure);
+
+    status.InitFromChipError(CHIP_IM_CLUSTER_STATUS_SUCCESS(123));
+
+    EXPECT_TRUE(status.IsSuccess());
+    ASSERT_TRUE(status.mClusterStatus.HasValue());
+    EXPECT_EQ(status.mClusterStatus.Value(), 123u);
+    EXPECT_EQ(status.mStatus, Status::Success);
+    // ToChipError explicitly LOSES the IM cluster info on success
+    EXPECT_EQ(status.ToChipError(), CHIP_NO_ERROR);
+}
+
 #if !CHIP_CONFIG_SHORT_ERROR_STR
 TEST_F(TestStatusIB, TestStatusIBErrorToString)
 {

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -155,7 +155,7 @@ public:
             if (report.Is<chip::Controller::CommissioningErrorInfo>())
             {
                 uint8_t code     = chip::to_underlying(report.Get<chip::Controller::CommissioningErrorInfo>().commissioningError);
-                mCompletionError = chip::ChipError(chip::ChipError::SdkPart::kIMClusterStatus, code);
+                mCompletionError = chip::ChipError(chip::ChipError::SdkPart::kIMClusterStatusFailure, code);
             }
             else
             {

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -455,6 +455,12 @@ using CHIP_ERROR = ::chip::ChipError;
 //
 // value must be a compile-time constant as mandated by CHIP_SDK_ERROR.
 //
+// NOTE: CLUSTER_STATUS are generally treated as ERRORS for most logging since
+//       they do not equal CHIP_NO_ERROR and return false on IsSuccess.
+//
+//       The existence of IM_CLUSTER_STATUS_SUCCESS is for complete conversion
+//       to a StatusIB.
+//
 // value MUST be uint8_t sized
 //
 #define CHIP_IM_CLUSTER_STATUS_FAILURE(value) CHIP_SDK_ERROR(::chip::ChipError::SdkPart::kIMClusterStatusFailure, value)

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -158,7 +158,8 @@ public:
     {}
 #else
     constexpr ChipError(SdkPart part, uint8_t code, const char * file, unsigned int line) :
-        mError(MakeInteger(part, code)) CHIP_INITIALIZE_ERROR_SOURCE(file, line, /*loc=*/nullptr){}
+        mError(MakeInteger(part, code)) CHIP_INITIALIZE_ERROR_SOURCE(file, line, /*loc=*/nullptr)
+    {}
 #endif // CHIP_CONFIG_ERROR_SOURCE && __cplusplus >= 202002L
 
     /**

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -341,11 +341,11 @@ private:
      * density on embedded builds. Arm 32, Xtensa, and RISC-V can all handle 11-bit values in a move-immediate instruction.
      * Further, SdkPart::kCore is 0 so that the most common errors fit in 8 bits for additional density on some processors.
      *
-     *  31        28          24      20      16      12                8       4       0    Bit
-     *  |          |           |       |       |       |                |       |       |
-     *  |        range         |                     value                              |
-     *  |       kSdk==0        |       0               |      part      |    code       |   SDK error
-     *  |       01 - FF        |          encapsulated error code                       |   Encapsulated error
+     *  31    28      24      20      16      12       8       4       0    Bit
+     *  |       |       |       |       |       |       |       |       |
+     *  |     range     |                     value                     |
+     *  |    kSdk==0    |       0               |   part|    code       |   SDK error
+     *  |    01 - FF    |          encapsulated error code              |   Encapsulated error
      */
     static constexpr int kRangeStart  = 24;
     static constexpr int kRangeLength = 8;

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -354,11 +354,8 @@ private:
 
     static constexpr int kSdkPartStart  = 8;
     static constexpr int kSdkPartLength = 4;
-    static constexpr int kSdkCodeStart  = 0; // shared with IMClusterStatusCode
-    static constexpr int kSdkCodeLength = 8; // shared with IMClusterStatusCode
-
-    static constexpr int kImStatusSuccess       = 8;
-    static constexpr int kImStatusSuccessLength = 1;
+    static constexpr int kSdkCodeStart  = 0;
+    static constexpr int kSdkCodeLength = 8;
 
     static constexpr StorageType GetField(unsigned int start, unsigned int length, StorageType value)
     {

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <type_traits>
 
+#include <lib/core/CHIPError.h>
 #include <lib/core/Unchecked.h>
 #include <lib/support/CodeUtils.h>
 


### PR DESCRIPTION
CHIP_ERROR currently covers global IM statuses as well as cluster-specific failures, however we did not cover cluster specific successes.

This PR adds a new part to CHIP_ERROR that encodes cluster statuses and updates StatusIB to be able to convert from them. Note that this still considers such `success` statuses as a CHIP_ERROR since the overhead of converting all tests to not check CHIP_NO_ERROR and have code inside IsSuccess would be quite expensive.

#### Background of this change:

Working on DataModel interface split, where Writes may return a CHIP_ERROR currently however that fails to encode ClusterSuccess.

I also considered making the DM provider interfaces return `ClusterStatus` however that requires more work since ReadAttribute relies on non-status errors like CHIP_NO_MEMORY to control code paths. As such, having a better return (e.g. a `std::variant<ClusterStatus, ProcessingError>` where ProcessingError would be out of space) requires more thought. Also a lot of SDK code returns CHIP_ERROR, so a CHIP_ERROR based interface seems slightly more convenient to use at this point).