### PR TITLE
[FabricAdmin] Refactor FS specific attribute handlings out of general HandleAttributeData function

### DIFF
--- a/examples/fabric-admin/commands/clusters/ClusterCommand.h
+++ b/examples/fabric-admin/commands/clusters/ClusterCommand.h
@@ -84,7 +84,7 @@ public:
         if (data != nullptr)
         {
             LogErrorOnFailure(RemoteDataModelLogger::LogCommandAsJSON(path, data));
-            DeviceMgr().HandleCommandResponse(path, data);
+            DeviceMgr().HandleCommandResponse(path, *data);
         }
     }
 

--- a/examples/fabric-admin/commands/clusters/ReportCommand.cpp
+++ b/examples/fabric-admin/commands/clusters/ReportCommand.cpp
@@ -46,7 +46,7 @@ void ReportCommand::OnAttributeData(const app::ConcreteDataAttributePath & path,
 
     LogErrorOnFailure(RemoteDataModelLogger::LogAttributeAsJSON(path, data));
 
-    DeviceMgr().HandleAttributeData(path, data);
+    DeviceMgr().HandleAttributeData(path, *data);
 }
 
 void ReportCommand::OnEventData(const app::EventHeader & eventHeader, TLV::TLVReader * data, const app::StatusIB * status)
@@ -73,5 +73,5 @@ void ReportCommand::OnEventData(const app::EventHeader & eventHeader, TLV::TLVRe
 
     LogErrorOnFailure(RemoteDataModelLogger::LogEventAsJSON(eventHeader, data));
 
-    DeviceMgr().HandleEventData(eventHeader, data);
+    DeviceMgr().HandleEventData(eventHeader, *data);
 }

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -237,12 +237,12 @@ void DeviceManager::ReadSupportedDeviceCategories()
     PushCommand(commandBuilder.c_str());
 }
 
-void DeviceManager::HandleReadSupportedDeviceCategories(chip::TLV::TLVReader * data)
+void DeviceManager::HandleReadSupportedDeviceCategories(chip::TLV::TLVReader & data)
 {
     ChipLogProgress(NotSpecified, "Attribute SupportedDeviceCategories detected.");
 
     BitMask<CommissionerControl::SupportedDeviceCategoryBitmap> value;
-    CHIP_ERROR error = app::DataModel::Decode(*data, value);
+    CHIP_ERROR error = app::DataModel::Decode(data, value);
     if (error != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "Failed to decode attribute value. Error: %" CHIP_ERROR_FORMAT, error.Format());
@@ -273,12 +273,12 @@ void DeviceManager::RequestCommissioningApproval()
     PushCommand(commandBuilder.c_str());
 }
 
-void DeviceManager::HandleCommissioningRequestResult(TLV::TLVReader * data)
+void DeviceManager::HandleCommissioningRequestResult(TLV::TLVReader & data)
 {
     ChipLogProgress(NotSpecified, "CommissioningRequestResult event received.");
 
     CommissionerControl::Events::CommissioningRequestResult::DecodableType value;
-    CHIP_ERROR error = app::DataModel::Decode(*data, value);
+    CHIP_ERROR error = app::DataModel::Decode(data, value);
     if (error != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "Failed to decode event value. Error: %" CHIP_ERROR_FORMAT, error.Format());
@@ -302,12 +302,12 @@ void DeviceManager::HandleCommissioningRequestResult(TLV::TLVReader * data)
     SendCommissionNodeRequest(value.requestId, kResponseTimeoutSeconds);
 }
 
