### PR TITLE
[Fabric-Admin] Add API to commission local bridge within its own fabric 

### DIFF
--- a/examples/fabric-admin/commands/fabric-sync/Commands.h
+++ b/examples/fabric-admin/commands/fabric-sync/Commands.h
@@ -28,6 +28,8 @@ void registerCommandsFabricSync(Commands & commands, CredentialIssuerCommands * 
     commands_list clusterCommands = {
         make_unique<FabricSyncAddBridgeCommand>(credsIssuerConfig),
         make_unique<FabricSyncRemoveBridgeCommand>(credsIssuerConfig),
+        make_unique<FabricSyncAddLocalBridgeCommand>(credsIssuerConfig),
+        make_unique<FabricSyncRemoveLocalBridgeCommand>(credsIssuerConfig),
         make_unique<FabricSyncDeviceCommand>(credsIssuerConfig),
         make_unique<FabricAutoSyncCommand>(credsIssuerConfig),
     };

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -218,7 +218,7 @@ void FabricSyncRemoveLocalBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_E
 {
     if (mLocalBridgeNodeId != deviceId)
     {
-        ChipLogProgress(NotSpecified, "An non-bridge device: NodeId: " ChipLogFormatX64 " is removed.", ChipLogValueX64(deviceId));
+        ChipLogProgress(NotSpecified, "A non-bridge device: NodeId: " ChipLogFormatX64 " is removed.", ChipLogValueX64(deviceId));
         return;
     }
 

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -199,12 +199,7 @@ CHIP_ERROR FabricSyncAddLocalBridgeCommand::RunCommand(NodeId deviceId)
     }
 
     PairingCommand * pairingCommand = static_cast<PairingCommand *>(CommandMgr().GetCommandByName("pairing", "already-discovered"));
-
-    if (pairingCommand == nullptr)
-    {
-        ChipLogError(NotSpecified, "Pairing already-discovered command is not available");
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
+    VerifyOrDie(pairingCommand != nullptr);
 
     pairingCommand->RegisterCommissioningDelegate(this);
     mLocalBridgeNodeId = deviceId;
@@ -271,7 +266,7 @@ void FabricSyncDeviceCommand::OnCommissioningWindowOpened(NodeId deviceId, CHIP_
 
     if (err == CHIP_NO_ERROR)
     {
-        char payloadBuffer[kMaxManaulCodeLength + 1];
+        char payloadBuffer[kMaxManualCodeLength + 1];
         MutableCharSpan manualCode(payloadBuffer);
         CHIP_ERROR error = ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(manualCode);
         if (error == CHIP_NO_ERROR)

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -32,10 +32,6 @@ using namespace ::chip;
 
 namespace {
 
-// Constants
-constexpr uint32_t kCommissionPrepareTimeMs = 500;
-constexpr uint16_t kMaxManaulCodeLength     = 21;
-
 void CheckFabricBridgeSynchronizationSupport(intptr_t ignored)
 {
     DeviceMgr().ReadSupportedDeviceCategories();
@@ -43,7 +39,7 @@ void CheckFabricBridgeSynchronizationSupport(intptr_t ignored)
 
 } // namespace
 
-void FabricSyncAddBridgeCommand::OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR err)
+void FabricSyncAddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
 {
     if (mBridgeNodeId != deviceId)
     {
@@ -90,7 +86,7 @@ CHIP_ERROR FabricSyncAddBridgeCommand::RunCommand(NodeId remoteId)
     if (DeviceMgr().IsFabricSyncReady())
     {
         // print to console
-        fprintf(stderr, "Remote Fabric Bridge has been alread configured.");
+        fprintf(stderr, "Remote Fabric Bridge has alread been configured.");
         return CHIP_NO_ERROR;
     }
 
@@ -98,7 +94,7 @@ CHIP_ERROR FabricSyncAddBridgeCommand::RunCommand(NodeId remoteId)
 
     if (pairingCommand == nullptr)
     {
-        ChipLogError(NotSpecified, "Pairing onnetwork command is not available");
+        ChipLogError(NotSpecified, "Pairing already-discovered command is not available");
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
@@ -110,7 +106,7 @@ CHIP_ERROR FabricSyncAddBridgeCommand::RunCommand(NodeId remoteId)
     return CHIP_NO_ERROR;
 }
 
-void FabricSyncRemoveBridgeCommand::OnDeviceRemoved(chip::NodeId deviceId, CHIP_ERROR err)
+void FabricSyncRemoveBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
 {
     if (mBridgeNodeId != deviceId)
     {
@@ -150,13 +146,121 @@ CHIP_ERROR FabricSyncRemoveBridgeCommand::RunCommand()
 
     if (pairingCommand == nullptr)
     {
-        ChipLogError(NotSpecified, "Pairing code command is not available");
+        ChipLogError(NotSpecified, "Pairing unpair command is not available");
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
     pairingCommand->RegisterPairingDelegate(this);
 
     DeviceMgr().UnpairRemoteFabricBridge();
+
+    return CHIP_NO_ERROR;
+}
+
+void FabricSyncAddLocalBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
+{
+    if (mLocalBridgeNodeId != deviceId)
+    {
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(NotSpecified, "Failed to pair non-bridge device (0x:" ChipLogFormatX64 ") with error: %" CHIP_ERROR_FORMAT,
+                         ChipLogValueX64(deviceId), err.Format());
+        }
+        else
+        {
+            ChipLogProgress(NotSpecified, "Commissioning complete for non-bridge device: NodeId: " ChipLogFormatX64,
+                            ChipLogValueX64(deviceId));
+        }
+        return;
+    }
+
+    if (err == CHIP_NO_ERROR)
+    {
+        DeviceMgr().SetLocalBridgeNodeId(mLocalBridgeNodeId);
+        ChipLogProgress(NotSpecified, "Successfully paired local bridge device: NodeId: " ChipLogFormatX64,
+                        ChipLogValueX64(mLocalBridgeNodeId));
+    }
+    else
+    {
+        ChipLogError(NotSpecified, "Failed to pair local bridge device (0x:" ChipLogFormatX64 ") with error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(deviceId), err.Format());
+    }
+
+    mLocalBridgeNodeId = kUndefinedNodeId;
+}
+
+CHIP_ERROR FabricSyncAddLocalBridgeCommand::RunCommand(NodeId deviceId)
+{
+    if (DeviceMgr().IsLocalBridgeReady())
+    {
+        // print to console
+        fprintf(stderr, "Local Fabric Bridge has already been configured.");
+        return CHIP_NO_ERROR;
+    }
+
+    PairingCommand * pairingCommand = static_cast<PairingCommand *>(CommandMgr().GetCommandByName("pairing", "already-discovered"));
+
+    if (pairingCommand == nullptr)
+    {
+        ChipLogError(NotSpecified, "Pairing already-discovered command is not available");
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    pairingCommand->RegisterCommissioningDelegate(this);
+    mLocalBridgeNodeId = deviceId;
+
+    DeviceMgr().PairLocalFabricBridge(deviceId);
+
+    return CHIP_NO_ERROR;
+}
+
+void FabricSyncRemoveLocalBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
+{
+    if (mLocalBridgeNodeId != deviceId)
+    {
+        ChipLogProgress(NotSpecified, "An non-bridge device: NodeId: " ChipLogFormatX64 " is removed.", ChipLogValueX64(deviceId));
+        return;
+    }
+
+    if (err == CHIP_NO_ERROR)
+    {
+        DeviceMgr().SetLocalBridgeNodeId(kUndefinedNodeId);
+        ChipLogProgress(NotSpecified, "Successfully removed local bridge device: NodeId: " ChipLogFormatX64,
+                        ChipLogValueX64(mLocalBridgeNodeId));
+    }
+    else
+    {
+        ChipLogError(NotSpecified, "Failed to remove local bridge device (0x:" ChipLogFormatX64 ") with error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(deviceId), err.Format());
+    }
+
+    mLocalBridgeNodeId = kUndefinedNodeId;
+}
+
+CHIP_ERROR FabricSyncRemoveLocalBridgeCommand::RunCommand()
+{
+    NodeId bridgeNodeId = DeviceMgr().GetLocalBridgeNodeId();
+
+    if (bridgeNodeId == kUndefinedNodeId)
+    {
+        // print to console
+        fprintf(stderr, "Local Fabric Bridge is not configured yet, nothing to remove.");
+        return CHIP_NO_ERROR;
+    }
+
+    mLocalBridgeNodeId = bridgeNodeId;
+
+    PairingCommand * pairingCommand = static_cast<PairingCommand *>(CommandMgr().GetCommandByName("pairing", "unpair"));
+
+    if (pairingCommand == nullptr)
+    {
+        ChipLogError(NotSpecified, "Pairing unpair command is not available");
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+
+    pairingCommand->RegisterPairingDelegate(this);
+
+    DeviceMgr().UnpairLocalFabricBridge();
 
     return CHIP_NO_ERROR;
 }
@@ -202,7 +306,7 @@ void FabricSyncDeviceCommand::OnCommissioningWindowOpened(NodeId deviceId, CHIP_
     }
 }
 
-void FabricSyncDeviceCommand::OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR err)
+void FabricSyncDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
 {
     if (mAssignedNodeId != deviceId)
     {

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -86,7 +86,7 @@ CHIP_ERROR FabricSyncAddBridgeCommand::RunCommand(NodeId remoteId)
     if (DeviceMgr().IsFabricSyncReady())
     {
         // print to console
-        fprintf(stderr, "Remote Fabric Bridge has alread been configured.");
+        fprintf(stderr, "Remote Fabric Bridge has already been configured.");
         return CHIP_NO_ERROR;
     }
 

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -32,7 +32,8 @@ namespace {
 
 // Constants
 constexpr uint32_t kSetupPinCode               = 20202021;
-constexpr uint16_t kRemoteBridgePort           = 5540;
+constexpr uint16_t kRemoteBridgePort           = 6541;
+constexpr uint16_t kLocalBridgePort            = 6540;
 constexpr uint16_t kWindowTimeout              = 300;
 constexpr uint16_t kIteration                  = 1000;
 constexpr uint16_t kSubscribeMinInterval       = 0;
@@ -117,6 +118,8 @@ void DeviceManager::RemoveSyncedDevice(NodeId nodeId)
 void DeviceManager::OpenDeviceCommissioningWindow(NodeId nodeId, uint32_t commissioningTimeout, uint32_t iterations,
                                                   uint32_t discriminator, const char * saltHex, const char * verifierHex)
 {
+    ChipLogProgress(NotSpecified, "Open the commissioning window of device with NodeId:" ChipLogFormatX64, ChipLogValueX64(nodeId));
+
     // Open the commissioning window of a device within its own fabric.
     StringBuilder<kMaxCommandSize> commandBuilder;
 
@@ -132,7 +135,7 @@ void DeviceManager::OpenRemoteDeviceCommissioningWindow(EndpointId remoteEndpoin
     // Open the commissioning window of a device from another fabric via its fabric bridge.
     // This method constructs and sends a command to open the commissioning window for a device
     // that is part of a different fabric, accessed through a fabric bridge.
-    StringBuilder<512> commandBuilder;
+    StringBuilder<kMaxCommandSize> commandBuilder;
 
     // Use random discriminator to have less chance of collission.
     uint16_t discriminator =
@@ -166,12 +169,32 @@ void DeviceManager::PairRemoteDevice(chip::NodeId nodeId, const char * payload)
     PushCommand(commandBuilder.c_str());
 }
 
+void DeviceManager::PairLocalFabricBridge(NodeId nodeId)
+{
+    StringBuilder<kMaxCommandSize> commandBuilder;
+
+    commandBuilder.Add("pairing already-discovered ");
+    commandBuilder.AddFormat("%lu %d ::1 %d", nodeId, kSetupPinCode, kLocalBridgePort);
+
+    PushCommand(commandBuilder.c_str());
+}
+
 void DeviceManager::UnpairRemoteFabricBridge()
 {
     StringBuilder<kMaxCommandSize> commandBuilder;
 
     commandBuilder.Add("pairing unpair ");
     commandBuilder.AddFormat("%lu", mRemoteBridgeNodeId);
+
+    PushCommand(commandBuilder.c_str());
+}
+
+void DeviceManager::UnpairLocalFabricBridge()
+{
+    StringBuilder<kMaxCommandSize> commandBuilder;
+
+    commandBuilder.Add("pairing unpair ");
+    commandBuilder.AddFormat("%lu", mLocalBridgeNodeId);
 
     PushCommand(commandBuilder.c_str());
 }

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -32,8 +32,8 @@ namespace {
 
 // Constants
 constexpr uint32_t kSetupPinCode               = 20202021;
-constexpr uint16_t kRemoteBridgePort           = 6541;
-constexpr uint16_t kLocalBridgePort            = 6540;
+constexpr uint16_t kRemoteBridgePort           = 5540;
+constexpr uint16_t kLocalBridgePort            = 5540;
 constexpr uint16_t kWindowTimeout              = 300;
 constexpr uint16_t kIteration                  = 1000;
 constexpr uint16_t kSubscribeMinInterval       = 0;

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -55,13 +55,19 @@ public:
 
     chip::NodeId GetRemoteBridgeNodeId() const { return mRemoteBridgeNodeId; }
 
+    chip::NodeId GetLocalBridgeNodeId() const { return mLocalBridgeNodeId; }
+
     void UpdateLastUsedNodeId(chip::NodeId nodeId);
 
-    void SetRemoteBridgeNodeId(chip::NodeId remoteBridgeNodeId) { mRemoteBridgeNodeId = remoteBridgeNodeId; }
+    void SetRemoteBridgeNodeId(chip::NodeId nodeId) { mRemoteBridgeNodeId = nodeId; }
+
+    void SetLocalBridgeNodeId(chip::NodeId nodeId) { mLocalBridgeNodeId = nodeId; }
 
     bool IsAutoSyncEnabled() const { return mAutoSyncEnabled; }
 
     bool IsFabricSyncReady() const { return mRemoteBridgeNodeId != chip::kUndefinedNodeId; }
+
+    bool IsLocalBridgeReady() const { return mLocalBridgeNodeId != chip::kUndefinedNodeId; }
 
     void EnableAutoSync(bool state) { mAutoSyncEnabled = state; }
 
@@ -126,7 +132,19 @@ public:
      */
     void PairRemoteDevice(chip::NodeId nodeId, const char * payload);
 
+    /**
+     * @brief Pair a local fabric bridge with a given node ID.
+     *
+     * This function initiates the pairing process for the local fabric bridge using the specified parameters.
+
+     * @param nodeId            The user-defined ID for the node being commissioned. It doesn’t need to be the same ID,
+     *                          as for the first fabric.
+     */
+    void PairLocalFabricBridge(chip::NodeId nodeId);
+
     void UnpairRemoteFabricBridge();
+
+    void UnpairLocalFabricBridge();
 
     void SubscribeRemoteFabricBridge();
 
@@ -147,8 +165,16 @@ private:
 
     static DeviceManager sInstance;
 
-    chip::NodeId mLastUsedNodeId     = 0;
+    chip::NodeId mLastUsedNodeId = 0;
+
+    // The Node ID of the remote bridge used for Fabric-Sync
+    // This represents the bridge on the other ecosystem.
     chip::NodeId mRemoteBridgeNodeId = chip::kUndefinedNodeId;
+
+    // The Node ID of the local bridge used for Fabric-Sync
+    // This represents the bridge within its own ecosystem.
+    chip::NodeId mLocalBridgeNodeId = chip::kUndefinedNodeId;
+
     std::set<Device> mSyncedDevices;
     bool mAutoSyncEnabled = false;
     bool mInitialized     = false;


### PR DESCRIPTION
This PR is refactored from https://github.com/project-chip/connectedhomeip/pull/34990 to make review easier.

In E2E (End-to-End), each side consists of a Fabric-Admin and a Fabric-Bridge. The Fabric-Bridge needs to be commissioned to both sides to conduct fabric sync. Therefore, each Fabric-Admin needs to manage two bridges: one within its own fabric and one from the remote ecosystem. 

In commercial hub products, such as HomePod and Google Home, which host the fabric bridge, the hub is typically self-commissioned to its own fabric during startup

