### PR TITLE
Use timedInteraction for RevokeCommissioning in CCTRL_2_2

### DIFF
--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -161,7 +161,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
         self.step(9)
         cmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
         # If no exception is raised, this is success
-        await self.send_single_cmd(cmd)
+        await self.send_single_cmd(cmd, timedRequestTimeoutMs=5000)
 
         self.step(10)
         if not events:


### PR DESCRIPTION
Without it, we fail with a `chip.interaction_model.Status.NeedsTimedInteraction`