### PR TITLE
[Android] Implement Establish PASE Connection for SetupCode

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -867,7 +867,8 @@ JNI_METHOD(void, establishPaseConnectionByCode)
 
     JniUtfString setUpCodeJniString(env, setUpCode);
 
-    err = wrapper->Controller()->EstablishPASEConnection(static_cast<chip::NodeId>(deviceId), setUpCodeJniString.c_str(), discoveryType);
+    err = wrapper->Controller()->EstablishPASEConnection(static_cast<chip::NodeId>(deviceId), setUpCodeJniString.c_str(),
+                                                         discoveryType);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -852,6 +852,30 @@ JNI_METHOD(void, establishPaseConnectionByAddress)
     }
 }
 
+JNI_METHOD(void, establishPaseConnectionByCode)
+(JNIEnv * env, jobject self, jlong handle, jlong deviceId, jstring setUpCode, jboolean useOnlyOnNetworkDiscovery)
+{
+    chip::DeviceLayer::StackLock lock;
+    CHIP_ERROR err                           = CHIP_NO_ERROR;
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+
+    auto discoveryType = DiscoveryType::kAll;
+    if (useOnlyOnNetworkDiscovery)
+    {
+        discoveryType = DiscoveryType::kDiscoveryNetworkOnly;
+    }
+
+    JniUtfString setUpCodeJniString(env, setUpCode);
+
+    err = wrapper->Controller()->EstablishPASEConnection(static_cast<chip::NodeId>(deviceId), setUpCodeJniString.c_str(), discoveryType);
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to establish PASE connection.");
+        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
+    }
+}
+
 JNI_METHOD(void, continueCommissioning)
 (JNIEnv * env, jobject self, jlong handle, jlong devicePtr, jboolean ignoreAttestationFailure)
 {

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -478,9 +478,11 @@ public class ChipDeviceController {
    * @param useOnlyOnNetworkDiscovery the flag to indicate the commissionable device is available on
    *     the network
    */
-  public void establishPaseConnection(long deviceId, String setupCode, boolean useOnlyOnNetworkDiscovery) {
+  public void establishPaseConnection(
+      long deviceId, String setupCode, boolean useOnlyOnNetworkDiscovery) {
     Log.d(TAG, "Establishing PASE connection using Code: " + setupCode);
-    establishPaseConnectionByCode(deviceControllerPtr, deviceId, setupCode, useOnlyOnNetworkDiscovery);
+    establishPaseConnectionByCode(
+        deviceControllerPtr, deviceId, setupCode, useOnlyOnNetworkDiscovery);
   }
 
   /**
@@ -1638,7 +1640,7 @@ public class ChipDeviceController {
       long deviceControllerPtr, long deviceId, String address, int port, long setupPincode);
 
   private native void establishPaseConnectionByCode(
-        long deviceControllerPtr, long deviceId, String setupCode, boolean useOnlyOnNetworkDiscovery);
+      long deviceControllerPtr, long deviceId, String setupCode, boolean useOnlyOnNetworkDiscovery);
 
   private native void commissionDevice(
       long deviceControllerPtr,

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -471,6 +471,19 @@ public class ChipDeviceController {
   }
 
   /**
+   * Establish a secure PASE connection using the scanned QR code or manual entry code.
+   *
+   * @param deviceId the ID of the node to connect to
+   * @param setupCode the scanned QR code or manual entry code
+   * @param useOnlyOnNetworkDiscovery the flag to indicate the commissionable device is available on
+   *     the network
+   */
+  public void establishPaseConnection(long deviceId, String setupCode, boolean useOnlyOnNetworkDiscovery) {
+    Log.d(TAG, "Establishing PASE connection using Code: " + setupCode);
+    establishPaseConnectionByCode(deviceControllerPtr, deviceId, setupCode, useOnlyOnNetworkDiscovery);
+  }
+
+  /**
    * Initiates the automatic commissioning flow using the specified network credentials. It is
    * expected that a secure session has already been established via {@link
    * #establishPaseConnection(long, int, long)}.
@@ -1623,6 +1636,9 @@ public class ChipDeviceController {
 
   private native void establishPaseConnectionByAddress(
       long deviceControllerPtr, long deviceId, String address, int port, long setupPincode);
+
+  private native void establishPaseConnectionByCode(
+        long deviceControllerPtr, long deviceId, String setupCode, boolean useOnlyOnNetworkDiscovery);
 
   private native void commissionDevice(
       long deviceControllerPtr,


### PR DESCRIPTION
Implement establishPaseConnection method for Android Platform.
 -> There is an IP Address, BLE only establishPaseConnection method, but there is no establishPaseConnection method using setupCode, so a new one was added.

