### PR TITLE
Add fabric scoping to ECOINFO cluster attributes

### DIFF
--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
@@ -237,7 +237,6 @@ CHIP_ERROR EcosystemLocationStruct::Encode(const AttributeValueEncoder::ListEnco
     locationStruct.locationDescriptor         = GetEncodableLocationDescriptorStruct(mLocationDescriptor);
     locationStruct.locationDescriptorLastEdit = mLocationDescriptorLastEditEpochUs;
     locationStruct.SetFabricIndex(aFabricIndex);
-
     return aEncoder.Encode(locationStruct);
 }
 

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
@@ -387,9 +387,9 @@ CHIP_ERROR EcosystemInformationServer::EncodeLocationStructAttribute(EndpointId 
     }
 
     return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
-        for (auto & [id, device] : deviceInfo.mLocationDirectory)
+        for (auto & [key, device] : deviceInfo.mLocationDirectory)
         {
-            ReturnErrorOnFailure(device->Encode(encoder, id));
+            ReturnErrorOnFailure(device->Encode(encoder, key.mUniqueLocationId, key.mFabricIndex));
         }
         return CHIP_NO_ERROR;
     });

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
@@ -233,8 +233,7 @@ CHIP_ERROR EcosystemLocationStruct::Encode(const AttributeValueEncoder::ListEnco
                                            const std::string & aUniqueLocationId, const FabricIndex & aFabricIndex)
 {
     Structs::EcosystemLocationStruct::Type locationStruct;
-    locationStruct.uniqueLocationID =
-        CharSpan(aUniqueLocationId.c_str(), aUniqueLocationId.size());
+    locationStruct.uniqueLocationID           = CharSpan(aUniqueLocationId.c_str(), aUniqueLocationId.size());
     locationStruct.locationDescriptor         = GetEncodableLocationDescriptorStruct(mLocationDescriptor);
     locationStruct.locationDescriptorLastEdit = mLocationDescriptorLastEditEpochUs;
     locationStruct.SetFabricIndex(aFabricIndex);
@@ -280,7 +279,7 @@ CHIP_ERROR EcosystemInformationServer::AddLocationInfo(EndpointId aEndpoint, con
     VerifyOrReturnError(aFabricIndex >= kMinValidFabricIndex, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(aFabricIndex <= kMaxValidFabricIndex, CHIP_ERROR_INVALID_ARGUMENT);
 
-    auto & deviceInfo = mDevicesMap[aEndpoint];
+    auto & deviceInfo        = mDevicesMap[aEndpoint];
     EcosystemLocationKey key = { .mUniqueLocationId = aLocationId, .mFabricIndex = aFabricIndex };
     VerifyOrReturnError((deviceInfo.mLocationDirectory.find(key) == deviceInfo.mLocationDirectory.end()),
                         CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
@@ -230,14 +230,14 @@ std::unique_ptr<EcosystemLocationStruct> EcosystemLocationStruct::Builder::Build
 }
 
 CHIP_ERROR EcosystemLocationStruct::Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder,
-                                           const EcosystemLocationIdentifier & aUniqueLocationId)
+                                           const std::string & aUniqueLocationId, const FabricIndex & aFabricIndex)
 {
     Structs::EcosystemLocationStruct::Type locationStruct;
     locationStruct.uniqueLocationID =
-        CharSpan(aUniqueLocationId.mUniqueLocationId.c_str(), aUniqueLocationId.mUniqueLocationId.size());
+        CharSpan(aUniqueLocationId.c_str(), aUniqueLocationId.size());
     locationStruct.locationDescriptor         = GetEncodableLocationDescriptorStruct(mLocationDescriptor);
     locationStruct.locationDescriptorLastEdit = mLocationDescriptorLastEditEpochUs;
-    locationStruct.SetFabricIndex(aUniqueLocationId.mFabricIndex);
+    locationStruct.SetFabricIndex(aFabricIndex);
 
     return aEncoder.Encode(locationStruct);
 }
@@ -281,12 +281,11 @@ CHIP_ERROR EcosystemInformationServer::AddLocationInfo(EndpointId aEndpoint, con
     VerifyOrReturnError(aFabricIndex <= kMaxValidFabricIndex, CHIP_ERROR_INVALID_ARGUMENT);
 
     auto & deviceInfo = mDevicesMap[aEndpoint];
-    // TODO rename foobar
-    EcosystemLocationIdentifier foobar = { .mUniqueLocationId = aLocationId, .mFabricIndex = aFabricIndex };
-    VerifyOrReturnError((deviceInfo.mLocationDirectory.find(foobar) == deviceInfo.mLocationDirectory.end()),
+    EcosystemLocationKey key = { .mUniqueLocationId = aLocationId, .mFabricIndex = aFabricIndex };
+    VerifyOrReturnError((deviceInfo.mLocationDirectory.find(key) == deviceInfo.mLocationDirectory.end()),
                         CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError((deviceInfo.mLocationDirectory.size() < kLocationDirectoryMaxSize), CHIP_ERROR_NO_MEMORY);
-    deviceInfo.mLocationDirectory[foobar] = std::move(aLocation);
+    deviceInfo.mLocationDirectory[key] = std::move(aLocation);
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
@@ -233,7 +233,8 @@ CHIP_ERROR EcosystemLocationStruct::Encode(const AttributeValueEncoder::ListEnco
                                            const EcosystemLocationIdentifier & aUniqueLocationId)
 {
     Structs::EcosystemLocationStruct::Type locationStruct;
-    locationStruct.uniqueLocationID           = CharSpan(aUniqueLocationId.mUniqueLocationId.c_str(), aUniqueLocationId.mUniqueLocationId.size());
+    locationStruct.uniqueLocationID =
+        CharSpan(aUniqueLocationId.mUniqueLocationId.c_str(), aUniqueLocationId.mUniqueLocationId.size());
     locationStruct.locationDescriptor         = GetEncodableLocationDescriptorStruct(mLocationDescriptor);
     locationStruct.locationDescriptorLastEdit = mLocationDescriptorLastEditEpochUs;
     locationStruct.SetFabricIndex(aUniqueLocationId.mFabricIndex);
@@ -271,8 +272,7 @@ CHIP_ERROR EcosystemInformationServer::AddDeviceInfo(EndpointId aEndpoint, std::
 }
 
 CHIP_ERROR EcosystemInformationServer::AddLocationInfo(EndpointId aEndpoint, const std::string & aLocationId,
-                                                       FabricIndex aFabricIndex,
-                                                       std::unique_ptr<EcosystemLocationStruct> aLocation)
+                                                       FabricIndex aFabricIndex, std::unique_ptr<EcosystemLocationStruct> aLocation)
 {
     VerifyOrReturnError(aLocation, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError((aEndpoint != kRootEndpointId && aEndpoint != kInvalidEndpointId), CHIP_ERROR_INVALID_ARGUMENT);
@@ -282,7 +282,7 @@ CHIP_ERROR EcosystemInformationServer::AddLocationInfo(EndpointId aEndpoint, con
 
     auto & deviceInfo = mDevicesMap[aEndpoint];
     // TODO rename foobar
-    EcosystemLocationIdentifier foobar = {.mUniqueLocationId=aLocationId, .mFabricIndex=aFabricIndex};
+    EcosystemLocationIdentifier foobar = { .mUniqueLocationId = aLocationId, .mFabricIndex = aFabricIndex };
     VerifyOrReturnError((deviceInfo.mLocationDirectory.find(foobar) == deviceInfo.mLocationDirectory.end()),
                         CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError((deviceInfo.mLocationDirectory.size() < kLocationDirectoryMaxSize), CHIP_ERROR_NO_MEMORY);

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
@@ -136,7 +136,7 @@ private:
         mLocationDescriptor(aLocationDescriptor), mLocationDescriptorLastEditEpochUs(aLocationDescriptorLastEditEpochUs)
     {}
     // EcosystemLocationStruct is used as a value in a key-value map.
-    // Because UniqueLocationId and FabricIndex are manditory when an entry exist,
+    // Because UniqueLocationId and FabricIndex are mandatory when an entry exist,
     // and needs to be unique, we use it as a key to the key-value pair and is why it is
     // not explicitly in this struct.
     LocationDescriptorStruct mLocationDescriptor;

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
@@ -126,8 +126,8 @@ public:
         bool mIsAlreadyBuilt                        = false;
     };
 
-    CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder,
-                      const std::string & aUniqueLocationId, const FabricIndex & aFabricIndex);
+    CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder, const std::string & aUniqueLocationId,
+                      const FabricIndex & aFabricIndex);
 
 private:
     // Constructor is intentionally private. This is to ensure that it is only constructed with

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
@@ -49,6 +49,7 @@ public:
         Builder & SetOriginalEndpoint(EndpointId aOriginalEndpoint);
         Builder & AddDeviceType(Structs::DeviceTypeStruct::Type aDeviceType);
         Builder & AddUniqueLocationId(std::string aUniqueLocationId, uint64_t aUniqueLocationIdsLastEditEpochUs);
+        Builder & SetFabricIndex(FabricIndex aFabricIndex);
 
         // Upon success this object will have moved all ownership of underlying
         // types to EcosystemDeviceStruct and should not be used afterwards.
@@ -62,21 +63,25 @@ public:
         std::vector<Structs::DeviceTypeStruct::Type> mDeviceTypes;
         std::vector<std::string> mUniqueLocationIds;
         uint64_t mUniqueLocationIdsLastEditEpochUs = 0;
+        FabricIndex mFabricIndex                   = kUndefinedFabricIndex;
         bool mIsAlreadyBuilt                       = false;
     };
 
-    CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder, const FabricIndex & aFabricIndex);
+    CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder);
 
 private:
     // Constructor is intentionally private. This is to ensure that it is only constructed with
     // values that conform to the spec.
     explicit EcosystemDeviceStruct(std::string && aDeviceName, uint64_t aDeviceNameLastEditEpochUs, EndpointId aBridgedEndpoint,
                                    EndpointId aOriginalEndpoint, std::vector<Structs::DeviceTypeStruct::Type> && aDeviceTypes,
-                                   std::vector<std::string> && aUniqueLocationIds, uint64_t aUniqueLocationIdsLastEditEpochUs) :
+                                   std::vector<std::string> && aUniqueLocationIds, uint64_t aUniqueLocationIdsLastEditEpochUs,
+                                   FabricIndex aFabricIndex) :
         mDeviceName(std::move(aDeviceName)),
         mDeviceNameLastEditEpochUs(aDeviceNameLastEditEpochUs), mBridgedEndpoint(aBridgedEndpoint),
         mOriginalEndpoint(aOriginalEndpoint), mDeviceTypes(std::move(aDeviceTypes)),
-        mUniqueLocationIds(std::move(aUniqueLocationIds)), mUniqueLocationIdsLastEditEpochUs(aUniqueLocationIdsLastEditEpochUs)
+        mUniqueLocationIds(std::move(aUniqueLocationIds)), mUniqueLocationIdsLastEditEpochUs(aUniqueLocationIdsLastEditEpochUs),
+        mFabricIndex(aFabricIndex)
+
     {}
 
     const std::string mDeviceName;
@@ -86,10 +91,7 @@ private:
     std::vector<Structs::DeviceTypeStruct::Type> mDeviceTypes;
     std::vector<std::string> mUniqueLocationIds;
     uint64_t mUniqueLocationIdsLastEditEpochUs;
-    // TODO(#33223) This structure needs to contain fabric index to be spec compliant.
-    // To keep initial PR smaller, we are going to assume that all entries
-    // here are for any fabric. This will allow follow up PR introducing
-    // fabric scoped to be more throughly reviewed with focus on fabric scoping.
+    FabricIndex mFabricIndex;
 };
 
 struct LocationDescriptorStruct
