### PR TITLE
[v1.2-branch][Infineon] Cherry-pick #34770 Provision to enable/disable NOC key-pair generation using HSM #34924

### DIFF
--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_P256_trustm.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_P256_trustm.cpp
@@ -78,7 +78,6 @@ extern CHIP_ERROR ECDSA_validate_msg_signature_H(const P256PublicKey * public_ke
 extern CHIP_ERROR ECDSA_validate_hash_signature_H(const P256PublicKey * public_key, const uint8_t * hash, const size_t hash_length,
                                                   const P256ECDSASignature & signature);
 
-#if (ENABLE_TRUSTM_GENERATE_EC_KEY || ENABLE_TRUSTM_ECDSA_VERIFY)
 static CHIP_ERROR get_trustm_keyid_from_keypair(const P256KeypairContext mKeypair, uint32_t * key_id)
 {
     if (0 != memcmp(&mKeypair.mBytes[0], trustm_magic_no, sizeof(trustm_magic_no)))
@@ -87,21 +86,14 @@ static CHIP_ERROR get_trustm_keyid_from_keypair(const P256KeypairContext mKeypai
     }
 
     *key_id += (mKeypair.mBytes[CRYPTO_KEYPAIR_KEYID_OFFSET]) | (mKeypair.mBytes[CRYPTO_KEYPAIR_KEYID_OFFSET + 1] << 8);
-
     return CHIP_NO_ERROR;
 }
-#endif // #if (ENABLE_TRUSTM_GENERATE_EC_KEY || ENABLE_TRUSTM_ECDSA_VERIFY)
 
 P256Keypair::~P256Keypair()
 {
-    // Add method to get the keyid
     if (CHIP_NO_ERROR != get_trustm_keyid_from_keypair(mKeypair, &keyid))
     {
         Clear();
-    }
-    else
-    {
-        // Delete the key in SE
     }
 }
 
@@ -109,14 +101,6 @@ CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
 {
     CHIP_ERROR error = CHIP_ERROR_INTERNAL;
 
-#if !ENABLE_TRUSTM_GENERATE_EC_KEY
-    if (CHIP_NO_ERROR == Initialize_H(this, &mPublicKey, &mKeypair))
-    {
-        mInitialized = true;
-    }
-    error = CHIP_NO_ERROR;
-    return error;
-#else
     uint8_t pubkey[128] = {
         0,
     };
@@ -136,11 +120,20 @@ CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
     }
     else
     {
+#if !ENABLE_TRUSTM_NOC_KEYGEN
+        error = Initialize_H(this, &mPublicKey, &mKeypair);
+        if (CHIP_NO_ERROR == error)
+        {
+            mInitialized = true;
+        }
+        return error;
+#else
         // Add the logic to use different keyid
         keyid = TRUSTM_NODE_OID_KEY_START;
         // Trust M ECC 256 Key Gen
         ChipLogDetail(Crypto, "Generating NIST256 key in TrustM !");
         key_usage = (optiga_key_usage_t) (OPTIGA_KEY_USAGE_SIGN | OPTIGA_KEY_USAGE_AUTHENTICATION);
+#endif //! ENABLE_TRUSTM_NOC_KEYGEN
     }
     // Trust M init
     trustm_Open();
@@ -167,14 +160,13 @@ exit:
         trustm_close();
     }
     return error;
-#endif
 }
 
 CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P256ECDSASignature & out_signature) const
 {
-#if !ENABLE_TRUSTM_GENERATE_EC_KEY
-    return ECDSA_sign_msg_H(&mKeypair, msg, msg_length, out_signature);
-#else
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_WELL_UNINITIALIZED);
+    uint16_t keyid = (mKeypair.mBytes[CRYPTO_KEYPAIR_KEYID_OFFSET]) | (mKeypair.mBytes[CRYPTO_KEYPAIR_KEYID_OFFSET + 1] << 8);
+
     CHIP_ERROR error                  = CHIP_ERROR_INTERNAL;
     optiga_lib_status_t return_status = OPTIGA_LIB_BUSY;
 
