### PR TITLE
Address followup issues for preset/atomic-write implementation.

### DIFF
--- a/src/app/GlobalAttributes.h
+++ b/src/app/GlobalAttributes.h
@@ -40,5 +40,18 @@ constexpr AttributeId GlobalAttributesNotInMetadata[] = {
 
 static_assert(ArrayIsSorted(GlobalAttributesNotInMetadata), "Array of global attribute ids must be sorted");
 
+inline bool IsSupportedGlobalAttributeNotInMetadata(AttributeId attributeId)
+{
+    for (auto & attr : GlobalAttributesNotInMetadata)
+    {
+        if (attr == attributeId)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 } // namespace app
 } // namespace chip


### PR DESCRIPTION
* Puts some file-local functions in an anonymous namespace.
* Fixes the "is this attribute supported?" check to correctly check for global attributes that are not in Ember metadata.
* Moves the comment explaining why it's OK to skip the spec-required ACL check to the place where that check is being skipped.
* Removes a non-spec-compliant "error if the timeout is 0" bit.

Fixes https://github.com/project-chip/connectedhomeip/issues/35168
