### PR TITLE
Fix fabric-bridge-app crash

### DIFF
--- a/examples/fabric-bridge-app/linux/RpcServer.cpp
+++ b/examples/fabric-bridge-app/linux/RpcServer.cpp
@@ -117,8 +117,11 @@ pw::Status FabricBridge::AddSynchronizedDevice(const chip_rpc_SynchronizedDevice
         return pw::Status::Unknown();
     }
 
+    BridgedDevice * addedDevice = BridgeDeviceMgr().GetDeviceByNodeId(nodeId);
+    VerifyOrDie(addedDevice);
+
     CHIP_ERROR err = EcosystemInformation::EcosystemInformationServer::Instance().AddEcosystemInformationClusterToEndpoint(
-        device->GetEndpointId());
+        addedDevice->GetEndpointId());
     VerifyOrDie(err == CHIP_NO_ERROR);
 
     return pw::OkStatus();


### PR DESCRIPTION
Multiple merges have been going in around this code, which resulted in this crash that happens after you add a new device


We are getting close to having something stable enough to add to CI that would have caught something like this but for the time being we only catch things like this after the fact
