### PR TITLE
Add matter_enable_recommended meta-setting

### DIFF
--- a/.github/workflows/minimal-build.yaml
+++ b/.github/workflows/minimal-build.yaml
@@ -17,7 +17,7 @@ name: Minimal Build (Linux / configure)
 on:
     push:
         branches-ignore:
-            - 'dependabot/**'
+            - "dependabot/**"
     pull_request:
     merge_group:
 
@@ -42,11 +42,11 @@ jobs:
             - name: Checkout submodules # but don't bootstrap!
               uses: ./.github/actions/checkout-submodules
               with:
-                platform: linux
+                  platform: linux
 
             - name: Configure and build All Clusters App
               run: |
-                  CC=gcc CXX=g++ scripts/configure --project=examples/all-clusters-app/linux && ./ninja-build
+                  CC=gcc CXX=g++ scripts/configure --project=examples/all-clusters-app/linux --enable-recommended=no && ./ninja-build
 
     minimal-network-manager:
         name: Linux / configure build of network-manager-app
@@ -64,8 +64,8 @@ jobs:
             - name: Checkout submodules # but don't bootstrap!
               uses: ./.github/actions/checkout-submodules
               with:
-                platform: linux
+                  platform: linux
 
             - name: Configure and build Network Manager App
               run: |
-                  CC=gcc CXX=g++ scripts/configure --project=examples/network-manager-app/linux && ./ninja-build
+                  CC=gcc CXX=g++ scripts/configure --project=examples/network-manager-app/linux --enable-recommended=no && ./ninja-build

--- a/config/recommended.gni
+++ b/config/recommended.gni
@@ -1,0 +1,31 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  # Note for SDK developers:  As additional features with their own settings
+  # are added to the SDK, consider using the `matter_enable_recommended`
+  # meta-setting instead of a default value of 'true', especially where a
+  # different default is used based on platform (current_os): Often various
+  # debugging features have previously been defaulted to on for Linux and/or
+  # Mac but off for embedded platforms (on the assumption that Linux / Mac
+  # don't have resource constraints?); build settings of that nature should
+  # instead reference this meta-setting. E.g.
+  #   enable_flux_capacitor =  matter_enable_recommended && current_os == "linux"
+
+  # Enable recommended settings by default. This is a meta-setting
+  # that is enabled by default, and acts as a default for various
+  # other settings. Setting it to false produces a more conservative /
+  # minimal set of defaults.
+  matter_enable_recommended = true
+}

