### PR TITLE
THNETDIR and WIFINM: Align with latest spec and other small fixes

### DIFF
--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
@@ -130,6 +130,14 @@ _ALIASES = {
                 'has_destination': False,
                 'has_endpoint': False,
             },
+            'EstablishPASESession': {
+                'alias': 'code-paseonly',
+                'arguments': {
+                    'nodeId': 'node-id'
+                },
+                'has_destination': False,
+                'has_endpoint': False,
+            },
             'GetCommissionerNodeId': {
                 'has_destination': False,
                 'has_endpoint': False,

--- a/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/commissioner_commands.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/pseudo_clusters/clusters/commissioner_commands.py
@@ -57,6 +57,11 @@ _DEFINITION = '''<?xml version="1.0"?>
       <arg name="IPK" type="octet_string"/>
     </command>
 
+    <command source="client" code="5" name="EstablishPASESession">
+      <arg name="nodeId" type="node_id"/>
+      <arg name="payload" type="char_string"/>
+    </command>
+
 </cluster>
 </configurator>
 '''

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -220,6 +220,7 @@ def _GetDarwinFrameworkToolUnsupportedTests() -> Set[str]:
         "Test_TC_SC_4_1",  # darwin-framework-tool does not support dns-sd commands.
         "Test_TC_SC_5_2",  # darwin-framework-tool does not support group commands.
         "Test_TC_S_2_3",  # darwin-framework-tool does not support group commands.
+        "Test_TC_THNETDIR_2_2",  # darwin-framework-tool does not support negative timed-invoke tests
     }
 
 

--- a/src/app/clusters/wifi-network-management-server/wifi-network-management-server.cpp
+++ b/src/app/clusters/wifi-network-management-server/wifi-network-management-server.cpp
@@ -32,7 +32,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WiFiNetworkManagement::Attributes;
 using namespace chip::app::Clusters::WiFiNetworkManagement::Commands;
-using namespace std::placeholders;
+using IMStatus = chip::Protocols::InteractionModel::Status;
 
 namespace chip {
 namespace app {
@@ -143,6 +143,12 @@ void WiFiNetworkManagementServer::InvokeCommand(HandlerContext & ctx)
 void WiFiNetworkManagementServer::HandleNetworkPassphraseRequest(HandlerContext & ctx,
                                                                  const NetworkPassphraseRequest::DecodableType & req)
 {
+    if (ctx.mCommandHandler.GetSubjectDescriptor().authMode != Access::AuthMode::kCase)
+    {
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, IMStatus::UnsupportedAccess);
+        return;
+    }
+
     if (HaveNetworkCredentials())
     {
         NetworkPassphraseResponse::Type response;
@@ -151,8 +157,7 @@ void WiFiNetworkManagementServer::HandleNetworkPassphraseRequest(HandlerContext 
     }
     else
     {
-        // TODO: Status code TBC: https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/9234
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::InvalidInState);
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, IMStatus::InvalidInState);
     }
 }
 

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_1.yaml
@@ -47,5 +47,4 @@ tests:
       response:
           constraints:
               type: int8u
-              minValue: 10 # assume 5 supported fabrics
-              # python: value >= 2 * supportedFabrics
+              python: value >= 2 * supportedFabrics

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
@@ -116,18 +116,18 @@ tests:
       response:
           constraints:
               type: list
-              #   python: |
-              #       # Split the list into test (our TestNetwork) and rest (everything else)
-              #       test = next((n for n in value if n['ExtendedPanID'] == TestNetworkExtendedPanId), None)
-              #       rest = [n for n in value if n != test]
-              #       # Check test has the expected values and rest == initialNetworks (ignoring order)
-              #       return (test is not None and
-              #               test['NetworkName'] == TestNetworkName and
-              #               test['Channel'] == TestNetworkChannel and
-              #               test['ActiveTimestamp'] == TestNetworkActiveTimestamp and
-              #               len(value) == len(initialNetworks) + 1 and
-              #               len(rest) == len(initialNetworks) and
-              #               all(n in initialNetworks for n in rest))
+              python: |
+                  # Split the list into test (our TestNetwork) and rest (everything else)
+                  test = next((n for n in value if n['ExtendedPanID'] == TestNetworkExtendedPanId), None)
+                  rest = [n for n in value if n != test]
+                  # Check test has the expected values and rest == initialNetworks (ignoring order)
+                  return (test is not None and
+                          test['NetworkName'] == TestNetworkName and
+                          test['Channel'] == TestNetworkChannel and
+                          test['ActiveTimestamp'] == TestNetworkActiveTimestamp and
+                          len(value) == len(initialNetworks) + 1 and
+                          len(rest) == len(initialNetworks) and
+                          all(n in initialNetworks for n in rest))
 
     - label:
           "TH sends GetOperationalDataset command to DUT with ExtendedPanID from
