### PR TITLE
ModeSelect: Add setter API for SupportedModesManager.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/static-supported-modes-manager.h
+++ b/examples/all-clusters-app/all-clusters-common/include/static-supported-modes-manager.h
@@ -31,7 +31,7 @@ namespace ModeSelect {
  * This implementation statically defines the options.
  */
 
-class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::SupportedModesManager
+class StaticSupportedModesManager : public SupportedModesManager
 {
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
     using storage_value_type   = const ModeOptionStructType;
@@ -52,8 +52,6 @@ class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::Supp
     static const EndpointSpanPair supportedOptionsByEndpoints[MATTER_DM_MODE_SELECT_CLUSTER_SERVER_ENDPOINT_COUNT];
 
 public:
-    static const StaticSupportedModesManager instance;
-
     SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;
 
     Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
@@ -62,11 +60,7 @@ public:
     ~StaticSupportedModesManager(){};
 
     StaticSupportedModesManager() {}
-
-    static inline const StaticSupportedModesManager & getStaticSupportedModesManagerInstance() { return instance; }
 };
-
-const SupportedModesManager * getSupportedModesManager();
 
 } // namespace ModeSelect
 } // namespace Clusters

--- a/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
@@ -39,8 +39,6 @@ const StaticSupportedModesManager::EndpointSpanPair
         EndpointSpanPair(1, Span<storage_value_type>(StaticSupportedModesManager::coffeeOptions)) // Options for Endpoint 1
     };
 
-const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
-
 SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeOptionsProvider(EndpointId endpointId) const
 {
     for (auto & endpointSpanPair : supportedOptionsByEndpoints)
@@ -75,9 +73,4 @@ Status StaticSupportedModesManager::getModeOptionByMode(unsigned short endpointI
     }
     ChipLogProgress(Zcl, "Cannot find the mode %u", mode);
     return Status::InvalidCommand;
-}
-
-const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()
-{
-    return &StaticSupportedModesManager::instance;
 }

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -47,6 +47,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <static-supported-modes-manager.h>
 #include <static-supported-temperature-levels.h>
 #include <support/CHIPMem.h>
 #if CONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER
@@ -77,6 +78,7 @@ app::Clusters::NetworkCommissioning::Instance
                                       &(NetworkCommissioning::AmebaWiFiDriver::GetInstance()));
 
 app::Clusters::TemperatureControl::AppSupportedTemperatureLevelsDelegate sAppSupportedTemperatureLevelsDelegate;
+Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 } // namespace
 
 void NetWorkCommissioningInstInit()
@@ -181,6 +183,7 @@ static void InitServer(intptr_t context)
     InitManualOperation();
 #endif
     app::Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
+    Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
     MatterMicrowaveOvenServerInit();
 #if CONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER
     static SmokeCOTestEventTriggerHandler sSmokeCOTestEventTriggerHandler;

--- a/examples/all-clusters-app/asr/src/AppTask.cpp
+++ b/examples/all-clusters-app/asr/src/AppTask.cpp
@@ -42,6 +42,7 @@
 #include <protocols/interaction_model/StatusCode.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
+#include <static-supported-modes-manager.h>
 #include <static-supported-temperature-levels.h>
 
 using chip::Protocols::InteractionModel::Status;
@@ -66,6 +67,7 @@ app::Clusters::NetworkCommissioning::Instance
     sWiFiNetworkCommissioningInstance(kNetworkCommissioningEndpointMain /* Endpoint Id */,
                                       &(NetworkCommissioning::ASRWiFiDriver::GetInstance()));
 app::Clusters::TemperatureControl::AppSupportedTemperatureLevelsDelegate sAppSupportedTemperatureLevelsDelegate;
+app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 } // namespace
 
 AppTask AppTask::sAppTask;
@@ -131,6 +133,7 @@ CHIP_ERROR AppTask::Init()
 #endif /* CONFIG_NETWORK_LAYER_BLE */
 
     app::Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
+    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 
     return CHIP_NO_ERROR;
 }

--- a/examples/all-clusters-app/cc13x4_26x4/main/AppTask.cpp
+++ b/examples/all-clusters-app/cc13x4_26x4/main/AppTask.cpp
@@ -49,6 +49,7 @@
 #include <app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerHandler.h>
 #include <src/platform/cc13xx_26xx/DefaultTestEventTriggerDelegate.h>
 
