### PR TITLE
Enable TCP Keepalive for the received connection on the Server.

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -578,6 +578,9 @@ void TCPBase::HandleIncomingConnection(Inet::TCPEndPoint * listenEndPoint, Inet:
         tcp->mUsedEndPointCount++;
         activeConnection->mConnectionState = TCPState::kConnected;
 
+        // Set the TCPKeepalive configurations on the received connection
+        endPoint->EnableKeepAlive(activeConnection->mTCPKeepAliveIntervalSecs, activeConnection->mTCPMaxNumKeepAliveProbes);
+
         char addrStr[Transport::PeerAddress::kMaxToStringSize];
         peerAddress.ToString(addrStr);
         ChipLogProgress(Inet, "Incoming connection established with peer at %s.", addrStr);


### PR DESCRIPTION
The TCP KeepAlive was enabled on the client side.
Enable TCP Keepalive from the server side as well.
