### PR TITLE
use CHIP_DEVICE_CONFIG_FAILSAFE_EXPIRY_LENGTH_SEC define to arm the …

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -221,7 +221,8 @@ void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & sess
     }
     else
     {
-        err = failSafeContext.ArmFailSafe(kUndefinedFabricIndex, System::Clock::Seconds16(60));
+        err = failSafeContext.ArmFailSafe(kUndefinedFabricIndex,
+                                          System::Clock::Seconds16(CHIP_DEVICE_CONFIG_FAILSAFE_EXPIRY_LENGTH_SEC));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(AppServer, "Error arming failsafe on PASE session establishment completion");


### PR DESCRIPTION
…failsafe of the commissioning window session rather than a constant value.

`CHIP_DEVICE_CONFIG_FAILSAFE_EXPIRY_LENGTH_SEC` can be configured by users in their `ChipProjectConfig.h `for example



