### PR TITLE
[Fabric-Sync] Update the FS setup guide to wait for reverse commissioning complete

### DIFF
--- a/docs/guides/fabric_synchronization_guide.md
+++ b/docs/guides/fabric_synchronization_guide.md
@@ -110,6 +110,14 @@ Pair the Ecosystem 2 bridge to Ecosystem 1 with node ID 2:
 fabricsync add-bridge 2 <e2-fabric-bridge-ip>
 ```
 
+This command will initiate the reverse commissioning process. After a few seconds,
+you should see the following message, indicating that the local bridge of Ecosystem
+1 has successfully paired with Ecosystem 2 on Endpoint 2:
+
+```
+>>> A new device is added on Endpoint 2.
+```
+
 ### Pair Light Example to Ecosystem 2
 
 Since Fabric-Bridge also functions as a Matter server, running it alongside the

--- a/docs/guides/fabric_synchronization_guide.md
+++ b/docs/guides/fabric_synchronization_guide.md
@@ -110,9 +110,9 @@ Pair the Ecosystem 2 bridge to Ecosystem 1 with node ID 2:
 fabricsync add-bridge 2 <e2-fabric-bridge-ip>
 ```
 
-This command will initiate the reverse commissioning process. After a few seconds,
-you should see the following message, indicating that the local bridge of Ecosystem
-1 has successfully paired with Ecosystem 2 on Endpoint 2:
+This command will initiate the reverse commissioning process. After a few
+seconds, you should see the following message, indicating that the local bridge
+of Ecosystem 1 has successfully paired with Ecosystem 2 on Endpoint 2:
 
 ```
 >>> A new device is added on Endpoint 2.


### PR DESCRIPTION
Add text to wait until the reverse commissioning process is complete before proceeding to the fabric sync device process.
