### PR TITLE
[Fabric-Admin] We should only start the reverse commission process if the local fabric bridge is ready.

### DIFF
--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -64,7 +64,7 @@ void FabricSyncAddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_E
 
         DeviceMgr().SubscribeRemoteFabricBridge();
 
-        if (DeviceMgr.IsLocalBridgeReady())
+        if (DeviceMgr().IsLocalBridgeReady())
         {
             // After successful commissioning of the Commissionee, initiate Reverse Commissioning
             // via the Commissioner Control Cluster. However, we must first verify that the

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -64,13 +64,16 @@ void FabricSyncAddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_E
 
         DeviceMgr().SubscribeRemoteFabricBridge();
 
-        // After successful commissioning of the Commissionee, initiate Reverse Commissioning
-        // via the Commissioner Control Cluster. However, we must first verify that the
-        // remote Fabric-Bridge supports Fabric Synchronization.
-        //
-        // Note: The Fabric-Admin MUST NOT send the RequestCommissioningApproval command
-        // if the remote Fabric-Bridge lacks Fabric Synchronization support.
-        DeviceLayer::PlatformMgr().ScheduleWork(CheckFabricBridgeSynchronizationSupport, 0);
+        if (DeviceMgr.IsLocalBridgeReady())
+        {
+            // After successful commissioning of the Commissionee, initiate Reverse Commissioning
+            // via the Commissioner Control Cluster. However, we must first verify that the
+            // remote Fabric-Bridge supports Fabric Synchronization.
+            //
+            // Note: The Fabric-Admin MUST NOT send the RequestCommissioningApproval command
+            // if the remote Fabric-Bridge lacks Fabric Synchronization support.
+            DeviceLayer::PlatformMgr().ScheduleWork(CheckFabricBridgeSynchronizationSupport, 0);
+        }
     }
     else
     {


### PR DESCRIPTION
Reproduction steps
```
Start fabric-sync on E1
./examples/fabric-admin/scripts/run_fabric_source.sh --verbose

Start fabric-sync on E2
./examples/fabric-admin/scripts/run_fabric_source.sh --verbose

Trigger FS setup process from E1
fabricsync add-bridge 1 192.168.86.50
```

We can see the E2 fabric-admin try to look for and pair non-existing fabric bridge of E1 and always fail. We should only start the reverse commission process if the local fabric is ready.

Fixes https://github.com/project-chip/connectedhomeip/issues/35078