+#include <static-supported-modes-manager.h>
 #include <ti/drivers/apps/Button.h>
 #include <ti/drivers/apps/LED.h>
 
@@ -73,6 +74,7 @@ static Button_Handle sAppRightHandle;
 static DeviceInfoProviderImpl sExampleDeviceInfoProvider;
 
 AppTask AppTask::sAppTask;
+app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 
 constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 
@@ -334,6 +336,7 @@ int AppTask::Init()
     // QR code will be used with CHIP Tool
     PrintOnboardingCodes(RendezvousInformationFlags(RendezvousInformationFlag::kBLE));
 
+    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
     return 0;
 }
 

--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -34,7 +34,6 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/ota"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/common"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/shell_extension"
-                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/mode-support"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/icd/server"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/src/app/util"
@@ -106,8 +105,6 @@ set(SRC_DIRS_LIST
 )
 
 
-set(EXCLUDE_SRCS "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp")
-
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build
 set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
@@ -137,8 +134,7 @@ if (CONFIG_ENABLE_ICD_SERVER)
 endif()
 
 idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}
-                       SRC_DIRS ${SRC_DIRS_LIST}
-                       EXCLUDE_SRCS ${EXCLUDE_SRCS})
+                       SRC_DIRS ${SRC_DIRS_LIST})
 
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -41,8 +41,8 @@
 #include <common/Esp32ThreadInit.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
-#include <examples/platform/esp32/mode-support/static-supported-modes-manager.h>
 #include <platform/ESP32/ESP32Utils.h>
+#include <static-supported-modes-manager.h>
 #include <static-supported-temperature-levels.h>
 
 #if CONFIG_HAVE_DISPLAY
@@ -95,6 +95,7 @@ public:
 AppCallbacks sCallbacks;
 
 app::Clusters::TemperatureControl::AppSupportedTemperatureLevelsDelegate sAppSupportedTemperatureLevelsDelegate;
+app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 
 constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 
@@ -122,15 +123,9 @@ static void InitServer(intptr_t context)
 #if CONFIG_DEVICE_TYPE_M5STACK
     SetupPretendDevices();
 #endif
-    CHIP_ERROR err =
-        app::Clusters::ModeSelect::StaticSupportedModesManager::getStaticSupportedModesManagerInstance().InitEndpointArray(
-            FIXED_ENDPOINT_COUNT);
-    if (err != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "Failed to initialize endpoint array for supported-modes, err:%" CHIP_ERROR_FORMAT, err.Format());
-    }
 
     app::Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
+    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 }
 
 // #include <laundry-washer-controls-server/laundry-washer-controls-server.h>

--- a/examples/all-clusters-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/all-clusters-app/infineon/psoc6/src/AppTask.cpp
@@ -99,7 +99,7 @@ OTAImageProcessorImpl gImageProcessor;
 #endif
 
 chip::app::Clusters::TemperatureControl::AppSupportedTemperatureLevelsDelegate sAppSupportedTemperatureLevelsDelegate;
-app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
+chip::app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 } // namespace
 
 using namespace ::chip;
@@ -143,7 +143,7 @@ static void InitServer(intptr_t context)
     GetAppTask().InitOTARequestor();
 #endif
     chip::app::Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
-    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
+    chip::app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 }
 
 CHIP_ERROR AppTask::StartAppTask()

--- a/examples/all-clusters-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/all-clusters-app/infineon/psoc6/src/AppTask.cpp
@@ -41,6 +41,7 @@
 #include <DeviceInfoProviderImpl.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <platform/Infineon/PSOC6/NetworkCommissioningDriver.h>
+#include <static-supported-modes-manager.h>
 #include <static-supported-temperature-levels.h>
 
 /* OTA related includes */
@@ -98,6 +99,7 @@ OTAImageProcessorImpl gImageProcessor;
 #endif
 
 chip::app::Clusters::TemperatureControl::AppSupportedTemperatureLevelsDelegate sAppSupportedTemperatureLevelsDelegate;
+app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 } // namespace
 
 using namespace ::chip;
@@ -141,6 +143,7 @@ static void InitServer(intptr_t context)
     GetAppTask().InitOTARequestor();
 #endif
     chip::app::Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
