### PR TITLE
[Bouffalo Lab] Add littlefs to access flash storage

### DIFF
--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -57,9 +57,9 @@ jobs:
         run: |
           ./scripts/run_in_build_env.sh \
             "./scripts/build/build_examples.py \
-              --target bouffalolab-bl602-night-light-light \
-              --target bouffalolab-bl602-night-light-light-mfd \
-              --target bouffalolab-bl602-iot-matter-v1-light-115200-rpc \
+              --target bouffalolab-bl602dk-light-easyflash \
+              --target bouffalolab-bl602dk-light-mfd-littlefs \
+              --target bouffalolab-bl602dk-light-rpc-115200-littlefs \
               build \
               --copy-artifacts-to out/artifacts \
             "
@@ -67,15 +67,15 @@ jobs:
         run: |
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
               bl602 bl602 lighting-app \
-              out/artifacts/bouffalolab-bl602-night-light-light/chip-bl602-lighting-example.out \
+              out/artifacts/bouffalolab-bl602dk-light-easyflash/chip-bl602-lighting-example.out \
               /tmp/bloat_reports/
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
               bl602 bl602+mfd lighting-app \
-              out/artifacts/bouffalolab-bl602-night-light-light-mfd/chip-bl602-lighting-example.out \
+              out/artifacts/bouffalolab-bl602dk-light-mfd-littlefs/chip-bl602-lighting-example.out \
               /tmp/bloat_reports/
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
               bl602 bl602+rpc lighting-app \
-              out/artifacts/bouffalolab-bl602-iot-matter-v1-light-115200-rpc/chip-bl602-lighting-example.out \
+              out/artifacts/bouffalolab-bl602dk-light-rpc-115200-littlefs/chip-bl602-lighting-example.out \
               /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out
@@ -84,11 +84,11 @@ jobs:
         run: |
           ./scripts/run_in_build_env.sh \
             "./scripts/build/build_examples.py \
-              --target bouffalolab-bl706-night-light-light \
-              --target bouffalolab-bl706-night-light-light-mfd \
-              --target bouffalolab-bl706dk-light-ethernet \
-              --target bouffalolab-bl706dk-light-wifi-fp \
-              --target bouffalolab-xt-zb6-devkit-light-115200-rpc \
+              --target bouffalolab-bl706dk-light-easyflash \
+              --target bouffalolab-bl706dk-light-mfd-littlefs \
+              --target bouffalolab-bl706dk-light-ethernet-littlefs \
+              --target bouffalolab-bl706dk-light-wifi-littlefs \
+              --target bouffalolab-bl706dk-light-rpc-115200-littlefs \
               build \
               --copy-artifacts-to out/artifacts \
             "
@@ -96,23 +96,23 @@ jobs:
         run: |
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
               bl702 bl702 lighting-app \
-              out/artifacts/bouffalolab-bl706-night-light-light/chip-bl702-lighting-example.out \
+              out/artifacts/bouffalolab-bl706dk-light-easyflash/chip-bl702-lighting-example.out \
               /tmp/bloat_reports/
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
               bl702 bl702+mfd lighting-app \
-              out/artifacts/bouffalolab-bl706-night-light-light-mfd/chip-bl702-lighting-example.out \
+              out/artifacts/bouffalolab-bl706dk-light-mfd-littlefs/chip-bl702-lighting-example.out \
               /tmp/bloat_reports/
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
               bl702 bl706-eth lighting-app \
-              out/artifacts/bouffalolab-bl706dk-light-ethernet/chip-bl702-lighting-example.out \
+              out/artifacts/bouffalolab-bl706dk-light-ethernet-littlefs/chip-bl702-lighting-example.out \
               /tmp/bloat_reports/
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
               bl702 bl706-wifi lighting-app \
-              out/artifacts/bouffalolab-bl706dk-light-wifi-fp/chip-bl702-lighting-example.out \
+              out/artifacts/bouffalolab-bl706dk-light-wifi-littlefs/chip-bl702-lighting-example.out \
               /tmp/bloat_reports/
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
               bl702 bl702+rpc lighting-app \
-              out/artifacts/bouffalolab-xt-zb6-devkit-light-115200-rpc/chip-bl702-lighting-example.out \
+              out/artifacts/bouffalolab-bl706dk-light-rpc-115200-littlefs/chip-bl702-lighting-example.out \
               /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out
@@ -122,8 +122,8 @@ jobs:
         run: |
           ./scripts/run_in_build_env.sh \
             "./scripts/build/build_examples.py \
-              --target bouffalolab-bl704ldk-light \
-              --target bouffalolab-bl704ldk-light-mfd \
+              --target bouffalolab-bl704ldk-light-easyflash \
+              --target bouffalolab-bl704ldk-light-mfd-littlefs \
               build \
               --copy-artifacts-to out/artifacts \
             "
@@ -131,11 +131,11 @@ jobs:
         run: |
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
               bl702l bl702l lighting-app \
-              out/artifacts/bouffalolab-bl704ldk-light/chip-bl702l-lighting-example.out \
+              out/artifacts/bouffalolab-bl704ldk-light-easyflash/chip-bl702l-lighting-example.out \
               /tmp/bloat_reports/
           .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
               bl702l bl702l+mfd lighting-app \
-              out/artifacts/bouffalolab-bl704ldk-light-mfd/chip-bl702l-lighting-example.out \
+              out/artifacts/bouffalolab-bl704ldk-light-mfd-littlefs/chip-bl702l-lighting-example.out \
               /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out

--- a/examples/lighting-app/bouffalolab/common/AppTask.cpp
+++ b/examples/lighting-app/bouffalolab/common/AppTask.cpp
@@ -46,8 +46,6 @@
 #include <LEDWidget.h>
 #include <plat.h>
 
