### PR TITLE
Truncate map and area names

### DIFF
--- a/src/app/clusters/service-area-server/service-area-cluster-objects.h
+++ b/src/app/clusters/service-area-server/service-area-cluster-objects.h
@@ -109,10 +109,12 @@ struct AreaStructureWrapper : public chip::app::Clusters::ServiceArea::Structs::
                                            const DataModel::Nullable<Globals::AreaTypeTag> & areaType)
     {
         areaDesc.locationInfo.SetNonNull();
-        // Copy the name
-        auto areaNameSpan = MutableCharSpan(mAreaNameBuffer, kAreaNameMaxSize);
-        CopyCharSpanToMutableCharSpan(locationName, areaNameSpan);
-        areaDesc.locationInfo.Value().locationName = CharSpan(areaNameSpan.data(), areaNameSpan.size());
+
+        // Copy the name. If the name is larger than kAreaNameMaxSize, truncate it to fit.
+        auto sizeToCopy = std::min(kAreaNameMaxSize, locationName.size());
+        memcpy(mAreaNameBuffer, locationName.data(), sizeToCopy);
+        areaDesc.locationInfo.Value().locationName = CharSpan(mAreaNameBuffer, sizeToCopy);
+
         areaDesc.locationInfo.Value().floorNumber  = floorNumber;
         areaDesc.locationInfo.Value().areaType     = areaType;
 
@@ -321,9 +323,10 @@ struct MapStructureWrapper : public chip::app::Clusters::ServiceArea::Structs::M
     void Set(uint32_t aMapId, const CharSpan & aMapName)
     {
         mapID            = aMapId;
-        auto mapNameSpan = MutableCharSpan(mMapNameBuffer, kMapNameMaxSize);
-        CopyCharSpanToMutableCharSpan(aMapName, mapNameSpan);
-        name = CharSpan(mapNameSpan.data(), mapNameSpan.size());
+        // Copy the name. If the name is larger than kMapNameMaxSize, truncate it to fit.
+        auto sizeToCopy = std::min(kMapNameMaxSize, aMapName.size());
+        memcpy(mMapNameBuffer, aMapName.data(), sizeToCopy);
+        name = CharSpan(mMapNameBuffer, sizeToCopy);
     }
 
     /**

--- a/src/app/clusters/service-area-server/service-area-cluster-objects.h
+++ b/src/app/clusters/service-area-server/service-area-cluster-objects.h
@@ -115,8 +115,8 @@ struct AreaStructureWrapper : public chip::app::Clusters::ServiceArea::Structs::
         memcpy(mAreaNameBuffer, locationName.data(), sizeToCopy);
         areaDesc.locationInfo.Value().locationName = CharSpan(mAreaNameBuffer, sizeToCopy);
 
-        areaDesc.locationInfo.Value().floorNumber  = floorNumber;
-        areaDesc.locationInfo.Value().areaType     = areaType;
+        areaDesc.locationInfo.Value().floorNumber = floorNumber;
+        areaDesc.locationInfo.Value().areaType    = areaType;
 
         return *this;
     }
@@ -322,7 +322,7 @@ struct MapStructureWrapper : public chip::app::Clusters::ServiceArea::Structs::M
      */
     void Set(uint32_t aMapId, const CharSpan & aMapName)
     {
-        mapID            = aMapId;
+        mapID = aMapId;
         // Copy the name. If the name is larger than kMapNameMaxSize, truncate it to fit.
         auto sizeToCopy = std::min(kMapNameMaxSize, aMapName.size());
         memcpy(mMapNameBuffer, aMapName.data(), sizeToCopy);


### PR DESCRIPTION
Following from [this discussion](https://github.com/project-chip/connectedhomeip/pull/35075#discussion_r1723940286), this PR updates the setting of the area and map names so that if the name given is greater than the buffer size, it's truncated rater to set to empty.
