### PR TITLE
Optimize RAM utilization for WriteHandler

### DIFF
--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -564,26 +564,26 @@ Status WriteHandler::ProcessWriteRequest(System::PacketBufferHandle && aPayload,
 
     boolValue = mStateFlags.Has(StateBits::kSuppressResponse);
     err       = writeRequestParser.GetSuppressResponse(&boolValue);
-    mStateFlags.Set(StateBits::kSuppressResponse, boolValue);
     if (err == CHIP_END_OF_TLV)
     {
         err = CHIP_NO_ERROR;
     }
     SuccessOrExit(err);
+    mStateFlags.Set(StateBits::kSuppressResponse, boolValue);
 
     boolValue = mStateFlags.Has(StateBits::kIsTimedRequest);
     err       = writeRequestParser.GetTimedRequest(&boolValue);
-    mStateFlags.Set(StateBits::kIsTimedRequest, boolValue);
     SuccessOrExit(err);
+    mStateFlags.Set(StateBits::kIsTimedRequest, boolValue);
 
     boolValue = mStateFlags.Has(StateBits::kHasMoreChunks);
     err       = writeRequestParser.GetMoreChunkedMessages(&boolValue);
-    mStateFlags.Set(StateBits::kHasMoreChunks, boolValue);
     if (err == CHIP_ERROR_END_OF_TLV)
     {
         err = CHIP_NO_ERROR;
     }
     SuccessOrExit(err);
+    mStateFlags.Set(StateBits::kHasMoreChunks, boolValue);
 
     if (mStateFlags.Has(StateBits::kHasMoreChunks) &&
         (mExchangeCtx->IsGroupExchangeContext() || mStateFlags.Has(StateBits::kIsTimedRequest)))

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -18,21 +18,17 @@
 
 #include <app/AppConfig.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
-#include <app/AttributeValueDecoder.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/EventPathIB.h>
 #include <app/MessageDef/StatusIB.h>
 #include <app/StatusResponse.h>
 #include <app/WriteHandler.h>
-#include <app/data-model-provider/OperationTypes.h>
 #include <app/reporting/Engine.h>
 #include <app/util/MatterCallbacks.h>
 #include <app/util/ember-compatibility-functions.h>
 #include <credentials/GroupDataProvider.h>
-#include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TypeTraits.h>
-#include <messaging/ExchangeContext.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {


### PR DESCRIPTION
This is pulled from #34754 as a stand-alone improvement:

- WriteHandlers have a multiplicity factor as an object pool resides in InteractionModelEngine
- Replacing various booleans with a bit-based flag system as well as re-ordering members should result in some RAM savings (likely minor, but non-zero)