### PR TITLE
Remove StatusIB::InitFromChipError.

### DIFF
--- a/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/chip-tool/commands/common/RemoteDataModelLogger.cpp
@@ -160,8 +160,7 @@ CHIP_ERROR LogErrorAsJSON(const CHIP_ERROR & error)
     VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
 
     Json::Value value;
-    chip::app::StatusIB status;
-    status.InitFromChipError(error);
+    chip::app::StatusIB status(error);
     return LogError(value, status);
 }
 

--- a/examples/fabric-admin/commands/common/RemoteDataModelLogger.cpp
+++ b/examples/fabric-admin/commands/common/RemoteDataModelLogger.cpp
@@ -160,8 +160,7 @@ CHIP_ERROR LogErrorAsJSON(const CHIP_ERROR & error)
     VerifyOrReturnError(gDelegate != nullptr, CHIP_NO_ERROR);
 
     Json::Value value;
-    chip::app::StatusIB status;
-    status.InitFromChipError(error);
+    chip::app::StatusIB status(error);
     return LogError(value, status);
 }
 

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -100,8 +100,8 @@ public:
          * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
          * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
          * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific
-         *   status response from the server.  In that case,
-         *   StatusIB::InitFromChipError can be used to extract the status.
+         *   status response from the server.  In that case, constructing
+         *   a StatusIB from the error can be used to extract the status.
          * - CHIP_ERROR*: All other cases.
          */
         CHIP_ERROR error;

--- a/src/app/CommandSenderLegacyCallback.h
+++ b/src/app/CommandSenderLegacyCallback.h
@@ -65,8 +65,8 @@ public:
      * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
      * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
      * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific or path-specific
-     *   status response from the server.  In that case,
-     *   StatusIB::InitFromChipError can be used to extract the status.
+     *   status response from the server.  In that case, constructing a
+     *   StatusIB from the error can be used to extract the status.
      *      - Note: a CommandSender using `CommandSender::Callback` only supports sending
      *        a single InvokeRequest. As a result, only one path-specific error is expected
      *        to ever be sent to the OnError callback.

--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -149,7 +149,7 @@ CHIP_ERROR StatusIB::ToChipError() const
     return ChipError(ChipError::SdkPart::kIMGlobalStatus, to_underlying(mStatus));
 }
 
