### PR TITLE
[ICD] Add missing polling function to NoWifi connectivity manager

### DIFF
--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
@@ -78,7 +78,7 @@ public:
     static const char * _WiFiAPModeToStr(ConnectivityManager::WiFiAPMode mode);
     static const char * _WiFiStationStateToStr(ConnectivityManager::WiFiStationState state);
     static const char * _WiFiAPStateToStr(ConnectivityManager::WiFiAPState state);
-    // TODO ICD rework: ambiguous declaration of _SetPollingInterval when thread and wifi are both build together
+    // TODO ICD rework: ambiguous declaration of _SetPollingInterval when thread and no-wifi are both built together
 #if CHIP_CONFIG_ENABLE_ICD_SERVER && !CHIP_DEVICE_CONFIG_ENABLE_THREAD
     CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 #endif

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
@@ -78,6 +78,10 @@ public:
     static const char * _WiFiAPModeToStr(ConnectivityManager::WiFiAPMode mode);
     static const char * _WiFiStationStateToStr(ConnectivityManager::WiFiStationState state);
     static const char * _WiFiAPStateToStr(ConnectivityManager::WiFiAPState state);
+    // TODO ICD rework: ambiguous declaration of _SetPollingInterval when thread and wifi are both build together
+#if CHIP_CONFIG_ENABLE_ICD_SERVER && !CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
+#endif
 
 private:
     ImplClass * Impl() { return static_cast<ImplClass *>(this); }
@@ -220,6 +224,15 @@ inline const char * GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_WiFiAPSta
 {
     return nullptr;
 }
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER && !CHIP_DEVICE_CONFIG_ENABLE_THREAD
+template <class ImplClass>
+inline CHIP_ERROR
+GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_SetPollingInterval(System::Clock::Milliseconds32 pollingInterval)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+#endif
 
 } // namespace Internal
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Desription
Missing SetPollingInterval function was causing the lit-icd no-wifi build to fail.
PR adds the missing API to the connectivity manager.

#### Tests
Built `darwin-arm64-lit-icd-ipv6only-no-ble-no-thread-tsan-clang-test`

