### PR TITLE
[Fabric-Sync] Allow to specify custom port in fabric-bridge

### DIFF
--- a/examples/fabric-bridge-app/fabric-bridge-common/include/CHIPProjectAppConfig.h
+++ b/examples/fabric-bridge-app/fabric-bridge-common/include/CHIPProjectAppConfig.h
@@ -32,3 +32,6 @@
 
 // include the CHIPProjectConfig from config/standalone
 #include <CHIPProjectConfig.h>
+
+// Allows app options (ports) to be configured on launch of app
+#define CHIP_DEVICE_ENABLE_PORT_PARAMS 1

--- a/examples/fabric-bridge-app/linux/args.gni
+++ b/examples/fabric-bridge-app/linux/args.gni
@@ -21,7 +21,7 @@ chip_project_config_include = "<CHIPProjectAppConfig.h>"
 chip_system_project_config_include = "<SystemProjectConfig.h>"
 
 chip_project_config_include_dirs =
-    [ "${chip_root}/examples/bridge-app/bridge-common/include" ]
+    [ "${chip_root}/examples/fabric-bridge-app/fabric-bridge-common/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 matter_enable_tracing_support = true


### PR DESCRIPTION
### Problem

Example application for fabric-sync does not allow commissioning port customization. This is required to run more then one application on the same host.