### PR TITLE
[Fabric-Sync] Simplify the build instructions with build_examples.py

### DIFF
--- a/examples/fabric-admin/README.md
+++ b/examples/fabric-admin/README.md
@@ -14,7 +14,8 @@ fabrics.
 For Linux host example:
 
 ```
-./scripts/examples/gn_build_example.sh examples/fabric-admin out/debug/standalone 'import("//with_pw_rpc.gni")'
+source scripts/activate.sh
+./scripts/build/build_examples.py --target linux-x64-fabric-admin-rpc build
 ```
 
 For Raspberry Pi 4 example:

--- a/examples/fabric-bridge-app/linux/README.md
+++ b/examples/fabric-bridge-app/linux/README.md
@@ -91,7 +91,8 @@ defined:
     ### For Linux host example:
 
     ```
-    ./scripts/examples/gn_build_example.sh examples/fabric-bridge-app/linux out/debug/standalone chip_config_network_layer_ble=false 'import("//with_pw_rpc.gni")'
+    source scripts/activate.sh
+    ./scripts/build/build_examples.py --target linux-x64-fabric-bridge-rpc build
     ```
 
     ### For Raspberry Pi 4 example:


### PR DESCRIPTION
'build_examples.py' is a higher level wrapper to build the example apps 

Simplify the build instructions with build_examples.py

