### PR TITLE
Add TC_CCTRL_2_1.py test implementation

### DIFF
--- a/src/python_testing/TC_CCTRL_2_1.py
+++ b/src/python_testing/TC_CCTRL_2_1.py
@@ -1,0 +1,42 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import chip.clusters as Clusters
+from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, per_endpoint_test
+from mobly import asserts
+
+
+class TC_CCTRL_2_1(MatterBaseTest):
+
+    def steps_TC_CCTRL_2_1(self) -> list[TestStep]:
+        steps = [TestStep(1, "Read MCORE.FS PICS code", is_commissioning=True),
+                 TestStep(2, "Validate SupportedDeviceCategories is set accordingly based on MCORE.FS")]
+        return steps
+
+    @per_endpoint_test(has_cluster(Clusters.CommissionerControl))
+    async def test_TC_CCTRL_2_1(self):
+        self.step(1)
+        is_fabric_sync_pics_enabled = self.check_pics("MCORE.FS")
+
+        self.step(2)
+        supported_device_categories = await self.read_single_attribute_check_success(cluster=Clusters.CommissionerControl, attribute=Clusters.CommissionerControl.Attributes.SupportedDeviceCategories)
+        is_fabric_sync_bit_set = bool(supported_device_categories & Clusters.CommissionerControl.Bitmaps.SupportedDeviceCategoryBitmap.kFabricSynchronization)
+        asserts.assert_equal(is_fabric_sync_bit_set, is_fabric_sync_pics_enabled, "Mismatch between PICS MCORE.FS value and what attribute indicates")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_CCTRL_2_1.py
+++ b/src/python_testing/TC_CCTRL_2_1.py
@@ -16,7 +16,7 @@
 #
 
 import chip.clusters as Clusters
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster, per_endpoint_test
+from matter_testing_support import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, per_endpoint_test
 from mobly import asserts
 
 

--- a/src/python_testing/TC_CCTRL_2_1.py
+++ b/src/python_testing/TC_CCTRL_2_1.py
@@ -34,8 +34,10 @@ class TC_CCTRL_2_1(MatterBaseTest):
 
         self.step(2)
         supported_device_categories = await self.read_single_attribute_check_success(cluster=Clusters.CommissionerControl, attribute=Clusters.CommissionerControl.Attributes.SupportedDeviceCategories)
-        is_fabric_sync_bit_set = bool(supported_device_categories & Clusters.CommissionerControl.Bitmaps.SupportedDeviceCategoryBitmap.kFabricSynchronization)
-        asserts.assert_equal(is_fabric_sync_bit_set, is_fabric_sync_pics_enabled, "Mismatch between PICS MCORE.FS value and what attribute indicates")
+        is_fabric_sync_bit_set = bool(supported_device_categories &
+                                      Clusters.CommissionerControl.Bitmaps.SupportedDeviceCategoryBitmap.kFabricSynchronization)
+        asserts.assert_equal(is_fabric_sync_bit_set, is_fabric_sync_pics_enabled,
+                             "Mismatch between PICS MCORE.FS value and what attribute indicates")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements TC_CCTRL_2_1 from testplan https://github.com/CHIP-Specifications/chip-test-plans/pull/4342

