### PR TITLE
Add constraint enforcement on responseTimeoutSeconds in commissioner control cluster

### DIFF
--- a/src/app/clusters/commissioner-control-server/commissioner-control-server.cpp
+++ b/src/app/clusters/commissioner-control-server/commissioner-control-server.cpp
@@ -216,7 +216,7 @@ bool emberAfCommissionerControlClusterCommissionNodeCallback(
 
     auto sourceNodeId = GetNodeId(commandObj);
 
-    // Constraint on responseTimeoutSeconds is [0; 120] seconds
+    // Constraint on responseTimeoutSeconds is [30; 120] seconds
     if ((commandData.responseTimeoutSeconds < 30) || (commandData.responseTimeoutSeconds > 120))
     {
         ChipLogError(Zcl, "Invalid responseTimeoutSeconds for CommissionNode.");

--- a/src/app/clusters/commissioner-control-server/commissioner-control-server.cpp
+++ b/src/app/clusters/commissioner-control-server/commissioner-control-server.cpp
@@ -216,6 +216,14 @@ bool emberAfCommissionerControlClusterCommissionNodeCallback(
 
     auto sourceNodeId = GetNodeId(commandObj);
 
+    // Constraint on responseTimeoutSeconds is [0; 120] seconds
+    if ((commandData.responseTimeoutSeconds < 30) || (commandData.responseTimeoutSeconds > 120))
+    {
+        ChipLogError(Zcl, "Invalid responseTimeoutSeconds for CommissionNode.");
+        commandObj->AddStatus(commandPath, Status::ConstraintError);
+        return true;
+    }
+
     // Check if the command is executed via a CASE session
     if (sourceNodeId == kUndefinedNodeId)
     {

--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -211,7 +211,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
             await self.send_single_cmd(cmd=cmd)
             asserts.fail("Unexpected success on CommissionNode")
         except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.Failure, "Incorrect error returned")
+            asserts.assert_equal(e.status, Status.ConstraintError, "Incorrect error returned")
 
         self.step(16)
         cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=good_request_id, responseTimeoutSeconds=121)
@@ -219,7 +219,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
             await self.send_single_cmd(cmd=cmd)
             asserts.fail("Unexpected success on CommissionNode")
         except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.Failure, "Incorrect error returned")
+            asserts.assert_equal(e.status, Status.ConstraintError, "Incorrect error returned")
 
         self.step(17)
         cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=good_request_id, responseTimeoutSeconds=30)


### PR DESCRIPTION
This adds constraints in the implementation and also fixes up error codes in CCTRL_2_2 test.


