### PR TITLE
Test automation for FabricSync ICD BridgedDeviceBasicInfoCluster

### DIFF
--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -36,6 +36,7 @@ from mobly import asserts
 logger = logging.getLogger(__name__)
 _ROOT_ENDPOINT_ID = 0
 
+
 class TC_BRBINFO_4_1(MatterBaseTest):
 
     #

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -44,6 +44,7 @@ kRootEndpointId = 0
 kMaxUserActiveModeBitmap = 0x1FFFF
 kMaxUserActiveModeTriggerInstructionByteLength = 128
 
+
 class TC_BRBINFO_4_1(MatterBaseTest):
 
     #
@@ -62,7 +63,6 @@ class TC_BRBINFO_4_1(MatterBaseTest):
     def default_timeout(self) -> int:
         return 63*60
 
-
     def desc_TC_BRBINFO_4_1(self) -> str:
         """Returns a description of this test"""
         return "[TC_BRBINFO_4_1] Verification of KeepActive Command [DUT-Server]"
@@ -80,12 +80,12 @@ class TC_BRBINFO_4_1(MatterBaseTest):
     def _ask_for_vendor_commissioniong_ux_operation(self, discriminator, setupPinCode, setupManualCode, setupQRCode):
         self.wait_for_user_input(
             prompt_msg=f"Using the DUT vendor's provided interface, commission the ICD device using the following parameters:\n"
-                        f"- discriminator: {discriminator}\n"
-                        f"- setupPinCode: {setupPinCode}\n"
-                        f"- setupQRCode: {setupQRCode}\n"
-                        f"- setupManualcode: {setupManualCode}\n"
-                        f"If using FabricSync Admin test app, you may type:\n"
-                        f">>> pairing onnetwork 111 {setupPinCode}")
+            f"- discriminator: {discriminator}\n"
+            f"- setupPinCode: {setupPinCode}\n"
+            f"- setupQRCode: {setupQRCode}\n"
+            f"- setupManualcode: {setupManualCode}\n"
+            f"If using FabricSync Admin test app, you may type:\n"
+            f">>> pairing onnetwork 111 {setupPinCode}")
 
     async def _send_keep_active_command(self, duration, endpoint_id) -> int:
         logging.info("Sending keep active command")
@@ -104,12 +104,12 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         root_part_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=Clusters.Descriptor.Attributes.PartsList, endpoint=kRootEndpointId)
         set_of_endpoints_after_adding_device = set(root_part_list)
 
-        asserts.assert_true(set_of_endpoints_after_adding_device.issuperset(self.set_of_dut_endpoints_before_adding_device), "Expected only new endpoints to be added")
+        asserts.assert_true(set_of_endpoints_after_adding_device.issuperset(
+            self.set_of_dut_endpoints_before_adding_device), "Expected only new endpoints to be added")
         unique_endpoints_set = set_of_endpoints_after_adding_device - self.set_of_dut_endpoints_before_adding_device
         asserts.assert_equal(len(unique_endpoints_set), 1, "Expected only one new endpoint")
         newly_added_endpoint = list(unique_endpoints_set)[0]
         return newly_added_endpoint
-
 
     @async_test_body
     async def setup_class(self):
@@ -128,7 +128,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         discriminator = 3850
         passcode = 20202021
         app_args = f'--secured-device-port {self.port} --discriminator {discriminator} --passcode {passcode} --KVS {self.kvs} ' + \
-          '--secured-device-port 5545'
+            '--secured-device-port 5545'
         cmd = f'{app} {app_args}'
 
         logging.info("Starting ICD Server App")
@@ -145,7 +145,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         params = await self.openCommissioningWindow(dev_ctrl=self.default_controller, node_id=self.icd_nodeid)
 
         self._ask_for_vendor_commissioniong_ux_operation(params.randomDiscriminator, params.commissioningParameters.setupPinCode,
-            params.commissioningParameters.setupManualCode, params.commissioningParameters.setupQRCode)
+                                                         params.commissioningParameters.setupManualCode, params.commissioningParameters.setupQRCode)
 
     def teardown_class(self):
         logging.warning("Stopping app with SIGTERM")
@@ -177,37 +177,37 @@ class TC_BRBINFO_4_1(MatterBaseTest):
 
         # Confirms commissioning of DUT on TH as it reads its fature map
         await self._read_attribute_expect_success(
-          kRootEndpointId,
-          basic_info_cluster,
-          basic_info_attributes.FeatureMap,
-          self.dut_node_id
+            kRootEndpointId,
+            basic_info_cluster,
+            basic_info_attributes.FeatureMap,
+            self.dut_node_id
         )
 
         logging.info("Ensuring ICD is commissioned to TH")
 
         # Confirms commissioning of ICD on TH as it reads its feature map
         await self._read_attribute_expect_success(
-          kRootEndpointId,
-          basic_info_cluster,
-          basic_info_attributes.FeatureMap,
-          self.icd_nodeid
+            kRootEndpointId,
+            basic_info_cluster,
+            basic_info_attributes.FeatureMap,
+            self.icd_nodeid
         )
 
         self.step("1a")
 
         idle_mode_duration = await self._read_attribute_expect_success(
-          kRootEndpointId,
-          icdm_cluster,
-          icdm_attributes.IdleModeDuration,
-          self.icd_nodeid
+            kRootEndpointId,
+            icdm_cluster,
+            icdm_attributes.IdleModeDuration,
+            self.icd_nodeid
         )
         logging.info(f"IdleModeDuration: {idle_mode_duration}")
 
         active_mode_duration = await self._read_attribute_expect_success(
-          kRootEndpointId,
-          icdm_cluster,
-          icdm_attributes.ActiveModeDuration,
-          self.icd_nodeid
+            kRootEndpointId,
+            icdm_cluster,
+            icdm_attributes.ActiveModeDuration,
+            self.icd_nodeid
         )
         logging.info(f"ActiveModeDuration: {active_mode_duration}")
 
