### PR TITLE
[Darwin] more `MTRDevice`/`MTRDeviceController` ivar/property raises

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -313,22 +313,6 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
 @end
 
-// Declaring selector so compiler won't complain about testing and calling it in _handleReportEnd
-#ifdef DEBUG
-@protocol MTRDeviceUnitTestDelegate <MTRDeviceDelegate>
-- (void)unitTestReportEndForDevice:(MTRDevice *)device;
-- (BOOL)unitTestShouldSetUpSubscriptionForDevice:(MTRDevice *)device;
-- (BOOL)unitTestShouldSkipExpectedValuesForWrite:(MTRDevice *)device;
-- (NSNumber *)unitTestMaxIntervalOverrideForSubscription:(MTRDevice *)device;
-- (BOOL)unitTestForceAttributeReportsIfMatchingCache:(MTRDevice *)device;
-- (BOOL)unitTestPretendThreadEnabled:(MTRDevice *)device;
-- (void)unitTestSubscriptionPoolDequeue:(MTRDevice *)device;
-- (void)unitTestSubscriptionPoolWorkComplete:(MTRDevice *)device;
-- (void)unitTestClusterDataPersisted:(MTRDevice *)device;
-- (BOOL)unitTestSuppressTimeBasedReachabilityChanges:(MTRDevice *)device;
-@end
-#endif
-
 @implementation MTRDevice
 
 @synthesize delegates = _delegates;

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -298,7 +298,6 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
 @interface MTRDevice ()
 
-
 @property (nonatomic) chip::FabricIndex fabricIndex;
 @property (nonatomic) NSMutableArray<NSDictionary<NSString *, id> *> * unreportedEvents;
 
@@ -330,91 +329,9 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 @end
 #endif
 
-@implementation MTRDevice {
-#ifdef DEBUG
-    NSUInteger _unitTestAttributesReportedSinceLastCheck;
-#endif
-
-    // _deviceCachePrimed is true if we have the data that comes from an initial
-    // subscription priming report (whether it came from storage or from our
-    // subscription).
-    BOOL _deviceCachePrimed;
-
-    // _persistedClusterData stores data that we have already persisted (when we have
-    // cluster data persistence enabled).  Nil when we have no persistence enabled.
-    NSCache<MTRClusterPath *, MTRDeviceClusterData *> * _Nullable _persistedClusterData;
-    // _clusterDataToPersist stores data that needs to be persisted.  If we
-    // don't have persistence enabled, this is our only data store.  Nil if we
-    // currently have nothing that could need persisting.
-    NSMutableDictionary<MTRClusterPath *, MTRDeviceClusterData *> * _Nullable _clusterDataToPersist;
-    // _persistedClusters stores the set of "valid" keys into _persistedClusterData.
-    // These are keys that could have values in _persistedClusterData even if they don't
-    // right now (because they have been evicted).
-    NSMutableSet<MTRClusterPath *> * _persistedClusters;
-
-    // When we last failed to subscribe to the device (either via
-    // _setupSubscriptionWithReason or via the auto-resubscribe behavior
-    // of the ReadClient).  Nil if we have had no such failures.
-    NSDate * _Nullable _lastSubscriptionFailureTime;
-    MTRDeviceConnectivityMonitor * _connectivityMonitor;
-
-    // This boolean keeps track of any device configuration changes received in an attribute report.
-    // If this is true when the report ends, we notify the delegate.
-    BOOL _deviceConfigurationChanged;
-
-    // The completion block is set when the subscription / resubscription work is enqueued, and called / cleared when any of the following happen:
-    //   1. Subscription establishes
-    //   2. OnResubscriptionNeeded is called
-    //   3. Subscription reset (including when getSessionForNode fails)
-    MTRAsyncWorkCompletionBlock _subscriptionPoolWorkCompletionBlock;
-
-    // Tracking of initial subscribe latency.  When _initialSubscribeStart is
-    // nil, we are not tracking the latency.
-    NSDate * _Nullable _initialSubscribeStart;
-
-    // Storage behavior configuration and variables to keep track of the logic
-    //  _clusterDataPersistenceFirstScheduledTime is used to track the start time of the delay between
-    //      report and persistence.
-    //  _mostRecentReportTimes is a list of the most recent report timestamps used for calculating
-    //      the running average time between reports.
-    //  _deviceReportingExcessivelyStartTime tracks when a device starts reporting excessively.
-    //  _reportToPersistenceDelayCurrentMultiplier is the current multiplier that is calculated when a
-    //      report comes in.
-    MTRDeviceStorageBehaviorConfiguration * _storageBehaviorConfiguration;
-    NSDate * _Nullable _clusterDataPersistenceFirstScheduledTime;
-    NSMutableArray<NSDate *> * _mostRecentReportTimes;
-    NSDate * _Nullable _deviceReportingExcessivelyStartTime;
-    double _reportToPersistenceDelayCurrentMultiplier;
-
-    // System time change observer reference
-    id _systemTimeChangeObserverToken;
-
-    NSMutableSet<MTRDeviceDelegateInfo *> * _delegates;
-
-    // Protects mutable state used by our description getter.  This is a separate lock from "lock"
-    // so that we don't need to worry about getting our description while holding "lock" (e.g due to
-    // logging self).  This lock _must_ be held narrowly, with no other lock acquisitions allowed
-    // while it's held, to avoid deadlock.
-    os_unfair_lock _descriptionLock;
-
-    // State used by our description getter: access to these must be protected by descriptionLock.
-    NSNumber * _Nullable _vid; // nil if unknown
-    NSNumber * _Nullable _pid; // nil if unknown
-    // _allNetworkFeatures is a bitwise or of the feature maps of all network commissioning clusters
-    // present on the device, or nil if there aren't any.
-    NSNumber * _Nullable _allNetworkFeatures;
-    // Copy of _internalDeviceState that is safe to use in description.
-    MTRInternalDeviceState _internalDeviceStateForDescription;
-    // Copy of _lastSubscriptionAttemptWait that is safe to use in description.
-    uint32_t _lastSubscriptionAttemptWaitForDescription;
-    // Most recent entry in _mostRecentReportTimes, if any.
-    NSDate * _Nullable _mostRecentReportTimeForDescription;
-    // Copy of _lastSubscriptionFailureTime that is safe to use in description.
-    NSDate * _Nullable _lastSubscriptionFailureTimeForDescription;
-}
+@implementation MTRDevice
 
 @synthesize delegates = _delegates;
