### PR TITLE
IDM-12.1: Also dump to log

### DIFF
--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -775,7 +775,17 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
         software_version = self.endpoints[0][Clusters.BasicInformation][Clusters.BasicInformation.Attributes.SoftwareVersion]
         filename = f'device_dump_0x{vid:04X}_0x{pid:04X}_{software_version}.json'
         dump_device_composition_path = self.user_params.get("dump_device_composition_path", filename)
-        self.dump_wildcard(dump_device_composition_path)
+        json_str, txt_str = self.dump_wildcard(dump_device_composition_path)
+
+        # Structured dump so we can pull these back out of the logs
+        def log_structured_data(start_tag: str, dump_string):
+            lines = dump_string.splitlines(keepends=True)
+            logging.info(f'{start_tag}BEGIN ({len(lines)} lines)====')
+            logging.info(f'{start_tag}{start_tag.join(lines)}')
+            logging.info(f'{start_tag}END ====')
+
+        log_structured_data('==== json: ', json_str)
+        log_structured_data('==== txt: ', txt_str)
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -779,9 +779,10 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
 
         # Structured dump so we can pull these back out of the logs
         def log_structured_data(start_tag: str, dump_string):
-            lines = dump_string.splitlines(keepends=True)
+            lines = dump_string.splitlines()
             logging.info(f'{start_tag}BEGIN ({len(lines)} lines)====')
-            logging.info(f'{start_tag}{start_tag.join(lines)}')
+            for line in lines:
+                logging.info(f'{start_tag}{line}')
             logging.info(f'{start_tag}END ====')
 
         log_structured_data('==== json: ', json_str)

--- a/src/python_testing/basic_composition_support.py
+++ b/src/python_testing/basic_composition_support.py
@@ -23,7 +23,7 @@ import logging
 import pathlib
 import sys
 import typing
-from pprint import pprint
+from pprint import pformat, pprint
 from typing import Any, Optional
 
 import chip.clusters.ClusterObjects
@@ -105,15 +105,20 @@ class BasicCompositionTests:
         asserts.assert_equal(len(setupCode), 1, "Require one of either --qr-code or --manual-code.")
         await dev_ctrl.FindOrEstablishPASESession(setupCode[0], self.dut_node_id)
 
-    def dump_wildcard(self, dump_device_composition_path: typing.Optional[str]):
+    def dump_wildcard(self, dump_device_composition_path: typing.Optional[str]) -> tuple[str, str]:
+        """ Dumps a json and a txt file of the attribute wildcard for this device if the dump_device_composition_path is supplied.
+            Returns the json and txt as strings.
+        """
         node_dump_dict = {endpoint_id: MatterTlvToJson(self.endpoints_tlv[endpoint_id]) for endpoint_id in self.endpoints_tlv}
-        logging.debug(f"Raw TLV contents of Node: {json.dumps(node_dump_dict, indent=2)}")
+        json_dump_string = json.dumps(node_dump_dict, indent=2)
+        logging.debug(f"Raw TLV contents of Node: {json_dump_string}")
 
         if dump_device_composition_path is not None:
             with open(pathlib.Path(dump_device_composition_path).with_suffix(".json"), "wt+") as outfile:
                 json.dump(node_dump_dict, outfile, indent=2)
             with open(pathlib.Path(dump_device_composition_path).with_suffix(".txt"), "wt+") as outfile:
                 pprint(self.endpoints, outfile, indent=1, width=200, compact=True)
+        return (json_dump_string, pformat(self.endpoints, indent=1, width=200, compact=True))
 
     async def setup_class_helper(self, default_to_pase: bool = True):
         dev_ctrl = self.default_controller


### PR DESCRIPTION
I was a bit to optimistic about getting these files submitted separately. It would still be great to get the files, but as a backstop, I'm printing these into the logs as structured data so we can extract them if necessary from the output logs.

