### PR TITLE
[ESP32] Update the esp-idf version to v5.3 release.

### DIFF
--- a/docs/guides/esp32/setup_idf_chip.md
+++ b/docs/guides/esp32/setup_idf_chip.md
@@ -13,25 +13,25 @@ step.
 
 ### Install Prerequisites
 
--   [Linux](https://docs.espressif.com/projects/esp-idf/en/v5.1.2/esp32/get-started/linux-macos-setup.html#for-linux-users)
--   [macOS](https://docs.espressif.com/projects/esp-idf/en/v5.1.2/esp32/get-started/linux-macos-setup.html#for-macos-users)
+-   [Linux](https://docs.espressif.com/projects/esp-idf/en/v5.3/esp32/get-started/linux-macos-setup.html#for-linux-users)
+-   [macOS](https://docs.espressif.com/projects/esp-idf/en/v5.3/esp32/get-started/linux-macos-setup.html#for-macos-users)
 
 ### Get IDF v5.1.2
 
--   Clone ESP-IDF [v5.1.2
-    release](https://github.com/espressif/esp-idf/releases/tag/v5.1.2
+-   Clone ESP-IDF [v5.3
+    release](https://github.com/espressif/esp-idf/releases/tag/v5.3
 
     ```
-    git clone -b v5.1.2 --recursive --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git
+    git clone -b v5.3 --recursive --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git
     cd esp-idf
     ./install.sh
     ```
 
--   To update an existing esp-idf toolchain to v5.1.2:
+-   To update an existing esp-idf toolchain to v5.3:
 
     ```
     cd path/to/esp-idf
-    git fetch --depth 1 origin v5.1.2
+    git fetch --depth 1 origin v5.3
     git reset --hard FETCH_HEAD
     git submodule update --depth 1 --recursive --init
 

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-66 : [Telink] Update Docker image (Zephyr update)
+67 : [ESP32] Update esp-idf to v5.3

--- a/integrations/docker/images/stage-2/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-esp32/Dockerfile
@@ -12,7 +12,7 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && git clone --recursive -b v5.1.2 --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git /tmp/esp-idf \
+    && git clone --recursive -b v5.3 --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git /tmp/esp-idf \
     && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}


### PR DESCRIPTION
**Change Overview**
Upgrade to ESP-IDF v5.3 release.

**Tests:**
i. Compilation of lighting-app esp32.
ii. Commissioning and cluster control using chip-tool.

