### PR TITLE
Remove code duplication for CHIP_ERROR to ClusterCode conversion.

### DIFF
--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -24,6 +24,7 @@
 #include "StatusIB.h"
 
 #include "MessageDefHelper.h"
+#include "protocols/interaction_model/StatusCode.h"
 
 #include <inttypes.h>
 #include <stdarg.h>
@@ -151,27 +152,10 @@ CHIP_ERROR StatusIB::ToChipError() const
 
 StatusIB::StatusIB(CHIP_ERROR aError)
 {
-    if (aError.IsPart(ChipError::SdkPart::kIMClusterStatus))
-    {
-        mStatus        = Status::Failure;
-        mClusterStatus = MakeOptional(aError.GetSdkCode());
-        return;
-    }
+    ClusterStatusCode statusCode(aError);
 
-    mClusterStatus = NullOptional;
-    if (aError == CHIP_NO_ERROR)
-    {
-        mStatus = Status::Success;
-        return;
-    }
-
-    if (aError.IsPart(ChipError::SdkPart::kIMGlobalStatus))
-    {
-        mStatus = static_cast<Status>(aError.GetSdkCode());
-        return;
-    }
-
-    mStatus = Status::Failure;
+    mStatus        = statusCode.GetStatus();
+    mClusterStatus = statusCode.GetClusterSpecificCode();
 }
 
 namespace {

--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -150,14 +150,6 @@ CHIP_ERROR StatusIB::ToChipError() const
     return ChipError(ChipError::SdkPart::kIMGlobalStatus, to_underlying(mStatus));
 }
 
-StatusIB::StatusIB(CHIP_ERROR aError)
-{
-    ClusterStatusCode statusCode(aError);
-
-    mStatus        = statusCode.GetStatus();
-    mClusterStatus = statusCode.GetClusterSpecificCode();
-}
-
 namespace {
 bool FormatStatusIBError(char * buf, uint16_t bufSize, CHIP_ERROR err)
 {

--- a/src/app/MessageDef/StatusIB.h
+++ b/src/app/MessageDef/StatusIB.h
@@ -60,7 +60,7 @@ struct StatusIB
         }
     }
 
-    explicit StatusIB(CHIP_ERROR error);
+    explicit StatusIB(CHIP_ERROR error) : StatusIB(Protocols::InteractionModel::ClusterStatusCode(error)) {}
 
     enum class Tag : uint8_t
     {


### PR DESCRIPTION
We have a complete implementation of this in ClusterStatusCode. Remove the logic in StatusIB and use the ClusterStatusCode one instead.

Generally StatusIB is just a ClusterStatusCode ontainer, however due to direct TLV reads, it splits out its contents. I only updated the constructor to use common code.
