### PR TITLE
[Silabs] Use provision storage manager singleton in OTA factory data processor

### DIFF
--- a/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
@@ -22,7 +22,7 @@
 
 namespace chip {
 
-using FactoryProvider = DeviceLayer::Silabs::Provision::Storage;
+using namespace ::chip::DeviceLayer::Silabs;
 
 CHIP_ERROR OTAFactoryDataProcessor::Init()
 {
@@ -146,21 +146,20 @@ CHIP_ERROR OTAFactoryDataProcessor::Update(uint8_t tag, Optional<ByteSpan> & opt
 
 CHIP_ERROR OTAFactoryDataProcessor::UpdateValue(uint8_t tag, ByteSpan & newValue)
 {
-    FactoryProvider factoryProvider;
     switch (tag)
     {
     case (int) FactoryTags::kDacKey:
         ChipLogProgress(SoftwareUpdate, "Set Device Attestation Key");
-        return factoryProvider.FactoryProvider::SetDeviceAttestationKey(newValue);
+        return Provision::Manager::GetInstance().GetStorage().SetDeviceAttestationKey(newValue);
     case (int) FactoryTags::kDacCert:
         ChipLogProgress(SoftwareUpdate, "Set Device Attestation Cert");
-        return factoryProvider.FactoryProvider::SetDeviceAttestationCert(newValue);
+        return Provision::Manager::GetInstance().GetStorage().SetDeviceAttestationCert(newValue);
     case (int) FactoryTags::kPaiCert:
         ChipLogProgress(SoftwareUpdate, "Set Product Attestionation Intermediate Cert");
-        return factoryProvider.FactoryProvider::SetProductAttestationIntermediateCert(newValue);
+        return Provision::Manager::GetInstance().GetStorage().SetProductAttestationIntermediateCert(newValue);
     case (int) FactoryTags::kCdCert:
         ChipLogProgress(SoftwareUpdate, "Set Certification Declaration");
-        return factoryProvider.FactoryProvider::SetCertificationDeclaration(newValue);
+        return Provision::Manager::GetInstance().GetStorage().SetCertificationDeclaration(newValue);
     }
 
     ChipLogError(DeviceLayer, "Failed to find tag %d.", tag);

--- a/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.h
+++ b/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.h
@@ -22,8 +22,8 @@
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/Span.h>
 #include <platform/silabs/multi-ota/OTATlvProcessor.h>
-#include <provision/ProvisionStorage.h>        // nogncheck
-#include <provision/ProvisionStorageGeneric.h> // nogncheck
+#include <ProvisionStorage.h>
+#include <ProvisionManager.h>
 
 namespace chip {
 

--- a/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.h
+++ b/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.h
@@ -18,12 +18,12 @@
 
 #pragma once
 
+#include <ProvisionManager.h>
+#include <ProvisionStorage.h>
 #include <lib/core/Optional.h>
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/Span.h>
 #include <platform/silabs/multi-ota/OTATlvProcessor.h>
-#include <ProvisionStorage.h>
-#include <ProvisionManager.h>
 
 namespace chip {
 


### PR DESCRIPTION
The silabs implementation of OTA factory data processor was instantiating its own Provision Storage class. This PR changes it to using the Provision Manager singleton which can access the Provision Storage class. This fixes a linking issue when enabling the feature. 
