### PR TITLE
Updated DoorLock Python scripts and DRLK_2_1 yaml.

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_1.yaml
@@ -35,104 +35,6 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "Precondition: Create new user"
-      PICS: DRLK.S.F00 && DRLK.S.F07
-      command: "SetUser"
-      timedInteractionTimeoutMs: 1000
-      arguments:
-          values:
-              - name: "OperationType"
-                value: 0
-              - name: "UserIndex"
-                value: 1
-              - name: "UserName"
-                value: "xxx"
-              - name: "UserUniqueID"
-                value: 6452
-              - name: "UserStatus"
-                value: 1
-              - name: "UserType"
-                value: 0
-              - name: "CredentialRule"
-                value: 0
-
-    - label: "Precondition: Read the user back and verify its fields"
-      PICS: DRLK.S.F00 && DRLK.S.F07
-      command: "GetUser"
-      arguments:
-          values:
-              - name: "UserIndex"
-                value: 1
-      response:
-          values:
-              - name: "UserIndex"
-                value: 1
-              - name: "UserName"
-                value: "xxx"
-              - name: "UserUniqueID"
-                value: 6452
-              - name: "UserStatus"
-                value: 1
-              - name: "UserType"
-                value: 0
-              - name: "CredentialRule"
-                value: 0
-              - name: "Credentials"
-                value: []
-              - name: "CreatorFabricIndex"
-                value: 1
-              - name: "LastModifiedFabricIndex"
-                value: 1
-              - name: "NextUserIndex"
-                value: null
-
-    - label: "Precondition: Create new PIN credential and lock/unlock user"
-      PICS: DRLK.S.F00 && DRLK.S.F07
-      command: "SetCredential"
-      timedInteractionTimeoutMs: 1000
-      arguments:
-          values:
-              - name: "OperationType"
-                value: 0
-              - name: "Credential"
-                value: { CredentialType: 1, CredentialIndex: 1 }
-              - name: "CredentialData"
-                value: "123456"
-              - name: "UserIndex"
-                value: 1
-              - name: "UserStatus"
-                value: null
-              - name: "UserType"
-                value: null
-      response:
-          values:
-              - name: "Status"
-                value: 0
-              - name: "UserIndex"
-                value: null
-              - name: "NextCredentialIndex"
-                value: 2
-
-    - label: "Precondition: Verify created PIN credential"
-      PICS: DRLK.S.F00 && DRLK.S.F07
-      command: "GetCredentialStatus"
-      arguments:
-          values:
-              - name: "Credential"
-                value: { CredentialType: 1, CredentialIndex: 1 }
-      response:
-          values:
-              - name: "CredentialExists"
-                value: true
-              - name: "UserIndex"
-                value: 1
-              - name: "CreatorFabricIndex"
-                value: 1
-              - name: "LastModifiedFabricIndex"
-                value: 1
-              - name: "NextCredentialIndex"
-                value: null
-
     - label: "Step 1a: TH reads LockState attribute from DUT"
       PICS: DRLK.S.A0000
       command: "readAttribute"
@@ -160,8 +62,70 @@ tests:
       response:
           value: LockStateValue
 
+    - label: "Step 1d: TH sends SetUser Command to DUT"
+      PICS: DRLK.S.F08 && DRLK.S.C1a.Rsp
+      command: "SetUser"
+      timedInteractionTimeoutMs: 1000
+      arguments:
+          values:
+            - name: "OperationType"
+              value: 0
+            - name: "UserIndex"
+              value: 1
+            - name: "UserName"
+              value: "xxx"
+            - name: "UserUniqueID"
+              value: 6452
+            - name: "UserStatus"
+              value: 1
+            - name: "UserType"
+              value: 0
+            - name: "CredentialRule"
+              value: 0
+
+    - label: "Step 1e: TH reads MinPINCodeLength attribute and saves the value as min_pin_code_length"
+      PICS: DRLK.S.F08 && DRLK.S.F00
+      command: "readAttribute"
+      attribute: "MinPINCodeLength"
+      response:
+        saveAs: min_pin_code_length
+        constraints:
+          type: int8u
+          minValue: 0
+          maxValue: 255
+
+    - label: "Step 1f: TH reads MaxPINCodeLength attribute and saves the value as max_pin_code_length"
+      PICS: DRLK.S.F08 && DRLK.S.F00
+      command: "readAttribute"
+      attribute: "MaxPINCodeLength"
+      response:
+        saveAs: max_pin_code_length
+        constraints:
+          type: int8u
+          minValue: 0
+          maxValue: 255
+
+    - label: "Step 1g: TH sends SetCredential Command"
+      PICS: DRLK.S.F00 && DRLK.S.F08 && DRLK.S.C22.Rsp && DRLK.S.C23.Tx
+      command: "SetCredential"
+      timedInteractionTimeoutMs: 1000
+      arguments:
+        values:
+          - name: "OperationType"
+            value: 0
+          - name: "Credential"
+            value: { CredentialType: 1, CredentialIndex: 1 }
+          - name: "CredentialData"
+            value: "123456"
+          - name: "UserIndex"
+            value: 1
+          - name: "UserStatus"
+            value: null
+          - name: "UserType"
+            value: null
+
     - label:
-          "Step 1d: TH sends a Lock Door command to the DUT. If DRLK.S.F00(PIN)
+          "Step 1h: TH sends a Lock Door command to the DUT. If DRLK.S.F00(PIN)
           & DRLK.S.F07(COTA), include a Valid PINCode in the Lock Door command."
       PICS: DRLK.S.C00.Rsp && DRLK.S.F00 && DRLK.S.F07 && DRLK.S.A0000
       command: "LockDoor"
@@ -171,7 +135,7 @@ tests:
               - name: "PINCode"
                 value: "123456"
 
-    - label: "Step 1d: TH sends a Lock Door command to the DUT."
+    - label: "Step 1h: TH sends a Lock Door command to the DUT without pin_code."
       PICS: DRLK.S.C00.Rsp && !DRLK.S.F00 && !DRLK.S.F07 && DRLK.S.A0000
       command: "LockDoor"
       timedInteractionTimeoutMs: 1000
