### PR TITLE
Make struct name fixup work correctly for nested structs.

### DIFF
--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
@@ -322,7 +322,7 @@ class StructFieldsNameConverter():
                     provided_field_name = provided_field_name[0].lower(
                     ) + provided_field_name[1:]
 
-                if provided_field_name in value and provided_field_name != field_name:
+                if provided_field_name in value:
                     value[field_name] = self.run(
                         specs,
                         value[provided_field_name],
@@ -330,7 +330,8 @@ class StructFieldsNameConverter():
                         field_type,
                         field_array
                     )
-                    del value[provided_field_name]
+                    if provided_field_name != field_name:
+                        del value[provided_field_name]
 
             if specs.is_fabric_scoped(struct):
                 if _FABRIC_INDEX_FIELD_CODE in value:


### PR DESCRIPTION
The code that did struct name fixup did not handle nested structs (e.g. struct-typed command fields, or struct-typed struct fields) correctly.  In particular, it would not recursively call itself on the value for a field unless it was fixing up the field name.  But there might be field names that don't need fixup that have values that are structs whose fields do need name fixup.

The fix is to always call StructFieldsNameConverter on field values, and only condition the deletion of the "old name" from the value dictionary on whether the name is being fixed up.
