### PR TITLE
Fix TCP test script naming

### DIFF
--- a/src/python_testing/TCP_Tests.py
+++ b/src/python_testing/TCP_Tests.py
@@ -32,8 +32,9 @@ from mobly import asserts
 
 class TCP_Tests(MatterBaseTest):
 
+    # TCP Connection Establishment
     @async_test_body
-    async def test_TCPConnectionEstablishment(self):
+    async def test_TC_SC_8_1(self):
 
         try:
             device = await self.default_controller.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000,
@@ -43,8 +44,9 @@ class TCP_Tests(MatterBaseTest):
         asserts.assert_equal(device.isSessionOverTCPConnection, True, "Session does not have associated TCP connection")
         asserts.assert_equal(device.isActiveSession, True, "Large Payload Session should be active over TCP connection")
 
+    # Large Payload Session Establishment
     @async_test_body
-    async def test_LargePayloadSessionEstablishment(self):
+    async def test_TC_SC_8_2(self):
 
         try:
             device = await self.default_controller.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000,
@@ -53,8 +55,9 @@ class TCP_Tests(MatterBaseTest):
             asserts.fail("Unable to establish a CASE session over TCP to the device")
         asserts.assert_equal(device.sessionAllowsLargePayload, True, "Session does not have associated TCP connection")
 
+    # Session Inactive After TCP Disconnect
     @async_test_body
-    async def test_SessionInactiveAfterTCPDisconnect(self):
+    async def test_TC_SC_8_3(self):
 
         try:
             device = await self.default_controller.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000,
@@ -67,8 +70,9 @@ class TCP_Tests(MatterBaseTest):
         asserts.assert_equal(device.isActiveSession, False,
                              "Large Payload Session should not be active after TCP connection closure")
 
+    # TCP Connect, Disconnect, Then Connect Again
     @async_test_body
-    async def test_TCPConnectDisconnectThenConnectAgain(self):
+    async def test_TC_SC_8_4(self):
 
         try:
             device = await self.default_controller.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000,
@@ -90,8 +94,9 @@ class TCP_Tests(MatterBaseTest):
         asserts.assert_equal(device.isSessionOverTCPConnection, True, "Session does not have associated TCP connection")
         asserts.assert_equal(device.isActiveSession, True, "Large Payload Session should be active over TCP connection")
 
+    # OnOff Cluster Toggle Command Over TCP Session
     @async_test_body
-    async def test_OnOffToggleCommandOverTCPSession(self):
+    async def test_TC_SC_8_5(self):
 
         try:
             device = await self.default_controller.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000,
@@ -109,8 +114,9 @@ class TCP_Tests(MatterBaseTest):
         except InteractionModelError:
             asserts.fail("Unexpected error returned by DUT")
 
+    # WildCard Read Over TCP Session
     @async_test_body
-    async def test_WildCardReadOverTCPSession(self):
+    async def test_TC_SC_8_6(self):
 
         try:
             device = await self.default_controller.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000,
@@ -126,8 +132,9 @@ class TCP_Tests(MatterBaseTest):
         except InteractionModelError:
             asserts.fail("Unexpected error returned by DUT")
 
+    # Use TCP Session If Available For MRP Interaction
     @async_test_body
-    async def test_UseTCPSessionIfAvailableForMRPInteraction(self):
+    async def test_TC_SC_8_7(self):
 
         try:
             device = await self.default_controller.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000,


### PR DESCRIPTION
Change from test names to test case Ids.

Fixes #34666 
