### PR TITLE
[Tizen] Implement GetThreadVersion() for Thread driver

### DIFF
--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -179,6 +179,7 @@ private:
 
     void OnPlatformEvent(const ChipDeviceEvent * event);
     void ErasePersistentInfo();
+    uint16_t GetThreadVersion();
     ConnectivityManager::ThreadDeviceType GetThreadDeviceType();
     CHIP_ERROR SetThreadDeviceType(ConnectivityManager::ThreadDeviceType threadRole);
 
@@ -395,6 +396,11 @@ inline CHIP_ERROR ThreadStackManager::StartThreadScan(NetworkCommissioning::Thre
 inline void ThreadStackManager::ErasePersistentInfo()
 {
     static_cast<ImplClass *>(this)->_ErasePersistentInfo();
+}
+
+inline uint16_t ThreadStackManager::GetThreadVersion()
+{
+    return static_cast<ImplClass *>(this)->_GetThreadVersion();
 }
 
 inline ConnectivityManager::ThreadDeviceType ThreadStackManager::GetThreadDeviceType()

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -105,6 +105,7 @@ public:
     CHIP_ERROR GetAndLogThreadTopologyFull();
     CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf);
     CHIP_ERROR GetExternalIPv6Address(chip::Inet::IPAddress & addr);
+    CHIP_ERROR GetThreadVersion(uint16_t & version);
     CHIP_ERROR GetPollPeriod(uint32_t & buf);
 
     CHIP_ERROR SetThreadProvision(ByteSpan aDataset);
@@ -179,7 +180,6 @@ private:
 
     void OnPlatformEvent(const ChipDeviceEvent * event);
     void ErasePersistentInfo();
-    uint16_t GetThreadVersion();
     ConnectivityManager::ThreadDeviceType GetThreadDeviceType();
     CHIP_ERROR SetThreadDeviceType(ConnectivityManager::ThreadDeviceType threadRole);
 
@@ -398,11 +398,6 @@ inline void ThreadStackManager::ErasePersistentInfo()
     static_cast<ImplClass *>(this)->_ErasePersistentInfo();
 }
 
