### PR TITLE
Add unit test for IPAddress::FromString method

### DIFF
--- a/src/transport/raw/tests/TestPeerAddress.cpp
+++ b/src/transport/raw/tests/TestPeerAddress.cpp
@@ -101,4 +101,12 @@ TEST(TestPeerAddress, TestToString)
     }
 }
 
+TEST(TestPeerAddress, TestFromString)
+{
+    chip::Inet::IPAddress ipAddress;
+    const char * ipStrBuf = "192.168.1.8";
+    bool result           = chip::Inet::IPAddress::FromString(ipStrBuf, ipAddress);
+    EXPECT_TRUE(result);
+}
+
 } // namespace


### PR DESCRIPTION
QA reported the following error message while testing. I don't see how this is possible... Added a unit test to test if there should be an issue or not.

```
[1722894966.101286][2144:2145] CHIP:DL: Got IP address on interface: wlan0 IP: 192.168.1.8
[1722894966.101388][2144:2145] CHIP:DL: Failed to report IP address - ip address parsing failed
```