### PR TITLE
tv-casting-app fixed memory issues around stopDiscovery function

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -58,7 +58,8 @@ public class ConnectionExampleFragment extends Fragment {
   private TextView connectionFragmentStatusTextView;
   private Button connectionFragmentNextButton;
 
-  // Get a singleton instance of the MatterCastingPlayerDiscovery. Which can be used to call stopDiscovery() during connection.
+  // Get a singleton instance of the MatterCastingPlayerDiscovery. Which can be used to call
+  // stopDiscovery() during connection.
   static final CastingPlayerDiscovery matterCastingPlayerDiscovery =
       MatterCastingPlayerDiscovery.getInstance();
 
@@ -369,15 +370,20 @@ public class ConnectionExampleFragment extends Fragment {
   }
 
   private void stopDiscovery() {
-    Log.i(TAG, "ConnectionExampleFragment stopDiscovery() called, calling MatterCastingPlayerDiscovery.stopDiscovery()");
+    Log.i(
+        TAG,
+        "ConnectionExampleFragment stopDiscovery() called, calling MatterCastingPlayerDiscovery.stopDiscovery()");
 
     MatterError err = matterCastingPlayerDiscovery.stopDiscovery();
     if (err.hasError()) {
       Log.e(
           TAG,
-          "ConnectionExampleFragment stopDiscovery() MatterCastingPlayerDiscovery.stopDiscovery() called, err Stop: " + err);
+          "ConnectionExampleFragment stopDiscovery() MatterCastingPlayerDiscovery.stopDiscovery() called, err Stop: "
+              + err);
     } else {
-      Log.d(TAG, "ConnectionExampleFragment stopDiscovery() MatterCastingPlayerDiscovery.stopDiscovery() success");
+      Log.d(
+          TAG,
+          "ConnectionExampleFragment stopDiscovery() MatterCastingPlayerDiscovery.stopDiscovery() success");
     }
   }
 

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -31,8 +31,6 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import com.R;
 import com.matter.casting.core.CastingPlayer;
-import com.matter.casting.core.CastingPlayerDiscovery;
-import com.matter.casting.core.MatterCastingPlayerDiscovery;
 import com.matter.casting.support.CommissionerDeclaration;
 import com.matter.casting.support.ConnectionCallbacks;
 import com.matter.casting.support.IdentificationDeclarationOptions;