+    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 }
 
 CHIP_ERROR AppTask::StartAppTask()

--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -249,7 +249,6 @@ void ApplicationInit()
 #endif
     Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
     Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
-    ;
 
     Clusters::ValveConfigurationAndControl::SetDefaultDelegate(chip::EndpointId(1), &sValveDelegate);
     Clusters::TimeSynchronization::SetDefaultDelegate(&sTimeSyncDelegate);

--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -58,6 +58,7 @@
 #include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/DiagnosticDataProvider.h>
 #include <platform/PlatformManager.h>
+#include <static-supported-modes-manager.h>
 #include <static-supported-temperature-levels.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/SessionManager.h>
@@ -80,6 +81,7 @@ AllClustersCommandDelegate sAllClustersCommandDelegate;
 Clusters::WindowCovering::WindowCoveringManager sWindowCoveringManager;
 
 Clusters::TemperatureControl::AppSupportedTemperatureLevelsDelegate sAppSupportedTemperatureLevelsDelegate;
+Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 Clusters::ValveConfigurationAndControl::ValveControlDelegate sValveDelegate;
 Clusters::TimeSynchronization::ExtendedTimeSyncDelegate sTimeSyncDelegate;
 
@@ -246,6 +248,8 @@ void ApplicationInit()
     MatterDishwasherAlarmServerInit();
 #endif
     Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
+    Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
+    ;
 
     Clusters::ValveConfigurationAndControl::SetDefaultDelegate(chip::EndpointId(1), &sValveDelegate);
     Clusters::TimeSynchronization::SetDefaultDelegate(&sTimeSyncDelegate);

--- a/examples/all-clusters-app/mbed/main/AppTask.cpp
+++ b/examples/all-clusters-app/mbed/main/AppTask.cpp
@@ -25,6 +25,7 @@
 #include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <static-supported-modes-manager.h>
 #include <static-supported-temperature-levels.h>
 
 #include <lib/support/logging/CHIPLogging.h>
@@ -45,7 +46,8 @@ using namespace ::chip::Credentials;
 
 namespace {
 app::Clusters::TemperatureControl::AppSupportedTemperatureLevelsDelegate sAppSupportedTemperatureLevelsDelegate;
-}
+app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
+} // namespace
 
 AppTask AppTask::sAppTask;
 
@@ -90,6 +92,7 @@ int AppTask::Init()
         return EXIT_FAILURE;
     }
     app::Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
+    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
     return 0;
 }
 

--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -35,6 +35,7 @@
 
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <static-supported-modes-manager.h>
 #include <static-supported-temperature-levels.h>
 
 #ifdef CONFIG_CHIP_WIFI
@@ -95,6 +96,7 @@ bool sIsNetworkEnabled     = false;
 bool sHaveBLEConnections   = false;
 
 app::Clusters::TemperatureControl::AppSupportedTemperatureLevelsDelegate sAppSupportedTemperatureLevelsDelegate;
+app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 
 #ifdef CONFIG_CHIP_CRYPTO_PSA
 chip::Crypto::PSAOperationalKeystore sPSAOperationalKeystore{};
@@ -257,6 +259,7 @@ CHIP_ERROR AppTask::Init()
     }
 
     app::Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
+    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
     return err;
 }
 

--- a/examples/all-clusters-app/nxp/mw320/main.cpp
+++ b/examples/all-clusters-app/nxp/mw320/main.cpp
@@ -41,6 +41,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <static-supported-modes-manager.h>
 #include <static-supported-temperature-levels.h>
 
 #include <app/InteractionModelEngine.h>
@@ -121,6 +122,7 @@ static struct wlan_network sta_network;
 static struct wlan_network uap_network;
 
 chip::app::Clusters::TemperatureControl::AppSupportedTemperatureLevelsDelegate sAppSupportedTemperatureLevelsDelegate;
+chip::app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 
 const int TASK_MAIN_PRIO         = OS_PRIO_3;
 const int TASK_MAIN_STACK_SIZE   = 800;
@@ -1083,6 +1085,7 @@ static void run_chip_srv(System::Layer * aSystemLayer, void * aAppState)
     // binding --
 
     chip::app::Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
+    chip::app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 
     return;
 }

