### PR TITLE
[Telink] w91 remove not connected PWM channels

### DIFF
--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -416,7 +416,7 @@ void AppTaskCommon::LinkPwms(PwmManager & pwmManager)
 {
 #if CONFIG_BOARD_TLSR9118BDK40D // TLSR9118BDK40D EVK supports only 1 PWM channel connected to LED
     pwmManager.linkPwm(PwmManager::EAppPwm_Red, 0);
-#elif CONFIG_WS2812_STRIP 
+#elif CONFIG_WS2812_STRIP
     pwmManager.linkPwm(PwmManager::EAppPwm_Red, 0);
     pwmManager.linkPwm(PwmManager::EAppPwm_Green, 1);
     pwmManager.linkPwm(PwmManager::EAppPwm_Blue, 2);

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -414,8 +414,9 @@ void AppTaskCommon::InitPwms()
 
 void AppTaskCommon::LinkPwms(PwmManager & pwmManager)
 {
-#if CONFIG_WS2812_STRIP ||                                                                                                         \
-    CONFIG_BOARD_TLSR9118BDK40D // TLSR9118BDK40D EVK buttons located on 4th PWM channel (see tlsr9118bdk40d.overlay)
+#if CONFIG_BOARD_TLSR9118BDK40D // TLSR9118BDK40D EVK supports only 1 PWM channel connected to LED
+    pwmManager.linkPwm(PwmManager::EAppPwm_Red, 0);
+#elif CONFIG_WS2812_STRIP 
     pwmManager.linkPwm(PwmManager::EAppPwm_Red, 0);
     pwmManager.linkPwm(PwmManager::EAppPwm_Green, 1);
     pwmManager.linkPwm(PwmManager::EAppPwm_Blue, 2);

--- a/src/platform/telink/tlsr9118bdk40d.overlay
+++ b/src/platform/telink/tlsr9118bdk40d.overlay
@@ -33,16 +33,7 @@
 	pwm_pool {
 		compatible = "pwm-leds";
 		out {
-			pwms = <&pwm0 4 PWM_MSEC(1) PWM_POLARITY_NORMAL>,
-				   <&pwm0 2 PWM_MSEC(1) PWM_POLARITY_NORMAL>,
-				   <&pwm0 3 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 4 PWM_MSEC(1) PWM_POLARITY_NORMAL>;
 		};
 	};
-};
-
-&pwm0 {
-	/* On board RGB LEDs */
-	pinctrl-ch4 = <&pwm_ch4_p20_default>;
-	pinctrl-ch2 = <&pwm_ch2_p17_default>;
-	pinctrl-ch3 = <&pwm_ch3_p18_default>;
 };


### PR DESCRIPTION
**Change overview**

Remove not connected PWM channels, because TLSR9118BDK40D EVK supports only 1 PWM channel connected to LED