### PR TITLE
Make the MTRDevice ivars protected.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -108,20 +108,7 @@ MTR_DIRECT_MEMBERS
 
 @interface MTRDevice () {
     // Ivars needed to implement shared MTRDevice functionality.
-    //
-    // Unfortunately, we can't use @protected here, because that exports the
-    // symbols (so that subclasses that are not part of the framework can see
-    // them), but TAPI does not see these declarations, because they are in a
-    // project header.
-    //
-    // Using @package means that the symbols do not need to be exported, but
-    // unfortunately gets treated as @public from inside our framework, which
-    // means random other framework code can access these ivars.  Hopefully the
-    // naming with leading '_' will make it clearer that random other code
-    // should not touch these.
-    //
-    // TODO: Figure out some way of doing @protected but still not exporting the symbol.
-@package
+@protected
     // Lock that protects overall device state, including delegate storage.
     os_unfair_lock _lock;
     NSMutableSet<MTRDeviceDelegateInfo *> * _delegates;

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -2565,6 +2565,7 @@
 					"-Wl,-unexported_symbol,\"___*\"",
 					"-Wl,-unexported_symbol,\"__Unwind_*\"",
 					"-Wl,-unexported_symbol,\"_unw_*\"",
+					"-Wl,-unexported_symbol,\"_OBJC_IVAR_*\"",
 					"-Wl,-hidden-lCHIP",
 				);
 				"OTHER_LDFLAGS[sdk=macosx*]" = (
@@ -2583,6 +2584,7 @@
 					"-Wl,-unexported_symbol,\"___*\"",
 					"-Wl,-unexported_symbol,\"__Unwind_*\"",
 					"-Wl,-unexported_symbol,\"_unw_*\"",
+					"-Wl,-unexported_symbol,\"_OBJC_IVAR_*\"",
 					"-Wl,-hidden-lCHIP",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.csa.matter;


### PR DESCRIPTION
It seems like by default we have the following visibility options here:

`@private` - subclasses can't touch, not workable.
`@public` - anyone can touch, not desirable.
`@package` - `@public` inside Matter.framework, `@private` ouside it. Does not export
           the symbols, but anyone inside Matter.framework can touch.
`@protected` - only subclasses can touch, but exports the symbols in case we have
             out-of-framework subclasses who want to touch it.  Since the
             declarations are in a project header that TAPI does not know about,
             we get complaints about mismatches between what's declared public
             and what's exported.

What we would really want here is "`@protected` inside Matter.framework, `@private` ouside it", but that does not exist.  So this switches to `@protected`, and uses linker arguments to not export the symbols.  Since the header itself is not public, this accomplishes the same goal.

The linker arguments just prevent exporting all ivar symbols, since we shouldn't be exporting any of those anyway.
