### PR TITLE
Fix typo in NXP dockerfile: missing backslash

### DIFF
--- a/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-k32w/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
 
 RUN set -x \
     && mkdir -p k32w1/repo \
-    && cd k32w1/repo
+    && cd k32w1/repo \
     && west init -m https://github.com/nxp-mcuxpresso/mcux-sdk --mr "MCUX_2.16.000" \
     && west update -o=--depth=1 -n -f smart \
     && cd - \


### PR DESCRIPTION
Fix typo in #34927

Did not update dockerfile version as the update makes no difference (dockerfile could not be built previously anyway).