### PR TITLE
Prevent cancellation of task with timeout in asyncio runner.

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/runner.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/runner.py
@@ -162,7 +162,8 @@ class TestRunner(TestRunnerBase):
         try:
             if config.auto_start_stop:
                 await self.start()
-            status = await asyncio.wait_for(self._run(parser, config), parser.timeout)
+            task = self._run(parser, config)
+            status = await asyncio.wait_for(asyncio.shield(task), parser.timeout)
         except (Exception, CancelledError) as exception:
             status = exception
         finally:


### PR DESCRIPTION
I am yet unclear why on new python/os/websocket we do not get a timeout error, however from what I could tell, wait_for would cancel the websocket.recv and that stops instead of throwing a timeout exception, resulting in a full success result.

What I believe is happening:
  - wait_for attempts a `cancel`
  - new websocket does handle cancel and returns immediately
  - test execution for loop returns immediately and executes the `finally` returning `True`
  - `True` is processed

Something is still off because I do not understand how we can execute the `finally` even though our loop is fully interrupted and no exception is reported. I have never seen such a thing (an entire block is skipped without an exeception and finally takes effect). Shield essentially protects the execution from being cancelled by wait_for.


Making this change seems to make the test TestPurposefulFailureExtraReportingOnToggle pass on my machine (well ... fail as expected instead of passing with a successful stop)
This fixes repl tests after trying to move to ubunt 24.04 (see #35009)

This is what we are dealing with:

![image](https://github.com/user-attachments/assets/2fb4448f-5751-4094-8f37-2baeb9678b59)