--- a/examples/shell/shell_common/BUILD.gn
+++ b/examples/shell/shell_common/BUILD.gn
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("//build_overrides/openthread.gni")
-import("${chip_root}/src/lib/core/core.gni")
+import("${chip_root}/config/recommended.gni")
 import("${chip_root}/src/platform/device.gni")
 
 declare_args() {

--- a/examples/shell/shell_common/BUILD.gn
+++ b/examples/shell/shell_common/BUILD.gn
@@ -14,12 +14,12 @@
 
 import("//build_overrides/chip.gni")
 import("//build_overrides/openthread.gni")
-
+import("${chip_root}/src/lib/core/core.gni")
 import("${chip_root}/src/platform/device.gni")
 
 declare_args() {
-  # Enable server command only on linux for now.
-  chip_shell_cmd_server = current_os == "linux" || current_os == "mac"
+  chip_shell_cmd_server = matter_enable_recommended &&
+                          (current_os == "linux" || current_os == "mac")
 }
 
 config("shell_common_config") {

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
-import("${chip_root}/src/lib/core/core.gni")
+import("${chip_root}/config/recommended.gni")
 
 declare_args() {
   # Temporary flag for interaction model and echo protocols, set it to true to enable

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/chip.gni")
+import("${chip_root}/src/lib/core/core.gni")
+
 declare_args() {
   # Temporary flag for interaction model and echo protocols, set it to true to enable
   chip_app_use_echo = false
@@ -26,7 +29,7 @@ declare_args() {
   #   - disabled: does not use data model interface at all
   #   - check:    runs BOTH datamodel and non-data-model (if possible) functionality and compares results
   #   - enabled:  runs only the data model interface (does not use the legacy code)
-  if (current_os == "linux") {
+  if (matter_enable_recommended && current_os == "linux") {
     chip_use_data_model_interface = "check"
   } else {
     chip_use_data_model_interface = "disabled"

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -14,8 +14,17 @@
 
 declare_args() {
   # Enable recommended settings by default. This is a meta-setting
-  # that acts as a default for various other settings. Setting it
-  # to false produces a more conservative / minimal set of defaults.
+  # that is enabled by default, and acts as a default for various
+  # other settings. Setting it to false produces a more conservative /
+  # minimal set of defaults.
+  #
+  # As additional features with their own settings are added to the SDK,
+  # consider using this meta-setting instead of a default value of 'true',
+  # especially where a different default is used based on platform (current_os):
+  # E.g. various debugging features have previously been defaulted to on
+  # for Linux and/or Mac but off for embedded platforms (on the assumption
+  # that Linux / Mac don't have resource constraints?); build settings of that
+  # nature should instead reference this meta-setting.
   matter_enable_recommended = true
 
   # Enable logging. Shorthand for chip_error_logging, etc.

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 declare_args() {
+  # Enable recommended settings by default. This is a meta-setting
+  # that acts as a default for various other settings. Setting it
+  # to false produces a more conservative / minimal set of defaults.
+  matter_enable_recommended = true
+
   # Enable logging. Shorthand for chip_error_logging, etc.
   chip_logging = true
 }
@@ -28,13 +33,16 @@ declare_args() {
   chip_progress_logging = chip_logging
 
   # Enable detail logging.
-  chip_detail_logging = chip_logging
+  chip_detail_logging = matter_enable_recommended && chip_logging
 
   # Enable automation logging.
-  chip_automation_logging = chip_logging
+  chip_automation_logging = matter_enable_recommended && chip_logging
+}
 
+declare_args() {
   # Configure the maximum size for logged messages
-  if (current_os == "linux" || current_os == "mac" || current_os == "ios") {
+  if ((matter_enable_recommended || chip_detail_logging) &&
+      (current_os == "linux" || current_os == "mac" || current_os == "ios")) {
     # Allow base64 encoding of 1 MTU (4 * (1280 / 3) + padding
     chip_log_message_max_size = 1708
   } else {
@@ -88,7 +96,8 @@ declare_args() {
   chip_config_memory_debug_dmalloc = false
 
   # When enabled trace messages using tansport trace hook.
-  chip_enable_transport_trace = current_os == "linux" || current_os == "mac"
+  chip_enable_transport_trace = matter_enable_recommended &&
+                                (current_os == "linux" || current_os == "mac")
 
   # When this is enabled trace messages will be sent to pw_trace.
   chip_enable_transport_pw_trace = false

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -12,21 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-declare_args() {
-  # Enable recommended settings by default. This is a meta-setting
-  # that is enabled by default, and acts as a default for various
-  # other settings. Setting it to false produces a more conservative /
-  # minimal set of defaults.
-  #
-  # As additional features with their own settings are added to the SDK,
-  # consider using this meta-setting instead of a default value of 'true',
-  # especially where a different default is used based on platform (current_os):
-  # E.g. various debugging features have previously been defaulted to on
-  # for Linux and/or Mac but off for embedded platforms (on the assumption
-  # that Linux / Mac don't have resource constraints?); build settings of that
-  # nature should instead reference this meta-setting.
-  matter_enable_recommended = true
+import("//build_overrides/chip.gni")
+import("${chip_root}/config/recommended.gni")
 
+declare_args() {
   # Enable logging. Shorthand for chip_error_logging, etc.
   chip_logging = true
 }

--- a/src/tracing/tracing_args.gni
+++ b/src/tracing/tracing_args.gni
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("${build_root}/config/compiler/compiler.gni")
-import("${chip_root}/src/lib/core/core.gni")
+import("${chip_root}/config/recommended.gni")
 import("${chip_root}/src/platform/device.gni")
 
 declare_args() {

--- a/src/tracing/tracing_args.gni
+++ b/src/tracing/tracing_args.gni
@@ -14,6 +14,7 @@
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 import("${build_root}/config/compiler/compiler.gni")
+import("${chip_root}/src/lib/core/core.gni")
 import("${chip_root}/src/platform/device.gni")
 
 declare_args() {
@@ -24,7 +25,8 @@ declare_args() {
   # Additionally, if tracing is enabled, the main() function has to add
   # backends explicitly
   matter_enable_tracing_support =
-      current_os == "android" || chip_device_platform == "darwin"
+      matter_enable_recommended &&
+      (current_os == "android" || chip_device_platform == "darwin")
 
   # Defines the trace backend. Current matter tracing splits the logic
   # into two parts:


### PR DESCRIPTION
This setting defaults to true which leaves current behavior unchanged.

However it can be set to false to achieve a more conservative / minimal set of defaults, without having to manually disable an ever-increasing set of features. Consider using this setting as the default value for other settings that increase code size or add debugging / tracing or similar features that are not always desired. Especially settings that default to true on Linux and Mac ("because you're probably building for development") should likely use this option for their default, e.g.

```
matter_foo = matter_enable_recommended && (current_os == "linux" || current_os == "mac")
```