### PR TITLE
[Scenes] Unit Test Reliance Removal

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_S_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_2.yaml
@@ -50,36 +50,6 @@ tests:
               - name: "SceneTableSize"
                 saveAs: maxScenes
 
-    - label: "Arithmetic operation to get the maxScenes - 1"
-      cluster: "Unit Testing"
-      command: "TestAddArguments"
-      arguments:
-          values:
-              - name: "arg1"
-                value: maxScenes - 1
-              - name: "arg2"
-                value: 0
-      response:
-          values:
-              - name: "returnValue"
-                saveAs: maxScenesMinusOne
-                value: maxScenes - 1
-
-    - label: "Arithmetic operation to get the fabric Capacity"
-      cluster: "Unit Testing"
-      command: "TestAddArguments"
-      arguments:
-          values:
-              - name: "arg1"
-                value: maxScenesMinusOne / 2
-              - name: "arg2"
-                value: 0
-      response:
-          values:
-              - name: "returnValue"
-                saveAs: fabricCapacity
-                value: maxScenesMinusOne / 2
-
     - label:
           "Step 0a :TH reads attribute {ServerList} from the Descriptor cluster
           of the endpoint that implements the Scenes Management server on the
@@ -202,7 +172,8 @@ tests:
               - name: "Status"
                 value: 0x00
               - name: "Capacity"
-                value: fabricCapacity
+                value: (maxScenes - 1) / 2
+                saveAs: fabricCapacity
               - name: "GroupID"
                 value: G1
 

--- a/src/app/tests/suites/certification/Test_TC_S_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_S_2_3.yaml
@@ -50,36 +50,6 @@ tests:
               - name: "SceneTableSize"
                 saveAs: maxScenes
 
-    - label: "Arithmetic operation to get the maxScenes - 1"
-      cluster: "Unit Testing"
-      command: "TestAddArguments"
-      arguments:
-          values:
-              - name: "arg1"
-                value: maxScenes - 1
-              - name: "arg2"
-                value: 0
-      response:
-          values:
-              - name: "returnValue"
-                saveAs: maxScenesMinusOne
-                value: maxScenes - 1
-
-    - label: "Arithmetic operation to get the fabric Capacity"
-      cluster: "Unit Testing"
-      command: "TestAddArguments"
-      arguments:
-          values:
-              - name: "arg1"
-                value: maxScenesMinusOne / 2
-              - name: "arg2"
-                value: 0
-      response:
-          values:
-              - name: "returnValue"
-                saveAs: fabricCapacity
-                value: maxScenesMinusOne / 2
-
     - label:
           "Step 0a: TH sends KeySetWrite command in the GroupKeyManagement
           cluster to DUT using a key that is pre-installed on the TH.
@@ -259,7 +229,8 @@ tests:
               - name: "Status"
                 value: 0x00
               - name: "Capacity"
-                value: fabricCapacity
+                value: (maxScenes - 1) / 2
+                saveAs: fabricCapacity
               - name: "GroupID"
                 value: G1
               - name: "SceneList"


### PR DESCRIPTION
Removed Arithmetics operations relying on Unit test cluster from TC_2_2 and TC_S_2_3

Fixes: https://github.com/project-chip/connectedhomeip/issues/32620

