### PR TITLE
Fix failing to kill fabric-bridge process from script

### DIFF
--- a/examples/fabric-admin/scripts/stop_fabric_source.sh
+++ b/examples/fabric-admin/scripts/stop_fabric_source.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 
-FABRIC_ADMIN_PATH="/fabric-admin"
-FABRIC_BRIDGE_APP_PATH="/fabric-bridge-app"
+FABRIC_ADMIN_PATH="fabric-admin"
+FABRIC_BRIDGE_APP_PATH="fabric-bridge"
 
 # Kill fabric-admin if it is running
-fabric_admin_pid=$(pgrep -f "$FABRIC_ADMIN_PATH")
+fabric_admin_pid=$(pgrep "$FABRIC_ADMIN_PATH")
+echo "Found fabric-admin PID: $fabric_admin_pid"
 if [ ! -z "$fabric_admin_pid" ]; then
     kill -9 "$fabric_admin_pid"
     echo "Killed fabric-admin with PID $fabric_admin_pid"
 fi
 
 # Kill fabric-bridge-app if it is running
-fabric_bridge_app_pid=$(pgrep -f "$FABRIC_BRIDGE_APP_PATH")
+fabric_bridge_app_pid=$(pgrep "$FABRIC_BRIDGE_APP_PATH")
+echo "Found fabric-bridge-app PID: $fabric_bridge_app_pid"
 if [ ! -z "$fabric_bridge_app_pid" ]; then
     kill -9 "$fabric_bridge_app_pid"
     echo "Killed fabric-bridge-app with PID $fabric_bridge_app_pid"


### PR DESCRIPTION
Current 'stop_fabric_source.sh" fail to clean up legacy fabric-bridge-app process

```
yufengw@yufengw:~/connectedhomeip$ ps -A | grep fabric
  16873 pts/1    00:00:00 fabric-bridge-a
yufengw@yufengw:~/connectedhomeip$ pgrep -f "/fabric-bridge-app"
16873
yufengw@yufengw:~/connectedhomeip$ ./examples/fabric-admin/scripts/stop_fabric_source.sh 
Killed
yufengw@yufengw:~/connectedhomeip$ ps -A | grep fabric
  16873 pts/1    00:00:00 fabric-bridge-a
```

The reason is pgrep -f "/fabric-admin" command is returning the PID of run_fabric_sour because -f option makes pgrep match against the full command line, not just the process name. If the command line of run_fabric_sour contains the string /fabric-admin, it will match and return the PID.

To avoid this, you can use pgrep without -f to only match the process name.

```
yufengw@yufengw:~/connectedhomeip$ ps -A | grep fabric
  13857 pts/1    00:00:00 fabric-bridge-a
yufengw@yufengw:~/connectedhomeip$ pgrep "fabric-bridge-app"
yufengw@yufengw:~/connectedhomeip$ 
yufengw@yufengw:~/connectedhomeip$ pgrep "fabric-bridge"
13857
yufengw@yufengw:~/connectedhomeip$ 
yufengw@yufengw:~/connectedhomeip$ ./examples/fabric-admin/scripts/stop_fabric_source.sh 
Found fabric-admin PID: 
Found fabric-bridge-app PID: 13857
Killed fabric-bridge-app with PID 13857
Removed /tmp/chip_* files and directories
```


