### PR TITLE
Fix compile error on older g++

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/WhmDelegate.h
+++ b/examples/all-clusters-app/all-clusters-common/include/WhmDelegate.h
@@ -167,7 +167,7 @@ public:
      * @param percentageReplaced  The % of water being replaced with water with a temperature of replacedWaterTemperature.
      * @param replacedWaterTemperature  The temperature of the percentageReplaced water.
      */
-    void DrawOffHotWater(uint8_t percentageReplaced, uint16_t replacedWaterTemperature);
+    void DrawOffHotWater(chip::Percent percentageReplaced, uint16_t replacedWaterTemperature);
 
 private:
     /**

--- a/examples/all-clusters-app/all-clusters-common/src/WhmDelegateImpl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/WhmDelegateImpl.cpp
@@ -294,7 +294,7 @@ void WaterHeaterManagementDelegate::SetTargetWaterTemperature(uint16_t targetWat
     CheckIfHeatNeedsToBeTurnedOnOrOff();
 }
 
-void WaterHeaterManagementDelegate::DrawOffHotWater(uint8_t percentageReplaced, uint16_t replacedWaterTemperature)
+void WaterHeaterManagementDelegate::DrawOffHotWater(Percent percentageReplaced, uint16_t replacedWaterTemperature)
 {
     // Only supported in the kTankPercent is supported.
     // Replaces percentageReplaced% of the water in the tank with water of a temperature replacedWaterTemperature
@@ -303,7 +303,7 @@ void WaterHeaterManagementDelegate::DrawOffHotWater(uint8_t percentageReplaced, 
         // See if all of the water has now been replaced with replacedWaterTemperature
         if (mTankPercentage >= percentageReplaced)
         {
-            mTankPercentage -= percentageReplaced;
+            mTankPercentage = static_cast<Percent>(mTankPercentage - percentageReplaced);
         }
         else
         {


### PR DESCRIPTION
- Older g++ in Ubuntu 20.04LTS seems to have issues with invalidly doing integer promotion in some cases where it otherwise should not happen. This broke for some developers with:

```
../../third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/src/WhmDelegateImpl.cpp: In member function ‘void chip::app::Clusters::WaterHeaterManagement::WaterHeaterManagementDelegate::DrawOffHotWater(chip::Percent, uint16_t)’:
../../third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/src/WhmDelegateImpl.cpp:306:29: error: conversion from ‘int’ to ‘chip::Percent’ {aka ‘unsigned char’} may change value [-Werror=conversion]
  306 |             mTankPercentage -= percentageReplaced;
      |             ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
At global scope:
cc1plus: error: unrecognized command line option ‘-Wno-unknown-warning-option’ [-Werror]
cc1plus: all warnings being treated as errors
[17/171] c++ obj/third_party/connectedhomeip/examples/energy-management-app/energy-management-common/src/chip-all-clusters-common.device-energy-management-mode.cpp.o
ninja: build stopped: subcommand failed.
```

- This PR fixes the issue (validated with one such user).