--- a/examples/all-clusters-app/telink/src/AppTask.cpp
+++ b/examples/all-clusters-app/telink/src/AppTask.cpp
@@ -18,10 +18,12 @@
 
 #include "AppTask.h"
 #include "binding-handler.h"
+#include <static-supported-modes-manager.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
 AppTask AppTask::sAppTask;
+chip::app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 
 CHIP_ERROR AppTask::Init(void)
 {
@@ -35,5 +37,6 @@ CHIP_ERROR AppTask::Init(void)
         return err;
     }
 
+    chip::app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
     return CHIP_NO_ERROR;
 }

--- a/examples/all-clusters-app/tizen/src/main.cpp
+++ b/examples/all-clusters-app/tizen/src/main.cpp
@@ -22,6 +22,7 @@
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/util/endpoint-config-api.h>
 #include <platform/Tizen/NetworkCommissioningDriver.h>
+#include <static-supported-modes-manager.h>
 #include <static-supported-temperature-levels.h>
 
 #include <TizenServiceAppMain.h>
@@ -40,6 +41,7 @@ NetworkCommissioning::TizenEthernetDriver sEthernetDriver;
 Clusters::NetworkCommissioning::Instance sEthernetNetworkCommissioningInstance(kNetworkCommissioningEndpointMain, &sEthernetDriver);
 
 app::Clusters::TemperatureControl::AppSupportedTemperatureLevelsDelegate sAppSupportedTemperatureLevelsDelegate;
+Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 } // namespace
 
 void ApplicationInit()
@@ -49,6 +51,7 @@ void ApplicationInit()
 
     sEthernetNetworkCommissioningInstance.Init();
     app::Clusters::TemperatureControl::SetInstance(&sAppSupportedTemperatureLevelsDelegate);
+    Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 }
 
 void ApplicationShutdown() {}

--- a/examples/all-clusters-minimal-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-minimal-app/ameba/main/chipinterface.cpp
@@ -37,6 +37,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <static-supported-modes-manager.h>
 #include <support/CHIPMem.h>
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
@@ -64,6 +65,7 @@ namespace { // Network Commissioning
 constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
 constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 
+Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 app::Clusters::NetworkCommissioning::Instance
     sWiFiNetworkCommissioningInstance(kNetworkCommissioningEndpointMain /* Endpoint Id */,
                                       &(NetworkCommissioning::AmebaWiFiDriver::GetInstance()));
@@ -170,6 +172,7 @@ static void InitServer(intptr_t context)
         // QR code will be used with CHIP Tool
         PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
     }
+    Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 }
 
 extern "C" void ChipTest(void)

--- a/examples/all-clusters-minimal-app/asr/src/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/asr/src/AppTask.cpp
@@ -42,6 +42,7 @@
 #include <queue.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
+#include <static-supported-modes-manager.h>
 
 #include "init_Matter.h"
 #include "lega_rtos_api.h"
@@ -60,6 +61,7 @@ QueueHandle_t sAppEventQueue;
 constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
 constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 
+app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 app::Clusters::NetworkCommissioning::Instance
     sWiFiNetworkCommissioningInstance(kNetworkCommissioningEndpointMain /* Endpoint Id */,
                                       &(NetworkCommissioning::ASRWiFiDriver::GetInstance()));
@@ -120,6 +122,7 @@ CHIP_ERROR AppTask::Init()
 
     sLightLED.Init(LIGHT_LED);
 
+    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
     return CHIP_NO_ERROR;
 }
 

--- a/examples/all-clusters-minimal-app/esp32/main/main.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/main.cpp
@@ -43,6 +43,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <platform/ESP32/ESP32Utils.h>
+#include <static-supported-modes-manager.h>
 
 #if CONFIG_HAVE_DISPLAY
 #include "DeviceWithDisplay.h"
@@ -74,6 +75,7 @@ extern const char TAG[] = "all-clusters-minimal-app";
 
 static AppDeviceCallbacks EchoCallbacks;
 static AppDeviceCallbacksDelegate sAppDeviceCallbacksDelegate;
+app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 namespace {
 
 class AppCallbacks : public AppDelegate
@@ -116,6 +118,7 @@ static void InitServer(intptr_t context)
 #if CONFIG_DEVICE_TYPE_M5STACK
     SetupPretendDevices();
 #endif
+    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 }
 
 extern "C" void app_main()

