### PR TITLE
Add expiry to KeepActive as per spec into fabric-admin example

### DIFF
--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -47,6 +47,8 @@ class FabricAdmin final : public rpc::FabricAdmin, public IcdManager::Delegate
 public:
     void OnCheckInCompleted(const chip::app::ICDClientInfo & clientInfo) override
     {
+        // Needs for accessing mPendingCheckIn
+        assertChipStackLockedByCurrentThread();
         NodeId nodeId = clientInfo.peer_node.GetNodeId();
         auto it       = mPendingCheckIn.find(nodeId);
         VerifyOrReturn(it != mPendingCheckIn.end());
@@ -155,6 +157,8 @@ public:
 
     void ScheduleSendingKeepActiveOnCheckIn(chip::NodeId nodeId, uint32_t stayActiveDurationMs)
     {
+        // Needs for accessing mPendingCheckIn
+        assertChipStackLockedByCurrentThread();
 
         auto timeNow = System::SystemClock().GetMonotonicTimestamp();
         // Spec says we should expire the request 60 mins after we get it

--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -56,8 +56,10 @@ public:
         System::Clock::Milliseconds64 timeNowMs =
             std::chrono::duration_cast<System::Clock::Milliseconds64>(System::SystemClock().GetMonotonicMilliseconds64());
 
-        if (timeNowMs > checkInData.mRequestExpiresAtMs) {
-            ChipLogError(NotSpecified, "ICD check-in for device we have been waiting, came after KeepActive expiry. Reqeust dropped");
+        if (timeNowMs > checkInData.mRequestExpiresAtMs)
+        {
+            ChipLogError(NotSpecified,
+                         "ICD check-in for device we have been waiting, came after KeepActive expiry. Reqeust dropped");
             return;
         }
 
@@ -154,9 +156,10 @@ public:
         System::Clock::Milliseconds64 timeNowMs =
             std::chrono::duration_cast<System::Clock::Milliseconds64>(System::SystemClock().GetMonotonicMilliseconds64());
         // Spec says we should expire the request 60 mins after we get it
-        System::Clock::Milliseconds64 expireTimeMs = timeNowMs + System::Clock::Milliseconds64(60*60*1000);
-        KeepActiveDataForCheckIn checkInData = {.mStayActiveDurationMs = stayActiveDurationMs, .mRequestExpiresAtMs = expireTimeMs};
-        mPendingKeepActiveTimesMs[nodeId] = checkInData;
+        System::Clock::Milliseconds64 expireTimeMs = timeNowMs + System::Clock::Milliseconds64(60 * 60 * 1000);
+        KeepActiveDataForCheckIn checkInData       = { .mStayActiveDurationMs = stayActiveDurationMs,
+                                                       .mRequestExpiresAtMs   = expireTimeMs };
+        mPendingKeepActiveTimesMs[nodeId]          = checkInData;
     }
 
 private:

--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -157,9 +157,9 @@ public:
         auto timeNowMs = System::SystemClock().GetMonotonicTimestamp();
         // Spec says we should expire the request 60 mins after we get it
         System::Clock::Timestamp expiryTimestamp = timeNowMs + System::Clock::Seconds64(60 * 60);
-        KeepActiveDataForCheckIn checkInData       = { .mStayActiveDurationMs   = stayActiveDurationMs,
-                                                       .mRequestExpiryTimestamp = expiryTimestamp };
-        mPendingCheckIn[nodeId]          = checkInData;
+        KeepActiveDataForCheckIn checkInData     = { .mStayActiveDurationMs   = stayActiveDurationMs,
+                                                     .mRequestExpiryTimestamp = expiryTimestamp };
+        mPendingCheckIn[nodeId]                  = checkInData;
     }
 
 private:

--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -56,8 +56,8 @@ public:
         // request.
         mPendingCheckIn.erase(nodeId);
 
-        auto timeNowMs = System::SystemClock().GetMonotonicTimestamp();
-        if (timeNowMs > checkInData.mRequestExpiryTimestamp)
+        auto timeNow = System::SystemClock().GetMonotonicTimestamp();
+        if (timeNow > checkInData.mRequestExpiryTimestamp)
         {
             ChipLogError(NotSpecified,
                          "ICD check-in for device we have been waiting, came after KeepActive expiry. Reqeust dropped");
@@ -154,9 +154,9 @@ public:
     void ScheduleSendingKeepActiveOnCheckIn(chip::NodeId nodeId, uint32_t stayActiveDurationMs)
     {
 
-        auto timeNowMs = System::SystemClock().GetMonotonicTimestamp();
+        auto timeNow = System::SystemClock().GetMonotonicTimestamp();
         // Spec says we should expire the request 60 mins after we get it
-        System::Clock::Timestamp expiryTimestamp = timeNowMs + System::Clock::Seconds64(60 * 60);
+        System::Clock::Timestamp expiryTimestamp = timeNow + System::Clock::Seconds64(60 * 60);
         KeepActiveDataForCheckIn checkInData     = { .mStayActiveDurationMs   = stayActiveDurationMs,
                                                      .mRequestExpiryTimestamp = expiryTimestamp };
         mPendingCheckIn[nodeId]                  = checkInData;

--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -47,7 +47,7 @@ class FabricAdmin final : public rpc::FabricAdmin, public IcdManager::Delegate
 public:
     void OnCheckInCompleted(const chip::app::ICDClientInfo & clientInfo) override
     {
-        chip::NodeId nodeId = clientInfo.peer_node.GetNodeId();
+        NodeId nodeId = clientInfo.peer_node.GetNodeId();
         auto it             = mPendingCheckIn.find(nodeId);
         VerifyOrReturn(it != mPendingCheckIn.end());
 
@@ -190,7 +190,7 @@ private:
     // Modifications to mPendingCheckIn should be done on the MatterEventLoop thread
     // otherwise we would need a mutex protecting this data to prevent race as this
     // data is accessible by both RPC thread and Matter eventloop.
-    std::unordered_map<chip::NodeId, KeepActiveDataForCheckIn> mPendingCheckIn;
+    std::unordered_map<NodeId, KeepActiveDataForCheckIn> mPendingCheckIn;
 };
 
 FabricAdmin fabric_admin_service;

--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -48,7 +48,7 @@ public:
     void OnCheckInCompleted(const chip::app::ICDClientInfo & clientInfo) override
     {
         NodeId nodeId = clientInfo.peer_node.GetNodeId();
-        auto it             = mPendingCheckIn.find(nodeId);
+        auto it       = mPendingCheckIn.find(nodeId);
         VerifyOrReturn(it != mPendingCheckIn.end());
 
         KeepActiveDataForCheckIn checkInData = it->second;
@@ -59,8 +59,10 @@ public:
         auto timeNow = System::SystemClock().GetMonotonicTimestamp();
         if (timeNow > checkInData.mRequestExpiryTimestamp)
         {
-            ChipLogError(NotSpecified,
-                         "ICD check-in for device we have been waiting, came after KeepActive expiry. Reqeust dropped for Node ID: 0x%lx", nodeId);
+            ChipLogError(
+                NotSpecified,
+                "ICD check-in for device we have been waiting, came after KeepActive expiry. Reqeust dropped for Node ID: 0x%lx",
+                nodeId);
             return;
         }
 

--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -60,7 +60,7 @@ public:
         if (timeNow > checkInData.mRequestExpiryTimestamp)
         {
             ChipLogError(NotSpecified,
-                         "ICD check-in for device we have been waiting, came after KeepActive expiry. Reqeust dropped");
+                         "ICD check-in for device we have been waiting, came after KeepActive expiry. Reqeust dropped for Node ID: 0x%lx", nodeId);
             return;
         }
 
@@ -188,7 +188,9 @@ private:
     }
 
     // Modifications to mPendingCheckIn should be done on the MatterEventLoop thread
-    std::map<chip::NodeId, KeepActiveDataForCheckIn> mPendingCheckIn;
+    // otherwise we would need a mutex protecting this data to prevent race as this
+    // data is accessible by both RPC thread and Matter eventloop.
+    std::unordered_map<chip::NodeId, KeepActiveDataForCheckIn> mPendingCheckIn;
 };
 
 FabricAdmin fabric_admin_service;


### PR DESCRIPTION
Spec states that KeepActive request should be dropped if the ICD device has not checked-in for over an hour. If a FS device wants to be aware the moment ICD wakes up it should kick the KeepActive Command at least once per hour