### PR TITLE
Python testing: Fix reporting on setup_class error

### DIFF
--- a/src/controller/python/chip/exceptions/__init__.py
+++ b/src/controller/python/chip/exceptions/__init__.py
@@ -39,21 +39,17 @@ class ChipStackException(Exception):
 
 
 class ChipStackError(ChipStackException):
-    def __init__(self, chip_error: PyChipError, msg=None):
-        self._chip_error = chip_error
-        self.msg = msg if msg else "Chip Stack Error %d" % chip_error.code
+    def __init__(self, code: int, msg=None):
+        self.code = code
+        self.msg = msg if msg else "Chip Stack Error %d" % self.code
 
     @classmethod
     def from_chip_error(cls, chip_error: PyChipError) -> ChipStackError:
-        return cls(chip_error, str(chip_error))
-
-    @property
-    def chip_error(self) -> PyChipError | None:
-        return self._chip_error
+        return cls(chip_error.code, str(chip_error))
 
     @property
     def err(self) -> int:
-        return self._chip_error.code
+        return self.code
 
     def __str__(self):
         return self.msg

--- a/src/controller/python/chip/native/__init__.py
+++ b/src/controller/python/chip/native/__init__.py
@@ -69,7 +69,7 @@ class ErrorSDKPart(enum.IntEnum):
 class PyChipError(ctypes.Structure):
     ''' The ChipError for Python library.
 
-    We are using the following struct for passing the infomations of CHIP_ERROR between C++ and Python:
+    We are using the following struct for passing the information of CHIP_ERROR between C++ and Python:
 
     ```c
     struct PyChipError

--- a/src/controller/python/chip/native/__init__.py
+++ b/src/controller/python/chip/native/__init__.py
@@ -88,6 +88,10 @@ class PyChipError(ctypes.Structure):
             if exception is not None:  # Ensure exception is not None to avoid mypy error and only raise valid exceptions
                 raise exception
 
+    @classmethod
+    def from_code(cls, code):
+        return cls(code=code, line=0, file=ctypes.c_void_p())
+
     @property
     def is_success(self) -> bool:
         return self.code == 0

--- a/src/python_testing/TC_CADMIN_1_9.py
+++ b/src/python_testing/TC_CADMIN_1_9.py
@@ -31,6 +31,7 @@ import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.ChipDeviceCtrl import CommissioningParameters
 from chip.exceptions import ChipStackError
+from chip.native import PyChipError
 from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 
@@ -74,7 +75,7 @@ class TC_CADMIN_1_9(MatterBaseTest):
             await self.th2.CommissionOnNetwork(
                 nodeId=self.dut_node_id, setupPinCode=setup_code,
                 filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.discriminator)
-        errcode = ctx.exception.chip_error
+        errcode = PyChipError.from_code(ctx.exception.err)
         return errcode
 
     async def CommissionAttempt(

--- a/src/python_testing/TC_CGEN_2_4.py
+++ b/src/python_testing/TC_CGEN_2_4.py
@@ -38,6 +38,7 @@ import chip.FabricAdmin
 from chip import ChipDeviceCtrl
 from chip.ChipDeviceCtrl import CommissioningParameters
 from chip.exceptions import ChipStackError
+from chip.native import PyChipError
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main
 from mobly import asserts
 
@@ -78,7 +79,7 @@ class TC_CGEN_2_4(MatterBaseTest):
             await self.th2.CommissionOnNetwork(
                 nodeId=self.dut_node_id, setupPinCode=params.setupPinCode,
                 filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.discriminator)
-        errcode = ctx.exception.chip_error
+        errcode = PyChipError.from_code(ctx.exception.err)
         asserts.assert_true(errcode.sdk_part == expectedErrorPart, 'Unexpected error type returned from CommissioningComplete')
         asserts.assert_true(errcode.sdk_code == expectedErrCode, 'Unexpected error code returned from CommissioningComplete')
         revokeCmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -27,9 +27,9 @@ import queue
 import random
 import re
 import sys
+import textwrap
 import time
 import typing
-import textwrap
 import uuid
 from binascii import hexlify, unhexlify
 from dataclasses import asdict as dataclass_asdict

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -1148,7 +1148,7 @@ class MatterBaseTest(base_test.BaseTestClass):
 
                 if isinstance(exception, signals.TestError):
                     # Exception gets raised by the mobly framework, so the proximal error is one line back in the stack trace
-                    assert_candidates = [idx for idx, line in enumerate(trace) if "asserts" in line and not "asserts.py" in line]
+                    assert_candidates = [idx for idx, line in enumerate(trace) if "asserts" in line and "asserts.py" not in line]
                     if not assert_candidates:
                         return "Unknown error, please see stack trace above", ""
                     assert_candidate_idx = assert_candidates[-1]


### PR DESCRIPTION
Also add error text to make the error easier to find.

Fixes: https://github.com/project-chip/connectedhomeip/issues/34959