@@ -188,20 +180,31 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P
 
     VerifyOrReturnError(msg != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(msg_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
-    ChipLogDetail(Crypto, "TrustM: ECDSA_sign_msg");
     // Trust M Init
     trustm_Open();
     // Hash to get the digest
     Hash_SHA256(msg, msg_length, &digest[0]);
-    uint16_t keyid = (mKeypair.mBytes[CRYPTO_KEYPAIR_KEYID_OFFSET]) | (mKeypair.mBytes[CRYPTO_KEYPAIR_KEYID_OFFSET + 1] << 8);
-    // Api call to calculate the signature
-    if (keyid == OPTIGA_KEY_ID_E0F2)
+
+    if (keyid == OPTIGA_KEY_ID_E0F0)
     {
-        return_status = trustm_ecdsa_sign(OPTIGA_KEY_ID_E0F2, digest, digest_length, signature_trustm, &signature_trustm_len);
+        ChipLogDetail(Crypto, "TrustM: ECDSA_sign_msg");
+
+        // Api call to calculate the signature
+        return_status = trustm_ecdsa_sign(OPTIGA_KEY_ID_E0F0, digest, digest_length, signature_trustm, &signature_trustm_len);
     }
     else
     {
-        return_status = trustm_ecdsa_sign(OPTIGA_KEY_ID_E0F0, digest, digest_length, signature_trustm, &signature_trustm_len);
+#if !ENABLE_TRUSTM_NOC_KEYGEN
+        // Use the mbedtls based method
+        ChipLogDetail(Crypto, "ECDSA sing msg mbedtls");
+        return ECDSA_sign_msg_H(&mKeypair, msg, msg_length, out_signature);
+#else
+        if (keyid == OPTIGA_KEY_ID_E0F2)
+        {
+            ChipLogDetail(Crypto, "TrustM: ECDSA_sign_msg");
+            return_status = trustm_ecdsa_sign(OPTIGA_KEY_ID_E0F2, digest, digest_length, signature_trustm, &signature_trustm_len);
+        }
+#endif //! ENABLE_TRUSTM_NOC_KEYGEN
     }
 
     VerifyOrExit(return_status == OPTIGA_LIB_SUCCESS, error = CHIP_ERROR_INTERNAL);
@@ -220,14 +223,10 @@ exit:
         trustm_close();
     }
     return error;
-#endif
 }
 
 CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const
 {
-#if !ENABLE_TRUSTM_GENERATE_EC_KEY
-    return ECDH_derive_secret_H(&mKeypair, remote_public_key, out_secret);
-#else
     CHIP_ERROR error                  = CHIP_ERROR_INTERNAL;
     optiga_lib_status_t return_status = OPTIGA_LIB_BUSY;
     size_t secret_length              = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
@@ -262,7 +261,6 @@ exit:
         trustm_close();
     }
     return error;
-#endif
 }
 
 CHIP_ERROR P256PublicKey::ECDSA_validate_hash_signature(const uint8_t * hash, size_t hash_length,
@@ -313,6 +311,12 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
         0,
     };
 
+    if (0 != memcmp(&mKeypair.mBytes[0], trustm_magic_no, sizeof(trustm_magic_no)))
+    {
+        VerifyOrReturnError(mInitialized, CHIP_ERROR_WELL_UNINITIALIZED);
+        return Serialize_H(mKeypair, mPublicKey, output);
+    }
+
     /* Set the public key */
     P256PublicKey & public_key = const_cast<P256PublicKey &>(Pubkey());
     bbuf.Put(Uint8::to_uchar(public_key), public_key.Length());
@@ -358,16 +362,11 @@ CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
     }
     else
     {
-#if !ENABLE_TRUSTM_KEY_IMPORT
         if (CHIP_NO_ERROR == (error = Deserialize_H(this, &mPublicKey, &mKeypair, input)))
         {
             mInitialized = true;
         }
         return error;
-#else
-        // Add in code for Trust M
-        return CHIP_NO_ERROR;
-#endif
     }
 }
 
@@ -430,9 +429,6 @@ static void add_tlv(uint8_t * buf, size_t buf_index, uint8_t tag, size_t len, ui
 
 CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length) const
 {
-#if !ENABLE_TRUSTM_GENERATE_EC_KEY
-    return NewCertificateSigningRequest_H(&mKeypair, csr, csr_length);
-#else
     CHIP_ERROR error                  = CHIP_ERROR_INTERNAL;
     optiga_lib_status_t return_status = OPTIGA_LIB_BUSY;
 
@@ -585,8 +581,6 @@ exit:
         trustm_close();
     }
     return error;
-
-#endif
 }
 
 } // namespace Crypto

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_config_trustm.h
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_config_trustm.h
@@ -33,11 +33,6 @@
 #define ENABLE_TRUSTM_ECDSA_VERIFY 1
 
 /*
- * Enable Key Import for trustm
- */
-#define ENABLE_TRUSTM_KEY_IMPORT 0
-
-/*
  * Enable trustm for HKDF SHA256
  */
 #define ENABLE_TRUSTM_HKDF_SHA256 0
@@ -51,3 +46,8 @@
  * Enable trustm for DA
  */
 #define ENABLE_TRUSTM_DEVICE_ATTESTATION 1
+
+/*
+ * Enable trustm for NOC key-pair generation
+ */
+#define ENABLE_TRUSTM_NOC_KEYGEN 0

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.h
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHsm_utils_trustm.h
@@ -51,7 +51,7 @@ extern optiga_util_t * p_local_util;
     }
 
 static const uint8_t trustm_magic_no[] = IFX_CRYPTO_KEY_MAGIC;
-static const uint8_t DA_KEY_ID[]       = { 0xE0, 0xF0 };
+static const uint8_t DA_KEY_ID[]       = { 0xF0, 0xE0 }; // OID --> 0xE0F0
 /* Open session to trustm */
 void trustm_Open(void);
 void read_certificate_from_optiga(uint16_t optiga_oid, char * cert_pem, uint16_t * cert_pem_length);

