### PR TITLE
[esp32]: Remove invalid symlinks

### DIFF
--- a/examples/platform/esp32/external_platform/ESP32_custom/WiFiDnssdImpl.cpp
+++ b/examples/platform/esp32/external_platform/ESP32_custom/WiFiDnssdImpl.cpp
@@ -1,1 +1,0 @@
-../../../../../src/platform/ESP32/WiFiDnssdImpl.cpp

--- a/examples/platform/esp32/external_platform/ESP32_custom/WiFiDnssdImpl.h
+++ b/examples/platform/esp32/external_platform/ESP32_custom/WiFiDnssdImpl.h
@@ -1,1 +1,0 @@
-../../../../../src/platform/ESP32/WiFiDnssdImpl.h


### PR DESCRIPTION
**Description :** 
Source files moved/renamed, causing invalid symlinks. 

**Solution:**
Removed the invalid symlinks. 