### PR TITLE
[Telink] Disable Wi-Fi LPM during the OTA

### DIFF
--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -304,9 +304,6 @@ config CHIP_WIFI
 	select NET_IPV6_ND # enable Neighbor Discovery to handle Router Advertisements
 	select NET_IPV6_NBR_CACHE
 	select NET_STATISTICS_USER_API
-#	select NET_IPV4 # TODO: remove IPv4 when IPv6 will be ready (see CHIP_IPV4)
-#	select NET_CONFIG_NEED_IPV4
-#	select NET_DHCPV4
 
 if CHIP_WIFI
 

--- a/src/platform/telink/BUILD.gn
+++ b/src/platform/telink/BUILD.gn
@@ -93,6 +93,7 @@ static_library("telink") {
 
   if (chip_enable_wifi) {
     sources += [
+      "OTAImageProcessorImplWiFi.h",
       "wifi/ConnectivityManagerImplWiFi.cpp",
       "wifi/ConnectivityManagerImplWiFi.h",
       "wifi/TelinkWiFiDriver.cpp",

--- a/src/platform/telink/OTAImageProcessorImplWiFi.h
+++ b/src/platform/telink/OTAImageProcessorImplWiFi.h
@@ -1,0 +1,63 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "OTAImageProcessorImpl.h"
+#include "wifi/WiFiManager.h"
+
+namespace chip {
+
+namespace DeviceLayer {
+
+class OTAImageProcessorImplWiFi : public OTAImageProcessorImpl
+{
+public:
+    explicit OTAImageProcessorImplWiFi(ExternalFlashManager * flashHandler = nullptr) : OTAImageProcessorImpl(flashHandler) {}
+
+    CHIP_ERROR PrepareDownload() override
+    {
+        CHIP_ERROR err = WiFiManager::Instance().SetLowPowerMode(false);
+        if (err == CHIP_NO_ERROR)
+        {
+            return OTAImageProcessorImpl::PrepareDownload();
+        }
+        return err;
+    };
+
+    CHIP_ERROR Abort() override
+    {
+        CHIP_ERROR err = OTAImageProcessorImpl::Abort();
+        if (err == CHIP_NO_ERROR)
+        {
+            return WiFiManager::Instance().SetLowPowerMode(true);
+        }
+        return err;
+    };
+
+    CHIP_ERROR Apply() override
+    {
+        CHIP_ERROR err = OTAImageProcessorImpl::Apply();
+        if (err == CHIP_NO_ERROR)
+        {
+            return WiFiManager::Instance().SetLowPowerMode(true);
+        }
+        return err;
+    };
+};
+
+} // namespace DeviceLayer
+} // namespace chip


### PR DESCRIPTION
**Change overview**

- Introduced a subclass of OTAImageProcessorImpl designed to enhance Wi-Fi performance for Low Power Mode (LPM), which needs to be deactivated during OTA updates to accommodate the need for high data transfer rates.
- Remove IPv4 temporarry debug configs