### PR TITLE
Tidy up logging dependencies

### DIFF
--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -301,11 +301,9 @@ static_library("support") {
     "${chip_root}/src/inet:inet_config_header",
   ]
 
-  # Android has no 'platform' that provides logging
-  if (current_os == "android") {
-    public_deps += [ "${chip_root}/src/platform/android:logging" ]
-  }
-
+  # Platforms that utilize CHIP_SYSTEM_CONFIG_PLATFORM_LOG need to
+  # be pulled in here as public_deps since they hook into logging at
+  # the macro level rather than just providing a LogV implementation.
   if (current_os == "mac" || current_os == "ios") {
     public_deps += [ "${chip_root}/src/platform/Darwin:logging" ]
   }

--- a/src/platform/logging/BUILD.gn
+++ b/src/platform/logging/BUILD.gn
@@ -76,10 +76,11 @@ source_set("default") {
       deps += [ ":stdio" ]
     } else if (chip_device_platform == "nuttx") {
       deps += [ "${chip_root}/src/platform/NuttX:logging" ]
+    } else if (chip_device_platform == "android") {
+      deps += [ "${chip_root}/src/platform/android:logging" ]
     } else {
-      assert(
-          chip_device_platform == "fake" || chip_device_platform == "android" ||
-          chip_device_platform == "external" || chip_device_platform == "none")
+      assert(chip_device_platform == "fake" ||
+             chip_device_platform == "external" || chip_device_platform == "none")
     }
   }
 }

--- a/src/platform/logging/BUILD.gn
+++ b/src/platform/logging/BUILD.gn
@@ -88,11 +88,6 @@ source_set("headers") {
   public = [ "LogV.h" ]
 }
 
-# We need to reference the output file of ":stdio" at build time,
-# but get_target_outputs() does not work for binary targets. As a
-# workaround, define a reasonable path and make the target use it.
-stdio_archive = "$root_out_dir/liblogging-stdio.a"
-
 source_set("stdio") {
   sources = [ "impl/stdio/Logging.cpp" ]
 
@@ -104,10 +99,4 @@ source_set("stdio") {
     "${chip_root}/src/platform:platform_config_header",
     "${chip_root}/src/platform/logging:headers",
   ]
-
-  # Ensure we end up with the expected output file name
-  output_dir = get_path_info(stdio_archive, "dir")
-  output_name = get_path_info(stdio_archive, "name")
-  output_extension = get_path_info(stdio_archive, "extension")
-  output_prefix_override = true
 }


### PR DESCRIPTION
- Remove workarounds for stdio logging target (no longer needed as of #32119)
- Pull in android logging in the standard way and add a comment regarding Darwin
