### PR TITLE
Fix header usage in rvc

### DIFF
--- a/examples/rvc-app/rvc-common/include/rvc-service-area-delegate.h
+++ b/examples/rvc-app/rvc-common/include/rvc-service-area-delegate.h
@@ -21,7 +21,7 @@
 #include <app/clusters/service-area-server/service-area-server.h>
 #include <app/util/config.h>
 #include <cstring>
-#include <utility>
+#include <vector>
 
 namespace chip {
 namespace app {


### PR DESCRIPTION
include `vector` since this header uses vectors. Utility does not seem used.