@@ -113,6 +115,7 @@ public:
         Builder & SetFloorNumber(std::optional<int16_t> aFloorNumber);
         Builder & SetAreaTypeTag(std::optional<Globals::AreaTypeTag> aAreaTypeTag);
         Builder & SetLocationDescriptorLastEdit(uint64_t aLocationDescriptorLastEditEpochUs);
+        Builder & SetFabricIndex(FabricIndex aFabricIndex);
 
         // Upon success this object will have moved all ownership of underlying
         // types to EcosystemDeviceStruct and should not be used afterwards.
@@ -121,17 +124,17 @@ public:
     private:
         LocationDescriptorStruct mLocationDescriptor;
         uint64_t mLocationDescriptorLastEditEpochUs = 0;
+        FabricIndex mFabricIndex                    = kUndefinedFabricIndex;
         bool mIsAlreadyBuilt                        = false;
     };
 
-    CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder, const std::string & aUniqueLocationId,
-                      const FabricIndex & aFabricIndex);
+    CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder, const std::string & aUniqueLocationId);
 
 private:
     // Constructor is intentionally private. This is to ensure that it is only constructed with
     // values that conform to the spec.
-    explicit EcosystemLocationStruct(LocationDescriptorStruct && aLocationDescriptor, uint64_t aLocationDescriptorLastEditEpochUs) :
-        mLocationDescriptor(aLocationDescriptor), mLocationDescriptorLastEditEpochUs(aLocationDescriptorLastEditEpochUs)
+    explicit EcosystemLocationStruct(LocationDescriptorStruct && aLocationDescriptor, uint64_t aLocationDescriptorLastEditEpochUs, FabricIndex aFabricIndex) :
+        mLocationDescriptor(aLocationDescriptor), mLocationDescriptorLastEditEpochUs(aLocationDescriptorLastEditEpochUs), mFabricIndex(aFabricIndex)
     {}
     // EcosystemLocationStruct is used as a value in a key-value map.
     // Because UniqueLocationId is manditory when an entry exist, and
