### PR TITLE
Add missing CFLAGS to instrument things for fuzzers.

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -415,6 +415,8 @@ declare_args() {
 config("sanitize_address") {
   defines = []
   cflags = [
+    "-fsanitize-coverage=inline-8bit-counters,trace-cmp",
+    "-fno-sanitize-coverage=pc-table",
     "-fsanitize=address",
     "-fno-omit-frame-pointer",
   ]


### PR DESCRIPTION
-fno-sanitize-coverage=pc-table is added since we are already using inline-8bit-counters and trace-cmp to provide instrumentation for the fuzzers. It also helps reduce memory usage and improve fuzzer performance.

