### PR TITLE
Fixed devcontainer creation for huge user ids

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update \
     && :
 
 RUN groupadd -g $USER_GID $USERNAME \
-    && useradd -s /bin/bash -u $USER_UID -g $USER_GID -G docker,sudo -m $USERNAME \
+    && useradd --no-log-init -s /bin/bash -u $USER_UID -g $USER_GID -G docker,sudo -m $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     && :


### PR DESCRIPTION
### Issue
 
The useradd command generates entries in the lastlog file with offsets based on user IDs. Typically, this does not pose a problem due to:
 
User IDs generally being around a 1000.
File systems that support sparse files, which do not allocate actual disk space for unused file regions.
However, in cases where user IDs are significantly larger and the file system does not support sparse files, the lastlog file can grow to several hundred gigabytes.
 
### Proposed Solution
 
Introduce the --no-log-init flag to prevent useradd from updating the lastlog file.

### Testing

Tested locally with uid=1556251776.