-
 
 - (instancetype)initForSubclasses
 {

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -389,7 +389,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     [[NSNotificationCenter defaultCenter] removeObserver:_systemTimeChangeObserverToken];
 
     // TODO: retain cycle and clean up https://github.com/project-chip/connectedhomeip/issues/34267
-    MTR_LOG("MTRDevice dealloc: %p", self);
+    MTR_LOG("%@ dealloc: %p", self, self);
 }
 
 - (NSString *)description

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -311,8 +311,15 @@ using namespace chip::Tracing::DarwinFramework;
     return _cppCommissioner != nullptr;
 }
 
+
+//#define TESTING_IGNORE_MTRDEVICECONTROLLER_SHUTDOWN
+
 - (void)shutdown
 {
+#ifdef TESTING_IGNORE_MTRDEVICECONTROLLER_SHUTDOWN
+    MTR_LOG("****** IGNORING call to shutdown in %@", self);
+    return;
+#else
     MTR_LOG("%@ shutdown called", self);
     if (_cppCommissioner == nullptr) {
         // Already shut down.
@@ -321,6 +328,7 @@ using namespace chip::Tracing::DarwinFramework;
 
     MTR_LOG("Shutting down %@: %@", NSStringFromClass(self.class), self);
     [self cleanupAfterStartup];
+#endif // TESTING_IGNORE_MTRDEVICECONTROLLER_SHUTDOWN
 }
 
 // Clean up from a state where startup was called.

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -311,8 +311,7 @@ using namespace chip::Tracing::DarwinFramework;
     return _cppCommissioner != nullptr;
 }
 