@@ -265,7 +265,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         logging.info(f"Sending KeepActiveCommand({stay_active_duration})")
         self._send_keep_active_command(stay_active_duration, dynamic_endpoint_id)
 
-        ## stops (halts) the ICD server process by sending a SIGTOP signal
+        # stops (halts) the ICD server process by sending a SIGTOP signal
         self.app_process.send_signal(signal.SIGSTOP.value)
 
         if not self.is_ci:
@@ -273,7 +273,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
             self._timeout
             time.sleep(60*60)
 
-        ## resumes (continues) the ICD server process by sending a SIGCONT signal
+        # resumes (continues) the ICD server process by sending a SIGCONT signal
         self.app_process.send_signal(signal.SIGCONT.value)
 
         # wait for active changed event, expect no event will be sent
@@ -282,6 +282,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
             promised_active_duration = self.q.get(block=True, timeout=event_timeout)
         finally:
             asserts.assert_true(queue.Empty(), "ActiveChanged event received when not expected")
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -220,7 +220,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         logging.info("Waiting for ActiveChanged from DUT...")
         promised_active_duration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
 
-        asserts.assert_true(promised_active_duration >= stay_active_duration, "PromisedActiveDuration < StayActiveDuration")
+        asserts.assert_greater_equal(promised_active_duration, stay_active_duration, "PromisedActiveDuration < StayActiveDuration")
 
         self.step("2")
 

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -18,19 +18,15 @@
 # See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
 # for details about the block below.
 #
-# === BEGIN CI TEST ARGUMENTS ===
-# test-runner-runs: run1
-# test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
-# test-runner-run/run1/factoryreset: True
-# test-runner-run/run1/quiet: True
-# test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
-# test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-# === END CI TEST ARGUMENTS ===
+
+# This test requires a TH_SERVER application. Please specify with --string-arg th_server_app_path:<path_to_app>
+# TH_SERVER must support following arguments: --secured-device-port --discriminator --passcode --KVS --secured-device-port
+# E.g: python3 src/python_testing/TC_BRBINFO_4_1.py --commissioning-method on-network --qr-code MT:-24J042C00KA0648G00 \
+#      --string-arg th_server_app_path:out/linux-x64-lit-icd/lit-icd-app
 
 import logging
 import os
 import queue
-import pathlib
 import uuid
 import subprocess
 import time
@@ -38,21 +34,15 @@ import signal
 
 
 import chip.clusters as Clusters
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, SimpleEventCallback
+from chip import ChipDeviceCtrl
+from matter_testing_support import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, SimpleEventCallback)
 from mobly import asserts
 
-from chip import ChipDeviceCtrl  # Needed before chip.FabricAdmin
 
 logger = logging.getLogger(__name__)
 kRootEndpointId = 0
-kICDMEndpointId = 0
-kICDBridgedEndpointId = 2
 kMaxUserActiveModeBitmap = 0x1FFFF
 kMaxUserActiveModeTriggerInstructionByteLength = 128
-
-#uat = cluster.Bitmaps.UserActiveModeTriggerBitmap
-#modes = cluster.Enums.OperatingModeEnum
-#features = cluster.Bitmaps.Feature
 
 class TC_BRBINFO_4_1(MatterBaseTest):
 
@@ -66,6 +56,12 @@ class TC_BRBINFO_4_1(MatterBaseTest):
     #
     # Test Harness Helpers
     #
+
+    # Override default timeout to support a 60 min wait
+    @property
+    def default_timeout(self) -> int:
+        return 63*60
+
 
     def desc_TC_BRBINFO_4_1(self) -> str:
         """Returns a description of this test"""
@@ -82,13 +78,6 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         return steps
 
 
-    def pics_TC_BRBINFO_4_1(self) -> list[str]:
-        """ This function returns a list of PICS for this test case that must be True for the test to be run"""
-        pics = [
-            "BRBINFO.C.80",
-        ]
-        return pics
-
     def _ask_for_vendor_commissioniong_ux_operation(self, discriminator, setupPinCode):
         self.wait_for_user_input(
             prompt_msg=f"Using the DUT vendor's provided interface, commission the ICD device using the following parameters:\n"
@@ -97,12 +86,9 @@ class TC_BRBINFO_4_1(MatterBaseTest):
                         f"If using FabricSync Admin, you may type:\n"
                         f">>> pairing onnetwork 111 {setupPinCode}")
 
