### PR TITLE
Fix typo in wait_for_user_input (test harness test issue in several tests for fabric sync)

### DIFF
--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -182,7 +182,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
 
         self.step(12)
         if not self.is_ci:
-            self.wait_for_use_input("Approve Commissioning approval request using manufacturer specified mechanism")
+            self.wait_for_user_input("Approve Commissioning approval request using manufacturer specified mechanism")
 
         self.step(13)
         if not events:
@@ -257,7 +257,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
 
         self.step(23)
         if not self.is_ci:
-            self.wait_for_use_input("Approve Commissioning approval request using manufacturer specified mechanism")
+            self.wait_for_user_input("Approve Commissioning approval request using manufacturer specified mechanism")
 
         self.step(24)
         events = new_event

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -102,7 +102,7 @@ class TC_MCORE_FS_1_1(MatterBaseTest):
         await self.send_single_cmd(cmd, endpoint=dut_commissioning_control_endpoint)
 
         if not self.is_ci:
-            self.wait_for_use_input("Approve Commissioning approval request on DUT using manufacturer specified mechanism")
+            self.wait_for_user_input("Approve Commissioning approval request on DUT using manufacturer specified mechanism")
 
         if not events:
             new_event = await self.default_controller.ReadEvent(nodeid=self.dut_node_id, events=event_path)

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -118,7 +118,7 @@ class TC_MCORE_FS_1_2(MatterBaseTest):
 
         self.step(4)
         if not self.is_ci:
-            self.wait_for_use_input(
+            self.wait_for_user_input(
                 "Commission TH_SED_DUT onto DUT_FSA’s fabric using the manufacturer specified mechanism. (ensure Synchronization is enabled.)")
         else:
             logging.info("Stopping after step 3 while running in CI to avoid manual steps.")


### PR DESCRIPTION
Missing a `r` for `user`