### PR TITLE
[Fabric-Sync] Add VID/PID fields to IPC method CommissionNode

### DIFF
--- a/examples/common/pigweed/protos/fabric_admin_service.proto
+++ b/examples/common/pigweed/protos/fabric_admin_service.proto
@@ -19,7 +19,9 @@ message DeviceCommissioningInfo {
   uint32 discriminator = 1;
   uint32 iterations = 2;
   uint32 setup_pin = 3;
-  bytes salt = 4;
+  uint32 vendor_id = 4;
+  uint32 product_id = 5;  
+  bytes salt = 6;
 }
 
 message KeepActiveParameters {

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -156,10 +156,10 @@ public:
 
     void HandleCommandResponse(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader & data);
 
-    void OnDeviceRemoved(chip::NodeId deviceId, CHIP_ERROR err) override;
-
 private:
     friend DeviceManager & DeviceMgr();
+
+    void OnDeviceRemoved(chip::NodeId deviceId, CHIP_ERROR err) override;
 
     void RequestCommissioningApproval();
 

--- a/examples/fabric-bridge-app/linux/CommissionerControl.cpp
+++ b/examples/fabric-bridge-app/linux/CommissionerControl.cpp
@@ -137,7 +137,8 @@ CHIP_ERROR CommissionerControlDelegate::HandleCommissionNode(const Commissioning
                               .SetTimeout(params.commissioningTimeout)
                               .SetDiscriminator(params.discriminator)
                               .SetIteration(params.iterations)
-                              .SetSalt(params.salt));
+                              .SetSalt(params.salt),
+                          mVendorId, mProductId);
 #else
     ChipLogProgress(NotSpecified, "Failed to reverse commission bridge: PW_RPC_FABRIC_BRIDGE_SERVICE not defined");
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/examples/fabric-bridge-app/linux/RpcClient.cpp
+++ b/examples/fabric-bridge-app/linux/RpcClient.cpp
@@ -163,12 +163,14 @@ OpenCommissioningWindow(chip::Controller::CommissioningWindowVerifierParams para
 }
 
 CHIP_ERROR
-CommissionNode(chip::Controller::CommissioningWindowPasscodeParams params)
+CommissionNode(chip::Controller::CommissioningWindowPasscodeParams params, VendorId vendorId, uint16_t productId)
 {
     chip_rpc_DeviceCommissioningInfo device;
     device.setup_pin     = params.GetSetupPIN();
     device.discriminator = params.GetDiscriminator();
     device.iterations    = params.GetIteration();
+    device.vendor_id     = vendorId;
+    device.product_id    = productId;
 
     VerifyOrReturnError(params.GetSalt().size() <= sizeof(device.salt.bytes), CHIP_ERROR_BUFFER_TOO_SMALL);
     memcpy(device.salt.bytes, params.GetSalt().data(), params.GetSalt().size());

--- a/examples/fabric-bridge-app/linux/include/RpcClient.h
+++ b/examples/fabric-bridge-app/linux/include/RpcClient.h
@@ -60,12 +60,20 @@ OpenCommissioningWindow(chip::Controller::CommissioningWindowVerifierParams para
 /**
  * Commission a node using the specified parameters.
  *
- * @param params    Params for commissioning the device using passcode.
+ * This function initiates the commissioning process for a node, utilizing
+ * the provided passcode parameters, vendor ID, and product ID.
+ *
+ * @param params    Parameters required for commissioning the device using passcode.
+ * @param vendorId  The Vendor ID (VID) of the device being commissioned. This identifies
+ *                  the manufacturer of the device.
+ * @param productId The Product ID (PID) of the device being commissioned. This identifies
+ *                  the specific product within the vendor's lineup.
+ *
  * @return CHIP_ERROR An error code indicating the success or failure of the operation.
- * - CHIP_NO_ERROR: The RPC command was successfully sent.
- * - CHIP_ERROR_INTERNAL: An internal error occurred.
+ * - CHIP_NO_ERROR: The RPC command was successfully sent and the commissioning process was initiated.
+ * - CHIP_ERROR_INTERNAL: An internal error occurred during the preparation or sending of the command.
  */
 CHIP_ERROR
-CommissionNode(chip::Controller::CommissioningWindowPasscodeParams params);
+CommissionNode(chip::Controller::CommissioningWindowPasscodeParams params, chip::VendorId vendorId, uint16_t productId);
 
 CHIP_ERROR KeepActive(chip::NodeId nodeId, uint32_t stayActiveDurationMs);


### PR DESCRIPTION
We need to pass VID/PID fields extracted from RequestCommissioningApproval to FabricAdmin as part of CommissionNode IPC.

The receiving FabricAdmin could use these values to validate against the actual VID/PID of the device to be commissioned . 