-void DeviceManager::HanldeAttributePartsListUpdate(chip::TLV::TLVReader * data)
+void DeviceManager::HanldeAttributePartsListUpdate(chip::TLV::TLVReader & data)
 {
     ChipLogProgress(NotSpecified, "Attribute PartsList change detected:");
 
     app::DataModel::DecodableList<EndpointId> value;
-    CHIP_ERROR error = app::DataModel::Decode(*data, value);
+    CHIP_ERROR error = app::DataModel::Decode(data, value);
     if (error != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "Failed to decode attribute value. Error: %" CHIP_ERROR_FORMAT, error.Format());
@@ -416,10 +416,10 @@ void DeviceManager::SendCommissionNodeRequest(uint64_t requestId, uint16_t respo
     PushCommand(commandBuilder.c_str());
 }
 
-void DeviceManager::HandleReverseOpenCommissioningWindow(TLV::TLVReader * data)
+void DeviceManager::HandleReverseOpenCommissioningWindow(TLV::TLVReader & data)
 {
     CommissionerControl::Commands::ReverseOpenCommissioningWindow::DecodableType value;
-    CHIP_ERROR error = app::DataModel::Decode(*data, value);
+    CHIP_ERROR error = app::DataModel::Decode(data, value);
     if (error != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "Failed to decode command response value. Error: %" CHIP_ERROR_FORMAT, error.Format());
@@ -445,7 +445,7 @@ void DeviceManager::HandleReverseOpenCommissioningWindow(TLV::TLVReader * data)
                                   verifierHex);
 }
 
-void DeviceManager::HandleAttributeData(const app::ConcreteDataAttributePath & path, TLV::TLVReader * data)
+void DeviceManager::HandleAttributeData(const app::ConcreteDataAttributePath & path, TLV::TLVReader & data)
 {
     if (path.mClusterId == CommissionerControl::Id &&
         path.mAttributeId == CommissionerControl::Attributes::SupportedDeviceCategories::Id)
@@ -461,7 +461,7 @@ void DeviceManager::HandleAttributeData(const app::ConcreteDataAttributePath & p
     }
 }
 
-void DeviceManager::HandleEventData(const app::EventHeader & header, TLV::TLVReader * data)
+void DeviceManager::HandleEventData(const app::EventHeader & header, TLV::TLVReader & data)
 {
     if (header.mPath.mClusterId == CommissionerControl::Id &&
         header.mPath.mEventId == CommissionerControl::Events::CommissioningRequestResult::Id)
@@ -470,7 +470,7 @@ void DeviceManager::HandleEventData(const app::EventHeader & header, TLV::TLVRea
     }
 }
 
-void DeviceManager::HandleCommandResponse(const app::ConcreteCommandPath & path, TLV::TLVReader * data)
+void DeviceManager::HandleCommandResponse(const app::ConcreteCommandPath & path, TLV::TLVReader & data)
 {
     ChipLogProgress(NotSpecified, "Command Response received.");
 

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -302,7 +302,7 @@ void DeviceManager::HandleCommissioningRequestResult(TLV::TLVReader & data)
     SendCommissionNodeRequest(value.requestId, kResponseTimeoutSeconds);
 }
 
-void DeviceManager::HanldeAttributePartsListUpdate(chip::TLV::TLVReader & data)
+void DeviceManager::HandleAttributePartsListUpdate(chip::TLV::TLVReader & data)
 {
     ChipLogProgress(NotSpecified, "Attribute PartsList change detected:");
 
@@ -456,7 +456,7 @@ void DeviceManager::HandleAttributeData(const app::ConcreteDataAttributePath & p
 
     if (path.mClusterId == Descriptor::Id && path.mAttributeId == Descriptor::Attributes::PartsList::Id)
     {
-        HanldeAttributePartsListUpdate(data);
+        HandleAttributePartsListUpdate(data);
         return;
     }
 }

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -237,6 +237,25 @@ void DeviceManager::ReadSupportedDeviceCategories()
     PushCommand(commandBuilder.c_str());
 }
 
