### PR TITLE
Chef disable AutoRelockTimer and fix compilation

### DIFF
--- a/examples/chef/common/chef-concentration-measurement.cpp
+++ b/examples/chef/common/chef-concentration-measurement.cpp
@@ -91,7 +91,7 @@ Protocols::InteractionModel::Status chefConcentrationMeasurementWriteCallback(
         CHIP_ERROR err = clusterInstance->SetMeasuredValue(MakeNullable(newValue));
         if (CHIP_NO_ERROR == err)
         {
-            ChipLogDetail(DeviceLayer, "Updated EP:%d, Cluster: 0x%04x to MeasuredValue: %g", endpoint, clusterId, newValue);
+            ChipLogDetail(DeviceLayer, "Updated EP:%d, Cluster: 0x%04x MeasuredValue", endpoint, clusterId);
         }
         else
         {

--- a/examples/chef/common/chef-concentration-measurement.cpp
+++ b/examples/chef/common/chef-concentration-measurement.cpp
@@ -91,7 +91,7 @@ Protocols::InteractionModel::Status chefConcentrationMeasurementWriteCallback(
         CHIP_ERROR err = clusterInstance->SetMeasuredValue(MakeNullable(newValue));
         if (CHIP_NO_ERROR == err)
         {
-            ChipLogDetail(DeviceLayer, "Updated EP:%d, Cluster: 0x%04x to MeasuredValue: %f", endpoint, clusterId, newValue);
+            ChipLogDetail(DeviceLayer, "Updated EP:%d, Cluster: 0x%04x to MeasuredValue: %g", endpoint, clusterId, newValue);
         }
         else
         {

--- a/examples/chef/common/chef-rpc-actions-worker.cpp
+++ b/examples/chef/common/chef-rpc-actions-worker.cpp
@@ -147,7 +147,9 @@ void ChefRpcActionsWorker::RegisterRpcActionsDelegate(ClusterId clusterId, Actio
 
 ChefRpcActionsWorker::ChefRpcActionsWorker()
 {
+#if CONFIG_ENABLE_PW_RPC
     chip::rpc::SubscribeActions(ChefRpcActionsCallback);
+#endif
 }
 
 static ChefRpcActionsWorker instance;

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
@@ -2726,7 +2726,7 @@ endpoint 1 {
     ram      attribute credentialRulesSupport default = 1;
     ram      attribute numberOfCredentialsSupportedPerUser default = 5;
     ram      attribute language default = "en";
-    ram      attribute autoRelockTime default = 5;
+    ram      attribute autoRelockTime default = 0;
     ram      attribute soundVolume default = 0;
     ram      attribute operatingMode default = 0;
     ram      attribute supportedOperatingModes default = 0xFFFF;

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.zap
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.zap
@@ -3665,7 +3665,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "5",
+              "defaultValue": "0",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,


### PR DESCRIPTION
1. Disable AutoRelockTimer which was too short (5 seconds) and cause testing confusion
2. Fix compilation issue caused by disabling RPC and float definition with nRFConnect toolchain
