### PR TITLE
Adding CIFuzz to Actions

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -17,6 +17,7 @@ jobs:
       with:
         oss-fuzz-project-name: 'connectedhomeip'
         language: c++
+        dry-run: true
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
@@ -24,6 +25,7 @@ jobs:
         language: c++
         fuzz-seconds: 300
         output-sarif: true
+        dry-run: true
     - name: Upload Crash
       uses: actions/upload-artifact@v3
       if: failure() && steps.build.outcome == 'success'

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,39 @@
+name: CIFuzz
+on:
+  pull_request:
+    paths:
+      - '**.cpp'
+      - '**.h'
+permissions: {}
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'connectedhomeip'
+        language: c++
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'connectedhomeip'
+        language: c++
+        fuzz-seconds: 300
+        output-sarif: true
+    - name: Upload Crash
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts   
+    - name: Upload Sarif
+      if: always() && steps.build.outcome == 'success'
+      uses: github/codeql-action/upload-sarif@v2
+      with:
+        # Path to SARIF file relative to the root of the repository
+        sarif_file: cifuzz-sarif/results.sarif
+        checkout_path: cifuzz-sarif


### PR DESCRIPTION
- This PR adds a GitHub workflow to build and run Fuzzers on PRs.

- This workflow (CIFuzz) is based on OSS-Fuzz; it uses the same docker image for connectedhomeip, with same exact toolchain.

- I have currently set `dry-run` to True so it does not report failures if build crashes

- Time of running the fuzzer is configurable: `fuzz-seconds`

more info here: https://google.github.io/oss-fuzz/getting-started/continuous-integration/