-
-//#define TESTING_IGNORE_MTRDEVICECONTROLLER_SHUTDOWN
+// #define TESTING_IGNORE_MTRDEVICECONTROLLER_SHUTDOWN
 
 - (void)shutdown
 {

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -109,9 +109,6 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
 using namespace chip::Tracing::DarwinFramework;
 
 @implementation MTRDeviceController {
-    // queue used to serialize all work performed by the MTRDeviceController
-    dispatch_queue_t _chipWorkQueue;
-
     chip::Controller::DeviceCommissioner * _cppCommissioner;
     chip::Credentials::PartialDACVerifier * _partialDACVerifier;
     chip::Credentials::DefaultDACVerifier * _defaultDACVerifier;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -900,8 +900,11 @@ MTR_DIRECT_MEMBERS
     app::DnssdServer::Instance().StartServer();
 }
 
+//#define TESTING_IGNORE_MTRDEVICECONTROLLERFACTORY_SHUTDOWN
+
 - (void)controllerShuttingDown:(MTRDeviceController *)controller
 {
+#ifndef TESTING_IGNORE_MTRDEVICECONTROLLERFACTORY_SHUTDOWN
     [self _assertCurrentQueueIsNotMatterQueue];
 
     if (![_controllers containsObject:controller]) {
@@ -960,6 +963,7 @@ MTR_DIRECT_MEMBERS
     });
 
     [controller deinitFromFactory];
+#endif // TESTING_IGNORE_MTRDEVICECONTROLLERFACTORY_SHUTDOWN
 }
 
 - (NSArray<MTRDeviceController *> *)getRunningControllers

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -900,7 +900,7 @@ MTR_DIRECT_MEMBERS
     app::DnssdServer::Instance().StartServer();
 }
 
-//#define TESTING_IGNORE_MTRDEVICECONTROLLERFACTORY_SHUTDOWN
+// #define TESTING_IGNORE_MTRDEVICECONTROLLERFACTORY_SHUTDOWN
 
 - (void)controllerShuttingDown:(MTRDeviceController *)controller
 {

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -67,6 +67,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readwrite, nullable) NSMapTable * nodeIDToDeviceMap;
 @property (readonly, assign) os_unfair_lock_t deviceMapLock;
+// queue used to serialize all work performed by the MTRDeviceController
+@property (readwrite, retain) dispatch_queue_t chipWorkQueue;
+
 
 - (instancetype)initForSubclasses;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -70,7 +70,6 @@ NS_ASSUME_NONNULL_BEGIN
 // queue used to serialize all work performed by the MTRDeviceController
 @property (readwrite, retain) dispatch_queue_t chipWorkQueue;
 
-
 - (instancetype)initForSubclasses;
 
 #pragma mark - MTRDeviceControllerFactory methods

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -59,6 +59,7 @@
 
         self.xpcConnection = connectionBlock();
         self.uniqueIdentifier = UUID;
