### PR TITLE
[Darwin] XPC interface for invoke fix

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -43,6 +43,21 @@
 
 @synthesize uniqueIdentifier = _uniqueIdentifier;
 
+- (NSXPCInterface *)_interfaceForServerProtocol
+{
+    NSXPCInterface * interface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCServerProtocol)];
+
+    NSSet * allowedClasses = [NSSet setWithArray:@[
+        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class], [MTRCommandPath class], [MTRAttributePath class]
+    ]];
+
+    [interface setClasses:allowedClasses
+              forSelector:@selector(deviceController:nodeID:invokeCommandWithEndpointID:clusterID:commandID:commandFields:expectedValues:expectedValueInterval:timedInvokeTimeout:completion:)
+            argumentIndex:0
+                  ofReply:YES];
+    return interface;
+}
+
 - (NSXPCInterface *)_interfaceForClientProtocol
 {
     NSXPCInterface * interface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCClientProtocol)];
@@ -84,7 +99,7 @@
 
         MTR_LOG("Set up XPC Connection: %@", self.xpcConnection);
         if (self.xpcConnection) {
-            self.xpcConnection.remoteObjectInterface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCServerProtocol)];
+            self.xpcConnection.remoteObjectInterface = [self _interfaceForServerProtocol];
 
             self.xpcConnection.exportedInterface = [self _interfaceForClientProtocol];
             self.xpcConnection.exportedObject = self;
@@ -118,9 +133,9 @@
 
         MTR_LOG("Set up XPC Connection: %@", self.xpcConnection);
         if (self.xpcConnection) {
-            self.xpcConnection.remoteObjectInterface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCServerProtocol)];
+            self.xpcConnection.remoteObjectInterface = [self _interfaceForServerProtocol];
 
-            self.xpcConnection.exportedInterface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCClientProtocol)];
+            self.xpcConnection.exportedInterface = [self _interfaceForClientProtocol];
             self.xpcConnection.exportedObject = self;
 
             MTR_LOG("%s: resuming new XPC connection");


### PR DESCRIPTION
The MTRDeviceController_XPC interface for invoke in the server protocol needs to take into account the reply may contain non-property-list objects.