### PR TITLE
[Telink] Update tlsr9528a_4m_flash.overlay

### DIFF
--- a/src/platform/telink/tlsr9528a_4m_flash.overlay
+++ b/src/platform/telink/tlsr9528a_4m_flash.overlay
@@ -14,31 +14,35 @@
 		};
 		slot0_partition: partition@13000 {
 			label = "image-0";
-			reg = <0x13000 0x1ec000>;
+			reg = <0x13000 0x1ea000>;
 		};
-		factory_partition: partition@1ff000 {
-			label = "factory-data";
-			reg = <0x1ff000 0x1000>;
-		};
-		dac_keypair_partition: partition@200000 {
-			label = "dac-keypair";
-			reg = <0x200000 0x1000>; //store dac and key pair.
-		};
-		descriptor_partition: partition@201000 {
-			label = "sboot-descriptor";
-			reg = <0x201000 0x2000>;
-		};
-		storage_partition: partition@203000 {
-			label = "storage";
-			reg = <0x203000 0xf000>;
-		};
-		slot1_partition: partition@212000 {
+		slot1_partition: partition@1fd000 {
 			label = "image-1";
-			reg = <0x212000 0x1ec000>;
+			reg = <0x1fd000 0x1ea000>;
+		};
+		storage_partition: partition@3e7000 {
+			label = "storage";
+			reg = <0x3e7000 0xf000>; // matter nvs part 
+		};
+		dac_keypair_partition: partition@3f6000 {
+			label = "dac-keypair";
+			reg = <0x3f6000 0x1000>; //store dac and key pair.
+		};
+		factory_partition: partition@3f7000 {
+			label = "factory-data";
+			reg = <0x3f7000 0x1000>; // factory data info 
+		};
+		secure_partition: partition@3f8000 {
+ 			label = "secure";
+			reg = <0x3f8000 0x4000>; //secure info ,reserved for secure boot .if not use , can be used by other way .
+ 		};
+		vendor_rfu_partition: partition@3fc000 {
+			label = "vendor-rfu";
+			reg = <0x3fc000 0x2000>;// reserved for chip extend.
 		};
 		vendor_partition: partition@3fe000 {
 			label = "vendor-data";
-			reg = <0x3fe000 0x2000>;
+			reg = <0x3fe000 0x2000>;// mac and adc info.
 		};
 	};
 };


### PR DESCRIPTION
**Change overview**

This update rearranges the flash memory layout to optimize configuration interface related to B92 flash protection. It positions the NVS at the tail and the bootloader along with firmware slots at the head of the flash, enabling enhanced flash protection settings with an initial safeguard of the first 1M.