### PR TITLE
Use explicit storage for ActionReturnStatus::c_str

### DIFF
--- a/src/app/data-model-provider/ActionReturnStatus.cpp
+++ b/src/app/data-model-provider/ActionReturnStatus.cpp
@@ -163,6 +163,8 @@ const char * ActionReturnStatus::c_str(ActionReturnStatus::StringStorage & stora
 
     if (const ClusterStatusCode * status = std::get_if<ClusterStatusCode>(&mReturnStatus))
     {
+        storage.formatBuffer.Reset();
+
 #if CHIP_CONFIG_IM_STATUS_CODE_VERBOSE_FORMAT
         storage.formatBuffer.AddFormat("%s(%d)", Protocols::InteractionModel::StatusName(status->GetStatus()),
                                        static_cast<int>(status->GetStatus()));

--- a/src/app/data-model-provider/ActionReturnStatus.cpp
+++ b/src/app/data-model-provider/ActionReturnStatus.cpp
@@ -149,45 +149,40 @@ bool ActionReturnStatus::IsOutOfSpaceEncodingResponse() const
     return false;
 }
 
-const char * ActionReturnStatus::c_str() const
+const char * ActionReturnStatus::c_str(ActionReturnStatus::StringStorage & storage) const
 {
-
-    // Generally size should be sufficient.
-    // len("Status<123>, Code 255") == 21 (and then 22 for null terminator. We have slack.)
-    static chip::StringBuilder<32> sFormatBuffer;
-
     if (const CHIP_ERROR * err = std::get_if<CHIP_ERROR>(&mReturnStatus))
     {
 #if CHIP_CONFIG_ERROR_FORMAT_AS_STRING
         return err->Format(); // any length
 #else
-        sFormatBuffer.Reset().AddFormat("%" CHIP_ERROR_FORMAT, err->Format());
-        return sFormatBuffer.c_str();
+        storage.formatBuffer.Reset().AddFormat("%" CHIP_ERROR_FORMAT, err->Format());
+        return storage.formatBuffer.c_str();
 #endif
     }
 
     if (const ClusterStatusCode * status = std::get_if<ClusterStatusCode>(&mReturnStatus))
     {
 #if CHIP_CONFIG_IM_STATUS_CODE_VERBOSE_FORMAT
-        sFormatBuffer.AddFormat("%s(%d)", Protocols::InteractionModel::StatusName(status->GetStatus()),
-                                static_cast<int>(status->GetStatus()));
+        storage.formatBuffer.AddFormat("%s(%d)", Protocols::InteractionModel::StatusName(status->GetStatus()),
+                                       static_cast<int>(status->GetStatus()));
 #else
         if (status->IsSuccess())
         {
-            sFormatBuffer.Add("Success");
+            storage.formatBuffer.Add("Success");
         }
         else
         {
-            sFormatBuffer.AddFormat("Status<%d>", static_cast<int>(status->GetStatus()));
+            storage.formatBuffer.AddFormat("Status<%d>", static_cast<int>(status->GetStatus()));
         }
 #endif
 
         chip::Optional<ClusterStatus> clusterCode = status->GetClusterSpecificCode();
         if (clusterCode.HasValue())
         {
-            sFormatBuffer.AddFormat(", Code %d", static_cast<int>(clusterCode.Value()));
+            storage.formatBuffer.AddFormat(", Code %d", static_cast<int>(clusterCode.Value()));
         }
-        return sFormatBuffer.c_str();
+        return storage.formatBuffer.c_str();
     }
 
     // all std::variant cases exhausted

--- a/src/app/data-model-provider/ActionReturnStatus.h
+++ b/src/app/data-model-provider/ActionReturnStatus.h
@@ -48,7 +48,13 @@ public:
     struct StringStorage
     {
         // Generally size should be sufficient.
-        // len("Status<123>, Code 255") == 21 (and then 22 for null terminator. We have slack.)
+        // The longest status code from StatusCodeList is NO_UPSTREAM_SUBSCRIPTION(197)
+        // so we need space for one of:
+        //    "NO_UPSTREAM_SUBSCRIPTION(197)\0" = 30   // explicit verbose status code
+        //    "FAILURE(1), Code 255\0")                // cluster failure, verbose
+        //    "SUCCESS(0), Code 255\0")                // cluster success, verbose
+        //    "Status<197>, Code 255\0")               // Cluster failure, non-verbose
+        // 
         // CHIP_ERROR has its own (global/static!) storage
         chip::StringBuilder<32> formatBuffer;
     };

--- a/src/app/data-model-provider/ActionReturnStatus.h
+++ b/src/app/data-model-provider/ActionReturnStatus.h
@@ -54,7 +54,7 @@ public:
         //    "FAILURE(1), Code 255\0")                // cluster failure, verbose
         //    "SUCCESS(0), Code 255\0")                // cluster success, verbose
         //    "Status<197>, Code 255\0")               // Cluster failure, non-verbose
-        // 
+        //
         // CHIP_ERROR has its own (global/static!) storage
         chip::StringBuilder<32> formatBuffer;
     };

--- a/src/app/data-model-provider/ActionReturnStatus.h
+++ b/src/app/data-model-provider/ActionReturnStatus.h
@@ -44,6 +44,15 @@ namespace DataModel {
 class ActionReturnStatus
 {
 public:
+    /// Provides storage for the c_str() call for the action status.
+    struct StringStorage
+    {
+        // Generally size should be sufficient.
+        // len("Status<123>, Code 255") == 21 (and then 22 for null terminator. We have slack.)
+        // CHIP_ERROR has its own (global/static!) storage
+        chip::StringBuilder<32> formatBuffer;
+    };
+
     ActionReturnStatus(CHIP_ERROR error) : mReturnStatus(error) {}
     ActionReturnStatus(Protocols::InteractionModel::Status status) :
         mReturnStatus(Protocols::InteractionModel::ClusterStatusCode(status))
@@ -81,12 +90,8 @@ public:
 
     /// Get the formatted string of this status.
     ///
-    /// NOTE: this is NOT thread safe in the general case, however the safety guarantees
-    ///       are similar to chip::ErrorStr which also assumes a static buffer.
-    ///
-    /// Use this in the chip main event loop (and since that is a single thread,
-    /// there should be no races)
-    const char * c_str() const;
+    /// May use `storage` for storying the actual underlying character string.
+    const char * c_str(StringStorage & storage) const;
 
 private:
     std::variant<CHIP_ERROR, Protocols::InteractionModel::ClusterStatusCode> mReturnStatus;

--- a/src/app/data-model-provider/StringBuilderAdapters.cpp
+++ b/src/app/data-model-provider/StringBuilderAdapters.cpp
@@ -13,6 +13,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include "app/data-model-provider/ActionReturnStatus.h"
 #include <app/data-model-provider/StringBuilderAdapters.h>
 
 #include <lib/core/StringBuilderAdapters.h>
@@ -23,7 +24,8 @@ template <>
 StatusWithSize ToString<chip::app::DataModel::ActionReturnStatus>(const chip::app::DataModel::ActionReturnStatus & status,
                                                                   pw::span<char> buffer)
 {
-    return pw::string::Format(buffer, "ActionReturnStatus<%s>", status.c_str());
+    chip::app::DataModel::ActionReturnStatus::StringStorage storage;
+    return pw::string::Format(buffer, "ActionReturnStatus<%s>", status.c_str(storage));
 }
 
 } // namespace pw

--- a/src/app/data-model-provider/StringBuilderAdapters.cpp
+++ b/src/app/data-model-provider/StringBuilderAdapters.cpp
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "app/data-model-provider/ActionReturnStatus.h"
 #include <app/data-model-provider/StringBuilderAdapters.h>
 
 #include <lib/core/StringBuilderAdapters.h>

--- a/src/app/data-model-provider/tests/TestActionReturnStatus.cpp
+++ b/src/app/data-model-provider/tests/TestActionReturnStatus.cpp
@@ -111,3 +111,46 @@ TEST(TestActionReturnStatus, TestStatusCode)
     ASSERT_EQ(ActionReturnStatus(CHIP_IM_CLUSTER_STATUS(0x12)).GetStatusCode(), ClusterStatusCode::ClusterSpecificFailure(0x12));
     ASSERT_EQ(ActionReturnStatus(CHIP_IM_GLOBAL_STATUS(Timeout)).GetStatusCode(), ClusterStatusCode(Status::Timeout));
 }
+
+TEST(TestActionReturnStatus, TestCString)
+{
+    /// only tests the strings that we build and NOT the CHIP_ERROR ones which
+    /// are tested separately. for chip_error we just say it should not be empty.
+    ActionReturnStatus::StringStorage buffer;
+    ActionReturnStatus status(Status::Success);
+
+    // chip-error returns something non-empty
+    status = CHIP_ERROR_NOT_FOUND;
+    ASSERT_STRNE(status.c_str(buffer), "");
+
+    status = CHIP_NO_ERROR;
+    ASSERT_STRNE(status.c_str(buffer), "");
+
+    // the items below we control
+#if CHIP_CONFIG_IM_STATUS_CODE_VERBOSE_FORMAT
+    status = Status::Success;
+    ASSERT_STREQ(status.c_str(buffer), "SUCCESS(0)");
+
+    status = Status::UnsupportedCommand;
+    ASSERT_STREQ(status.c_str(buffer), "UNSUPPORTED_COMMAND(129)");
+
+    status = ClusterStatusCode::ClusterSpecificSuccess(31);
+    ASSERT_STREQ(status.c_str(buffer), "SUCCESS(0), Code 31");
+
+    status = ClusterStatusCode::ClusterSpecificFailure(32);
+    ASSERT_STREQ(status.c_str(buffer), "FAILURE(1), Code 32");
+#else
+    status = Status::Success;
+    ASSERT_STREQ(status.c_str(buffer), "Success");
+
+    status = Status::UnsupportedCommand;
+    ASSERT_STREQ(status.c_str(buffer), "Status<129>");
+
+    status = ClusterStatusCode::ClusterSpecificSuccess(31);
+    ASSERT_STREQ(status.c_str(buffer), "Status<0>, Code 31");
+
+    status = ClusterStatusCode::ClusterSpecificFailure(32);
+    ASSERT_STREQ(status.c_str(buffer), "Status<1>, Code 32");
+#endif
+
+}

--- a/src/app/data-model-provider/tests/TestActionReturnStatus.cpp
+++ b/src/app/data-model-provider/tests/TestActionReturnStatus.cpp
@@ -152,5 +152,4 @@ TEST(TestActionReturnStatus, TestCString)
     status = ClusterStatusCode::ClusterSpecificFailure(32);
     ASSERT_STREQ(status.c_str(buffer), "Status<1>, Code 32");
 #endif
-
 }