-void StatusIB::InitFromChipError(CHIP_ERROR aError)
+StatusIB::StatusIB(CHIP_ERROR aError)
 {
     if (aError.IsPart(ChipError::SdkPart::kIMClusterStatus))
     {
@@ -204,8 +204,7 @@ bool FormatStatusIBError(char * buf, uint16_t bufSize, CHIP_ERROR err)
     constexpr size_t formattedSize = max(sizeof(generalFormat) + statusNameMaxLength, sizeof(clusterFormat));
     char formattedString[formattedSize];
 
-    StatusIB status;
-    status.InitFromChipError(err);
+    StatusIB status(err);
     if (status.mClusterStatus.HasValue())
     {
         snprintf(formattedString, formattedSize, clusterFormat, status.mClusterStatus.Value());

--- a/src/app/MessageDef/StatusIB.h
+++ b/src/app/MessageDef/StatusIB.h
@@ -60,7 +60,7 @@ struct StatusIB
         }
     }
 
-    explicit StatusIB(CHIP_ERROR error) { InitFromChipError(error); }
+    explicit StatusIB(CHIP_ERROR error);
 
     enum class Tag : uint8_t
     {
@@ -104,13 +104,6 @@ struct StatusIB
      * CHIP_NO_ERROR or test true for IsIMStatus().
      */
     CHIP_ERROR ToChipError() const;
-
-    /**
-     * Extract a CHIP_ERROR into this StatusIB.  If IsIMStatus() is false for
-     * the error, this might do a best-effort attempt to come up with a
-     * corresponding StatusIB, defaulting to a generic Status::Failure.
-     */
-    void InitFromChipError(CHIP_ERROR aError);
 
     /**
      * Test whether this status is a success.

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -195,8 +195,8 @@ public:
          * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
          * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
          * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific
-         *   status response from the server.  In that case,
-         *   StatusIB::InitFromChipError can be used to extract the status.
+         *   status response from the server.  In that case, constructing
+         *   a StatusIB from the error can be used to extract the status.
          * - CHIP_ERROR*: All other cases.
          *
          * This object MUST continue to exist after this call is completed. The application shall wait until it

--- a/src/app/TimedRequest.h
+++ b/src/app/TimedRequest.h
@@ -38,8 +38,8 @@ public:
     // but came in after we sent a timed request).
     //
     // If the response is a failure StatusResponse, its status will be
-    // encapsulated in the CHIP_ERROR this returns.  In that case,
-    // StatusIB::InitFromChipError can be used to extract the status.
+    // encapsulated in the CHIP_ERROR this returns.  In that case, constructing
+    // a StatusIB from the error can be used to extract the status.
     static CHIP_ERROR HandleResponse(const PayloadHeader & aPayloadHeader, System::PacketBufferHandle && aPayload);
 };
 

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -88,8 +88,8 @@ public:
          * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
          * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
          * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific
-         *   status response from the server.  In that case,
-         *   StatusIB::InitFromChipError can be used to extract the status.
+         *   status response from the server.  In that case, constructing
+         *   a StatusIB from the error can be used to extract the status.
          * - CHIP_ERROR*: All other cases.
          *
          * The WriteClient object MUST continue to exist after this call is completed. The application shall wait until it

--- a/src/app/tests/TestStatusIB.cpp
+++ b/src/app/tests/TestStatusIB.cpp
@@ -46,8 +46,7 @@ public:
 #define VERIFY_ROUNDTRIP(err, status)                                                                                              \
     do                                                                                                                             \
     {                                                                                                                              \
-        StatusIB newStatus;                                                                                                        \
-        newStatus.InitFromChipError(err);                                                                                          \
+        StatusIB newStatus(err);                                                                                                   \
         EXPECT_EQ(newStatus.mStatus, status.mStatus);                                                                              \
         EXPECT_EQ(newStatus.mClusterStatus, status.mClusterStatus);                                                                \
     } while (0);
@@ -86,16 +85,14 @@ TEST_F(TestStatusIB, TestStatusIBToFromChipError)
     err            = status.ToChipError();
     EXPECT_NE(err, CHIP_NO_ERROR);
     {
-        StatusIB newStatus;
-        newStatus.InitFromChipError(err);
+        StatusIB newStatus(err);
         EXPECT_EQ(newStatus.mStatus, Status::Failure);
         EXPECT_EQ(newStatus.mClusterStatus, status.mClusterStatus);
     }
 
     err = CHIP_ERROR_NO_MEMORY;
     {
-        StatusIB newStatus;
-        newStatus.InitFromChipError(err);
+        StatusIB newStatus(err);
         EXPECT_EQ(newStatus.mStatus, Status::Failure);
         EXPECT_FALSE(newStatus.mClusterStatus.HasValue());
     }

--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -43,8 +43,8 @@ namespace Controller {
  *     encapsulate a StatusIB).  This could be a path-specific error or it
  *     could be a general error for the entire request; the distinction is not
  *     that important, because we only have one path involved.  If the
- *     CHIP_ERROR encapsulates a StatusIB, StatusIB::InitFromChipError can be
- *     used to extract the status.
+ *     CHIP_ERROR encapsulates a StatusIB, constructing a StatusIB from it will
+ *     extract the status.
  */
 template <typename DecodableAttributeType>
 class TypedReadAttributeCallback final : public app::ReadClient::Callback


### PR DESCRIPTION
The constructor is a better fit for being able to convert CHIP_ERROR to ClusterStatusCode and then to StatusIB.
