### PR TITLE
[Fabric-Admin] Fix fabric-bridge is accidentally added into sync list as a BridgedDevice

### DIFF
--- a/examples/fabric-admin/commands/pairing/DeviceSynchronization.cpp
+++ b/examples/fabric-admin/commands/pairing/DeviceSynchronization.cpp
@@ -24,6 +24,7 @@
 
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
+#include <device_manager/DeviceManager.h>
 
 using namespace ::chip;
 using namespace ::chip::app;
@@ -120,7 +121,10 @@ void DeviceSynchronizer::OnReportEnd()
 {
     // Report end is at the end of all attributes (success)
 #if defined(PW_RPC_ENABLED)
-    AddSynchronizedDevice(mCurrentDeviceData);
+    if (!DeviceMgr().IsCurrentBridgeDevice(mCurrentDeviceData.node_id))
+    {
+        AddSynchronizedDevice(mCurrentDeviceData);
+    }
 #else
     ChipLogError(NotSpecified, "Cannot synchronize device with fabric bridge: RPC not enabled");
 #endif

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -76,6 +76,15 @@ public:
     void RemoveSyncedDevice(chip::NodeId nodeId);
 
     /**
+     * @brief Determines whether a given nodeId corresponds to the "current bridge device," either local or remote.
+     *
+     * @param nodeId            The ID of the node being checked.
+     *
+     * @return true if the nodeId matches either the local or remote bridge device; otherwise, false.
+     */
+    bool IsCurrentBridgeDevice(chip::NodeId nodeId) const { return nodeId == mLocalBridgeNodeId || nodeId == mRemoteBridgeNodeId; }
+
+    /**
      * @brief Open the commissioning window for a specific device within its own fabric.
      *
      * This function initiates the process to open the commissioning window for a device identified by the given node ID.


### PR DESCRIPTION
This seems a regression, when add a local bridge or remote bridge, the bridge device itself is added as the BridgedDevice at the local bridge.

```
fabricsync add-local-bridge 1
or
fabricsync add-bridge 2 192.168.86.246

[1724259734.783] [197094:197100] [-] AddSynchronizedDevice
[1724259734.824] [197094:197102] [-] AddSynchronizedDevice RPC call succeeded!
```