@@ -182,25 +146,17 @@ tests:
       command: "WaitForMs"
       arguments:
           values:
-              - name: "ms"
-                value: WaitAfterLockAandUnlockDoor
-
-    - label: "Step 1d: TH reads LockState attribute from DUT"
+            - name: "ms"
+              value: WaitAfterLockAandUnlockDoor
+    - label: "Step 1h: TH reads LockState attribute from DUT"
       PICS: DRLK.S.A0000
       command: "readAttribute"
       attribute: "LockState"
       response:
           value: 1
-
-    - label:
-          "Step 1e: TH sends a Unlock Door command to the DUT. If
+    - label: "Step 1i: TH sends a Unlock Door command to the DUT. If
           DRLK.S.F00(PIN) & DRLK.S.F07(COTA), include a Valid PINCode in the
           Unlock Door command"
-      PICS: DRLK.S.C01.Rsp && !DRLK.S.F00 && !DRLK.S.F07 && DRLK.S.A0000
-      command: "UnlockDoor"
-      timedInteractionTimeoutMs: 1000
-
-    - label: "Step 1e: TH sends a Unlock Door command to the DUT."
       PICS: DRLK.S.C01.Rsp && DRLK.S.F00 && DRLK.S.F07 && DRLK.S.A0000
       command: "UnlockDoor"
       timedInteractionTimeoutMs: 1000
@@ -208,7 +164,12 @@ tests:
           values:
               - name: "PINCode"
                 value: "123456"
-
+    
+    - label: "Step 1i: TH sends a Unlock Door command to the DUT without pincode."
+      PICS: DRLK.S.C01.Rsp && !DRLK.S.F00 && !DRLK.S.F07 && DRLK.S.A0000
+      command: "UnlockDoor"
+      timedInteractionTimeoutMs: 1000
+      
     - label: "Wait after Unlock Door"
       PICS: DRLK.S.C00.Rsp
       cluster: "DelayCommands"
@@ -218,14 +179,14 @@ tests:
               - name: "ms"
                 value: WaitAfterLockAandUnlockDoor
 
-    - label: "Step 1e: TH reads LockState attribute from DUT"
+    - label: "Step 1i: TH reads LockState attribute from DUT"
       PICS: DRLK.S.A0000
       command: "readAttribute"
       attribute: "LockState"
       response:
           value: 2
 
-    - label: "Step 1f: Simulate a not fully locked scenario on the DUT."
+    - label: "Step 1j: Simulate a not fully locked scenario on the DUT."
       PICS:
           DRLK.S.A0000 && DRLK.S.M.SimulateNotFullyLocked &&
           PICS_SKIP_SAMPLE_APP
@@ -1366,6 +1327,26 @@ tests:
       response:
           value: Current_WrongCode_EntryLimit
 
+    - label: "Step 31b: TH writes WrongCodeEntryLimit attribute as 8"
+      PICS:
+          " ( DRLK.S.F00 || DRLK.S.F01 ) && DRLK.S.A0030 &&
+          DRLK.S.M.WrongCodeEntryLimitAttributeWritable "
+      command: "writeAttribute"
+      attribute: "WrongCodeEntryLimit"
+      arguments:
+          value: 8
+
+    - label: "Step 31b: TH writes WrongCodeEntryLimit attribute as 8"
+      PICS:
+          " ( DRLK.S.F00 || DRLK.S.F01 ) && DRLK.S.A0030 &&
+          !DRLK.S.M.WrongCodeEntryLimitAttributeWritable "
+      command: "writeAttribute"
+      attribute: "WrongCodeEntryLimit"
+      arguments:
+          value: 8
+      response:
+          error: UNSUPPORTED_WRITE
+
     - label:
           "Step 32a: TH reads UserCodeTemporary DisableTime attribute from DUT
           TH saves the values as Current_UserCode TemporaryDisableTime"
@@ -1552,7 +1533,7 @@ tests:
           value: NumberOfCredentialsSupportedPerUserValue
 
     - label: "Step 36: TH sends ClearCredential Command to DUT"
-      PICS: DRLK.S.F00 && DRLK.S.F07 && DRLK.S.C26.Rsp
+      PICS: DRLK.S.F00 && DRLK.S.F08 && DRLK.S.C26.Rsp
       command: "ClearCredential"
       timedInteractionTimeoutMs: 1000
       arguments:
@@ -1562,7 +1543,7 @@ tests:
 
     - label:
           "Step 37: TH sends ClearUser Command to DUT with the UserIndex as 1"
-      PICS: DRLK.S.F07 && DRLK.S.C1d.Rsp
+      PICS: DRLK.S.F08 && DRLK.S.C1d.Rsp
       command: "ClearUser"
       timedInteractionTimeoutMs: 1000
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_1.yaml
@@ -164,12 +164,12 @@ tests:
           values:
               - name: "PINCode"
                 value: "123456"
-    
+
     - label: "Step 1i: TH sends a Unlock Door command to the DUT without pincode."
       PICS: DRLK.S.C01.Rsp && !DRLK.S.F00 && !DRLK.S.F07 && DRLK.S.A0000
       command: "UnlockDoor"
       timedInteractionTimeoutMs: 1000
-      
+
     - label: "Wait after Unlock Door"
       PICS: DRLK.S.C00.Rsp
       cluster: "DelayCommands"

--- a/src/app/tests/suites/certification/Test_TC_DRLK_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DRLK_2_1.yaml
@@ -68,61 +68,65 @@ tests:
       timedInteractionTimeoutMs: 1000
       arguments:
           values:
-            - name: "OperationType"
-              value: 0
-            - name: "UserIndex"
-              value: 1
-            - name: "UserName"
-              value: "xxx"
-            - name: "UserUniqueID"
-              value: 6452
-            - name: "UserStatus"
-              value: 1
-            - name: "UserType"
-              value: 0
-            - name: "CredentialRule"
-              value: 0
+              - name: "OperationType"
+                value: 0
+              - name: "UserIndex"
+                value: 1
+              - name: "UserName"
+                value: "xxx"
+              - name: "UserUniqueID"
+                value: 6452
+              - name: "UserStatus"
+                value: 1
+              - name: "UserType"
+                value: 0
+              - name: "CredentialRule"
+                value: 0
 
