### PR TITLE
tv-casting-app fixed 32-bit vs 64-bit formatting issue

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -63,7 +63,7 @@ CHIP_ERROR CastingPlayerDiscovery::StartDiscovery(uint32_t deviceTypeFilter)
 
 CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 {
-    ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() mCastingPlayers: %lu, mCastingPlayersInternal: %lu",
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() mCastingPlayers: %zu, mCastingPlayersInternal: %zu",
                     mCastingPlayers.size(), mCastingPlayersInternal.size());
     VerifyOrReturnError(mState == DISCOVERY_RUNNING, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mCommissionableNodeController.StopDiscovery());
@@ -80,7 +80,7 @@ CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 
 void CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal()
 {
-    ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal() mCastingPlayersInternal: %lu",
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal() mCastingPlayersInternal: %zu",
                     mCastingPlayersInternal.size());
     // Only clear the CastingPlayers in mCastingPlayersInternal with ConnectionState == CASTING_PLAYER_NOT_CONNECTED
     for (auto it = mCastingPlayersInternal.begin(); it != mCastingPlayersInternal.end();)

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -64,7 +64,7 @@ CHIP_ERROR CastingPlayerDiscovery::StartDiscovery(uint32_t deviceTypeFilter)
 CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 {
     ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() mCastingPlayers: %u, mCastingPlayersInternal: %u",
-                    static_cast<unsigned int>mCastingPlayers.size(), static_cast<unsigned int>mCastingPlayersInternal.size());
+                    static_cast<unsigned int> mCastingPlayers.size(), static_cast<unsigned int> mCastingPlayersInternal.size());
     VerifyOrReturnError(mState == DISCOVERY_RUNNING, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mCommissionableNodeController.StopDiscovery());
 
@@ -81,7 +81,7 @@ CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 void CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal()
 {
     ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal() mCastingPlayersInternal: %u",
-                    static_cast<unsigned int>mCastingPlayersInternal.size());
+                    static_cast<unsigned int> mCastingPlayersInternal.size());
     // Only clear the CastingPlayers in mCastingPlayersInternal with ConnectionState == CASTING_PLAYER_NOT_CONNECTED
     for (auto it = mCastingPlayersInternal.begin(); it != mCastingPlayersInternal.end();)
     {

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -63,8 +63,8 @@ CHIP_ERROR CastingPlayerDiscovery::StartDiscovery(uint32_t deviceTypeFilter)
 
 CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 {
-    ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() mCastingPlayers: %zu, mCastingPlayersInternal: %zu",
-                    mCastingPlayers.size(), mCastingPlayersInternal.size());
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() mCastingPlayers: %u, mCastingPlayersInternal: %u",
+                    static_cast<unsigned int>mCastingPlayers.size(), static_cast<unsigned int>mCastingPlayersInternal.size());
     VerifyOrReturnError(mState == DISCOVERY_RUNNING, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mCommissionableNodeController.StopDiscovery());
 
@@ -80,8 +80,8 @@ CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 
 void CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal()
 {
-    ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal() mCastingPlayersInternal: %zu",
-                    mCastingPlayersInternal.size());
+    ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal() mCastingPlayersInternal: %u",
+                    static_cast<unsigned int>mCastingPlayersInternal.size());
     // Only clear the CastingPlayers in mCastingPlayersInternal with ConnectionState == CASTING_PLAYER_NOT_CONNECTED
     for (auto it = mCastingPlayersInternal.begin(); it != mCastingPlayersInternal.end();)
     {


### PR DESCRIPTION
In connectedhomeip/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp

To ensure compatibility across both 32-bit and 64-bit platforms, using the %zu format specifier for size_t values, which are returned by the size() methods of STL containers. This approach is platform-independent and will work correctly on both 32-bit and 64-bit systems.