-inline uint16_t ThreadStackManager::GetThreadVersion()
-{
-    return static_cast<ImplClass *>(this)->_GetThreadVersion();
-}
-
 inline ConnectivityManager::ThreadDeviceType ThreadStackManager::GetThreadDeviceType()
 {
     return static_cast<ImplClass *>(this)->_GetThreadDeviceType();
@@ -448,6 +443,11 @@ inline CHIP_ERROR ThreadStackManager::GetPrimary802154MACAddress(uint8_t * buf)
 inline CHIP_ERROR ThreadStackManager::GetExternalIPv6Address(chip::Inet::IPAddress & addr)
 {
     return static_cast<ImplClass *>(this)->_GetExternalIPv6Address(addr);
+}
+
+inline CHIP_ERROR ThreadStackManager::GetThreadVersion(uint16_t & version)
+{
+    return static_cast<ImplClass *>(this)->_GetThreadVersion(version);
 }
 
 inline CHIP_ERROR ThreadStackManager::GetPollPeriod(uint32_t & buf)

--- a/src/platform/Linux/NetworkCommissioningThreadDriver.cpp
+++ b/src/platform/Linux/NetworkCommissioningThreadDriver.cpp
@@ -211,9 +211,9 @@ ThreadCapabilities LinuxThreadDriver::GetSupportedThreadFeatures()
 
 uint16_t LinuxThreadDriver::GetThreadVersion()
 {
-    // TODO https://github.com/project-chip/connectedhomeip/issues/30602
-    // Needs to be implemented with DBUS io.openthread.BorderRouter Thread API
-    return 0;
+    uint16_t version = 0;
+    ThreadStackMgrImpl().GetThreadVersion(version);
+    return version;
 }
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -563,6 +563,13 @@ CHIP_ERROR ThreadStackManagerImpl::_GetExternalIPv6Address(chip::Inet::IPAddress
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+CHIP_ERROR ThreadStackManagerImpl::_GetThreadVersion(uint16_t & version)
+{
+    // TODO https://github.com/project-chip/connectedhomeip/issues/30602
+    // Needs to be implemented with DBUS io.openthread.BorderRouter Thread API
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR ThreadStackManagerImpl::_GetPollPeriod(uint32_t & buf)
 {
     // TODO: Remove Weave legacy APIs

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -113,7 +113,7 @@ public:
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
 
     CHIP_ERROR _GetExternalIPv6Address(chip::Inet::IPAddress & addr);
-
+    CHIP_ERROR _GetThreadVersion(uint16_t & version);
     CHIP_ERROR _GetPollPeriod(uint32_t & buf);
 
     void _ResetThreadNetworkDiagnosticsCounts();

--- a/src/platform/NuttX/NetworkCommissioningThreadDriver.cpp
+++ b/src/platform/NuttX/NetworkCommissioningThreadDriver.cpp
@@ -211,9 +211,9 @@ ThreadCapabilities LinuxThreadDriver::GetSupportedThreadFeatures()
 
 uint16_t LinuxThreadDriver::GetThreadVersion()
 {
-    // TODO https://github.com/project-chip/connectedhomeip/issues/30602
-    // Needs to be implemented with DBUS io.openthread.BorderRouter Thread API
-    return 0;
+    uint16_t version = 0;
+    ThreadStackMgrImpl().GetThreadVersion(version);
+    return version;
 }
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/NuttX/ThreadStackManagerImpl.cpp
+++ b/src/platform/NuttX/ThreadStackManagerImpl.cpp
@@ -568,6 +568,13 @@ CHIP_ERROR ThreadStackManagerImpl::_GetExternalIPv6Address(chip::Inet::IPAddress
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+CHIP_ERROR ThreadStackManagerImpl::_GetThreadVersion(uint16_t & version)
+{
+    // TODO https://github.com/project-chip/connectedhomeip/issues/30602
+    // Needs to be implemented with DBUS io.openthread.BorderRouter Thread API
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR ThreadStackManagerImpl::_GetPollPeriod(uint32_t & buf)
 {
     // TODO: Remove Weave legacy APIs

--- a/src/platform/NuttX/ThreadStackManagerImpl.h
+++ b/src/platform/NuttX/ThreadStackManagerImpl.h
@@ -114,7 +114,7 @@ public:
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
 
     CHIP_ERROR _GetExternalIPv6Address(chip::Inet::IPAddress & addr);
-
+    CHIP_ERROR _GetThreadVersion(uint16_t & version);
     CHIP_ERROR _GetPollPeriod(uint32_t & buf);
 
     CHIP_ERROR _JoinerStart();

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -325,8 +325,8 @@ ThreadCapabilities GenericThreadDriver::GetSupportedThreadFeatures()
 
 uint16_t GenericThreadDriver::GetThreadVersion()
 {
-    uint16_t version;
-    VerifyOrReturnError(ConnectivityMgrImpl().GetThreadVersion(version) == CHIP_NO_ERROR, 0);
+    uint16_t version = 0;
+    ThreadStackMgrImpl().GetThreadVersion(version);
     return version;
 }
 

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -325,7 +325,7 @@ ThreadCapabilities GenericThreadDriver::GetSupportedThreadFeatures()
 
 uint16_t GenericThreadDriver::GetThreadVersion()
 {
-    return otThreadGetVersion();
+    return ThreadStackMgrImpl().GetThreadVersion();
 }
 
 } // namespace NetworkCommissioning

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -325,7 +325,9 @@ ThreadCapabilities GenericThreadDriver::GetSupportedThreadFeatures()
 
 uint16_t GenericThreadDriver::GetThreadVersion()
 {
-    return ThreadStackMgrImpl().GetThreadVersion();
+    uint16_t version;
+    VerifyOrReturnError(ConnectivityMgrImpl().GetThreadVersion(version) == CHIP_NO_ERROR, 0);
+    return version;
 }
 
 } // namespace NetworkCommissioning

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -70,7 +70,7 @@ public:
 
     otInstance * OTInstance() const;
     static void OnOpenThreadStateChange(uint32_t flags, void * context);
-    inline void OverrunErrorTally(void);
+    inline void OverrunErrorTally();
     void
     SetNetworkStatusChangeCallback(NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * statusChangeCallback)
     {
@@ -80,22 +80,22 @@ public:
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
-    void _ProcessThreadActivity(void);
+    void _ProcessThreadActivity();
     bool _HaveRouteToAddress(const Inet::IPAddress & destAddr);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
-    bool _IsThreadEnabled(void);
+    bool _IsThreadEnabled();
     CHIP_ERROR _SetThreadEnabled(bool val);
 
-    bool _IsThreadProvisioned(void);
-    bool _IsThreadAttached(void);
+    bool _IsThreadProvisioned();
+    bool _IsThreadAttached();
     CHIP_ERROR _GetThreadProvision(Thread::OperationalDataset & dataset);
     CHIP_ERROR _SetThreadProvision(ByteSpan netInfo);
     CHIP_ERROR _AttachToThreadNetwork(const Thread::OperationalDataset & dataset,
                                       NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * callback);
-    void _OnThreadAttachFinished(void);
-    void _ErasePersistentInfo(void);
+    void _OnThreadAttachFinished();
+    void _ErasePersistentInfo();
     uint16_t _GetThreadVersion();
-    ConnectivityManager::ThreadDeviceType _GetThreadDeviceType(void);
+    ConnectivityManager::ThreadDeviceType _GetThreadDeviceType();
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
     CHIP_ERROR _StartThreadScan(NetworkCommissioning::ThreadDriver::ScanCallback * callback);
     static void _OnNetworkScanFinished(otActiveScanResult * aResult, void * aContext);
@@ -106,16 +106,16 @@ protected:
     CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
-    bool _HaveMeshConnectivity(void);
-    CHIP_ERROR _GetAndLogThreadStatsCounters(void);
-    CHIP_ERROR _GetAndLogThreadTopologyMinimal(void);
-    CHIP_ERROR _GetAndLogThreadTopologyFull(void);
+    bool _HaveMeshConnectivity();
+    CHIP_ERROR _GetAndLogThreadStatsCounters();
+    CHIP_ERROR _GetAndLogThreadTopologyMinimal();
+    CHIP_ERROR _GetAndLogThreadTopologyFull();
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
     CHIP_ERROR _GetExternalIPv6Address(chip::Inet::IPAddress & addr);
-    void _ResetThreadNetworkDiagnosticsCounts(void);
+    void _ResetThreadNetworkDiagnosticsCounts();
     CHIP_ERROR _GetPollPeriod(uint32_t & buf);
-    void _OnWoBLEAdvertisingStart(void);
-    void _OnWoBLEAdvertisingStop(void);
+    void _OnWoBLEAdvertisingStart();
+    void _OnWoBLEAdvertisingStop();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     CHIP_ERROR _AddSrpService(const char * aInstanceName, const char * aName, uint16_t aPort,
@@ -145,8 +145,8 @@ protected:
 
     CHIP_ERROR ConfigureThreadStack(otInstance * otInst);
     CHIP_ERROR DoInit(otInstance * otInst);
-    bool IsThreadAttachedNoLock(void);
-    bool IsThreadInterfaceUpNoLock(void);
+    bool IsThreadAttachedNoLock();
+    bool IsThreadInterfaceUpNoLock();
 
 private:
     // ===== Private members for use by this class only.
@@ -283,19 +283,19 @@ inline otInstance * GenericThreadStackManagerImpl_OpenThread<ImplClass>::OTInsta
 }
 
 template <class ImplClass>
-inline void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OverrunErrorTally(void)
+inline void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OverrunErrorTally()
 {
     mOverrunCount++;
 }
 
 template <class ImplClass>
-inline void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnWoBLEAdvertisingStart(void)
+inline void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnWoBLEAdvertisingStart()
 {
     // Do nothing by default.
 }
 
 template <class ImplClass>
-inline void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnWoBLEAdvertisingStop(void)
+inline void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnWoBLEAdvertisingStop()
 {
     // Do nothing by default.
 }

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -94,6 +94,7 @@ protected:
                                       NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * callback);
     void _OnThreadAttachFinished(void);
     void _ErasePersistentInfo(void);
+    uint16_t _GetThreadVersion();
     ConnectivityManager::ThreadDeviceType _GetThreadDeviceType(void);
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
     CHIP_ERROR _StartThreadScan(NetworkCommissioning::ThreadDriver::ScanCallback * callback);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -94,7 +94,6 @@ protected:
                                       NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * callback);
     void _OnThreadAttachFinished();
     void _ErasePersistentInfo();
-    uint16_t _GetThreadVersion();
     ConnectivityManager::ThreadDeviceType _GetThreadDeviceType();
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
     CHIP_ERROR _StartThreadScan(NetworkCommissioning::ThreadDriver::ScanCallback * callback);
@@ -112,6 +111,7 @@ protected:
     CHIP_ERROR _GetAndLogThreadTopologyFull();
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
     CHIP_ERROR _GetExternalIPv6Address(chip::Inet::IPAddress & addr);
+    CHIP_ERROR _GetThreadVersion(uint16_t & version);
     void _ResetThreadNetworkDiagnosticsCounts();
     CHIP_ERROR _GetPollPeriod(uint32_t & buf);
     void _OnWoBLEAdvertisingStart();

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -525,12 +525,6 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnNetworkScanFinished
 }
 
 template <class ImplClass>
-uint16_t GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetThreadVersion()
-{
-    return otThreadGetVersion();
-}
-
-template <class ImplClass>
 ConnectivityManager::ThreadDeviceType GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetThreadDeviceType()
 {
     VerifyOrReturnValue(mOTInst, ConnectivityManager::kThreadDeviceType_NotSupported);
@@ -1075,6 +1069,13 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetExternalIPv6
     }
 
     return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+}
+
+template <class ImplClass>
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetThreadVersion(uint16_t & version)
+{
+    version = otThreadGetVersion();
+    return CHIP_NO_ERROR;
 }
 
 template <class ImplClass>

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -525,6 +525,12 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnNetworkScanFinished
 }
 
 template <class ImplClass>
+uint16_t GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetThreadVersion()
+{
+    return otThreadGetVersion();
+}
+
+template <class ImplClass>
 ConnectivityManager::ThreadDeviceType GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetThreadDeviceType(void)
 {
     VerifyOrReturnValue(mOTInst, ConnectivityManager::kThreadDeviceType_NotSupported);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -27,6 +27,7 @@
 #define GENERIC_THREAD_STACK_MANAGER_IMPL_OPENTHREAD_IPP
 
 #include <cassert>
+#include <limits>
 
 #include <openthread/cli.h>
 #include <openthread/dataset.h>
@@ -59,7 +60,6 @@
 #include <platform/ThreadStackManager.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
-#include <limits>
 extern "C" void otSysProcessDrivers(otInstance * aInstance);
 
 #if CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
@@ -80,7 +80,7 @@ app::Clusters::NetworkCommissioning::Instance
     sThreadNetworkCommissioningInstance(CHIP_DEVICE_CONFIG_THREAD_NETWORK_ENDPOINT_ID /* Endpoint Id */, &sGenericThreadDriver);
 #endif
 
-void initNetworkCommissioningThreadDriver(void)
+void initNetworkCommissioningThreadDriver()
 {
 #ifndef _NO_GENERIC_THREAD_NETWORK_COMMISSIONING_DRIVER_
     sThreadNetworkCommissioningInstance.Init();
@@ -143,7 +143,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnOpenThreadStateChang
 }
 
 template <class ImplClass>
-void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ProcessThreadActivity(void)
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ProcessThreadActivity()
 {
     otTaskletsProcess(mOTInst);
     otSysProcessDrivers(mOTInst);
@@ -256,7 +256,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnPlatformEvent(const
 }
 
 template <class ImplClass>
-bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::_IsThreadEnabled(void)
+bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::_IsThreadEnabled()
 {
     VerifyOrReturnValue(mOTInst, false);
     otDeviceRole curRole;
@@ -330,7 +330,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetThreadProvis
 }
 
 template <class ImplClass>
-bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::_IsThreadProvisioned(void)
+bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::_IsThreadProvisioned()
 {
     VerifyOrReturnValue(mOTInst, false);
     bool provisioned;
@@ -363,7 +363,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetThreadProvis
 }
 
 template <class ImplClass>
-bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::_IsThreadAttached(void)
+bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::_IsThreadAttached()
 {
     VerifyOrReturnValue(mOTInst, false);
     otDeviceRole curRole;
@@ -531,7 +531,7 @@ uint16_t GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetThreadVersion(
 }
 
 template <class ImplClass>
-ConnectivityManager::ThreadDeviceType GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetThreadDeviceType(void)
+ConnectivityManager::ThreadDeviceType GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetThreadDeviceType()
 {
     VerifyOrReturnValue(mOTInst, ConnectivityManager::kThreadDeviceType_NotSupported);
     ConnectivityManager::ThreadDeviceType deviceType;
@@ -657,7 +657,7 @@ exit:
 }
 
 template <class ImplClass>
-bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::_HaveMeshConnectivity(void)
+bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::_HaveMeshConnectivity()
 {
     VerifyOrReturnValue(mOTInst, false);
     bool res;
@@ -706,7 +706,7 @@ bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::_HaveMeshConnectivity(
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThreadStatsCounters(void)
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThreadStatsCounters()
 {
     VerifyOrReturnError(mOTInst, CHIP_ERROR_INCORRECT_STATE);
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -801,7 +801,7 @@ exit:
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThreadTopologyMinimal(void)
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetAndLogThreadTopologyMinimal()
 {
     VerifyOrReturnError(mOTInst, CHIP_ERROR_INCORRECT_STATE);
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1078,7 +1078,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_GetExternalIPv6
 }
 
 template <class ImplClass>
-void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ResetThreadNetworkDiagnosticsCounts(void)
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ResetThreadNetworkDiagnosticsCounts()
 {
     // Based on the spec, only OverrunCount should be resetted.
     mOverrunCount = 0;
@@ -1181,14 +1181,14 @@ exit:
 }
 
 template <class ImplClass>
-bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::IsThreadAttachedNoLock(void)
+bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::IsThreadAttachedNoLock()
 {
     otDeviceRole curRole = otThreadGetDeviceRole(mOTInst);
     return (curRole != OT_DEVICE_ROLE_DISABLED && curRole != OT_DEVICE_ROLE_DETACHED);
 }
 
 template <class ImplClass>
-bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::IsThreadInterfaceUpNoLock(void)
+bool GenericThreadStackManagerImpl_OpenThread<ImplClass>::IsThreadInterfaceUpNoLock()
 {
     return otIp6IsEnabled(mOTInst);
 }
@@ -1248,7 +1248,7 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_SetPollingInter
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 template <class ImplClass>
-void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ErasePersistentInfo(void)
+void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ErasePersistentInfo()
 {
     VerifyOrReturn(mOTInst);
     ChipLogProgress(DeviceLayer, "Erasing Thread persistent info...");

--- a/src/platform/OpenThread/OpenThreadUtils.cpp
+++ b/src/platform/OpenThread/OpenThreadUtils.cpp
@@ -80,7 +80,7 @@ bool FormatOpenThreadError(char * buf, uint16_t bufSize, CHIP_ERROR err)
 /**
  * Register a text error formatter for OpenThread errors.
  */
-void RegisterOpenThreadErrorFormatter(void)
+void RegisterOpenThreadErrorFormatter()
 {
     static ErrorFormatter sOpenThreadErrorFormatter = { FormatOpenThreadError, NULL };
 

--- a/src/platform/OpenThread/OpenThreadUtils.h
+++ b/src/platform/OpenThread/OpenThreadUtils.h
@@ -59,7 +59,7 @@ namespace Internal {
 #endif // CHIP_CONFIG_OPENTHREAD_ERROR_MAX
 
 extern CHIP_ERROR MapOpenThreadError(otError otErr);
-extern void RegisterOpenThreadErrorFormatter(void);
+extern void RegisterOpenThreadErrorFormatter();
 
 /**
  * Log information related to a state change in the OpenThread stack.

--- a/src/platform/Tizen/NetworkCommissioningThreadDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningThreadDriver.cpp
@@ -178,7 +178,9 @@ ThreadCapabilities TizenThreadDriver::GetSupportedThreadFeatures()
 
 uint16_t TizenThreadDriver::GetThreadVersion()
 {
-    return DeviceLayer::ThreadStackMgr().GetThreadVersion();
+    uint16_t version = 0;
+    DeviceLayer::ThreadStackMgr().GetThreadVersion(version);
+    return version;
 }
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/Tizen/NetworkCommissioningThreadDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningThreadDriver.cpp
@@ -28,7 +28,6 @@
 #include <platform/ThreadStackManager.h>
 
 #include "NetworkCommissioningDriver.h"
-#include "ThreadStackManagerImpl.h"
 
 namespace chip {
 namespace DeviceLayer {
@@ -38,8 +37,8 @@ namespace NetworkCommissioning {
 
 CHIP_ERROR TizenThreadDriver::Init(BaseDriver::NetworkStatusChangeCallback * networkStatusChangeCallback)
 {
-    VerifyOrReturnError(ConnectivityMgrImpl().IsThreadAttached(), CHIP_NO_ERROR);
-    VerifyOrReturnError(ThreadStackMgrImpl().GetThreadProvision(mStagingNetwork) == CHIP_NO_ERROR, CHIP_NO_ERROR);
+    VerifyOrReturnError(ConnectivityMgr().IsThreadAttached(), CHIP_NO_ERROR);
+    VerifyOrReturnError(ThreadStackMgr().GetThreadProvision(mStagingNetwork) == CHIP_NO_ERROR, CHIP_NO_ERROR);
 
     mSavedNetwork.Init(mStagingNetwork.AsByteSpan());
 
@@ -133,7 +132,7 @@ void TizenThreadDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * cal
         (networkId.size() == Thread::kSizeExtendedPanId && memcmp(networkId.data(), extpanid, Thread::kSizeExtendedPanId) == 0),
         status = Status::kNetworkNotFound);
 
-    VerifyOrExit(DeviceLayer::ThreadStackMgrImpl().AttachToThreadNetwork(mStagingNetwork, callback) == CHIP_NO_ERROR,
+    VerifyOrExit(DeviceLayer::ThreadStackMgr().AttachToThreadNetwork(mStagingNetwork, callback) == CHIP_NO_ERROR,
                  status = Status::kUnknownError);
 
 exit:
@@ -145,7 +144,7 @@ exit:
 
 void TizenThreadDriver::ScanNetworks(ThreadDriver::ScanCallback * callback)
 {
-    CHIP_ERROR err = DeviceLayer::ThreadStackMgrImpl().StartThreadScan(callback);
+    CHIP_ERROR err = DeviceLayer::ThreadStackMgr().StartThreadScan(callback);
     if (err != CHIP_NO_ERROR)
     {
         callback->OnFinished(Status::kUnknownError, CharSpan(), nullptr);
@@ -179,8 +178,7 @@ ThreadCapabilities TizenThreadDriver::GetSupportedThreadFeatures()
 
 uint16_t TizenThreadDriver::GetThreadVersion()
 {
-    // TODO Needs to be implemented with Tizen Thread stack api
-    return 0;
+    return DeviceLayer::ThreadStackMgr().GetThreadVersion();
 }
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -394,6 +394,22 @@ exit:
     return CHIP_ERROR_INTERNAL;
 }
 
+uint16_t ThreadStackManagerImpl::_GetThreadVersion()
+{
+    int threadErr            = THREAD_ERROR_NONE;
+    thread_version_e version = 0;
+
+    VerifyOrExit(mIsInitialized, ChipLogError(DeviceLayer, "Thread stack not initialized"));
+
+    threadErr = thread_get_version(mThreadInstance, &version);
+    VerifyOrExit(threadErr == THREAD_ERROR_NONE, ChipLogError(DeviceLayer, "FAIL: get thread version"));
+
+    ChipLogProgress(DeviceLayer, "Thread version [%u]", version);
+
+exit:
+    return version;
+}
+
 ConnectivityManager::ThreadDeviceType ThreadStackManagerImpl::_GetThreadDeviceType()
 {
     VerifyOrReturnError(mIsInitialized, ConnectivityManager::ThreadDeviceType::kThreadDeviceType_NotSupported,

--- a/src/platform/Tizen/ThreadStackManagerImpl.h
+++ b/src/platform/Tizen/ThreadStackManagerImpl.h
@@ -84,8 +84,6 @@ public:
 
     void _OnThreadAttachFinished(void);
 
-    uint16_t _GetThreadVersion();
-
     ConnectivityManager::ThreadDeviceType _GetThreadDeviceType();
 
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);
@@ -93,15 +91,11 @@ public:
     bool _HaveMeshConnectivity();
 
     CHIP_ERROR _GetAndLogThreadStatsCounters();
-
     CHIP_ERROR _GetAndLogThreadTopologyMinimal();
-
     CHIP_ERROR _GetAndLogThreadTopologyFull();
-
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
-
     CHIP_ERROR _GetExternalIPv6Address(chip::Inet::IPAddress & addr);
-
+    CHIP_ERROR _GetThreadVersion(uint16_t & version);
     CHIP_ERROR _GetPollPeriod(uint32_t & buf);
 
     void _ResetThreadNetworkDiagnosticsCounts();

--- a/src/platform/Tizen/ThreadStackManagerImpl.h
+++ b/src/platform/Tizen/ThreadStackManagerImpl.h
@@ -84,6 +84,8 @@ public:
 
     void _OnThreadAttachFinished(void);
 
+    uint16_t _GetThreadVersion();
+
     ConnectivityManager::ThreadDeviceType _GetThreadDeviceType();
 
     CHIP_ERROR _SetThreadDeviceType(ConnectivityManager::ThreadDeviceType deviceType);

--- a/src/platform/webos/NetworkCommissioningThreadDriver.cpp
+++ b/src/platform/webos/NetworkCommissioningThreadDriver.cpp
@@ -211,9 +211,9 @@ ThreadCapabilities LinuxThreadDriver::GetSupportedThreadFeatures()
 
 uint16_t LinuxThreadDriver::GetThreadVersion()
 {
-    // TODO https://github.com/project-chip/connectedhomeip/issues/30602
-    // Needs to be implemented with DBUS io.openthread.BorderRouter Thread API
-    return 0;
+    uint16_t version = 0;
+    ThreadStackMgrImpl().GetThreadVersion(version);
+    return version;
 }
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/webos/ThreadStackManagerImpl.cpp
+++ b/src/platform/webos/ThreadStackManagerImpl.cpp
@@ -525,6 +525,13 @@ CHIP_ERROR ThreadStackManagerImpl::_GetExternalIPv6Address(chip::Inet::IPAddress
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+CHIP_ERROR ThreadStackManagerImpl::_GetThreadVersion(uint16_t & version)
+{
+    // TODO https://github.com/project-chip/connectedhomeip/issues/30602
+    // Needs to be implemented with DBUS io.openthread.BorderRouter Thread API
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR ThreadStackManagerImpl::_GetPollPeriod(uint32_t & buf)
 {
     // TODO: Remove Weave legacy APIs

--- a/src/platform/webos/ThreadStackManagerImpl.h
+++ b/src/platform/webos/ThreadStackManagerImpl.h
@@ -101,7 +101,7 @@ public:
     CHIP_ERROR _GetPrimary802154MACAddress(uint8_t * buf);
 
     CHIP_ERROR _GetExternalIPv6Address(chip::Inet::IPAddress & addr);
-
+    CHIP_ERROR _GetThreadVersion(uint16_t & version);
     CHIP_ERROR _GetPollPeriod(uint32_t & buf);
 
     void _ResetThreadNetworkDiagnosticsCounts();


### PR DESCRIPTION
### Problem

Tizen platform lacks `GetThreadVersion()` implementation. Since Tizen SDK 8.0, such functionality is possible to implement.

Also, the backend for GetThreadVersion should be with other Thread functionality, which is Thread stack manager, not Thread driver.

### Changes

- Implement `GetThreadVersion` in thread stack manager
- Move `GetThreadVersion` backend implementation to thread stack manager in other platforms as well

### Testing

CI will verify build failures.