-    - label: "Step 1e: TH reads MinPINCodeLength attribute and saves the value as min_pin_code_length"
+    - label:
+          "Step 1e: TH reads MinPINCodeLength attribute and saves the value as
+          min_pin_code_length"
       PICS: DRLK.S.F08 && DRLK.S.F00
       command: "readAttribute"
       attribute: "MinPINCodeLength"
       response:
-        saveAs: min_pin_code_length
-        constraints:
-          type: int8u
-          minValue: 0
-          maxValue: 255
+          saveAs: min_pin_code_length
+          constraints:
+              type: int8u
+              minValue: 0
+              maxValue: 255
 
-    - label: "Step 1f: TH reads MaxPINCodeLength attribute and saves the value as max_pin_code_length"
+    - label:
+          "Step 1f: TH reads MaxPINCodeLength attribute and saves the value as
+          max_pin_code_length"
       PICS: DRLK.S.F08 && DRLK.S.F00
       command: "readAttribute"
       attribute: "MaxPINCodeLength"
       response:
-        saveAs: max_pin_code_length
-        constraints:
-          type: int8u
-          minValue: 0
-          maxValue: 255
+          saveAs: max_pin_code_length
+          constraints:
+              type: int8u
+              minValue: 0
+              maxValue: 255
 
     - label: "Step 1g: TH sends SetCredential Command"
       PICS: DRLK.S.F00 && DRLK.S.F08 && DRLK.S.C22.Rsp && DRLK.S.C23.Tx
       command: "SetCredential"
       timedInteractionTimeoutMs: 1000
       arguments:
-        values:
-          - name: "OperationType"
-            value: 0
-          - name: "Credential"
-            value: { CredentialType: 1, CredentialIndex: 1 }
-          - name: "CredentialData"
-            value: "123456"
-          - name: "UserIndex"
-            value: 1
-          - name: "UserStatus"
-            value: null
-          - name: "UserType"
-            value: null
+          values:
+              - name: "OperationType"
+                value: 0
+              - name: "Credential"
+                value: { CredentialType: 1, CredentialIndex: 1 }
+              - name: "CredentialData"
+                value: "123456"
+              - name: "UserIndex"
+                value: 1
+              - name: "UserStatus"
+                value: null
+              - name: "UserType"
+                value: null
 
     - label:
           "Step 1h: TH sends a Lock Door command to the DUT. If DRLK.S.F00(PIN)
@@ -135,7 +139,8 @@ tests:
               - name: "PINCode"
                 value: "123456"
 
-    - label: "Step 1h: TH sends a Lock Door command to the DUT without pin_code."
+    - label:
+          "Step 1h: TH sends a Lock Door command to the DUT without pin_code."
       PICS: DRLK.S.C00.Rsp && !DRLK.S.F00 && !DRLK.S.F07 && DRLK.S.A0000
       command: "LockDoor"
       timedInteractionTimeoutMs: 1000
@@ -146,15 +151,16 @@ tests:
       command: "WaitForMs"
       arguments:
           values:
-            - name: "ms"
-              value: WaitAfterLockAandUnlockDoor
+              - name: "ms"
+                value: WaitAfterLockAandUnlockDoor
     - label: "Step 1h: TH reads LockState attribute from DUT"
       PICS: DRLK.S.A0000
       command: "readAttribute"
       attribute: "LockState"
       response:
           value: 1
-    - label: "Step 1i: TH sends a Unlock Door command to the DUT. If
+    - label:
+          "Step 1i: TH sends a Unlock Door command to the DUT. If
           DRLK.S.F00(PIN) & DRLK.S.F07(COTA), include a Valid PINCode in the
           Unlock Door command"
       PICS: DRLK.S.C01.Rsp && DRLK.S.F00 && DRLK.S.F07 && DRLK.S.A0000
@@ -165,7 +171,8 @@ tests:
               - name: "PINCode"
                 value: "123456"
 
-    - label: "Step 1i: TH sends a Unlock Door command to the DUT without pincode."
+    - label:
+          "Step 1i: TH sends a Unlock Door command to the DUT without pincode."
       PICS: DRLK.S.C01.Rsp && !DRLK.S.F00 && !DRLK.S.F07 && DRLK.S.A0000
       command: "UnlockDoor"
       timedInteractionTimeoutMs: 1000

