### PR TITLE
Fix int promotion compile errors on thermostat application

### DIFF
--- a/examples/thermostat/linux/thermostat-delegate-impl.cpp
+++ b/examples/thermostat/linux/thermostat-delegate-impl.cpp
@@ -96,10 +96,10 @@ void ThermostatDelegate::InitializePresets()
         const uint8_t handle[] = { static_cast<uint8_t>(presetScenario) };
         mPresets[index].SetPresetHandle(DataModel::MakeNullable(ByteSpan(handle)));
         mPresets[index].SetName(NullOptional);
-        int16_t coolingSetpointValue = 2500 + index * 100;
+        int16_t coolingSetpointValue = static_cast<int16_t>(2500 + index * 100);
         mPresets[index].SetCoolingSetpoint(MakeOptional(coolingSetpointValue));
 
-        int16_t heatingSetpointValue = 2100 - index * 100;
+        int16_t heatingSetpointValue = static_cast<int16_t>(2100 - index * 100);
         mPresets[index].SetHeatingSetpoint(MakeOptional(heatingSetpointValue));
         mPresets[index].SetBuiltIn(DataModel::MakeNullable(true));
         index++;

--- a/examples/thermostat/linux/thermostat-delegate-impl.cpp
+++ b/examples/thermostat/linux/thermostat-delegate-impl.cpp
@@ -96,10 +96,10 @@ void ThermostatDelegate::InitializePresets()
         const uint8_t handle[] = { static_cast<uint8_t>(presetScenario) };
         mPresets[index].SetPresetHandle(DataModel::MakeNullable(ByteSpan(handle)));
         mPresets[index].SetName(NullOptional);
-        int16_t coolingSetpointValue = static_cast<int16_t>(2500 + index * 100);
+        int16_t coolingSetpointValue = static_cast<int16_t>(2500 + (index * 100));
         mPresets[index].SetCoolingSetpoint(MakeOptional(coolingSetpointValue));
 
-        int16_t heatingSetpointValue = static_cast<int16_t>(2100 - index * 100);
+        int16_t heatingSetpointValue = static_cast<int16_t>(2100 - (index * 100));
         mPresets[index].SetHeatingSetpoint(MakeOptional(heatingSetpointValue));
         mPresets[index].SetBuiltIn(DataModel::MakeNullable(true));
         index++;

