### PR TITLE
fix unused variable issue on non-macOS testing

### DIFF
--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestServerAppRunner.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestServerAppRunner.m
@@ -21,11 +21,13 @@
 
 static unsigned sAppRunnerIndex = 1;
 
+#if HAVE_NSTASK
 // kBasePort gets the discriminator added to it to figure out the port the app
 // should be using.  This ensures that apps with distinct discriminators use
 // distinct ports.
 static const uint16_t kMinDiscriminator = 1111;
 static const uint16_t kBasePort = 5542 - kMinDiscriminator;
+#endif // HAVE_NSTASK
 
 @implementation MTRTestServerAppRunner {
     unsigned _uniqueIndex;


### PR DESCRIPTION
because unused variables / functions are treated as errors, these conditionally-used variables must not be present when testing for platforms that don't have `NSTask`