--- a/examples/all-clusters-minimal-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/infineon/psoc6/src/AppTask.cpp
@@ -41,6 +41,7 @@
 #include <DeviceInfoProviderImpl.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <platform/Infineon/PSOC6/NetworkCommissioningDriver.h>
+#include <static-supported-modes-manager.h>
 
 /* OTA related includes */
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
@@ -87,6 +88,7 @@ StaticQueue_t sAppEventQueueStruct;
 
 StackType_t appStack[APP_TASK_STACK_SIZE / sizeof(StackType_t)];
 StaticTask_t appTaskStruct;
+app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
 DefaultOTARequestor gRequestorCore;
@@ -138,6 +140,7 @@ static void InitServer(intptr_t context)
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
     GetAppTask().InitOTARequestor();
 #endif
+    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 }
 
 CHIP_ERROR AppTask::StartAppTask()

--- a/examples/all-clusters-minimal-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/infineon/psoc6/src/AppTask.cpp
@@ -88,7 +88,7 @@ StaticQueue_t sAppEventQueueStruct;
 
 StackType_t appStack[APP_TASK_STACK_SIZE / sizeof(StackType_t)];
 StaticTask_t appTaskStruct;
-app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
+chip::app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
 DefaultOTARequestor gRequestorCore;
@@ -140,7 +140,7 @@ static void InitServer(intptr_t context)
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
     GetAppTask().InitOTARequestor();
 #endif
-    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
+    chip::app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 }
 
 CHIP_ERROR AppTask::StartAppTask()

--- a/examples/all-clusters-minimal-app/linux/main-common.cpp
+++ b/examples/all-clusters-minimal-app/linux/main-common.cpp
@@ -25,6 +25,7 @@
 #include <lib/support/CHIPMem.h>
 #include <new>
 #include <platform/PlatformManager.h>
+#include <static-supported-modes-manager.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/SessionManager.h>
 #include <transport/raw/PeerAddress.h>
@@ -37,6 +38,7 @@ using namespace chip::DeviceLayer;
 
 namespace {
 static LowPowerManager lowPowerManager;
+Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 } // namespace
 
 void OnIdentifyStart(::Identify *)
@@ -81,7 +83,10 @@ static Identify gIdentify1 = {
     OnTriggerEffect,
 };
 
-void ApplicationInit() {}
+void ApplicationInit()
+{
+    Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
+}
 
 void ApplicationShutdown() {}
 

--- a/examples/all-clusters-minimal-app/mbed/main/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/mbed/main/AppTask.cpp
@@ -27,6 +27,7 @@
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
 #include <lib/support/logging/CHIPLogging.h>
+#include <static-supported-modes-manager.h>
 
 static LEDWidget sStatusLED(MBED_CONF_APP_SYSTEM_STATE_LED);
 
@@ -43,6 +44,7 @@ using namespace ::chip::DeviceLayer;
 using namespace ::chip::Credentials;
 
 AppTask AppTask::sAppTask;
+app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 
 int AppTask::Init()
 {
@@ -85,6 +87,7 @@ int AppTask::Init()
         return EXIT_FAILURE;
     }
 
+    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
     return 0;
 }
 

--- a/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
@@ -30,6 +30,7 @@
 
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <static-supported-modes-manager.h>
 
 #if CONFIG_CHIP_OTA_REQUESTOR
 #include "OTAUtil.h"
@@ -63,6 +64,7 @@ static k_timer sFunctionTimer;
 
 LEDWidget sStatusLED;
 FactoryResetLEDsWrapper<3> sFactoryResetLEDs{ { FACTORY_RESET_SIGNAL_LED, FACTORY_RESET_SIGNAL_LED1, FACTORY_RESET_SIGNAL_LED2 } };
+app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 
 bool sIsNetworkProvisioned = false;
 bool sIsNetworkEnabled     = false;
@@ -198,6 +200,7 @@ CHIP_ERROR AppTask::Init()
     {
         LOG_ERR("PlatformMgr().StartEventLoopTask() failed");
     }
+    app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 
     return err;
 }

--- a/examples/all-clusters-minimal-app/telink/src/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/telink/src/AppTask.cpp
@@ -18,10 +18,12 @@
 
 #include "AppTask.h"
 #include "binding-handler.h"