-    def _display_message_and_wait_for_user_input(self, message):
-        self.wait_for_user_input(prompt_msg=message)
-
-    async def _send_keep_active_command(self, duration) -> int:
-        logging.info("Mock sending keep active command")
-        keep_active = await self.default_controller.SendCommand(nodeid=self.dut_node_id, endpoint=kICDBridgedEndpointId, payload=Clusters.Objects.BridgedDeviceBasicInformation.Commands.KeepActive(stayActiveDuration=duration))
+    async def _send_keep_active_command(self, duration, endpoint_id) -> int:
+        logging.info("Sending keep active command")
+        keep_active = await self.default_controller.SendCommand(nodeid=self.dut_node_id, endpoint=endpoint_id, payload=Clusters.Objects.BridgedDeviceBasicInformation.Commands.KeepActive(stayActiveDuration=duration))
         return keep_active
 
     async def _wait_for_active_changed_event(self, timeout) -> int:
@@ -111,13 +97,30 @@ class TC_BRBINFO_4_1(MatterBaseTest):
             logging.info(f"PromisedActiveDuration: {promised_active_duration}")
             return promised_active_duration
         except queue.Empty:
-            asserts.fail("Timeout on event")
+            asserts.fail("Timeout on event ActiveChanged")
+
+    async def _get_dynamic_endpoint(self) -> int:
+        root_part_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=Clusters.Descriptor.Attributes.PartsList, endpoint=kRootEndpointId)
+        set_of_endpoints_after_adding_device = set(root_part_list)
+
+        asserts.assert_true(set_of_endpoints_after_adding_device.issuperset(self.set_of_dut_endpoints_before_adding_device), "Expected only new endpoints to be added")
+        unique_endpoints_set = set_of_endpoints_after_adding_device - self.set_of_dut_endpoints_before_adding_device
+        asserts.assert_equal(len(unique_endpoints_set), 1, "Expected only one new endpoint")
+        newly_added_endpoint = list(unique_endpoints_set)[0]
+        return newly_added_endpoint
 
 
     @async_test_body
     async def setup_class(self):
+        # These steps are not explicitly, but they help identify the dynamically added endpoint
+        # The second part of this process happens on _get_dynamic_endpoint()
+        root_part_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=Clusters.Descriptor.Attributes.PartsList, endpoint=kRootEndpointId)
+        self.set_of_dut_endpoints_before_adding_device = set(root_part_list)
+
         super().setup_class()
-        app = os.path.join(pathlib.Path(__file__).resolve().parent, '..','..','out', 'linux-x64-lit-icd', 'lit-icd-app')
+        app = self.user_params.get("th_server_app_path", None)
+        if not app:
+            asserts.fail('This test requires a TH_SERVER app. Specify app path with --string-arg th_server_app_path:<path_to_app>')
 
         self.kvs = f'kvs_{str(uuid.uuid4())}'
         self.port = 5543
@@ -162,12 +165,15 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         basic_info_cluster = Clusters.Objects.BasicInformation
         basic_info_attributes = basic_info_cluster.Attributes
 
+        dynamic_endpoint_id = await self._get_dynamic_endpoint()
+        logging.info(f"Dynamic endpoint is {dynamic_endpoint_id}")
+
         # Preconditions
         self.step("0")
 
         logging.info("Ensuring DUT is commissioned to TH")
 
