### PR TITLE
Disable TI builds from CI

### DIFF
--- a/.github/workflows/examples-cc13xx_26xx.yaml
+++ b/.github/workflows/examples-cc13xx_26xx.yaml
@@ -15,11 +15,15 @@
 name: Build example - TI CC13XX_26XX
 
 on:
-    push:
-        branches-ignore:
-            - "dependabot/**"
-    pull_request:
-    merge_group:
+    workflow_dispatch:
+    # Temporarely disabled:
+    #    - TI CI runs out of disk space
+    #    - Image should be updated to an Ubuntu 24.04 or higher based one (move from :54 version)
+    # push:
+    #     branches-ignore:
+    #         - 'dependabot/**'
+    # pull_request:
+    # merge_group:
 
 concurrency:
     group:

--- a/.github/workflows/examples-cc32xx.yaml
+++ b/.github/workflows/examples-cc32xx.yaml
@@ -15,11 +15,15 @@
 name: Build example - TI CC32XX
 
 on:
-    push:
-        branches-ignore:
-            - 'dependabot/**'
-    pull_request:
-    merge_group:
+    workflow_dispatch:
+    # Temporarely disabled:
+    #    - TI CI runs out of disk space
+    #    - Image should be updated to an Ubuntu 24.04 or higher based one (move from :54 version)
+    # push:
+    #     branches-ignore:
+    #         - 'dependabot/**'
+    # pull_request:
+    # merge_group:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}


### PR DESCRIPTION
This is because we seem to perma-fail due to out of space recently.

To be enabled when we have space AND we update to a more recent image.