+#include <static-supported-modes-manager.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);
 
 AppTask AppTask::sAppTask;
+chip::app::Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 
 CHIP_ERROR AppTask::Init()
 {
@@ -35,5 +37,6 @@ CHIP_ERROR AppTask::Init()
         return err;
     }
 
+    chip::app::Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
     return CHIP_NO_ERROR;
 }

--- a/examples/all-clusters-minimal-app/tizen/src/main.cpp
+++ b/examples/all-clusters-minimal-app/tizen/src/main.cpp
@@ -22,6 +22,7 @@
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/util/endpoint-config-api.h>
 #include <platform/Tizen/NetworkCommissioningDriver.h>
+#include <static-supported-modes-manager.h>
 
 #include <TizenServiceAppMain.h>
 #include <binding-handler.h>
@@ -36,6 +37,7 @@ constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
 constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 
 NetworkCommissioning::TizenEthernetDriver sEthernetDriver;
+Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 Clusters::NetworkCommissioning::Instance sEthernetNetworkCommissioningInstance(kNetworkCommissioningEndpointMain, &sEthernetDriver);
 } // namespace
 
@@ -45,6 +47,7 @@ void ApplicationInit()
     emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
 
     sEthernetNetworkCommissioningInstance.Init();
+    Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
 }
 
 void ApplicationShutdown(){};

--- a/examples/placeholder/linux/include/static-supported-modes-manager.h
+++ b/examples/placeholder/linux/include/static-supported-modes-manager.h
@@ -31,7 +31,7 @@ namespace ModeSelect {
  * This implementation statically defines the options.
  */
 
-class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::SupportedModesManager
+class StaticSupportedModesManager : public SupportedModesManager
 {
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
     using storage_value_type   = const ModeOptionStructType;
@@ -52,8 +52,6 @@ class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::Supp
     static const EndpointSpanPair supportedOptionsByEndpoints[MATTER_DM_MODE_SELECT_CLUSTER_SERVER_ENDPOINT_COUNT];
 
 public:
-    static const StaticSupportedModesManager instance;
-
     SupportedModesManager::ModeOptionsProvider getModeOptionsProvider(EndpointId endpointId) const override;
 
     Protocols::InteractionModel::Status getModeOptionByMode(EndpointId endpointId, uint8_t mode,
@@ -62,11 +60,7 @@ public:
     ~StaticSupportedModesManager(){};
 
     StaticSupportedModesManager() {}
-
-    static inline const StaticSupportedModesManager & getStaticSupportedModesManagerInstance() { return instance; }
 };
-
-const SupportedModesManager * getSupportedModesManager();
 
 } // namespace ModeSelect
 } // namespace Clusters

--- a/examples/placeholder/linux/static-supported-modes-manager.cpp
+++ b/examples/placeholder/linux/static-supported-modes-manager.cpp
@@ -39,8 +39,6 @@ const StaticSupportedModesManager::EndpointSpanPair
         EndpointSpanPair(1, Span<storage_value_type>(StaticSupportedModesManager::coffeeOptions)) // Options for Endpoint 1
     };
 
-const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
-
 SupportedModesManager::ModeOptionsProvider StaticSupportedModesManager::getModeOptionsProvider(EndpointId endpointId) const
 {
     for (auto & endpointSpanPair : supportedOptionsByEndpoints)
@@ -75,9 +73,4 @@ Status StaticSupportedModesManager::getModeOptionByMode(unsigned short endpointI
     }
     ChipLogProgress(Zcl, "Cannot find the mode %u", mode);
     return Status::InvalidCommand;
-}
-
-const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()
-{
-    return &StaticSupportedModesManager::instance;
 }

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.cpp
@@ -33,8 +33,6 @@ using List = app::DataModel::List<T>;
 
 SupportedModesManager::ModeOptionsProvider * StaticSupportedModesManager::epModeOptionsProviderList = nullptr;
 
-const StaticSupportedModesManager StaticSupportedModesManager::instance = StaticSupportedModesManager();
-
 int StaticSupportedModesManager::mSize = 0;
 
 CHIP_ERROR StaticSupportedModesManager::InitEndpointArray(int size)
