### PR TITLE
removing unneccessary git fetch from restyle-diff.sh

### DIFF
--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -78,7 +78,7 @@ done
 
 if [[ -z "$ref" ]]; then
     ref="master"
-    git remote | grep -qxF upstream && ref="upstream/master" && git fetch upstream
+    git remote | grep -qxF upstream && ref="upstream/master"
 fi
 
 if [[ $pull_image -eq 1 ]]; then


### PR DESCRIPTION
removing an unnecessary git fetch (allows us to run the script offline)
