### PR TITLE
python: Add direct attribute paths to Read

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -1351,8 +1351,12 @@ class ChipDeviceControllerBase():
         # Wildcard attribute id
         typing.Tuple[int, typing.Type[ClusterObjects.Cluster]],
         # Concrete path
-        typing.Tuple[int, typing.Type[ClusterObjects.ClusterAttributeDescriptor]]
+        typing.Tuple[int, typing.Type[ClusterObjects.ClusterAttributeDescriptor]],
+        # Directly specified attribute path
+        ClusterAttribute.AttributePath
     ]):
+        if isinstance(pathTuple, ClusterAttribute.AttributePath):
+            return pathTuple
         if pathTuple == ('*') or pathTuple == ():
             # Wildcard
             return ClusterAttribute.AttributePath()
@@ -1437,7 +1441,9 @@ class ChipDeviceControllerBase():
         # Wildcard attribute id
         typing.Tuple[int, typing.Type[ClusterObjects.Cluster]],
         # Concrete path
-        typing.Tuple[int, typing.Type[ClusterObjects.ClusterAttributeDescriptor]]
+        typing.Tuple[int, typing.Type[ClusterObjects.ClusterAttributeDescriptor]],
+        # Directly specified attribute path
+        ClusterAttribute.AttributePath
     ]]] = None,
         dataVersionFilters: typing.Optional[typing.List[typing.Tuple[int, typing.Type[ClusterObjects.Cluster], int]]] = None, events: typing.Optional[typing.List[
             typing.Union[
@@ -1475,6 +1481,8 @@ class ChipDeviceControllerBase():
                 ReadAttribute(1, [ 1 ] ) -- case 4 above.
                 ReadAttribute(1, [ Clusters.BasicInformation ] ) -- case 5 above.
                 ReadAttribute(1, [ (1, Clusters.BasicInformation.Attributes.Location ] ) -- case 1 above.
+
+            An AttributePath can also be specified directly by [chip.cluster.Attribute.AttributePath(...)]
 
         dataVersionFilters: A list of tuples of (endpoint, cluster, data version).
 
@@ -1543,7 +1551,9 @@ class ChipDeviceControllerBase():
         # Wildcard attribute id
         typing.Tuple[int, typing.Type[ClusterObjects.Cluster]],
         # Concrete path
-        typing.Tuple[int, typing.Type[ClusterObjects.ClusterAttributeDescriptor]]
+        typing.Tuple[int, typing.Type[ClusterObjects.ClusterAttributeDescriptor]],
+        # Directly specified attribute path
+        ClusterAttribute.AttributePath
     ]]], dataVersionFilters: typing.Optional[typing.List[typing.Tuple[int, typing.Type[ClusterObjects.Cluster], int]]] = None,
             returnClusterObject: bool = False,
             reportInterval: typing.Optional[typing.Tuple[int, int]] = None,
@@ -1567,6 +1577,8 @@ class ChipDeviceControllerBase():
                 ReadAttribute(1, [ 1 ] ) -- case 4 above.
                 ReadAttribute(1, [ Clusters.BasicInformation ] ) -- case 5 above.
                 ReadAttribute(1, [ (1, Clusters.BasicInformation.Attributes.Location ] ) -- case 1 above.
+
+            An AttributePath can also be specified directly by [chip.cluster.Attribute.AttributePath(...)]
 
         returnClusterObject: This returns the data as consolidated cluster objects, with all attributes for a cluster inside
                              a single cluster-wide cluster object.

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -49,6 +49,7 @@ from chip.ChipDeviceCtrl import CommissioningParameters
 
 # isort: on
 import chip.clusters as Clusters
+from chip.clusters import Attribute
 import chip.logging
 import chip.native
 from chip import discovery
@@ -1863,7 +1864,7 @@ async def get_accepted_endpoints_for_test(self: MatterBaseTest, accept_function:
 
         Returns a list of endpoints on which the test should be run given the accept_function for the test.
     """
-    wildcard = await self.default_controller.Read(self.dut_node_id, [()])
+    wildcard = await self.default_controller.Read(self.dut_node_id, [(Clusters.Descriptor), Attribute.AttributePath(None, None, GlobalAttributeIds.ATTRIBUTE_LIST_ID), Attribute.AttributePath(None, None, GlobalAttributeIds.FEATURE_MAP_ID), Attribute.AttributePath(None, None, GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID)])
     return [e for e in wildcard.attributes.keys() if accept_function(wildcard, e)]
 
 

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -49,11 +49,11 @@ from chip.ChipDeviceCtrl import CommissioningParameters
 
 # isort: on
 import chip.clusters as Clusters
-from chip.clusters import Attribute
 import chip.logging
 import chip.native
 from chip import discovery
 from chip.ChipStack import ChipStack
+from chip.clusters import Attribute
 from chip.clusters import ClusterObjects as ClusterObjects
 from chip.clusters.Attribute import EventReadResult, SubscriptionTransaction, TypedAttributePath
 from chip.exceptions import ChipStackError


### PR DESCRIPTION
Supports one particular use case: read one or all endpoints, all clusters, specific (global) attribute. See spec 8.9.2.4. This is an allowed wildcard construct that is not currently expressible in the API.

Test: Used on wildcard read for matter_testing_support. This is
      therefore tested on any test using that decorator - switch
      and timesync.