@@ -192,11 +190,6 @@ Status StaticSupportedModesManager::getModeOptionByMode(unsigned short endpointI
     }
     ChipLogProgress(Zcl, "Cannot find the mode %u", mode);
     return Status::InvalidCommand;
-}
-
-const ModeSelect::SupportedModesManager * ModeSelect::getSupportedModesManager()
-{
-    return &StaticSupportedModesManager::getStaticSupportedModesManagerInstance();
 }
 
 void StaticSupportedModesManager::FreeSupportedModes(EndpointId endpointId) const

--- a/examples/platform/esp32/mode-support/static-supported-modes-manager.h
+++ b/examples/platform/esp32/mode-support/static-supported-modes-manager.h
@@ -25,7 +25,7 @@ namespace app {
 namespace Clusters {
 namespace ModeSelect {
 
-class StaticSupportedModesManager : public chip::app::Clusters::ModeSelect::SupportedModesManager
+class StaticSupportedModesManager : public SupportedModesManager
 {
 private:
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
@@ -35,8 +35,6 @@ private:
     static ModeOptionsProvider * epModeOptionsProviderList;
 
     void FreeSupportedModes(EndpointId endpointId) const;
-
-    static const StaticSupportedModesManager instance;
 
 public:
     // InitEndpointArray should be called only once in the application. Memory allocated to the
@@ -68,11 +66,7 @@ public:
             FreeSupportedModes(i);
         }
     }
-
-    static inline const StaticSupportedModesManager & getStaticSupportedModesManagerInstance() { return instance; }
 };
-
-const SupportedModesManager * getSupportedModesManager();
 
 } // namespace ModeSelect
 } // namespace Clusters

--- a/examples/shell/cc13x4_26x4/main/AppTask.cpp
+++ b/examples/shell/cc13x4_26x4/main/AppTask.cpp
@@ -41,6 +41,7 @@
 #include <lib/support/CHIPPlatformMemory.h>
 
 #include <app/server/OnboardingCodesUtil.h>
+#include <static-supported-modes-manager.h>
 
 /* syscfg */
 #include <ti_drivers_config.h>
@@ -54,6 +55,7 @@ using namespace ::chip::DeviceLayer;
 using chip::Shell::Engine;
 
 AppTask AppTask::sAppTask;
+Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 
 static TaskHandle_t sAppTaskHandle;
 
@@ -171,6 +173,7 @@ CHIP_ERROR AppTask::Init()
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
     InitializeOTARequestor();
 #endif
+    Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
     return err;
 }
 

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -49,7 +49,7 @@ using BootReasonType = GeneralDiagnostics::BootReasonEnum;
 
 static InteractionModel::Status verifyModeValue(const EndpointId endpointId, const uint8_t newMode);
 
