### PR TITLE
[Darwin] MTRDeviceController_XPC client protocol xpc interface fix

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -43,6 +43,26 @@
 
 @synthesize uniqueIdentifier = _uniqueIdentifier;
 
+- (NSXPCInterface *)_interfaceForClientProtocol
+{
+    NSXPCInterface * interface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCClientProtocol)];
+    NSSet * allowedClasses = [NSSet setWithArray:@[
+        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class], [MTRAttributePath class]
+    ]];
+    [interface setClasses:allowedClasses
+              forSelector:@selector(device:receivedAttributeReport:)
+            argumentIndex:1
+                  ofReply:NO];
+    allowedClasses = [NSSet setWithArray:@[
+        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class], [MTREventPath class]
+    ]];
+    [interface setClasses:allowedClasses
+              forSelector:@selector(device:receivedEventReport:)
+            argumentIndex:1
+                  ofReply:NO];
+    return interface;
+}
+
 - (id)initWithUniqueIdentifier:(NSUUID *)UUID xpConnectionBlock:(NSXPCConnection * (^)(void) )connectionBlock
 {
     if (self = [super initForSubclasses]) {
@@ -64,7 +84,7 @@
         if (self.xpcConnection) {
             self.xpcConnection.remoteObjectInterface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCServerProtocol)];
 
-            self.xpcConnection.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCClientProtocol)];
+            self.xpcConnection.exportedInterface = [self _interfaceForClientProtocol];
             self.xpcConnection.exportedObject = self;
 
             self.xpcConnection.interruptionHandler = ^{


### PR DESCRIPTION
MTRAttributePath and MTREventPath classes need to be added to the interface for MTRXPCClientProtocol's XPCInterface for attribute and event reports.