### PR TITLE
[Darwin] MTRDevice subscription estalished handler should change state before async

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1193,7 +1193,7 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 {
     os_unfair_lock_lock(&self->_lock);
 
-    // If subscription had reset since this handler was scheduled, do not ececute "established" logic below
+    // If subscription had reset since this handler was scheduled, do not execute "established" logic below
     if (!HaveSubscriptionEstablishedRightNow(_internalDeviceState)) {
         MTR_LOG("%@ _handleSubscriptionEstablished run with internal state %lu - skipping subscription establishment logic", self, static_cast<unsigned long>(_internalDeviceState));
         return;

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1193,22 +1193,19 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 {
     os_unfair_lock_lock(&self->_lock);
 
+    // If subscription had reset since this handler was scheduled, do not ececute "established" logic below
+    if (!HaveSubscriptionEstablishedRightNow(_internalDeviceState)) {
+        MTR_LOG("%@ _handleSubscriptionEstablished run with internal state %lu - skipping subscription establishment logic", self, static_cast<unsigned long>(_internalDeviceState));
+        return;
+    }
+
     // We have completed the subscription work - remove from the subscription pool.
     [self _clearSubscriptionPoolWork];
 
-    // reset subscription attempt wait time when subscription succeeds
-    _lastSubscriptionAttemptWait = 0;
-    if (HadSubscriptionEstablishedOnce(_internalDeviceState)) {
-        [self _changeInternalState:MTRInternalDeviceStateLaterSubscriptionEstablished];
-    } else {
-        MATTER_LOG_METRIC_END(kMetricMTRDeviceInitialSubscriptionSetup, CHIP_NO_ERROR);
-        [self _changeInternalState:MTRInternalDeviceStateInitialSubscriptionEstablished];
-    }
-
-    [self _changeState:MTRDeviceStateReachable];
-
     // No need to monitor connectivity after subscription establishment
     [self _stopConnectivityMonitoring];
+
+    _lastSubscriptionAttemptWait = 0;
 
     auto initialSubscribeStart = _initialSubscribeStart;
     // We no longer need to track subscribe latency for this device.
@@ -2476,6 +2473,21 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
                                },
                                ^(void) {
                                    MTR_LOG("%@ got subscription established", self);
+                                   std::lock_guard lock(self->_lock);
+
+                                   // First synchronously change state
+
+                                   // reset subscription attempt wait time when subscription succeeds
+                                   if (HadSubscriptionEstablishedOnce(self->_internalDeviceState)) {
+                                       [self _changeInternalState:MTRInternalDeviceStateLaterSubscriptionEstablished];
+                                   } else {
+                                       MATTER_LOG_METRIC_END(kMetricMTRDeviceInitialSubscriptionSetup, CHIP_NO_ERROR);
+                                       [self _changeInternalState:MTRInternalDeviceStateInitialSubscriptionEstablished];
+                                   }
+
+                                   [self _changeState:MTRDeviceStateReachable];
+
+                                   // Then async work that shouldn't be performed on the matter queue
                                    dispatch_async(self.queue, ^{
                                        // OnSubscriptionEstablished
                                        [self _handleSubscriptionEstablished];

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1205,6 +1205,7 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
     // No need to monitor connectivity after subscription establishment
     [self _stopConnectivityMonitoring];
 
+    // reset subscription attempt wait time when subscription succeeds
     _lastSubscriptionAttemptWait = 0;
 
     auto initialSubscribeStart = _initialSubscribeStart;
@@ -2476,8 +2477,6 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
                                    std::lock_guard lock(self->_lock);
 
                                    // First synchronously change state
-
-                                   // reset subscription attempt wait time when subscription succeeds
                                    if (HadSubscriptionEstablishedOnce(self->_internalDeviceState)) {
                                        [self _changeInternalState:MTRInternalDeviceStateLaterSubscriptionEstablished];
                                    } else {


### PR DESCRIPTION
The `-[MTRPerControllerStorageTests testMTRDeviceResetSubscription]` test in Darwin tests has been flaky, due to the new subscription reset mechanism introducing a race between read client callback and MTRDevice internal state changes.

This patch fixes the specific unit test failure. For the general cases, I've filed: https://github.com/project-chip/connectedhomeip/issues/34796