### PR TITLE
[NXP][Zephyr] Provide AP band in connection request parameters

### DIFF
--- a/src/platform/Zephyr/wifi/WiFiManager.cpp
+++ b/src/platform/Zephyr/wifi/WiFiManager.cpp
@@ -347,7 +347,8 @@ void WiFiManager::ScanResultHandler(Platform::UniquePtr<uint8_t> data)
             Instance().mWiFiParams.mParams.security =
                 scanResult->security <= WIFI_SECURITY_TYPE_MAX ? scanResult->security : WIFI_SECURITY_TYPE_PSK;
             Instance().mWiFiParams.mParams.psk_length = static_cast<uint8_t>(Instance().mWantedNetwork.passLen);
-            Instance().mWiFiParams.mParams.mfp = (scanResult->mfp == WIFI_MFP_REQUIRED) ? WIFI_MFP_REQUIRED : WIFI_MFP_OPTIONAL;
+            Instance().mWiFiParams.mParams.mfp        = scanResult->mfp;
+            Instance().mWiFiParams.mParams.band       = scanResult->band;
 
             // If the security is none, WiFi driver expects the psk to be nullptr
             if (Instance().mWiFiParams.mParams.security == WIFI_SECURITY_TYPE_NONE)


### PR DESCRIPTION
Some wifi drivers may need the AP band information in the connection request parameters (this is our case), but currently this field is ignored.
This fix aims to fix this by getting the band info from the scan result and adding it to the connection parameters.