--- a/src/python_testing/TC_BOOLCFG_3_1.py
+++ b/src/python_testing/TC_BOOLCFG_3_1.py
@@ -45,7 +45,7 @@ class TC_BOOLCFG_3_1(MatterBaseTest):
         steps = [
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep("2a", "Read FeatureMap attribute"),
-            TestStep("2b", "Verify SENS feature is supported"),
+            TestStep("2b", "Verify SENSLVL feature is supported"),
             TestStep("2c", "Read AttributeList attribute"),
             TestStep(3, "Read SupportedSensitivityLevels attribute"),
             TestStep(4, "Read DefaultSensitivityLevel attribute, if supported"),

--- a/src/python_testing/TC_DRLK_2_12.py
+++ b/src/python_testing/TC_DRLK_2_12.py
@@ -31,6 +31,8 @@ from drlk_2_x_common import DRLK_COMMON
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main
 
 # Configurable parameters:
+# - userIndex: userIndex to use when creating a user on the DUT for testing purposes
+#     defaults to 1. Add `--int-arg user_index:<index>` to command line to override
 # - CredentialIndex: CredentialIndex to use when creating a Credential on the DUT for testing purposes
 #     defaults to 1. Add `--int-arg credential_index:<index>` to command line to override
 # - UserCodeTemporaryDisableTime: Value used to configure DUT for testing purposes.
@@ -42,6 +44,12 @@ from matter_testing_support import MatterBaseTest, async_test_body, default_matt
 
 
 class TC_DRLK_2_12(MatterBaseTest, DRLK_COMMON):
+
+    @async_test_body
+    async def teardown_test(self):
+        await self.teardown()
+        return super().teardown_test()
+
     def setup_class(self):
         return super().setup_class()
 

--- a/src/python_testing/TC_DRLK_2_12.py
+++ b/src/python_testing/TC_DRLK_2_12.py
@@ -45,11 +45,6 @@ class TC_DRLK_2_12(MatterBaseTest, DRLK_COMMON):
     def setup_class(self):
         return super().setup_class()
 
-    @async_test_body
-    async def teardown_test(self):
-        await self.teardown()
-        return super().teardown_test()
-
     def pics_TC_DRLK_2_12(self) -> list[str]:
         return ["DRLK.S.F0c"]
 

--- a/src/python_testing/TC_DRLK_2_13.py
+++ b/src/python_testing/TC_DRLK_2_13.py
@@ -23,7 +23,7 @@
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
 # test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
-# test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --endpoint 1 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 # === END CI TEST ARGUMENTS ===
 
 import logging
@@ -357,7 +357,7 @@ class TC_DRLK_2_13(MatterBaseTest):
         self.groupIdentifier = bytes.fromhex("89d085fc302ca53e279bfcdecdf3c4ad")
         self.groupResolvingKey = bytes.fromhex("89d0859bfcdecdf3c4adfc302ca53e27")
         self.common_cluster_endpoint = 0
-        self.app_cluster_endpoint = 1
+        self.app_cluster_endpoint = self.matter_test_config.endpoint
         self.alirouser = "AliroUser"
         self.alirocredentialissuerkey = bytes.fromhex(
             "047a4c882d753924cdf3779a3c84fec2debaa6f0b3084450878acc7ddcce7856ae57b1ebbe2561015103dd7474c2a183675378ec55f1e465ac3436bf3dd5ca54d4")

--- a/src/python_testing/TC_DRLK_2_2.py
+++ b/src/python_testing/TC_DRLK_2_2.py
@@ -45,11 +45,6 @@ class TC_DRLK_2_2(MatterBaseTest, DRLK_COMMON):
     def setup_class(self):
         return super().setup_class()
 
-    @async_test_body
-    async def teardown_test(self):
-        await self.teardown()
-        return super().teardown_test()
-
     def pics_TC_DRLK_2_2(self) -> list[str]:
         return ["DRLK.S"]
 

--- a/src/python_testing/TC_DRLK_2_2.py
+++ b/src/python_testing/TC_DRLK_2_2.py
@@ -31,6 +31,8 @@ from drlk_2_x_common import DRLK_COMMON
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main
 
 # Configurable parameters:
+# - userIndex: userIndex to use when creating a user on the DUT for testing purposes
+#     defaults to 1. Add `--int-arg user_index:<index>` to command line to override
 # - CredentialIndex: CredentialIndex to use when creating a Credential on the DUT for testing purposes
 #     defaults to 1. Add `--int-arg credential_index:<index>` to command line to override
 # - UserCodeTemporaryDisableTime: Value used to configure DUT for testing purposes.
@@ -42,6 +44,12 @@ from matter_testing_support import MatterBaseTest, async_test_body, default_matt
 
 
 class TC_DRLK_2_2(MatterBaseTest, DRLK_COMMON):
+
+    @async_test_body
+    async def teardown_test(self):
+        await self.teardown()
+        return super().teardown_test()
+
     def setup_class(self):
         return super().setup_class()
 

--- a/src/python_testing/TC_DRLK_2_3.py
+++ b/src/python_testing/TC_DRLK_2_3.py
@@ -45,11 +45,6 @@ class TC_DRLK_2_3(MatterBaseTest, DRLK_COMMON):
     def setup_class(self):
         return super().setup_class()
 
-    @async_test_body
-    async def teardown_test(self):
-        await self.teardown()
-        return super().teardown_test()
-
     def pics_TC_DRLK_2_3(self) -> list[str]:
         return ["DRLK.S"]
 

--- a/src/python_testing/TC_DRLK_2_3.py
+++ b/src/python_testing/TC_DRLK_2_3.py
@@ -31,6 +31,8 @@ from drlk_2_x_common import DRLK_COMMON
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main
 
 # Configurable parameters:
+# - userIndex: userIndex to use when creating a user on the DUT for testing purposes
+#     defaults to 1. Add `--int-arg user_index:<index>` to command line to override
 # - CredentialIndex: CredentialIndex to use when creating a Credential on the DUT for testing purposes
 #     defaults to 1. Add `--int-arg credential_index:<index>` to command line to override
 # - UserCodeTemporaryDisableTime: Value used to configure DUT for testing purposes.
@@ -42,6 +44,12 @@ from matter_testing_support import MatterBaseTest, async_test_body, default_matt
 
 
 class TC_DRLK_2_3(MatterBaseTest, DRLK_COMMON):
+
+    @async_test_body
+    async def teardown_test(self):
+        await self.teardown()
+        return super().teardown_test()
+
     def setup_class(self):
         return super().setup_class()
 

--- a/src/python_testing/TC_PWRTL_2_1.py
+++ b/src/python_testing/TC_PWRTL_2_1.py
@@ -57,7 +57,7 @@ class TC_PWRTL_2_1(MatterBaseTest):
         available_endpoints = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=Clusters.Objects.PowerTopology, attribute=attributes.AvailableEndpoints)
 
         asserts.assert_less_equal(len(available_endpoints), 20,
-                                      "AvailableEndpoints length %d must be less than 21!" % len(available_endpoints))
+                                  "AvailableEndpoints length %d must be less than 21!" % len(available_endpoints))
 
         if not self.check_pics("PWRTL.S.A0001"):
             logging.info("Test skipped because PICS PWRTL.S.A0001 is not set")
@@ -67,10 +67,11 @@ class TC_PWRTL_2_1(MatterBaseTest):
         active_endpoints = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=Clusters.Objects.PowerTopology,  attribute=attributes.ActiveEndpoints)
         logging.info("ActiveEndpoints: %s" % (active_endpoints))
         asserts.assert_less_equal(len(active_endpoints), 20,
-                                      "ActiveEndpoints length %d must be less than 21!" % len(active_endpoints))
+                                  "ActiveEndpoints length %d must be less than 21!" % len(active_endpoints))
         # Verify that ActiveEndpoints is a subset of AvailableEndpoints
         asserts.assert_true(set(active_endpoints).issubset(set(available_endpoints)),
                             "ActiveEndpoints should be a subset of AvailableEndpoints")
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_PWRTL_2_1.py
+++ b/src/python_testing/TC_PWRTL_2_1.py
@@ -30,7 +30,6 @@
 import logging
 
 import chip.clusters as Clusters
