### PR TITLE
[TC-TSTAT-1.1] Remove wrong dependency to attribute id 82

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
@@ -575,7 +575,7 @@ tests:
       response:
           constraints:
               type: list
-              contains: [72, 74, 78, 80, 82]
+              contains: [72, 74, 78, 80]
 
     - label: "Step 5: TH reads EventList attribute from the DUT."
       PICS: PICS_EVENT_LIST_ENABLED


### PR DESCRIPTION
This was a left-over attribute id before a spec change where attributes got removed. After that the attribute id 82dec is `SetpointHoldExpiryTimestamp` which has nothing to do with Presets