-#include <easyflash.h>
-
 extern "C" {
 #include <bl_gpio.h>
 #include <hal_gpio.h>

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -688,6 +688,7 @@ def BuildBouffalolabTarget():
     target.AppendModifier('wifi', enable_wifi=True)
     target.AppendModifier('thread', enable_thread=True)
     target.AppendModifier('easyflash', enable_easyflash=True)
+    target.AppendModifier('littlefs', enable_littlefs=True)
     target.AppendModifier('shell', enable_shell=True)
     target.AppendModifier('mfd', enable_mfd=True)
     target.AppendModifier('rotating_device_id', enable_rotating_device_id=True)

--- a/scripts/build/builders/bouffalolab.py
+++ b/scripts/build/builders/bouffalolab.py
@@ -162,7 +162,7 @@ class BouffalolabBuilder(GnBuilder):
 
         self.argsOpt.append(f'chip_mdns="{chip_mdns}"')
         self.argsOpt.append(f'chip_inet_config_enable_ipv4={str(enable_ethernet or enable_wifi).lower()}')
-        
+
         if enable_easyflash and enable_littlefs:
             raise Exception("Only one of easyflash and littlefs can be enabled.")
 

--- a/scripts/build/builders/bouffalolab.py
+++ b/scripts/build/builders/bouffalolab.py
@@ -89,6 +89,7 @@ class BouffalolabBuilder(GnBuilder):
                  enable_heap_monitoring: bool = False,
                  use_matter_openthread: bool = False,
                  enable_easyflash: bool = False,
+                 enable_littlefs: bool = False
                  ):
 
         if 'BL602' == module_type:
@@ -161,8 +162,17 @@ class BouffalolabBuilder(GnBuilder):
 
         self.argsOpt.append(f'chip_mdns="{chip_mdns}"')
         self.argsOpt.append(f'chip_inet_config_enable_ipv4={str(enable_ethernet or enable_wifi).lower()}')
+        
+        if enable_easyflash and enable_littlefs:
+            raise Exception("Only one of easyflash and littlefs can be enabled.")
 
-        self.argsOpt.append(f'bouffalo_sdk_component_easyflash_enabled=true')
+        if not enable_easyflash and not enable_littlefs:
+            logging.fatal('*' * 80)
+            logging.fatal('littlefs is added to support for flash storage access.')
+            logging.fatal('Please consider and select one of easyflash and littlefs to use.')
+            logging.fatal('*' * 80)
+            raise Exception("None of easyflash and littlefs select to build.")
+        self.argsOpt.append(f'bouffalo_sdk_component_easyflash_enabled={"false" if enable_littlefs else "true"}')
 
         if enable_thread:
             self.argsOpt.append('chip_system_config_use_open_thread_inet_endpoints=true')

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -1,7 +1,7 @@
 ameba-amebad-{all-clusters,all-clusters-minimal,light,light-switch,pigweed}
 asr-{asr582x,asr595x,asr550x}-{all-clusters,all-clusters-minimal,lighting,light-switch,lock,bridge,temperature-measurement,thermostat,ota-requestor,dishwasher,refrigerator}[-ota][-shell][-no_logging][-factory][-rotating_id][-rio]
 android-{arm,arm64,x86,x64,androidstudio-arm,androidstudio-arm64,androidstudio-x86,androidstudio-x64}-{chip-tool,chip-test,tv-server,tv-casting-app,java-matter-controller,kotlin-matter-controller,virtual-device-app}[-no-debug]
-bouffalolab-{bl602dk,bl704ldk,bl706dk,bl602-night-light,bl706-night-light,bl602-iot-matter-v1,xt-zb6-devkit}-light[-ethernet][-wifi][-thread][-easyflash][-shell][-mfd][-rotating_device_id][-rpc][-cdc][-mot][-resetcnt][-memmonitor][-115200][-fp]
+bouffalolab-{bl602dk,bl704ldk,bl706dk,bl602-night-light,bl706-night-light,bl602-iot-matter-v1,xt-zb6-devkit}-light[-ethernet][-wifi][-thread][-easyflash][-littlefs][-shell][-mfd][-rotating_device_id][-rpc][-cdc][-mot][-resetcnt][-memmonitor][-115200][-fp]
 cc32xx-{lock,air-purifier}
 ti-cc13x4_26x4-{all-clusters,lighting,lock,pump,pump-controller}[-mtd][-ftd]
 cyw30739-{cyw30739b2_p5_evk_01,cyw30739b2_p5_evk_02,cyw30739b2_p5_evk_03,cyw930739m2evb_01,cyw930739m2evb_02}-{light,light-switch,lock,thermostat}

--- a/src/platform/bouffalolab/BL602/BUILD.gn
+++ b/src/platform/bouffalolab/BL602/BUILD.gn
@@ -61,9 +61,12 @@ static_library("BL602") {
       "../common/FactoryDataProvider.h",
     ]
   }
-
+  
   if (bouffalo_sdk_component_easyflash_enabled) {
     sources += [ "../common/BLConfig.cpp" ]
+  }
+  else {
+    sources += [ "../common/BLConfig_littlefs.cpp" ]
   }
 
   deps = [

--- a/src/platform/bouffalolab/BL602/BUILD.gn
+++ b/src/platform/bouffalolab/BL602/BUILD.gn
@@ -61,11 +61,10 @@ static_library("BL602") {
       "../common/FactoryDataProvider.h",
     ]
   }
-  
+
   if (bouffalo_sdk_component_easyflash_enabled) {
     sources += [ "../common/BLConfig.cpp" ]
-  }
-  else {
+  } else {
     sources += [ "../common/BLConfig_littlefs.cpp" ]
   }
 

--- a/src/platform/bouffalolab/BL702/BUILD.gn
+++ b/src/platform/bouffalolab/BL702/BUILD.gn
@@ -65,11 +65,10 @@ static_library("BL702") {
       "../common/FactoryDataProvider.h",
     ]
   }
-  
+
   if (bouffalo_sdk_component_easyflash_enabled) {
     sources += [ "../common/BLConfig.cpp" ]
-  }
-  else {
+  } else {
     sources += [ "../common/BLConfig_littlefs.cpp" ]
   }
 

--- a/src/platform/bouffalolab/BL702/BUILD.gn
+++ b/src/platform/bouffalolab/BL702/BUILD.gn
@@ -65,9 +65,12 @@ static_library("BL702") {
       "../common/FactoryDataProvider.h",
     ]
   }
-
+  
   if (bouffalo_sdk_component_easyflash_enabled) {
     sources += [ "../common/BLConfig.cpp" ]
+  }
+  else {
+    sources += [ "../common/BLConfig_littlefs.cpp" ]
   }
 
   if (chip_enable_wifi) {

--- a/src/platform/bouffalolab/BL702L/BUILD.gn
+++ b/src/platform/bouffalolab/BL702L/BUILD.gn
@@ -63,11 +63,10 @@ static_library("BL702L") {
       "../common/FactoryDataProvider.h",
     ]
   }