-from chip.clusters.Types import NullValue
 from matter_testing_support import MatterBaseTest, async_test_body, default_matter_test_main
 from mobly import asserts
 

--- a/src/python_testing/TC_PWRTL_2_1.py
+++ b/src/python_testing/TC_PWRTL_2_1.py
@@ -56,12 +56,7 @@ class TC_PWRTL_2_1(MatterBaseTest):
         self.print_step(2, "Read AvailableAttributes attribute")
         available_endpoints = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=Clusters.Objects.PowerTopology, attribute=attributes.AvailableEndpoints)
 
-        if available_endpoints == NullValue:
-            logging.info("AvailableEndpoints is null")
-        else:
-            logging.info("AvailableEndpoints: %s" % (available_endpoints))
-
-            asserts.assert_less_equal(len(available_endpoints), 21,
+        asserts.assert_less_equal(len(available_endpoints), 20,
                                       "AvailableEndpoints length %d must be less than 21!" % len(available_endpoints))
 
         if not self.check_pics("PWRTL.S.A0001"):
@@ -71,11 +66,11 @@ class TC_PWRTL_2_1(MatterBaseTest):
         self.print_step(3, "Read ActiveEndpoints attribute")
         active_endpoints = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=Clusters.Objects.PowerTopology,  attribute=attributes.ActiveEndpoints)
         logging.info("ActiveEndpoints: %s" % (active_endpoints))
-
-        if available_endpoints == NullValue:
-            asserts.assert_true(active_endpoints == NullValue,
-                                "ActiveEndpoints should be null when AvailableEndpoints is null: %s" % active_endpoints)
-
+        asserts.assert_less_equal(len(active_endpoints), 20,
+                                      "ActiveEndpoints length %d must be less than 21!" % len(active_endpoints))
+        # Verify that ActiveEndpoints is a subset of AvailableEndpoints
+        asserts.assert_true(set(active_endpoints).issubset(set(available_endpoints)),
+                            "ActiveEndpoints should be a subset of AvailableEndpoints")
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/drlk_2_x_common.py
+++ b/src/python_testing/drlk_2_x_common.py
@@ -102,7 +102,7 @@ class DRLK_COMMON:
             timedRequestTimeoutMs=1000
         )
 
-    async def read_and_verify_pincode_length(self,attribute,failure_message: str, min_range=0, max_range=255):
+    async def read_and_verify_pincode_length(self, attribute, failure_message: str, min_range=0, max_range=255):
         pin_code_length = await self.read_drlk_attribute_expect_success(attribute=attribute)
         verify_pin_code_length = True if min_range <= pin_code_length <= max_range else False
         asserts.assert_true(verify_pin_code_length, f"{failure_message}, got value {pin_code_length}")
@@ -173,35 +173,35 @@ class DRLK_COMMON:
                 self.print_step("4a", "TH writes the RequirePINforRemoteOperation attribute value as true on the DUT")
                 await self.set_user_command()
         if self.check_pics("DRLK.S.F00"):
-                self.print_step("4b", "TH reads MinPINCodeLength attribute and saves the value")
-                min_pin_code_length = await self.read_and_verify_pincode_length(
-                    attribute=Clusters.DoorLock.Attributes.MinPINCodeLength,
-                    failure_message="MinPINCodeLength attribute must be between 0 to 255"
-                )
-                self.print_step("4c", "TH reads MaxPINCodeLength attribute and saves the value")
-                max_pin_code_length = await self.read_and_verify_pincode_length(
-                    attribute=Clusters.DoorLock.Attributes.MaxPINCodeLength,
-                    failure_message=f"MinPINCodeLength attribute must be between 0 to 255"
-                )
-                self.print_step("4d", "Generate credential data and store as pin_code,Th sends SetCredential command"
-                                      "using pin_code")
-                credential_data_generated = await self.generate_pincode(max_pin_code_length, min_pin_code_length)
-                pin_code = bytes(credential_data_generated, "ascii")
-                if self.check_pics("DRLK.S.C22.Rsp") and self.check_pics("DRLK.S.C23.Tx"):
-                    set_cred_response = await self.send_set_credential_cmd(userIndex=1,
-                                                                           operationType=Clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd,
-                                                                           credential=credential,
-                                                                           credentialData=pin_code,
-                                                                           userStatus=NullValue,
-                                                                           userType=NullValue
-                                                                           )
-                    asserts.assert_true(
-                        type_matches(set_cred_response, Clusters.Objects.DoorLock.Commands.SetCredentialResponse),
-                        "Unexpected return type for SetCredential")
-                self.print_step("4e", f"TH sends {lockUnlockText} Command to the DUT with PINCode as pin_code.")
-                if self.check_pics(lockUnlockCmdRspPICS):
-                    command = lockUnlockCommand(PINCode=pin_code)
-                    await self.send_drlk_cmd_expect_success(command=command)
+            self.print_step("4b", "TH reads MinPINCodeLength attribute and saves the value")
+            min_pin_code_length = await self.read_and_verify_pincode_length(
+                attribute=Clusters.DoorLock.Attributes.MinPINCodeLength,
+                failure_message="MinPINCodeLength attribute must be between 0 to 255"
+            )
+            self.print_step("4c", "TH reads MaxPINCodeLength attribute and saves the value")
+            max_pin_code_length = await self.read_and_verify_pincode_length(
+                attribute=Clusters.DoorLock.Attributes.MaxPINCodeLength,
+                failure_message=f"MinPINCodeLength attribute must be between 0 to 255"
+            )
+            self.print_step("4d", "Generate credential data and store as pin_code,Th sends SetCredential command"
+                                  "using pin_code")
+            credential_data_generated = await self.generate_pincode(max_pin_code_length, min_pin_code_length)
+            pin_code = bytes(credential_data_generated, "ascii")
+            if self.check_pics("DRLK.S.C22.Rsp") and self.check_pics("DRLK.S.C23.Tx"):
+                set_cred_response = await self.send_set_credential_cmd(userIndex=1,
+                                                                       operationType=Clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd,
+                                                                       credential=credential,
+                                                                       credentialData=pin_code,
+                                                                       userStatus=NullValue,
+                                                                       userType=NullValue
+                                                                       )
+                asserts.assert_true(
+                    type_matches(set_cred_response, Clusters.Objects.DoorLock.Commands.SetCredentialResponse),
+                    "Unexpected return type for SetCredential")
+            self.print_step("4e", f"TH sends {lockUnlockText} Command to the DUT with PINCode as pin_code.")
+            if self.check_pics(lockUnlockCmdRspPICS):
+                command = lockUnlockCommand(PINCode=pin_code)
+                await self.send_drlk_cmd_expect_success(command=command)
 
         if self.check_pics("DRLK.S.F00") and self.check_pics("DRLK.S.F07"):
             self.print_step("5", "TH writes the RequirePINforRemoteOperation attribute value as true on the DUT")