+void DeviceManager::HandleReadSupportedDeviceCategories(chip::TLV::TLVReader * data)
+{
+    ChipLogProgress(NotSpecified, "Attribute SupportedDeviceCategories detected.");
+
+    BitMask<CommissionerControl::SupportedDeviceCategoryBitmap> value;
+    CHIP_ERROR error = app::DataModel::Decode(*data, value);
+    if (error != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "Failed to decode attribute value. Error: %" CHIP_ERROR_FORMAT, error.Format());
+        return;
+    }
+
+    if (value.Has(CommissionerControl::SupportedDeviceCategoryBitmap::kFabricSynchronization))
+    {
+        ChipLogProgress(NotSpecified, "Remote Fabric-Bridge supports Fabric Synchronization, start reverse commissioning.");
+        RequestCommissioningApproval();
+    }
+}
+
 void DeviceManager::RequestCommissioningApproval()
 {
     ChipLogProgress(NotSpecified, "Starting reverse commissioning for bridge device: NodeId: " ChipLogFormatX64,
@@ -283,79 +302,9 @@ void DeviceManager::HandleCommissioningRequestResult(TLV::TLVReader * data)
     SendCommissionNodeRequest(value.requestId, kResponseTimeoutSeconds);
 }
 
-void DeviceManager::SendCommissionNodeRequest(uint64_t requestId, uint16_t responseTimeoutSeconds)
+void DeviceManager::HanldeAttributePartsListUpdate(chip::TLV::TLVReader * data)
 {
-    ChipLogProgress(NotSpecified, "Request the Commissioner Control Server to begin commissioning a previously approved request.");
-
-    StringBuilder<kMaxCommandSize> commandBuilder;
-    commandBuilder.Add("commissionercontrol commission-node ");
-    commandBuilder.AddFormat("%lu %u %lu %d", requestId, responseTimeoutSeconds, mRemoteBridgeNodeId, kRootEndpointId);
-
-    PushCommand(commandBuilder.c_str());
-}
-
-void DeviceManager::HandleReverseOpenCommissioningWindow(TLV::TLVReader * data)
-{
-    CommissionerControl::Commands::ReverseOpenCommissioningWindow::DecodableType value;
-    CHIP_ERROR error = app::DataModel::Decode(*data, value);
-    if (error != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "Failed to decode command response value. Error: %" CHIP_ERROR_FORMAT, error.Format());
-        return;
-    }
-
-    // Log all fields
-    ChipLogProgress(NotSpecified, "DecodableType fields:");
-    ChipLogProgress(NotSpecified, "  commissioningTimeout: %u", value.commissioningTimeout);
-    ChipLogProgress(NotSpecified, "  discriminator: %u", value.discriminator);
-    ChipLogProgress(NotSpecified, "  iterations: %u", value.iterations);
-
-    char verifierHex[Crypto::kSpake2p_VerifierSerialized_Length * 2 + 1];
-    Encoding::BytesToHex(value.PAKEPasscodeVerifier.data(), value.PAKEPasscodeVerifier.size(), verifierHex, sizeof(verifierHex),
-                         Encoding::HexFlags::kNullTerminate);
-    ChipLogProgress(NotSpecified, "  PAKEPasscodeVerifier: %s", verifierHex);
-
-    char saltHex[Crypto::kSpake2p_Max_PBKDF_Salt_Length * 2 + 1];
-    Encoding::BytesToHex(value.salt.data(), value.salt.size(), saltHex, sizeof(saltHex), Encoding::HexFlags::kNullTerminate);
-    ChipLogProgress(NotSpecified, "  salt: %s", saltHex);
-
-    OpenDeviceCommissioningWindow(mLocalBridgeNodeId, value.commissioningTimeout, value.iterations, value.discriminator, saltHex,
-                                  verifierHex);
-}
-
-void DeviceManager::HandleAttributeData(const app::ConcreteDataAttributePath & path, TLV::TLVReader * data)
-{
-    if (path.mClusterId == CommissionerControl::Id &&
-        path.mAttributeId == CommissionerControl::Attributes::SupportedDeviceCategories::Id)
-    {
-        ChipLogProgress(NotSpecified, "Attribute SupportedDeviceCategories detected.");
-
-        BitMask<CommissionerControl::SupportedDeviceCategoryBitmap> value;
-        CHIP_ERROR error = app::DataModel::Decode(*data, value);
-        if (error != CHIP_NO_ERROR)
-        {
-            ChipLogError(NotSpecified, "Failed to decode attribute value. Error: %" CHIP_ERROR_FORMAT, error.Format());
-            return;
-        }
-
-        if (value.Has(CommissionerControl::SupportedDeviceCategoryBitmap::kFabricSynchronization))
-        {
-            ChipLogProgress(NotSpecified, "Remote Fabric-Bridge supports Fabric Synchronization, start reverse commissioning.");
-            RequestCommissioningApproval();
-        }
-
-        return;
-    }
-
-    if (path.mClusterId != Descriptor::Id || path.mAttributeId != Descriptor::Attributes::PartsList::Id)
-    {
-        return;
-    }
-
-    ChipLogProgress(NotSpecified, "Attribute change detected:");
-    ChipLogProgress(
-        NotSpecified, "Endpoint: %u, Cluster: " ChipLogFormatMEI ", Attribute: " ChipLogFormatMEI ", DataVersion: %" PRIu32,
-        path.mEndpointId, ChipLogValueMEI(path.mClusterId), ChipLogValueMEI(path.mAttributeId), path.mDataVersion.ValueOr(0));
+    ChipLogProgress(NotSpecified, "Attribute PartsList change detected:");
 
     app::DataModel::DecodableList<EndpointId> value;
     CHIP_ERROR error = app::DataModel::Decode(*data, value);
@@ -453,6 +402,62 @@ void DeviceManager::HandleAttributeData(const app::ConcreteDataAttributePath & p
             pairingCommand->RegisterPairingDelegate(this);
             PushCommand(commandBuilder.c_str());
         }
+    }
+}
+
+void DeviceManager::SendCommissionNodeRequest(uint64_t requestId, uint16_t responseTimeoutSeconds)
+{
+    ChipLogProgress(NotSpecified, "Request the Commissioner Control Server to begin commissioning a previously approved request.");
+
+    StringBuilder<kMaxCommandSize> commandBuilder;
+    commandBuilder.Add("commissionercontrol commission-node ");
+    commandBuilder.AddFormat("%lu %u %lu %d", requestId, responseTimeoutSeconds, mRemoteBridgeNodeId, kRootEndpointId);
+
+    PushCommand(commandBuilder.c_str());
+}
+
+void DeviceManager::HandleReverseOpenCommissioningWindow(TLV::TLVReader * data)
+{
+    CommissionerControl::Commands::ReverseOpenCommissioningWindow::DecodableType value;
+    CHIP_ERROR error = app::DataModel::Decode(*data, value);
+    if (error != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "Failed to decode command response value. Error: %" CHIP_ERROR_FORMAT, error.Format());
+        return;
+    }
+
+    // Log all fields
+    ChipLogProgress(NotSpecified, "DecodableType fields:");
+    ChipLogProgress(NotSpecified, "  commissioningTimeout: %u", value.commissioningTimeout);
+    ChipLogProgress(NotSpecified, "  discriminator: %u", value.discriminator);
+    ChipLogProgress(NotSpecified, "  iterations: %u", value.iterations);
+
+    char verifierHex[Crypto::kSpake2p_VerifierSerialized_Length * 2 + 1];
+    Encoding::BytesToHex(value.PAKEPasscodeVerifier.data(), value.PAKEPasscodeVerifier.size(), verifierHex, sizeof(verifierHex),
+                         Encoding::HexFlags::kNullTerminate);
+    ChipLogProgress(NotSpecified, "  PAKEPasscodeVerifier: %s", verifierHex);
+
+    char saltHex[Crypto::kSpake2p_Max_PBKDF_Salt_Length * 2 + 1];
+    Encoding::BytesToHex(value.salt.data(), value.salt.size(), saltHex, sizeof(saltHex), Encoding::HexFlags::kNullTerminate);
+    ChipLogProgress(NotSpecified, "  salt: %s", saltHex);
+
+    OpenDeviceCommissioningWindow(mLocalBridgeNodeId, value.commissioningTimeout, value.iterations, value.discriminator, saltHex,
+                                  verifierHex);
+}
+
+void DeviceManager::HandleAttributeData(const app::ConcreteDataAttributePath & path, TLV::TLVReader * data)
+{
+    if (path.mClusterId == CommissionerControl::Id &&
+        path.mAttributeId == CommissionerControl::Attributes::SupportedDeviceCategories::Id)
+    {
+        HandleReadSupportedDeviceCategories(data);
+        return;
+    }
+
+    if (path.mClusterId == Descriptor::Id && path.mAttributeId == Descriptor::Attributes::PartsList::Id)
+    {
+        HanldeAttributePartsListUpdate(data);
+        return;
     }
 }
 

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -167,7 +167,7 @@ private:
 
     void HandleCommissioningRequestResult(chip::TLV::TLVReader & data);
 
