### PR TITLE
[Darwin] more XPC service tweaks

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -120,7 +120,8 @@ using namespace chip::Tracing::DarwinFramework;
     MTRDeviceAttestationDelegateBridge * _deviceAttestationDelegateBridge;
     MTRDeviceControllerFactory * _factory;
     NSMapTable * _nodeIDToDeviceMap;
-    os_unfair_lock _deviceMapLock; // protects nodeIDToDeviceMap
+    os_unfair_lock_t _deviceMapLock; // protects nodeIDToDeviceMap
+    os_unfair_lock _underlyingDeviceMapLock;
     MTRCommissionableBrowser * _commissionableBrowser;
     MTRAttestationTrustStoreBridge * _attestationTrustStoreBridge;
 
@@ -134,14 +135,16 @@ using namespace chip::Tracing::DarwinFramework;
     MTRP256KeypairBridge _operationalKeypairBridge;
 }
 
-@synthesize deviceMapLock = _deviceMapLock;
+- (os_unfair_lock_t)deviceMapLock {
+    return &_underlyingDeviceMapLock;
+}
 
 - (instancetype)initForSubclasses
 {
     if (self = [super init]) {
         // nothing, as superclass of MTRDeviceController is NSObject
     }
-
+    _underlyingDeviceMapLock = OS_UNFAIR_LOCK_INIT;
     return self;
 }
 
@@ -252,7 +255,7 @@ using namespace chip::Tracing::DarwinFramework;
 
         _chipWorkQueue = queue;
         _factory = factory;
-        _deviceMapLock = OS_UNFAIR_LOCK_INIT;
+        _underlyingDeviceMapLock = OS_UNFAIR_LOCK_INIT;
         _nodeIDToDeviceMap = [NSMapTable strongToWeakObjectsMapTable];
         _serverEndpoints = [[NSMutableArray alloc] init];
         _commissionableBrowser = nil;
@@ -332,10 +335,10 @@ using namespace chip::Tracing::DarwinFramework;
     // while calling out into arbitrary invalidation code, snapshot the list of
     // devices before we start invalidating.
     MTR_LOG("cleanupAfterStartup MTRDeviceController: %@", self);
-    os_unfair_lock_lock(&_deviceMapLock);
+    os_unfair_lock_lock(self.deviceMapLock);
     NSEnumerator * devices = [_nodeIDToDeviceMap objectEnumerator];
     [_nodeIDToDeviceMap removeAllObjects];
