### PR TITLE
[Fabric-Admin] Fix 'fabricsync sync-device' command always fails

### DIFF
--- a/examples/fabric-admin/commands/common/CHIPCommand.h
+++ b/examples/fabric-admin/commands/common/CHIPCommand.h
@@ -51,7 +51,7 @@ inline constexpr char kIdentityGamma[] = "gamma";
 // (CASE) communcation.
 inline constexpr char kIdentityNull[] = "null-fabric-commissioner";
 
-constexpr uint16_t kMaxCommandSize = 128;
+constexpr uint16_t kMaxCommandSize = 384;
 
 class CHIPCommand : public Command
 {

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -163,6 +163,8 @@ CHIP_ERROR FabricSyncRemoveBridgeCommand::RunCommand()
 
 void FabricSyncDeviceCommand::OnCommissioningWindowOpened(NodeId deviceId, CHIP_ERROR err, chip::SetupPayload payload)
 {
+    ChipLogProgress(NotSpecified, "FabricSyncDeviceCommand::OnCommissioningWindowOpened");
+
     if (err == CHIP_NO_ERROR)
     {
         char payloadBuffer[kMaxManaulCodeLength + 1];

--- a/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.cpp
+++ b/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.cpp
@@ -55,6 +55,7 @@ CHIP_ERROR OpenCommissioningWindowCommand::RunCommand()
                                                               .SetTimeout(mCommissioningWindowTimeout)
                                                               .SetIteration(mIteration)
                                                               .SetDiscriminator(mDiscriminator)
+                                                              .SetSetupPIN(mSetupPIN)
                                                               .SetSalt(mSalt)
                                                               .SetReadVIDPIDAttributes(true)
                                                               .SetCallback(&mOnOpenCommissioningWindowCallback),

--- a/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.h
@@ -48,7 +48,7 @@ public:
                     &mIteration, "Number of PBKDF iterations to use to derive the verifier.  Ignored if 'option' is 0.");
         AddArgument("discriminator", 0, 4095, &mDiscriminator, "Discriminator to use for advertising.  Ignored if 'option' is 0.");
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout, "Time, in seconds, before this command is considered to have timed out.");
-        AddArgument("setup-pin", 1, kSetupPINCodeMaximumValue, &mSetupPIN, "The setup PIN (Passcode) to use.");
+        AddArgument("setup-pin", 1, chip::kSetupPINCodeMaximumValue, &mSetupPIN, "The setup PIN (Passcode) to use.");
         AddArgument("salt", &mSalt,
                     "Salt payload encoded in hexadecimal. Random salt will be generated if absent. "
                     "This needs to be present if verifier is provided, corresponding to salt used for generating verifier");

--- a/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.h
@@ -46,7 +46,7 @@ public:
                     "Time, in seconds, before the commissioning window closes.");
         AddArgument("iteration", chip::Crypto::kSpake2p_Min_PBKDF_Iterations, chip::Crypto::kSpake2p_Max_PBKDF_Iterations,
                     &mIteration, "Number of PBKDF iterations to use to derive the verifier.  Ignored if 'option' is 0.");
-        AddArgument("discriminator", 0, 4096, &mDiscriminator, "Discriminator to use for advertising.  Ignored if 'option' is 0.");
+        AddArgument("discriminator", 0, 4095, &mDiscriminator, "Discriminator to use for advertising.  Ignored if 'option' is 0.");
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout, "Time, in seconds, before this command is considered to have timed out.");
         AddArgument("setup-pin", 1, 99999998, &mSetupPIN, "The setup PIN (Passcode) to use.");
         AddArgument("salt", &mSalt,

--- a/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.h
@@ -48,7 +48,7 @@ public:
                     &mIteration, "Number of PBKDF iterations to use to derive the verifier.  Ignored if 'option' is 0.");
         AddArgument("discriminator", 0, 4095, &mDiscriminator, "Discriminator to use for advertising.  Ignored if 'option' is 0.");
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout, "Time, in seconds, before this command is considered to have timed out.");
-        AddArgument("setup-pin", 1, 99999998, &mSetupPIN, "The setup PIN (Passcode) to use.");
+        AddArgument("setup-pin", 1, kSetupPINCodeMaximumValue, &mSetupPIN, "The setup PIN (Passcode) to use.");
         AddArgument("salt", &mSalt,
                     "Salt payload encoded in hexadecimal. Random salt will be generated if absent. "
                     "This needs to be present if verifier is provided, corresponding to salt used for generating verifier");

--- a/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/fabric-admin/commands/pairing/OpenCommissioningWindowCommand.h
@@ -48,6 +48,7 @@ public:
                     &mIteration, "Number of PBKDF iterations to use to derive the verifier.  Ignored if 'option' is 0.");
         AddArgument("discriminator", 0, 4096, &mDiscriminator, "Discriminator to use for advertising.  Ignored if 'option' is 0.");
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout, "Time, in seconds, before this command is considered to have timed out.");
+        AddArgument("setup-pin", 1, 99999998, &mSetupPIN, "The setup PIN (Passcode) to use.");
         AddArgument("salt", &mSalt,
                     "Salt payload encoded in hexadecimal. Random salt will be generated if absent. "
                     "This needs to be present if verifier is provided, corresponding to salt used for generating verifier");
