### PR TITLE
[ESP32] Fix compiling temperature measurement app when built with BT …

### DIFF
--- a/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/temperature-measurement-app/esp32/main/DeviceCallbacks.cpp
@@ -23,6 +23,7 @@
  *
  **/
 #include "DeviceCallbacks.h"
+#include <esp_log.h>
 
 static const char TAG[] = "echo-devicecallbacks";
 


### PR DESCRIPTION
…disabled

Somehow `esp_log.h` is pulled in when BT is enabled, so need to include that header file when BT is disabled.