### PR TITLE
[Fabric-Admin] Fix the new added device failed to get reported

### DIFF
--- a/docs/guides/fabric_synchronization_guide.md
+++ b/docs/guides/fabric_synchronization_guide.md
@@ -136,8 +136,8 @@ Pair the Light Example with node ID 3 using its payload number:
 pairing already-discovered 3 20202021 <ip> 5543
 ```
 
-After the device is successfully added, you will observe the following message on
-Ecosystem 2 with the newly assigned Node ID:
+After the device is successfully added, you will observe the following message
+on Ecosystem 2 with the newly assigned Node ID:
 
 ```
 >>> New device with Node ID: 0x3 has been successfully added.

--- a/docs/guides/fabric_synchronization_guide.md
+++ b/docs/guides/fabric_synchronization_guide.md
@@ -98,6 +98,12 @@ Run the Fabric Synchronization script:
 
 In Ecosystem 1 Fabric-Admin console:
 
+Pair the local bridge of Ecosystem 1 with node ID 1:
+
+```
+fabricsync add-local-bridge 1
+```
+
 Pair the Ecosystem 2 bridge to Ecosystem 1 with node ID 2:
 
 ```
@@ -130,7 +136,7 @@ Pair the Light Example with node ID 3 using its payload number:
 pairing already-discovered 3 20202021 <ip> 5543
 ```
 
-After the device is successfully added, you will observe the following on
+After the device is successfully added, you will observe the following message on
 Ecosystem 2 with the newly assigned Node ID:
 
 ```

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -215,8 +215,8 @@ void DeviceManager::SubscribeRemoteFabricBridge()
 
     // Prepare and push the commissioner control subscribe command
     commandBuilder.Add("commissionercontrol subscribe-event commissioning-request-result ");
-    commandBuilder.AddFormat("%d %d %lu %d --is-urgent true", kSubscribeMinInterval, kSubscribeMaxInterval, mRemoteBridgeNodeId,
-                             kRootEndpointId);
+    commandBuilder.AddFormat("%d %d %lu %d --is-urgent true --keepSubscriptions true", kSubscribeMinInterval, kSubscribeMaxInterval,
+                             mRemoteBridgeNodeId, kRootEndpointId);
     PushCommand(commandBuilder.c_str());
 }
 
@@ -413,7 +413,7 @@ void DeviceManager::HandleAttributeData(const app::ConcreteDataAttributePath & p
     for (const auto & endpoint : addedEndpoints)
     {
         // print to console
-        fprintf(stderr, "A new devie is added on Endpoint: %u\n", endpoint);
+        fprintf(stderr, "A new device is added on Endpoint: %u\n", endpoint);
 
         if (mAutoSyncEnabled)
         {


### PR DESCRIPTION
This is the regression, after e2e has been setup between two ecosystems, a new added device on one side is not reported on the other side.  

Fix https://github.com/project-chip/connectedhomeip/issues/35059

