### PR TITLE
[OSS-FUZZ] Fix for OSS-Fuzz build failure: using same stdlib for compiling and linking

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -489,6 +489,7 @@ config("libfuzzer_fuzzing") {
 
 config("oss_fuzz") {
   cflags = string_split(getenv("CFLAGS"))
+  cflags_cc = string_split(getenv("CXXFLAGS"))
   ldflags = string_split(getenv("CXXFLAGS"))
   ldflags += [ getenv("LIB_FUZZING_ENGINE") ]
 }


### PR DESCRIPTION
- This fixes OSS-Fuzz failure that appeared after PR #34639 
  - the log: https://oss-fuzz-build-logs.storage.googleapis.com/log-4cb3cb61-efea-49a6-90ec-646e58c9cf59.txt
- Before this current PR, our GN build passed the OSS-Fuzz-provided `CXXFLAGS` env variable to the linking but not to the compilation phase.
- the `$CXXFLAGS` env variable adds `-stdlib=libc++` and not having that same flag during compilation results in linking failures, due to compatibility issues between libc++ and the default stdlib (`stdlibc++`) used for compilation.
- This only showed up recently because previous fuzzers did not use `std::string`  and only used simple std functions.

#### Testing
Tested on OSS-Fuzz Image locally using libfuzzer and centipede engines with address and memory sanitizers.