+        self.chipWorkQueue = dispatch_queue_create("MTRDeviceController_XPC_queue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 
         MTR_LOG("Set up XPC Connection: %@", self.xpcConnection);
         if (self.xpcConnection) {
@@ -119,6 +120,8 @@
     MTR_LOG_ERROR("%s: unimplemented method called", __PRETTY_FUNCTION__);
     return nil;
 }
+
+#pragma mark - Behavior Overrides
 
 // If prefetchedClusterData is not provided, load attributes individually from controller data store
 - (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData

--- a/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.h
@@ -17,8 +17,6 @@
 #import <Foundation/Foundation.h>
 #import "MTRDefines_Internal.h"
 
-#import <lib/support/CodeUtils.h>
-
 @protocol MTRDeviceDelegate;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.h
@@ -1,0 +1,61 @@
+/**
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import "MTRDefines_Internal.h"
+
+#import <lib/support/CodeUtils.h>
+
+@protocol MTRDeviceDelegate;
+
+NS_ASSUME_NONNULL_BEGIN
+
+// container of MTRDevice delegate weak reference, its queue, and its interested paths for attribute reports
+MTR_DIRECT_MEMBERS
+@interface MTRDeviceDelegateInfo : NSObject {
+@private
+    void * _delegatePointerValue;
+    __weak id _delegate;
+    dispatch_queue_t _queue;
+    NSArray * _Nullable _interestedPathsForAttributes;
+    NSArray * _Nullable _interestedPathsForEvents;
+}
+
+// Array of interested cluster paths, attribute paths, or endpointID, for attribute report filtering.
+@property (readonly, nullable) NSArray * interestedPathsForAttributes;
+
+// Array of interested cluster paths, attribute paths, or endpointID, for event report filtering.
+@property (readonly, nullable) NSArray * interestedPathsForEvents;
+
+// Expose delegate
+@property (readonly) id delegate;
+
+// Pointer value for logging purpose only
+@property (readonly) void * delegatePointerValue;
+
+- (instancetype)initWithDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedPathsForAttributes:(NSArray * _Nullable)interestedPathsForAttributes interestedPathsForEvents:(NSArray * _Nullable)interestedPathsForEvents;
+
+// Returns YES if delegate and queue are both non-null, and the block is scheduled to run.
+- (BOOL)callDelegateWithBlock:(void (^)(id<MTRDeviceDelegate>))block;
+
+#ifdef DEBUG
+// Only used for unit test purposes - normal delegate should not expect or handle being called back synchronously.
+- (BOOL)callDelegateSynchronouslyWithBlock:(void (^)(id<MTRDeviceDelegate>))block;
+#endif
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.h
@@ -14,8 +14,8 @@
  *    limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
 #import "MTRDefines_Internal.h"
+#import <Foundation/Foundation.h>
 
 @protocol MTRDeviceDelegate;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.mm
@@ -16,6 +16,8 @@
 
 #import "MTRDeviceDelegateInfo.h"
 
+#import <lib/support/CodeUtils.h>   // VerifyOrReturnValue
+
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation MTRDeviceDelegateInfo

--- a/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.mm
@@ -16,7 +16,7 @@
 
 #import "MTRDeviceDelegateInfo.h"
 
-#import <lib/support/CodeUtils.h>   // VerifyOrReturnValue
+#import <lib/support/CodeUtils.h> // VerifyOrReturnValue
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceDelegateInfo.mm
@@ -1,0 +1,64 @@
+/**
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRDeviceDelegateInfo.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation MTRDeviceDelegateInfo
+
+- (instancetype)initWithDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedPathsForAttributes:(NSArray * _Nullable)interestedPathsForAttributes interestedPathsForEvents:(NSArray * _Nullable)interestedPathsForEvents
+{
+    if (self = [super init]) {
+        _delegate = delegate;
+        _delegatePointerValue = (__bridge void *) delegate;
+        _queue = queue;
+        _interestedPathsForAttributes = [interestedPathsForAttributes copy];
+        _interestedPathsForEvents = [interestedPathsForEvents copy];
+    }
+    return self;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MTRDeviceDelegateInfo: %p delegate value %p interested attribute paths count %lu event paths count %lu>", self, _delegatePointerValue, static_cast<unsigned long>(_interestedPathsForAttributes.count), static_cast<unsigned long>(_interestedPathsForEvents.count)];
+}
+
+- (BOOL)callDelegateWithBlock:(void (^)(id<MTRDeviceDelegate>))block
+{
+    id<MTRDeviceDelegate> strongDelegate = _delegate;
+    VerifyOrReturnValue(strongDelegate, NO);
+    dispatch_async(_queue, ^{
+        block(strongDelegate);
+    });
+    return YES;
+}
+
+#ifdef DEBUG
+- (BOOL)callDelegateSynchronouslyWithBlock:(void (^)(id<MTRDeviceDelegate>))block
+{
+    id<MTRDeviceDelegate> strongDelegate = _delegate;
+    VerifyOrReturnValue(strongDelegate, NO);
+
+    block(strongDelegate);
+
+    return YES;
+}
+#endif
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -500,7 +500,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     [[NSNotificationCenter defaultCenter] removeObserver:_systemTimeChangeObserverToken];
 
     // TODO: retain cycle and clean up https://github.com/project-chip/connectedhomeip/issues/34267
-    MTR_LOG("MTRDevice dealloc: %p", self);
+    MTR_LOG("%@ dealloc: %p", self, self);
 }
 
 - (NSString *)description

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -319,13 +319,9 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 // Currently used/updated only in _getAttributesToReportWithNewExpectedValues:expirationTime:expectedValueID:
 @property (nonatomic) uint64_t expectedValueNextID;
 
-@property (nonatomic) BOOL expirationCheckScheduled;
-
 @property (nonatomic) BOOL timeUpdateScheduled;
 
 @property (nonatomic) NSDate * estimatedStartTimeFromGeneralDiagnosticsUpTime;
-
-@property (nonatomic) NSMutableDictionary * temporaryMetaDataCache;
 
 /**
  * If currentReadClient is non-null, that means that we successfully
@@ -444,8 +440,17 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 @synthesize state = _state;
 @synthesize estimatedStartTime = _estimatedStartTime;
 @synthesize estimatedSubscriptionLatency = _estimatedSubscriptionLatency;
-//@synthesize lock = _lock;
-//@synthesize persistedClusterData = _persistedClusterData;
+@synthesize lock = _lock;
+@synthesize timeSyncLock = _timeSyncLock;
+@synthesize expectedValueCache = _expectedValueCache;
+@synthesize internalDeviceState = _internalDeviceState;
+@synthesize timeUpdateScheduled = _timeUpdateScheduled;
+@synthesize receivingReport = _receivingReport;
+@synthesize lastSubscriptionAttemptWait = _lastSubscriptionAttemptWait;
+@synthesize reattemptingSubscription = _reattemptingSubscription;
+@synthesize receivingPrimingReport = _receivingPrimingReport;
+@synthesize expectedValueNextID = _expectedValueNextID;
+@synthesize estimatedStartTimeFromGeneralDiagnosticsUpTime = _estimatedStartTimeFromGeneralDiagnosticsUpTime;
 
 - (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller
 {

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -333,22 +333,6 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
 @end
 
-// Declaring selector so compiler won't complain about testing and calling it in _handleReportEnd
-#ifdef DEBUG
-@protocol MTRDeviceUnitTestDelegate <MTRDeviceDelegate>
-- (void)unitTestReportEndForDevice:(MTRDevice *)device;
-- (BOOL)unitTestShouldSetUpSubscriptionForDevice:(MTRDevice *)device;
-- (BOOL)unitTestShouldSkipExpectedValuesForWrite:(MTRDevice *)device;
-- (NSNumber *)unitTestMaxIntervalOverrideForSubscription:(MTRDevice *)device;
-- (BOOL)unitTestForceAttributeReportsIfMatchingCache:(MTRDevice *)device;
-- (BOOL)unitTestPretendThreadEnabled:(MTRDevice *)device;
-- (void)unitTestSubscriptionPoolDequeue:(MTRDevice *)device;
-- (void)unitTestSubscriptionPoolWorkComplete:(MTRDevice *)device;
-- (void)unitTestClusterDataPersisted:(MTRDevice *)device;
-- (BOOL)unitTestSuppressTimeBasedReachabilityChanges:(MTRDevice *)device;
-@end
-#endif
-
 @implementation MTRDevice_Concrete {
 #ifdef DEBUG
     NSUInteger _unitTestAttributesReportedSinceLastCheck;

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -21,8 +21,8 @@
 
 #import "MTRAsyncWorkQueue.h"
 #import "MTRDefines_Internal.h"
-#import "MTRDeviceStorageBehaviorConfiguration_Internal.h"
 #import "MTRDeviceDelegateInfo.h"
+#import "MTRDeviceStorageBehaviorConfiguration_Internal.h"
 
 #import <os/lock.h>
 
@@ -149,7 +149,6 @@ MTR_TESTABLE
     NSDate * _Nullable _mostRecentReportTimeForDescription;
     // Copy of _lastSubscriptionFailureTime that is safe to use in description.
     NSDate * _Nullable _lastSubscriptionFailureTimeForDescription;
-
 }
 
 - (instancetype)initForSubclasses;
@@ -260,8 +259,6 @@ MTR_TESTABLE
 
 - (void)_scheduleSubscriptionPoolWork:(dispatch_block_t)workBlock inNanoseconds:(int64_t)inNanoseconds description:(NSString *)description;
 - (void)_setupSubscriptionWithReason:(NSString *)reason;
-
-
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -277,4 +277,20 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 // Declared inside platform, but noting here for reference
 // static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOverride";
 
+// Declaring selector so compiler won't complain about testing and calling it in _handleReportEnd
+#ifdef DEBUG
+@protocol MTRDeviceUnitTestDelegate <MTRDeviceDelegate>
+- (void)unitTestReportEndForDevice:(MTRDevice *)device;
+- (BOOL)unitTestShouldSetUpSubscriptionForDevice:(MTRDevice *)device;
+- (BOOL)unitTestShouldSkipExpectedValuesForWrite:(MTRDevice *)device;
+- (NSNumber *)unitTestMaxIntervalOverrideForSubscription:(MTRDevice *)device;
+- (BOOL)unitTestForceAttributeReportsIfMatchingCache:(MTRDevice *)device;
+- (BOOL)unitTestPretendThreadEnabled:(MTRDevice *)device;
+- (void)unitTestSubscriptionPoolDequeue:(MTRDevice *)device;
+- (void)unitTestSubscriptionPoolWorkComplete:(MTRDevice *)device;
+- (void)unitTestClusterDataPersisted:(MTRDevice *)device;
+- (BOOL)unitTestSuppressTimeBasedReachabilityChanges:(MTRDevice *)device;
+@end
+#endif
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -247,6 +247,7 @@ MTR_TESTABLE
 
 #ifdef DEBUG
 - (NSUInteger)unitTestAttributeCount;
+- (void)_callFirstDelegateSynchronouslyWithBlock:(void (^)(id<MTRDeviceDelegate> delegate))block;
 #endif
 
 - (void)setStorageBehaviorConfiguration:(MTRDeviceStorageBehaviorConfiguration *)storageBehaviorConfiguration;

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -26,6 +26,8 @@
 
 #import <os/lock.h>
 
+@class MTRDeviceConnectivityMonitor;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class MTRAsyncWorkQueue;
@@ -68,7 +70,87 @@ MTR_TESTABLE
 - (nullable instancetype)initWithDataVersion:(NSNumber * _Nullable)dataVersion attributes:(NSDictionary<NSNumber *, MTRDeviceDataValueDictionary> * _Nullable)attributes;
 @end
 
-@interface MTRDevice ()
+@interface MTRDevice () {
+#ifdef DEBUG
+    NSUInteger _unitTestAttributesReportedSinceLastCheck;
+#endif
+
+    // _deviceCachePrimed is true if we have the data that comes from an initial
+    // subscription priming report (whether it came from storage or from our
+    // subscription).
+    BOOL _deviceCachePrimed;
+
+    // _persistedClusterData stores data that we have already persisted (when we have
+    // cluster data persistence enabled).  Nil when we have no persistence enabled.
+    NSCache<MTRClusterPath *, MTRDeviceClusterData *> * _Nullable _persistedClusterData;
+    // _clusterDataToPersist stores data that needs to be persisted.  If we
+    // don't have persistence enabled, this is our only data store.  Nil if we
+    // currently have nothing that could need persisting.
+    NSMutableDictionary<MTRClusterPath *, MTRDeviceClusterData *> * _Nullable _clusterDataToPersist;
+    // _persistedClusters stores the set of "valid" keys into _persistedClusterData.
+    // These are keys that could have values in _persistedClusterData even if they don't
+    // right now (because they have been evicted).
+    NSMutableSet<MTRClusterPath *> * _persistedClusters;
+
+    // When we last failed to subscribe to the device (either via
+    // _setupSubscriptionWithReason or via the auto-resubscribe behavior
+    // of the ReadClient).  Nil if we have had no such failures.
+    NSDate * _Nullable _lastSubscriptionFailureTime;
+    MTRDeviceConnectivityMonitor * _connectivityMonitor;
+
+    // This boolean keeps track of any device configuration changes received in an attribute report.
+    // If this is true when the report ends, we notify the delegate.
+    BOOL _deviceConfigurationChanged;
+
+    // The completion block is set when the subscription / resubscription work is enqueued, and called / cleared when any of the following happen:
+    //   1. Subscription establishes
+    //   2. OnResubscriptionNeeded is called
+    //   3. Subscription reset (including when getSessionForNode fails)
+    MTRAsyncWorkCompletionBlock _subscriptionPoolWorkCompletionBlock;
+
+    // Tracking of initial subscribe latency.  When _initialSubscribeStart is
+    // nil, we are not tracking the latency.
+    NSDate * _Nullable _initialSubscribeStart;
+
+    // Storage behavior configuration and variables to keep track of the logic
+    //  _clusterDataPersistenceFirstScheduledTime is used to track the start time of the delay between
+    //      report and persistence.
+    //  _mostRecentReportTimes is a list of the most recent report timestamps used for calculating
+    //      the running average time between reports.
+    //  _deviceReportingExcessivelyStartTime tracks when a device starts reporting excessively.
+    //  _reportToPersistenceDelayCurrentMultiplier is the current multiplier that is calculated when a
+    //      report comes in.
+    MTRDeviceStorageBehaviorConfiguration * _storageBehaviorConfiguration;
+    NSDate * _Nullable _clusterDataPersistenceFirstScheduledTime;
+    NSMutableArray<NSDate *> * _mostRecentReportTimes;
+    NSDate * _Nullable _deviceReportingExcessivelyStartTime;
+    double _reportToPersistenceDelayCurrentMultiplier;
+
+    // System time change observer reference
+    id _systemTimeChangeObserverToken;
+
+    // Protects mutable state used by our description getter.  This is a separate lock from "lock"
+    // so that we don't need to worry about getting our description while holding "lock" (e.g due to
+    // logging self).  This lock _must_ be held narrowly, with no other lock acquisitions allowed
+    // while it's held, to avoid deadlock.
+    os_unfair_lock _descriptionLock;
+
+    // State used by our description getter: access to these must be protected by descriptionLock.
+    NSNumber * _Nullable _vid; // nil if unknown
+    NSNumber * _Nullable _pid; // nil if unknown
+    // _allNetworkFeatures is a bitwise or of the feature maps of all network commissioning clusters
+    // present on the device, or nil if there aren't any.
+    NSNumber * _Nullable _allNetworkFeatures;
+    // Copy of _internalDeviceState that is safe to use in description.
+    MTRInternalDeviceState _internalDeviceStateForDescription;
+    // Copy of _lastSubscriptionAttemptWait that is safe to use in description.
+    uint32_t _lastSubscriptionAttemptWaitForDescription;
+    // Most recent entry in _mostRecentReportTimes, if any.
+    NSDate * _Nullable _mostRecentReportTimeForDescription;
+    // Copy of _lastSubscriptionFailureTime that is safe to use in description.
+    NSDate * _Nullable _lastSubscriptionFailureTimeForDescription;
+
+}
 
 - (instancetype)initForSubclasses;
 - (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -86,8 +86,8 @@
 
 - (void)_addDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedPathsForAttributes:(NSArray * _Nullable)interestedPathsForAttributes interestedPathsForEvents:(NSArray * _Nullable)interestedPathsForEvents
 {
-//    std::lock_guard lock(_lock); // TODO: LOCKING NOT SAFE HERE
-//
+    //    std::lock_guard lock(_lock); // TODO: LOCKING NOT SAFE HERE
+    //
     // Replace delegate info with the same delegate object, and opportunistically remove defunct delegate references
     NSMutableSet<MTRDeviceDelegateInfo *> * delegatesToRemove = [NSMutableSet set];
     for (MTRDeviceDelegateInfo * delegateInfo in self.delegates) {
@@ -110,7 +110,6 @@
     [self.delegates addObject:newDelegateInfo];
     MTR_LOG("%@ added delegate info %@", self, newDelegateInfo);
 }
-
 
 #pragma mark - Client Callbacks (MTRDeviceDelegate)
 

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -305,6 +305,8 @@
 		9B0484F52C701154006C2D5F /* MTRDeviceController_Concrete.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B0484F42C701154006C2D5F /* MTRDeviceController_Concrete.h */; };
 		9B231B042C62EF650030EB37 /* (null) in Headers */ = {isa = PBXBuildFile; };
 		9B231B052C62EF650030EB37 /* MTRDeviceController_Concrete.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9B231B032C62EF650030EB37 /* MTRDeviceController_Concrete.mm */; };