@@ -286,14 +286,12 @@ class DRLK_COMMON:
             if not doAutoRelockTest:
                 self.print_step("15", "Send %s with valid Pincode and verify success" % lockUnlockText)
                 credentials = cluster.Structs.CredentialStruct(credentialIndex=credentialIndex,
-                                                              credentialType=Clusters.DoorLock.Enums.CredentialTypeEnum.kPin)
+                                                               credentialType=Clusters.DoorLock.Enums.CredentialTypeEnum.kPin)
                 command = lockUnlockCommand(PINCode=pin_code)
                 await self.send_drlk_cmd_expect_success(command=command)
 
                 await self.cleanup_users_and_credentials(user_clear_step="17", clear_credential_step="16",
                                                          credentials=credentials, userIndex=1)
-
-
 
         if doAutoRelockTest:
             if self.check_pics("DRLK.S.A0023"):

--- a/src/python_testing/drlk_2_x_common.py
+++ b/src/python_testing/drlk_2_x_common.py
@@ -73,24 +73,44 @@ class DRLK_COMMON:
         await self.send_single_cmd(cmd=Clusters.Objects.DoorLock.Commands.ClearCredential(credential=credential),
                                    endpoint=self.endpoint,
                                    timedRequestTimeoutMs=1000)
-        ret = await self.send_single_cmd(cmd=Clusters.Objects.DoorLock.Commands.GetCredentialStatus(credential=self.createdCredential),
+        ret = await self.send_single_cmd(cmd=Clusters.Objects.DoorLock.Commands.GetCredentialStatus(credential=credential),
                                          endpoint=self.endpoint)
         asserts.assert_true(type_matches(ret, Clusters.Objects.DoorLock.Commands.GetCredentialStatusResponse),
                             "Unexpected return type for GetCredentialStatus")
         asserts.assert_false(ret.credentialExists, "Error clearing Credential (credentialExists==True)")
 
-    async def cleanup_users_and_credentials(self):
-        self.print_step("Cleanup", "Clear created User and Credential on the DUT")
-        if self.createdCredential:
-            await self.send_clear_credential_cmd(self.createdCredential)
-            logging.info("Credential cleared at CredentialIndex %d" % (self.createdCredential.credentialIndex))
-        self.createdCredential = None
+    async def cleanup_users_and_credentials(self, user_clear_step, clear_credential_step, credentials, userIndex):
+        if (self.check_pics("DRLK.S.F00") and self.check_pics("DRLK.S.F08")
+                and self.check_pics("DRLK.S.C26.Rsp")):
+            self.print_step(clear_credential_step, "TH sends ClearCredential Command to DUT")
+            await self.send_clear_credential_cmd(credentials)
+        if self.check_pics("DRLK.S.C1d.Rsp") and self.check_pics("DRLK.S.F08"):
+            self.print_step(user_clear_step, "TH sends ClearUser Command to DUT with the UserIndex as 1")
+            await self.send_drlk_cmd_expect_success(
+                command=Clusters.Objects.DoorLock.Commands.ClearUser(userIndex=userIndex))
 
-    async def generate_pincode(self, maxPincodeLength):
-        return ''.join(random.choices(string.digits, k=maxPincodeLength))
+    async def set_user_command(self):
+        await self.send_single_cmd(cmd=Clusters.Objects.DoorLock.Commands.SetUser(
+            operationType=Clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd,
+            userIndex=1,
+            userName="xxx",
+            userUniqueID=6452,
+            userStatus=Clusters.DoorLock.Enums.UserStatusEnum.kOccupiedEnabled,
+            credentialRule=Clusters.DoorLock.Enums.CredentialRuleEnum.kSingle
+        ),
+            endpoint=self.endpoint,
+            timedRequestTimeoutMs=1000
+        )
 
-    async def teardown(self):
-        await self.cleanup_users_and_credentials()
+    async def read_and_verify_pincode_length(self,attribute,failure_message: str, min_range=0, max_range=255):
+        pin_code_length = await self.read_drlk_attribute_expect_success(attribute=attribute)
+        verify_pin_code_length = True if min_range <= pin_code_length <= max_range else False
+        asserts.assert_true(verify_pin_code_length, f"{failure_message}, got value {pin_code_length}")
+        return pin_code_length
+
+    async def generate_pincode(self, maxPincodeLength, minPincodeLength):
+        length_of_pincode = random.randint(minPincodeLength, maxPincodeLength)
+        return ''.join(random.choices(string.digits, k=length_of_pincode))
 
     async def run_drlk_test_common(self, lockUnlockCommand, lockUnlockCmdRspPICS, lockUnlockText, doAutoRelockTest):
         is_ci = self.check_pics('PICS_SDK_CI_ONLY')
@@ -110,40 +130,11 @@ class DRLK_COMMON:
         cluster = Clusters.Objects.DoorLock
         attributes = Clusters.DoorLock.Attributes
 
-        validPincode = None
+        pin_code = None
         invalidPincode = None
-
+        credential = cluster.Structs.CredentialStruct(credentialIndex=credentialIndex,
+                                                      credentialType=Clusters.DoorLock.Enums.CredentialTypeEnum.kPin)
         self.print_step(0, "Commissioning, already done")
-
-        if self.check_pics("DRLK.S.F00") and self.check_pics("DRLK.S.F07"):
-            self.print_step("Preconditions.1a",
-                            "TH reads MaxPINCodeLength attribute from DUT and generates a valid PINCode")
-            maxPincodeLength_dut = await self.read_drlk_attribute_expect_success(attribute=attributes.MaxPINCodeLength)
-            logging.info("MaxPINCodeLength value is %s" % (maxPincodeLength_dut))
-
-            validPincodeString = await self.generate_pincode(maxPincodeLength_dut)
-            while True:
-                invalidPincodeString = await self.generate_pincode(maxPincodeLength_dut)
-                if invalidPincodeString != validPincodeString:
-                    break
-            logging.info("Valid PinCode=%s, Invalid PinCode=%s" % (validPincodeString, invalidPincodeString))
-
-            validPincode = bytes(validPincodeString, 'ascii')
-            invalidPincode = bytes(invalidPincodeString, 'ascii')
-
-            self.print_step("Preconditions.1b",
-                            "TH sends SetCredential command to DUT to set up User and Credential at CredentialIndex {}".format(str(credentialIndex)))
-            credential = cluster.Structs.CredentialStruct(credentialIndex=credentialIndex,
-                                                          credentialType=Clusters.DoorLock.Enums.CredentialTypeEnum.kPin)
-            ret = await self.send_set_credential_cmd(Clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd,
-                                                     credential,
-                                                     validPincode,
-                                                     NullValue,
-                                                     NullValue,
-                                                     NullValue)
-            logging.info("Credential created at CredentialIndex %d, UserIndex %d." % (credentialIndex, ret.userIndex))
-            self.createdCredential = credential
-
         requirePinForRemoteOperation_dut = False
         if self.check_pics("DRLK.S.F00") and self.check_pics("DRLK.S.F07"):
             self.print_step("1", "TH writes the RequirePINforRemoteOperation attribute value as false on the DUT")
@@ -174,12 +165,43 @@ class DRLK_COMMON:
                 await self.send_drlk_cmd_expect_error(command=command, error=Status.Failure)
             else:
                 await self.send_drlk_cmd_expect_success(command=command)
-
-            self.print_step("4", "TH sends %s Command to the DUT with valid PINCode" % lockUnlockText)
-            command = lockUnlockCommand(PINCode=validPincode)
-            await self.send_drlk_cmd_expect_success(command=command)
         else:
             asserts.assert_true(False, "%sResponse is a mandatory command response and must be supported in PICS" % lockUnlockText)
+
+        if self.check_pics("DRLK.S.F08"):
+            if self.check_pics("DRLK.S.C1a.Rsp"):
+                self.print_step("4a", "TH writes the RequirePINforRemoteOperation attribute value as true on the DUT")
+                await self.set_user_command()
+        if self.check_pics("DRLK.S.F00"):
+                self.print_step("4b", "TH reads MinPINCodeLength attribute and saves the value")
+                min_pin_code_length = await self.read_and_verify_pincode_length(
+                    attribute=Clusters.DoorLock.Attributes.MinPINCodeLength,
+                    failure_message="MinPINCodeLength attribute must be between 0 to 255"
+                )
+                self.print_step("4c", "TH reads MaxPINCodeLength attribute and saves the value")
+                max_pin_code_length = await self.read_and_verify_pincode_length(
+                    attribute=Clusters.DoorLock.Attributes.MaxPINCodeLength,
+                    failure_message=f"MinPINCodeLength attribute must be between 0 to 255"
+                )
+                self.print_step("4d", "Generate credential data and store as pin_code,Th sends SetCredential command"
+                                      "using pin_code")
+                credential_data_generated = await self.generate_pincode(max_pin_code_length, min_pin_code_length)
+                pin_code = bytes(credential_data_generated, "ascii")
+                if self.check_pics("DRLK.S.C22.Rsp") and self.check_pics("DRLK.S.C23.Tx"):
+                    set_cred_response = await self.send_set_credential_cmd(userIndex=1,
+                                                                           operationType=Clusters.DoorLock.Enums.DataOperationTypeEnum.kAdd,
+                                                                           credential=credential,
+                                                                           credentialData=pin_code,
+                                                                           userStatus=NullValue,
+                                                                           userType=NullValue
+                                                                           )
+                    asserts.assert_true(
+                        type_matches(set_cred_response, Clusters.Objects.DoorLock.Commands.SetCredentialResponse),
+                        "Unexpected return type for SetCredential")
+                self.print_step("4e", f"TH sends {lockUnlockText} Command to the DUT with PINCode as pin_code.")
+                if self.check_pics(lockUnlockCmdRspPICS):
+                    command = lockUnlockCommand(PINCode=pin_code)
+                    await self.send_drlk_cmd_expect_success(command=command)
 
         if self.check_pics("DRLK.S.F00") and self.check_pics("DRLK.S.F07"):
             self.print_step("5", "TH writes the RequirePINforRemoteOperation attribute value as true on the DUT")
@@ -197,7 +219,13 @@ class DRLK_COMMON:
                 if self.check_pics("DRLK.S.M.RequirePINForRemoteOperationAttributeWritable"):
                     self.print_step("6a", "TH verifies that RequirePINforRemoteOperation is TRUE")
                     asserts.assert_true(requirePinForRemoteOperation_dut, "RequirePINforRemoteOperation is expected to be TRUE")
-
+        # generate InvalidPincode
+        while True:
+            invalidPincodeString = await self.generate_pincode(max_pin_code_length, min_pin_code_length)
+            invalidPincode = bytes(invalidPincodeString, "ascii")
+            if invalidPincodeString != pin_code:
+                break
+        logging.info(" pin_code=%s, Invalid PinCode=%s" % (pin_code, invalidPincodeString))
         if self.check_pics("DRLK.S.F00") and self.check_pics(lockUnlockCmdRspPICS) and self.check_pics("DRLK.S.A0033"):
             self.print_step("7", "TH sends %s Command to the DUT with an invalid PINCode" % lockUnlockText)
             command = lockUnlockCommand(PINCode=invalidPincode)
@@ -212,7 +240,7 @@ class DRLK_COMMON:
 
         if self.check_pics(lockUnlockCmdRspPICS) and self.check_pics("DRLK.S.A0033"):
             self.print_step("9", "TH sends %s Command to the DUT with valid PINCode" % lockUnlockText)
-            command = lockUnlockCommand(PINCode=validPincode)
+            command = lockUnlockCommand(PINCode=pin_code)
             await self.send_drlk_cmd_expect_success(command=command)
 
         if self.check_pics("DRLK.S.F00") or self.check_pics("DRLK.S.F01"):
@@ -248,7 +276,7 @@ class DRLK_COMMON:
                 await self.send_drlk_cmd_expect_error(command=command, error=Status.Failure)
 
             self.print_step("13", "TH sends %s Command to the DUT with valid PINCode. Verify failure or no response" % lockUnlockText)
-            command = lockUnlockCommand(PINCode=validPincode)
+            command = lockUnlockCommand(PINCode=pin_code)
             await self.send_drlk_cmd_expect_error(command=command, error=Status.Failure)
 
             if self.check_pics("DRLK.S.A0031"):
@@ -257,8 +285,15 @@ class DRLK_COMMON:
 
             if not doAutoRelockTest:
                 self.print_step("15", "Send %s with valid Pincode and verify success" % lockUnlockText)
-                command = lockUnlockCommand(PINCode=validPincode)
+                credentials = cluster.Structs.CredentialStruct(credentialIndex=credentialIndex,
+                                                              credentialType=Clusters.DoorLock.Enums.CredentialTypeEnum.kPin)
+                command = lockUnlockCommand(PINCode=pin_code)
                 await self.send_drlk_cmd_expect_success(command=command)
+
+                await self.cleanup_users_and_credentials(user_clear_step="17", clear_credential_step="16",
+                                                         credentials=credentials, userIndex=1)
+
+
 
         if doAutoRelockTest:
             if self.check_pics("DRLK.S.A0023"):
@@ -275,22 +310,19 @@ class DRLK_COMMON:
 
             if self.check_pics(lockUnlockCmdRspPICS):
                 self.print_step("17", "Send %s with valid Pincode and verify success" % lockUnlockText)
-                command = lockUnlockCommand(PINCode=validPincode)
+                command = lockUnlockCommand(PINCode=pin_code)
                 await self.send_drlk_cmd_expect_success(command=command)
+            # Add additional wait time buffer for motor movement, etc.
+            time.sleep(autoRelockTime_dut + 5)
 
-            if self.check_pics("DRLK.S.A0023"):
-                self.print_step("18a", "Wait for AutoRelockTime seconds")
-                # Add additional wait time buffer for motor movement, etc.
-                time.sleep(autoRelockTime_dut + 5)
-
-                if self.check_pics("DRLK.S.A0000"):
-                    self.print_step("18b", "TH reads LockState attribute after AutoRelockTime Expires")
-                    lockstate_dut = await self.read_drlk_attribute_expect_success(attribute=attributes.LockState)
-                    logging.info("Current LockState is %s" % (lockstate_dut))
-                    asserts.assert_equal(lockstate_dut, Clusters.DoorLock.Enums.DlLockState.kLocked,
-                                         "LockState expected to be value==Locked")
-
-        await self.cleanup_users_and_credentials()
+            if self.check_pics("DRLK.S.A0000"):
+                self.print_step("18", "TH reads LockState attribute after AutoRelockTime Expires")
+                lockstate_dut = await self.read_drlk_attribute_expect_success(attribute=attributes.LockState)
+                logging.info("Current LockState is %s" % (lockstate_dut))
+                asserts.assert_equal(lockstate_dut, Clusters.DoorLock.Enums.DlLockState.kLocked,
+                                     "LockState expected to be value==Locked")
+            await self.cleanup_users_and_credentials(user_clear_step="20", clear_credential_step="19",
+                                                     credentials=credential, userIndex=1)
 
     async def run_drlk_test_2_2(self):
         await self.run_drlk_test_common(lockUnlockCommand=Clusters.Objects.DoorLock.Commands.LockDoor,

--- a/src/python_testing/drlk_2_x_common.py
+++ b/src/python_testing/drlk_2_x_common.py
@@ -181,7 +181,7 @@ class DRLK_COMMON:
             self.print_step("4c", "TH reads MaxPINCodeLength attribute and saves the value")
             max_pin_code_length = await self.read_and_verify_pincode_length(
                 attribute=Clusters.DoorLock.Attributes.MaxPINCodeLength,
-                failure_message=f"MinPINCodeLength attribute must be between 0 to 255"
+                failure_message="MinPINCodeLength attribute must be between 0 to 255"
             )
             self.print_step("4d", "Generate credential data and store as pin_code,Th sends SetCredential command"
                                   "using pin_code")


### PR DESCRIPTION
* TC-DRLK-2.2,2.3 & 2.12 , drlk_2_x_common.py - updated as per latest test plan

* TC_BOOLCFG_3_1.py - Test description is changed.

* TC_PWRTL_2_1.py - Added missing step for subset check as per latest test plan.

* Test_TC_DRLK_2_1.yaml - Script is updated with latest changes from test plan.

1.) Fix for https://github.com/project-chip/connectedhomeip/issues/35033  [TC_BOOLCFG_3_1.py]

2.) Fix for https://github.com/project-chip/connectedhomeip/issues/34344  [TC-DRLK-2.2,2.3 & 2.12 , drlk_2_x_common.py]

3.) Fix for https://github.com/project-chip/connectedhomeip/issues/34847   [TC_PWRTL_2_1.py]

4.) Fix for https://github.com/project-chip/connectedhomeip/issues/34710  [Test_TC_DRLK_2_1.yaml]

5.) Fix for https://github.com/project-chip/matter-test-scripts/issues/271  [Test_TC_DRLK_2_1.yaml]
Test plan changes for these DRLK scripts are in progress https://github.com/CHIP-Specifications/chip-test-plans/pull/4554
6.) Accept endpoint from command line argument, FIx for https://github.com/project-chip/matter-test-scripts/issues/334