### PR TITLE
[platform] Add empty platform_base source set

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -612,7 +612,8 @@ if (chip_device_platform != "none") {
     public_deps = [ ":platform_buildconfig" ]
   }
 
-  source_set("platform_base") {}
+  source_set("platform_base") {
+  }
 }
 
 source_set("syscalls_stub") {

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -611,6 +611,8 @@ if (chip_device_platform != "none") {
   group("platform") {
     public_deps = [ ":platform_buildconfig" ]
   }
+
+  source_set("platform_base") {}
 }
 
 source_set("syscalls_stub") {


### PR DESCRIPTION
When cross-compiling on Windows, bootstrap would fail because of some targets that are depending on `platform_base` source set, which is not defined for `chip_device_platform` None.

Reference PR: https://github.com/project-chip/connectedhomeip/pull/34830/files

