### PR TITLE
Mitigation to unauthenticated TCP support advertisement in DNS-SD that made it susceptible to potential DoS attacks.

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -140,6 +140,9 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     mOperationalKeystore           = initParams.operationalKeystore;
     mOpCertStore                   = initParams.opCertStore;
     mSessionKeystore               = initParams.sessionKeystore;
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    mPeerTCPParamsStorage = initParams.peerTCPParamsStorage;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     if (initParams.certificateValidityPolicy)
     {
@@ -277,6 +280,11 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
                                                        std::chrono::duration_cast<System::Clock::Milliseconds64>(mInitTimestamp));
     }
 #endif // CHIP_CONFIG_ENABLE_SERVER_IM_EVENT
+
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    // Set the TCP Params storage after initializing SessionManager
+    mSessions.SetPeerTCPParamsStorage(mPeerTCPParamsStorage);
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     // This initializes clusters, so should come after lower level initialization.
     InitDataModelHandler();
@@ -788,5 +796,8 @@ Crypto::DefaultSessionKeystore CommonCaseDeviceServerInitParams::sSessionKeystor
 #if CHIP_CONFIG_ENABLE_ICD_CIP
 app::DefaultICDCheckInBackOffStrategy CommonCaseDeviceServerInitParams::sDefaultICDCheckInBackOffStrategy;
 #endif
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+Transport::PeerTCPParamsStorage CommonCaseDeviceServerInitParams::sPeerTCPParamsStorage;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 } // namespace chip

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -71,6 +71,9 @@
 #include <app/TimerDelegates.h>
 #include <app/reporting/ReportSchedulerImpl.h>
 #include <transport/raw/UDP.h>
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+#include <transport/raw/PeerTCPParamsStorage.h>
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 #include <app/icd/server/ICDCheckInBackOffStrategy.h>
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -179,6 +182,11 @@ struct ServerInitParams
     // Optional. Support for the ICD Check-In BackOff strategy. Must be initialized before being provided.
     // If the ICD Check-In protocol use-case is supported and no strategy is provided, server will use the default strategy.
     app::ICDCheckInBackOffStrategy * icdCheckInBackOffStrategy = nullptr;
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    // Optional. Support Peer node's TCP Params when provided.
+    // Must be initialized before being provided.
+    chip::Transport::TCPParamsStorageInterface * peerTCPParamsStorage = nullptr;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 };
 
 /**
@@ -300,6 +308,11 @@ struct CommonCaseDeviceServerInitParams : public ServerInitParams
         }
 #endif
 
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+        ReturnErrorOnFailure(sPeerTCPParamsStorage.Init(this->persistentStorageDelegate));
+        this->peerTCPParamsStorage = &sPeerTCPParamsStorage;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
+
         return CHIP_NO_ERROR;
     }
 
@@ -311,6 +324,9 @@ private:
     static chip::app::DefaultTimerDelegate sTimerDelegate;
     static app::reporting::ReportSchedulerImpl sReportScheduler;
 
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    static chip::Transport::PeerTCPParamsStorage sPeerTCPParamsStorage;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 #if CHIP_CONFIG_ENABLE_SESSION_RESUMPTION
     static SimpleSessionResumptionStorage sSessionResumptionStorage;
 #endif
@@ -675,6 +691,9 @@ private:
     GroupDataProviderListener mListener;
     ServerFabricDelegate mFabricDelegate;
     app::reporting::ReportScheduler * mReportScheduler;
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    chip::Transport::TCPParamsStorageInterface * mPeerTCPParamsStorage;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     Access::AccessControl mAccessControl;
     app::AclStorage * mAclStorage;

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -35,6 +35,9 @@
 #include <credentials/OperationalCertificateStore.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
 #include <protocols/secure_channel/SessionResumptionStorage.h>
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+#include <transport/raw/TCPParamsStorageInterface.h>
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 namespace chip {
 
@@ -148,6 +151,9 @@ struct FactoryInitParams
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     Transport::WiFiPAFLayer * wifipaf_layer = nullptr;
 #endif
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    chip::Transport::TCPParamsStorageInterface * peerTCPParamsStorage = nullptr;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     //
     // Controls enabling server cluster interactions on a controller. This in turn
@@ -292,7 +298,10 @@ private:
     Credentials::OperationalCertificateStore * mOpCertStore             = nullptr;
     Credentials::CertificateValidityPolicy * mCertificateValidityPolicy = nullptr;
     SessionResumptionStorage * mSessionResumptionStorage                = nullptr;
-    bool mEnableServerInteractions                                      = false;
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    chip::Transport::TCPParamsStorageInterface * mPeerTCPParamsStorage = nullptr;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
+    bool mEnableServerInteractions = false;
 };
 
 } // namespace Controller

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -41,6 +41,9 @@
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/SimpleSessionResumptionStorage.h>
 #include <protocols/secure_channel/UnsolicitedStatusHandler.h>
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+#include <transport/raw/PeerTCPParamsStorage.h>
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 #include <transport/TransportMgr.h>
 #include <transport/raw/UDP.h>
@@ -135,6 +138,10 @@ struct DeviceControllerSystemStateParams
     FabricTable::Delegate * fabricTableDelegate                                   = nullptr;
     chip::app::reporting::ReportScheduler::TimerDelegate * timerDelegate          = nullptr;
     chip::app::reporting::ReportScheduler * reportScheduler                       = nullptr;
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    chip::Transport::TCPParamsStorageInterface * peerTCPParamsStorage = nullptr;
+    Platform::UniquePtr<chip::Transport::PeerTCPParamsStorage> ownedPeerTCPParamsStorage;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 };
 
 // A representation of the internal state maintained by the DeviceControllerFactory.
@@ -182,6 +189,17 @@ public:
 #if CONFIG_NETWORK_LAYER_BLE
         mBleLayer = params.bleLayer;
 #endif
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+        mOwnedPeerTCPParamsStorage = std::move(params.ownedPeerTCPParamsStorage);
+        if (mOwnedPeerTCPParamsStorage)
+        {
+            mPeerTCPParamsStorage = mOwnedPeerTCPParamsStorage.get();
+        }
+        else
+        {
+            mPeerTCPParamsStorage = params.peerTCPParamsStorage;
+        }
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
         VerifyOrDie(IsInitialized());
     };
 
@@ -273,6 +291,10 @@ private:
     FabricTable::Delegate * mFabricTableDelegate                                   = nullptr;
     SessionResumptionStorage * mSessionResumptionStorage                           = nullptr;
     Platform::UniquePtr<SimpleSessionResumptionStorage> mOwnedSessionResumptionStorage;
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    chip::Transport::TCPParamsStorageInterface * mPeerTCPParamsStorage = nullptr;
+    Platform::UniquePtr<chip::Transport::PeerTCPParamsStorage> mOwnedPeerTCPParamsStorage;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     // If mTempFabricTable is not null, it was created during
     // DeviceControllerFactory::InitSystemState and needs to be

--- a/src/controller/python/chip/utils/DeviceProxyUtils.cpp
+++ b/src/controller/python/chip/utils/DeviceProxyUtils.cpp
@@ -44,6 +44,10 @@ struct __attribute__((packed)) SessionParametersStruct
     uint16_t interactionModelRevision = 0;
     uint32_t specificationVersion     = 0;
     uint16_t maxPathsPerInvoke        = 0;
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    uint16_t supportedTransports = 0;
+    uint32_t maxTCPMessageSize   = 0;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 };
 
 } // namespace python
@@ -99,6 +103,11 @@ PyChipError pychip_DeviceProxy_GetRemoteSessionParameters(DeviceProxy * device, 
     sessionParam->interactionModelRevision = remoteSessionParameters.GetInteractionModelRevision().ValueOr(0);
     sessionParam->specificationVersion     = remoteSessionParameters.GetSpecificationVersion().ValueOr(0);
     sessionParam->maxPathsPerInvoke        = remoteSessionParameters.GetMaxPathsPerInvoke();
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    sessionParam->supportedTransports = remoteSessionParameters.GetSupportedTransports().ValueOr(0);
+    sessionParam->maxTCPMessageSize =
+        remoteSessionParameters.GetMaxTCPMessageSize().ValueOr(System::PacketBuffer::kLargeBufMaxSizeWithoutReserve - 4);
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
     return ToPyChipError(CHIP_NO_ERROR);
 }
 }

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -256,6 +256,14 @@ public:
     // when new fabric is created, this list needs to be updated,
     // when client init DefaultICDClientStorage, this table needs to be loaded.
     static StorageKeyName ICDFabricList() { return StorageKeyName::FromConst("g/icdfl"); }
+
+    // TCP peer parameters
+    static StorageKeyName TCPPeerParams(FabricIndex fabric, NodeId nodeId)
+    {
+        return StorageKeyName::Formatted("f/%x/tcp/%08" PRIX32 "%08" PRIX32, fabric, static_cast<uint32_t>(nodeId >> 32),
+                                         static_cast<uint32_t>(nodeId));
+    }
+    static StorageKeyName TCPPeerList() { return StorageKeyName::FromConst("g/tcpl"); }
 };
 
 } // namespace chip

--- a/src/messaging/SessionParameters.h
+++ b/src/messaging/SessionParameters.h
@@ -41,10 +41,19 @@ public:
     static constexpr size_t kSizeOfInteractionModelRevision = sizeof(uint16_t);
     static constexpr size_t kSizeOfSpecificationVersion     = sizeof(uint32_t);
     static constexpr size_t kSizeOfMaxPathsPerInvoke        = sizeof(uint16_t);
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    static constexpr size_t kSizeOfSupportedTransports = sizeof(uint16_t);
+    static constexpr size_t kSizeOfMaxTCPMessageSize   = sizeof(uint32_t);
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     static constexpr size_t kEstimatedTLVSize = TLV::EstimateStructOverhead(
         kSizeOfSessionIdleInterval, kSizeOfSessionActiveInterval, kSizeOfSessionActiveThreshold, kSizeOfDataModelRevision,
-        kSizeOfInteractionModelRevision, kSizeOfSpecificationVersion, kSizeOfMaxPathsPerInvoke);
+        kSizeOfInteractionModelRevision, kSizeOfSpecificationVersion, kSizeOfMaxPathsPerInvoke
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+        ,
+        kSizeOfSupportedTransports, kSizeOfMaxTCPMessageSize
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
+    );
 
     // From Section 4.12.8 "Parameters and Constants" in chapter "Secure Channel".
     enum Tag : uint32_t
@@ -56,6 +65,8 @@ public:
         kInteractionModelRevision = 5,
         kSpecificationVersion     = 6,
         kMaxPathsPerInvoke        = 7,
+        kSupportedTransports      = 8,
+        kMaxTCPMessageSize        = 9,
     };
 
     const ReliableMessageProtocolConfig & GetMRPConfig() const { return mMRPConfig; }
@@ -91,6 +102,13 @@ public:
     uint16_t GetMaxPathsPerInvoke() const { return mMaxPathsPerInvoke; }
     void SetMaxPathsPerInvoke(const uint16_t maxPathsPerInvoke) { mMaxPathsPerInvoke = maxPathsPerInvoke; }
 
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    const Optional<uint16_t> & GetSupportedTransports() const { return mSupportedTransports; }
+    void SetSupportedTransports(const uint16_t supportedTransports) { mSupportedTransports = MakeOptional(supportedTransports); }
+
+    const Optional<uint32_t> & GetMaxTCPMessageSize() const { return mMaxTCPMessageSize; }
+    void SetMaxTCPMessageSize(const uint32_t maxTCPMessageSize) { mMaxTCPMessageSize = MakeOptional(maxTCPMessageSize); }
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 private:
     ReliableMessageProtocolConfig mMRPConfig;
     // For legacy reasons if we do not get DataModelRevision it means either 16 or 17. But there isn't
@@ -104,6 +122,11 @@ private:
     Optional<uint32_t> mSpecificationVersion;
     // When maxPathsPerInvoke is not provided legacy is always 1
     uint16_t mMaxPathsPerInvoke = 1;
+
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    Optional<uint16_t> mSupportedTransports;
+    Optional<uint32_t> mMaxTCPMessageSize;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 };
 
 } // namespace chip

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -287,6 +287,7 @@ private:
     void InvalidateIfPendingEstablishmentOnFabric(FabricIndex fabricIndex);
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    CHIP_ERROR SaveTCPInfoFromRemoteSessionParams();
     static void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
     static void HandleConnectionClosed(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
 

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -54,6 +54,7 @@
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
 #include <transport/SessionConnectionDelegate.h>
+#include <transport/raw/PeerTCPParamsStorage.h>
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 namespace chip {
@@ -494,6 +495,11 @@ public:
 
     using OnTCPConnectionClosedCallback = void (*)(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr);
 
+    Transport::TCPParamsStorageInterface * GetPeerTCPParamsStorage() { return mPeerTCPParamsStorage; }
+    void SetPeerTCPParamsStorage(Transport::TCPParamsStorageInterface * tcpParamsStorage)
+    {
+        mPeerTCPParamsStorage = tcpParamsStorage;
+    }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     Optional<SessionHandle> CreateUnauthenticatedSession(const Transport::PeerAddress & peerAddress,
@@ -566,13 +572,11 @@ private:
     // Hold the TCPConnection callback context for the receiver application in the SessionManager.
     // On receipt of a connection from a peer, the SessionManager
     Transport::AppTCPConnectionCallbackCtxt * mServerTCPConnCbCtxt = nullptr;
+    Transport::TCPParamsStorageInterface * mPeerTCPParamsStorage   = nullptr;
+    SessionConnectionDelegate * mConnDelegate                      = nullptr;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     SessionMessageDelegate * mCB = nullptr;
-
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    SessionConnectionDelegate * mConnDelegate = nullptr;
-#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     TransportMgrBase * mTransportMgr                                   = nullptr;
     Transport::MessageCounterManagerInterface * mMessageCounterManager = nullptr;

--- a/src/transport/raw/BUILD.gn
+++ b/src/transport/raw/BUILD.gn
@@ -33,9 +33,12 @@ static_library("raw") {
   if (chip_inet_config_enable_tcp_endpoint) {
     sources += [
       "ActiveTCPConnectionState.h",
+      "PeerTCPParamsStorage.cpp",
+      "PeerTCPParamsStorage.h",
       "TCP.cpp",
       "TCP.h",
       "TCPConfig.h",
+      "TCPParamsStorageInterface.h",
     ]
   }
 

--- a/src/transport/raw/PeerTCPParamsStorage.cpp
+++ b/src/transport/raw/PeerTCPParamsStorage.cpp
@@ -1,0 +1,327 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the Peer TCP Parameter Storage object that provides
+ *      APIs for storage and retireval of the TCP parameters for a given peer
+ *      node scoped to a fabric.
+ */
+
+#include <transport/raw/PeerTCPParamsStorage.h>
+
+#include <lib/support/Base64.h>
+#include <lib/support/SafeInt.h>
+
+namespace chip {
+namespace Transport {
+
+constexpr TLV::Tag PeerTCPParamsStorage::kSupportedTransportsTag;
+constexpr TLV::Tag PeerTCPParamsStorage::kMaxTCPMessageSizeTag;
+
+StorageKeyName PeerTCPParamsStorage::GetStorageKey(const ScopedNodeId & node)
+{
+    return DefaultStorageKeyAllocator::TCPPeerParams(node.GetFabricIndex(), node.GetNodeId());
+}
+
+CHIP_ERROR PeerTCPParamsStorage::FindByScopedNodeId(const ScopedNodeId & node, uint16_t & supportedTransports,
+                                                    uint32_t & maxTCPMessageSize)
+{
+    return LoadTCPParamsFromStorage(node, supportedTransports, maxTCPMessageSize);
+}
+
+CHIP_ERROR PeerTCPParamsStorage::SaveTrackedNodesList(const TrackedNodesList & list)
+{
+    std::array<uint8_t, MaxNodesListSize()> buf;
+    TLV::TLVWriter writer;
+    writer.Init(buf);
+
+    TLV::TLVType arrayType;
+    ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Array, arrayType));
+
+    for (size_t i = 0; i < list.mSize; ++i)
+    {
+        TLV::TLVType innerType;
+        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, innerType));
+        ReturnErrorOnFailure(writer.Put(kFabricIndexTag, list.mNodes[i].GetFabricIndex()));
+        ReturnErrorOnFailure(writer.Put(kPeerNodeIdTag, list.mNodes[i].GetNodeId()));
+        ReturnErrorOnFailure(writer.EndContainer(innerType));
+    }
+
+    ReturnErrorOnFailure(writer.EndContainer(arrayType));
+
+    const auto len = writer.GetLengthWritten();
+    VerifyOrReturnError(CanCastTo<uint16_t>(len), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    return mTCPParamsStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::TCPPeerList().KeyName(), buf.data(),
+                                              static_cast<uint16_t>(len));
+}
+
+CHIP_ERROR PeerTCPParamsStorage::LoadTrackedNodesList(TrackedNodesList & list)
+{
+    std::array<uint8_t, MaxNodesListSize()> buf;
+    uint16_t len = static_cast<uint16_t>(buf.size());
+
+    if (mTCPParamsStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::TCPPeerList().KeyName(), buf.data(), len) != CHIP_NO_ERROR)
+    {
+        list.mSize = 0;
+        return CHIP_NO_ERROR;
+    }
+
+    TLV::ContiguousBufferTLVReader reader;
+    reader.Init(buf.data(), len);
+
+    ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Array, TLV::AnonymousTag()));
+    TLV::TLVType arrayType;
+    ReturnErrorOnFailure(reader.EnterContainer(arrayType));
+
+    size_t count = 0;
+    CHIP_ERROR err;
+    while ((err = reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag())) == CHIP_NO_ERROR)
+    {
+        if (count >= ArraySize(list.mNodes))
+        {
+            return CHIP_ERROR_NO_MEMORY;
+        }
+
+        TLV::TLVType containerType;
+        ReturnErrorOnFailure(reader.EnterContainer(containerType));
+
+        FabricIndex fabricIndex;
+        ReturnErrorOnFailure(reader.Next(kFabricIndexTag));
+        ReturnErrorOnFailure(reader.Get(fabricIndex));
+
+        NodeId peerNodeId;
+        ReturnErrorOnFailure(reader.Next(kPeerNodeIdTag));
+        ReturnErrorOnFailure(reader.Get(peerNodeId));
+
+        list.mNodes[count++] = ScopedNodeId(peerNodeId, fabricIndex);
+
+        ReturnErrorOnFailure(reader.ExitContainer(containerType));
+    }
+
+    if (err != CHIP_END_OF_TLV)
+    {
+        return err;
+    }
+
+    ReturnErrorOnFailure(reader.ExitContainer(arrayType));
+    ReturnErrorOnFailure(reader.VerifyEndOfContainer());
+
+    list.mSize = count;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PeerTCPParamsStorage::SaveTCPParams(const ScopedNodeId & node, const uint16_t & supportedTransports,
+                                               const uint32_t & maxTCPMessageSize)
+{
+    TrackedNodesList list;
+    ReturnErrorOnFailure(LoadTrackedNodesList(list));
+
+    for (size_t i = 0; i < list.mSize; ++i)
+    {
+        if (list.mNodes[i] == node)
+        {
+            // Node already exists in the list. Over-write new values.
+            ReturnErrorOnFailure(SaveTCPParamsToStorage(node, supportedTransports, maxTCPMessageSize));
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    // Not found in current list. If list is full, evict first one.
+    if (list.mSize == kMaxTrackedNodes)
+    {
+        ReturnErrorOnFailure(DeleteTCPParamsFromStorage(list.mNodes[0]));
+        ReturnErrorOnFailure(LoadTrackedNodesList(list));
+    }
+
+    ReturnErrorOnFailure(SaveTCPParamsToStorage(node, supportedTransports, maxTCPMessageSize));
+
+    list.mNodes[list.mSize++] = node;
+
+    // Save back the tracked nodes list
+    return SaveTrackedNodesList(list);
+}
+
+CHIP_ERROR PeerTCPParamsStorage::DeleteTCPParams(const ScopedNodeId & node)
+{
+    TrackedNodesList list;
+    ReturnErrorOnFailure(LoadTrackedNodesList(list));
+
+    CHIP_ERROR err = DeleteTCPParamsFromStorage(node);
+    if (err != CHIP_NO_ERROR && err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        // If unable to delete storage state, log error and move forward with attempt
+        // to remove node from tracked nodes list.
+        ChipLogError(SecureChannel,
+                     "Unable to delete TCP params info from storage for node " ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(node.GetNodeId()), err.Format());
+    }
+
+    size_t indexToRemove;
+    for (indexToRemove = 0; indexToRemove < list.mSize; indexToRemove++)
+    {
+        if (list.mNodes[indexToRemove] == node)
+        {
+            break;
+        }
+    }
+
+    if (indexToRemove >= list.mSize)
+    {
+        ChipLogError(SecureChannel,
+                     "Unable to find TCP params info for node in tracked nodes list" ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(node.GetNodeId()), err.Format());
+        return CHIP_NO_ERROR;
+    }
+
+    // Shift elements to the left
+    for (size_t j = indexToRemove; j < list.mSize - 1; j++)
+    {
+        list.mNodes[j] = list.mNodes[j + 1];
+    }
+
+    list.mSize -= 1;
+
+    // Save back the tracked nodes list
+    return SaveTrackedNodesList(list);
+}
+
+CHIP_ERROR PeerTCPParamsStorage::DeleteAllTCPParams(FabricIndex fabricIndex)
+{
+    CHIP_ERROR firstErr = CHIP_NO_ERROR;
+    size_t deletedCount = 0;
+    TrackedNodesList list;
+    // Load the current list of nodes with stored TCP params
+    ReturnErrorOnFailure(LoadTrackedNodesList(list));
+    size_t initialSize = list.mSize;
+
+    for (size_t i = 0; i < initialSize; ++i)
+    {
+        CHIP_ERROR err   = CHIP_NO_ERROR;
+        size_t cur       = i - deletedCount;
+        size_t remaining = initialSize - i;
+        uint16_t supportedTransports;
+        uint32_t maxTCPMessageSize;
+        // Skip the nodes outside the given fabric
+        if (list.mNodes[cur].GetFabricIndex() != fabricIndex)
+        {
+            continue;
+        }
+        err      = LoadTCPParamsFromStorage(list.mNodes[cur], supportedTransports, maxTCPMessageSize);
+        firstErr = (firstErr == CHIP_NO_ERROR) ? err : firstErr;
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(SecureChannel,
+                         "TCP params cache deletion partially failed for fabric index %u, "
+                         "unable to load node state: %" CHIP_ERROR_FORMAT,
+                         fabricIndex, err.Format());
+            continue;
+        }
+        err      = DeleteTCPParamsFromStorage(list.mNodes[cur]);
+        firstErr = firstErr == CHIP_NO_ERROR ? err : firstErr;
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(SecureChannel,
+                         "TCP params cache is in an inconsistent state!  "
+                         "Unable to delete node state during attempted deletion of fabric index %u: %" CHIP_ERROR_FORMAT,
+                         fabricIndex, err.Format());
+            continue;
+        }
+        ++deletedCount;
+        --remaining;
+        if (remaining)
+        {
+            // Shift nodes in the tracked list after the deletion of one.
+            memmove(&list.mNodes[cur], &list.mNodes[cur + 1], remaining * sizeof(list.mNodes[0]));
+        }
+    }
+    if (deletedCount)
+    {
+        // Adjust the tracked nodes list by the number of nodes deleted.
+        list.mSize -= deletedCount;
+        CHIP_ERROR err = SaveTrackedNodesList(list);
+        firstErr       = (firstErr == CHIP_NO_ERROR) ? err : firstErr;
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(SecureChannel,
+                         "TCP params cache is in an inconsistent state!  "
+                         "Unable to save tracked nodes list during attempted deletion of fabric index %u: %" CHIP_ERROR_FORMAT,
+                         fabricIndex, err.Format());
+        }
+    }
+
+    return firstErr;
+}
+
+CHIP_ERROR PeerTCPParamsStorage::SaveTCPParamsToStorage(const ScopedNodeId & node, const uint16_t & supportedTransports,
+                                                        const uint32_t & maxTCPMessageSize)
+{
+    // Save TCP params into key: /f/<fabricIndex>/tcp/<nodeId>
+    std::array<uint8_t, MaxTCPParamsInfoSize()> buf;
+    TLV::TLVWriter writer;
+    writer.Init(buf);
+
+    TLV::TLVType outerType;
+    ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerType));
+
+    ReturnErrorOnFailure(writer.Put(kSupportedTransportsTag, supportedTransports));
+    ReturnErrorOnFailure(writer.Put(kMaxTCPMessageSizeTag, maxTCPMessageSize));
+
+    ReturnErrorOnFailure(writer.EndContainer(outerType));
+
+    const auto len = writer.GetLengthWritten();
+    VerifyOrDie(CanCastTo<uint16_t>(len));
+
+    return mTCPParamsStorage->SyncSetKeyValue(GetStorageKey(node).KeyName(), buf.data(), static_cast<uint16_t>(len));
+}
+
+CHIP_ERROR PeerTCPParamsStorage::LoadTCPParamsFromStorage(const ScopedNodeId & node, uint16_t & supportedTransports,
+                                                          uint32_t & maxTCPMessageSize)
+{
+    std::array<uint8_t, MaxTCPParamsInfoSize()> buf;
+    uint16_t len = static_cast<uint16_t>(buf.size());
+
+    ReturnErrorOnFailure(mTCPParamsStorage->SyncGetKeyValue(GetStorageKey(node).KeyName(), buf.data(), len));
+
+    TLV::ContiguousBufferTLVReader reader;
+    reader.Init(buf.data(), len);
+
+    ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()));
+    TLV::TLVType containerType;
+    ReturnErrorOnFailure(reader.EnterContainer(containerType));
+
+    ReturnErrorOnFailure(reader.Next(kSupportedTransportsTag));
+    ReturnErrorOnFailure(reader.Get(supportedTransports));
+
+    ReturnErrorOnFailure(reader.Next(kMaxTCPMessageSizeTag));
+    ReturnErrorOnFailure(reader.Get(maxTCPMessageSize));
+
+    ReturnErrorOnFailure(reader.ExitContainer(containerType));
+    ReturnErrorOnFailure(reader.VerifyEndOfContainer());
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PeerTCPParamsStorage::DeleteTCPParamsFromStorage(const ScopedNodeId & node)
+{
+    return mTCPParamsStorage->SyncDeleteKeyValue(GetStorageKey(node).KeyName());
+}
+
+} // namespace Transport
+} // namespace chip

