### PR TITLE
dac_revocation: Perform cross validation against crl signer or crl signer delegator

### DIFF
--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
@@ -117,7 +117,7 @@ bool TestDACRevocationDelegateImpl::CrossValidateCert(const Json::Value & revoke
                                                       const std::string & issuerNameBase64Str)
 {
     std::string certPEM;
-    [[maybe_unused]] const char * certType;
+    [[maybe_unused]] std::string certType;
 
     if (revokedSet.isMember("crl_signer_delegator"))
     {
@@ -134,8 +134,8 @@ bool TestDACRevocationDelegateImpl::CrossValidateCert(const Json::Value & revoke
     std::string keyId;   // crl signer or crl signer delegator SKID
     VerifyOrReturnValue(CHIP_NO_ERROR == GetSubjectAndKeyIdFromPEMCert(certPEM, subject, keyId), false);
 
-    ChipLogDetail(NotSpecified, "%s: Subject: %s", certType, subject.c_str());
-    ChipLogDetail(NotSpecified, "%s: SKID: %s", certType, keyId.c_str());
+    ChipLogDetail(NotSpecified, "%s: Subject: %s", certType.c_str(), subject.c_str());
+    ChipLogDetail(NotSpecified, "%s: SKID: %s", certType.c_str(), keyId.c_str());
 
     return (akidHexStr == keyId && issuerNameBase64Str == subject);
 }
@@ -315,8 +315,8 @@ void TestDACRevocationDelegateImpl::CheckForRevokedDACChain(
 
     if (mDeviceAttestationRevocationSetPath.empty())
     {
-
         onCompletion->mCall(onCompletion->mContext, info, attestationError);
+        return;
     }
 
     ChipLogDetail(NotSpecified, "Checking for revoked DAC in %s", mDeviceAttestationRevocationSetPath.c_str());

--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
@@ -289,7 +289,7 @@ CHIP_ERROR TestDACRevocationDelegateImpl::GetSubjectNameBase64Str(const ByteSpan
     return GetRDNBase64Str(certDer, outSubjectNameBase64String, false /* isIssuer */);
 }
 
-// @param certDer Certificate to check for revocation in DER format
+// @param certDer Certificate, in DER format, to check for revocation
 bool TestDACRevocationDelegateImpl::IsCertificateRevoked(const ByteSpan & certDer)
 {
     char issuerNameBuffer[kMaxIssuerBase64Len]                           = { 0 };

--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
@@ -21,6 +21,7 @@
 #include <lib/support/BytesToHex.h>
 #include <lib/support/logging/CHIPLogging.h>
 
+#include <algorithm>
 #include <fstream>
 #include <json/json.h>
 
@@ -29,9 +30,10 @@ using namespace chip::Crypto;
 namespace chip {
 namespace Credentials {
 
+namespace {
+
 static constexpr uint32_t kMaxIssuerBase64Len = BASE64_ENCODED_LEN(kMaxCertificateDistinguishedNameLength);
 
-namespace {
 CHIP_ERROR BytesToHexStr(const ByteSpan & bytes, MutableCharSpan & outHexStr)
 {
     Encoding::HexFlags flags = Encoding::HexFlags::kUppercase;
@@ -287,8 +289,6 @@ CHIP_ERROR TestDACRevocationDelegateImpl::GetSubjectNameBase64Str(const ByteSpan
 // @param isPAI true if the certificate being tested is a PAI, false otherwise
 bool TestDACRevocationDelegateImpl::IsCertificateRevoked(const ByteSpan & certDer, bool isPAI)
 {
-    static constexpr uint32_t kMaxIssuerBase64Len = BASE64_ENCODED_LEN(kMaxCertificateDistinguishedNameLength);
-
     char issuerNameBuffer[kMaxIssuerBase64Len]                           = { 0 };
     char serialNumberHexStrBuffer[2 * kMaxCertificateSerialNumberLength] = { 0 };
     char akidHexStrBuffer[2 * kAuthorityKeyIdentifierLength]             = { 0 };

--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
@@ -108,7 +108,7 @@ bool TestDACRevocationDelegateImpl::CrossValidateCert(const Json::Value & revoke
                                                       const CharSpan & issuerNameBase64Str)
 {
     std::string certPEM;
-    const char * certType;
+    const char * certType __attribute__((unused));
 
     if (revokedSet.isMember("crl_signer_delegator"))
     {

--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
@@ -57,6 +57,10 @@ CHIP_ERROR X509_PemToDer(const std::string & pemCert, MutableByteSpan & derCert)
     plainB64Str.erase(std::remove(plainB64Str.begin(), plainB64Str.end(), '\n'), plainB64Str.end());
     plainB64Str.erase(std::remove(plainB64Str.begin(), plainB64Str.end(), '\r'), plainB64Str.end());
 
+    // Verify we have enough room to store the decoded certificate
+    size_t maxDecodeLen = BASE64_MAX_DECODED_LEN(plainB64Str.size());
+    VerifyOrReturnError(derCert.size() >= maxDecodeLen, CHIP_ERROR_BUFFER_TOO_SMALL);
+
     // decode b64
     uint16_t derLen = Base64Decode(plainB64Str.c_str(), static_cast<uint16_t>(plainB64Str.size()), derCert.data());
     VerifyOrReturnError(derLen != UINT16_MAX, CHIP_ERROR_INVALID_ARGUMENT);
@@ -108,7 +112,7 @@ bool TestDACRevocationDelegateImpl::CrossValidateCert(const Json::Value & revoke
                                                       const CharSpan & issuerNameBase64Str)
 {
     std::string certPEM;
-    const char * certType __attribute__((unused));
+    [[maybe_unused]] const char * certType;
 
     if (revokedSet.isMember("crl_signer_delegator"))
     {

--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
@@ -48,7 +48,10 @@ CHIP_ERROR X509_PemToDer(const std::string & pemCert, MutableByteSpan & derCert)
     std::string endMarker   = "-----END CERTIFICATE-----";
 
     std::size_t beginPos = pemCert.find(beginMarker);
-    std::size_t endPos   = pemCert.find(endMarker);
+    VerifyOrReturnError(beginPos != std::string::npos, CHIP_ERROR_INVALID_ARGUMENT);
+
+    std::size_t endPos = pemCert.find(endMarker);
+    VerifyOrReturnError(endPos != std::string::npos, CHIP_ERROR_INVALID_ARGUMENT);
 
     // Extract content between markers
     std::string plainB64Str = pemCert.substr(beginPos + beginMarker.length(), endPos - (beginPos + beginMarker.length()));
@@ -56,6 +59,8 @@ CHIP_ERROR X509_PemToDer(const std::string & pemCert, MutableByteSpan & derCert)
     // Remove all newline characters '\n' and '\r'
     plainB64Str.erase(std::remove(plainB64Str.begin(), plainB64Str.end(), '\n'), plainB64Str.end());
     plainB64Str.erase(std::remove(plainB64Str.begin(), plainB64Str.end(), '\r'), plainB64Str.end());
+
+    VerifyOrReturnError(!plainB64Str.empty(), CHIP_ERROR_INVALID_ARGUMENT);
 
     // Verify we have enough room to store the decoded certificate
     size_t maxDecodeLen = BASE64_MAX_DECODED_LEN(plainB64Str.size());

--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.h
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <json/json.h>
 #include <lib/support/Span.h>
 
 #include <string>
@@ -52,12 +53,24 @@ public:
     void ClearDeviceAttestationRevocationSetPath();
 
 private:
+    bool CrossValidateCert(const Json::Value & revokedSet, const CharSpan & akIdHexStr, const CharSpan & issuerNameBase64Str);
+
+    CHIP_ERROR GetKeyIDHexStr(const ByteSpan & certDer, MutableCharSpan & outKeyIDHexStr, bool isAKID);
     CHIP_ERROR GetAKIDHexStr(const ByteSpan & certDer, MutableCharSpan & outAKIDHexStr);
+    CHIP_ERROR GetSKIDHexStr(const ByteSpan & certDer, MutableCharSpan & outSKIDHexStr);
+
     CHIP_ERROR GetSerialNumberHexStr(const ByteSpan & certDer, MutableCharSpan & outSerialNumberHexStr);
+
+    CHIP_ERROR GetRDNBase64Str(const ByteSpan & certDer, MutableCharSpan & outRDNBase64String, bool isIssuer);
     CHIP_ERROR GetIssuerNameBase64Str(const ByteSpan & certDer, MutableCharSpan & outIssuerNameBase64String);
+    CHIP_ERROR GetSubjectNameBase64Str(const ByteSpan & certDer, MutableCharSpan & outSubjectNameBase64String);
+
+    CHIP_ERROR GetSubjectAndKeyIdFromPEMCert(const std::string & certPEM, std::string & outSubject, std::string & outKeyId);
+
     bool IsEntryInRevocationSet(const CharSpan & akidHexStr, const CharSpan & issuerNameBase64Str,
-                                const CharSpan & serialNumberHexStr);
-    bool IsCertificateRevoked(const ByteSpan & certDer);
+                                const CharSpan & serialNumberHexStr, bool isPAI);
+
+    bool IsCertificateRevoked(const ByteSpan & certDer, bool isPAI);
 
     std::string mDeviceAttestationRevocationSetPath;
 };

--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.h
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.h
@@ -53,7 +53,7 @@ public:
     void ClearDeviceAttestationRevocationSetPath();
 
 private:
-    bool CrossValidateCert(const Json::Value & revokedSet, const CharSpan & akIdHexStr, const CharSpan & issuerNameBase64Str);
+    bool CrossValidateCert(const Json::Value & revokedSet, const std::string & akIdHexStr, const std::string & issuerNameBase64Str);
 
     CHIP_ERROR GetKeyIDHexStr(const ByteSpan & certDer, MutableCharSpan & outKeyIDHexStr, bool isAKID);
     CHIP_ERROR GetAKIDHexStr(const ByteSpan & certDer, MutableCharSpan & outAKIDHexStr);
@@ -68,9 +68,9 @@ private:
     CHIP_ERROR GetSubjectAndKeyIdFromPEMCert(const std::string & certPEM, std::string & outSubject, std::string & outKeyId);
 
     bool IsEntryInRevocationSet(const CharSpan & akidHexStr, const CharSpan & issuerNameBase64Str,
-                                const CharSpan & serialNumberHexStr, bool isPAI);
+                                const CharSpan & serialNumberHexStr);
 
-    bool IsCertificateRevoked(const ByteSpan & certDer, bool isPAI);
+    bool IsCertificateRevoked(const ByteSpan & certDer);
 
     std::string mDeviceAttestationRevocationSetPath;
 };

--- a/src/credentials/tests/TestDeviceAttestationCredentials.cpp
+++ b/src/credentials/tests/TestDeviceAttestationCredentials.cpp
@@ -468,12 +468,13 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 
-    // Test DAC is revoked
+    // Test DAC is revoked, crl signer is PAI itself
     const char * jsonData = R"(
     [{
         "type": "revocation_set",
         "issuer_subject_key_id": "AF42B7094DEBD515EC6ECF33B81115225F325288",
         "issuer_name": "MEYxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBSTEUMBIGCisGAQQBgqJ8AgEMBEZGRjExFDASBgorBgEEAYKifAICDAQ4MDAw",
+        "crl_signer_cert": "-----BEGIN CERTIFICATE-----\nMIIB1DCCAXqgAwIBAgIIPmzmUJrYQM0wCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowRjEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFJMRQwEgYKKwYBBAGConwCAQwERkZGMTEUMBIGCisGAQQBgqJ8AgIMBDgwMDAw\nWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASA3fEbIo8+MfY7z1eY2hRiOuu96C7z\neO6tv7GP4avOMdCO1LIGBLbMxtm1+rZOfeEMt0vgF8nsFRYFbXDyzQsio2YwZDAS\nBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUr0K3\nCU3r1RXsbs8zuBEVIl8yUogwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGh\ncX4wCgYIKoZIzj0EAwIDSAAwRQIhAJbJyM8uAYhgBdj1vHLAe3X9mldpWsSRETET\ni+oDPOUDAiAlVJQ75X1T1sR199I+v8/CA2zSm6Y5PsfvrYcUq3GCGQ==\n-----END CERTIFICATE-----",
         "revoked_serial_numbers": ["0C694F7F866067B2"]
     }]
     )";
@@ -481,12 +482,13 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kDacRevoked);
 
-    // Test PAI is revoked
+    // Test PAI is revoked, crl signer is PAA itself
     jsonData = R"(
     [{
         "type": "revocation_set",
         "issuer_subject_key_id": "6AFD22771F511FECBF1641976710DCDC31A1717E",
         "issuer_name": "MDAxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBQTEUMBIGCisGAQQBgqJ8AgEMBEZGRjE=",
+        "crl_signer_cert": "-----BEGIN CERTIFICATE-----\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZMBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END CERTIFICATE-----",
         "revoked_serial_numbers": ["3E6CE6509AD840CD"]
     }]
     )";
@@ -494,18 +496,20 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kPaiRevoked);
 
-    // Test DAC and PAI both revoked
+    // Test DAC and PAI both revoked, crl signers are PAI and PAA respectively
     jsonData = R"(
     [{
         "type": "revocation_set",
         "issuer_subject_key_id": "AF42B7094DEBD515EC6ECF33B81115225F325288",
         "issuer_name": "MEYxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBSTEUMBIGCisGAQQBgqJ8AgEMBEZGRjExFDASBgorBgEEAYKifAICDAQ4MDAw",
+        "crl_signer_cert": "-----BEGIN CERTIFICATE-----\nMIIB1DCCAXqgAwIBAgIIPmzmUJrYQM0wCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowRjEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFJMRQwEgYKKwYBBAGConwCAQwERkZGMTEUMBIGCisGAQQBgqJ8AgIMBDgwMDAw\nWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASA3fEbIo8+MfY7z1eY2hRiOuu96C7z\neO6tv7GP4avOMdCO1LIGBLbMxtm1+rZOfeEMt0vgF8nsFRYFbXDyzQsio2YwZDAS\nBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUr0K3\nCU3r1RXsbs8zuBEVIl8yUogwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGh\ncX4wCgYIKoZIzj0EAwIDSAAwRQIhAJbJyM8uAYhgBdj1vHLAe3X9mldpWsSRETET\ni+oDPOUDAiAlVJQ75X1T1sR199I+v8/CA2zSm6Y5PsfvrYcUq3GCGQ==\n-----END CERTIFICATE-----",
         "revoked_serial_numbers": ["0C694F7F866067B2"]
     },
     {
         "type": "revocation_set",
         "issuer_subject_key_id": "6AFD22771F511FECBF1641976710DCDC31A1717E",
         "issuer_name": "MDAxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBQTEUMBIGCisGAQQBgqJ8AgEMBEZGRjE=",
+        "crl_signer_cert": "-----BEGIN CERTIFICATE-----\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZMBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END CERTIFICATE-----",
         "revoked_serial_numbers": ["3E6CE6509AD840CD"]
     }]
     )";
@@ -522,11 +526,13 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 
     // Test issuer does not match
+    // crl_signer_cert is not a valid and just used for testing
     jsonData = R"(
     [{
         "type": "revocation_set",
         "issuer_subject_key_id": "BF42B7094DEBD515EC6ECF33B81115225F325289",
         "issuer_name": "MEYxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBSTEUMBIGCisGAQQBgqJ8AgEMBEZGRjExFDASBgorBgEEAYKifAICDAQ4MDAw",
+        "crl_signer_cert": "-----BEGIN CERTIFICATE-----\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZMBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END CERTIFICATE-----",
         "revoked_serial_numbers": ["0C694F7F866067B2"]
     }]
     )";
@@ -535,11 +541,13 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 
     // Test subject key ID does not match
+    // crl_signer_cert is not a valid and just used for testing
     jsonData = R"(
     [{
         "type": "revocation_set",
         "issuer_subject_key_id": "BF42B7094DEBD515EC6ECF33B81115225F325289",
         "issuer_name": "MEYxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBSTEUMBIGCisGAQQBgqJ8AgEMBEZGRjExFDASBgorBgEEAYKifAICDAQ4MDAw",
+        "crl_signer_cert": "-----BEGIN CERTIFICATE-----\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZMBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END CERTIFICATE-----",
         "revoked_serial_numbers": ["0C694F7F866067B2"]
     }]
     )";
@@ -548,11 +556,13 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 
     // Test serial number does not match
+    // crl_signer_cert is not a valid and just used for testing
     jsonData = R"(
     [{
         "type": "revocation_set",
         "issuer_subject_key_id": "AF42B7094DEBD515EC6ECF33B81115225F325288",
         "issuer_name": "MEYxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBSTEUMBIGCisGAQQBgqJ8AgEMBEZGRjExFDASBgorBgEEAYKifAICDAQ4MDAw",
+        "crl_signer_cert": "-----BEGIN CERTIFICATE-----\nMIIB1DCCAXqgAwIBAgIIPmzmUJrYQM0wCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowRjEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFJMRQwEgYKKwYBBAGConwCAQwERkZGMTEUMBIGCisGAQQBgqJ8AgIMBDgwMDAw\nWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASA3fEbIo8+MfY7z1eY2hRiOuu96C7z\neO6tv7GP4avOMdCO1LIGBLbMxtm1+rZOfeEMt0vgF8nsFRYFbXDyzQsio2YwZDAS\nBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUr0K3\nCU3r1RXsbs8zuBEVIl8yUogwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGh\ncX4wCgYIKoZIzj0EAwIDSAAwRQIhAJbJyM8uAYhgBdj1vHLAe3X9mldpWsSRETET\ni+oDPOUDAiAlVJQ75X1T1sR199I+v8/CA2zSm6Y5PsfvrYcUq3GCGQ==\n-----END CERTIFICATE-----",
         "revoked_serial_numbers": ["3E6CE6509AD840CD1", "BC694F7F866067B1"]
     }]
     )";
@@ -560,16 +570,34 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 
-    // Test starting serial number bytes match but not all
+    // Test starting serial number bytes match but not all,
+    // crl_signer_cert is not a valid and just used for testing
     jsonData = R"(
     [{
         "type": "revocation_set",
         "issuer_subject_key_id": "AF42B7094DEBD515EC6ECF33B81115225F325288",
         "issuer_name": "MEYxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBSTEUMBIGCisGAQQBgqJ8AgEMBEZGRjExFDASBgorBgEEAYKifAICDAQ4MDAw",
+        "crl_signer_cert": "-----BEGIN CERTIFICATE-----\nMIIB1DCCAXqgAwIBAgIIPmzmUJrYQM0wCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowRjEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFJMRQwEgYKKwYBBAGConwCAQwERkZGMTEUMBIGCisGAQQBgqJ8AgIMBDgwMDAw\nWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASA3fEbIo8+MfY7z1eY2hRiOuu96C7z\neO6tv7GP4avOMdCO1LIGBLbMxtm1+rZOfeEMt0vgF8nsFRYFbXDyzQsio2YwZDAS\nBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUr0K3\nCU3r1RXsbs8zuBEVIl8yUogwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGh\ncX4wCgYIKoZIzj0EAwIDSAAwRQIhAJbJyM8uAYhgBdj1vHLAe3X9mldpWsSRETET\ni+oDPOUDAiAlVJQ75X1T1sR199I+v8/CA2zSm6Y5PsfvrYcUq3GCGQ==\n-----END CERTIFICATE-----",
         "revoked_serial_numbers": ["0C694F7F866067B21234"]
     }]
     )";
     WriteTestRevokedData(jsonData, tmpJsonFile);
     revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
+
+    // Test DAC is revoked, and crl signer delegator is present
+    // crl_signer_cert is not a valid and just used for testing
+    jsonData = R"(
+    [{
+        "type": "revocation_set",
+        "issuer_subject_key_id": "AF42B7094DEBD515EC6ECF33B81115225F325288",
+        "issuer_name": "MEYxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBSTEUMBIGCisGAQQBgqJ8AgEMBEZGRjExFDASBgorBgEEAYKifAICDAQ4MDAw",
+        "crl_signer_cert": "-----BEGIN CERTIFICATE-----\nMIIB1DCCAXqgAwIBAgIIPmzmUJrYQM0wCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowRjEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFJMRQwEgYKKwYBBAGConwCAQwERkZGMTEUMBIGCisGAQQBgqJ8AgIMBDgwMDAw\nWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASA3fEbIo8+MfY7z1eY2hRiOuu96C7z\neO6tv7GP4avOMdCO1LIGBLbMxtm1+rZOfeEMt0vgF8nsFRYFbXDyzQsio2YwZDAS\nBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUr0K3\nCU3r1RXsbs8zuBEVIl8yUogwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGh\ncX4wCgYIKoZIzj0EAwIDSAAwRQIhAJbJyM8uAYhgBdj1vHLAe3X9mldpWsSRETET\ni+oDPOUDAiAlVJQ75X1T1sR199I+v8/CA2zSm6Y5PsfvrYcUq3GCGQ==\n-----END CERTIFICATE-----",
+        "crl_signer_delegator": "-----BEGIN CERTIFICATE-----\nMIIB1DCCAXqgAwIBAgIIPmzmUJrYQM0wCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowRjEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFJMRQwEgYKKwYBBAGConwCAQwERkZGMTEUMBIGCisGAQQBgqJ8AgIMBDgwMDAw\nWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASA3fEbIo8+MfY7z1eY2hRiOuu96C7z\neO6tv7GP4avOMdCO1LIGBLbMxtm1+rZOfeEMt0vgF8nsFRYFbXDyzQsio2YwZDAS\nBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUr0K3\nCU3r1RXsbs8zuBEVIl8yUogwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGh\ncX4wCgYIKoZIzj0EAwIDSAAwRQIhAJbJyM8uAYhgBdj1vHLAe3X9mldpWsSRETET\ni+oDPOUDAiAlVJQ75X1T1sR199I+v8/CA2zSm6Y5PsfvrYcUq3GCGQ==\n-----END CERTIFICATE-----",
+        "revoked_serial_numbers": ["0C694F7F866067B2"]
+    }]
+    )";
+    WriteTestRevokedData(jsonData, tmpJsonFile);
+    revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);
+    EXPECT_EQ(attestationResult, AttestationVerificationResult::kDacRevoked);
 }

