### PR TITLE
[Darwin] Enable taking assertion on MTRDeviceController

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -346,15 +346,13 @@ using namespace chip::Tracing::DarwinFramework;
     NSNumber *fabricID = [MTRDeviceControllerParameters nodeIDFromNOC:parameters.operationalCertificate];
     NSData *publicKey = [MTRDeviceControllerParameters publicKeyFromCertificate:parameters.rootCertificate];
 
-    __block BOOL matches = FALSE;
-    dispatch_sync(_chipWorkQueue, ^{
-        matches =  _keepRunningAssertionCounter > 0 &&
-                   _shutdownPending &&
-                   MTREqualObjects(nodeID, self->_nodeID) &&
-                   MTREqualObjects(fabricID, self->_fabricID) &&
-                   MTREqualObjects(publicKey, self->_rootPublicKey);
-    });
-    return matches;
+    std::lock_guard lock(_assertionLock);
+
+    return  _keepRunningAssertionCounter > 0 &&
+            _shutdownPending &&
+            MTREqualObjects(nodeID, self->_nodeID) &&
+            MTREqualObjects(fabricID, self->_fabricID) &&
+            MTREqualObjects(publicKey, self->_rootPublicKey);
 }
 
 - (void)addRunAssertion

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -336,17 +336,13 @@ using namespace chip::Tracing::DarwinFramework;
     if (!parameters.operationalCertificate || !parameters.rootCertificate) {
         return FALSE;
     }
-    NSNumber *nodeID = [MTRDeviceControllerParameters nodeIDFromNOC:parameters.operationalCertificate];
-    NSNumber *fabricID = [MTRDeviceControllerParameters fabricIDFromNOC:parameters.operationalCertificate];
-    NSData *publicKey = [MTRDeviceControllerParameters publicKeyFromCertificate:parameters.rootCertificate];
+    NSNumber * nodeID = [MTRDeviceControllerParameters nodeIDFromNOC:parameters.operationalCertificate];
+    NSNumber * fabricID = [MTRDeviceControllerParameters fabricIDFromNOC:parameters.operationalCertificate];
+    NSData * publicKey = [MTRDeviceControllerParameters publicKeyFromCertificate:parameters.rootCertificate];
 
     std::lock_guard lock(_assertionLock);
 
-    return  _keepRunningAssertionCounter > 0 &&
-            _shutdownPending &&
-            MTREqualObjects(nodeID, self.nodeID) &&
-            MTREqualObjects(fabricID, self.fabricID) &&
-            MTREqualObjects(publicKey, self.rootPublicKey);
+    return _keepRunningAssertionCounter > 0 && _shutdownPending && MTREqualObjects(nodeID, self.nodeID) && MTREqualObjects(fabricID, self.fabricID) && MTREqualObjects(publicKey, self.rootPublicKey);
 }
 
 - (void)addRunAssertion
@@ -701,9 +697,9 @@ using namespace chip::Tracing::DarwinFramework;
 
         chip::Crypto::P256PublicKey rootPublicKey;
         if (_cppCommissioner->GetRootPublicKey(rootPublicKey) == CHIP_NO_ERROR) {
-             self.rootPublicKey = [NSData dataWithBytes:rootPublicKey.Bytes() length:rootPublicKey.Length()];
-             self.nodeID = @(_cppCommissioner->GetNodeId());
-             self.fabricID = @(_cppCommissioner->GetFabricId());
+            self.rootPublicKey = [NSData dataWithBytes:rootPublicKey.Bytes() length:rootPublicKey.Length()];
+            self.nodeID = @(_cppCommissioner->GetNodeId());
+            self.fabricID = @(_cppCommissioner->GetFabricId());
         }
 
         commissionerInitialized = YES;

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -14,9 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <Foundation/Foundation.h>
-#include <MTRDeviceController.h>
-#include <MTRUtilities.h>
 #import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceControllerParameters.h>
 
@@ -49,6 +46,7 @@
 #import "MTRSetupPayload.h"
 #import "MTRTimeUtils.h"
 #import "MTRUnfairLock.h"