-    os_unfair_lock_unlock(&_deviceMapLock);
+    os_unfair_lock_unlock(self.deviceMapLock);
 
     for (MTRDevice * device in devices) {
         [device invalidate];
@@ -636,7 +639,7 @@ using namespace chip::Tracing::DarwinFramework;
         [_controllerDataStore fetchAttributeDataForAllDevices:^(NSDictionary<NSNumber *, NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *> * _Nonnull clusterDataByNode) {
             MTR_LOG("%@ Loaded attribute values for %lu nodes from storage for controller uuid %@", self, static_cast<unsigned long>(clusterDataByNode.count), self->_uniqueIdentifier);
 
-            std::lock_guard lock(self->_deviceMapLock);
+            std::lock_guard lock(*self.deviceMapLock);
             NSMutableArray * deviceList = [NSMutableArray array];
             for (NSNumber * nodeID in clusterDataByNode) {
                 NSDictionary * clusterData = clusterDataByNode[nodeID];
@@ -1006,7 +1009,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 // If prefetchedClusterData is not provided, load attributes individually from controller data store
 - (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData
 {
-    os_unfair_lock_assert_owner(&_deviceMapLock);
+    os_unfair_lock_assert_owner(self.deviceMapLock);
 
     MTRDevice * deviceToReturn = [[MTRDevice_Concrete alloc] initWithNodeID:nodeID controller:self];
     // If we're not running, don't add the device to our map.  That would
@@ -1045,7 +1048,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
 - (MTRDevice *)deviceForNodeID:(NSNumber *)nodeID
 {
-    std::lock_guard lock(_deviceMapLock);
+    std::lock_guard lock(*self.deviceMapLock);
     MTRDevice * deviceToReturn = [_nodeIDToDeviceMap objectForKey:nodeID];
     if (!deviceToReturn) {
         deviceToReturn = [self _setupDeviceForNodeID:nodeID prefetchedClusterData:nil];
@@ -1056,7 +1059,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
 - (void)removeDevice:(MTRDevice *)device
 {
-    std::lock_guard lock(_deviceMapLock);
+    std::lock_guard lock(*self.deviceMapLock);
     auto * nodeID = device.nodeID;
     MTRDevice * deviceToRemove = [_nodeIDToDeviceMap objectForKey:nodeID];
     if (deviceToRemove == device) {
@@ -1070,7 +1073,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 #ifdef DEBUG
 - (NSDictionary<NSNumber *, NSNumber *> *)unitTestGetDeviceAttributeCounts
 {
-    std::lock_guard lock(_deviceMapLock);
+    std::lock_guard lock(*self.deviceMapLock);
     NSMutableDictionary<NSNumber *, NSNumber *> * deviceAttributeCounts = [NSMutableDictionary dictionary];
     for (NSNumber * nodeID in _nodeIDToDeviceMap) {
         deviceAttributeCounts[nodeID] = @([[_nodeIDToDeviceMap objectForKey:nodeID] unitTestAttributeCount]);
@@ -1510,9 +1513,9 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 {
     // Don't use deviceForNodeID here, because we don't want to create the
     // device if it does not already exist.
-    os_unfair_lock_lock(&_deviceMapLock);
+    os_unfair_lock_lock(self.deviceMapLock);
     MTRDevice * device = [_nodeIDToDeviceMap objectForKey:@(nodeID)];
-    os_unfair_lock_unlock(&_deviceMapLock);
+    os_unfair_lock_unlock(self.deviceMapLock);
 
     if (device == nil) {
         return;

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -134,7 +134,8 @@ using namespace chip::Tracing::DarwinFramework;
     MTRP256KeypairBridge _operationalKeypairBridge;
 }
 
-- (os_unfair_lock_t)deviceMapLock {
+- (os_unfair_lock_t)deviceMapLock
+{
     return &_underlyingDeviceMapLock;
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -120,7 +120,6 @@ using namespace chip::Tracing::DarwinFramework;
     MTRDeviceAttestationDelegateBridge * _deviceAttestationDelegateBridge;
     MTRDeviceControllerFactory * _factory;
     NSMapTable * _nodeIDToDeviceMap;
-    os_unfair_lock_t _deviceMapLock; // protects nodeIDToDeviceMap
     os_unfair_lock _underlyingDeviceMapLock;
     MTRCommissionableBrowser * _commissionableBrowser;
     MTRAttestationTrustStoreBridge * _attestationTrustStoreBridge;

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -134,6 +134,8 @@ using namespace chip::Tracing::DarwinFramework;
     MTRP256KeypairBridge _operationalKeypairBridge;
 }
 
+@synthesize deviceMapLock = _deviceMapLock;
+
 - (instancetype)initForSubclasses
 {
     if (self = [super init]) {

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -136,6 +136,7 @@ using namespace chip::Tracing::DarwinFramework;
 @synthesize commissionableBrowser = _commissionableBrowser;
 @synthesize concurrentSubscriptionPool = _concurrentSubscriptionPool;
 @synthesize storageBehaviorConfiguration = _storageBehaviorConfiguration;
+@synthesize nodeIDToDeviceMap = _nodeIDToDeviceMap;
 
 - (nullable instancetype)initWithParameters:(MTRDeviceControllerAbstractParameters *)parameters
                                       error:(NSError * __autoreleasing *)error

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -29,7 +29,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 
-#include <os/lock.h>
+#import <os/lock.h>
 
 #import "MTRBaseDevice.h"
 #import "MTRDeviceController.h"
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRDeviceController ()
 
 @property (nonatomic, readwrite, nullable) NSMapTable * nodeIDToDeviceMap;
-@property (nonatomic, readonly) os_unfair_lock deviceMapLock;
+@property (readonly, assign) os_unfair_lock_t deviceMapLock;
 
 - (instancetype)initForSubclasses;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -275,7 +275,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Device-specific data and SDK access
 // DeviceController will act as a central repository for this opaque dictionary that MTRDevice manages
 - (MTRDevice *)deviceForNodeID:(NSNumber *)nodeID;
-- (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData;
+- (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(nullable NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData;
 - (void)removeDevice:(MTRDevice *)device;
 
 /**

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -275,6 +275,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Device-specific data and SDK access
 // DeviceController will act as a central repository for this opaque dictionary that MTRDevice manages
 - (MTRDevice *)deviceForNodeID:(NSNumber *)nodeID;
+- (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData;
 - (void)removeDevice:(MTRDevice *)device;
 
 /**

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -29,6 +29,8 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 
+#include <os/lock.h>
+
 #import "MTRBaseDevice.h"
 #import "MTRDeviceController.h"
 #import "MTRDeviceControllerDataStore.h"
@@ -62,6 +64,9 @@ namespace Controller {
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDeviceController ()
+
+@property (nonatomic, readonly, nullable) NSMapTable * nodeIDToDeviceMap;
+@property (nonatomic, readonly) os_unfair_lock deviceMapLock;
 
 - (instancetype)initForSubclasses;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDeviceController ()
 
-@property (nonatomic, readonly, nullable) NSMapTable * nodeIDToDeviceMap;
+@property (nonatomic, readwrite, nullable) NSMapTable * nodeIDToDeviceMap;
 @property (nonatomic, readonly) os_unfair_lock deviceMapLock;
 
 - (instancetype)initForSubclasses;

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -14,11 +14,10 @@
  *    limitations under the License.
  */
 
-#import <os/lock.h>
+#import "MTRDeviceController_XPC.h"
 
 #import "MTRDefines_Internal.h"
 #import "MTRDeviceController_Internal.h"
-#import "MTRDeviceController_XPC.h"
 #import "MTRDevice_XPC.h"
 #import "MTRLogging_Internal.h"
 #import "MTRXPCClientProtocol.h"
@@ -43,7 +42,6 @@
 @implementation MTRDeviceController_XPC
 
 @synthesize uniqueIdentifier = _uniqueIdentifier;
-@synthesize deviceMapLock = _deviceMapLock;
 
 - (id)initWithUniqueIdentifier:(NSUUID *)UUID xpConnectionBlock:(NSXPCConnection * (^)(void) )connectionBlock
 {

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -51,7 +51,7 @@
 - (id)initWithUniqueIdentifier:(NSUUID *)UUID xpConnectionBlock:(NSXPCConnection * (^)(void) )connectionBlock
 {
     if (self = [super initForSubclasses]) {
-        MTR_LOG("Setting up XPC Controller for UUID: %@  with connection block: %p", UUID, connectionBlock);
+        MTR_LOG("Setting up XPC Controller for UUID: %@ with connection block: %p", UUID, connectionBlock);
 
         if (UUID == nil) {
             MTR_LOG_ERROR("MTRDeviceController_XPC initWithUniqueIdentifier failed, nil UUID");
@@ -120,6 +120,7 @@
 // If prefetchedClusterData is not provided, load attributes individually from controller data store
 - (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData
 {
+    MTR_LOG("%s", __PRETTY_FUNCTION__);
     os_unfair_lock_assert_owner(&_deviceMapLock);
 
     MTRDevice * deviceToReturn = [[MTRDevice_XPC alloc] initWithNodeID:nodeID controller:self];
@@ -130,7 +131,7 @@
     if ([self isRunning]) {
         [_nodeIDToDeviceMap setObject:deviceToReturn forKey:nodeID];
     }
-
+    MTR_LOG("%s: returning XPC device for node id %@", __PRETTY_FUNCTION__, nodeID);
     return deviceToReturn;
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -16,9 +16,9 @@
 
 #import <os/lock.h>
 
-#import "MTRDeviceController_XPC.h"
 #import "MTRDefines_Internal.h"
 #import "MTRDeviceController_Internal.h"
+#import "MTRDeviceController_XPC.h"
 #import "MTRDevice_XPC.h"
 #import "MTRLogging_Internal.h"
 #import "MTRXPCClientProtocol.h"

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -35,8 +35,6 @@
 @interface MTRDeviceController_XPC ()
 
 @property (nonatomic, retain, readwrite) NSUUID * uniqueIdentifier;
-@property (nonatomic, readonly, nullable) NSMapTable * nodeIDToDeviceMap;
-@property (nonatomic, readonly) os_unfair_lock deviceMapLock;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -43,7 +43,6 @@
 @implementation MTRDeviceController_XPC
 
 @synthesize uniqueIdentifier = _uniqueIdentifier;
-@synthesize nodeIDToDeviceMap = _nodeIDToDeviceMap;
 @synthesize deviceMapLock = _deviceMapLock;
 
 - (id)initWithUniqueIdentifier:(NSUUID *)UUID xpConnectionBlock:(NSXPCConnection * (^)(void) )connectionBlock
@@ -127,7 +126,7 @@
     // which will be in exactly the state it would be in if it were created
     // while we were running and then we got shut down.
     if ([self isRunning]) {
-        [_nodeIDToDeviceMap setObject:deviceToReturn forKey:nodeID];
+        [self.nodeIDToDeviceMap setObject:deviceToReturn forKey:nodeID];
     }
     MTR_LOG("%s: returning XPC device for node id %@", __PRETTY_FUNCTION__, nodeID);
     return deviceToReturn;

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -118,7 +118,7 @@
 - (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData
 {
     MTR_LOG("%s", __PRETTY_FUNCTION__);
-    os_unfair_lock_assert_owner(&_deviceMapLock);
+    os_unfair_lock_assert_owner(self.deviceMapLock);
 
     MTRDevice * deviceToReturn = [[MTRDevice_XPC alloc] initWithNodeID:nodeID controller:self];
     // If we're not running, don't add the device to our map.  That would

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -85,24 +85,28 @@
 #pragma mark - Client Callbacks
 - (oneway void)device:(NSNumber *)nodeID stateChanged:(MTRDeviceState)state
 {
+    MTR_LOG_DEBUG("%s", __PRETTY_FUNCTION__);
     [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
         [delegate device:self stateChanged:state];
     }];
 }
 - (oneway void)device:(NSNumber *)nodeID receivedAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport
 {
+    MTR_LOG_DEBUG("%s", __PRETTY_FUNCTION__);
     [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
         [delegate device:self receivedAttributeReport:attributeReport];
     }];
 }
 - (oneway void)device:(NSNumber *)nodeID receivedEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport
 {
+    MTR_LOG_DEBUG("%s", __PRETTY_FUNCTION__);
     [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
         [delegate device:self receivedEventReport:eventReport];
     }];
 }
 - (oneway void)deviceBecameActive:(NSNumber *)nodeID
 {
+    MTR_LOG_DEBUG("%s", __PRETTY_FUNCTION__);
     [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
         [delegate deviceBecameActive:self];
     }];

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -85,28 +85,28 @@
 #pragma mark - Client Callbacks
 - (oneway void)device:(NSNumber *)nodeID stateChanged:(MTRDeviceState)state
 {
-    MTR_LOG_DEBUG("%s", __PRETTY_FUNCTION__);
+    MTR_LOG("%s", __PRETTY_FUNCTION__);
     [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
         [delegate device:self stateChanged:state];
     }];
 }
 - (oneway void)device:(NSNumber *)nodeID receivedAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport
 {
-    MTR_LOG_DEBUG("%s", __PRETTY_FUNCTION__);
+    MTR_LOG("%s", __PRETTY_FUNCTION__);
     [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
         [delegate device:self receivedAttributeReport:attributeReport];
     }];
 }
 - (oneway void)device:(NSNumber *)nodeID receivedEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport
 {
-    MTR_LOG_DEBUG("%s", __PRETTY_FUNCTION__);
+    MTR_LOG("%s", __PRETTY_FUNCTION__);
     [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
         [delegate device:self receivedEventReport:eventReport];
     }];
 }
 - (oneway void)deviceBecameActive:(NSNumber *)nodeID
 {
-    MTR_LOG_DEBUG("%s", __PRETTY_FUNCTION__);
+    MTR_LOG("%s", __PRETTY_FUNCTION__);
     [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
         [delegate deviceBecameActive:self];
     }];

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -82,7 +82,9 @@
 
 @implementation MTRDevice_XPC
 
-#pragma mark - Client Callbacks
+#pragma mark - Client Callbacks (MTRDeviceDelegate)
+
+// required methods for MTRDeviceDelegates
 - (oneway void)device:(NSNumber *)nodeID stateChanged:(MTRDeviceState)state
 {
     MTR_LOG("%s", __PRETTY_FUNCTION__);
@@ -90,6 +92,7 @@
         [delegate device:self stateChanged:state];
     }];
 }
+
 - (oneway void)device:(NSNumber *)nodeID receivedAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport
 {
     MTR_LOG("%s", __PRETTY_FUNCTION__);
@@ -97,6 +100,7 @@
         [delegate device:self receivedAttributeReport:attributeReport];
     }];
 }
+
 - (oneway void)device:(NSNumber *)nodeID receivedEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport
 {
     MTR_LOG("%s", __PRETTY_FUNCTION__);
@@ -104,23 +108,33 @@
         [delegate device:self receivedEventReport:eventReport];
     }];
 }
+
+// optional methods for MTRDeviceDelegates - check for implementation before calling
 - (oneway void)deviceBecameActive:(NSNumber *)nodeID
 {
     MTR_LOG("%s", __PRETTY_FUNCTION__);
     [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
-        [delegate deviceBecameActive:self];
+        if ([delegate respondsToSelector:@selector(deviceBecameActive:)]) {
+            [delegate deviceBecameActive:self];
+        }
     }];
 }
+
 - (oneway void)deviceCachePrimed:(NSNumber *)nodeID
 {
     [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
-        [delegate deviceCachePrimed:self];
+        if ([delegate respondsToSelector:@selector(deviceCachePrimed:)]) {
+            [delegate deviceCachePrimed:self];
+        }
     }];
 }
+
 - (oneway void)deviceConfigurationChanged:(NSNumber *)nodeID
 {
     [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
-        [delegate deviceConfigurationChanged:self];
+        if ([delegate respondsToSelector:@selector(deviceConfigurationChanged:)]) {
+            [delegate deviceConfigurationChanged:self];
+        }
     }];
 }
 


### PR DESCRIPTION
- override `_setupDeviceForNodeID:...` so we can get `MTRDevice_XPC`s from it
- more logging
- raise device map and its locks