### PR TITLE
[Darwin] Adding missing property on XPC controller

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -78,6 +78,11 @@
     return interface;
 }
 
+- (id<NSCopying>)controllerXPCID
+{
+    return [self.uniqueIdentifier UUIDString];
+}
+
 - (id)initWithUniqueIdentifier:(NSUUID *)UUID xpConnectionBlock:(NSXPCConnection * (^)(void) )connectionBlock
 {
     if (self = [super initForSubclasses]) {


### PR DESCRIPTION
- Added controllerID to match the OverXPC interface