-    void HanldeAttributePartsListUpdate(chip::TLV::TLVReader & data);
+    void HandleAttributePartsListUpdate(chip::TLV::TLVReader & data);
 
     void SendCommissionNodeRequest(uint64_t requestId, uint16_t responseTimeoutSeconds);
 

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -163,7 +163,11 @@ private:
 
     void RequestCommissioningApproval();
 
+    void HandleReadSupportedDeviceCategories(chip::TLV::TLVReader * data);
+
     void HandleCommissioningRequestResult(chip::TLV::TLVReader * data);
+
+    void HanldeAttributePartsListUpdate(chip::TLV::TLVReader * data);
 
     void SendCommissionNodeRequest(uint64_t requestId, uint16_t responseTimeoutSeconds);
 

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -150,11 +150,11 @@ public:
 
     void ReadSupportedDeviceCategories();
 
-    void HandleAttributeData(const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader * data);
+    void HandleAttributeData(const chip::app::ConcreteDataAttributePath & path, chip::TLV::TLVReader & data);
 
-    void HandleEventData(const chip::app::EventHeader & header, chip::TLV::TLVReader * data);
+    void HandleEventData(const chip::app::EventHeader & header, chip::TLV::TLVReader & data);
 
-    void HandleCommandResponse(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader * data);
+    void HandleCommandResponse(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader & data);
 
     void OnDeviceRemoved(chip::NodeId deviceId, CHIP_ERROR err) override;
 
@@ -163,15 +163,15 @@ private:
 
     void RequestCommissioningApproval();
 
-    void HandleReadSupportedDeviceCategories(chip::TLV::TLVReader * data);
+    void HandleReadSupportedDeviceCategories(chip::TLV::TLVReader & data);
 
-    void HandleCommissioningRequestResult(chip::TLV::TLVReader * data);
+    void HandleCommissioningRequestResult(chip::TLV::TLVReader & data);
 
-    void HanldeAttributePartsListUpdate(chip::TLV::TLVReader * data);
+    void HanldeAttributePartsListUpdate(chip::TLV::TLVReader & data);
 
     void SendCommissionNodeRequest(uint64_t requestId, uint16_t responseTimeoutSeconds);
 
-    void HandleReverseOpenCommissioningWindow(chip::TLV::TLVReader * data);
+    void HandleReverseOpenCommissioningWindow(chip::TLV::TLVReader & data);
 
     static DeviceManager sInstance;
 


### PR DESCRIPTION
No logic change, refactor the current handling logic within HandleAttributeData function to

    void HandleReadSupportedDeviceCategories(chip::TLV::TLVReader & data);
    void HanldeAttributePartsListUpdate(chip::TLV::TLVReader & data);