--- a/examples/thermostat/linux/thermostat-manager.cpp
+++ b/examples/thermostat/linux/thermostat-manager.cpp
@@ -398,8 +398,8 @@ void ThermostatManager::EvalThermostatState()
 
 void ThermostatManager::UpdateRunningModeForHeating()
 {
-    const int16_t heatingOnThreshold  = mOccupiedHeatingSetpoint - mOccupiedSetback * 10;
-    const int16_t heatingOffThreshold = mOccupiedHeatingSetpoint + mOccupiedSetback * 10;
+    const int16_t heatingOnThreshold  = static_cast<uint16_t>(mOccupiedHeatingSetpoint - mOccupiedSetback * 10);
+    const int16_t heatingOffThreshold = static_cast<uint16_t>(mOccupiedHeatingSetpoint + mOccupiedSetback * 10);
 
     if (mRunningMode == ThermostatRunningModeEnum::kHeat)
     {
@@ -429,8 +429,8 @@ void ThermostatManager::UpdateRunningModeForHeating()
 
 void ThermostatManager::UpdateRunningModeForCooling()
 {
-    const int16_t coolingOffThreshold = mOccupiedCoolingSetpoint - mOccupiedSetback * 10;
-    const int16_t coolingOnThreshold  = mOccupiedCoolingSetpoint + mOccupiedSetback * 10;
+    const int16_t coolingOffThreshold = static_cast<uint16_t>(mOccupiedCoolingSetpoint - mOccupiedSetback * 10);
+    const int16_t coolingOnThreshold  = static_cast<uint16_t>(mOccupiedCoolingSetpoint + mOccupiedSetback * 10);
 
     if (mRunningMode == ThermostatRunningModeEnum::kCool)
     {

--- a/examples/thermostat/linux/thermostat-manager.cpp
+++ b/examples/thermostat/linux/thermostat-manager.cpp
@@ -399,7 +399,7 @@ void ThermostatManager::EvalThermostatState()
 void ThermostatManager::UpdateRunningModeForHeating()
 {
     const int16_t heatingOnThreshold  = mOccupiedHeatingSetpoint - static_cast<int16_t>(mOccupiedSetback * 10);
-    const int16_t heatingOffThreshold = mOccupiedHeatingSetpoint - static_cast<int16_t>(mOccupiedSetback * 10);
+    const int16_t heatingOffThreshold = mOccupiedHeatingSetpoint + static_cast<int16_t>(mOccupiedSetback * 10);
 
     if (mRunningMode == ThermostatRunningModeEnum::kHeat)
     {

--- a/examples/thermostat/linux/thermostat-manager.cpp
+++ b/examples/thermostat/linux/thermostat-manager.cpp
@@ -398,8 +398,8 @@ void ThermostatManager::EvalThermostatState()
 
 void ThermostatManager::UpdateRunningModeForHeating()
 {
-    const int16_t heatingOnThreshold  = static_cast<uint16_t>(mOccupiedHeatingSetpoint - mOccupiedSetback * 10);
-    const int16_t heatingOffThreshold = static_cast<uint16_t>(mOccupiedHeatingSetpoint + mOccupiedSetback * 10);
+    const int16_t heatingOnThreshold  = static_cast<int16_t>(mOccupiedHeatingSetpoint - mOccupiedSetback * 10);
+    const int16_t heatingOffThreshold = static_cast<int16_t>(mOccupiedHeatingSetpoint + mOccupiedSetback * 10);
 
     if (mRunningMode == ThermostatRunningModeEnum::kHeat)
     {
@@ -429,8 +429,8 @@ void ThermostatManager::UpdateRunningModeForHeating()
 
 void ThermostatManager::UpdateRunningModeForCooling()
 {
-    const int16_t coolingOffThreshold = static_cast<uint16_t>(mOccupiedCoolingSetpoint - mOccupiedSetback * 10);
-    const int16_t coolingOnThreshold  = static_cast<uint16_t>(mOccupiedCoolingSetpoint + mOccupiedSetback * 10);
+    const int16_t coolingOffThreshold = static_cast<int16_t>(mOccupiedCoolingSetpoint - mOccupiedSetback * 10);
+    const int16_t coolingOnThreshold  = static_cast<int16_t>(mOccupiedCoolingSetpoint + mOccupiedSetback * 10);
 
     if (mRunningMode == ThermostatRunningModeEnum::kCool)
     {

--- a/examples/thermostat/linux/thermostat-manager.cpp
+++ b/examples/thermostat/linux/thermostat-manager.cpp
@@ -398,8 +398,8 @@ void ThermostatManager::EvalThermostatState()
 
 void ThermostatManager::UpdateRunningModeForHeating()
 {
-    const int16_t heatingOnThreshold  = static_cast<int16_t>(mOccupiedHeatingSetpoint - mOccupiedSetback * 10);
-    const int16_t heatingOffThreshold = static_cast<int16_t>(mOccupiedHeatingSetpoint + mOccupiedSetback * 10);
+    const int16_t heatingOnThreshold  = mOccupiedHeatingSetpoint - static_cast<int16_t>(mOccupiedSetback * 10);
+    const int16_t heatingOffThreshold = mOccupiedHeatingSetpoint - static_cast<int16_t>(mOccupiedSetback * 10);
 
     if (mRunningMode == ThermostatRunningModeEnum::kHeat)
     {
@@ -429,8 +429,8 @@ void ThermostatManager::UpdateRunningModeForHeating()
 
 void ThermostatManager::UpdateRunningModeForCooling()
 {
-    const int16_t coolingOffThreshold = static_cast<int16_t>(mOccupiedCoolingSetpoint - mOccupiedSetback * 10);
-    const int16_t coolingOnThreshold  = static_cast<int16_t>(mOccupiedCoolingSetpoint + mOccupiedSetback * 10);
+    const int16_t coolingOffThreshold = mOccupiedCoolingSetpoint - static_cast<int16_t>(mOccupiedSetback * 10);
+    const int16_t coolingOnThreshold  = mOccupiedCoolingSetpoint + static_cast<int16_t>(mOccupiedSetback * 10);
 
     if (mRunningMode == ThermostatRunningModeEnum::kCool)
     {


### PR DESCRIPTION
Build of thermostat app fails on some compilers due to promotion to int on arithmetic operations and failure to assign int to int16_t.