-  
+
   if (bouffalo_sdk_component_easyflash_enabled) {
     sources += [ "../common/BLConfig.cpp" ]
-  }
-  else {
+  } else {
     sources += [ "../common/BLConfig_littlefs.cpp" ]
   }
 

--- a/src/platform/bouffalolab/BL702L/BUILD.gn
+++ b/src/platform/bouffalolab/BL702L/BUILD.gn
@@ -63,9 +63,12 @@ static_library("BL702L") {
       "../common/FactoryDataProvider.h",
     ]
   }
-
+  
   if (bouffalo_sdk_component_easyflash_enabled) {
     sources += [ "../common/BLConfig.cpp" ]
+  }
+  else {
+    sources += [ "../common/BLConfig_littlefs.cpp" ]
   }
 
   if (chip_enable_openthread) {

--- a/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
+++ b/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
@@ -20,8 +20,8 @@ extern "C" {
 #include <lfs_port.h>
 }
 
-#include <platform/bouffalolab/common/BLConfig.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/bouffalolab/common/BLConfig.h>
 
 #ifndef BLCONFIG_LFS_NAMESPACE
 #define BLCONFIG_LFS_NAMESPACE "/_blcfg_"

--- a/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
+++ b/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
@@ -21,6 +21,7 @@ extern "C" {
 }
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
+
 #include <platform/bouffalolab/common/BLConfig.h>
 
 #ifndef BLCONFIG_LFS_NAMESPACE

--- a/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
+++ b/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
@@ -1,0 +1,346 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string>
+#include <regex>
+
+#include <lfs.h>
+extern "C" {
+#include <lfs_port.h>
+}
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/bouffalolab/common/BLConfig.h>
+
+#ifndef BLCONFIG_LFS_NAMESPACE
+#define BLCONFIG_LFS_NAMESPACE "/_blcfg_"
+#endif
+
+#ifndef BLCONFIG_SLASH
+#define BLCONFIG_SLASH "-"
+#endif
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+static lfs_t      * blconfig_lfs = nullptr;
+
+static inline std::string  blcfg_convert_key(std::string key, std::string lfs_ns = std::string("")) 
+{
+    return lfs_ns + std::string("/") + regex_replace(key, std::regex("/"), std::string(BLCONFIG_SLASH));
+}
+
+static CHIP_ERROR blcfg_do_factory_reset(void) 
+{
+    CHIP_ERROR      err = CHIP_NO_ERROR;
+    int             ret;
+    struct lfs_info stat;
+    lfs_file_t      file;
+    lfs_dir_t       dir = {};
+    std::string     factory_reset_key = blcfg_convert_key(std::string(BLConfig::kBLKey_factoryResetFlag));
+
+    blconfig_lfs->cfg->lock(blconfig_lfs->cfg);
+
+    ret = lfs_stat(blconfig_lfs, const_cast<char*>(factory_reset_key.c_str()), &stat);
+
+    if (LFS_ERR_OK == ret) {
+        err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+
+        do {
+            ret = lfs_file_open(blconfig_lfs, &file, const_cast<char*>(factory_reset_key.c_str()), LFS_O_RDONLY);
+            VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+            lfs_file_close(blconfig_lfs, &file);
+
+            ret = lfs_dir_open(blconfig_lfs, &dir, BLCONFIG_LFS_NAMESPACE);
+            VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+
+            while (1) {
+                ret = lfs_dir_read(blconfig_lfs, &dir, &stat);
+                if (ret <= 0) {
+                    break;
+                }
+
+                if (stat.type != LFS_TYPE_REG) {
+                    continue;
+                }
+                std::string delete_key = blcfg_convert_key(std::string(stat.name), std::string(BLCONFIG_LFS_NAMESPACE));
+
+                ret = lfs_remove(blconfig_lfs, const_cast<char*>(delete_key.c_str())); 
+                if (ret != LFS_ERR_OK) {
+                    break;
+                }
+            }
+
+            lfs_dir_close(blconfig_lfs, &dir);
+
+            ret = lfs_remove(blconfig_lfs, const_cast<char*>(factory_reset_key.c_str()));
+            if (ret != LFS_ERR_OK) {
+                break;
+            }
+
+            err = CHIP_NO_ERROR;
+        } while(0);
+    }
+
+exit: 
+    blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);
+
+    return err;
+}
+
+void BLConfig::Init(void)
+{
+    CHIP_ERROR      err = CHIP_NO_ERROR;
+    int             ret;
+    struct lfs_info stat;
+    
+    blconfig_lfs = lfs_xip_init();
+    VerifyOrExit(blconfig_lfs != NULL, err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+
+    /* init namespace */
+    ret = lfs_stat(blconfig_lfs, BLCONFIG_LFS_NAMESPACE, &stat);
+    if (ret != LFS_ERR_OK) {
+        ret = lfs_mkdir(blconfig_lfs, BLCONFIG_LFS_NAMESPACE);
+        VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+
+        ret = lfs_stat(blconfig_lfs, BLCONFIG_LFS_NAMESPACE, &stat);
+    }
+    VerifyOrExit(ret == LFS_ERR_OK && stat.type == LFS_TYPE_DIR, err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+
+    err = blcfg_do_factory_reset();
+exit:
+    configASSERT(err == CHIP_NO_ERROR);
+}
+
+CHIP_ERROR BLConfig::ReadConfigValue(const char * key, uint8_t * val, size_t size, size_t & readsize)
+{
+    CHIP_ERROR   err = CHIP_NO_ERROR;
+    int          ret = LFS_ERR_OK;
+    lfs_file_t   file;
+    std::string  read_key = blcfg_convert_key(std::string(key), std::string(BLCONFIG_LFS_NAMESPACE));
+
+    blconfig_lfs->cfg->lock(blconfig_lfs->cfg);
+
+    ret = lfs_file_open(blconfig_lfs, &file, const_cast<char*>(read_key.c_str()), LFS_O_RDONLY);
+    VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+
+    if (val && size) {
+        ret = lfs_file_read(blconfig_lfs, &file, val, size);
+        readsize = ret;
+    }
+    lfs_file_close(blconfig_lfs, &file);
+
+exit:
+    blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);
+
+    return err;
+}
+
+CHIP_ERROR BLConfig::ReadConfigValue(const char * key, bool & val)
+{
+    size_t readlen = 0;
+    return ReadConfigValue(key, (uint8_t *) &val, 1, readlen);
+}
+
+CHIP_ERROR BLConfig::ReadConfigValue(const char * key, uint32_t & val)
+{
+    size_t readlen = 0;
+    return ReadConfigValue(key, (uint8_t *) &val, sizeof(val), readlen);
+}
+
+CHIP_ERROR BLConfig::ReadConfigValue(const char * key, uint64_t & val)
+{
+    size_t readlen = 0;
+    return ReadConfigValue(key, (uint8_t *) &val, sizeof(val), readlen);
+}
+
+CHIP_ERROR BLConfig::ReadConfigValueStr(const char * key, char * buf, size_t bufSize, size_t & outLen)
+{
+    size_t readlen = 0;
+    if (CHIP_NO_ERROR == ReadConfigValue(key, (uint8_t *) buf, bufSize, readlen))
+    {
+        outLen = readlen;
+        if (readlen && readlen < bufSize)
+        {
+            buf[readlen] = '\0';
+        }
+
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+}
+
+CHIP_ERROR BLConfig::ReadConfigValueBin(const char * key, uint8_t * buf, size_t bufSize, size_t & outLen)
+{
+    size_t readlen = 0;
+    if (CHIP_NO_ERROR == ReadConfigValue(key, (uint8_t *) buf, bufSize, readlen))
+    {
+        outLen = readlen;
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+}
+
+CHIP_ERROR BLConfig::WriteConfigValue(const char * key, uint8_t * val, size_t size)
+{
+    int          ret = LFS_ERR_OK;
+    CHIP_ERROR   err = CHIP_NO_ERROR;
+    lfs_file_t   file;
+    std::string  write_key = blcfg_convert_key(std::string(key), std::string(BLCONFIG_LFS_NAMESPACE));
+
+    blconfig_lfs->cfg->lock(blconfig_lfs->cfg);
+
+    ret = lfs_file_open(blconfig_lfs, &file, const_cast<char*>(write_key.c_str()), LFS_O_CREAT | LFS_O_RDWR);
+    VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+
+    lfs_file_write(blconfig_lfs, &file, val, size);
+    lfs_file_close(blconfig_lfs, &file);
+
+exit: 
+    blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);
+
+    return err;
+}
+
+CHIP_ERROR BLConfig::WriteConfigValue(const char * key, bool val)
+{
+    return WriteConfigValue(key, (uint8_t *) &val, sizeof(val));
+}
+
+CHIP_ERROR BLConfig::WriteConfigValue(const char * key, uint32_t val)
+{
+    return WriteConfigValue(key, (uint8_t *) &val, sizeof(val));
+}
+
+CHIP_ERROR BLConfig::WriteConfigValue(const char * key, uint64_t val)
+{
+    return WriteConfigValue(key, (uint8_t *) &val, sizeof(val));
+}
+
+CHIP_ERROR BLConfig::WriteConfigValueStr(const char * key, const char * str)
+{
+    return WriteConfigValue(key, (uint8_t *) str, strlen(str) + 1);
+}
+
+CHIP_ERROR BLConfig::WriteConfigValueStr(const char * key, const char * str, size_t strLen)
+{
+    return WriteConfigValue(key, (uint8_t *) str, strLen);
+}
+
+CHIP_ERROR BLConfig::WriteConfigValueBin(const char * key, const uint8_t * data, size_t dataLen)
+{
+    return WriteConfigValue(key, (uint8_t *) data, dataLen);
+}
+
+CHIP_ERROR BLConfig::ClearConfigValue(const char * key)
+{
+    std::string  delete_key = blcfg_convert_key(std::string(key), std::string(BLCONFIG_LFS_NAMESPACE));
+
+    int ret = lfs_remove(blconfig_lfs, const_cast<char*>(delete_key.c_str()));
+
+    return (ret >= LFS_ERR_OK || ret == LFS_ERR_NOENT) ? CHIP_NO_ERROR: CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+}
+
+CHIP_ERROR BLConfig::FactoryResetConfig(void)
+{
+    int          ret = LFS_ERR_OK;
+    lfs_file_t   file;
+    std::string  reset_key = blcfg_convert_key(std::string(kBLKey_factoryResetFlag));
+    const char   reset_key_value[] = "pending";
+
+    blconfig_lfs->cfg->lock(blconfig_lfs->cfg);
+
+    ret = lfs_file_open(blconfig_lfs, &file, const_cast<char*>(reset_key.c_str()), LFS_O_CREAT | LFS_O_RDWR);
+    if (ret != LFS_ERR_OK) {
+        blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);
+        return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+    }
+
+    lfs_file_write(blconfig_lfs, &file, reset_key_value, sizeof(reset_key_value));
+    lfs_file_close(blconfig_lfs, &file);
+
+    blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);
+
+    return blcfg_do_factory_reset();
+}
+
+void BLConfig::RunConfigUnitTest() {}
+
+bool BLConfig::ConfigValueExists(const char * key)
+{
+    std::string     exist_key = blcfg_convert_key(std::string(key), std::string(BLCONFIG_LFS_NAMESPACE));
+    struct lfs_info stat;
+
+    return lfs_stat(blconfig_lfs, const_cast<char*>(exist_key.c_str()), &stat) == LFS_ERR_OK;
+}
+
+CHIP_ERROR BLConfig::ReadKVS(const char * key, void * value, size_t value_size, size_t * read_bytes_size, size_t offset_bytes)
+{
+    CHIP_ERROR   err = CHIP_NO_ERROR;
+    int          ret = LFS_ERR_OK;
+    lfs_file_t   file;
+    std::string  read_key = blcfg_convert_key(std::string(key), std::string(BLCONFIG_LFS_NAMESPACE));
+
+    if (read_bytes_size) {
+        * read_bytes_size = 0;
+    }
+
+    blconfig_lfs->cfg->lock(blconfig_lfs->cfg);
+
+    ret = lfs_file_open(blconfig_lfs, &file, const_cast<char*>(read_key.c_str()), LFS_O_RDONLY);
+    VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+
+    if (value && value_size) {
+        do {
+            ret = 0;
+            if (offset_bytes > 0 && lfs_file_seek(blconfig_lfs, &file, offset_bytes, 0) < 0) {
+                err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+                break;
+            }
+            ret = lfs_file_read(blconfig_lfs, &file, value, value_size);
+            if (ret > 0) {
+                * read_bytes_size = ret;
+            }
+        } while (0);
+    }
+
+    lfs_file_close(blconfig_lfs, &file);
+exit:
+    blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);
+
+    return err;
+}
+
+CHIP_ERROR BLConfig::WriteKVS(const char * key, const void * value, size_t value_size)
+{
+    return WriteConfigValueBin(key, (const uint8_t *)value, value_size);
+}
+
+CHIP_ERROR BLConfig::ClearKVS(const char * key)
+{
+    return ClearConfigValue(key);
+}
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
+++ b/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
@@ -20,9 +20,8 @@ extern "C" {
 #include <lfs_port.h>
 }
 
