### PR TITLE
[HVAC] Use Globals.Enums.AtomicRequestTypeEnum in TC_TSTAT_4_2

### DIFF
--- a/src/python_testing/TC_TSTAT_4_2.py
+++ b/src/python_testing/TC_TSTAT_4_2.py
@@ -30,6 +30,7 @@ import copy
 import logging
 
 import chip.clusters as Clusters
+from chip.clusters import Globals
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
@@ -65,7 +66,7 @@ class TC_TSTAT_4_2(MatterBaseTest):
                                                      endpoint: int = None,
                                                      expected_status: Status = Status.Success):
         try:
-            await self.send_single_cmd(cmd=cluster.Commands.AtomicRequest(requestType=0,
+            await self.send_single_cmd(cmd=cluster.Commands.AtomicRequest(requestType=Globals.Enums.AtomicRequestTypeEnum.kBeginWrite,
                                                                           attributeRequests=[
                                                                               cluster.Attributes.Presets.attribute_id],
                                                                           timeout=1800),
@@ -81,7 +82,7 @@ class TC_TSTAT_4_2(MatterBaseTest):
                                                       expected_overall_status: Status = Status.Success,
                                                       expected_preset_status: Status = Status.Success):
         try:
-            response = await self.send_single_cmd(cmd=cluster.Commands.AtomicRequest(requestType=1,
+            response = await self.send_single_cmd(cmd=cluster.Commands.AtomicRequest(requestType=Globals.Enums.AtomicRequestTypeEnum.kCommitWrite,
                                                                                      attributeRequests=[cluster.Attributes.Presets.attribute_id, cluster.Attributes.Schedules.attribute_id]),
                                                   endpoint=endpoint)
             asserts.assert_equal(expected_status, Status.Success, "We expected we had a valid commit command")
@@ -100,7 +101,7 @@ class TC_TSTAT_4_2(MatterBaseTest):
                                                         endpoint: int = None,
                                                         expected_status: Status = Status.Success):
         try:
-            await self.send_single_cmd(cmd=cluster.Commands.AtomicRequest(requestType=2,
+            await self.send_single_cmd(cmd=cluster.Commands.AtomicRequest(requestType=Globals.Enums.AtomicRequestTypeEnum.kRollbackWrite,
                                                                           attributeRequests=[cluster.Attributes.Presets.attribute_id, cluster.Attributes.Schedules.attribute_id]),
                                        endpoint=endpoint)
             asserts.assert_equal(expected_status, Status.Success)


### PR DESCRIPTION
Fixes: #34742