-ModeSelect::SupportedModesManager *sSupportedModesManager = nullptr;
+ModeSelect::SupportedModesManager * sSupportedModesManager = nullptr;
 
 const SupportedModesManager * ModeSelect::getSupportedModesManager()
 {

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -49,7 +49,7 @@ using BootReasonType = GeneralDiagnostics::BootReasonEnum;
 
 static InteractionModel::Status verifyModeValue(const EndpointId endpointId, const uint8_t newMode);
 
-ModeSelect::SupportedModesManager * sSupportedModesManager = nullptr;
+static ModeSelect::SupportedModesManager * sSupportedModesManager = nullptr;
 
 const SupportedModesManager * ModeSelect::getSupportedModesManager()
 {
@@ -82,6 +82,12 @@ CHIP_ERROR ModeSelectAttrAccess::Read(const ConcreteReadAttributePath & aPath, A
 
     if (ModeSelect::Attributes::SupportedModes::Id == aPath.mAttributeId)
     {
+        if (gSupportedModeManager == nullptr)
+        {
+            ChipLogError(Zcl, "ModeSelect: SupportedModesManager is NULL");
+            aEncoder.EncodeEmptyList();
+            return CHIP_NO_ERROR;
+        }
         const ModeSelect::SupportedModesManager::ModeOptionsProvider modeOptionsProvider =
             gSupportedModeManager->getModeOptionsProvider(aPath.mEndpointId);
         if (modeOptionsProvider.begin() == nullptr)
@@ -115,8 +121,14 @@ bool emberAfModeSelectClusterChangeToModeCallback(CommandHandler * commandHandle
     uint8_t newMode       = commandData.newMode;
     // Check that the newMode matches one of the supported options
     const ModeSelect::Structs::ModeOptionStruct::Type * modeOptionPtr;
-    Status checkSupportedModeStatus =
-        ModeSelect::getSupportedModesManager()->getModeOptionByMode(endpointId, newMode, &modeOptionPtr);
+    const ModeSelect::SupportedModesManager * gSupportedModeManager = ModeSelect::getSupportedModesManager();
+    if (gSupportedModeManager == nullptr)
+    {
+        ChipLogError(Zcl, "ModeSelect: SupportedModesManager is NULL");
+        commandHandler->AddStatus(commandPath, Status::Failure);
+        return true;
+    }
+    Status checkSupportedModeStatus = gSupportedModeManager->getModeOptionByMode(endpointId, newMode, &modeOptionPtr);
     if (Status::Success != checkSupportedModeStatus)
     {
         ChipLogProgress(Zcl, "ModeSelect: Failed to find the option with mode %u", newMode);
@@ -276,5 +288,11 @@ static InteractionModel::Status verifyModeValue(const EndpointId endpointId, con
         return InteractionModel::Status::Success;
     }
     const ModeSelect::Structs::ModeOptionStruct::Type * modeOptionPtr;
-    return ModeSelect::getSupportedModesManager()->getModeOptionByMode(endpointId, newMode, &modeOptionPtr);
+    const ModeSelect::SupportedModesManager * gSupportedModeManager = ModeSelect::getSupportedModesManager();
+    if (gSupportedModeManager == nullptr)
+    {
+        ChipLogError(Zcl, "ModeSelect: SupportedModesManager is NULL");
+        return Status::Failure;
+    }
+    return gSupportedModeManager->getModeOptionByMode(endpointId, newMode, &modeOptionPtr);
 }

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -49,6 +49,17 @@ using BootReasonType = GeneralDiagnostics::BootReasonEnum;
 
 static InteractionModel::Status verifyModeValue(const EndpointId endpointId, const uint8_t newMode);
 
+ModeSelect::SupportedModesManager *sSupportedModesManager = nullptr;
+
+const SupportedModesManager * ModeSelect::getSupportedModesManager()
+{
+    return sSupportedModesManager;
+}
+
+void ModeSelect::setSupportedModesManager(ModeSelect::SupportedModesManager * aSupportedModesManager)
+{
+    sSupportedModesManager = aSupportedModesManager;
+}
 namespace {
 
 inline bool areStartUpModeAndCurrentModeNonVolatile(EndpointId endpoint);

--- a/src/app/clusters/mode-select-server/supported-modes-manager.h
+++ b/src/app/clusters/mode-select-server/supported-modes-manager.h
@@ -34,6 +34,7 @@ class SupportedModesManager
 {
 
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
+
 public:
     /**
      * A class that can return the supported ModeOptions for a specific endpoint.
@@ -79,7 +80,6 @@ public:
                                                                     const ModeOptionStructType ** dataPtr) const = 0;
 
     virtual ~SupportedModesManager() {}
-
 };
 
 const SupportedModesManager * getSupportedModesManager();

--- a/src/app/clusters/mode-select-server/supported-modes-manager.h
+++ b/src/app/clusters/mode-select-server/supported-modes-manager.h
@@ -34,7 +34,6 @@ class SupportedModesManager
 {
 
     using ModeOptionStructType = Structs::ModeOptionStruct::Type;
-
 public:
     /**
      * A class that can return the supported ModeOptions for a specific endpoint.
@@ -80,9 +79,12 @@ public:
                                                                     const ModeOptionStructType ** dataPtr) const = 0;
 
     virtual ~SupportedModesManager() {}
+
 };
 
 const SupportedModesManager * getSupportedModesManager();
+
+void setSupportedModesManager(SupportedModesManager * aSupportedModesManager);
 
 } // namespace ModeSelect
 } // namespace Clusters


### PR DESCRIPTION
### Problem
- There should be a setter API for SupportedModesManager so the application can set it to its custom implementation.

### Changes
- Add setter API for SupportedModesManager.
- Use common static implementation for esp32.
- Set SupportedModesManager in the examples.

### Testing
- Tested all cluster app on linux and esp32.