-#include <platform/bouffalolab/common/BLConfig.h>
-
 #include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <platform/bouffalolab/common/BLConfig.h>
 
 #ifndef BLCONFIG_LFS_NAMESPACE
 #define BLCONFIG_LFS_NAMESPACE "/_blcfg_"

--- a/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
+++ b/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
@@ -20,8 +20,9 @@ extern "C" {
 #include <lfs_port.h>
 }
 
-#include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/bouffalolab/common/BLConfig.h>
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #ifndef BLCONFIG_LFS_NAMESPACE
 #define BLCONFIG_LFS_NAMESPACE "/_blcfg_"

--- a/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
+++ b/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
@@ -20,8 +20,8 @@ extern "C" {
 #include <lfs_port.h>
 }
 
-#include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/bouffalolab/common/BLConfig.h>
+#include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #ifndef BLCONFIG_LFS_NAMESPACE
 #define BLCONFIG_LFS_NAMESPACE "/_blcfg_"
@@ -35,31 +35,36 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-static lfs_t      * blconfig_lfs = nullptr;
+static lfs_t * blconfig_lfs = nullptr;
 
-static inline char *  blcfg_convert_key(const char *pKey, const char *pNameSpace = NULL) 
+static inline char * blcfg_convert_key(const char * pKey, const char * pNameSpace = NULL)
 {
     int len_key = 0, len_namespace = 0;
-    
-    if (pNameSpace) {
+
+    if (pNameSpace)
+    {
         len_namespace = strlen(pNameSpace);
     }
     len_key = strlen(pKey);
 
-    char * pName = (char *)malloc(len_namespace + 1 + len_key + 1);
-    if (nullptr == pName) {
+    char * pName = (char *) malloc(len_namespace + 1 + len_key + 1);
+    if (nullptr == pName)
+    {
         return nullptr;
     }
 
-    if (pNameSpace) {
+    if (pNameSpace)
+    {
         memcpy(pName, pNameSpace, len_namespace);
     }
     pName[len_namespace] = '/';
     memcpy(pName + len_namespace + 1, pKey, len_key);
     pName[len_namespace + 1 + len_key] = '\0';
 
-    for (int i = len_namespace + 1; i < len_namespace + 1 + len_key; i ++) {
-        if (pName[i] == '/') {
+    for (int i = len_namespace + 1; i < len_namespace + 1 + len_key; i++)
+    {
+        if (pName[i] == '/')
+        {
             pName[i] = '_';
         }
     }
@@ -67,14 +72,14 @@ static inline char *  blcfg_convert_key(const char *pKey, const char *pNameSpace
     return pName;
 }
 
-static CHIP_ERROR blcfg_do_factory_reset(void) 
+static CHIP_ERROR blcfg_do_factory_reset(void)
 {
-    CHIP_ERROR      err = CHIP_NO_ERROR;
-    int             ret;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    int ret;
     struct lfs_info stat;
-    lfs_file_t      file;
-    lfs_dir_t       dir = {};
-    char            * factory_reset_key = blcfg_convert_key(BLConfig::kBLKey_factoryResetFlag);
+    lfs_file_t file;
+    lfs_dir_t dir            = {};
+    char * factory_reset_key = blcfg_convert_key(BLConfig::kBLKey_factoryResetFlag);
 
     VerifyOrExit(factory_reset_key != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
@@ -82,10 +87,12 @@ static CHIP_ERROR blcfg_do_factory_reset(void)
 
     ret = lfs_stat(blconfig_lfs, factory_reset_key, &stat);
 
-    if (LFS_ERR_OK == ret) {
+    if (LFS_ERR_OK == ret)
+    {
         err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
 
-        do {
+        do
+        {
             ret = lfs_file_open(blconfig_lfs, &file, factory_reset_key, LFS_O_RDONLY);
             VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
             lfs_file_close(blconfig_lfs, &file);
@@ -93,22 +100,26 @@ static CHIP_ERROR blcfg_do_factory_reset(void)
             ret = lfs_dir_open(blconfig_lfs, &dir, BLCONFIG_LFS_NAMESPACE);
             VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
 
-            while (1) {
+            while (1)
+            {
                 ret = lfs_dir_read(blconfig_lfs, &dir, &stat);
-                if (ret <= 0) {
+                if (ret <= 0)
+                {
                     break;
                 }
 
-                if (stat.type != LFS_TYPE_REG) {
+                if (stat.type != LFS_TYPE_REG)
+                {
                     continue;
                 }
                 char * delete_key = blcfg_convert_key(stat.name, BLCONFIG_LFS_NAMESPACE);
                 VerifyOrExit(delete_key != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
-                ret = lfs_remove(blconfig_lfs, delete_key); 
+                ret = lfs_remove(blconfig_lfs, delete_key);
                 free(delete_key);
 
-                if (ret != LFS_ERR_OK) {
+                if (ret != LFS_ERR_OK)
+                {
                     break;
                 }
             }
@@ -116,17 +127,19 @@ static CHIP_ERROR blcfg_do_factory_reset(void)
             lfs_dir_close(blconfig_lfs, &dir);
 
             ret = lfs_remove(blconfig_lfs, factory_reset_key);
-            if (ret != LFS_ERR_OK) {
+            if (ret != LFS_ERR_OK)
+            {
                 break;
             }
 
             err = CHIP_NO_ERROR;
-        } while(0);
+        } while (0);
     }
 
-exit: 
+exit:
     blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);
-    if (factory_reset_key) {
+    if (factory_reset_key)
+    {
         free(factory_reset_key);
     }
 
@@ -135,16 +148,17 @@ exit:
 
 void BLConfig::Init(void)
 {
-    CHIP_ERROR      err = CHIP_NO_ERROR;
-    int             ret;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    int ret;
     struct lfs_info stat;
-    
+
     blconfig_lfs = lfs_xip_init();
     VerifyOrExit(blconfig_lfs != NULL, err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
 
     /* init namespace */
     ret = lfs_stat(blconfig_lfs, BLCONFIG_LFS_NAMESPACE, &stat);
-    if (ret != LFS_ERR_OK) {
+    if (ret != LFS_ERR_OK)
+    {
         ret = lfs_mkdir(blconfig_lfs, BLCONFIG_LFS_NAMESPACE);
         VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
 
@@ -159,10 +173,10 @@ exit:
 
 CHIP_ERROR BLConfig::ReadConfigValue(const char * key, uint8_t * val, size_t size, size_t & readsize)
 {
-    CHIP_ERROR   err = CHIP_NO_ERROR;
-    int          ret = LFS_ERR_OK;
-    lfs_file_t   file;
-    char         * read_key = blcfg_convert_key(key, BLCONFIG_LFS_NAMESPACE);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    int ret        = LFS_ERR_OK;
+    lfs_file_t file;
+    char * read_key = blcfg_convert_key(key, BLCONFIG_LFS_NAMESPACE);
 
     VerifyOrExit(read_key != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
@@ -171,15 +185,17 @@ CHIP_ERROR BLConfig::ReadConfigValue(const char * key, uint8_t * val, size_t siz
     ret = lfs_file_open(blconfig_lfs, &file, read_key, LFS_O_RDONLY);
     VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
-    if (val && size) {
-        ret = lfs_file_read(blconfig_lfs, &file, val, size);
+    if (val && size)
+    {
+        ret      = lfs_file_read(blconfig_lfs, &file, val, size);
         readsize = ret;
     }
     lfs_file_close(blconfig_lfs, &file);
 
 exit:
     blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);
-    if (read_key) {
+    if (read_key)
+    {
         free(read_key);
     }
 
@@ -235,10 +251,10 @@ CHIP_ERROR BLConfig::ReadConfigValueBin(const char * key, uint8_t * buf, size_t 
 
 CHIP_ERROR BLConfig::WriteConfigValue(const char * key, uint8_t * val, size_t size)
 {
-    int          ret = LFS_ERR_OK;
-    CHIP_ERROR   err = CHIP_NO_ERROR;
-    lfs_file_t   file;
-    char         * write_key = blcfg_convert_key(key, BLCONFIG_LFS_NAMESPACE);
+    int ret        = LFS_ERR_OK;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    lfs_file_t file;
+    char * write_key = blcfg_convert_key(key, BLCONFIG_LFS_NAMESPACE);
 
     VerifyOrExit(write_key != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
@@ -250,9 +266,10 @@ CHIP_ERROR BLConfig::WriteConfigValue(const char * key, uint8_t * val, size_t si
     lfs_file_write(blconfig_lfs, &file, val, size);
     lfs_file_close(blconfig_lfs, &file);
 
-exit: 
+exit:
     blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);
-    if (write_key) {
+    if (write_key)
+    {
         free(write_key);
     }
 
@@ -293,31 +310,34 @@ CHIP_ERROR BLConfig::ClearConfigValue(const char * key)
 {
     char * delete_key = blcfg_convert_key(key, BLCONFIG_LFS_NAMESPACE);
 
-    if (delete_key == nullptr) {
+    if (delete_key == nullptr)
+    {
         return CHIP_ERROR_NO_MEMORY;
     }
 
     int ret = lfs_remove(blconfig_lfs, delete_key);
     free(delete_key);
 
-    return (ret >= LFS_ERR_OK || ret == LFS_ERR_NOENT) ? CHIP_NO_ERROR: CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+    return (ret >= LFS_ERR_OK || ret == LFS_ERR_NOENT) ? CHIP_NO_ERROR : CHIP_ERROR_PERSISTED_STORAGE_FAILED;
 }
 
 CHIP_ERROR BLConfig::FactoryResetConfig(void)
 {
-    int          ret = LFS_ERR_OK;
-    lfs_file_t   file;
-    char         * reset_key = blcfg_convert_key(kBLKey_factoryResetFlag);
-    const char   reset_key_value[] = "pending";
+    int ret = LFS_ERR_OK;
+    lfs_file_t file;
+    char * reset_key             = blcfg_convert_key(kBLKey_factoryResetFlag);
+    const char reset_key_value[] = "pending";
 
-    if (nullptr == reset_key) {
+    if (nullptr == reset_key)
+    {
         return CHIP_ERROR_NO_MEMORY;
     }
 
     blconfig_lfs->cfg->lock(blconfig_lfs->cfg);
 
     ret = lfs_file_open(blconfig_lfs, &file, reset_key, LFS_O_CREAT | LFS_O_RDWR);
-    if (ret != LFS_ERR_OK) {
+    if (ret != LFS_ERR_OK)
+    {
         blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);
         return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     }
@@ -335,9 +355,9 @@ void BLConfig::RunConfigUnitTest() {}
 
 bool BLConfig::ConfigValueExists(const char * key)
 {
-    char            * exist_key = blcfg_convert_key(key, BLCONFIG_LFS_NAMESPACE);
+    char * exist_key = blcfg_convert_key(key, BLCONFIG_LFS_NAMESPACE);
     struct lfs_info stat;
-    bool            bret;
+    bool bret;
 
     bret = (lfs_stat(blconfig_lfs, exist_key, &stat) == LFS_ERR_OK);
     free(exist_key);
@@ -347,15 +367,16 @@ bool BLConfig::ConfigValueExists(const char * key)
 
 CHIP_ERROR BLConfig::ReadKVS(const char * key, void * value, size_t value_size, size_t * read_bytes_size, size_t offset_bytes)
 {
-    CHIP_ERROR   err = CHIP_NO_ERROR;
-    int          ret = LFS_ERR_OK;
-    lfs_file_t   file;
-    char         * read_key = blcfg_convert_key(key, BLCONFIG_LFS_NAMESPACE);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    int ret        = LFS_ERR_OK;
+    lfs_file_t file;
+    char * read_key = blcfg_convert_key(key, BLCONFIG_LFS_NAMESPACE);
 
     VerifyOrExit(read_key != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
-    if (read_bytes_size) {
-        * read_bytes_size = 0;
+    if (read_bytes_size)
+    {
+        *read_bytes_size = 0;
     }
 
     blconfig_lfs->cfg->lock(blconfig_lfs->cfg);
@@ -363,16 +384,20 @@ CHIP_ERROR BLConfig::ReadKVS(const char * key, void * value, size_t value_size, 
     ret = lfs_file_open(blconfig_lfs, &file, read_key, LFS_O_RDONLY);
     VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
-    if (value && value_size) {
-        do {
+    if (value && value_size)
+    {
+        do
+        {
             ret = 0;
-            if (offset_bytes > 0 && lfs_file_seek(blconfig_lfs, &file, offset_bytes, 0) < 0) {
+            if (offset_bytes > 0 && lfs_file_seek(blconfig_lfs, &file, offset_bytes, 0) < 0)
+            {
                 err = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
                 break;
             }
             ret = lfs_file_read(blconfig_lfs, &file, value, value_size);
-            if (ret > 0) {
-                * read_bytes_size = ret;
+            if (ret > 0)
+            {
+                *read_bytes_size = ret;
             }
         } while (0);
     }
@@ -380,7 +405,8 @@ CHIP_ERROR BLConfig::ReadKVS(const char * key, void * value, size_t value_size, 
     lfs_file_close(blconfig_lfs, &file);
 exit:
     blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);
-    if (read_key) {
+    if (read_key)
+    {
         free(read_key);
     }
 
@@ -389,7 +415,7 @@ exit:
 
 CHIP_ERROR BLConfig::WriteKVS(const char * key, const void * value, size_t value_size)
 {
-    return WriteConfigValueBin(key, (const uint8_t *)value, value_size);
+    return WriteConfigValueBin(key, (const uint8_t *) value, value_size);
 }
 
 CHIP_ERROR BLConfig::ClearKVS(const char * key)

--- a/third_party/bouffalolab/bl602/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl602/bl_iot_sdk.gni
@@ -361,11 +361,11 @@ template("bl_iot_sdk") {
     if (defined(invoker.bouffalo_sdk_component_easyflash_enabled) &&
         invoker.bouffalo_sdk_component_easyflash_enabled) {
       include_dirs += [ "${bl_iot_sdk_root}/components/stage/easyflash4/inc" ]
-    }
-    else {
+    } else {
       defines = [ "LFS_THREADSAFE" ]
 
-      include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/littlefs" ]
+      include_dirs +=
+          [ "${bl_iot_sdk_root}/components/stage/littlefs/littlefs" ]
       include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/port" ]
     }
   }
@@ -412,16 +412,15 @@ template("bl_iot_sdk") {
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_port.c",
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_utils.c",
       ]
-    }
-    else {
+    } else {
       defines += [
         "CONFIG_LITTLEFS",
         "CONFIG_FREERTOS",
       ]
 
       sources += [
-        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs_util.c",
         "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs.c",
+        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs_util.c",
         "${bl_iot_sdk_root}/components/stage/littlefs/port/lfs_xip_flash.c",
       ]
       configs += [ ":${sdk_target_name}_config_hosal" ]

--- a/third_party/bouffalolab/bl602/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl602/bl_iot_sdk.gni
@@ -362,6 +362,12 @@ template("bl_iot_sdk") {
         invoker.bouffalo_sdk_component_easyflash_enabled) {
       include_dirs += [ "${bl_iot_sdk_root}/components/stage/easyflash4/inc" ]
     }
+    else {
+      defines = [ "LFS_THREADSAFE" ]
+
+      include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/littlefs" ]
+      include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/port" ]
+    }
   }
 
   source_set("${sdk_target_name}_stage") {
@@ -406,6 +412,19 @@ template("bl_iot_sdk") {
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_port.c",
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_utils.c",
       ]
+    }
+    else {
+      defines += [
+        "CONFIG_LITTLEFS",
+        "CONFIG_FREERTOS",
+      ]
+
+      sources += [
+        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs_util.c",
+        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs.c",
+        "${bl_iot_sdk_root}/components/stage/littlefs/port/lfs_xip_flash.c",
+      ]
+      configs += [ ":${sdk_target_name}_config_hosal" ]
     }
 
     public_configs = [ ":${sdk_target_name}_config_stage" ]

--- a/third_party/bouffalolab/bl702/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702/bl_iot_sdk.gni
@@ -406,6 +406,12 @@ template("bl_iot_sdk") {
         invoker.bouffalo_sdk_component_easyflash_enabled) {
       include_dirs += [ "${bl_iot_sdk_root}/components/stage/easyflash4/inc" ]
     }
+    else {
+      defines = [ "LFS_THREADSAFE" ]
+
+      include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/littlefs" ]
+      include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/port" ]
+    }
 
     if (defined(invoker.enable_cdc_module) && invoker.enable_cdc_module) {
       cflags_cc = [ "-Wno-shadow" ]
@@ -453,6 +459,19 @@ template("bl_iot_sdk") {
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_port.c",
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_utils.c",
       ]
+    }
+    else {
+      defines += [
+        "CONFIG_LITTLEFS",
+        "CONFIG_FREERTOS",
+      ]
+
+      sources += [
+        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs_util.c",
+        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs.c",
+        "${bl_iot_sdk_root}/components/stage/littlefs/port/lfs_xip_flash.c",
+      ]
+      configs += [ ":${sdk_target_name}_config_hosal" ]
     }
 
     public_configs = [ ":${sdk_target_name}_config_stage" ]
@@ -760,6 +779,9 @@ template("bl_iot_sdk") {
     if (defined(invoker.bouffalo_sdk_component_easyflash_enabled) &&
         invoker.bouffalo_sdk_component_easyflash_enabled) {
       sources += [ "${bl_iot_sdk_root}/components/network/thread/openthread_port/ot_settings_easyflash.c" ]
+    }
+    else {
+      sources += [ "${bl_iot_sdk_root}/components/network/thread/openthread_port/ot_settings_littlefs.c" ]
     }
 
     libs = [

--- a/third_party/bouffalolab/bl702/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702/bl_iot_sdk.gni
@@ -405,11 +405,11 @@ template("bl_iot_sdk") {
     if (defined(invoker.bouffalo_sdk_component_easyflash_enabled) &&
         invoker.bouffalo_sdk_component_easyflash_enabled) {
       include_dirs += [ "${bl_iot_sdk_root}/components/stage/easyflash4/inc" ]
-    }
-    else {
+    } else {
       defines = [ "LFS_THREADSAFE" ]
 
-      include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/littlefs" ]
+      include_dirs +=
+          [ "${bl_iot_sdk_root}/components/stage/littlefs/littlefs" ]
       include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/port" ]
     }
 
@@ -459,16 +459,15 @@ template("bl_iot_sdk") {
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_port.c",
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_utils.c",
       ]
-    }
-    else {
+    } else {
       defines += [
         "CONFIG_LITTLEFS",
         "CONFIG_FREERTOS",
       ]
 
       sources += [
-        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs_util.c",
         "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs.c",
+        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs_util.c",
         "${bl_iot_sdk_root}/components/stage/littlefs/port/lfs_xip_flash.c",
       ]
       configs += [ ":${sdk_target_name}_config_hosal" ]
@@ -779,8 +778,7 @@ template("bl_iot_sdk") {
     if (defined(invoker.bouffalo_sdk_component_easyflash_enabled) &&
         invoker.bouffalo_sdk_component_easyflash_enabled) {
       sources += [ "${bl_iot_sdk_root}/components/network/thread/openthread_port/ot_settings_easyflash.c" ]
-    }
-    else {
+    } else {
       sources += [ "${bl_iot_sdk_root}/components/network/thread/openthread_port/ot_settings_littlefs.c" ]
     }
 

--- a/third_party/bouffalolab/bl702l/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702l/bl_iot_sdk.gni
@@ -369,6 +369,12 @@ template("bl_iot_sdk") {
         invoker.bouffalo_sdk_component_easyflash_enabled) {
       include_dirs += [ "${bl_iot_sdk_root}/components/stage/easyflash4/inc" ]
     }
+    else {
+      defines = [ "LFS_THREADSAFE" ]
+
+      include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/littlefs" ]
+      include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/port" ]
+    }
   }
 
   source_set("${sdk_target_name}_stage") {
@@ -412,6 +418,19 @@ template("bl_iot_sdk") {
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_port.c",
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_utils.c",
       ]
+    }
+    else {
+      defines += [
+        "CONFIG_LITTLEFS",
+        "CONFIG_FREERTOS",
+      ]
+
+      sources += [
+        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs_util.c",
+        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs.c",
+        "${bl_iot_sdk_root}/components/stage/littlefs/port/lfs_xip_flash.c",
+      ]
+      configs += [ ":${sdk_target_name}_config_hosal" ]
     }
 
     public_configs = [ ":${sdk_target_name}_config_stage" ]
@@ -706,6 +725,9 @@ template("bl_iot_sdk") {
     if (defined(invoker.bouffalo_sdk_component_easyflash_enabled) &&
         invoker.bouffalo_sdk_component_easyflash_enabled) {
       sources += [ "${bl_iot_sdk_root}/components/network/thread/openthread_port/ot_settings_easyflash.c" ]
+    }
+    else {
+      sources += [ "${bl_iot_sdk_root}/components/network/thread/openthread_port/ot_settings_littlefs.c" ]
     }
 
     libs = [

--- a/third_party/bouffalolab/bl702l/bl_iot_sdk.gni
+++ b/third_party/bouffalolab/bl702l/bl_iot_sdk.gni
@@ -368,11 +368,11 @@ template("bl_iot_sdk") {
     if (defined(invoker.bouffalo_sdk_component_easyflash_enabled) &&
         invoker.bouffalo_sdk_component_easyflash_enabled) {
       include_dirs += [ "${bl_iot_sdk_root}/components/stage/easyflash4/inc" ]
-    }
-    else {
+    } else {
       defines = [ "LFS_THREADSAFE" ]
 
-      include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/littlefs" ]
+      include_dirs +=
+          [ "${bl_iot_sdk_root}/components/stage/littlefs/littlefs" ]
       include_dirs += [ "${bl_iot_sdk_root}/components/stage/littlefs/port" ]
     }
   }
@@ -418,16 +418,15 @@ template("bl_iot_sdk") {
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_port.c",
         "${bl_iot_sdk_root}/components/stage/easyflash4/src/ef_utils.c",
       ]
-    }
-    else {
+    } else {
       defines += [
         "CONFIG_LITTLEFS",
         "CONFIG_FREERTOS",
       ]
 
       sources += [
-        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs_util.c",
         "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs.c",
+        "${bl_iot_sdk_root}/components/stage/littlefs/littlefs/lfs_util.c",
         "${bl_iot_sdk_root}/components/stage/littlefs/port/lfs_xip_flash.c",
       ]
       configs += [ ":${sdk_target_name}_config_hosal" ]
@@ -725,8 +724,7 @@ template("bl_iot_sdk") {
     if (defined(invoker.bouffalo_sdk_component_easyflash_enabled) &&
         invoker.bouffalo_sdk_component_easyflash_enabled) {
       sources += [ "${bl_iot_sdk_root}/components/network/thread/openthread_port/ot_settings_easyflash.c" ]
-    }
-    else {
+    } else {
       sources += [ "${bl_iot_sdk_root}/components/network/thread/openthread_port/ot_settings_littlefs.c" ]
     }
 


### PR DESCRIPTION

Add littlefs support to accelerate speed of flash stoarge access. 
- `-easyflash`, current implemenatation uses easyflash for flash access which has different flash layout with littlefs, customer should use `-easyflash` compile option to use easyflash
- `-littlefs`, customer should use `-littlefs` to use littlefs for flash access.
 

