### PR TITLE
Update default file header for Matter.framework files.

### DIFF
--- a/src/darwin/Darwin.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/src/darwin/Darwin.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -3,9 +3,8 @@
 <plist version="1.0">
 <dict>
     <key>FILEHEADER</key>
-    <string>
-/**
- *    Copyright (c) 2023 Project CHIP Authors
+    <string>/**
+ *    Copyright (c) 2024 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Removes blank line at the top, makes copyright year be saner.