+#import "MTRUtilities.h"
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"
 #import <setup_payload/ManualSetupPayloadGenerator.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -352,7 +352,7 @@ using namespace chip::Tracing::DarwinFramework;
     // Only take an assertion if running
     if ([self isRunning]) {
         ++_keepRunningAssertionCounter;
-        MTR_LOG("%@ Adding keep running assertion, total %lu", self, (unsigned long) _keepRunningAssertionCounter);
+        MTR_LOG("%@ Adding keep running assertion, total %lu", self, static_cast<unsigned long>(_keepRunningAssertionCounter));
     }
 }
 
@@ -362,7 +362,7 @@ using namespace chip::Tracing::DarwinFramework;
 
     if (_keepRunningAssertionCounter > 0) {
         --_keepRunningAssertionCounter;
-        MTR_LOG("%@ Removing keep running assertion, total %lu", self, (unsigned long) _keepRunningAssertionCounter);
+        MTR_LOG("%@ Removing keep running assertion, total %lu", self, static_cast<unsigned long>(_keepRunningAssertionCounter));
 
         if ([self isRunning] && _keepRunningAssertionCounter == 0 && _shutdownPending) {
             MTR_LOG("%@ All assertions removed and shutdown is pending, shutting down", self);
@@ -382,7 +382,7 @@ using namespace chip::Tracing::DarwinFramework;
     std::lock_guard lock(_assertionLock);
 
     if (_keepRunningAssertionCounter > 0) {
-        MTR_LOG("%@ Pending shutdown since %lu assertions are present", self, (unsigned long) _keepRunningAssertionCounter);
+        MTR_LOG("%@ Pending shutdown since %lu assertions are present", self, static_cast<unsigned long>(_keepRunningAssertionCounter));
         _shutdownPending = YES;
         return;
     }

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -342,6 +342,7 @@ using namespace chip::Tracing::DarwinFramework;
 
     std::lock_guard lock(_assertionLock);
 
+    // If any of the local above are nil, the return will be false since MTREqualObjects handles them correctly
     return _keepRunningAssertionCounter > 0 && _shutdownPending && MTREqualObjects(nodeID, self.nodeID) && MTREqualObjects(fabricID, self.fabricID) && MTREqualObjects(publicKey, self.rootPublicKey);
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -334,7 +334,7 @@ using namespace chip::Tracing::DarwinFramework;
 {
     dispatch_sync(_chipWorkQueue, ^{
         ++self.keepRunningAssertionCounter;
-        MTR_LOG("%@ Adding keep running assertion, total %lu", self, self.keepRunningAssertionCounter);
+        MTR_LOG("%@ Adding keep running assertion, total %lu", self, (unsigned long) self.keepRunningAssertionCounter);
     });
 }
 
@@ -344,7 +344,7 @@ using namespace chip::Tracing::DarwinFramework;
     dispatch_sync(_chipWorkQueue, ^{
         if (self.keepRunningAssertionCounter > 0) {
             --self.keepRunningAssertionCounter;
-            MTR_LOG("%@ Removing keep running assertion, total %lu", self, self.keepRunningAssertionCounter);
+            MTR_LOG("%@ Removing keep running assertion, total %lu", self, (unsigned long) self.keepRunningAssertionCounter);
             if (self.keepRunningAssertionCounter == 0 && self.shutdownPending) {
                 shouldShutdown = TRUE;
             }
@@ -360,7 +360,7 @@ using namespace chip::Tracing::DarwinFramework;
 {
     NSUInteger assertionCount = [self shutdownPrecheck];
     if (assertionCount != 0) {
-        MTR_LOG("%@ Pending shutdown since %lu assertions are present", self, assertionCount);
+        MTR_LOG("%@ Pending shutdown since %lu assertions are present", self, (unsigned long) assertionCount);
         return;
     }
     [self finalShutdown];

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -1136,7 +1136,7 @@ MTR_DIRECT_MEMBERS
 - (nullable MTRDeviceController *)_findControllerMatchingParams:(MTRDeviceControllerParameters *)parameters
 {
     std::lock_guard lock(_controllersLock);
-    for (MTRDeviceController *controller in _controllers) {
+    for (MTRDeviceController * controller in _controllers) {
         if ([controller matchesPendingShutdownWithParams:parameters]) {
             MTR_LOG("%@ Found existing controller %@ that is pending shutdown and matching parameters, re-using it", self, controller);
             [controller clearPendingShutdown];
@@ -1153,7 +1153,7 @@ MTR_DIRECT_MEMBERS
     [self _assertCurrentQueueIsNotMatterQueue];
 
     // If there is a controller already running with matching parameters, re-use it
-    MTRDeviceController *existingController = [self _findControllerMatchingParams:parameters];
+    MTRDeviceController * existingController = [self _findControllerMatchingParams:parameters];
     if (existingController) {
         return existingController;
     }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -15,7 +15,6 @@
  */
 
 #import "MTRDeviceControllerFactory.h"
-#include <MTRDeviceController_Concrete.h>
 #import "MTRDeviceControllerFactory_Internal.h"
 
 #import <Matter/MTRDefines.h>

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -1153,7 +1153,7 @@ MTR_DIRECT_MEMBERS
     [self _assertCurrentQueueIsNotMatterQueue];
 
     // If there is a controller already running with matching parameters that is conceptually shut down from the API consumer's viewpoint, re-use it.
-    MTRDeviceController * existingController = [self _findControllerMatchingParams:parameters];
+    MTRDeviceController * existingController = [self _findControllerWithPendingShutdownMatchingParams:parameters];
     if (existingController) {
         return existingController;
     }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -1133,7 +1133,7 @@ MTR_DIRECT_MEMBERS
     }
 }
 
-- (nullable MTRDeviceController *)_findControllerMatchingParams:(MTRDeviceControllerParameters *)parameters
+- (nullable MTRDeviceController *)_findControllerWithPendingShutdownMatchingParams:(MTRDeviceControllerParameters *)parameters
 {
     std::lock_guard lock(_controllersLock);
     for (MTRDeviceController * controller in _controllers) {
@@ -1152,7 +1152,7 @@ MTR_DIRECT_MEMBERS
 {
     [self _assertCurrentQueueIsNotMatterQueue];
 
-    // If there is a controller already running with matching parameters, re-use it
+    // If there is a controller already running with matching parameters that is conceptually shut down from the API consumer's viewpoint, re-use it.
     MTRDeviceController * existingController = [self _findControllerMatchingParams:parameters];
     if (existingController) {
         return existingController;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -15,6 +15,8 @@
  */
 
 #import "MTRDeviceControllerStartupParams.h"
+#include <MTRDefines.h>
+#include <lib/core/CHIPError.h>
 #import "MTRCertificates.h"
 #import "MTRConversion.h"
 #import "MTRDeviceControllerStartupParams_Internal.h"
@@ -304,6 +306,29 @@ constexpr NSUInteger kDefaultConcurrentSubscriptionPoolSize = 300;
 {
     _otaProviderDelegate = otaProviderDelegate;
     _otaProviderDelegateQueue = queue;
+}
+
++ (nullable NSNumber *)nodeIDFromNOC:(MTRCertificateDERBytes)noc
+{
+    NSNumber *nodeID = nil;
+    ExtractNodeIDFromNOC(noc, &nodeID);
+    return nodeID;
+}
+
++ (nullable NSNumber *)fabricIDFromNOC:(MTRCertificateDERBytes)noc
+{
+    NSNumber *fabricID = nil;
+    ExtractFabricIDFromNOC(noc, &fabricID);
+    return fabricID;
+}
+
++ (NSData *)publicKeyFromCertificate:(MTRCertificateDERBytes)certificate
+{
+    Crypto::P256PublicKey pubKey;
+    if (ExtractPubkeyFromX509Cert(AsByteSpan(certificate), pubKey) != CHIP_NO_ERROR) {
+        return nil;
+    }
+    return [NSData dataWithBytes:pubKey.Bytes() length:pubKey.Length()];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -15,8 +15,6 @@
  */
 
 #import "MTRDeviceControllerStartupParams.h"
-#include <MTRDefines.h>
-#include <lib/core/CHIPError.h>
 #import "MTRCertificates.h"
 #import "MTRConversion.h"
 #import "MTRDeviceControllerStartupParams_Internal.h"

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -308,14 +308,14 @@ constexpr NSUInteger kDefaultConcurrentSubscriptionPoolSize = 300;
 
 + (nullable NSNumber *)nodeIDFromNOC:(MTRCertificateDERBytes)noc
 {
-    NSNumber *nodeID = nil;
+    NSNumber * nodeID = nil;
     ExtractNodeIDFromNOC(noc, &nodeID);
     return nodeID;
 }
 
 + (nullable NSNumber *)fabricIDFromNOC:(MTRCertificateDERBytes)noc
 {
-    NSNumber *fabricID = nil;
+    NSNumber * fabricID = nil;
     ExtractFabricIDFromNOC(noc, &fabricID);
     return fabricID;
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -320,7 +320,7 @@ constexpr NSUInteger kDefaultConcurrentSubscriptionPoolSize = 300;
     return fabricID;
 }
 
-+ (NSData *)publicKeyFromCertificate:(MTRCertificateDERBytes)certificate
++ (nullable NSData *)publicKeyFromCertificate:(MTRCertificateDERBytes)certificate
 {
     Crypto::P256PublicKey pubKey;
     if (ExtractPubkeyFromX509Cert(AsByteSpan(certificate), pubKey) != CHIP_NO_ERROR) {

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -87,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable NSNumber *)nodeIDFromNOC:(MTRCertificateDERBytes)noc;
 + (nullable NSNumber *)fabricIDFromNOC:(MTRCertificateDERBytes)noc;
-+ (NSData *)publicKeyFromCertificate:(MTRCertificateDERBytes)certificate;
++ (nullable NSData *)publicKeyFromCertificate:(MTRCertificateDERBytes)certificate;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -85,6 +85,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly, nullable) id<MTROTAProviderDelegate> otaProviderDelegate;
 @property (nonatomic, strong, readonly, nullable) dispatch_queue_t otaProviderDelegateQueue;
 
++ (nullable NSNumber *)nodeIDFromNOC:(MTRCertificateDERBytes)noc;
++ (nullable NSNumber *)fabricIDFromNOC:(MTRCertificateDERBytes)noc;
++ (NSData *)publicKeyFromCertificate:(MTRCertificateDERBytes)certificate;
+
 @end
 
 @interface MTRDeviceControllerStartupParamsInternal : MTRDeviceControllerStartupParams

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -327,16 +327,6 @@ using namespace chip::Tracing::DarwinFramework;
 
 - (void)shutdown
 {
-    NSUInteger assertionCount = [self shutdownPrecheck];
-    if (assertionCount != 0) {
-        MTR_LOG("%@ Pending shutdown since %lu assertions are present", self, (unsigned long) assertionCount);
-        return;
-    }
-    [self finalShutdown];
-}
-
-- (void)finalShutdown
-{
     MTR_LOG("%@ shutdown called", self);
     if (_cppCommissioner == nullptr) {
         // Already shut down.

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -327,6 +327,16 @@ using namespace chip::Tracing::DarwinFramework;
 
 - (void)shutdown
 {
+    NSUInteger assertionCount = [self shutdownPrecheck];
+    if (assertionCount != 0) {
+        MTR_LOG("%@ Pending shutdown since %lu assertions are present", self, assertionCount);
+        return;
+    }
+    [self finalShutdown];
+}
+
+- (void)finalShutdown
+{
     MTR_LOG("%@ shutdown called", self);
     if (_cppCommissioner == nullptr) {
         // Already shut down.

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -329,7 +329,7 @@ using namespace chip::Tracing::DarwinFramework;
 {
     NSUInteger assertionCount = [self shutdownPrecheck];
     if (assertionCount != 0) {
-        MTR_LOG("%@ Pending shutdown since %lu assertions are present", self, assertionCount);
+        MTR_LOG("%@ Pending shutdown since %lu assertions are present", self, (unsigned long) assertionCount);
         return;
     }
     [self finalShutdown];

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -45,6 +45,7 @@
 #import <Matter/MTRDiagnosticLogsType.h>
 #import <Matter/MTROTAProviderDelegate.h>
 
+@class MTRDeviceControllerParameters;
 @class MTRDeviceControllerStartupParamsInternal;
 @class MTRDeviceControllerFactory;
 @class MTRDevice;
@@ -313,6 +314,16 @@ NS_ASSUME_NONNULL_BEGIN
  * until all assertions have been removed.
  */
 - (NSUInteger)shutdownPrecheck;
+
+/**
+ * This method returns TRUE if this controller matches the fabric reference and node ID as listed in the parameters.
+ */
+- (BOOL)matchesPendingShutdownWithParams:(MTRDeviceControllerParameters *)parameters;
+
+/**
+ * Clear any pending shutdown request.
+ */
+- (void)clearPendingShutdown;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -119,6 +119,22 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) MTRAsyncWorkQueue<MTRDeviceController *> * concurrentSubscriptionPool;
 
 /**
+ * Fabric ID tied to controller
+ */
+@property (nonatomic, retain, nullable) NSNumber * fabricID;
+
+/**
+ * Node ID tied to controller
+ */
+@property (nonatomic, retain, nullable) NSNumber * nodeID;
+
+/**
+ * Root Public Key tied to controller
+ */
+@property (nonatomic, retain, nullable) NSData * rootPublicKey;
+
+
+/**
  * Init a newly created controller.
  *
  * Only MTRDeviceControllerFactory should be calling this.

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -73,10 +73,6 @@ NS_ASSUME_NONNULL_BEGIN
 // (moved here so subclasses can initialize differently)
 @property (readwrite, retain) dispatch_queue_t chipWorkQueue;
 
-// Counters to track assertion status
-@property (nonatomic, readwrite) NSUInteger keepRunningAssertionCounter;
-@property (nonatomic, readwrite) BOOL shutdownPending;
-
 - (instancetype)initForSubclasses;
 
 #pragma mark - MTRDeviceControllerFactory methods

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -133,7 +133,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, retain, nullable) NSData * rootPublicKey;
 
-
 /**
  * Init a newly created controller.
  *

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -305,13 +305,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeRunAssertion;
 
 /**
- * This methods marks a request to shutdown.
- * Returns the number of run assertions currently being held. If the value returned is not zero, it implies shutdown has to be delayed
- * until all assertions have been removed.
- */
-- (NSUInteger)shutdownPrecheck;
-
-/**
  * This method returns TRUE if this controller matches the fabric reference and node ID as listed in the parameters.
  */
 - (BOOL)matchesPendingShutdownWithParams:(MTRDeviceControllerParameters *)parameters;

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -72,6 +72,10 @@ NS_ASSUME_NONNULL_BEGIN
 // (moved here so subclasses can initialize differently)
 @property (readwrite, retain) dispatch_queue_t chipWorkQueue;
 
+// Counters to track assertion status
+@property (nonatomic, readwrite) NSUInteger keepRunningAssertionCounter;
+@property (nonatomic, readwrite) BOOL shutdownPending;
+
 - (instancetype)initForSubclasses;
 
 #pragma mark - MTRDeviceControllerFactory methods
@@ -288,6 +292,27 @@ NS_ASSUME_NONNULL_BEGIN
  * makes use of the subscription pool.
  */
 - (void)directlyGetSessionForNode:(chip::NodeId)nodeID completion:(MTRInternalDeviceConnectionCallback)completion;
+
+/**
+ * Takes an assertion to keep the controller running. If `-[MTRDeviceController shutdown]` is called while an assertion
+ * is held, the shutdown will be honored only after all assertions are released. Invoking this method multiple times increases
+ * the number of assertions and needs to be matched with equal amount of '-[MTRDeviceController removeRunAssertion]` to release
+ * the assertion.
+ */
+- (void)addRunAssertion;
+
+/**
+ * Removes an assertion to allow the controller to shutdown once all assertions have been released.
+ * Invoking this method once all assertions have been released in a noop.
+ */
+- (void)removeRunAssertion;
+
+/**
+ * This methods marks a request to shutdown.
+ * Returns the number of run assertions currently being held. If the value returned is not zero, it implies shutdown has to be delayed
+ * until all assertions have been removed.
+ */
+- (NSUInteger)shutdownPrecheck;
 
 @end
 


### PR DESCRIPTION
- Added ability to take assertion on MTRDeviceController to keep it running until all assertions are removed
- A request to shutdown will take place only if there are no assertions are present
