### PR TITLE
[NXP][docker] Update k32w1 SDK

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-69 : [Infineon] Update ModusToolbox version to 3.2
+70 : [NXP] Update k32w1 SDK

--- a/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
@@ -14,7 +14,10 @@ RUN set -x \
 WORKDIR /opt/sdk
 
 RUN set -x \
-    && python3 -m pip install --break-system-packages -U --no-cache-dir west==1.0.0 \
+    && python3 -m pip install --break-system-packages -U --no-cache-dir west==1.2.0 \
+    && : # last line
+
+RUN set -x \
     && west init -m https://github.com/nxp-mcuxpresso/mcux-sdk --mr "MCUX_2.6.14_K32W0" \
     && west update \
     && chmod +x core/tools/imagetool/sign_images.sh \
@@ -24,14 +27,16 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && mkdir -p k32w1 \
-    && wget https://cache.nxp.com/lgfiles/bsps/SDK_2_12_7_K32W148-EVK.zip \
-    && unzip SDK_2_12_7_K32W148-EVK.zip -d k32w1 \
-    && rm -rf SDK_2_12_7_K32W148-EVK.zip
+    && mkdir -p k32w1/repo \
+    && cd k32w1/repo
+    && west init -m https://github.com/nxp-mcuxpresso/mcux-sdk --mr "MCUX_2.16.000" \
+    && west update -o=--depth=1 -n -f smart \
+    && cd - \
+    && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}
 
 COPY --from=build /opt/sdk/ /opt/sdk/
 
 ENV NXP_K32W0_SDK_ROOT=/opt/sdk/core
-ENV NXP_K32W1_SDK_ROOT=/opt/sdk/k32w1
+ENV NXP_SDK_ROOT=/opt/sdk/k32w1/repo


### PR DESCRIPTION
Update docker image to use the github SDK 2.16 for `k32w1`.

Needed by https://github.com/project-chip/connectedhomeip/pull/34926.