### PR TITLE
Update build instruction for fabric-admin

### DIFF
--- a/examples/fabric-admin/README.md
+++ b/examples/fabric-admin/README.md
@@ -14,7 +14,7 @@ fabrics.
 For Linux host example:
 
 ```
-./scripts/examples/gn_build_example.sh examples/fabric-admin out/debug/standalone chip_config_network_layer_ble=false 'import("//with_pw_rpc.gni")'
+./scripts/examples/gn_build_example.sh examples/fabric-admin out/debug/standalone 'import("//with_pw_rpc.gni")'
 ```
 
 For Raspberry Pi 4 example:


### PR DESCRIPTION
We need to enable BLE support in fabric-admin to pair a commercial Matter device.

This also fix a link error when compile the fabric-admin app if build with flag 'chip_config_network_layer_ble=false'  