--- a/third_party/infineon/psoc6/psoc6_sdk/configs/mbedtls_user_config.h
+++ b/third_party/infineon/psoc6/psoc6_sdk/configs/mbedtls_user_config.h
@@ -73,13 +73,13 @@
  * Uncomment a macro to enable alternate implementation of specific base
  * platform function
  */
-//#define MBEDTLS_PLATFORM_EXIT_ALT
+// #define MBEDTLS_PLATFORM_EXIT_ALT
 #define MBEDTLS_PLATFORM_TIME_ALT
-//#define MBEDTLS_PLATFORM_FPRINTF_ALT
-//#define MBEDTLS_PLATFORM_PRINTF_ALT
-//#define MBEDTLS_PLATFORM_SNPRINTF_ALT
-//#define MBEDTLS_PLATFORM_NV_SEED_ALT
-//#define MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT
+// #define MBEDTLS_PLATFORM_FPRINTF_ALT
+// #define MBEDTLS_PLATFORM_PRINTF_ALT
+// #define MBEDTLS_PLATFORM_SNPRINTF_ALT
+// #define MBEDTLS_PLATFORM_NV_SEED_ALT
+// #define MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT
 
 /**
  * \def MBEDTLS_ENTROPY_HARDWARE_ALT
@@ -103,7 +103,7 @@
  */
 #undef MBEDTLS_ECP_DP_SECP192R1_ENABLED
 #undef MBEDTLS_ECP_DP_SECP224R1_ENABLED
-//#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+// #define MBEDTLS_ECP_DP_SECP256R1_ENABLED
 #undef MBEDTLS_ECP_DP_SECP384R1_ENABLED
 #undef MBEDTLS_ECP_DP_SECP521R1_ENABLED
 #undef MBEDTLS_ECP_DP_SECP192K1_ENABLED
@@ -112,7 +112,7 @@
 #undef MBEDTLS_ECP_DP_BP256R1_ENABLED
 #undef MBEDTLS_ECP_DP_BP384R1_ENABLED
 #undef MBEDTLS_ECP_DP_BP512R1_ENABLED
-//#undef MBEDTLS_ECP_DP_CURVE25519_ENABLED
+// #undef MBEDTLS_ECP_DP_CURVE25519_ENABLED
 #undef MBEDTLS_ECP_DP_CURVE448_ENABLED
 
 /**
@@ -246,7 +246,7 @@
  *
  * Uncomment this macro to enable support for SSLv2 Client Hello messages.
  */
-//#define MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO
+// #define MBEDTLS_SSL_SRV_SUPPORT_SSLV2_CLIENT_HELLO
 
 /**
  * \def MBEDTLS_SSL_PROTO_TLS1
@@ -468,7 +468,7 @@
  *
  * This module is required for X.509 CRL parsing.
  */
-//#undef MBEDTLS_X509_CRL_PARSE_C
+// #undef MBEDTLS_X509_CRL_PARSE_C
 
 /**
  * \def MBEDTLS_X509_CSR_PARSE_C
@@ -482,7 +482,7 @@
  *
  * This module is used for reading X.509 certificate request.
  */
-//#undef MBEDTLS_X509_CSR_PARSE_C
+// #undef MBEDTLS_X509_CSR_PARSE_C
 
 /**
  * \def MBEDTLS_X509_CREATE_C
@@ -495,7 +495,7 @@
  *
  * This module is the basis for creating X.509 certificates and CSRs.
  */
-//#undef MBEDTLS_X509_CREATE_C
+// #undef MBEDTLS_X509_CREATE_C
 
 /**
  * \def MBEDTLS_X509_CSR_WRITE_C
@@ -508,7 +508,7 @@
  *
  * This module is required for X.509 certificate request writing.
  */
-//#undef MBEDTLS_X509_CSR_WRITE_C
+// #undef MBEDTLS_X509_CSR_WRITE_C
 
 /**
  * \def MBEDTLS_X509_CRT_WRITE_C
@@ -521,7 +521,7 @@
  *
  * This module is required for X.509 certificate creation.
  */
-//#undef MBEDTLS_X509_CRT_WRITE_C
+// #undef MBEDTLS_X509_CRT_WRITE_C
 
 /**
  * \def MBEDTLS_CERTS_C
@@ -778,5 +778,11 @@
  * Uncomment to get errors on using deprecated functions and features.
  */
 #define MBEDTLS_DEPRECATED_REMOVED
+
+#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_ECDSA_C
+#define MBEDTLS_PK_WRITE_C
+#define MBEDTLS_X509_CREATE_C
+#define MBEDTLS_X509_CSR_WRITE_C
 
 #endif /* MBEDTLS_USER_CONFIG_HEADER */


### PR DESCRIPTION


Cherry-pick https://github.com/project-chip/connectedhomeip/pull/34770

Added the flag ENABLE_TRUSTM_NOC_KEYGEN in the config.
Updated the functions to support NOC keygen with and without Trust M MTR.
Restyled changes