@@ -139,10 +142,7 @@ private:
     // not explicitly in this struct.
     LocationDescriptorStruct mLocationDescriptor;
     uint64_t mLocationDescriptorLastEditEpochUs;
-    // TODO(#33223) This structure needs to contain fabric index to be spec compliant.
-    // To keep initial PR smaller, we are going to assume that all entries
-    // here are for any fabric. This will allow follow up PR introducing
-    // fabric scoped to be more throughly reviewed with focus on fabric scoping.
+    FabricIndex mFabricIndex;
 };
 
 class EcosystemInformationServer

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
@@ -101,17 +101,6 @@ struct LocationDescriptorStruct
     std::optional<Globals::AreaTypeTag> mAreaType;
 };
 
-struct EcosystemLocationIdentifier
-{
-    bool operator<(const EcosystemLocationIdentifier & other) const
-    {
-        return mUniqueLocationId < other.mUniqueLocationId ||
-            (mUniqueLocationId == other.mUniqueLocationId && mFabricIndex < other.mFabricIndex);
-    }
-    std::string mUniqueLocationId;
-    FabricIndex mFabricIndex;
-};
-
 // This intentionally mirrors Structs::EcosystemLocationStruct::Type but has ownership
 // of underlying types.
 class EcosystemLocationStruct
