### PR TITLE
adding mandatory endpointComposition data to XML for ZAP to consume

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2210,7 +2210,7 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <endpointComposition>
-            <compositionType fullFamily="false", tree="true"></compositionType>
+            <compositionType fullFamily="false", tree="true"/>
             <endpoint mandatory="true" constraint="min 1">
                     <deviceType>0x0071</deviceType>
             </endpoint>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2209,6 +2209,12 @@ limitations under the License.
         <deviceId editable="false">0x0070</deviceId>
         <class>Simple</class>
         <scope>Endpoint</scope>
+        <endpointComposition>
+            <compositionType>tree</compositionType>
+            <endpoint mandatory="true" constraint="1">
+                    <deviceType>0x0071</deviceType>
+            </endpoint>
+        </endpointComposition>
         <clusters lockOthers="true">
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2210,7 +2210,7 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <endpointComposition>
-            <compositionType fullFamily="false", tree="true"/>
+            <compositionType>tree</compositionType>
             <endpoint mandatory="true" constraint="min 1">
                     <deviceType>0x0071</deviceType>
             </endpoint>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2210,8 +2210,8 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <endpointComposition>
-            <compositionType>tree</compositionType>
-            <endpoint mandatory="true" constraint="1">
+            <compositionType fullFamily="false", tree="true"></compositionType>
+            <endpoint mandatory="true" constraint="min 1">
                     <deviceType>0x0071</deviceType>
             </endpoint>
         </endpointComposition>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2211,7 +2211,7 @@ limitations under the License.
         <scope>Endpoint</scope>
         <endpointComposition>
             <compositionType>tree</compositionType>
-            <endpoint mandatory="true" constraint="min 1">
+            <endpoint conformance="M" constraint="min 1">
                     <deviceType>0x0071</deviceType>
             </endpoint>
         </endpointComposition>


### PR DESCRIPTION
Fixes #32941 Adds mandatory endpointComposition data to XML for ZAP to consume