@@ -76,6 +77,7 @@ private:
     uint16_t mDiscriminator;
 
     chip::Optional<uint16_t> mTimeout;
+    chip::Optional<uint32_t> mSetupPIN;
     chip::Optional<chip::ByteSpan> mSalt;
     chip::Optional<chip::ByteSpan> mVerifier;
 

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -33,7 +33,6 @@ namespace {
 // Constants
 constexpr uint32_t kSetupPinCode               = 20202021;
 constexpr uint16_t kRemoteBridgePort           = 5540;
-constexpr uint16_t kDiscriminator              = 3840;
 constexpr uint16_t kWindowTimeout              = 300;
 constexpr uint16_t kIteration                  = 1000;
 constexpr uint16_t kSubscribeMinInterval       = 0;
@@ -132,11 +131,16 @@ void DeviceManager::OpenRemoteDeviceCommissioningWindow(EndpointId remoteEndpoin
     // Open the commissioning window of a device from another fabric via its fabric bridge.
     // This method constructs and sends a command to open the commissioning window for a device
     // that is part of a different fabric, accessed through a fabric bridge.
-    StringBuilder<kMaxCommandSize> commandBuilder;
+    StringBuilder<512> commandBuilder;
+
+    // Use random discriminator to have less chance of collission.
+    uint16_t discriminator = Crypto::GetRandU16() % 4097; // 4097 to include the upper limit 4096
 
     commandBuilder.Add("pairing open-commissioning-window ");
     commandBuilder.AddFormat("%lu %d %d %d %d %d", mRemoteBridgeNodeId, remoteEndpointId, kEnhancedCommissioningMethod,
-                             kWindowTimeout, kIteration, kDiscriminator);
+                             kWindowTimeout, kIteration, discriminator);
+    commandBuilder.Add(" --setup-pin 20202021");
+    commandBuilder.Add(" --salt hex:4c38d8d7708e777b5df816886167839828578ee98280ddac6e801124e8e695e7");
 
     PushCommand(commandBuilder.c_str());
 }

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -134,13 +134,12 @@ void DeviceManager::OpenRemoteDeviceCommissioningWindow(EndpointId remoteEndpoin
     StringBuilder<512> commandBuilder;
 
     // Use random discriminator to have less chance of collission.
-    uint16_t discriminator = Crypto::GetRandU16() % 4097; // 4097 to include the upper limit 4096
+    uint16_t discriminator = Crypto::GetRandU16() % 4096; // 4096 to include the upper limit 4095
 
     commandBuilder.Add("pairing open-commissioning-window ");
     commandBuilder.AddFormat("%lu %d %d %d %d %d", mRemoteBridgeNodeId, remoteEndpointId, kEnhancedCommissioningMethod,
                              kWindowTimeout, kIteration, discriminator);
     commandBuilder.Add(" --setup-pin 20202021");
-    commandBuilder.Add(" --salt hex:4c38d8d7708e777b5df816886167839828578ee98280ddac6e801124e8e695e7");
 
     PushCommand(commandBuilder.c_str());
 }

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -38,6 +38,7 @@ constexpr uint16_t kIteration                  = 1000;
 constexpr uint16_t kSubscribeMinInterval       = 0;
 constexpr uint16_t kSubscribeMaxInterval       = 60;
 constexpr uint16_t kAggragatorEndpointId       = 1;
+constexpr uint16_t kMaxDiscriminatorLength     = 4095;
 constexpr uint8_t kEnhancedCommissioningMethod = 1;
 
 } // namespace
@@ -117,7 +118,7 @@ void DeviceManager::OpenDeviceCommissioningWindow(NodeId nodeId, uint32_t commis
                                                   uint32_t discriminator, const char * saltHex, const char * verifierHex)
 {
     // Open the commissioning window of a device within its own fabric.
-    StringBuilder<512> commandBuilder;
+    StringBuilder<kMaxCommandSize> commandBuilder;
 
     commandBuilder.Add("pairing open-commissioning-window ");
     commandBuilder.AddFormat("%lu %d %d %d %d %d --salt hex:%s --verifier hex:%s", nodeId, kRootEndpointId,
@@ -134,7 +135,8 @@ void DeviceManager::OpenRemoteDeviceCommissioningWindow(EndpointId remoteEndpoin
     StringBuilder<512> commandBuilder;
 
     // Use random discriminator to have less chance of collission.
-    uint16_t discriminator = Crypto::GetRandU16() % 4096; // 4096 to include the upper limit 4095
+    uint16_t discriminator =
+        Crypto::GetRandU16() % (kMaxDiscriminatorLength + 1); // Include the upper limit kMaxDiscriminatorLength
 
     commandBuilder.Add("pairing open-commissioning-window ");
     commandBuilder.AddFormat("%lu %d %d %d %d %d", mRemoteBridgeNodeId, remoteEndpointId, kEnhancedCommissioningMethod,


### PR DESCRIPTION
 'fabricsync sync-device' command always fails on master after the OCW API has been refactored. We need to update the fabric-admin example app to adapt to the new interface.
 
 
 
 

