### PR TITLE
ECOINFO Remove EcosystemInformationServer::Instance() where it wasn't needed

### DIFF
--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
@@ -282,11 +282,11 @@ CHIP_ERROR EcosystemInformationServer::ReadAttribute(const ConcreteReadAttribute
     switch (aPath.mAttributeId)
     {
     case Attributes::RemovedOn::Id:
-        return EcosystemInformationServer::Instance().EncodeRemovedOnAttribute(aPath.mEndpointId, aEncoder);
+        return EncodeRemovedOnAttribute(aPath.mEndpointId, aEncoder);
     case Attributes::DeviceDirectory::Id:
-        return EcosystemInformationServer::Instance().EncodeDeviceDirectoryAttribute(aPath.mEndpointId, aEncoder);
+        return EncodeDeviceDirectoryAttribute(aPath.mEndpointId, aEncoder);
     case Attributes::LocationDirectory::Id:
-        return EcosystemInformationServer::Instance().EncodeLocationStructAttribute(aPath.mEndpointId, aEncoder);
+        return EncodeLocationStructAttribute(aPath.mEndpointId, aEncoder);
     case Attributes::ClusterRevision::Id: {
         uint16_t rev = ZCL_ECOSYSTEM_INFORMATION_CLUSTER_REVISION;
         return aEncoder.Encode(rev);


### PR DESCRIPTION
Addressing https://github.com/project-chip/connectedhomeip/pull/34792#discussion_r1706249539 that was made post merge

