### PR TITLE
fix static_cast syntax in `CastingPlayerDiscovery`

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -64,7 +64,7 @@ CHIP_ERROR CastingPlayerDiscovery::StartDiscovery(uint32_t deviceTypeFilter)
 CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 {
     ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() mCastingPlayers: %u, mCastingPlayersInternal: %u",
-                    static_cast<unsigned int> mCastingPlayers.size(), static_cast<unsigned int> mCastingPlayersInternal.size());
+                    static_cast<unsigned int>(mCastingPlayers.size()), static_cast<unsigned int>(mCastingPlayersInternal.size());
     VerifyOrReturnError(mState == DISCOVERY_RUNNING, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mCommissionableNodeController.StopDiscovery());
 
@@ -81,7 +81,7 @@ CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 void CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal()
 {
     ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal() mCastingPlayersInternal: %u",
-                    static_cast<unsigned int> mCastingPlayersInternal.size());
+                    static_cast<unsigned int>(mCastingPlayersInternal.size());
     // Only clear the CastingPlayers in mCastingPlayersInternal with ConnectionState == CASTING_PLAYER_NOT_CONNECTED
     for (auto it = mCastingPlayersInternal.begin(); it != mCastingPlayersInternal.end();)
     {

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.cpp
@@ -64,7 +64,7 @@ CHIP_ERROR CastingPlayerDiscovery::StartDiscovery(uint32_t deviceTypeFilter)
 CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 {
     ChipLogProgress(Discovery, "CastingPlayerDiscovery::StopDiscovery() mCastingPlayers: %u, mCastingPlayersInternal: %u",
-                    static_cast<unsigned int>(mCastingPlayers.size()), static_cast<unsigned int>(mCastingPlayersInternal.size());
+                    static_cast<unsigned int>(mCastingPlayers.size()), static_cast<unsigned int>(mCastingPlayersInternal.size()));
     VerifyOrReturnError(mState == DISCOVERY_RUNNING, CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(mCommissionableNodeController.StopDiscovery());
 
@@ -81,7 +81,7 @@ CHIP_ERROR CastingPlayerDiscovery::StopDiscovery()
 void CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal()
 {
     ChipLogProgress(Discovery, "CastingPlayerDiscovery::ClearDisconnectedCastingPlayersInternal() mCastingPlayersInternal: %u",
-                    static_cast<unsigned int>(mCastingPlayersInternal.size());
+                    static_cast<unsigned int>(mCastingPlayersInternal.size()));
     // Only clear the CastingPlayers in mCastingPlayersInternal with ConnectionState == CASTING_PLAYER_NOT_CONNECTED
     for (auto it = mCastingPlayersInternal.begin(); it != mCastingPlayersInternal.end();)
     {


### PR DESCRIPTION
fix mistake I made in applying `static_cast<unsigned integer>` in an attempt to fix `master` builds
