### PR TITLE
Fix simplified Linux tv-casting-app gn build error.

### DIFF
--- a/examples/tv-casting-app/linux/BUILD.gn
+++ b/examples/tv-casting-app/linux/BUILD.gn
@@ -58,10 +58,12 @@ executable("chip-tv-casting-app") {
 
   if (chip_build_libshell) {
     defines += [ "ENABLE_CHIP_SHELL" ]
-    sources += [
-      "CastingShellCommands.cpp",
-      "CastingShellCommands.h",
-    ]
+    if (!chip_casting_simplified) {
+      sources += [
+        "CastingShellCommands.cpp",
+        "CastingShellCommands.h",
+      ]
+    }
   }
 
   output_dir = root_out_dir


### PR DESCRIPTION
**Problem**
The gn build of the simplified Linux tv-casting-app was including some files that shouldn't have been included. These files should only be included in the build for the non-simplified Linux tv-casting-app, so when `chip_casting_simplified=false`. 

**Testing**
Verified locally in ubuntu environment that both the simplified and non-simplified Linux tv-casting-app builds successfully with the following commands:
Simplified Linux tv-casting-app:
1. gn gen --check --fail-on-unused-args --root=examples/tv-casting-app/linux/ out/tv-casting-app '--args=chip_casting_simplified=true chip_crypto="boringssl" is_asan=true'
2. ninja -C out/tv-casting-app

Non-simplified Linux tv-casting-app:
1. gn gen --check --fail-on-unused-args --root=examples/tv-casting-app/linux/ out/tv-casting-app '--args=chip_casting_simplified=false chip_crypto="boringssl" is_asan=true'
2. ninja -C out/tv-casting-app