@@ -57,11 +55,6 @@ public class ConnectionExampleFragment extends Fragment {
   private final boolean useCommissionerGeneratedPasscode;
   private TextView connectionFragmentStatusTextView;
   private Button connectionFragmentNextButton;
-
-  // Get a singleton instance of the MatterCastingPlayerDiscovery. Which can be used to call
-  // stopDiscovery() during connection.
-  static final CastingPlayerDiscovery matterCastingPlayerDiscovery =
-      MatterCastingPlayerDiscovery.getInstance();
 
   public ConnectionExampleFragment(
       CastingPlayer targetCastingPlayer, boolean useCommissionerGeneratedPasscode) {
@@ -128,13 +121,6 @@ public class ConnectionExampleFragment extends Fragment {
         v -> {
           Log.i(TAG, "onViewCreated() NEXT clicked. Calling handleConnectionComplete()");
           callback.handleConnectionComplete(targetCastingPlayer, useCommissionerGeneratedPasscode);
-        });
-
-    Button stopDiscoveryButton = getView().findViewById(R.id.stopDiscoveryButton);
-    stopDiscoveryButton.setOnClickListener(
-        v -> {
-          Log.i(TAG, "onViewCreated() stopDiscoveryButton button clicked. Calling stopDiscovery()");
-          stopDiscovery();
         });
 
     Executors.newSingleThreadExecutor()
@@ -367,24 +353,6 @@ public class ConnectionExampleFragment extends Fragment {
     alertDialog
         .getWindow()
         .setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
-  }
-
-  private void stopDiscovery() {
-    Log.i(
-        TAG,
-        "ConnectionExampleFragment stopDiscovery() called, calling MatterCastingPlayerDiscovery.stopDiscovery()");
-
-    MatterError err = matterCastingPlayerDiscovery.stopDiscovery();
-    if (err.hasError()) {
-      Log.e(
-          TAG,
-          "ConnectionExampleFragment stopDiscovery() MatterCastingPlayerDiscovery.stopDiscovery() called, err Stop: "
-              + err);
-    } else {
-      Log.d(
-          TAG,
-          "ConnectionExampleFragment stopDiscovery() MatterCastingPlayerDiscovery.stopDiscovery() success");
-    }
   }
 
   /** Interface for notifying the host. */

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
@@ -67,7 +67,7 @@ public class DiscoveryExampleFragment extends Fragment {
             public void onAdded(CastingPlayer castingPlayer) {
               Log.i(
                   TAG,
-                  "onAdded() Discovered CastingPlayer deviceId: " + castingPlayer.getDeviceId());
+                  "DiscoveryExampleFragment onAdded() Discovered CastingPlayer deviceId: " + castingPlayer.getDeviceId());
               // Display CastingPlayer info on the screen
               new Handler(Looper.getMainLooper())
                   .post(
@@ -80,7 +80,7 @@ public class DiscoveryExampleFragment extends Fragment {
             public void onChanged(CastingPlayer castingPlayer) {
               Log.i(
                   TAG,
-                  "onChanged() Discovered changes to CastingPlayer with deviceId: "
+                  "DiscoveryExampleFragment onChanged() Discovered changes to CastingPlayer with deviceId: "
                       + castingPlayer.getDeviceId());
               // Update the CastingPlayer on the screen
               new Handler(Looper.getMainLooper())
@@ -107,7 +107,7 @@ public class DiscoveryExampleFragment extends Fragment {
             public void onRemoved(CastingPlayer castingPlayer) {
               Log.i(
                   TAG,
-                  "onRemoved() Removed CastingPlayer with deviceId: "
+                  "DiscoveryExampleFragment onRemoved() Removed CastingPlayer with deviceId: "
                       + castingPlayer.getDeviceId());
               // Remove CastingPlayer from the screen
               new Handler(Looper.getMainLooper())
@@ -215,7 +215,9 @@ public class DiscoveryExampleFragment extends Fragment {
   @Override
   public void onPause() {
     super.onPause();
-    Log.i(TAG, "onPause() called");
+    Log.i(TAG, "DiscoveryExampleFragment onPause() called, calling stopDiscovery()");
+    // Stop discovery when leaving the fragment, for example, while displaying the ConnectionExampleFragment.
+    stopDiscovery();
   }
 
   /** Interface for notifying the host. */
@@ -261,7 +263,7 @@ public class DiscoveryExampleFragment extends Fragment {
   }
 
   private void stopDiscovery() {
-    Log.i(TAG, "stopDiscovery() called");
+    Log.i(TAG, "DiscoveryExampleFragment stopDiscovery() called");
     matterDiscoveryErrorMessageTextView.setText(
         getString(R.string.matter_discovery_error_message_initial));
 

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/DiscoveryExampleFragment.java
@@ -67,7 +67,8 @@ public class DiscoveryExampleFragment extends Fragment {
             public void onAdded(CastingPlayer castingPlayer) {
               Log.i(
                   TAG,
-                  "DiscoveryExampleFragment onAdded() Discovered CastingPlayer deviceId: " + castingPlayer.getDeviceId());
+                  "DiscoveryExampleFragment onAdded() Discovered CastingPlayer deviceId: "
+                      + castingPlayer.getDeviceId());
               // Display CastingPlayer info on the screen
               new Handler(Looper.getMainLooper())
                   .post(
@@ -216,7 +217,8 @@ public class DiscoveryExampleFragment extends Fragment {
   public void onPause() {
     super.onPause();
     Log.i(TAG, "DiscoveryExampleFragment onPause() called, calling stopDiscovery()");
-    // Stop discovery when leaving the fragment, for example, while displaying the ConnectionExampleFragment.
+    // Stop discovery when leaving the fragment, for example, while displaying the
+    // ConnectionExampleFragment.
     stopDiscovery();
   }
 

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/custom_passcode_dialog.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/custom_passcode_dialog.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -11,7 +12,6 @@
         android:textStyle="bold"
         android:textSize="18sp"
         android:padding="16dp"
-        android:textColor="@android:color/white"
         android:gravity="center"
         android:text="@string/matter_connection_input_dialog_title" />
 
@@ -24,7 +24,6 @@
         android:paddingEnd="16dp"
         android:paddingTop="8dp"
         android:paddingBottom="8dp"
-        android:textColor="@android:color/white"
         android:text="@string/matter_connection_input_dialog_instructions" />
 
     <EditText

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_connection_example.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_connection_example.xml
@@ -29,13 +29,6 @@
             android:layout_height="wrap_content"
             android:text="@string/matter_connection_next_button_text" />
 
-        <Button
-            android:enabled="true"
-            android:id="@+id/stopDiscoveryButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/matter_stop_discovery_button_text" />
-
     </LinearLayout>
 
 </RelativeLayout>

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_connection_example.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_matter_connection_example.xml
@@ -6,18 +6,36 @@
     tools:context=".matter.casting.ConnectionExampleFragment"
     android:padding="10sp">
 
-    <TextView
-        android:id="@+id/connectionFragmentStatusText"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="24sp"/>
-
-    <Button
-        android:enabled="false"
-        android:id="@+id/connectionFragmentNextButton"
-        android:layout_below="@id/connectionFragmentStatusText"
+    <LinearLayout
+        android:id="@+id/connectionFragmentLinearLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/matter_connection_next_button_text" />
+        android:orientation="vertical"
+        tools:layout_editor_absoluteX="1dp"
+        tools:layout_editor_absoluteY="1dp"
+        android:padding="10sp">
+
+        <TextView
+            android:id="@+id/connectionFragmentStatusText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="24sp"/>
+
+        <Button
+            android:enabled="false"
+            android:id="@+id/connectionFragmentNextButton"
+            android:layout_below="@id/connectionFragmentStatusText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/matter_connection_next_button_text" />
+
+        <Button
+            android:enabled="true"
+            android:id="@+id/stopDiscoveryButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/matter_stop_discovery_button_text" />
+
+    </LinearLayout>
 
 </RelativeLayout>

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -122,7 +122,8 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                     nullptr,
                     [](void * context, chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle) {
                         ChipLogProgress(AppServer,
-                                        "CastingPlayer::VerifyOrEstablishConnection() FindOrEstablishSession Connection to CastingPlayer successful");
+                                        "CastingPlayer::VerifyOrEstablishConnection() FindOrEstablishSession Connection to "
+                                        "CastingPlayer successful");
                         CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_CONNECTED;
 
                         // this async call will Load all the endpoints with their respective attributes into the TargetCastingPlayer
@@ -131,7 +132,9 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                         support::EndpointListLoader::GetInstance()->Load();
                     },
                     [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
-                        ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection() FindOrEstablishSession Connection to CastingPlayer failed");
+                        ChipLogError(AppServer,
+                                     "CastingPlayer::VerifyOrEstablishConnection() FindOrEstablishSession Connection to "
+                                     "CastingPlayer failed");
                         CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
                         CHIP_ERROR e = support::CastingStore::GetInstance()->Delete(*CastingPlayer::GetTargetCastingPlayer());
                         if (e != CHIP_NO_ERROR)
@@ -197,7 +200,7 @@ CHIP_ERROR CastingPlayer::ContinueConnecting()
                      "CastingPlayer::ContinueConnecting() mIdOptions.mCommissionerPasscode == false, ContinueConnecting() should "
                      "only be called when the CastingPlayer/Commissioner-Generated passcode commissioning flow is in progress."););
 
-    CHIP_ERROR err           = CHIP_NO_ERROR;
+    CHIP_ERROR err       = CHIP_NO_ERROR;
     mTargetCastingPlayer = weak_from_this();
 
     ChipLogProgress(AppServer, "CastingPlayer::ContinueConnecting() calling OpenBasicCommissioningWindow()");
@@ -288,7 +291,7 @@ void CastingPlayer::resetState(CHIP_ERROR err)
 void CastingPlayer::Disconnect()
 {
     ChipLogProgress(AppServer, "CastingPlayer::Disconnect()");
-    mConnectionState     = CASTING_PLAYER_NOT_CONNECTED;
+    mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
     mTargetCastingPlayer.reset();
     CastingPlayerDiscovery::GetInstance()->ClearCastingPlayersInternal();
 }
@@ -487,10 +490,14 @@ ConnectionContext::ConnectionContext(void * clientContext, core::CastingPlayer *
         [](void * context, chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle) {
             ChipLogProgress(AppServer, "CastingPlayer::ConnectionContext() Device Connection success callback called");
             ConnectionContext * connectionContext = static_cast<ConnectionContext *>(context);
-            VerifyOrReturn(connectionContext != nullptr && connectionContext->mTargetCastingPlayer != nullptr,
-                           ChipLogError(AppServer, "CastingPlayer::ConnectionContext() Invalid ConnectionContext received in DeviceConnection success callback"));
+            VerifyOrReturn(
+                connectionContext != nullptr && connectionContext->mTargetCastingPlayer != nullptr,
+                ChipLogError(
+                    AppServer,
+                    "CastingPlayer::ConnectionContext() Invalid ConnectionContext received in DeviceConnection success callback"));
 
-            ChipLogProgress(AppServer, "CastingPlayer::ConnectionContext() calling mConnectionState = core::CASTING_PLAYER_CONNECTED");
+            ChipLogProgress(AppServer,
+                            "CastingPlayer::ConnectionContext() calling mConnectionState = core::CASTING_PLAYER_CONNECTED");
             connectionContext->mTargetCastingPlayer->mConnectionState = core::CASTING_PLAYER_CONNECTED;
             ChipLogProgress(AppServer, "CastingPlayer::ConnectionContext() calling mOnDeviceConnectedFn");
             connectionContext->mOnDeviceConnectedFn(connectionContext->mClientContext, exchangeMgr, sessionHandle);
@@ -501,10 +508,15 @@ ConnectionContext::ConnectionContext(void * clientContext, core::CastingPlayer *
 
     mOnConnectionFailureCallback = new chip::Callback::Callback<chip::OnDeviceConnectionFailure>(
         [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
-            ChipLogError(AppServer, "CastingPlayer::ConnectionContext() Device Connection failure callback called with %" CHIP_ERROR_FORMAT, error.Format());
+            ChipLogError(AppServer,
+                         "CastingPlayer::ConnectionContext() Device Connection failure callback called with %" CHIP_ERROR_FORMAT,
+                         error.Format());
             ConnectionContext * connectionContext = static_cast<ConnectionContext *>(context);
-            VerifyOrReturn(connectionContext != nullptr && connectionContext->mTargetCastingPlayer != nullptr,
-                           ChipLogError(AppServer, "CastingPlayer::ConnectionContext() Invalid ConnectionContext received in DeviceConnection failure callback"));
+            VerifyOrReturn(
+                connectionContext != nullptr && connectionContext->mTargetCastingPlayer != nullptr,
+                ChipLogError(
+                    AppServer,
+                    "CastingPlayer::ConnectionContext() Invalid ConnectionContext received in DeviceConnection failure callback"));
             connectionContext->mTargetCastingPlayer->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
             connectionContext->mOnDeviceConnectionFailureFn(connectionContext->mClientContext, peerId, error);
             delete connectionContext;

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "CastingPlayer.h"
-#include "Endpoint.h"
+#include "CastingPlayerDiscovery.h"
 
 #include "support/CastingStore.h"
 
@@ -27,13 +27,14 @@ namespace matter {
 namespace casting {
 namespace core {
 
-CastingPlayer * CastingPlayer::mTargetCastingPlayer = nullptr;
+memory::Weak<CastingPlayer> CastingPlayer::mTargetCastingPlayer;
 
 void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCallbacks, uint16_t commissioningWindowTimeoutSec,
                                                 IdentificationDeclarationOptions idOptions)
 {
     ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() called");
 
+    CastingPlayerDiscovery * castingPlayerDiscovery = CastingPlayerDiscovery::GetInstance();
     std::vector<core::CastingPlayer>::iterator it;
     std::vector<core::CastingPlayer> cachedCastingPlayers = support::CastingStore::GetInstance()->ReadAll();
 
@@ -53,8 +54,9 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
     mConnectionState               = CASTING_PLAYER_CONNECTING;
     mOnCompleted                   = connectionCallbacks.mOnConnectionComplete;
     mCommissioningWindowTimeoutSec = commissioningWindowTimeoutSec;
-    mTargetCastingPlayer           = this;
+    mTargetCastingPlayer           = weak_from_this();
     mIdOptions                     = idOptions;
+    castingPlayerDiscovery->ClearDisconnectedCastingPlayersInternal();
 
     // Register the handler for Commissioner's CommissionerDeclaration messages. The CommissionerDeclaration messages provide
     // information indicating the Commissioner's pre-commissioning state.
@@ -120,7 +122,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                     nullptr,
                     [](void * context, chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle) {
                         ChipLogProgress(AppServer,
-                                        "CastingPlayer::VerifyOrEstablishConnection() Connection to CastingPlayer successful");
+                                        "CastingPlayer::VerifyOrEstablishConnection() FindOrEstablishSession Connection to CastingPlayer successful");
                         CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_CONNECTED;
 
                         // this async call will Load all the endpoints with their respective attributes into the TargetCastingPlayer
@@ -129,7 +131,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
                         support::EndpointListLoader::GetInstance()->Load();
                     },
                     [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
-                        ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection() Connection to CastingPlayer failed");
+                        ChipLogError(AppServer, "CastingPlayer::VerifyOrEstablishConnection() FindOrEstablishSession Connection to CastingPlayer failed");
                         CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
                         CHIP_ERROR e = support::CastingStore::GetInstance()->Delete(*CastingPlayer::GetTargetCastingPlayer());
                         if (e != CHIP_NO_ERROR)
@@ -139,7 +141,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
 
                         VerifyOrReturn(CastingPlayer::GetTargetCastingPlayer()->mOnCompleted);
                         CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(error, nullptr);
-                        mTargetCastingPlayer = nullptr;
+                        mTargetCastingPlayer.reset();
                     });
                 return; // FindOrEstablishSession called. Return early.
             }
@@ -195,8 +197,8 @@ CHIP_ERROR CastingPlayer::ContinueConnecting()
                      "CastingPlayer::ContinueConnecting() mIdOptions.mCommissionerPasscode == false, ContinueConnecting() should "
                      "only be called when the CastingPlayer/Commissioner-Generated passcode commissioning flow is in progress."););
 
-    CHIP_ERROR err       = CHIP_NO_ERROR;
-    mTargetCastingPlayer = this;
+    CHIP_ERROR err           = CHIP_NO_ERROR;
+    mTargetCastingPlayer = weak_from_this();
 
     ChipLogProgress(AppServer, "CastingPlayer::ContinueConnecting() calling OpenBasicCommissioningWindow()");
     SuccessOrExit(err = chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(
@@ -235,7 +237,8 @@ CHIP_ERROR CastingPlayer::StopConnecting()
     mIdOptions.mCancelPasscode     = true;
     mConnectionState               = CASTING_PLAYER_NOT_CONNECTED;
     mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
-    mTargetCastingPlayer           = nullptr;
+    mTargetCastingPlayer.reset();
+    CastingPlayerDiscovery::GetInstance()->ClearCastingPlayersInternal();
 
     // If a CastingPlayer::ContinueConnecting() error occurs, StopConnecting() can be called while sUdcInProgress == true.
     // sUdcInProgress should be set to false before sending the CancelPasscode IdentificationDeclaration message to the
@@ -273,18 +276,21 @@ void CastingPlayer::resetState(CHIP_ERROR err)
     support::ChipDeviceEventHandler::SetUdcStatus(false);
     mConnectionState               = CASTING_PLAYER_NOT_CONNECTED;
     mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
-    mTargetCastingPlayer           = nullptr;
+    mTargetCastingPlayer.reset();
     if (mOnCompleted)
     {
         mOnCompleted(err, nullptr);
         mOnCompleted = nullptr;
     }
+    CastingPlayerDiscovery::GetInstance()->ClearCastingPlayersInternal();
 }
 
 void CastingPlayer::Disconnect()
 {
+    ChipLogProgress(AppServer, "CastingPlayer::Disconnect()");
     mConnectionState     = CASTING_PLAYER_NOT_CONNECTED;
-    mTargetCastingPlayer = nullptr;
+    mTargetCastingPlayer.reset();
+    CastingPlayerDiscovery::GetInstance()->ClearCastingPlayersInternal();
 }
 
 void CastingPlayer::RegisterEndpoint(const memory::Strong<Endpoint> endpoint)
@@ -320,6 +326,7 @@ CHIP_ERROR CastingPlayer::SendUserDirectedCommissioningRequest()
     ReturnErrorOnFailure(chip::Server::GetInstance().SendUserDirectedCommissioningRequest(
         chip::Transport::PeerAddress::UDP(*ipAddressToUse, mAttributes.port, mAttributes.interfaceId), id));
 
+    ChipLogProgress(AppServer, "CastingPlayer::SendUserDirectedCommissioningRequest() complete");
     return CHIP_NO_ERROR;
 }
 
@@ -478,23 +485,26 @@ ConnectionContext::ConnectionContext(void * clientContext, core::CastingPlayer *
 
     mOnConnectedCallback = new chip::Callback::Callback<chip::OnDeviceConnected>(
         [](void * context, chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle) {
-            ChipLogProgress(AppServer, "Device Connection success callback called");
+            ChipLogProgress(AppServer, "CastingPlayer::ConnectionContext() Device Connection success callback called");
             ConnectionContext * connectionContext = static_cast<ConnectionContext *>(context);
             VerifyOrReturn(connectionContext != nullptr && connectionContext->mTargetCastingPlayer != nullptr,
-                           ChipLogError(AppServer, "Invalid ConnectionContext received in DeviceConnection success callback"));
+                           ChipLogError(AppServer, "CastingPlayer::ConnectionContext() Invalid ConnectionContext received in DeviceConnection success callback"));
 
+            ChipLogProgress(AppServer, "CastingPlayer::ConnectionContext() calling mConnectionState = core::CASTING_PLAYER_CONNECTED");
             connectionContext->mTargetCastingPlayer->mConnectionState = core::CASTING_PLAYER_CONNECTED;
+            ChipLogProgress(AppServer, "CastingPlayer::ConnectionContext() calling mOnDeviceConnectedFn");
             connectionContext->mOnDeviceConnectedFn(connectionContext->mClientContext, exchangeMgr, sessionHandle);
+            ChipLogProgress(AppServer, "CastingPlayer::ConnectionContext() calling delete connectionContext");
             delete connectionContext;
         },
         this);
 
     mOnConnectionFailureCallback = new chip::Callback::Callback<chip::OnDeviceConnectionFailure>(
         [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
-            ChipLogError(AppServer, "Device Connection failure callback called with %" CHIP_ERROR_FORMAT, error.Format());
+            ChipLogError(AppServer, "CastingPlayer::ConnectionContext() Device Connection failure callback called with %" CHIP_ERROR_FORMAT, error.Format());
             ConnectionContext * connectionContext = static_cast<ConnectionContext *>(context);
             VerifyOrReturn(connectionContext != nullptr && connectionContext->mTargetCastingPlayer != nullptr,
-                           ChipLogError(AppServer, "Invalid ConnectionContext received in DeviceConnection failure callback"));
+                           ChipLogError(AppServer, "CastingPlayer::ConnectionContext() Invalid ConnectionContext received in DeviceConnection failure callback"));
             connectionContext->mTargetCastingPlayer->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
             connectionContext->mOnDeviceConnectionFailureFn(connectionContext->mClientContext, peerId, error);
             delete connectionContext;

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -100,7 +100,19 @@ public:
     /**
      * @brief Get the CastingPlayer object targeted currently (may not be connected)
      */
-    static CastingPlayer * GetTargetCastingPlayer() { return mTargetCastingPlayer; }
+    static CastingPlayer * GetTargetCastingPlayer() {
+        ChipLogProgress(AppServer, "CastingPlayer::GetTargetCastingPlayer() called");
+        std::shared_ptr<CastingPlayer> sharedPtr = mTargetCastingPlayer.lock();
+        CastingPlayer* rawPtr = nullptr;
+        if (sharedPtr) {
+            rawPtr = sharedPtr.get();
+            ChipLogProgress(AppServer, "CastingPlayer::GetTargetCastingPlayer() Got rawPtr from mTargetCastingPlayer, sharedPtr reference count: %lu", sharedPtr.use_count());
+            sharedPtr.reset();
+        } else {
+            ChipLogError(AppServer, "CastingPlayer::GetTargetCastingPlayer() The shared pointer observed by mTargetCastingPlayer has expired (become nullptr)");
+        }
+        return rawPtr;
+    }
 
     /**
      * @brief Compares based on the Id
@@ -257,12 +269,23 @@ public:
 
     void SetFabricIndex(chip::FabricIndex fabricIndex) { mAttributes.fabricIndex = fabricIndex; }
 
+    /**
+     * @brief Return the current state of the CastingPlayer
+     */
+    ConnectionState GetConnectionState() const {
+        return mConnectionState;
+    }
+
 private:
     std::vector<memory::Strong<Endpoint>> mEndpoints;
     ConnectionState mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
     CastingPlayerAttributes mAttributes;
     IdentificationDeclarationOptions mIdOptions;
-    static CastingPlayer * mTargetCastingPlayer;
+    // This is a std::weak_ptr. A std::weak_ptr is a non-owning reference to an object managed by one
+    // or more std::shared_ptr instances. When the last std::shared_ptr instance that owns the managed
+    // object is destroyed or reset, the object itself is automatically destroyed, and all
+    // std::weak_ptr instances that reference that object become expired.
+    static memory::Weak<CastingPlayer> mTargetCastingPlayer;
     uint16_t mCommissioningWindowTimeoutSec = kCommissioningWindowTimeoutSec;
     ConnectCallback mOnCompleted            = {};
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -100,16 +100,25 @@ public:
     /**
      * @brief Get the CastingPlayer object targeted currently (may not be connected)
      */
-    static CastingPlayer * GetTargetCastingPlayer() {
+    static CastingPlayer * GetTargetCastingPlayer()
+    {
         ChipLogProgress(AppServer, "CastingPlayer::GetTargetCastingPlayer() called");
         std::shared_ptr<CastingPlayer> sharedPtr = mTargetCastingPlayer.lock();
-        CastingPlayer* rawPtr = nullptr;
-        if (sharedPtr) {
+        CastingPlayer * rawPtr                   = nullptr;
+        if (sharedPtr)
+        {
             rawPtr = sharedPtr.get();
-            ChipLogProgress(AppServer, "CastingPlayer::GetTargetCastingPlayer() Got rawPtr from mTargetCastingPlayer, sharedPtr reference count: %lu", sharedPtr.use_count());
+            ChipLogProgress(
+                AppServer,
+                "CastingPlayer::GetTargetCastingPlayer() Got rawPtr from mTargetCastingPlayer, sharedPtr reference count: %lu",
+                sharedPtr.use_count());
             sharedPtr.reset();
-        } else {
-            ChipLogError(AppServer, "CastingPlayer::GetTargetCastingPlayer() The shared pointer observed by mTargetCastingPlayer has expired (become nullptr)");
+        }
+        else
+        {
+            ChipLogError(AppServer,
+                         "CastingPlayer::GetTargetCastingPlayer() The shared pointer observed by mTargetCastingPlayer has expired "
+                         "(become nullptr)");
         }
         return rawPtr;
     }
@@ -272,9 +281,7 @@ public:
     /**
      * @brief Return the current state of the CastingPlayer
      */
-    ConnectionState GetConnectionState() const {
-        return mConnectionState;
-    }
+    ConnectionState GetConnectionState() const { return mConnectionState; }
 
 private:
     std::vector<memory::Strong<Endpoint>> mEndpoints;

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -63,14 +63,53 @@ CHIP_ERROR CastingPlayerDiscovery::StartDiscovery(uint32_t deviceTypeFilter)
 
 CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 {
-    ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() called");
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() mCastingPlayers: %lu, mCastingPlayersInternal: %lu", mCastingPlayers.size(), mCastingPlayersInternal.size());
     VerifyOrReturnError(mState == DISCOVERY_RUNNING, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mCommissionableNodeController.StopDiscovery());
 
+    // Clear mCastingPlayersInternal of disconnected CastingPlayers
+    ClearDisconnectedCastingPlayersInternal();
+    for (const auto& player : mCastingPlayers)
+    {
+        mCastingPlayersInternal.push_back(player);
+    }
+    // Clear mCastingPlayers of all CastingPlayers
     mCastingPlayers.clear();
     mState = DISCOVERY_READY;
 
     return CHIP_NO_ERROR;
+}
+
+void CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal()
+{
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal() mCastingPlayersInternal: %lu", mCastingPlayersInternal.size());
+    // Only clear the CastingPlayers in mCastingPlayersInternal with ConnectionState == CASTING_PLAYER_NOT_CONNECTED
+    ClearDisconnectedCastingPlayers(mCastingPlayersInternal);
+}
+
+void CastingPlayerDiscovery::ClearDisconnectedCastingPlayers(std::vector<std::shared_ptr<CastingPlayer>>& castingPlayers)
+{
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayers() called");
+    for (auto it = castingPlayers.begin(); it != castingPlayers.end();)
+    {
+        auto& player = *it;
+        if (player->GetConnectionState() == CASTING_PLAYER_NOT_CONNECTED)
+        {
+            ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayers() Removing disconnected CastingPlayer: %s with reference count: %lu",
+                             player->GetDeviceName(), player.use_count());
+            it = castingPlayers.erase(it);
+        }
+        else
+        {
+            ++it; // Move to the next element if the current one is not removed
+        }
+    }
+}
+
+void CastingPlayerDiscovery::ClearCastingPlayersInternal()
+{
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearCastingPlayersInternal()");
+    mCastingPlayersInternal.clear();
 }
 
 void DeviceDiscoveryDelegateImpl::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData)

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -63,13 +63,14 @@ CHIP_ERROR CastingPlayerDiscovery::StartDiscovery(uint32_t deviceTypeFilter)
 
 CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 {
-    ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() mCastingPlayers: %lu, mCastingPlayersInternal: %lu", mCastingPlayers.size(), mCastingPlayersInternal.size());
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() mCastingPlayers: %lu, mCastingPlayersInternal: %lu",
+                    mCastingPlayers.size(), mCastingPlayersInternal.size());
     VerifyOrReturnError(mState == DISCOVERY_RUNNING, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mCommissionableNodeController.StopDiscovery());
 
     // Clear mCastingPlayersInternal of disconnected CastingPlayers
     ClearDisconnectedCastingPlayersInternal();
-    for (const auto& player : mCastingPlayers)
+    for (const auto & player : mCastingPlayers)
     {
         mCastingPlayersInternal.push_back(player);
     }
@@ -82,21 +83,24 @@ CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 
 void CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal()
 {
-    ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal() mCastingPlayersInternal: %lu", mCastingPlayersInternal.size());
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal() mCastingPlayersInternal: %lu",
+                    mCastingPlayersInternal.size());
     // Only clear the CastingPlayers in mCastingPlayersInternal with ConnectionState == CASTING_PLAYER_NOT_CONNECTED
     ClearDisconnectedCastingPlayers(mCastingPlayersInternal);
 }
 
-void CastingPlayerDiscovery::ClearDisconnectedCastingPlayers(std::vector<std::shared_ptr<CastingPlayer>>& castingPlayers)
+void CastingPlayerDiscovery::ClearDisconnectedCastingPlayers(std::vector<std::shared_ptr<CastingPlayer>> & castingPlayers)
 {
     ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayers() called");
     for (auto it = castingPlayers.begin(); it != castingPlayers.end();)
     {
-        auto& player = *it;
+        auto & player = *it;
         if (player->GetConnectionState() == CASTING_PLAYER_NOT_CONNECTED)
         {
-            ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayers() Removing disconnected CastingPlayer: %s with reference count: %lu",
-                             player->GetDeviceName(), player.use_count());
+            ChipLogProgress(Discovery,
+                            "CastingPlayerDiscovery::ClearDisconnectedCastingPlayers() Removing disconnected CastingPlayer: %s "
+                            "with reference count: %lu",
+                            player->GetDeviceName(), player.use_count());
             it = castingPlayers.erase(it);
         }
         else

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
@@ -100,13 +100,6 @@ private:
     void ClearDisconnectedCastingPlayersInternal();
 
     /**
-     * @brief Clear CastingPlayers in the specified vector with ConnectionState == CASTING_PLAYER_NOT_CONNECTED
-     *
-     * @param castingPlayers vector of CastingPlayers to clear
-     */
-    void ClearDisconnectedCastingPlayers(std::vector<std::shared_ptr<CastingPlayer>> & castingPlayers);
-
-    /**
      * @brief Clear all CastingPlayers in mCastingPlayersInternal
      */
     void ClearCastingPlayersInternal();

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
@@ -52,7 +52,7 @@ public:
     virtual void HandleOnUpdated(memory::Strong<CastingPlayer> players) = 0;
     // virtual void HandleOnRemoved(memory::Strong<CastingPlayer> players) = 0;
 };
-
+class CastingPlayer; // Forward declaration of the CastingPlayer class
 class CastingPlayerDiscovery;
 
 /**
@@ -79,6 +79,10 @@ class CastingPlayerDiscovery
 
 private:
     std::vector<memory::Strong<CastingPlayer>> mCastingPlayers;
+    // This vector is used to store CastingPlayers that we might want to connect to. This ensures
+    // that CastingPlayers are not deleted prior to calling verify VerifyOrEstablishConnection() on
+    // the CastingPlayer we want to connect to.
+    std::vector<memory::Strong<CastingPlayer>> mCastingPlayersInternal;
     DeviceDiscoveryDelegateImpl mDelegate;
 
     CastingPlayerDiscovery();
@@ -90,8 +94,29 @@ private:
     chip::Controller::CommissionableNodeController mCommissionableNodeController;
     CastingPlayerDiscoveryState mState = DISCOVERY_NOT_READY;
 
+    /**
+     * @brief Clear CastingPlayers in mCastingPlayersInternal with ConnectionState == CASTING_PLAYER_NOT_CONNECTED
+     */
+    void ClearDisconnectedCastingPlayersInternal();
+
+    /**
+     * @brief Clear CastingPlayers in the specified vector with ConnectionState == CASTING_PLAYER_NOT_CONNECTED
+     *
+     * @param castingPlayers vector of CastingPlayers to clear
+     */
+    void ClearDisconnectedCastingPlayers(std::vector<std::shared_ptr<CastingPlayer>>& castingPlayers);
+
+    /**
+     * @brief Clear all CastingPlayers in mCastingPlayersInternal
+     */
+    void ClearCastingPlayersInternal();
+
 public:
     static CastingPlayerDiscovery * GetInstance();
+    ~CastingPlayerDiscovery() {
+        mCastingPlayers.clear();
+        mCastingPlayersInternal.clear();
+    }
 
     /**
      * @brief Starts the discovery for CastingPlayers
@@ -126,6 +151,7 @@ public:
     std::vector<memory::Strong<CastingPlayer>> GetCastingPlayers() { return mCastingPlayers; }
 
     friend class DeviceDiscoveryDelegateImpl;
+    friend class CastingPlayer;
 };
 
 }; // namespace core

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
@@ -104,7 +104,7 @@ private:
      *
      * @param castingPlayers vector of CastingPlayers to clear
      */
-    void ClearDisconnectedCastingPlayers(std::vector<std::shared_ptr<CastingPlayer>>& castingPlayers);
+    void ClearDisconnectedCastingPlayers(std::vector<std::shared_ptr<CastingPlayer>> & castingPlayers);
 
     /**
      * @brief Clear all CastingPlayers in mCastingPlayersInternal
@@ -113,7 +113,8 @@ private:
 
 public:
     static CastingPlayerDiscovery * GetInstance();
-    ~CastingPlayerDiscovery() {
+    ~CastingPlayerDiscovery()
+    {
         mCastingPlayers.clear();
         mCastingPlayersInternal.clear();
     }

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -40,7 +40,8 @@ CastingStore * CastingStore::GetInstance()
 
 CHIP_ERROR CastingStore::AddOrUpdate(core::CastingPlayer castingPlayer)
 {
-    ChipLogProgress(AppServer, "CastingStore::AddOrUpdate() called with CastingPlayer deviceName: %s", castingPlayer.GetDeviceName());
+    ChipLogProgress(AppServer, "CastingStore::AddOrUpdate() called with CastingPlayer deviceName: %s",
+                    castingPlayer.GetDeviceName());
 
     // Read cache of CastingPlayers
     std::vector<core::CastingPlayer> castingPlayers = ReadAll();
@@ -445,7 +446,8 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
     VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
-    ChipLogProgress(AppServer, "CastingStore::ReadAll() CastingPlayers size: %lu", static_cast<unsigned long>(castingPlayers.size()));
+    ChipLogProgress(AppServer, "CastingStore::ReadAll() CastingPlayers size: %lu",
+                    static_cast<unsigned long>(castingPlayers.size()));
     return castingPlayers;
 }
 

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -40,7 +40,7 @@ CastingStore * CastingStore::GetInstance()
 
 CHIP_ERROR CastingStore::AddOrUpdate(core::CastingPlayer castingPlayer)
 {
-    ChipLogProgress(AppServer, "CastingStore::AddOrUpdate");
+    ChipLogProgress(AppServer, "CastingStore::AddOrUpdate() called with CastingPlayer deviceName: %s", castingPlayer.GetDeviceName());
 
     // Read cache of CastingPlayers
     std::vector<core::CastingPlayer> castingPlayers = ReadAll();
@@ -56,20 +56,20 @@ CHIP_ERROR CastingStore::AddOrUpdate(core::CastingPlayer castingPlayer)
         {
             unsigned index        = (unsigned int) std::distance(castingPlayers.begin(), it);
             castingPlayers[index] = castingPlayer;
-            ChipLogProgress(AppServer, "CastingStore::AddOrUpdate updating CastingPlayer in CastingStore cache");
+            ChipLogProgress(AppServer, "CastingStore::AddOrUpdate() updating CastingPlayer in CastingStore cache");
             return WriteAll(castingPlayers); // return early
         }
     }
 
     // add *new* castingPlayer to CastingStore cache
     castingPlayers.push_back(castingPlayer);
-    ChipLogProgress(AppServer, "CastingStore::AddOrUpdate adding new CastingPlayer in CastingStore cache");
+    ChipLogProgress(AppServer, "CastingStore::AddOrUpdate() adding new CastingPlayer in CastingStore cache");
     return WriteAll(castingPlayers);
 }
 
 std::vector<core::CastingPlayer> CastingStore::ReadAll()
 {
-    ChipLogProgress(AppServer, "CastingStore::ReadAll called");
+    ChipLogProgress(AppServer, "CastingStore::ReadAll() called");
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     std::vector<core::CastingPlayer> castingPlayers;
@@ -79,7 +79,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
                                                                       kCastingStoreDataMaxBytes, &castingStoreDataSize);
     VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
                         ChipLogError(AppServer, "KeyValueStoreMgr.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
-    ChipLogProgress(AppServer, "CastingStore::ReadAll Read TLV(CastingStoreData) from KVS store with size: %lu bytes",
+    ChipLogProgress(AppServer, "CastingStore::ReadAll() Read TLV(CastingStoreData) from KVS store with size: %lu bytes",
                     static_cast<unsigned long>(castingStoreDataSize));
 
     chip::TLV::TLVReader reader;
@@ -106,7 +106,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
     err = reader.Get(version);
     VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.Get failed %" CHIP_ERROR_FORMAT, err.Format()));
-    ChipLogProgress(AppServer, "CastingStore::ReadAll TLV(CastingStoreData) version: %d", version);
+    ChipLogProgress(AppServer, "CastingStore::ReadAll() TLV(CastingStoreData) version: %d", version);
 
     // Entering CastingPlayers container
     err = reader.Next();
@@ -445,7 +445,7 @@ std::vector<core::CastingPlayer> CastingStore::ReadAll()
     VerifyOrReturnValue(err == CHIP_NO_ERROR, std::vector<core::CastingPlayer>(),
                         ChipLogError(AppServer, "TLVReader.ExitContainer failed %" CHIP_ERROR_FORMAT, err.Format()));
 
-    ChipLogProgress(AppServer, "CastingStore::ReadAll CastingPlayers size: %lu", static_cast<unsigned long>(castingPlayers.size()));
+    ChipLogProgress(AppServer, "CastingStore::ReadAll() CastingPlayers size: %lu", static_cast<unsigned long>(castingPlayers.size()));
     return castingPlayers;
 }
 

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -35,7 +35,7 @@ bool ChipDeviceEventHandler::sUdcInProgress = false;
 
 void ChipDeviceEventHandler::Handle(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
-    ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle called");
+    ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle() called");
 
     bool runPostCommissioning           = false;
     chip::NodeId targetNodeId           = 0;
@@ -65,16 +65,17 @@ void ChipDeviceEventHandler::Handle(const chip::DeviceLayer::ChipDeviceEvent * e
         CastingPlayer::GetTargetCastingPlayer()->FindOrEstablishSession(
             nullptr,
             [](void * context, chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle) {
-                ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle: Connection to CastingPlayer successful");
+                ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle() Connection to CastingPlayer successful");
                 CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_CONNECTED;
 
                 // this async call will Load all the endpoints with their respective attributes into the TargetCastingPlayer
                 // persist the TargetCastingPlayer information into the CastingStore and call mOnCompleted()
                 EndpointListLoader::GetInstance()->Initialize(&exchangeMgr, &sessionHandle);
+                ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle() calling EndpointListLoader::GetInstance()->Load()");
                 EndpointListLoader::GetInstance()->Load();
             },
             [](void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error) {
-                ChipLogError(AppServer, "ChipDeviceEventHandler::Handle: Connection to CastingPlayer failed");
+                ChipLogError(AppServer, "ChipDeviceEventHandler::Handle(): Connection to CastingPlayer failed");
                 CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
                 CHIP_ERROR err = support::CastingStore::GetInstance()->Delete(*CastingPlayer::GetTargetCastingPlayer());
                 if (err != CHIP_NO_ERROR)
@@ -84,7 +85,7 @@ void ChipDeviceEventHandler::Handle(const chip::DeviceLayer::ChipDeviceEvent * e
 
                 VerifyOrReturn(CastingPlayer::GetTargetCastingPlayer()->mOnCompleted);
                 CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(error, nullptr);
-                CastingPlayer::mTargetCastingPlayer = nullptr;
+                CastingPlayer::mTargetCastingPlayer.reset();
             });
     }
 }
@@ -100,7 +101,7 @@ void ChipDeviceEventHandler::HandleFailSafeTimerExpired()
         CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
         CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(CHIP_ERROR_TIMEOUT, nullptr);
         CastingPlayer::GetTargetCastingPlayer()->mOnCompleted         = nullptr;
-        CastingPlayer::GetTargetCastingPlayer()->mTargetCastingPlayer = nullptr;
+        CastingPlayer::GetTargetCastingPlayer()->mTargetCastingPlayer.reset();
         return;
     }
 

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -100,7 +100,7 @@ void ChipDeviceEventHandler::HandleFailSafeTimerExpired()
         sUdcInProgress                                            = false;
         CastingPlayer::GetTargetCastingPlayer()->mConnectionState = CASTING_PLAYER_NOT_CONNECTED;
         CastingPlayer::GetTargetCastingPlayer()->mOnCompleted(CHIP_ERROR_TIMEOUT, nullptr);
-        CastingPlayer::GetTargetCastingPlayer()->mOnCompleted         = nullptr;
+        CastingPlayer::GetTargetCastingPlayer()->mOnCompleted = nullptr;
         CastingPlayer::GetTargetCastingPlayer()->mTargetCastingPlayer.reset();
         return;
     }


### PR DESCRIPTION
Updated the common Linux implementation of CastingPlayerDiscovery.h/cpp and CastingPlayer.h/cpp to better manage the lifecycle of CastingPlayers. The stopDiscovery() API can now be called anytime. 

**Change Details** 

1.	Updated CastingPlayerDiscovery.h/cpp to store CastingPlayers in an internal vector to ensure that the CastingPlayer we are trying to connect to is not deleted when switching fragments and prior to calling VerifyOrEstablishConnection().
2.	Updated CastingPlayer.h/cpp  to store static memory::Weak<CastingPlayer> mTargetCastingPlayerWeak; // This is a std::weak_ptr. 
3.	Updated DiscoveryExampleFragment public void onPause() to call stopDiscovery();. This was previously deleting all the CastingPlayers held by CastingPlayerDiscovery.h/cpp std::vector<memory::Strong<CastingPlayer>> mCastingPlayers;
4.	Updated connectedhomeip/examples/tv-casting-app/android/App/app/src/main/res/layout/custom_passcode_dialog.xml so that the dialog text instructions can be visible in both dark and light mode. The text was previously white making it invisible in light mode. 

**Testing**

Verified and tested locally with the Linux, Android and iOS tv-casting-app example mobile apps, and the Linux tv-app (CastingPlayer). Able to build and commission with the example apps using both the commissionee and commissioner generated passcode flows.