--- a/src/credentials/tests/TestDeviceAttestationCredentials.cpp
+++ b/src/credentials/tests/TestDeviceAttestationCredentials.cpp
@@ -526,7 +526,7 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 
     // Test issuer does not match
-    // crl_signer_cert is not a valid and just used for testing
+    // crl_signer_cert is not valid and just used for testing
     jsonData = R"(
     [{
         "type": "revocation_set",
@@ -541,7 +541,7 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 
     // Test subject key ID does not match
-    // crl_signer_cert is not a valid and just used for testing
+    // crl_signer_cert is not valid and just used for testing
     jsonData = R"(
     [{
         "type": "revocation_set",
@@ -556,7 +556,7 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 
     // Test serial number does not match
-    // crl_signer_cert is not a valid and just used for testing
+    // crl_signer_cert is not valid and just used for testing
     jsonData = R"(
     [{
         "type": "revocation_set",
@@ -571,7 +571,7 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 
     // Test starting serial number bytes match but not all,
-    // crl_signer_cert is not a valid and just used for testing
+    // crl_signer_cert is not valid and just used for testing
     jsonData = R"(
     [{
         "type": "revocation_set",
@@ -586,7 +586,7 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 
     // Test DAC is revoked, and crl signer delegator is present
-    // crl_signer_cert is not a valid and just used for testing
+    // crl_signer_cert is not valid and just used for testing
     jsonData = R"(
     [{
         "type": "revocation_set",
@@ -600,4 +600,34 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     WriteTestRevokedData(jsonData, tmpJsonFile);
     revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kDacRevoked);
+
+    // Test with invalid crl signer cert missing begin and end cert markers
+    jsonData = R"(
+    [{
+        "type": "revocation_set",
+        "issuer_subject_key_id": "AF42B7094DEBD515EC6ECF33B81115225F325288",
+        "issuer_name": "MEYxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBSTEUMBIGCisGAQQBgqJ8AgEMBEZGRjExFDASBgorBgEEAYKifAICDAQ4MDAw",
+        "crl_signer_cert": "MIIB1DCCAXqgAwIBAgIIPmzmUJrYQM0wCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowRjEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFJMRQwEgYKKwYBBAGConwCAQwERkZGMTEUMBIGCisGAQQBgqJ8AgIMBDgwMDAw\nWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASA3fEbIo8+MfY7z1eY2hRiOuu96C7z\neO6tv7GP4avOMdCO1LIGBLbMxtm1+rZOfeEMt0vgF8nsFRYFbXDyzQsio2YwZDAS\nBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUr0K3\nCU3r1RXsbs8zuBEVIl8yUogwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGh\ncX4wCgYIKoZIzj0EAwIDSAAwRQIhAJbJyM8uAYhgBdj1vHLAe3X9mldpWsSRETET\ni+oDPOUDAiAlVJQ75X1T1sR199I+v8/CA2zSm6Y5PsfvrYcUq3GCGQ=="
+        "revoked_serial_numbers": ["0C694F7F866067B2"]
+    }]
+    )";
+
+    WriteTestRevokedData(jsonData, tmpJsonFile);
+    revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);
+    EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
+
+    // test with malformed crl signer certificate
+    jsonData = R"(
+    [{
+        "type": "revocation_set",
+        "issuer_subject_key_id": "AF42B7094DEBD515EC6ECF33B81115225F325288",
+        "issuer_name": "MEYxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBSTEUMBIGCisGAQQBgqJ8AgEMBEZGRjExFDASBgorBgEEAYKifAICDAQ4MDAw",
+        "crl_signer_cert": "-----BEGIN CERTIFICATE-----\nMIIB1DCCAXqgAwIBAgIIPmzmUJrYQM0wCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowRjEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFJMRQwEgYKKwYBBAGConwCAQwERkZGMTEUMBIGCisGAQQBgqJ8AgIMBDgwMDAw\nWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASA3fEbIo8+MfY7z1eY2hRiOuu96C7z\neO6tv7GP4avOMdCO1LIGBLbMxtm1+rZOfeEMt0vgF8nsFRYFbXDyzQsio2YwZDAS\nBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUr0K3\nCU3r1RXsbs8zuBEVIl8yUogwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGh\ncX4wCgYIKoZIzj0EAwIDSAAwRQIhAJbJyM8uAYhgBdj1vHLAe3X9mldpWsSRETET\ni+oDPOUDAiAlVJQ75X1T1sR199I+v8/CA2zSm6Y5PsfvrYcUq3GCGQ==\n-----END CERTIFICATE-----",
+        "revoked_serial_numbers": ["0C694F7F866067B2"]
+    }]
+    )";
+
+    WriteTestRevokedData(jsonData, tmpJsonFile);
+    revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);
+    EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 }


### PR DESCRIPTION
#### Change Overview
- perform the cross validation of DAC/PAI with crl signer and crl signer delegator cert
- Extended and added unit tests for crl signer delegator case

#### Tests
- Added unit tests
- generated the sets for test-net and main-net dcl and used them with chip-tool.
- generated the revoked dataset and verified that commissioning fails when revoked entity is present.

Fixes #34587