--- a/src/transport/raw/PeerTCPParamsStorage.h
+++ b/src/transport/raw/PeerTCPParamsStorage.h
@@ -1,0 +1,119 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/ScopedNodeId.h>
+#include <lib/core/TLV.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
+#include <transport/raw/TCPConfig.h>
+#include <transport/raw/TCPParamsStorageInterface.h>
+
+namespace chip {
+namespace Transport {
+/**
+ * @brief Class to store and retrieve peer TCP support parameters.
+ * These parameters are received as part of operational session negotiations
+ * with peer.
+ *
+ */
+class PeerTCPParamsStorage : public TCPParamsStorageInterface
+{
+public:
+    CHIP_ERROR Init(PersistentStorageDelegate * storage)
+    {
+        VerifyOrReturnError(storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+        mTCPParamsStorage = storage;
+        return CHIP_NO_ERROR;
+    }
+
+    static constexpr size_t kMaxTrackedNodes = CHIP_CONFIG_PEER_TCP_PARAMS_CACHE_SIZE;
+
+    virtual ~PeerTCPParamsStorage(){};
+
+    /**
+     * Recover supported transports and max TCP message size values for a given
+     * fabric-scoped node identity.
+     *
+     * @param node the node for which to recover TCP parameter information
+     * @param supportedTransports the transport types supported by the node
+     * @param maxTCPMessageSize the maximum TCP message size that the node is capable of receiving
+     * @return CHIP_NO_ERROR on success, CHIP_ERROR_KEY_NOT_FOUND if no TCP parameter information can be found, else an
+     * appropriate CHIP error on failure
+     */
+    CHIP_ERROR FindByScopedNodeId(const ScopedNodeId & node, uint16_t & supportedTransports, uint32_t & maxTCPMessageSize) override;
+    /**
+     * Save TCP parameter information to storage.
+     *
+     * @param node the node for which to recover TCP parameter information
+     * @param supportedTransports the transport types supported by the node
+     * @param maxTCPMessageSize the maximum TCP message size that the node is capable of receiving
+     * @return CHIP_NO_ERROR on success, else an appropriate CHIP error on failure
+     */
+    CHIP_ERROR SaveTCPParams(const ScopedNodeId & node, const uint16_t & supportedTransports,
+                             const uint32_t & maxTCPMessageSize) override;
+
+    CHIP_ERROR DeleteTCPParams(const ScopedNodeId & node) override;
+    /**
+     * Remove all TCP parameter information associated with the specified
+     * fabric index.  If no entries for the fabric index exist, this is a no-op
+     * and is considered successful.
+     *
+     * @param fabricIndex the index of the fabric for which to remove TCP parameter information
+     * @return CHIP_NO_ERROR on success, else an appropriate CHIP error on failure
+     */
+    CHIP_ERROR DeleteAllTCPParams(FabricIndex fabricIndex) override;
+
+    static StorageKeyName GetStorageKey(const ScopedNodeId & node);
+
+private:
+    static constexpr size_t MaxScopedNodeIdSize() { return TLV::EstimateStructOverhead(sizeof(NodeId), sizeof(FabricIndex)); }
+
+    static constexpr size_t MaxNodesListSize()
+    {
+        // The max size of the list is (1 byte control + bytes for actual value) times max number of list items
+        return TLV::EstimateStructOverhead((1 + MaxScopedNodeIdSize()) * kMaxTrackedNodes);
+    }
+
+    struct TrackedNodesList
+    {
+        size_t mSize;
+        ScopedNodeId mNodes[kMaxTrackedNodes];
+    };
+
+    static constexpr size_t MaxTCPParamsInfoSize() { return TLV::EstimateStructOverhead(sizeof(uint16_t), sizeof(uint32_t)); }
+
+    CHIP_ERROR SaveTCPParamsToStorage(const ScopedNodeId & node, const uint16_t & supportedTransports,
+                                      const uint32_t & maxTCPMessageSize);
+
+    CHIP_ERROR LoadTCPParamsFromStorage(const ScopedNodeId & node, uint16_t & supportedTransports, uint32_t & maxTCPMessageSize);
+
+    CHIP_ERROR DeleteTCPParamsFromStorage(const ScopedNodeId & node);
+
+    CHIP_ERROR SaveTrackedNodesList(const TrackedNodesList & list);
+    CHIP_ERROR LoadTrackedNodesList(TrackedNodesList & list);
+
+    static constexpr TLV::Tag kFabricIndexTag         = TLV::ContextTag(1);
+    static constexpr TLV::Tag kPeerNodeIdTag          = TLV::ContextTag(2);
+    static constexpr TLV::Tag kSupportedTransportsTag = TLV::ContextTag(3);
+    static constexpr TLV::Tag kMaxTCPMessageSizeTag   = TLV::ContextTag(4);
+
+    PersistentStorageDelegate * mTCPParamsStorage;
+};
+
+} // namespace Transport
+} // namespace chip

--- a/src/transport/raw/TCPConfig.h
+++ b/src/transport/raw/TCPConfig.h
@@ -115,4 +115,16 @@ namespace chip {
 #define CHIP_CONFIG_MAX_UNACKED_DATA_TIMEOUT_SECS (30)
 #endif // CHIP_CONFIG_MAX_UNACKED_DATA_TIMEOUT_SECS
 
+/**
+ *  @def CHIP_CONFIG_PEER_TCP_PARAMS_CACHE_SIZE
+ *
+ *  @brief
+ *    This defines the default value for the size
+ *    of the storage cache for peer TCP parameters.
+ *
+ */
+#ifndef CHIP_CONFIG_PEER_TCP_PARAMS_CACHE_SIZE
+#define CHIP_CONFIG_PEER_TCP_PARAMS_CACHE_SIZE (32)
+#endif // CHIP_CONFIG_PEER_TCP_PARAMS_CACHE_SIZE
+
 } // namespace chip

--- a/src/transport/raw/TCPParamsStorageInterface.h
+++ b/src/transport/raw/TCPParamsStorageInterface.h
@@ -1,0 +1,76 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/ScopedNodeId.h>
+#include <transport/raw/TCPConfig.h>
+
+namespace chip {
+namespace Transport {
+/**
+ * @brief Interface to store and retrieve TCP session parameters.
+ * These parameters are received as part of operational session negotiations
+ * with peer before being stored. Before, attempting to establish a TCP session,
+ * the caller uses these APIs to retrieve the corresponding TCP parameters for
+ * the specific peer.
+ *
+ */
+class TCPParamsStorageInterface
+{
+public:
+    static constexpr size_t kMaxTrackedNodes = CHIP_CONFIG_PEER_TCP_PARAMS_CACHE_SIZE;
+
+    virtual ~TCPParamsStorageInterface(){};
+
+    /**
+     * Recover supported transports and max TCP message size values for a given
+     * fabric-scoped node identity.
+     *
+     * @param node the node for which to recover TCP parameter information
+     * @param supportedTransports the transport types supported by the node
+     * @param maxTCPMessageSize the maximum TCP message size that the node is capable of receiving
+     * @return CHIP_NO_ERROR on success, CHIP_ERROR_KEY_NOT_FOUND if no TCP parameter information can be found, else an
+     * appropriate CHIP error on failure
+     */
+    virtual CHIP_ERROR FindByScopedNodeId(const ScopedNodeId & node, uint16_t & supportedTransports,
+                                          uint32_t & maxTCPMessageSize) = 0;
+    /**
+     * Save TCP parameter information to storage.
+     *
+     * @param node the node for which to recover TCP parameter information
+     * @param supportedTransports the transport types supported by the node
+     * @param maxTCPMessageSize the maximum TCP message size that the node is capable of receiving
+     * @return CHIP_NO_ERROR on success, else an appropriate CHIP error on failure
+     */
+    virtual CHIP_ERROR SaveTCPParams(const ScopedNodeId & node, const uint16_t & supportedTransports,
+                                     const uint32_t & maxTCPMessageSize) = 0;
+
+    virtual CHIP_ERROR DeleteTCPParams(const ScopedNodeId & node) = 0;
+    /**
+     * Remove all TCP parameter information associated with the specified
+     * fabric index.  If no entries for the fabric index exist, this is a no-op
+     * and is considered successful.
+     *
+     * @param fabricIndex the index of the fabric for which to remove TCP parameter information
+     * @return CHIP_NO_ERROR on success, else an appropriate CHIP error on failure
+     */
+    virtual CHIP_ERROR DeleteAllTCPParams(FabricIndex fabricIndex) = 0;
+};
+
+} // namespace Transport
+} // namespace chip

--- a/src/transport/raw/tests/BUILD.gn
+++ b/src/transport/raw/tests/BUILD.gn
@@ -45,7 +45,10 @@ chip_test_suite("tests") {
   ]
 
   if (chip_inet_config_enable_tcp_endpoint) {
-    test_sources += [ "TestTCP.cpp" ]
+    test_sources += [
+      "TestPeerTCPParamsStorage.cpp",
+      "TestTCP.cpp",
+    ]
   }
 
   sources = [ "TCPBaseTestAccess.h" ]
@@ -57,6 +60,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/lib/support:test_utils",
+    "${chip_root}/src/lib/support:testing",
     "${chip_root}/src/transport",
     "${chip_root}/src/transport/raw",
   ]