-        # Confirms commissioning of DUT on TH as it reads basic info
+        # Confirms commissioning of DUT on TH as it reads its fature map
         await self._read_attribute_expect_success(
           kRootEndpointId,
           basic_info_cluster,
@@ -177,7 +183,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
 
         logging.info("Ensuring ICD is commissioned to TH")
 
-        # Confirms commissioning of ICD on TH as it reads basic info
+        # Confirms commissioning of ICD on TH as it reads its feature map
         await self._read_attribute_expect_success(
           kRootEndpointId,
           basic_info_cluster,
@@ -188,7 +194,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         self.step("1a")
 
         idle_mode_duration = await self._read_attribute_expect_success(
-          kICDMEndpointId,
+          kRootEndpointId,
           icdm_cluster,
           icdm_attributes.IdleModeDuration,
           self.icd_nodeid
@@ -196,7 +202,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         logging.info(f"IdleModeDuration: {idle_mode_duration}")
 
         active_mode_duration = await self._read_attribute_expect_success(
-          kICDMEndpointId,
+          kRootEndpointId,
           icdm_cluster,
           icdm_attributes.ActiveModeDuration,
           self.icd_nodeid
@@ -210,12 +216,12 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         self.q = queue.Queue()
         urgent = 1
         cb = SimpleEventCallback("ActiveChanged", event.cluster_id, event.event_id, self.q)
-        subscription = await self.default_controller.ReadEvent(nodeid=self.dut_node_id, events=[(kICDBridgedEndpointId, event, urgent)], reportInterval=[1, 3])
+        subscription = await self.default_controller.ReadEvent(nodeid=self.dut_node_id, events=[(dynamic_endpoint_id, event, urgent)], reportInterval=[1, 3])
         subscription.SetEventUpdateCallback(callback=cb)
 
         stay_active_duration = 1000
         logging.info(f"Sending KeepActiveCommand({stay_active_duration}ms)")
-        self._send_keep_active_command(stay_active_duration)
+        self._send_keep_active_command(stay_active_duration, dynamic_endpoint_id)
 
         logging.info("Waiting for ActiveChanged from DUT...")
         promised_active_duration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
@@ -232,18 +238,18 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         promised_active_duration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
 
         # wait for active time duration
-        time.sleep(max(stay_active_duration/1000, active_mode_duration))
+        time.sleep(max(stay_active_duration/1000, promised_active_duration))
         # ICD now should be in idle mode
 
         # sends 3x keep active commands
         logging.info(f"Sending KeepActiveCommand({stay_active_duration})")
-        self._send_keep_active_command(stay_active_duration)
+        self._send_keep_active_command(stay_active_duration, dynamic_endpoint_id)
         time.sleep(100)
         logging.info(f"Sending KeepActiveCommand({stay_active_duration})")
-        self._send_keep_active_command(stay_active_duration)
+        self._send_keep_active_command(stay_active_duration, dynamic_endpoint_id)
         time.sleep(100)
         logging.info(f"Sending KeepActiveCommand({stay_active_duration})")
-        self._send_keep_active_command(stay_active_duration)
+        self._send_keep_active_command(stay_active_duration, dynamic_endpoint_id)
         time.sleep(100)
 
         logging.info("Waiting for ActiveChanged from DUT...")
@@ -255,16 +261,17 @@ class TC_BRBINFO_4_1(MatterBaseTest):
 
         stay_active_duration = 10000
         logging.info(f"Sending KeepActiveCommand({stay_active_duration})")
-        self._send_keep_active_command(stay_active_duration)
+        self._send_keep_active_command(stay_active_duration, dynamic_endpoint_id)
 
-        ## halt the ICD process
+        ## stops (halts) the ICD server process by sending a SIGTOP signal
         self.app_process.send_signal(signal.SIGSTOP.value)
 
         if not self.is_ci:
             logging.info("Waiting for 60 minutes")
+            self._timeout
             time.sleep(60*60)
 
-        ## resume the ICD
+        ## resumes (continues) the ICD server process by sending a SIGCONT signal
         self.app_process.send_signal(signal.SIGCONT.value)
 
         # wait for active changed event, expect no event will be sent

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -15,10 +15,6 @@
 #    limitations under the License.
 #
 
-# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
-# for details about the block below.
-#
-
 # This test requires a TH_SERVER application. Please specify with --string-arg th_server_app_path:<path_to_app>
 # TH_SERVER must support following arguments: --secured-device-port --discriminator --passcode --KVS --secured-device-port
 # E.g: python3 src/python_testing/TC_BRBINFO_4_1.py --commissioning-method on-network --qr-code MT:-24J042C00KA0648G00 \

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -117,7 +117,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
             logging.info(f"PromisedActiveDuration: {PromisedActiveDuration}")
             return PromisedActiveDuration
         except queue.Empty:
-            asserts.assert_true(False, "Timeout on event")
+            asserts.fail("Timeout on event")
 
 
 

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -250,7 +250,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         logging.info("Waiting for ActiveChanged from DUT...")
         promised_active_duration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
 
-        asserts.assert_true(self.q.qSize() == 0, "More than one event received from DUT")
+        asserts.assert_equal(self.q.qSize(), 0, "More than one event received from DUT")
 
         self.step("3")
 

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -16,7 +16,7 @@
 #
 
 # This test requires a TH_SERVER application. Please specify with --string-arg th_server_app_path:<path_to_app>
-# TH_SERVER must support following arguments: --secured-device-port --discriminator --passcode --KVS --secured-device-port
+# TH_SERVER must support following arguments: --secured-device-port --discriminator --passcode --KVS
 # E.g: python3 src/python_testing/TC_BRBINFO_4_1.py --commissioning-method on-network --qr-code MT:-24J042C00KA0648G00 \
 #      --string-arg th_server_app_path:out/linux-x64-lit-icd/lit-icd-app
 
@@ -34,10 +34,7 @@ from matter_testing_support import MatterBaseTest, SimpleEventCallback, TestStep
 from mobly import asserts
 
 logger = logging.getLogger(__name__)
-kRootEndpointId = 0
-kMaxUserActiveModeBitmap = 0x1FFFF
-kMaxUserActiveModeTriggerInstructionByteLength = 128
-
+_ROOT_ENDPOINT_ID = 0
 
 class TC_BRBINFO_4_1(MatterBaseTest):
 
@@ -47,10 +44,6 @@ class TC_BRBINFO_4_1(MatterBaseTest):
 
     async def _read_attribute_expect_success(self, endpoint, cluster, attribute, node_id):
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute, node_id=node_id)
-
-    #
-    # Test Harness Helpers
-    #
 
     # Override default timeout to support a 60 min wait
     @property
@@ -95,7 +88,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
             asserts.fail("Timeout on event ActiveChanged")
 
     async def _get_dynamic_endpoint(self) -> int:
-        root_part_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=Clusters.Descriptor.Attributes.PartsList, endpoint=kRootEndpointId)
+        root_part_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=Clusters.Descriptor.Attributes.PartsList, endpoint=_ROOT_ENDPOINT_ID)
         set_of_endpoints_after_adding_device = set(root_part_list)
 
         asserts.assert_true(set_of_endpoints_after_adding_device.issuperset(
@@ -109,7 +102,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
     async def setup_class(self):
         # These steps are not explicitly, but they help identify the dynamically added endpoint
         # The second part of this process happens on _get_dynamic_endpoint()
-        root_part_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=Clusters.Descriptor.Attributes.PartsList, endpoint=kRootEndpointId)
+        root_part_list = await self.read_single_attribute_check_success(cluster=Clusters.Descriptor, attribute=Clusters.Descriptor.Attributes.PartsList, endpoint=_ROOT_ENDPOINT_ID)
         self.set_of_dut_endpoints_before_adding_device = set(root_part_list)
 
         super().setup_class()
@@ -170,7 +163,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
 
         # Confirms commissioning of DUT on TH as it reads its fature map
         await self._read_attribute_expect_success(
-            kRootEndpointId,
+            _ROOT_ENDPOINT_ID,
             basic_info_cluster,
             basic_info_attributes.FeatureMap,
             self.dut_node_id
@@ -180,7 +173,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
 
         # Confirms commissioning of ICD on TH as it reads its feature map
         await self._read_attribute_expect_success(
-            kRootEndpointId,
+            _ROOT_ENDPOINT_ID,
             basic_info_cluster,
             basic_info_attributes.FeatureMap,
             self.icd_nodeid
@@ -189,7 +182,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         self.step("1a")
 
         idle_mode_duration = await self._read_attribute_expect_success(
-            kRootEndpointId,
+            _ROOT_ENDPOINT_ID,
             icdm_cluster,
             icdm_attributes.IdleModeDuration,
             self.icd_nodeid
@@ -197,7 +190,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         logging.info(f"IdleModeDuration: {idle_mode_duration}")
 
         active_mode_duration = await self._read_attribute_expect_success(
-            kRootEndpointId,
+            _ROOT_ENDPOINT_ID,
             icdm_cluster,
             icdm_attributes.ActiveModeDuration,
             self.icd_nodeid

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -77,13 +77,14 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         ]
         return steps
 
-
-    def _ask_for_vendor_commissioniong_ux_operation(self, discriminator, setupPinCode):
+    def _ask_for_vendor_commissioniong_ux_operation(self, discriminator, setupPinCode, setupManualCode, setupQRCode):
         self.wait_for_user_input(
             prompt_msg=f"Using the DUT vendor's provided interface, commission the ICD device using the following parameters:\n"
                         f"- discriminator: {discriminator}\n"
                         f"- setupPinCode: {setupPinCode}\n"
-                        f"If using FabricSync Admin, you may type:\n"
+                        f"- setupQRCode: {setupQRCode}\n"
+                        f"- setupManualcode: {setupManualCode}\n"
+                        f"If using FabricSync Admin test app, you may type:\n"
                         f">>> pairing onnetwork 111 {setupPinCode}")
 
     async def _send_keep_active_command(self, duration, endpoint_id) -> int:
@@ -143,7 +144,8 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         logging.info("Commissioning of ICD to fabric two (DUT)")
         params = await self.openCommissioningWindow(dev_ctrl=self.default_controller, node_id=self.icd_nodeid)
 
-        self._ask_for_vendor_commissioniong_ux_operation(params.randomDiscriminator, params.commissioningParameters.setupPinCode)
+        self._ask_for_vendor_commissioniong_ux_operation(params.randomDiscriminator, params.commissioningParameters.setupPinCode,
+            params.commissioningParameters.setupManualCode, params.commissioningParameters.setupQRCode)
 
     def teardown_class(self):
         logging.warning("Stopping app with SIGTERM")

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -1,0 +1,213 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs: run1
+# test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
+# test-runner-run/run1/factoryreset: True
+# test-runner-run/run1/quiet: True
+# test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+# test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
+
+import logging
+import os
+import random
+import re
+import queue
+import pathlib
+import uuid
+import subprocess
+import time
+import signal
+
+import chip.clusters as Clusters
+from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, SimpleEventCallback
+from mobly import asserts
+
+from chip import ChipDeviceCtrl  # Needed before chip.FabricAdmin
+import chip.CertificateAuthority
+from chip.ChipDeviceCtrl import CommissioningParameters
+
+logger = logging.getLogger(__name__)
+kRootEndpointId = 0
+kICDBridgedEndpointId = 2
+kMaxUserActiveModeBitmap = 0x1FFFF
+kMaxUserActiveModeTriggerInstructionByteLength = 128
+
+#uat = cluster.Bitmaps.UserActiveModeTriggerBitmap
+#modes = cluster.Enums.OperatingModeEnum
+#features = cluster.Bitmaps.Feature
+
+class TC_BRBINFO_4_1(MatterBaseTest):
+
+    #
+    # Class Helper functions
+    #
+
+    async def _read_icdm_attribute_expect_success(self, attribute):
+        cluster = Clusters.Objects.IcdManagement
+        return await self.read_single_attribute_check_success(endpoint=kRootEndpointId, cluster=cluster, attribute=attribute)
+
+    async def _read_brbinfo_attribute_expect_success(self, attribute):
+        cluster = Clusters.Objects.BridgedDeviceBasicInformation
+        return await self.read_single_attribute_check_success(endpoint=kRootEndpointId, cluster=cluster, attribute=attribute)
+
+    async def _read_basicinfo_attribute_expect_success(self, attribute):
+        cluster = Clusters.Objects.BasicInformation
+        return await self.read_single_attribute_check_success(endpoint=kRootEndpointId, cluster=cluster, attribute=attribute)
+
+    #
+    # Test Harness Helpers
+    #
+
+    def desc_TC_BRBINFO_4_1(self) -> str:
+        """Returns a description of this test"""
+        return "[TC_BRBINFO_4_1] Verification of KeepActive Command [DUT-Server]"
+
+    def steps_TC_BRBINFO_4_1(self) -> list[TestStep]:
+        steps = [
+            TestStep(1, "Commissioning of the DUT, already done", is_commissioning=True),
+            TestStep(2, "Commissioning of the ICD, already done", is_commissioning=True),
+            TestStep(3, "TH reads from the ICD the IDLE_MODE_DURATION, ACTIVE_MODE_DURATION, ACTIVE_MODE_THRESHOLD attributes"),
+            TestStep(4, "Simple KeepActive command w/ subscription. ActiveChanged event received by TH contains PromisedActiveDuration"),
+            TestStep(5, "Multiple KeepActive commands. ActiveChanged event received by TH contains a PromisedActiveDuration"),
+            TestStep(6, "Simple KeepActive command w/ check-in. ActiveChanged event received by TH contains PromisedActiveDuration"),
+            TestStep(7, "KeepActive not returned after 60 minutes of offline ICD"),
+        ]
+        return steps
+
+
+    def pics_TC_BRBINFO_4_1(self) -> list[str]:
+        """ This function returns a list of PICS for this test case that must be True for the test to be run"""
+        pics = [
+            "BRBINFO.C.80",
+        ]
+        return pics
+
+    def _ask_for_vendor_commissioniong_ux_operation(self, discriminator, setupPinCode):
+        self.wait_for_user_input(
+            prompt_msg=f"Using the DUT vendor's provided interface, commission the ICD device using the following parameters:\n"
+                        f"- discriminator: {discriminator}\n"
+                        f"- setupPinCode: {setupPinCode}\n"
+                        f"If using FabricSync Admin, you may type:\n"
+                        f">>> pairing onnetwork 111 {setupPinCode}")
+
+    @async_test_body
+    async def setup_class(self):
+        super().setup_class()
+        # TODO: This needs to come from an arg and needs to be something available on the TH
+        # TODO: confirm whether we can open processes like this on the TH
+        app = os.path.join(pathlib.Path(__file__).resolve().parent, '..','..','out', 'linux-x64-lit-icd', 'lit-icd-app')
+
+        self.kvs = f'kvs_{str(uuid.uuid4())}'
+        self.port = 5543
+        discriminator = random.randint(0, 4095)
+        discriminator = 3850
+        passcode = 20202021
+        app_args = f'--secured-device-port {self.port} --discriminator {discriminator} --passcode {passcode} --KVS {self.kvs} ' + \
+          '--secured-device-port 5545'
+        cmd = f'{app} {app_args}'
+
+        logging.info("Starting ICD Server App")
+        self.app_process = subprocess.Popen(cmd, bufsize=0, shell=True)
+        logging.info("ICD started")
+        time.sleep(3)
+
+        logging.info("Commissioning of ICD to fabric one (TH)")
+        #new_certificate_authority = self.certificate_authority_manager.NewCertificateAuthority()
+        #new_fabric_admin = new_certificate_authority.NewFabricAdmin(vendorId=0xFFF1, fabricId=2)
+        #paa_path = str(self.matter_test_config.paa_trust_store_path)
+        #print(f"paa_path = {paa_path}  ------------------------------------------------")
+        #self.TH_server_controller = new_fabric_admin.NewController(nodeId=112233, paaTrustStorePath=paa_path)
+        self.server_nodeid = 1111
+
+        await self.default_controller.CommissionOnNetwork(nodeId=self.server_nodeid, setupPinCode=passcode, filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=discriminator)
+        # await self.TH_server_controller.CommissionOnNetwork(nodeId=self.server_nodeid, setupPinCode=passcode, filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=discriminator)
+        logging.info("Commissioning complete (1/2)")
+
+        logging.info("Commissioning of ICD to fabric two (DUT)")
+        params = await self.openCommissioningWindow(dev_ctrl=self.default_controller, node_id=self.server_nodeid)
+
+
+        self._ask_for_vendor_commissioniong_ux_operation(params.randomDiscriminator, params.commissioningParameters.setupPinCode)
+
+        # cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=1, responseTimeoutSeconds=30, ipAddress=ipaddr.packed, port=self.port)
+
+
+    def teardown_class(self):
+        logging.warning("Stopping app with SIGTERM")
+        self.app_process.send_signal(signal.SIGTERM.value)
+        test_app_exit_code = self.app_process.wait()
+        os.remove(self.kvs)
+        super().teardown_class()
+
+    #
+    # BRBINFO 4.1 Test Body
+    #
+
+    @async_test_body
+    async def test_TC_BRBINFO_4_1(self):
+
+        brbinfoCluster = Clusters.Objects.BridgedDeviceBasicInformation
+        basicinfoCluster = Clusters.Objects.BasicInformation
+
+
+        brbinfoAttributes = brbinfoCluster.Attributes
+        basicinfoAttributes = basicinfoCluster.Attributes
+
+        self.endpoint = 0
+
+        # Check commisisoned DUT
+        self.step(1)
+        # Confirms commissioning of DUT as it reads basic info from bridge device
+        featureMap = await self._read_basicinfo_attribute_expect_success(
+            basicinfoAttributes.FeatureMap)
+
+        self.step(2)
+        # Confirms commissioning of DUT as it reads basic info from bridge device
+        featureMap = await self._read_basicinfo_attribute_expect_success(
+            basicinfoAttributes.FeatureMap)
+
+        self.step(3)
+        ## ??
+
+        # dummy values
+        idle_mode_duration = 10000
+        active_mode_duration = 200
+
+        self.step(4)
+        event = brbinfoCluster.Events.ActiveChanged
+        self.q = queue.Queue()
+        urgent = 1
+        cb = SimpleEventCallback("KeepActive", event.cluster_id, event.event_id, self.q)
+        subscription = await self.default_controller.ReadEvent(nodeid=self.dut_node_id, events=[(self.endpoint, event, urgent)], reportInterval=[1, 3])
+        subscription.SetEventUpdateCallback(callback=cb)
+
+        self.step(5)
+
+
+        self.step(6)
+
+
+        self.step(7)
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -29,15 +29,12 @@
 
 import logging
 import os
-import random
-import re
 import queue
 import pathlib
 import uuid
 import subprocess
 import time
 import signal
-import time
 
 
 import chip.clusters as Clusters
@@ -45,8 +42,6 @@ from matter_testing_support import MatterBaseTest, TestStep, async_test_body, de
 from mobly import asserts
 
 from chip import ChipDeviceCtrl  # Needed before chip.FabricAdmin
-import chip.CertificateAuthority
-from chip.ChipDeviceCtrl import CommissioningParameters
 
 logger = logging.getLogger(__name__)
 kRootEndpointId = 0
@@ -150,7 +145,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
     def teardown_class(self):
         logging.warning("Stopping app with SIGTERM")
         self.app_process.send_signal(signal.SIGTERM.value)
-        test_app_exit_code = self.app_process.wait()
+        self.app_process.wait()
         os.remove(self.kvs)
         super().teardown_class()
 
@@ -164,14 +159,13 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         icdm_cluster = Clusters.Objects.IcdManagement
         icdm_attributes = icdm_cluster.Attributes
         brb_info_cluster = Clusters.Objects.BridgedDeviceBasicInformation
-        brb_info_attributes = brb_info_cluster.Attributes
         basic_info_cluster = Clusters.Objects.BasicInformation
         basic_info_attributes = basic_info_cluster.Attributes
 
         # Preconditions
         self.step("0")
 
-        logging.info(f"Ensuring DUT is commissioned to TH")
+        logging.info("Ensuring DUT is commissioned to TH")
 
         # Confirms commissioning of DUT on TH as it reads basic info
         await self._read_attribute_expect_success(
@@ -181,7 +175,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
           self.dut_node_id
         )
 
-        logging.info(f"Ensuring ICD is commissioned to TH")
+        logging.info("Ensuring ICD is commissioned to TH")
 
         # Confirms commissioning of ICD on TH as it reads basic info
         await self._read_attribute_expect_success(
@@ -223,7 +217,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         logging.info(f"Sending KeepActiveCommand({stay_active_duration}ms)")
         self._send_keep_active_command(stay_active_duration)
 
-        logging.info(f"Waiting for ActiveChanged from DUT...")
+        logging.info("Waiting for ActiveChanged from DUT...")
         promised_active_duration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
 
         asserts.assert_true(promised_active_duration >= stay_active_duration, "PromisedActiveDuration < StayActiveDuration")
@@ -234,7 +228,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         logging.info(f"Sending KeepActiveCommand({stay_active_duration}ms)")
         self._send_keep_active_command(stay_active_duration)
 
-        logging.info(f"Waiting for ActiveChanged from DUT...")
+        logging.info("Waiting for ActiveChanged from DUT...")
         promised_active_duration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
 
         # wait for active time duration
@@ -252,10 +246,10 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         self._send_keep_active_command(stay_active_duration)
         time.sleep(100)
 
-        logging.info(f"Waiting for ActiveChanged from DUT...")
+        logging.info("Waiting for ActiveChanged from DUT...")
         promised_active_duration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
 
-        asserts.assert_true(q.qSize() == 0, "More than one event received from DUT")
+        asserts.assert_true(self.q.qSize() == 0, "More than one event received from DUT")
 
         self.step("3")
 
@@ -267,7 +261,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         self.app_process.send_signal(signal.SIGSTOP.value)
 
         if not self.is_ci:
-            logging.info(f"Waiting for 60 minutes")
+            logging.info("Waiting for 60 minutes")
             time.sleep(60*60)
 
         ## resume the ICD

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -121,8 +121,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         self.port = 5543
         discriminator = 3850
         passcode = 20202021
-        app_args = f'--secured-device-port {self.port} --discriminator {discriminator} --passcode {passcode} --KVS {self.kvs} ' + \
-            '--secured-device-port 5545'
+        app_args = f'--secured-device-port {self.port} --discriminator {discriminator} --passcode {passcode} --KVS {self.kvs} '
         cmd = f'{app} {app_args}'
 
         logging.info("Starting ICD Server App")

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -27,17 +27,15 @@
 import logging
 import os
 import queue
-import uuid
+import signal
 import subprocess
 import time
-import signal
-
+import uuid
 
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
-from matter_testing_support import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, SimpleEventCallback)
+from matter_testing_support import MatterBaseTest, SimpleEventCallback, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
-
 
 logger = logging.getLogger(__name__)
 kRootEndpointId = 0

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -161,6 +161,12 @@ class TC_BRBINFO_4_1(MatterBaseTest):
     @async_test_body
     async def test_TC_BRBINFO_4_1(self):
         self.is_ci = self.check_pics('PICS_SDK_CI_ONLY')
+        icdm_cluster = Clusters.Objects.IcdManagement
+        icdm_attributes = icdm_cluster.Attributes
+        brb_info_cluster = Clusters.Objects.BridgedDeviceBasicInformation
+        brb_info_attributes = brb_info_cluster.Attributes
+        basic_info_cluster = Clusters.Objects.BasicInformation
+        basic_info_attributes = basic_info_cluster.Attributes
 
         # Preconditions
         self.step("0")
@@ -186,13 +192,6 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         )
 
         self.step("1a")
-
-        icdm_cluster = Clusters.Objects.IcdManagement
-        icdm_attributes = icdm_cluster.Attributes
-        brb_info_cluster = Clusters.Objects.BridgedDeviceBasicInformation
-        brb_info_attributes = brb_info_cluster.Attributes
-        basic_info_cluster = Clusters.Objects.BasicInformation
-        basic_info_attributes = basic_info_cluster.Attributes
 
         idle_mode_duration = await self._read_attribute_expect_success(
           kICDMEndpointId,
@@ -225,9 +224,9 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         self._send_keep_active_command(stay_active_duration)
 
         logging.info(f"Waiting for ActiveChanged from DUT...")
-        PromisedActiveDuration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
+        promised_active_duration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
 
-        asserts.assert_true(PromisedActiveDuration >= stay_active_duration, "PromisedActiveDuration < StayActiveDuration")
+        asserts.assert_true(promised_active_duration >= stay_active_duration, "PromisedActiveDuration < StayActiveDuration")
 
         self.step("2")
 
@@ -236,7 +235,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         self._send_keep_active_command(stay_active_duration)
 
         logging.info(f"Waiting for ActiveChanged from DUT...")
-        PromisedActiveDuration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
+        promised_active_duration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
 
         # wait for active time duration
         time.sleep(max(stay_active_duration/1000, active_mode_duration))
@@ -254,7 +253,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         time.sleep(100)
 
         logging.info(f"Waiting for ActiveChanged from DUT...")
-        PromisedActiveDuration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
+        promised_active_duration = await self._wait_for_active_changed_event((idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000)
 
         asserts.assert_true(q.qSize() == 0, "More than one event received from DUT")
 
@@ -277,7 +276,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         # wait for active changed event, expect no event will be sent
         event_timeout = (idle_mode_duration + max(active_mode_duration, stay_active_duration))/1000
         try:
-            PromisedActiveDuration = self.q.get(block=True, timeout=event_timeout)
+            promised_active_duration = self.q.get(block=True, timeout=event_timeout)
         finally:
             asserts.assert_true(queue.Empty(), "ActiveChanged event received when not expected")
 


### PR DESCRIPTION
PR adds automation for the three tests to the Bridged Device Basic Information Cluster, focused on testing the KeepActive command and ActiveChanged event.

Test Plan: https://github.com/CHIP-Specifications/chip-test-plans/pull/4337

Clarification issue on ICD behaviours: https://github.com/CHIP-Specifications/chip-test-plans/issues/4377