### PR TITLE
Draft enabling wifipaf on sample apps

### DIFF
--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -26,6 +26,7 @@ declare_args() {
   chip_enable_energy_reporting_trigger = false
   chip_enable_water_heater_management_trigger = false
   chip_enable_device_energy_management_trigger = false
+  chip_device_config_enable_wifipaf = true
 }
 
 config("app-main-config") {
@@ -133,6 +134,7 @@ source_set("app-main") {
     "CHIP_DEVICE_CONFIG_ENABLE_ENERGY_REPORTING_TRIGGER=${chip_enable_energy_reporting_trigger}",
     "CHIP_DEVICE_CONFIG_ENABLE_WATER_HEATER_MANAGEMENT_TRIGGER=${chip_enable_water_heater_management_trigger}",
     "CHIP_DEVICE_CONFIG_ENABLE_DEVICE_ENERGY_MANAGEMENT_TRIGGER=${chip_enable_device_energy_management_trigger}",
+    "CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF=${chip_device_config_enable_wifipaf}",
   ]
 
   public_configs = [ ":app-main-config" ]

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -26,7 +26,6 @@ declare_args() {
   chip_enable_energy_reporting_trigger = false
   chip_enable_water_heater_management_trigger = false
   chip_enable_device_energy_management_trigger = false
-  chip_device_config_enable_wifipaf = true
 }
 
 config("app-main-config") {
@@ -134,7 +133,6 @@ source_set("app-main") {
     "CHIP_DEVICE_CONFIG_ENABLE_ENERGY_REPORTING_TRIGGER=${chip_enable_energy_reporting_trigger}",
     "CHIP_DEVICE_CONFIG_ENABLE_WATER_HEATER_MANAGEMENT_TRIGGER=${chip_enable_water_heater_management_trigger}",
     "CHIP_DEVICE_CONFIG_ENABLE_DEVICE_ENERGY_MANAGEMENT_TRIGGER=${chip_enable_device_energy_management_trigger}",
-    "CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF=${chip_device_config_enable_wifipaf}",
   ]
 
   public_configs = [ ":app-main-config" ]

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -25,7 +25,7 @@ declare_args() {
   chip_fake_platform = false
 
   # Include wifi-paf to commission the device or not
-  chip_device_config_enable_wifipaf = (current_os == "linux")
+  chip_device_config_enable_wifipaf = current_os == "linux"
 }
 
 if (chip_device_platform == "auto") {

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -25,7 +25,7 @@ declare_args() {
   chip_fake_platform = false
 
   # Include wifi-paf to commission the device or not
-  chip_device_config_enable_wifipaf = false
+  chip_device_config_enable_wifipaf = true
 }
 
 if (chip_device_platform == "auto") {

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -25,7 +25,7 @@ declare_args() {
   chip_fake_platform = false
 
   # Include wifi-paf to commission the device or not
-  chip_device_config_enable_wifipaf = true
+  chip_device_config_enable_wifipaf = (current_os == "linux")
 }
 
 if (chip_device_platform == "auto") {


### PR DESCRIPTION
Support for wifipaf is not being  enabled on the  example apps  on the SDK Container.
SDK container is generated by using Dockerfile: 
https://github.com/project-chip/connectedhomeip/blob/master/integrations/docker/images/chip-cert-bins/Dockerfile


This PR is related / should be understood in the context of this Commit:

Add --wifipaf commission in chip-tool and apps of Linux platform (#33977). 30 Jul 2024 at 00:21
SHA: **085f57f3fc7827b45830c5976ddac16895c2fd3b**

The initial changes done here in this PR are not supposed to the  complete or  even the right solution for this issue but the entry point to get  help from who knew the right places that must be changed in order to get wifipaf available on the sample apps (SDK container)  used by Test Harness execution. 