@@ -212,10 +212,10 @@ tests:
       response:
           constraints:
               type: list
-              #   python: |
-              #       # value == initialNetworks (ignoring order)
-              #       return (len(value) == len(initialNetworks) and
-              #               all(n in initialNetworks for n in value))
+              python: |
+                  # value == initialNetworks (ignoring order)
+                  return (len(value) == len(initialNetworks) and
+                          all(n in initialNetworks for n in value))
 
     - label:
           "TH writes PreferredExtendedPanID to DUT, restoring the initial value"

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
@@ -25,13 +25,16 @@ config:
     # Note: TestNetwork* values need to match what's encoded in TestNetworkDataset
     TestNetworkDataset:
         type: octet_string
-        defaultValue: "hex:0e080000000000000001000300000f350407fff800020839758ec8144b07fb0708fdf1f1add0797dc00510f366cec7a446bab978d90d27abe38f23030f4f70656e5468726561642d353933380102593804103ca67c969efb0d0c74a4d8ee923b576c0c0402a0f7f8"
+        defaultValue: "hex:0e0800000000000c0001000300000f350407fff800020839758ec8144b07fb0708fdf1f1add0797dc00510f366cec7a446bab978d90d27abe38f23030f4f70656e5468726561642d353933380102593804103ca67c969efb0d0c74a4d8ee923b576c0c0402a0f7f8"
     TestNetworkExtendedPanId:
         type: octet_string
         defaultValue: "hex:39758ec8144b07fb"
     TestNetworkName: "OpenThread-5938"
     TestNetworkChannel: 15
-    TestNetworkActiveTimestamp: 1
+    TestNetworkActiveTimestamp: 0xc0001
+    TestNetworkUpdatedDataset:
+        type: octet_string
+        defaultValue: "hex:0e0800000000000d0001000300000f350407fff800020839758ec8144b07fb0708fdf1f1add0797dc00510f366cec7a446bab978d90d27abe38f23030f4f70656e5468726561642d353933380102593804103ca67c969efb0d0c74a4d8ee923b576c0c0402a0f7f8"
 
 tests:
     - label: "Wait for the commissioned device to be retrieved"
@@ -141,6 +144,78 @@ tests:
           values:
               - name: OperationalDataset
                 value: TestNetworkDataset
+
+    - label:
+          "TH sends AddNetwork command to DUT with TestNetwork dataset matching
+          existing Active Timestamp"
+      command: AddNetwork
+      timedInteractionTimeoutMs: 2000
+      arguments:
+          values:
+              - name: OperationalDataset
+                value: TestNetworkDataset
+      response:
+          error: INVALID_IN_STATE
+
+    - label:
+          "TH sends GetOperationalDataset command to DUT with ExtendedPanID from
+          TestNetwork"
+      command: GetOperationalDataset
+      arguments:
+          values:
+              - name: ExtendedPanID
+                value: TestNetworkExtendedPanId
+      response:
+          values:
+              - name: OperationalDataset
+                value: TestNetworkDataset
+
+    - label:
+          "TH sends AddNetwork command to DUT with updated TestNetwork dataset
+          with larger Active Timestamp"
+      command: AddNetwork
+      timedInteractionTimeoutMs: 2000
+      arguments:
+          values:
+              - name: OperationalDataset
+                value: TestNetworkUpdatedDataset
+
+    - label:
+          "TH sends GetOperationalDataset command to DUT with ExtendedPanID from
+          TestNetwork"
+      command: GetOperationalDataset
+      arguments:
+          values:
+              - name: ExtendedPanID
+                value: TestNetworkExtendedPanId
+      response:
+          values:
+              - name: OperationalDataset
+                value: TestNetworkUpdatedDataset
+
+    - label:
+          "TH sends AddNetwork command to DUT with original TestNetwork dataset"
+      command: AddNetwork
+      timedInteractionTimeoutMs: 2000
+      arguments:
+          values:
+              - name: OperationalDataset
+                value: TestNetworkDataset
+      response:
+          error: INVALID_IN_STATE
+
+    - label:
+          "TH sends GetOperationalDataset command to DUT with ExtendedPanID from
+          TestNetwork"
+      command: GetOperationalDataset
+      arguments:
+          values:
+              - name: ExtendedPanID
+                value: TestNetworkExtendedPanId
+      response:
+          values:
+              - name: OperationalDataset
+                value: TestNetworkUpdatedDataset
 
     - label:
           "TH writes ExtendedPanID from TestNetwork to PreferredExtendedPanID on

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_2.yaml
@@ -93,15 +93,15 @@ tests:
       response:
           error: NOT_FOUND
 
