### PR TITLE
Fixed ReviewFabricRestrictions command args

### DIFF
--- a/examples/air-purifier-app/air-purifier-common/air-purifier-app.matter
+++ b/examples/air-purifier-app/air-purifier-common/air-purifier-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.matter
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/air-quality-sensor-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -621,7 +621,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -514,7 +514,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -437,7 +437,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {
@@ -566,7 +566,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -514,7 +514,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_airpurifier_73a6fe2651.matter
+++ b/examples/chef/devices/rootnode_airpurifier_73a6fe2651.matter
@@ -291,7 +291,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
+++ b/examples/chef/devices/rootnode_airpurifier_airqualitysensor_temperaturesensor_humiditysensor_thermostat_56de3d5f45.matter
@@ -296,7 +296,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.matter
+++ b/examples/chef/devices/rootnode_airqualitysensor_e63187f6c9.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_basicvideoplayer_0ff86e943b.matter
+++ b/examples/chef/devices/rootnode_basicvideoplayer_0ff86e943b.matter
@@ -416,7 +416,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
+++ b/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
@@ -493,7 +493,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_contactsensor_27f76aeaf5.matter
+++ b/examples/chef/devices/rootnode_contactsensor_27f76aeaf5.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
+++ b/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
@@ -317,7 +317,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -514,7 +514,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_dimmablepluginunit_f8a9a0b9d4.matter
+++ b/examples/chef/devices/rootnode_dimmablepluginunit_f8a9a0b9d4.matter
@@ -514,7 +514,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_dishwasher_cc105034fe.matter
+++ b/examples/chef/devices/rootnode_dishwasher_cc105034fe.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
@@ -514,7 +514,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_fan_7N2TobIlOX.matter
+++ b/examples/chef/devices/rootnode_fan_7N2TobIlOX.matter
@@ -296,7 +296,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
+++ b/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
@@ -317,7 +317,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_genericswitch_2dfff6e516.matter
+++ b/examples/chef/devices/rootnode_genericswitch_2dfff6e516.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_genericswitch_9866e35d0b.matter
+++ b/examples/chef/devices/rootnode_genericswitch_9866e35d0b.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
@@ -514,7 +514,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
+++ b/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
@@ -317,7 +317,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.matter
+++ b/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
@@ -317,7 +317,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
+++ b/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
@@ -317,7 +317,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
@@ -514,7 +514,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_onofflight_samplemei.matter
+++ b/examples/chef/devices/rootnode_onofflight_samplemei.matter
@@ -514,7 +514,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
+++ b/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
@@ -461,7 +461,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
+++ b/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
@@ -389,7 +389,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
@@ -317,7 +317,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_pump_5f904818cc.matter
+++ b/examples/chef/devices/rootnode_pump_5f904818cc.matter
@@ -291,7 +291,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_pump_a811bb33a0.matter
+++ b/examples/chef/devices/rootnode_pump_a811bb33a0.matter
@@ -291,7 +291,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680.matter
+++ b/examples/chef/devices/rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
+++ b/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
@@ -296,7 +296,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_roomairconditioner_9cf3607804.matter
+++ b/examples/chef/devices/rootnode_roomairconditioner_9cf3607804.matter
@@ -368,7 +368,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_smokecoalarm_686fe0dcb8.matter
+++ b/examples/chef/devices/rootnode_smokecoalarm_686fe0dcb8.matter
@@ -296,7 +296,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
+++ b/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
@@ -437,7 +437,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
+++ b/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
@@ -317,7 +317,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
+++ b/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
@@ -317,7 +317,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
+++ b/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
@@ -317,7 +317,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
+++ b/examples/contact-sensor-app/contact-sensor-common/contact-sensor-app.matter
@@ -296,7 +296,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/contact-sensor-app/nxp/zap-lit/contact-sensor-app.matter
+++ b/examples/contact-sensor-app/nxp/zap-lit/contact-sensor-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/contact-sensor-app/nxp/zap-sit/contact-sensor-app.matter
+++ b/examples/contact-sensor-app/nxp/zap-sit/contact-sensor-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/dishwasher-app/dishwasher-common/dishwasher-app.matter
+++ b/examples/dishwasher-app/dishwasher-common/dishwasher-app.matter
@@ -317,7 +317,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/energy-management-app/energy-management-common/energy-management-app.matter
+++ b/examples/energy-management-app/energy-management-common/energy-management-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/fabric-bridge-app/fabric-bridge-common/fabric-bridge-app.matter
+++ b/examples/fabric-bridge-app/fabric-bridge-common/fabric-bridge-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {
@@ -348,7 +348,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/laundry-washer-app/nxp/zap/laundry-washer-app.matter
+++ b/examples/laundry-washer-app/nxp/zap/laundry-washer-app.matter
@@ -389,7 +389,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -439,7 +439,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/light-switch-app/qpg/zap/switch.matter
+++ b/examples/light-switch-app/qpg/zap/switch.matter
@@ -564,7 +564,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-ethernet.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-ethernet.matter
@@ -493,7 +493,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-thread.matter
@@ -493,7 +493,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
+++ b/examples/lighting-app/bouffalolab/data_model/lighting-app-wifi.matter
@@ -493,7 +493,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -493,7 +493,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lighting-app/nxp/zap/lighting-on-off.matter
+++ b/examples/lighting-app/nxp/zap/lighting-on-off.matter
@@ -493,7 +493,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lighting-app/qpg/zap/light.matter
+++ b/examples/lighting-app/qpg/zap/light.matter
@@ -493,7 +493,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-thread-app.matter
@@ -493,7 +493,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
+++ b/examples/lighting-app/silabs/data_model/lighting-wifi-app.matter
@@ -493,7 +493,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.matter
+++ b/examples/lit-icd-app/lit-icd-common/lit-icd-server-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lock-app/nxp/zap/lock-app.matter
+++ b/examples/lock-app/nxp/zap/lock-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/lock-app/qpg/zap/lock.matter
+++ b/examples/lock-app/qpg/zap/lock.matter
@@ -296,7 +296,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/log-source-app/log-source-common/log-source-app.matter
+++ b/examples/log-source-app/log-source-common/log-source-app.matter
@@ -136,7 +136,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/microwave-oven-app/microwave-oven-common/microwave-oven-app.matter
+++ b/examples/microwave-oven-app/microwave-oven-common/microwave-oven-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/network-manager-app/network-manager-common/network-manager-app.matter
+++ b/examples/network-manager-app/network-manager-common/network-manager-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
+++ b/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
@@ -169,7 +169,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {
@@ -298,7 +298,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -368,7 +368,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -740,7 +740,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -740,7 +740,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -437,7 +437,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/pump-app/silabs/data_model/pump-thread-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-thread-app.matter
@@ -437,7 +437,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/pump-app/silabs/data_model/pump-wifi-app.matter
+++ b/examples/pump-app/silabs/data_model/pump-wifi-app.matter
@@ -437,7 +437,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -312,7 +312,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/refrigerator-app/refrigerator-common/refrigerator-app.matter
+++ b/examples/refrigerator-app/refrigerator-common/refrigerator-app.matter
@@ -169,7 +169,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/rvc-app/rvc-common/rvc-app.matter
+++ b/examples/rvc-app/rvc-common/rvc-app.matter
@@ -219,7 +219,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
+++ b/examples/smoke-co-alarm-app/smoke-co-alarm-common/smoke-co-alarm-app.matter
@@ -296,7 +296,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/temperature-measurement-app/temperature-measurement-common/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/temperature-measurement-common/temperature-measurement.matter
@@ -169,7 +169,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/thermostat/nxp/zap/thermostat_matter_thread.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_thread.matter
@@ -367,7 +367,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/thermostat/nxp/zap/thermostat_matter_wifi.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_wifi.matter
@@ -367,7 +367,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/thermostat/qpg/zap/thermostaticRadiatorValve.matter
+++ b/examples/thermostat/qpg/zap/thermostaticRadiatorValve.matter
@@ -367,7 +367,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -367,7 +367,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -408,7 +408,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -568,7 +568,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
+++ b/examples/virtual-device-app/virtual-device-common/virtual-device-app.matter
@@ -389,7 +389,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -296,7 +296,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
@@ -130,7 +130,7 @@ limitations under the License.
     <command code="0x00" source="client" name="ReviewFabricRestrictions" isFabricScoped="true" optional="true">
       <description>This command signals to the service associated with the device vendor that the fabric administrator would like a review of the current restrictions on the accessing fabric.</description>
        <access op="invoke" privilege="administer"/>
-      <arg id="0" name="ARL" array="true" type="AccessRestrictionStruct"/>
+      <arg id="0" name="ARL" array="true" type="CommissioningAccessRestrictionEntryStruct"/>
      </command>
 
     <command code="0x01" source="server" name="ReviewFabricRestrictionsResponse" optional="true" disableDefaultResponse="true">

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -561,7 +561,7 @@ cluster AccessControl = 31 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ReviewFabricRestrictionsRequest {
-    AccessRestrictionStruct arl[] = 0;
+    CommissioningAccessRestrictionEntryStruct arl[] = 0;
   }
 
   response struct ReviewFabricRestrictionsResponse = 1 {

--- a/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
@@ -3982,11 +3982,11 @@ public class ChipClusters {
       return 0L;
     }
 
-    public void reviewFabricRestrictions(DefaultClusterCallback callback, ArrayList<ChipStructs.AccessControlClusterAccessRestrictionStruct> arl) {
+    public void reviewFabricRestrictions(DefaultClusterCallback callback, ArrayList<ChipStructs.AccessControlClusterCommissioningAccessRestrictionEntryStruct> arl) {
       reviewFabricRestrictions(callback, arl, 0);
     }
 
-    public void reviewFabricRestrictions(DefaultClusterCallback callback, ArrayList<ChipStructs.AccessControlClusterAccessRestrictionStruct> arl, int timedInvokeTimeoutMs) {
+    public void reviewFabricRestrictions(DefaultClusterCallback callback, ArrayList<ChipStructs.AccessControlClusterCommissioningAccessRestrictionEntryStruct> arl, int timedInvokeTimeoutMs) {
       final long commandId = 0L;
 
       ArrayList<StructElement> elements = new ArrayList<>();

--- a/src/controller/java/generated/java/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ClusterInfoMapping.java
@@ -23233,7 +23233,7 @@ public class ClusterInfoMapping {
       (cluster, callback, commandArguments) -> {
         ((ChipClusters.AccessControlCluster) cluster)
         .reviewFabricRestrictions((DefaultClusterCallback) callback
-        , (ArrayList<ChipStructs.AccessControlClusterAccessRestrictionStruct>)
+        , (ArrayList<ChipStructs.AccessControlClusterCommissioningAccessRestrictionEntryStruct>)
         commandArguments.get("arl")
         );
       },

--- a/src/controller/java/generated/java/matter/controller/cluster/clusters/AccessControlCluster.kt
+++ b/src/controller/java/generated/java/matter/controller/cluster/clusters/AccessControlCluster.kt
@@ -134,7 +134,7 @@ class AccessControlCluster(
   }
 
   suspend fun reviewFabricRestrictions(
-    arl: List<AccessControlClusterAccessRestrictionStruct>,
+    arl: List<AccessControlClusterCommissioningAccessRestrictionEntryStruct>,
     timedInvokeTimeout: Duration? = null,
   ) {
     val commandId: UInt = 0u

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -871,7 +871,7 @@ class ChipClusters:
                 "commandId": 0x00000000,
                 "commandName": "ReviewFabricRestrictions",
                 "args": {
-                    "arl": "AccessRestrictionStruct",
+                    "arl": "CommissioningAccessRestrictionEntryStruct",
                 },
             },
         },

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -2713,10 +2713,10 @@ class AccessControl(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields=[
-                        ClusterObjectFieldDescriptor(Label="arl", Tag=0, Type=typing.List[AccessControl.Structs.AccessRestrictionStruct]),
+                        ClusterObjectFieldDescriptor(Label="arl", Tag=0, Type=typing.List[AccessControl.Structs.CommissioningAccessRestrictionEntryStruct]),
                     ])
 
-            arl: 'typing.List[AccessControl.Structs.AccessRestrictionStruct]' = field(default_factory=lambda: [])
+            arl: 'typing.List[AccessControl.Structs.CommissioningAccessRestrictionEntryStruct]' = field(default_factory=lambda: [])
 
         @dataclass
         class ReviewFabricRestrictionsResponse(ClusterCommand):

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -2559,17 +2559,40 @@ NS_ASSUME_NONNULL_BEGIN
                 }
                 listFreer.add(listHolder_0);
                 for (size_t i_0 = 0; i_0 < self.arl.count; ++i_0) {
-                    if (![self.arl[i_0] isKindOfClass:[MTRAccessControlClusterAccessRestrictionStruct class]]) {
+                    if (![self.arl[i_0] isKindOfClass:[MTRAccessControlClusterCommissioningAccessRestrictionEntryStruct class]]) {
                         // Wrong kind of value.
                         return CHIP_ERROR_INVALID_ARGUMENT;
                     }
-                    auto element_0 = (MTRAccessControlClusterAccessRestrictionStruct *) self.arl[i_0];
-                    listHolder_0->mList[i_0].type = static_cast<std::remove_reference_t<decltype(listHolder_0->mList[i_0].type)>>(element_0.type.unsignedCharValue);
-                    if (element_0.id == nil) {
-                        listHolder_0->mList[i_0].id.SetNull();
-                    } else {
-                        auto & nonNullValue_2 = listHolder_0->mList[i_0].id.SetNonNull();
-                        nonNullValue_2 = element_0.id.unsignedIntValue;
+                    auto element_0 = (MTRAccessControlClusterCommissioningAccessRestrictionEntryStruct *) self.arl[i_0];
+                    listHolder_0->mList[i_0].endpoint = element_0.endpoint.unsignedShortValue;
+                    listHolder_0->mList[i_0].cluster = element_0.cluster.unsignedIntValue;
+                    {
+                        using ListType_2 = std::remove_reference_t<decltype(listHolder_0->mList[i_0].restrictions)>;
+                        using ListMemberType_2 = ListMemberTypeGetter<ListType_2>::Type;
+                        if (element_0.restrictions.count != 0) {
+                            auto * listHolder_2 = new ListHolder<ListMemberType_2>(element_0.restrictions.count);
+                            if (listHolder_2 == nullptr || listHolder_2->mList == nullptr) {
+                                return CHIP_ERROR_INVALID_ARGUMENT;
+                            }
+                            listFreer.add(listHolder_2);
+                            for (size_t i_2 = 0; i_2 < element_0.restrictions.count; ++i_2) {
+                                if (![element_0.restrictions[i_2] isKindOfClass:[MTRAccessControlClusterAccessRestrictionStruct class]]) {
+                                    // Wrong kind of value.
+                                    return CHIP_ERROR_INVALID_ARGUMENT;
+                                }
+                                auto element_2 = (MTRAccessControlClusterAccessRestrictionStruct *) element_0.restrictions[i_2];
+                                listHolder_2->mList[i_2].type = static_cast<std::remove_reference_t<decltype(listHolder_2->mList[i_2].type)>>(element_2.type.unsignedCharValue);
+                                if (element_2.id == nil) {
+                                    listHolder_2->mList[i_2].id.SetNull();
+                                } else {
+                                    auto & nonNullValue_4 = listHolder_2->mList[i_2].id.SetNonNull();
+                                    nonNullValue_4 = element_2.id.unsignedIntValue;
+                                }
+                            }
+                            listHolder_0->mList[i_0].restrictions = ListType_2(listHolder_2->mList, element_0.restrictions.count);
+                        } else {
+                            listHolder_0->mList[i_0].restrictions = ListType_2();
+                        }
                     }
                 }
                 encodableStruct.arl = ListType_0(listHolder_0->mList, self.arl.count);

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -2899,7 +2899,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ReviewFabricRestrictions::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::AccessControl::Id; }
 
-    DataModel::List<const Structs::AccessRestrictionStruct::Type> arl;
+    DataModel::List<const Structs::CommissioningAccessRestrictionEntryStruct::Type> arl;
 
     CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
 
@@ -2914,7 +2914,7 @@ public:
     static constexpr CommandId GetCommandId() { return Commands::ReviewFabricRestrictions::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::AccessControl::Id; }
 
-    DataModel::DecodableList<Structs::AccessRestrictionStruct::DecodableType> arl;
+    DataModel::DecodableList<Structs::CommissioningAccessRestrictionEntryStruct::DecodableType> arl;
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace ReviewFabricRestrictions

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -1313,8 +1313,8 @@ public:
 
 private:
     chip::app::Clusters::AccessControl::Commands::ReviewFabricRestrictions::Type mRequest;
-    TypedComplexArgument<
-        chip::app::DataModel::List<const chip::app::Clusters::AccessControl::Structs::AccessRestrictionStruct::Type>>
+    TypedComplexArgument<chip::app::DataModel::List<
+        const chip::app::Clusters::AccessControl::Structs::CommissioningAccessRestrictionEntryStruct::Type>>
         mComplex_Arl;
 };
 


### PR DESCRIPTION
Was supposed to be a list of AccessRestrictionEntryStructs, not AccessRestrictionStructs.  Spec text updated in PR 10176 Since AccessRestrictionEntryStruct is fabric-sensitive, we use CommissioningAccessRestrictionEntryStruct.

> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

