### PR TITLE
Fix failed to sync device when using dynamic setupPIN

### DIFF
--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -144,7 +144,6 @@ void DeviceManager::OpenRemoteDeviceCommissioningWindow(EndpointId remoteEndpoin
     commandBuilder.Add("pairing open-commissioning-window ");
     commandBuilder.AddFormat("%lu %d %d %d %d %d", mRemoteBridgeNodeId, remoteEndpointId, kEnhancedCommissioningMethod,
                              kWindowTimeout, kIteration, discriminator);
-    commandBuilder.Add(" --setup-pin 20202021");
 
     PushCommand(commandBuilder.c_str());
 }


### PR DESCRIPTION
Currently, we always use static setupPIn to pair synced device, it is better to switch to use a dynamic one to uniquely identify the synced device during pairing process.

If we does not specify the setupPIN, SDK should generate a random one, but this does not work on my home setup when try to sync a example Matter device.

Fixes [#12345` and a brief change description
](https://github.com/project-chip/connectedhomeip/issues/34963)