### PR TITLE
Disable flaky tv test

### DIFF
--- a/.github/workflows/examples-linux-tv-casting-app.yaml
+++ b/.github/workflows/examples-linux-tv-casting-app.yaml
@@ -71,13 +71,16 @@ jobs:
                     "python3 ./scripts/tests/run_tv_casting_test.py"
               timeout-minutes: 2 # Comment this out to debug if GitHub Action times out.
 
-            - name:
-                  Test casting from Linux tv-casting-app to Linux tv-app -
-                  Commissioner Generated Passcode
-              run: |
-                  ./scripts/run_in_build_env.sh \
-                    "python3 ./scripts/tests/run_tv_casting_test.py --commissioner-generated-passcode=True"
-              timeout-minutes: 2 # Comment this out to debug if GitHub Action times out.
+            # TODO: this test is flaky and was disabled
+            #       https://github.com/project-chip/connectedhomeip/issues/34598
+            #
+            #  - name:
+            #        Test casting from Linux tv-casting-app to Linux tv-app -
+            #        Commissioner Generated Passcode
+            #    run: |
+            #        ./scripts/run_in_build_env.sh \
+            #          "python3 ./scripts/tests/run_tv_casting_test.py --commissioner-generated-passcode=True"
+            #    timeout-minutes: 2 # Comment this out to debug if GitHub Action times out.
 
             - name: Uploading Size Reports
               uses: ./.github/actions/upload-size-reports


### PR DESCRIPTION
This disables the commissioner generated passcode test as it is flaky in CI.

#34598 was opened to track fixing this.