-    # TODO: Currently fails with darwin-framework-tool because it automatically performs a timed invoke
-    # - label: "TH sends AddNetwork command to DUT without a timed interaction"
-    #   command: AddNetwork
-    #   arguments:
-    #       values:
-    #           - name: OperationalDataset
-    #             value: TestNetworkDataset
-    #   response:
-    #       error: NEEDS_TIMED_INTERACTION
+    # Note: Unsupported with darwin-framework-tool because it automatically performs a timed invoke
+    - label: "TH sends AddNetwork command to DUT without a timed interaction"
+      command: AddNetwork
+      arguments:
+          values:
+              - name: OperationalDataset
+                value: TestNetworkDataset
+      response:
+          error: NEEDS_TIMED_INTERACTION
 
     - label: "TH sends AddNetwork command to DUT with TestNetwork dataset"
       command: AddNetwork
@@ -233,15 +233,15 @@ tests:
       response:
           value: TestNetworkExtendedPanId
 
-    # TODO: Currently fails with darwin-framework-tool because it automatically performs a timed invoke
-    # - label: "TH sends RemoveNetwork command to DUT without a timed interaction"
-    #   command: RemoveNetwork
-    #   arguments:
-    #       values:
-    #           - name: ExtendedPanID
-    #             value: TestNetworkExtendedPanId
-    #   response:
-    #       error: NEEDS_TIMED_INTERACTION
+    # Note: Unsupported with darwin-framework-tool because it automatically performs a timed invoke
+    - label: "TH sends RemoveNetwork command to DUT without a timed interaction"
+      command: RemoveNetwork
+      arguments:
+          values:
+              - name: ExtendedPanID
+                value: TestNetworkExtendedPanId
+      response:
+          error: NEEDS_TIMED_INTERACTION
 
     - label:
           "TH sends RemoveNetwork command to DUT with ExtendedPanID of

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_3.yaml
@@ -1,0 +1,85 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name:
+    "[TC-THNETDIR-2.3] Verify CASE session requirement for GetOperationalDataset"
+
+PICS:
+    - THNETDIR.S
+
+config:
+    nodeId: 0x12344321
+    cluster: Thread Network Directory
+    endpoint: 1
+
+    TestNetworkExtendedPanId:
+        type: octet_string
+        defaultValue: "hex:39758ec8144b07fb"
+
+    payload: "MT:-24J0AFN00KA0648G00"
+    discriminator: 3840
+    PakeVerifier:
+        type: octet_string
+        defaultValue: "hex:b96170aae803346884724fe9a3b287c30330c2a660375d17bb205a8cf1aecb350457f8ab79ee253ab6a8e46bb09e543ae422736de501e3db37d441fe344920d09548e4c18240630c4ff4913c53513839b7c07fcc0627a1b8573a149fcd1fa466cf"
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: DelayCommands
+      command: WaitForCommissionee
+      arguments:
+          values:
+              - name: nodeId
+                value: nodeId
+
+    - label: "Open Commissioning Window"
+      endpoint: 0
+      cluster: Administrator Commissioning
+      command: OpenCommissioningWindow
+      timedInteractionTimeoutMs: 2000
+      arguments:
+          values:
+              - name: CommissioningTimeout
+                value: 180
+              - name: PAKEPasscodeVerifier
+                value: PakeVerifier
+              - name: Discriminator
+                value: discriminator
+              - name: Iterations
+                value: 1000
+              - name: Salt
+                value: "SPAKE2P Key Salt"
+
+    - label: "TH establishes a PASE session with the DUT"
+      identity: beta
+      endpoint: 0
+      cluster: CommissionerCommands
+      command: EstablishPASESession
+      arguments:
+          values:
+              - name: nodeId
+                value: nodeId
+              - name: payload
+                value: payload
+
+    - label:
+          "TH sends GetOperationalDataset command to the DUT over the PASE
+          session"
+      identity: beta
+      command: GetOperationalDataset
+      arguments:
+          values:
+              - name: ExtendedPanID
+                value: TestNetworkExtendedPanId
+      response:
+          error: UNSUPPORTED_ACCESS

--- a/src/app/tests/suites/certification/Test_TC_THNETDIR_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_THNETDIR_2_3.yaml
@@ -60,7 +60,7 @@ tests:
               - name: Salt
                 value: "SPAKE2P Key Salt"
 
-    - label: "TH establishes a PASE session with the DUT"
+    - label: "TH2 establishes a PASE session with the DUT"
       identity: beta
       endpoint: 0
       cluster: CommissionerCommands
@@ -73,7 +73,7 @@ tests:
                 value: payload
 
     - label:
-          "TH sends GetOperationalDataset command to the DUT over the PASE
+          "TH2 sends GetOperationalDataset command to the DUT over the PASE
           session"
       identity: beta
       command: GetOperationalDataset

