### PR TITLE
Fix Codegen data model write via AttributeAccessInterface

### DIFF
--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider_Write.cpp
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider_Write.cpp
@@ -51,7 +51,7 @@ using Protocols::InteractionModel::Status;
 ///
 /// If it returns std::nullopt, then there is no AAI to handle the given path
 /// and processing should figure out the value otherwise (generally from other ember data)
-std::optional<CHIP_ERROR> TryWriteViaAccessInterface(const ConcreteAttributePath & path, AttributeAccessInterface * aai,
+std::optional<CHIP_ERROR> TryWriteViaAccessInterface(const ConcreteDataAttributePath & path, AttributeAccessInterface * aai,
                                                      AttributeValueDecoder & decoder)
 {
     // Processing can happen only if an attribute access interface actually exists..


### PR DESCRIPTION
Found in #34754, pulling this as a stand-alone fix.

When writing lists, the list data is in `ConcreteDataAttributePath` and this full path is required to properly handle list operations. Unfortunately the compiler auto converts back and forth between ConcreteAttributePath and ConcreteDataAttributePath (and clears list indexes as a sideffect) so this was not noticed while compiling.

When we implement writes, this is absolutely caught by unit tests so keeping this as is (without additional coverage for now)