+		9B4144652C72F9B10030CFAB /* MTRDeviceDelegateInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B4144632C72F9B10030CFAB /* MTRDeviceDelegateInfo.h */; };
+		9B4144662C72F9B10030CFAB /* MTRDeviceDelegateInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9B4144642C72F9B10030CFAB /* MTRDeviceDelegateInfo.mm */; };
 		9B5CCB592C6E6FD3009DD99B /* MTRDeviceController_XPC_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B5CCB582C6E6FD3009DD99B /* MTRDeviceController_XPC_Internal.h */; };
 		9B5CCB5C2C6EC890009DD99B /* MTRDevice_XPC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9B5CCB5B2C6EC890009DD99B /* MTRDevice_XPC.mm */; };
 		9B5CCB5D2C6EC890009DD99B /* MTRDevice_XPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B5CCB5A2C6EC890009DD99B /* MTRDevice_XPC.h */; };
@@ -745,6 +747,8 @@
 		99D466E02798936D0089A18F /* MTRCommissioningParameters.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCommissioningParameters.h; sourceTree = "<group>"; };
 		9B0484F42C701154006C2D5F /* MTRDeviceController_Concrete.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDeviceController_Concrete.h; sourceTree = "<group>"; };
 		9B231B032C62EF650030EB37 /* MTRDeviceController_Concrete.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceController_Concrete.mm; sourceTree = "<group>"; };
+		9B4144632C72F9B10030CFAB /* MTRDeviceDelegateInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDeviceDelegateInfo.h; sourceTree = "<group>"; };
+		9B4144642C72F9B10030CFAB /* MTRDeviceDelegateInfo.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceDelegateInfo.mm; sourceTree = "<group>"; };
 		9B5CCB582C6E6FD3009DD99B /* MTRDeviceController_XPC_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDeviceController_XPC_Internal.h; sourceTree = "<group>"; };
 		9B5CCB5A2C6EC890009DD99B /* MTRDevice_XPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDevice_XPC.h; sourceTree = "<group>"; };
 		9B5CCB5B2C6EC890009DD99B /* MTRDevice_XPC.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDevice_XPC.mm; sourceTree = "<group>"; };
@@ -1432,6 +1436,8 @@
 				5173A47329C0E2ED00F67F48 /* MTRFabricInfo.mm */,
 				515BE4EC2B72C0C5000BC1FD /* MTRUnfairLock.h */,
 				3D69867E29382E58007314E7 /* Resources */,
