### PR TITLE
Fix Darwin to handle renames of Color Control data types.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBackwardsCompatShims.h
+++ b/src/darwin/Framework/CHIP/MTRBackwardsCompatShims.h
@@ -159,4 +159,33 @@ typedef NS_ENUM(uint8_t, MTROTASoftwareUpdateRequestorOTAUpdateState) {
     = 0x08,
 } MTR_DEPRECATED("Please use MTROTASoftwareUpdateRequestorUpdateState", ios(16.4, 17.2), macos(13.3, 14.2), watchos(9.4, 10.2), tvos(16.4, 17.2));
 
+/**
+ * ColorControl used to have HueMoveMode/SaturationMoveMode and HueStepMode/SaturationStepMode that had
+ * identical values.  Those got replaced with MoveModeEnum and StepModeEnum respectively.  We codegen
+ * HueMoveMode and HueStepMode as aliases of MoveModeEnum and StepModeEnum, but we need manual shims for
+ * SaturationMoveMode and SaturationStepMode.
+ */
+typedef NS_ENUM(uint8_t, MTRColorControlSaturationMoveMode) {
+    MTRColorControlSaturationMoveModeStop MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlMoveModeStop")
+    = 0x00,
+    MTRColorControlSaturationMoveModeUp MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlMoveModeUp")
+    = 0x01,
+    MTRColorControlSaturationMoveModeDown MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlMoveModeDown")
+    = 0x03,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+    MTR_NEWLY_DEPRECATED("Please use MTRColorControlMoveMode");
+
+typedef NS_ENUM(uint8_t, MTRColorControlSaturationStepMode) {
+    MTRColorControlSaturationStepModeUp MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlStepModeUp")
+    = 0x01,
+    MTRColorControlSaturationStepModeDown MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlStepModeDown")
+    = 0x03,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+    MTR_NEWLY_DEPRECATED("Please use MTRColorControlStepMode");
+
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/availability.yaml
+++ b/src/darwin/Framework/CHIP/templates/availability.yaml
@@ -3237,9 +3237,15 @@
               - FanModeSequenceType
               - FanModeType
           ColorControl:
-              - ColorLoopAction
-              - ColorLoopDirection
-              - ColorMode
+              # ColorLoopActionEnum, ColorLoopDirectionEnum and ColorModeEnum
+              # were originally named ColorLoopAction, ColorLoopDirection, and
+              # ColorMode, but we generate the same API for the names
+              # with/without "Enum" at the end and the cluster name
+              # present/absent at the beginning, so the names can just change
+              # here.
+              - ColorLoopActionEnum
+              - ColorLoopDirectionEnum
+              - ColorModeEnum
               - HueDirection
               - HueMoveMode
               - HueStepMode
@@ -3980,14 +3986,20 @@
                   - Auto
                   - Smart
           ColorControl:
-              ColorLoopAction:
+              # ColorLoopActionEnum, ColorLoopDirectionEnum and ColorModeEnum
+              # were originally named ColorLoopAction, ColorLoopDirection, and
+              # ColorMode, but we generate the same API for the names
+              # with/without "Enum" at the end and the cluster name
+              # present/absent at the beginning, so the names can just change
+              # here.
+              ColorLoopActionEnum:
                   - Deactivate
                   - ActivateFromColorLoopStartEnhancedHue
                   - ActivateFromEnhancedCurrentHue
-              ColorLoopDirection:
+              ColorLoopDirectionEnum:
                   - DecrementHue
                   - IncrementHue
-              ColorMode:
+              ColorModeEnum:
                   - CurrentHueAndCurrentSaturation
                   - CurrentXAndCurrentY
                   - ColorTemperature
@@ -9682,6 +9694,64 @@
 
 - release: "Future"
   versions: "future"
+  introduced:
+      enums:
+          ColorControl:
+              - DirectionEnum
+              - DriftCompensationEnum
+              - EnhancedColorModeEnum
+              - MoveModeEnum
+              - StepModeEnum
+      enum values:
+          ColorControl:
+              ColorLoopDirectionEnum:
+                  - Decrement
+                  - Increment
+              ColorModeEnum:
+                  - ColorTemperatureMireds
+              DirectionEnum:
+                  - Shortest
+                  - Longest
+                  - Up
+                  - Down
+              DriftCompensationEnum:
+                  - None
+                  - OtherOrUnknown
+                  - TemperatureMonitoring
+                  - OpticalLuminanceMonitoringAndFeedback
+                  - OpticalColorMonitoringAndFeedback
+              EnhancedColorModeEnum:
+                  - CurrentHueAndCurrentSaturation
+                  - CurrentXAndCurrentY
+                  - ColorTemperatureMireds
+                  - EnhancedCurrentHueAndCurrentSaturation
+              MoveModeEnum:
+                  - Stop
+                  - Up
+                  - Down
+              StepModeEnum:
+                  - Up
+                  - Down
+      bitmaps:
+          ColorControl:
+              - ColorCapabilitiesBitmap
+              - OptionsBitmap
+              - UpdateFlagsBitmap
+      bitmap values:
+          ColorControl:
+              ColorCapabilitiesBitmap:
+                  - HueSaturation
+                  - EnhancedHue
+                  - ColorLoop
+                  - XY
+                  - ColorTemperature
+              OptionsBitmap:
+                  - ExecuteIfOff
+              UpdateFlagsBitmap:
+                  - UpdateAction
+                  - UpdateDirection
+                  - UpdateTime
+                  - UpdateStartHue
   provisional:
       clusters:
           # Targeting 1.4
@@ -9820,3 +9890,64 @@
               Feature:
                   # Targeting 1.4
                   - ActionSwitch
+  renames:
+      enums:
+          ColorControl:
+              DirectionEnum: HueDirection
+              MoveModeEnum: HueMoveMode
+              StepModeEnum: HueStepMode
+      enum values:
+          ColorControl:
+              ColorLoopDirectionEnum:
+                  Decrement: DecrementHue
+                  Increment: IncrementHue
+              ColorModeEnum:
+                  ColorTemperatureMireds: ColorTemperature
+              HueDirection:
+                  Shortest: ShortestDistance
+                  Longest: LongestDistance
+      bitmaps:
+          ColorControl:
+              ColorCapabilitiesBitmap: ColorCapabilities
+              UpdateFlagsBitmap: ColorLoopUpdateFlags
+      bitmap values:
+          ColorControl:
+              ColorCapabilities:
+                  HueSaturation: HueSaturationSupported
+                  EnhancedHue: EnhancedHueSupported
+                  ColorLoop: ColorLoopSupported
+                  XY: XYAttributesSupported
+                  ColorTemperature: ColorTemperatureSupported
+  deprecated:
+      enums:
+          ColorControl:
+              - HueDirection
+              - HueMoveMode
+              - HueStepMode
+      enum values:
+          ColorControl:
+              ColorLoopDirectionEnum:
+                  - DecrementHue
+                  - IncrementHue
+              ColorModeEnum:
+                  - ColorTemperature
+      bitmaps:
+          ColorControl:
+              - ColorCapabilities
+              - ColorLoopUpdateFlags
+  removed:
+      enum values:
+          ColorControl:
+              # Don't expose the new value names on the old enum names
+              HueDirection:
+                  - Shortest
+                  - Longest
+      bitmap values:
+          ColorControl:
+              # Don't expose the new field names on the old bitmap names
+              ColorCapabilities:
+                  - HueSaturation
+                  - EnhancedHue
+                  - ColorLoop
+                  - XY
+                  - ColorTemperature

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -20203,62 +20203,129 @@ typedef NS_ENUM(uint8_t, MTRThermostatUserInterfaceConfigurationTemperatureDispl
 } MTR_AVAILABLE(ios(17.4), macos(14.4), watchos(10.4), tvos(17.4));
 
 typedef NS_ENUM(uint8_t, MTRColorControlColorLoopAction) {
-    MTRColorControlColorLoopActionDeactivate MTR_PROVISIONALLY_AVAILABLE = 0x00,
-    MTRColorControlColorLoopActionActivateFromColorLoopStartEnhancedHue MTR_PROVISIONALLY_AVAILABLE = 0x01,
-    MTRColorControlColorLoopActionActivateFromEnhancedCurrentHue MTR_PROVISIONALLY_AVAILABLE = 0x02,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRColorControlColorLoopActionDeactivate MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x00,
+    MTRColorControlColorLoopActionActivateFromColorLoopStartEnhancedHue MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x01,
+    MTRColorControlColorLoopActionActivateFromEnhancedCurrentHue MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x02,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_ENUM(uint8_t, MTRColorControlColorLoopDirection) {
-    MTRColorControlColorLoopDirectionDecrement MTR_PROVISIONALLY_AVAILABLE = 0x00,
-    MTRColorControlColorLoopDirectionIncrement MTR_PROVISIONALLY_AVAILABLE = 0x01,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRColorControlColorLoopDirectionDecrement MTR_NEWLY_AVAILABLE = 0x00,
+    MTRColorControlColorLoopDirectionDecrementHue MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlColorLoopDirectionDecrement")
+    = 0x00,
+    MTRColorControlColorLoopDirectionIncrement MTR_NEWLY_AVAILABLE = 0x01,
+    MTRColorControlColorLoopDirectionIncrementHue MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlColorLoopDirectionIncrement")
+    = 0x01,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_ENUM(uint8_t, MTRColorControlColorMode) {
-    MTRColorControlColorModeCurrentHueAndCurrentSaturation MTR_PROVISIONALLY_AVAILABLE = 0x00,
-    MTRColorControlColorModeCurrentXAndCurrentY MTR_PROVISIONALLY_AVAILABLE = 0x01,
-    MTRColorControlColorModeColorTemperatureMireds MTR_PROVISIONALLY_AVAILABLE = 0x02,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRColorControlColorModeCurrentHueAndCurrentSaturation MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x00,
+    MTRColorControlColorModeCurrentXAndCurrentY MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x01,
+    MTRColorControlColorModeColorTemperatureMireds MTR_NEWLY_AVAILABLE = 0x02,
+    MTRColorControlColorModeColorTemperature MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlColorModeColorTemperatureMireds")
+    = 0x02,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_ENUM(uint8_t, MTRColorControlDirection) {
-    MTRColorControlDirectionShortest MTR_PROVISIONALLY_AVAILABLE = 0x00,
-    MTRColorControlDirectionLongest MTR_PROVISIONALLY_AVAILABLE = 0x01,
-    MTRColorControlDirectionUp MTR_PROVISIONALLY_AVAILABLE = 0x02,
-    MTRColorControlDirectionDown MTR_PROVISIONALLY_AVAILABLE = 0x03,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRColorControlDirectionShortest MTR_NEWLY_AVAILABLE = 0x00,
+    MTRColorControlDirectionLongest MTR_NEWLY_AVAILABLE = 0x01,
+    MTRColorControlDirectionUp MTR_NEWLY_AVAILABLE = 0x02,
+    MTRColorControlDirectionDown MTR_NEWLY_AVAILABLE = 0x03,
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_ENUM(uint8_t, MTRColorControlHueDirection) {
+    MTRColorControlHueDirectionShortestDistance MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlDirectionShortest")
+    = 0x00,
+    MTRColorControlHueDirectionLongestDistance MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlDirectionLongest")
+    = 0x01,
+    MTRColorControlHueDirectionUp MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlDirectionUp")
+    = 0x02,
+    MTRColorControlHueDirectionDown MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlDirectionDown")
+    = 0x03,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+    MTR_NEWLY_DEPRECATED("Please use MTRColorControlDirection");
 
 typedef NS_ENUM(uint8_t, MTRColorControlDriftCompensation) {
-    MTRColorControlDriftCompensationNone MTR_PROVISIONALLY_AVAILABLE = 0x00,
-    MTRColorControlDriftCompensationOtherOrUnknown MTR_PROVISIONALLY_AVAILABLE = 0x01,
-    MTRColorControlDriftCompensationTemperatureMonitoring MTR_PROVISIONALLY_AVAILABLE = 0x02,
-    MTRColorControlDriftCompensationOpticalLuminanceMonitoringAndFeedback MTR_PROVISIONALLY_AVAILABLE = 0x03,
-    MTRColorControlDriftCompensationOpticalColorMonitoringAndFeedback MTR_PROVISIONALLY_AVAILABLE = 0x04,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRColorControlDriftCompensationNone MTR_NEWLY_AVAILABLE = 0x00,
+    MTRColorControlDriftCompensationOtherOrUnknown MTR_NEWLY_AVAILABLE = 0x01,
+    MTRColorControlDriftCompensationTemperatureMonitoring MTR_NEWLY_AVAILABLE = 0x02,
+    MTRColorControlDriftCompensationOpticalLuminanceMonitoringAndFeedback MTR_NEWLY_AVAILABLE = 0x03,
+    MTRColorControlDriftCompensationOpticalColorMonitoringAndFeedback MTR_NEWLY_AVAILABLE = 0x04,
+} MTR_NEWLY_AVAILABLE;
 
 typedef NS_ENUM(uint8_t, MTRColorControlEnhancedColorMode) {
-    MTRColorControlEnhancedColorModeCurrentHueAndCurrentSaturation MTR_PROVISIONALLY_AVAILABLE = 0x00,
-    MTRColorControlEnhancedColorModeCurrentXAndCurrentY MTR_PROVISIONALLY_AVAILABLE = 0x01,
-    MTRColorControlEnhancedColorModeColorTemperatureMireds MTR_PROVISIONALLY_AVAILABLE = 0x02,
-    MTRColorControlEnhancedColorModeEnhancedCurrentHueAndCurrentSaturation MTR_PROVISIONALLY_AVAILABLE = 0x03,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRColorControlEnhancedColorModeCurrentHueAndCurrentSaturation MTR_NEWLY_AVAILABLE = 0x00,
+    MTRColorControlEnhancedColorModeCurrentXAndCurrentY MTR_NEWLY_AVAILABLE = 0x01,
+    MTRColorControlEnhancedColorModeColorTemperatureMireds MTR_NEWLY_AVAILABLE = 0x02,
+    MTRColorControlEnhancedColorModeEnhancedCurrentHueAndCurrentSaturation MTR_NEWLY_AVAILABLE = 0x03,
+} MTR_NEWLY_AVAILABLE;
 
 typedef NS_ENUM(uint8_t, MTRColorControlMoveMode) {
-    MTRColorControlMoveModeStop MTR_PROVISIONALLY_AVAILABLE = 0x00,
-    MTRColorControlMoveModeUp MTR_PROVISIONALLY_AVAILABLE = 0x01,
-    MTRColorControlMoveModeDown MTR_PROVISIONALLY_AVAILABLE = 0x03,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRColorControlMoveModeStop MTR_NEWLY_AVAILABLE = 0x00,
+    MTRColorControlMoveModeUp MTR_NEWLY_AVAILABLE = 0x01,
+    MTRColorControlMoveModeDown MTR_NEWLY_AVAILABLE = 0x03,
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_ENUM(uint8_t, MTRColorControlHueMoveMode) {
+    MTRColorControlHueMoveModeStop MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlMoveModeStop")
+    = 0x00,
+    MTRColorControlHueMoveModeUp MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlMoveModeUp")
+    = 0x01,
+    MTRColorControlHueMoveModeDown MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlMoveModeDown")
+    = 0x03,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+    MTR_NEWLY_DEPRECATED("Please use MTRColorControlMoveMode");
 
 typedef NS_ENUM(uint8_t, MTRColorControlStepMode) {
-    MTRColorControlStepModeUp MTR_PROVISIONALLY_AVAILABLE = 0x01,
-    MTRColorControlStepModeDown MTR_PROVISIONALLY_AVAILABLE = 0x03,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRColorControlStepModeUp MTR_NEWLY_AVAILABLE = 0x01,
+    MTRColorControlStepModeDown MTR_NEWLY_AVAILABLE = 0x03,
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_ENUM(uint8_t, MTRColorControlHueStepMode) {
+    MTRColorControlHueStepModeUp MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlStepModeUp")
+    = 0x01,
+    MTRColorControlHueStepModeDown MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlStepModeDown")
+    = 0x03,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+    MTR_NEWLY_DEPRECATED("Please use MTRColorControlStepMode");
 
 typedef NS_OPTIONS(uint16_t, MTRColorControlColorCapabilitiesBitmap) {
-    MTRColorControlColorCapabilitiesBitmapHueSaturation MTR_PROVISIONALLY_AVAILABLE = 0x1,
-    MTRColorControlColorCapabilitiesBitmapEnhancedHue MTR_PROVISIONALLY_AVAILABLE = 0x2,
-    MTRColorControlColorCapabilitiesBitmapColorLoop MTR_PROVISIONALLY_AVAILABLE = 0x4,
-    MTRColorControlColorCapabilitiesBitmapXY MTR_PROVISIONALLY_AVAILABLE = 0x8,
-    MTRColorControlColorCapabilitiesBitmapColorTemperature MTR_PROVISIONALLY_AVAILABLE = 0x10,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRColorControlColorCapabilitiesBitmapHueSaturation MTR_NEWLY_AVAILABLE = 0x1,
+    MTRColorControlColorCapabilitiesBitmapEnhancedHue MTR_NEWLY_AVAILABLE = 0x2,
+    MTRColorControlColorCapabilitiesBitmapColorLoop MTR_NEWLY_AVAILABLE = 0x4,
+    MTRColorControlColorCapabilitiesBitmapXY MTR_NEWLY_AVAILABLE = 0x8,
+    MTRColorControlColorCapabilitiesBitmapColorTemperature MTR_NEWLY_AVAILABLE = 0x10,
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_OPTIONS(uint16_t, MTRColorControlColorCapabilities) {
+    MTRColorControlColorCapabilitiesHueSaturationSupported MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlColorCapabilitiesBitmapHueSaturation")
+    = 0x1,
+    MTRColorControlColorCapabilitiesEnhancedHueSupported MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlColorCapabilitiesBitmapEnhancedHue")
+    = 0x2,
+    MTRColorControlColorCapabilitiesColorLoopSupported MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlColorCapabilitiesBitmapColorLoop")
+    = 0x4,
+    MTRColorControlColorCapabilitiesXYAttributesSupported MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlColorCapabilitiesBitmapXY")
+    = 0x8,
+    MTRColorControlColorCapabilitiesColorTemperatureSupported MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlColorCapabilitiesBitmapColorTemperature")
+    = 0x10,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+    MTR_NEWLY_DEPRECATED("Please use MTRColorControlColorCapabilitiesBitmap");
 
 typedef NS_OPTIONS(uint32_t, MTRColorControlFeature) {
     MTRColorControlFeatureHueAndSaturation MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1)) = 0x1,
@@ -20269,15 +20336,31 @@ typedef NS_OPTIONS(uint32_t, MTRColorControlFeature) {
 } MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 typedef NS_OPTIONS(uint8_t, MTRColorControlOptionsBitmap) {
-    MTRColorControlOptionsBitmapExecuteIfOff MTR_PROVISIONALLY_AVAILABLE = 0x1,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRColorControlOptionsBitmapExecuteIfOff MTR_NEWLY_AVAILABLE = 0x1,
+} MTR_NEWLY_AVAILABLE;
 
 typedef NS_OPTIONS(uint8_t, MTRColorControlUpdateFlagsBitmap) {
-    MTRColorControlUpdateFlagsBitmapUpdateAction MTR_PROVISIONALLY_AVAILABLE = 0x1,
-    MTRColorControlUpdateFlagsBitmapUpdateDirection MTR_PROVISIONALLY_AVAILABLE = 0x2,
-    MTRColorControlUpdateFlagsBitmapUpdateTime MTR_PROVISIONALLY_AVAILABLE = 0x4,
-    MTRColorControlUpdateFlagsBitmapUpdateStartHue MTR_PROVISIONALLY_AVAILABLE = 0x8,
-} MTR_PROVISIONALLY_AVAILABLE;
+    MTRColorControlUpdateFlagsBitmapUpdateAction MTR_NEWLY_AVAILABLE = 0x1,
+    MTRColorControlUpdateFlagsBitmapUpdateDirection MTR_NEWLY_AVAILABLE = 0x2,
+    MTRColorControlUpdateFlagsBitmapUpdateTime MTR_NEWLY_AVAILABLE = 0x4,
+    MTRColorControlUpdateFlagsBitmapUpdateStartHue MTR_NEWLY_AVAILABLE = 0x8,
+} MTR_NEWLY_AVAILABLE;
+
+typedef NS_OPTIONS(uint8_t, MTRColorControlColorLoopUpdateFlags) {
+    MTRColorControlColorLoopUpdateFlagsUpdateAction MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlUpdateFlagsBitmapUpdateAction")
+    = 0x1,
+    MTRColorControlColorLoopUpdateFlagsUpdateDirection MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlUpdateFlagsBitmapUpdateDirection")
+    = 0x2,
+    MTRColorControlColorLoopUpdateFlagsUpdateTime MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlUpdateFlagsBitmapUpdateTime")
+    = 0x4,
+    MTRColorControlColorLoopUpdateFlagsUpdateStartHue MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+        MTR_NEWLY_DEPRECATED("Please use MTRColorControlUpdateFlagsBitmapUpdateStartHue")
+    = 0x8,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
+    MTR_NEWLY_DEPRECATED("Please use MTRColorControlUpdateFlagsBitmap");
 
 typedef NS_OPTIONS(uint8_t, MTRBallastConfigurationBallastStatusBitmap) {
     MTRBallastConfigurationBallastStatusBitmapBallastNonOperational MTR_PROVISIONALLY_AVAILABLE = 0x1,


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/33612 made the following changes to the Color Control cluster:

1) Renamed HueDirection to DirectionEnum
2) Renamed the ShortestDistance and LongestDistance values of DirectionEnum to
   Shortest and Longest, respectively.
3) Renamed HueMoveMode to MoveModeEnum.
4) Renamed HueStepMode to StepModeEnum.
5) Removed SaturationMoveMode in favor of MoveModeEnum. 6) Removed SaturationStepMode in favor of StepModeEnum. 7) Renamed ColorMode to ColorModeEnum.
8) Renamed the ColorTemperature value to ColorTemperatureMireds 8) Renamed ColorCapabilities to ColorCapabilitiesBitmap. 9) Renamed various fields of ColorCapabilitiesBitmap. 10) Renamed ColorLoopUpdateFlags to UpdateFlagsBitmap. 11) Renamed ColorLoopAction to ColorLoopActionEnum. 12) Added OptionsBitmap, EnhancedColorModeEnum, DriftCompensationEnum. 13) Renamed ColorLoopDirection to ColorLoopDirectionEnum. 14) Renamed the DecrementHue and IncrementHue values of ColorLoopDirectionEnum
    to Decrement and Increment, respectively.

This change adds the right renamed/introduced/deprecated annotations for the above changes, and adds manual shims for the enums that got removed.
