### PR TITLE
[chip-tool] Adjust the maximum value of 'discriminator' to align with spec

### DIFF
--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
@@ -38,7 +38,7 @@ public:
                     "Time, in seconds, before the commissioning window closes.");
         AddArgument("iteration", chip::Crypto::kSpake2p_Min_PBKDF_Iterations, chip::Crypto::kSpake2p_Max_PBKDF_Iterations,
                     &mIteration, "Number of PBKDF iterations to use to derive the verifier.  Ignored if 'option' is 0.");
-        AddArgument("discriminator", 0, 4096, &mDiscriminator, "Discriminator to use for advertising.  Ignored if 'option' is 0.");
+        AddArgument("discriminator", 0, 4095, &mDiscriminator, "Discriminator to use for advertising.  Ignored if 'option' is 0.");
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout, "Time, in seconds, before this command is considered to have timed out.");
     }
 


### PR DESCRIPTION
https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/service_device_management/AdminCommissioningCluster.adoc#81-opencommissioningwindow-ocw-command

The maximum allowed value for  the 'discriminator' parameter of OpenCommissioningWindow (OCW) Command is 4095, not 4096.
