### PR TITLE
Credential modification should check type, not just index.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -2312,8 +2312,9 @@ DlStatus DoorLockServer::modifyCredentialForUser(chip::EndpointId endpointId, ch
 
     for (size_t i = 0; i < user.credentials.size(); ++i)
     {
-        // appclusters, 5.2.4.40: user should already be associated with given credentialIndex
-        if (user.credentials.data()[i].credentialIndex == credential.credentialIndex)
+        // appclusters, 5.2.4.40: user should already be associated with given credential
+        if (user.credentials[i].credentialType == credential.credentialType &&
+            user.credentials[i].credentialIndex == credential.credentialIndex)
         {
             chip::Platform::ScopedMemoryBuffer<CredentialStruct> newCredentials;
             if (!newCredentials.Alloc(user.credentials.size()))
@@ -2357,7 +2358,7 @@ DlStatus DoorLockServer::modifyCredentialForUser(chip::EndpointId endpointId, ch
         }
     }
 
-    // appclusters, 5.2.4.40: if user is not associated with credential index we should return INVALID_COMMAND
+    // appclusters, 5.2.4.40: if user is not associated with the given credential we should return INVALID_COMMAND
     ChipLogProgress(Zcl,
                     "[ModifyUserCredential] Unable to modify user credential: user is not associated with credential index "
                     "[endpointId=%d,userIndex=%d,credentialIndex=%d]",


### PR DESCRIPTION
Credential indices are per-type, so we should be checking both when locating the credential to be modified.

This is a backport of https://github.com/project-chip/connectedhomeip/pull/34841 to the 1.3 branch.