--- a/src/app/data-model-provider/tests/TestActionReturnStatus.cpp
+++ b/src/app/data-model-provider/tests/TestActionReturnStatus.cpp
@@ -147,7 +147,7 @@ TEST(TestActionReturnStatus, TestCString)
     ASSERT_STREQ(status.c_str(buffer), "Status<129>");
 
     status = ClusterStatusCode::ClusterSpecificSuccess(31);
-    ASSERT_STREQ(status.c_str(buffer), "Status<0>, Code 31");
+    ASSERT_STREQ(status.c_str(buffer), "Success, Code 31");
 
     status = ClusterStatusCode::ClusterSpecificFailure(32);
     ASSERT_STREQ(status.c_str(buffer), "Status<1>, Code 32");

--- a/src/app/reporting/Read-Checked.cpp
+++ b/src/app/reporting/Read-Checked.cpp
@@ -82,12 +82,13 @@ ActionReturnStatus RetrieveClusterData(DataModel::Provider * dataModel, const Ac
 
     if (statusEmber != statusDm)
     {
-        StringBuilder<128> buffer;
+        ActionReturnStatus::StringStorage buffer;
+
         // Note log + chipDie instead of VerifyOrDie so that breakpoints (and usage of rr)
         // is easier to debug.
         ChipLogError(Test, "Different return codes between ember and DM");
-        ChipLogError(Test, "  Ember status: %s", statusEmber.c_str());
-        ChipLogError(Test, "  DM status:    %s", statusDm.c_str());
+        ChipLogError(Test, "  Ember status: %s", statusEmber.c_str(buffer));
+        ChipLogError(Test, "  DM status:    %s", statusDm.c_str(buffer));
 
         // For time-dependent data, we may have size differences here: one data fitting in buffer
         // while another not, resulting in different errors (success vs out of space).

--- a/src/app/reporting/Read-DataModel.cpp
+++ b/src/app/reporting/Read-DataModel.cpp
@@ -95,7 +95,8 @@ DataModel::ActionReturnStatus RetrieveClusterData(DataModel::Provider * dataMode
     // and will be sent to the client as well).
     if (!status.IsOutOfSpaceEncodingResponse())
     {
-        ChipLogError(DataManagement, "Failed to read attribute: %s", status.c_str());
+        DataModel::ActionReturnStatus::StringStorage storage;
+        ChipLogError(DataManagement, "Failed to read attribute: %s", status.c_str(storage));
     }
     return status;
 }


### PR DESCRIPTION
Allocating some global storage for this is both not thread-safe and wastes RAM.

Use the stack for the small amount of storage (relatively ... same as 4 integers) that a return status string needs.

### Changes

- use separate storage for c_str and pass it in
- fix a "buffer reset" bug that existed in the code on buffer re-use
- Add unit tests