### PR TITLE
[examples][lock-common] Remove iostream include

### DIFF
--- a/examples/lock-app/lock-common/src/LockManager.cpp
+++ b/examples/lock-app/lock-common/src/LockManager.cpp
@@ -18,7 +18,6 @@
 
 #include "LockManager.h"
 
-#include <iostream>
 #include <lib/support/logging/CHIPLogging.h>
 #include <memory>
 


### PR DESCRIPTION
 * iostream adds a lot of unnecessary functions when lock-app is compiled for non-linux platforms, increasing flash and ram consumption
 * linux lock-app compiles without it, so the include is not necessary