+				9B4144632C72F9B10030CFAB /* MTRDeviceDelegateInfo.h */,
+				9B4144642C72F9B10030CFAB /* MTRDeviceDelegateInfo.mm */,
 			);
 			path = CHIP;
 			sourceTree = "<group>";
@@ -1659,6 +1665,7 @@
 				754784672BFE93B00089C372 /* MTRDeviceStorageBehaviorConfiguration.h in Headers */,
 				5136661528067D550025EDAE /* MTRDeviceControllerFactory_Internal.h in Headers */,
 				515C1C70284F9FFB00A48F0C /* MTRFramework.h in Headers */,
+				9B4144652C72F9B10030CFAB /* MTRDeviceDelegateInfo.h in Headers */,
 				7534F12928BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h in Headers */,
 				D4772A46285AE98400383630 /* MTRClusterConstants.h in Headers */,
 				3DA1A3552ABAB3B4004F0BB9 /* MTRAsyncWorkQueue.h in Headers */,
@@ -2020,6 +2027,7 @@
 				991DC0892475F47D00C13860 /* MTRDeviceController.mm in Sources */,
 				B2E0D7B7245B0B5C003C5B48 /* MTRQRCodeSetupPayloadParser.mm in Sources */,
 				514C79F32B62ED5500DD6D7B /* attribute-storage.cpp in Sources */,
+				9B4144662C72F9B10030CFAB /* MTRDeviceDelegateInfo.mm in Sources */,
 				514304202914CED9004DC7FE /* generic-callback-stubs.cpp in Sources */,
 				1EDCE546289049A100E41EC9 /* MTROTAHeader.mm in Sources */,
 				51D0B13D2B61B2F2006E3511 /* MTRDeviceTypeRevision.mm in Sources */,


### PR DESCRIPTION
raise various properties and ivars in `MTRDevice` and `MTRDeviceController` for use from subclasses.

NOTE:  tests currently not passing locally or in CI