--- a/src/transport/raw/tests/TestPeerTCPParamsStorage.cpp
+++ b/src/transport/raw/tests/TestPeerTCPParamsStorage.cpp
@@ -1,0 +1,172 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
+#include <transport/raw/PeerTCPParamsStorage.h>
+
+TEST(TestPeerTCPParamsStorage, TestSaveTCPParams)
+{
+    chip::Transport::PeerTCPParamsStorage tcpParamStorage;
+    chip::TestPersistentStorageDelegate storage;
+    tcpParamStorage.Init(&storage);
+    struct
+    {
+        uint16_t supportedTransports;
+        uint32_t maxTCPMessageSize;
+        chip::ScopedNodeId node;
+    } vectors[CHIP_CONFIG_PEER_TCP_PARAMS_CACHE_SIZE];
+
+    // Populate test vectors.
+    for (size_t i = 0; i < ArraySize(vectors); ++i)
+    {
+        vectors[i].supportedTransports = static_cast<uint16_t>(i % 6);
+        vectors[i].maxTCPMessageSize   = static_cast<uint32_t>(i * 1000);
+        vectors[i].node = chip::ScopedNodeId(static_cast<chip::NodeId>(i + 1), static_cast<chip::FabricIndex>(i + 1));
+    }
+
+    // Fill storage.
+    for (size_t i = 0; i < CHIP_CONFIG_PEER_TCP_PARAMS_CACHE_SIZE; ++i)
+    {
+        EXPECT_EQ(tcpParamStorage.SaveTCPParams(vectors[i].node, vectors[i].supportedTransports, vectors[i].maxTCPMessageSize),
+                  CHIP_NO_ERROR);
+    }
+
+    // Verify behavior for cache spillover, where index 0 entity is replaced.
+    {
+        size_t last = ArraySize(vectors) - 1;
+        EXPECT_EQ(
+            tcpParamStorage.SaveTCPParams(vectors[last].node, vectors[last].supportedTransports, vectors[last].maxTCPMessageSize),
+            CHIP_NO_ERROR);
+        // Copy our data to our test vector index 0 to match
+        // what is now in storage.
+        vectors[0].node                = vectors[last].node;
+        vectors[0].supportedTransports = vectors[last].supportedTransports;
+        vectors[0].maxTCPMessageSize   = vectors[last].maxTCPMessageSize;
+    }
+
+    // Read back and verify values.
+    for (auto & vector : vectors)
+    {
+        uint16_t outSupportedTransports;
+        uint32_t outMaxTCPMessageSize;
+
+        // Verify retrieval by node.
+        EXPECT_EQ(tcpParamStorage.FindByScopedNodeId(vector.node, outSupportedTransports, outMaxTCPMessageSize), CHIP_NO_ERROR);
+        EXPECT_EQ(vector.supportedTransports, outSupportedTransports);
+        EXPECT_EQ(vector.maxTCPMessageSize, outMaxTCPMessageSize);
+    }
+}
+
+TEST(TestPeerTCPParamsStorage, TestDeleteTCPParams)
+{
+    chip::Transport::PeerTCPParamsStorage tcpParamStorage;
+    chip::TestPersistentStorageDelegate storage;
+    tcpParamStorage.Init(&storage);
+    struct
+    {
+        uint16_t supportedTransports;
+        uint32_t maxTCPMessageSize;
+        chip::ScopedNodeId node;
+    } vectors[CHIP_CONFIG_PEER_TCP_PARAMS_CACHE_SIZE];
+
+    // Populate test vectors.
+    for (size_t i = 0; i < ArraySize(vectors); ++i)
+    {
+        vectors[i].supportedTransports = static_cast<uint16_t>(i);
+        vectors[i].maxTCPMessageSize   = static_cast<uint32_t>(i * 1000);
+        vectors[i].node = chip::ScopedNodeId(static_cast<chip::NodeId>(i + 1), static_cast<chip::FabricIndex>(i + 1));
+    }
+
+    // Fill storage.
+    for (auto & vector : vectors)
+    // for (size_t i = 0; i < CHIP_CONFIG_PEER_TCP_PARAMS_CACHE_SIZE; ++i)
+    {
+        EXPECT_EQ(tcpParamStorage.SaveTCPParams(vector.node, vector.supportedTransports, vector.maxTCPMessageSize), CHIP_NO_ERROR);
+    }
+
+    // Delete values in turn from storage and verify they are removed.
+    for (auto & vector : vectors)
+    {
+        uint16_t outSupportedTransports;
+        uint32_t outMaxTCPMessageSize;
+        EXPECT_EQ(tcpParamStorage.DeleteTCPParams(vector.node), CHIP_NO_ERROR);
+        EXPECT_NE(tcpParamStorage.FindByScopedNodeId(vector.node, outSupportedTransports, outMaxTCPMessageSize), CHIP_NO_ERROR);
+    }
+}
+
+TEST(TestDefaultSessionResumptionStorage, TestDeleteAllTCPParams)
+{
+    chip::Transport::PeerTCPParamsStorage tcpParamStorage;
+    chip::TestPersistentStorageDelegate storage;
+    tcpParamStorage.Init(&storage);
+
+    struct
+    {
+        chip::FabricIndex fabricIndex;
+        struct
+        {
+            chip::ScopedNodeId node;
+        } nodes[3];
+    } vectors[CHIP_CONFIG_PEER_TCP_PARAMS_CACHE_SIZE / 3];
+
+    // Populate test vectors.
+    for (size_t i = 0; i < sizeof(vectors) / sizeof(vectors[0]); ++i)
+    {
+        vectors[i].fabricIndex = static_cast<chip::FabricIndex>(i + 1);
+        for (size_t j = 0; j < sizeof(vectors[0].nodes) / sizeof(vectors[0].nodes[0]); ++j)
+        {
+            vectors[i].nodes[j].node = chip::ScopedNodeId(static_cast<chip::NodeId>(j), vectors[i].fabricIndex);
+        }
+    }
+
+    // Create sample maxTCPMessageSize and supportedTransports values. We can use the same one for all entries.
+    uint16_t supportedTransports = 0x06; // TCP Server and Client
+    uint32_t maxTCPMessageSize   = 48000;
+
+    // Fill storage.
+    for (auto & vector : vectors)
+    {
+        for (auto & node : vector.nodes)
+        {
+            EXPECT_EQ(tcpParamStorage.SaveTCPParams(node.node, supportedTransports, maxTCPMessageSize), CHIP_NO_ERROR);
+        }
+    }
+
+    // Validate Fabric deletion.
+    for (const auto & vector : vectors)
+    {
+        uint16_t outSupportedTransports;
+        uint32_t outMaxTCPMessageSize;
+        // Verify fabric node entries exist.
+        for (const auto & node : vector.nodes)
+        {
+            EXPECT_EQ(tcpParamStorage.FindByScopedNodeId(node.node, outSupportedTransports, outMaxTCPMessageSize), CHIP_NO_ERROR);
+        }
+        // Delete fabric.
+        EXPECT_EQ(tcpParamStorage.DeleteAllTCPParams(vector.fabricIndex), CHIP_NO_ERROR);
+        // Verify fabric node entries no longer exist.
+        for (const auto & node : vector.nodes)
+        {
+            EXPECT_NE(tcpParamStorage.FindByScopedNodeId(node.node, outSupportedTransports, outMaxTCPMessageSize), CHIP_NO_ERROR);
+        }
+    }
+}
+
+// Test Suite


### PR DESCRIPTION
Mitigation for DoS vulnerability of TCP params advertised over DNS-SD as described in (Spec Issue: https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/8692)
The mitigation is to include the same advertised info inside the CASE session parameters so that they are available over an authenticated path if a prior MRP CASE session was established.

As part of this resolution,
Add TCP support and Max receive size info within negotiated CASE Session parameters.
--Nodes publish TCP support information during CASE session(over MRP)
   negotiations.
--Add TCP param storage logic to persist received TCP support info
   to storage during CASE session establishment and retrieve it during
   future TCP session setup.
--During TCP session setup, first check if the TCP support info
   for peer is available in storage before falling back to the DNS-SD
   advertised values.