--- a/src/app/tests/suites/certification/Test_TC_WIFINM_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WIFINM_2_2.yaml
@@ -1,0 +1,82 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name:
+    "[TC-WIFINM-2.2] Verify CASE session requirement for
+    NetworkPassphraseRequest"
+
+PICS:
+    - WIFINM.S
+
+config:
+    nodeId: 0x12344321
+    cluster: WiFi Network Management
+    endpoint: 1
+
+    TestNetworkExtendedPanId:
+        type: octet_string
+        defaultValue: "hex:39758ec8144b07fb"
+
+    payload: "MT:-24J0AFN00KA0648G00"
+    discriminator: 3840
+    PakeVerifier:
+        type: octet_string
+        defaultValue: "hex:b96170aae803346884724fe9a3b287c30330c2a660375d17bb205a8cf1aecb350457f8ab79ee253ab6a8e46bb09e543ae422736de501e3db37d441fe344920d09548e4c18240630c4ff4913c53513839b7c07fcc0627a1b8573a149fcd1fa466cf"
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: DelayCommands
+      command: WaitForCommissionee
+      arguments:
+          values:
+              - name: nodeId
+                value: nodeId
+
+    - label: "Open Commissioning Window"
+      endpoint: 0
+      cluster: Administrator Commissioning
+      command: OpenCommissioningWindow
+      timedInteractionTimeoutMs: 2000
+      arguments:
+          values:
+              - name: CommissioningTimeout
+                value: 180
+              - name: PAKEPasscodeVerifier
+                value: PakeVerifier
+              - name: Discriminator
+                value: discriminator
+              - name: Iterations
+                value: 1000
+              - name: Salt
+                value: "SPAKE2P Key Salt"
+
+    - label: "TH establishes a PASE session with the DUT"
+      identity: beta
+      endpoint: 0
+      cluster: CommissionerCommands
+      command: EstablishPASESession
+      arguments:
+          values:
+              - name: nodeId
+                value: nodeId
+              - name: payload
+                value: payload
+
+    - label:
+          "TH sends the NetworkPassphraseRequest command to the DUT over the
+          PASE session"
+      identity: beta
+      command: NetworkPassphraseRequest
+      response:
+          error: UNSUPPORTED_ACCESS

--- a/src/app/tests/suites/certification/Test_TC_WIFINM_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_WIFINM_2_2.yaml
@@ -61,7 +61,7 @@ tests:
               - name: Salt
                 value: "SPAKE2P Key Salt"
 
-    - label: "TH establishes a PASE session with the DUT"
+    - label: "TH2 establishes a PASE session with the DUT"
       identity: beta
       endpoint: 0
       cluster: CommissionerCommands
@@ -74,7 +74,7 @@ tests:
                 value: payload
 
     - label:
-          "TH sends the NetworkPassphraseRequest command to the DUT over the
+          "TH2 sends the NetworkPassphraseRequest command to the DUT over the
           PASE session"
       identity: beta
       command: NetworkPassphraseRequest

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -650,7 +650,7 @@ class CommissionerCommandAction(BaseAction):
         if test_step.command == 'GetCommissionerNodeId':
             # Just setting the self._command is enough for run_action below.
             pass
-        elif test_step.command == 'PairWithCode':
+        elif test_step.command in ('PairWithCode', 'EstablishPASESession'):
             args = test_step.arguments['values']
             request_data_as_dict = Converter.convert_list_of_name_value_pair_to_dict(args)
             self._setup_payload = request_data_as_dict['payload']
@@ -663,7 +663,10 @@ class CommissionerCommandAction(BaseAction):
             return _ActionResult(status=_ActionStatus.SUCCESS, response=_GetCommissionerNodeIdResult(dev_ctrl.nodeId))
 
         try:
-            await dev_ctrl.CommissionWithCode(self._setup_payload, self._node_id)
+            if self._command == 'PairWithCode':
+                await dev_ctrl.CommissionWithCode(self._setup_payload, self._node_id)
+            elif self._command == 'EstablishPASESession':
+                await dev_ctrl.EstablishPASESession(self._setup_payload, self._node_id)
             return _ActionResult(status=_ActionStatus.SUCCESS, response=None)
         except ChipStackError:
             return _ActionResult(status=_ActionStatus.ERROR, response=None)


### PR DESCRIPTION
Aligns implementation with https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/10295

- THNETDIR: Implement ActiveTimestamp check for updates
- THNETDIR: Implement CASE session requirement for GetOperationalDataset
- WIFINM: Implement CASE session requirement for NetworkPassphraseRequest
- Update / add certification YAML tests accordingly

Fixes https://github.com/project-chip/matter-test-scripts/issues/359