@@ -138,7 +127,7 @@ public:
     };
 
     CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder,
-                      const EcosystemLocationIdentifier & aUniqueLocationId);
+                      const std::string & aUniqueLocationId, const FabricIndex & aFabricIndex);
 
 private:
     // Constructor is intentionally private. This is to ensure that it is only constructed with
@@ -212,11 +201,22 @@ public:
     CHIP_ERROR ReadAttribute(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder);
 
 private:
+    struct EcosystemLocationKey
+    {
+        bool operator<(const EcosystemLocationKey & other) const
+        {
+            return mUniqueLocationId < other.mUniqueLocationId ||
+                (mUniqueLocationId == other.mUniqueLocationId && mFabricIndex < other.mFabricIndex);
+        }
+        std::string mUniqueLocationId;
+        FabricIndex mFabricIndex;
+    };
+
     struct DeviceInfo
     {
         Optional<uint64_t> mRemovedOn = NullOptional;
         std::vector<std::unique_ptr<EcosystemDeviceStruct>> mDeviceDirectory;
-        std::map<EcosystemLocationIdentifier, std::unique_ptr<EcosystemLocationStruct>> mLocationDirectory;
+        std::map<EcosystemLocationKey, std::unique_ptr<EcosystemLocationStruct>> mLocationDirectory;
     };
 
     CHIP_ERROR EncodeRemovedOnAttribute(EndpointId aEndpoint, AttributeValueEncoder & aEncoder);

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
@@ -101,9 +101,12 @@ struct LocationDescriptorStruct
     std::optional<Globals::AreaTypeTag> mAreaType;
 };
 
-struct EcosystemLocationIdentifier {
-    bool operator<(const EcosystemLocationIdentifier& other) const {
-        return mUniqueLocationId < other.mUniqueLocationId || (mUniqueLocationId == other.mUniqueLocationId && mFabricIndex < other.mFabricIndex);
+struct EcosystemLocationIdentifier
+{
+    bool operator<(const EcosystemLocationIdentifier & other) const
+    {
+        return mUniqueLocationId < other.mUniqueLocationId ||
+            (mUniqueLocationId == other.mUniqueLocationId && mFabricIndex < other.mFabricIndex);
     }
     std::string mUniqueLocationId;
     FabricIndex mFabricIndex;
@@ -134,7 +137,8 @@ public:
         bool mIsAlreadyBuilt                        = false;
     };
 
-    CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder, const EcosystemLocationIdentifier & aUniqueLocationId);
+    CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder,
+                      const EcosystemLocationIdentifier & aUniqueLocationId);
 
 private:
     // Constructor is intentionally private. This is to ensure that it is only constructed with


### PR DESCRIPTION
This adds FabricIndex to properly implement fabric-scoping to the all the DeviceDirectory entries and LocationDirectory entries.

Alternate that was considered but not implemented:
* Have FabricIndex be a set in the entry as an allowlist of FabricIndex's
   * Why approach was not taken: Tracking number of element in the directory to remain conformant to spec max become more difficult. More corner cases to consider when adding API that allows the set to be change
* Have FabricIndex be a set in the entry as an denylist of FabricIndex's
   * Add complexity where this cluster code needs to know fabric table and be aware when fabrics are added removed.
   * Complexity on when add fabric occurs and we don't have enough entry space in the directory