### PR TITLE
[Bouffalo Lab] Add a script to demonstrate mfd partition generation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,4 +18,5 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	mkdir -p "$(SOURCEDIR)"
+	$(info "$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)")
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,5 +18,4 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	mkdir -p "$(SOURCEDIR)"
-	$(info "$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)")
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/guides/bouffalolab/matter_factory_data.md
+++ b/docs/guides/bouffalolab/matter_factory_data.md
@@ -1,0 +1,222 @@
+# Introduction to Matter factory data
+
+Each Matter device should have it own unique factory data manufactured. 
+
+This guide demonstrates what `Bouffalo Lab` provides to support factory data:
+
+- credential factory data protected by hardware security engine
+- reference tool to generate factory data
+- tool/method to program factory data
+
+# Matter factory data
+
+## How to enable
+
+One dedicate flash region allocates for factory data as below which is read-only for firmware.
+
+```toml
+name = "MFD"
+address0 = 0x3FE000
+size0 = 0x1000
+```
+
+To enable matter factory data feature, please append `-mfd` option at end of target name. Take BL616 Wi-Fi Matter Light as example.
+
+```
+./scripts/build/build_examples.py --target bouffalolab-bl616dk-light-wifi-mfd build
+```
+
+## Factory data
+
+This flash region is divided to two parts:
+
+- One is plain text data, such as Vendor ID, Product ID, Serial number and so on.
+
+  > For development/test purpose, all data can put in plain text data.
+
+- Other is cipher text data, such as private key for device attestation data. 
+
+  `Bouffalo Lab` provides hardware security engine to decrypt this part data with **only hardware access** efuse key.
+
+Current supported data
+
+-   DAC certificate and private key
+-   PAI certificate
+-   Certificate declaration
+
+-   Discriminator ID
+-   Pass Code
+-   Spake2p iteration count, salt and verifier
+-   Vendor ID and name
+-   Product ID and name
+-   Product part number and product label
+-   Manufacturing date
+-   Hardware version and version string
+-   Serial Number
+-   Unique identifier
+
+>  Note, it is available to add customer/product own information in factory data, please reference to `bl_mfd.h`/`bl_mfd.c` in SDK and reference generation script [generate_factory_data.py](../../../scripts/tools/bouffalolab/generate_factory_data.py)
+
+# Generate Matter factory data
+
+Script tool [generate_factory_data.py](../../../scripts/tools/bouffalolab/generate_factory_data.py) call `chip-cert` to generate test certificates and verify certificates. 
+
+Please run below command to compile `chip-cert` tool under `connnectedhomeip` repo.
+
+```shell
+./scripts/build/build_examples.py --target linux-x64-chip-cert build
+```
+
+## Command options
+
+- `--cd`, certificate declare
+
+  If not specified, `Chip-Test-CD-Signing-Cert.pem` and `Chip-Test-CD-Signing-Key.pem` will sign a test certificate declare for development and test purpose
+
+- `--pai_cert` and `--pai-key`, PAI certificate and PAI private key
+
+  If not specified,  `Chip-Test-PAI-FFF1-8000-Cert.pem` and `Chip-Test-PAI-FFF1-8000-Key.pem` will be used for development and test purpose.
+
+- `--dac_cert` and `--dac_key`, DAC certificate and DAC private key.
+
+  If not specified, script will use PAI certificate and key specified by`--pai_cert` and `--pai-key` to generate DAC certificate and private key for development and test prupose.
+
+- `--discriminator`, discriminator ID
+
+  If not specified, script will generate for user.
+
+- `--passcode`, passcode
+
+  If not specified, script will generate for user.
+
+- `--spake2p_it` and `--spake2p_salt`
+
+  If not specified, script will generate and calculate verifier for user. 
+
+Please reference to `--help` for more detail.
+
+## Generate with default test certificates
+
+- Run following command to generate all plain text factory data
+
+  ```shell
+  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert
+  ```
+
+- Run following command to generate factory data which encrypt private of device attestation data
+
+  ```shell
+  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --key <hex string of 16 bytes>
+  ```
+  
+  > An example of hex string of 16 bytes: 12345678123456781234567812345678
+
+After command executes successfully, the output folder will has files as below:
+
+- Test certificate declare file which file name ends with `cd.der`
+
+  If user wants to reuse CD generated before, please specify CD with option `--cd` as below.
+
+  ```shell
+  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --cd <cd file>
+  ```
+
+- Test DAC certificate and DAC certificate key which file names ends with `dac_cert.pem` and `dac_key.pem` separately.
+
+- QR code  picture which file name ends with `onboard.png`
+- On board information which file name ends with `onboard.txt`
+- Matter factory data which file name ends with `mfd.bin`. 
+
+## Generate with self-defined PAA/PAI certificates
+
+Self-defined PAA/PAI certificates may use in development and test scenario. But, user should know it has limit to work with real ecosystem.
+
+- Export environment variables in terminal for easy operations
+
+  ```
+  export TEST_CERT_VENDOR_ID=130D # Vendor ID hex string
+  export TEST_CERT_CN=BFLB        # Common Name
+  ```
+
+- Generate PAA certificate and key to `out/cert` folder. 
+
+  ```shell
+  mkdir out/test-cert
+  ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type a --subject-cn "${TEST_CERT_CN} PAA 01" --valid-from "2020-10-15 14:23:43" --lifetime 7305 --out-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --subject-vid ${TEST_CERT_VENDOR_ID}
+  ```
+
+- Convert PAA PEM format file to PAA DER format file
+
+  ```shell
+  ./out/linux-x64-chip-cert/chip-cert convert-cert -d out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.der
+  ```
+
+  > Please save this PAA DER format file which will be used by `chip-tool` during commissioning.
+
+- Generate PAI certificate and key:
+
+  ```shell
+  ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type i --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem
+  ```
+
+- Generate MFD in plain text data
+
+  ```shell
+  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem
+  ```
+
+  > Appending `--key <hex string of 16 bytes>` option to enable encrypt private key of attestation device data.
+
+## Generate with self-defined DAC certificate and key
+
+Self-defined DAC certificates may use in development and test scenario. But, user should know it has limit to work with real ecosystem.
+
+- Export environment variables in terminal for easy operations
+
+  ```
+  export TEST_CERT_VENDOR_ID=130D  # Vendor ID hex string
+  export TEST_CERT_PRODUCT_ID=1001 # Vendor ID hex string
+  export TEST_CERT_CN=BFLB         # Common Name
+  ```
+
+- Generate DAC certificate and key
+
+  ```shell
+  out/linux-x64-chip-cert/chip-cert gen-att-cert --type d --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --subject-pid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-16 14:23:43" --lifetime 5946 --ca-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-DAC-Key-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem --out out/test-cert/Chip-DAC-Cert-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem
+  ```
+
+  > **Note**,  `--valid-from` and `--lifetime` should be in `--valid-from`  and `--lifetime` of PAI certificate.
+
+- Generate MFD in plain text data
+
+  ```shell
+  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --dac_cert out/test-cert/Chip-DAC-Cert-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem --dac_key out/test-cert/Chip-DAC-Key-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem
+  ```
+
+  > Appending `--key <hex string of 16 bytes>` option to enable encrypt private key of attestation device data.
+
+
+# Program factory data
+
+After each target built successfully, a flash programming python script will be generated under out folder.
+
+Take BL616 Wi-Fi Matter Light as example, `chip-bl616-lighting-example.flash.py` is using to program firmware, and also for factory data and factory decryption key.
+
+  ```shell
+  /out/bouffalolab-bl616dk-light-wifi-mfd/chip-bl616-lighting-example.flash.py --port <serial port>  --mfd out/test-cert/<mfd bin file>
+  ```
+
+  > If mfd file has cipher text data, please append `--key <hex string of 16 bytes>` option to program to this key to efuse.
+
+- Limits on BL IOT SDK
+
+  If developer would like to program MFD with all plain text data, option `--key <hex string of 16 bytes>` needs pass to script, otherwise, flash tool will raise an error. And SoC BL602, BL702 and BL702L use BL IOT SDK for Matter Application.
+
+Please free contact to `Bouffalo Lab` for DAC provider service and higher security solution, such as SoC inside certificate requesting. 
+
+ 
+
+  
+
+  
+

--- a/docs/guides/bouffalolab/matter_factory_data.md
+++ b/docs/guides/bouffalolab/matter_factory_data.md
@@ -95,7 +95,7 @@ repo.
 
     If not specified, script will use PAI certificate and key specified
     by`--pai_cert` and `--pai-key` to generate DAC certificate and private key
-    for development and test prupose.
+    for development and test purpose.
 
 -   `--discriminator`, discriminator ID
 
@@ -116,6 +116,7 @@ Please reference to `--help` for more detail.
 -   Run following command to generate all plain text factory data
 
     Please create output folder first. Here takes `out/test-cert` as example.
+
     ```shell
     ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert
     ```
@@ -181,7 +182,7 @@ user should know it has limit to work with real ecosystem.
     ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type i --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem
     ```
 
--   Generate MFD in plain text data
+-   Generate `MFD` in plain text data
 
     ```shell
     ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem
@@ -212,7 +213,7 @@ user should know it has limit to work with real ecosystem.
     > **Note**, `--valid-from` and `--lifetime` should be in `--valid-from` and
     > `--lifetime` of PAI certificate.
 
--   Generate MFD in plain text data
+-   Generate `MFD` in plain text data
 
     ```shell
     ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --dac_cert out/test-cert/Chip-DAC-Cert-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem --dac_key out/test-cert/Chip-DAC-Key-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem
@@ -234,12 +235,12 @@ key.
 /out/bouffalolab-bl616dk-light-wifi-mfd/chip-bl616-lighting-example.flash.py --port <serial port>  --mfd out/test-cert/<mfd bin file>
 ```
 
-> If mfd file has cipher text data, please append
+> If `MFD` file has cipher text data, please append
 > `--key <hex string of 16 bytes>` option to program to this key to efuse.
 
 -   Limits on BL IOT SDK
 
-    If developer would like to program MFD with all plain text data, option
+    If developer would like to program `MFD` with all plain text data, option
     `--key <hex string of 16 bytes>` needs pass to script, otherwise, flash tool
     will raise an error. And SoC BL602, BL702 and BL702L use BL IOT SDK for
     Matter Application.

--- a/docs/guides/bouffalolab/matter_factory_data.md
+++ b/docs/guides/bouffalolab/matter_factory_data.md
@@ -1,18 +1,19 @@
 # Introduction to Matter factory data
 
-Each Matter device should have it own unique factory data manufactured. 
+Each Matter device should have it own unique factory data manufactured.
 
 This guide demonstrates what `Bouffalo Lab` provides to support factory data:
 
-- credential factory data protected by hardware security engine
-- reference tool to generate factory data
-- tool/method to program factory data
+-   credential factory data protected by hardware security engine
+-   reference tool to generate factory data
+-   tool/method to program factory data
 
 # Matter factory data
 
 ## How to enable
 
-One dedicate flash region allocates for factory data as below which is read-only for firmware.
+One dedicate flash region allocates for factory data as below which is read-only
+for firmware.
 
 ```toml
 name = "MFD"
@@ -20,7 +21,8 @@ address0 = 0x3FE000
 size0 = 0x1000
 ```
 
-To enable matter factory data feature, please append `-mfd` option at end of target name. Take BL616 Wi-Fi Matter Light as example.
+To enable matter factory data feature, please append `-mfd` option at end of
+target name. Take BL616 Wi-Fi Matter Light as example.
 
 ```
 ./scripts/build/build_examples.py --target bouffalolab-bl616dk-light-wifi-mfd build
@@ -30,13 +32,15 @@ To enable matter factory data feature, please append `-mfd` option at end of tar
 
 This flash region is divided to two parts:
 
-- One is plain text data, such as Vendor ID, Product ID, Serial number and so on.
+-   One is plain text data, such as Vendor ID, Product ID, Serial number and so
+    on.
 
-  > For development/test purpose, all data can put in plain text data.
+    > For development/test purpose, all data can put in plain text data.
 
-- Other is cipher text data, such as private key for device attestation data. 
+-   Other is cipher text data, such as private key for device attestation data.
 
-  `Bouffalo Lab` provides hardware security engine to decrypt this part data with **only hardware access** efuse key.
+    `Bouffalo Lab` provides hardware security engine to decrypt this part data
+    with **only hardware access** efuse key.
 
 Current supported data
 
@@ -55,13 +59,19 @@ Current supported data
 -   Serial Number
 -   Unique identifier
 
->  Note, it is available to add customer/product own information in factory data, please reference to `bl_mfd.h`/`bl_mfd.c` in SDK and reference generation script [generate_factory_data.py](../../../scripts/tools/bouffalolab/generate_factory_data.py)
+> Note, it is available to add customer/product own information in factory data,
+> please reference to `bl_mfd.h`/`bl_mfd.c` in SDK and reference generation
+> script
+> [generate_factory_data.py](../../../scripts/tools/bouffalolab/generate_factory_data.py)
 
 # Generate Matter factory data
 
-Script tool [generate_factory_data.py](../../../scripts/tools/bouffalolab/generate_factory_data.py) call `chip-cert` to generate test certificates and verify certificates. 
+Script tool
+[generate_factory_data.py](../../../scripts/tools/bouffalolab/generate_factory_data.py)
+call `chip-cert` to generate test certificates and verify certificates.
 
-Please run below command to compile `chip-cert` tool under `connnectedhomeip` repo.
+Please run below command to compile `chip-cert` tool under `connnectedhomeip`
+repo.
 
 ```shell
 ./scripts/build/build_examples.py --target linux-x64-chip-cert build
@@ -69,154 +79,169 @@ Please run below command to compile `chip-cert` tool under `connnectedhomeip` re
 
 ## Command options
 
-- `--cd`, certificate declare
+-   `--cd`, certificate declare
 
-  If not specified, `Chip-Test-CD-Signing-Cert.pem` and `Chip-Test-CD-Signing-Key.pem` will sign a test certificate declare for development and test purpose
+    If not specified, `Chip-Test-CD-Signing-Cert.pem` and
+    `Chip-Test-CD-Signing-Key.pem` will sign a test certificate declare for
+    development and test purpose
 
-- `--pai_cert` and `--pai-key`, PAI certificate and PAI private key
+-   `--pai_cert` and `--pai-key`, PAI certificate and PAI private key
 
-  If not specified,  `Chip-Test-PAI-FFF1-8000-Cert.pem` and `Chip-Test-PAI-FFF1-8000-Key.pem` will be used for development and test purpose.
+    If not specified, `Chip-Test-PAI-FFF1-8000-Cert.pem` and
+    `Chip-Test-PAI-FFF1-8000-Key.pem` will be used for development and test
+    purpose.
 
-- `--dac_cert` and `--dac_key`, DAC certificate and DAC private key.
+-   `--dac_cert` and `--dac_key`, DAC certificate and DAC private key.
 
-  If not specified, script will use PAI certificate and key specified by`--pai_cert` and `--pai-key` to generate DAC certificate and private key for development and test prupose.
+    If not specified, script will use PAI certificate and key specified
+    by`--pai_cert` and `--pai-key` to generate DAC certificate and private key
+    for development and test prupose.
 
-- `--discriminator`, discriminator ID
+-   `--discriminator`, discriminator ID
 
-  If not specified, script will generate for user.
+    If not specified, script will generate for user.
 
-- `--passcode`, passcode
+-   `--passcode`, passcode
 
-  If not specified, script will generate for user.
+    If not specified, script will generate for user.
 
-- `--spake2p_it` and `--spake2p_salt`
+-   `--spake2p_it` and `--spake2p_salt`
 
-  If not specified, script will generate and calculate verifier for user. 
+    If not specified, script will generate and calculate verifier for user.
 
 Please reference to `--help` for more detail.
 
 ## Generate with default test certificates
 
-- Run following command to generate all plain text factory data
+-   Run following command to generate all plain text factory data
 
-  ```shell
-  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert
-  ```
+    ```shell
+    ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert
+    ```
 
-- Run following command to generate factory data which encrypt private of device attestation data
+-   Run following command to generate factory data which encrypt private of
+    device attestation data
 
-  ```shell
-  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --key <hex string of 16 bytes>
-  ```
-  
-  > An example of hex string of 16 bytes: 12345678123456781234567812345678
+    ```shell
+    ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --key <hex string of 16 bytes>
+    ```
+
+    > An example of hex string of 16 bytes: 12345678123456781234567812345678
 
 After command executes successfully, the output folder will has files as below:
 
-- Test certificate declare file which file name ends with `cd.der`
+-   Test certificate declare file which file name ends with `cd.der`
 
-  If user wants to reuse CD generated before, please specify CD with option `--cd` as below.
+    If user wants to reuse CD generated before, please specify CD with option
+    `--cd` as below.
 
-  ```shell
-  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --cd <cd file>
-  ```
+    ```shell
+    ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --cd <cd file>
+    ```
 
-- Test DAC certificate and DAC certificate key which file names ends with `dac_cert.pem` and `dac_key.pem` separately.
+-   Test DAC certificate and DAC certificate key which file names ends with
+    `dac_cert.pem` and `dac_key.pem` separately.
 
-- QR code  picture which file name ends with `onboard.png`
-- On board information which file name ends with `onboard.txt`
-- Matter factory data which file name ends with `mfd.bin`. 
+-   QR code picture which file name ends with `onboard.png`
+-   On board information which file name ends with `onboard.txt`
+-   Matter factory data which file name ends with `mfd.bin`.
 
 ## Generate with self-defined PAA/PAI certificates
 
-Self-defined PAA/PAI certificates may use in development and test scenario. But, user should know it has limit to work with real ecosystem.
+Self-defined PAA/PAI certificates may use in development and test scenario. But,
+user should know it has limit to work with real ecosystem.
 
-- Export environment variables in terminal for easy operations
+-   Export environment variables in terminal for easy operations
 
-  ```
-  export TEST_CERT_VENDOR_ID=130D # Vendor ID hex string
-  export TEST_CERT_CN=BFLB        # Common Name
-  ```
+    ```
+    export TEST_CERT_VENDOR_ID=130D # Vendor ID hex string
+    export TEST_CERT_CN=BFLB        # Common Name
+    ```
 
-- Generate PAA certificate and key to `out/cert` folder. 
+-   Generate PAA certificate and key to `out/cert` folder.
 
-  ```shell
-  mkdir out/test-cert
-  ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type a --subject-cn "${TEST_CERT_CN} PAA 01" --valid-from "2020-10-15 14:23:43" --lifetime 7305 --out-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --subject-vid ${TEST_CERT_VENDOR_ID}
-  ```
+    ```shell
+    mkdir out/test-cert
+    ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type a --subject-cn "${TEST_CERT_CN} PAA 01" --valid-from "2020-10-15 14:23:43" --lifetime 7305 --out-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --subject-vid ${TEST_CERT_VENDOR_ID}
+    ```
 
-- Convert PAA PEM format file to PAA DER format file
+-   Convert PAA PEM format file to PAA DER format file
 
-  ```shell
-  ./out/linux-x64-chip-cert/chip-cert convert-cert -d out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.der
-  ```
+    ```shell
+    ./out/linux-x64-chip-cert/chip-cert convert-cert -d out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.der
+    ```
 
-  > Please save this PAA DER format file which will be used by `chip-tool` during commissioning.
+    > Please save this PAA DER format file which will be used by `chip-tool`
+    > during commissioning.
 
-- Generate PAI certificate and key:
+-   Generate PAI certificate and key:
 
-  ```shell
-  ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type i --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem
-  ```
+    ```shell
+    ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type i --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem
+    ```
 
-- Generate MFD in plain text data
+-   Generate MFD in plain text data
 
-  ```shell
-  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem
-  ```
+    ```shell
+    ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem
+    ```
 
-  > Appending `--key <hex string of 16 bytes>` option to enable encrypt private key of attestation device data.
+    > Appending `--key <hex string of 16 bytes>` option to enable encrypt
+    > private key of attestation device data.
 
 ## Generate with self-defined DAC certificate and key
 
-Self-defined DAC certificates may use in development and test scenario. But, user should know it has limit to work with real ecosystem.
+Self-defined DAC certificates may use in development and test scenario. But,
+user should know it has limit to work with real ecosystem.
 
-- Export environment variables in terminal for easy operations
+-   Export environment variables in terminal for easy operations
 
-  ```
-  export TEST_CERT_VENDOR_ID=130D  # Vendor ID hex string
-  export TEST_CERT_PRODUCT_ID=1001 # Vendor ID hex string
-  export TEST_CERT_CN=BFLB         # Common Name
-  ```
+    ```
+    export TEST_CERT_VENDOR_ID=130D  # Vendor ID hex string
+    export TEST_CERT_PRODUCT_ID=1001 # Vendor ID hex string
+    export TEST_CERT_CN=BFLB         # Common Name
+    ```
 
-- Generate DAC certificate and key
+-   Generate DAC certificate and key
 
-  ```shell
-  out/linux-x64-chip-cert/chip-cert gen-att-cert --type d --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --subject-pid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-16 14:23:43" --lifetime 5946 --ca-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-DAC-Key-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem --out out/test-cert/Chip-DAC-Cert-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem
-  ```
+    ```shell
+    out/linux-x64-chip-cert/chip-cert gen-att-cert --type d --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --subject-pid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-16 14:23:43" --lifetime 5946 --ca-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-DAC-Key-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem --out out/test-cert/Chip-DAC-Cert-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem
+    ```
 
-  > **Note**,  `--valid-from` and `--lifetime` should be in `--valid-from`  and `--lifetime` of PAI certificate.
+    > **Note**, `--valid-from` and `--lifetime` should be in `--valid-from` and
+    > `--lifetime` of PAI certificate.
 
-- Generate MFD in plain text data
+-   Generate MFD in plain text data
 
-  ```shell
-  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --dac_cert out/test-cert/Chip-DAC-Cert-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem --dac_key out/test-cert/Chip-DAC-Key-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem
-  ```
+    ```shell
+    ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --dac_cert out/test-cert/Chip-DAC-Cert-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem --dac_key out/test-cert/Chip-DAC-Key-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem
+    ```
 
-  > Appending `--key <hex string of 16 bytes>` option to enable encrypt private key of attestation device data.
-
+    > Appending `--key <hex string of 16 bytes>` option to enable encrypt
+    > private key of attestation device data.
 
 # Program factory data
 
-After each target built successfully, a flash programming python script will be generated under out folder.
+After each target built successfully, a flash programming python script will be
+generated under out folder.
 
-Take BL616 Wi-Fi Matter Light as example, `chip-bl616-lighting-example.flash.py` is using to program firmware, and also for factory data and factory decryption key.
+Take BL616 Wi-Fi Matter Light as example, `chip-bl616-lighting-example.flash.py`
+is using to program firmware, and also for factory data and factory decryption
+key.
 
-  ```shell
-  /out/bouffalolab-bl616dk-light-wifi-mfd/chip-bl616-lighting-example.flash.py --port <serial port>  --mfd out/test-cert/<mfd bin file>
-  ```
+```shell
+/out/bouffalolab-bl616dk-light-wifi-mfd/chip-bl616-lighting-example.flash.py --port <serial port>  --mfd out/test-cert/<mfd bin file>
+```
 
-  > If mfd file has cipher text data, please append `--key <hex string of 16 bytes>` option to program to this key to efuse.
+> If mfd file has cipher text data, please append
+> `--key <hex string of 16 bytes>` option to program to this key to efuse.
 
-- Limits on BL IOT SDK
+-   Limits on BL IOT SDK
 
-  If developer would like to program MFD with all plain text data, option `--key <hex string of 16 bytes>` needs pass to script, otherwise, flash tool will raise an error. And SoC BL602, BL702 and BL702L use BL IOT SDK for Matter Application.
+    If developer would like to program MFD with all plain text data, option
+    `--key <hex string of 16 bytes>` needs pass to script, otherwise, flash tool
+    will raise an error. And SoC BL602, BL702 and BL702L use BL IOT SDK for
+    Matter Application.
 
-Please free contact to `Bouffalo Lab` for DAC provider service and higher security solution, such as SoC inside certificate requesting. 
-
- 
-
-  
-
-  
-
+Please free contact to `Bouffalo Lab` for DAC provider service and higher
+security solution, such as SoC inside certificate requesting.

--- a/docs/guides/bouffalolab/matter_factory_data.md
+++ b/docs/guides/bouffalolab/matter_factory_data.md
@@ -22,10 +22,10 @@ size0 = 0x1000
 ```
 
 To enable matter factory data feature, please append `-mfd` option at end of
-target name. Take BL616 Wi-Fi Matter Light as example.
+target name. Take BL602 Wi-Fi Matter Light as example.
 
 ```
-./scripts/build/build_examples.py --target bouffalolab-bl616dk-light-wifi-mfd build
+./scripts/build/build_examples.py --target bouffalolab-bl602dk-light-littlefs-mfd build
 ```
 
 ## Factory data
@@ -115,6 +115,7 @@ Please reference to `--help` for more detail.
 
 -   Run following command to generate all plain text factory data
 
+    Please create output folder first. Here takes `out/test-cert` as example.
     ```shell
     ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert
     ```

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,6 +9,7 @@ and features.
 :hidden:
 
 *
+bouffalolab/matter_factory_data
 esp32/README
 nxp/README
 ti/ti_matter_overview

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -23,6 +23,7 @@ ti/ti_matter_overview
 -   [Android - Building](./android_building.md)
 -   [Apple - Testing with iPhone, iPad, macOS, Apple TV, HomePod, Watch, etc](./darwin.md)
 -   [ASR - Getting Started Guide](./asr_getting_started_guide.md)
+-   [Bouffalo Lab - Matter factory data generation](./bouffalolab/matter_factory_data.md)
 -   [Espressif (ESP32) - Getting Started Guide](./esp32/README.md)
 -   [Infineon PSoC6 - Software Update](./infineon_psoc6_software_update.md)
 -   [Linux - Simulated Devices](./simulated_device_linux.md)

--- a/examples/lighting-app/bouffalolab/README.md
+++ b/examples/lighting-app/bouffalolab/README.md
@@ -99,6 +99,7 @@ The following steps take examples for `BL602DK`, `BL704LDK` and `BL706DK`.
 
     ```
     ./scripts/build/build_examples.py --target bouffalolab-bl602dk-light build
+    ./scripts/build/build_examples.py --target bouffalolab-bl616dk-light-wifi build
     ./scripts/build/build_examples.py --target bouffalolab-bl704ldk-light build
     ./scripts/build/build_examples.py --target bouffalolab-bl706dk-light build
     ```
@@ -113,23 +114,23 @@ The following steps take examples for `BL602DK`, `BL704LDK` and `BL706DK`.
 
 ### Build options with build_examples.py
 
--   `-wifi`, to specify that connectivity Wi-Fi is enabled for Matter
+-   `-wifi`, specifies to use Wi-Fi for Matter application.
+
+    -   BL602 uses Wi-Fi by defualt. `-wifi` could be elided.
+    -   BL702 needs it to specify to use BL706 + BL602 for Wi-Fi.
+
+-   `-thread`, specifies to use Thread for Matter
     application.
 
-    -   BL602 uses `-wifi` by default
-    -   BL702 needs specify to use BL706 + BL602 for Wi-Fi connectivity.
+    -   BL70X uses Thread by defualt. `-thread` could be elided.
 
--   `-thread`, to specify that connectivity Thread is enabled for Matter
-    application.
+-   `-ethernet`, specifies to use Ethernet for Matter application.
 
-    -   BL70X uses `-thread` by default.
+    -   BL706 needs it to specify to use Ethernet.
 
--   `-ethernet`, to specify that connectivity Ethernet is enabled for Matte
-    application.
-
-    -   BL706 needs specify to use Ethernet connectivity.
-
--   `-easyflash`, to specify that `easyflash` is used for flash storage access.
+-   `-littlefs`, specifies to use littlefs for flash access.
+-   `-easyflash`, specifies to use `easyflash` for flash access.
+    -   for platform BL602/BL70X, it is necessary to specify one of `-easyflash` and `-littlefs`.
 -   `-mfd`, enable Matter factory data feature, which load factory data from
     `MFD` partition
 -   `-shell`, enable command line
@@ -175,9 +176,10 @@ The following steps take examples for `BL602DK`, `BL704LDK` and `BL706DK`.
 
 
             ```shell
-            ./out/bouffalolab-bl602dk-light/chip-bl602-lighting-example.flash.py --port /dev/ttyACM0
-            ./out/bouffalolab-bl704ldk-light/chip-bl702l-lighting-example.flash.py --port /dev/ttyACM0
-            ./out/bouffalolab-bl706dk-light/chip-bl702-lighting-example.flash.py --port /dev/ttyACM0
+          ./out/bouffalolab-bl602dk-light-littlefs/chip-bl602-lighting-example.flash.py --port /dev/ttyACM0
+          ./out/bouffalolab-bl616dk-light-wifi/chip-bl616dk-lighting-example.flash.py --port /dev/ttyACM0
+          ./out/bouffalolab-bl704ldk-light-littlefs/chip-bl702l-lighting-example.flash.py --port /dev/ttyACM0
+          ./out/bouffalolab-bl706dk-light-littlefs/chip-bl702-lighting-example.flash.py --port /dev/ttyACM0
             ```
 
         -   To wipe out flash and download image, please append `--erase`

--- a/examples/lighting-app/bouffalolab/README.md
+++ b/examples/lighting-app/bouffalolab/README.md
@@ -1,4 +1,4 @@
-# `Bouffalo Lab`
+# Matter `Bouffalo Lab` Lighting Example
 
 This example functions as a light bulb device type, with on/off and level
 capabilities and uses a test Vendor ID (VID) and a Product ID (PID)

--- a/examples/lighting-app/bouffalolab/README.md
+++ b/examples/lighting-app/bouffalolab/README.md
@@ -17,8 +17,6 @@ Legacy supported boards:
 -   `BL602-NIGHT-LIGHT`
 -   `XT-ZB6-DevKit`
 -   `BL706-NIGHT-LIGHT`
--   `BL706DK`
--   `BL704LDK`
 
 > Warning: Changing the VID/PID may cause compilation problems, we recommend
 > leaving it as the default while using this example.
@@ -119,8 +117,7 @@ The following steps take examples for `BL602DK`, `BL704LDK` and `BL706DK`.
     -   BL602 uses Wi-Fi by defualt. `-wifi` could be elided.
     -   BL702 needs it to specify to use BL706 + BL602 for Wi-Fi.
 
--   `-thread`, specifies to use Thread for Matter
-    application.
+-   `-thread`, specifies to use Thread for Matter application.
 
     -   BL70X uses Thread by defualt. `-thread` could be elided.
 
@@ -130,9 +127,11 @@ The following steps take examples for `BL602DK`, `BL704LDK` and `BL706DK`.
 
 -   `-littlefs`, specifies to use littlefs for flash access.
 -   `-easyflash`, specifies to use `easyflash` for flash access.
-    -   for platform BL602/BL70X, it is necessary to specify one of `-easyflash` and `-littlefs`.
+    -   for platform BL602/BL70X, it is necessary to specify one of `-easyflash`
+        and `-littlefs`.
 -   `-mfd`, enable Matter factory data feature, which load factory data from
     `MFD` partition
+    -   Please refer to [Bouffalo Lab Matter factory data guide](../../../docs/guides/bouffalolab/matter_factory_data.md) or contact to `Bouffalo Lab` for support.
 -   `-shell`, enable command line
 -   `-rpc`, enable Pigweed RPC feature
 -   `-115200`, set UART baudrate to 115200 for log and command line

--- a/examples/lighting-app/bouffalolab/README.md
+++ b/examples/lighting-app/bouffalolab/README.md
@@ -131,7 +131,9 @@ The following steps take examples for `BL602DK`, `BL704LDK` and `BL706DK`.
         and `-littlefs`.
 -   `-mfd`, enable Matter factory data feature, which load factory data from
     `MFD` partition
-    -   Please refer to [Bouffalo Lab Matter factory data guide](../../../docs/guides/bouffalolab/matter_factory_data.md) or contact to `Bouffalo Lab` for support.
+    -   Please refer to
+        [Bouffalo Lab Matter factory data guide](../../../docs/guides/bouffalolab/matter_factory_data.md)
+        or contact to `Bouffalo Lab` for support.
 -   `-shell`, enable command line
 -   `-rpc`, enable Pigweed RPC feature
 -   `-115200`, set UART baudrate to 115200 for log and command line

--- a/examples/lighting-app/bouffalolab/README.md
+++ b/examples/lighting-app/bouffalolab/README.md
@@ -114,18 +114,18 @@ The following steps take examples for `BL602DK`, `BL704LDK` and `BL706DK`.
 
 -   `-wifi`, specifies to use Wi-Fi for Matter application.
 
-    -   BL602 uses Wi-Fi by defualt. `-wifi` could be elided.
+    -   BL602 uses Wi-Fi by default. `-wifi` could be elided.
     -   BL702 needs it to specify to use BL706 + BL602 for Wi-Fi.
 
 -   `-thread`, specifies to use Thread for Matter application.
 
-    -   BL70X uses Thread by defualt. `-thread` could be elided.
+    -   BL70X uses Thread by default. `-thread` could be elided.
 
 -   `-ethernet`, specifies to use Ethernet for Matter application.
 
     -   BL706 needs it to specify to use Ethernet.
 
--   `-littlefs`, specifies to use littlefs for flash access.
+-   `-littlefs`, specifies to use `littlefs` for flash access.
 -   `-easyflash`, specifies to use `easyflash` for flash access.
     -   for platform BL602/BL70X, it is necessary to specify one of `-easyflash`
         and `-littlefs`.

--- a/scripts/tools/bouffalolab/generate_factory_data.py
+++ b/scripts/tools/bouffalolab/generate_factory_data.py
@@ -1,0 +1,562 @@
+#!/usr/bin/env python3
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import argparse
+import base64
+import logging as log
+import os
+import secrets
+import subprocess
+import sys
+import random
+import ssl
+import binascii
+
+from pathlib import Path
+from datetime import datetime, timedelta
+from Crypto.Cipher import AES
+
+from cryptography import x509
+from cryptography.x509.oid import ObjectIdentifier
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import load_der_private_key
+
+
+MATTER_ROOT = os.path.dirname(os.path.realpath(__file__))[:-len("/scripts/tools/bouffalolab")]
+
+TEST_CD_CERT = MATTER_ROOT + "/credentials/test/certification-declaration/Chip-Test-CD-Signing-Cert.pem"
+TEST_CD_KEY = MATTER_ROOT + "/credentials/test/certification-declaration/Chip-Test-CD-Signing-Key.pem"
+TEST_PAA_CERT = MATTER_ROOT + "/credentials/test/attestation/Chip-Test-PAA-FFF1-Cert.pem"
+TEST_PAA_KEY = MATTER_ROOT + "/credentials/test/attestation/Chip-Test-PAA-FFF1-Key.pem"
+TEST_PAI_CERT = MATTER_ROOT + "/credentials/test/attestation/Chip-Test-PAI-FFF1-8000-Cert.pem"
+TEST_PAI_KEY = MATTER_ROOT + "/credentials/test/attestation/Chip-Test-PAI-FFF1-8000-Key.pem"
+TEST_CHIP_CERT = MATTER_ROOT + "/out/linux-x64-chip-cert/chip-cert"
+TEST_CD_TYPE = 1 # 0 - development, 1 - provisional, 2 - official
+
+
+def gen_test_passcode(passcode):
+
+    INVALID_PASSCODES = [0, 11111111, 22222222, 33333333, 44444444,
+                         55555555, 66666666, 77777777, 88888888, 99999999, 
+                         12345678, 87654321]
+
+    def check_passcode(passcode):
+        return 0 <= passcode <= 99999999 and passcode not in INVALID_PASSCODES
+
+    if isinstance(passcode, int):
+        if check_passcode(passcode):
+            raise Exception("passcode is invalid value.")
+        return passcode
+
+    passcode = -1
+    while not check_passcode(passcode):
+        passcode = random.randint(0, 99999999)
+
+    return passcode
+
+
+def gen_test_discriminator(discriminator):
+
+    if isinstance(discriminator, int):
+        if discriminator > 0xfff:
+            raise Exception("discriminator is invalid value.")
+
+    discriminator = random.randint(0, 0xfff)
+
+    return discriminator
+
+
+def gen_test_unique_id(unique_id):
+
+    if isinstance(unique_id, bytes):
+        if len(unique_id) != 16:
+            raise Exception("rotating unique id has invalid length.")
+        return unique_id
+
+    unique_id = secrets.token_bytes(16)
+
+    return unique_id
+
+
+def gen_test_spake2(passcode, spake2p_it, spake2p_salt, spake2p_verifier = None):
+
+    sys.path.insert(0, os.path.join(MATTER_ROOT, 'scripts', 'tools', 'spake2p'))
+    from spake2p import generate_verifier
+
+    if isinstance(spake2p_it, int):
+        if not 1000 <= spake2p_it <= 100000:
+            raise Exception("SPAKE2+ iteration count out of range.")
+    else:
+        spake2p_it = random.randint(1000, 100000)
+
+    if spake2p_salt is None:
+        spake2p_salt_len = random.randint(16, 32)
+        spake2p_salt = bytes(random.sample(range(0, 255), spake2p_salt_len))
+    else:
+        spake2p_salt = base64.b64decode(spake2p_salt)
+        if not 16 <= len(spake2p_salt) <= 32:
+            raise Exception("SPAKE2+ slat is invalid.")
+
+    if spake2p_verifier is None:
+        spake2p_verifier = generate_verifier(passcode, spake2p_salt, spake2p_it)
+    else:
+        if generate_verifier(passcode, spake2p_salt, spake2p_it) != spake2p_verifier:
+            raise Exception("SPAKE2+ verifier is invalid.")
+
+    return spake2p_it, spake2p_salt, spake2p_verifier
+
+
+def gen_test_certs(chip_cert: str,
+                   output: str,
+                   vendor_id: int,
+                   product_id: int,
+                   device_name: str,
+                   cd_cert: str = None,
+                   cd_key: str = None,
+                   cd: str = None,
+                   paa_cert: str = None,
+                   paa_key: str = None,
+                   pai_cert: str = None,
+                   pai_key: str = None,
+                   dac_cert: str = None,
+                   dac_key: str = None):
+
+    def parse_cert_file(cert):
+
+        def get_subject_attr(subject, oid):
+            try:
+                return subject.get_attributes_for_oid(oid)
+            except Exception:
+                return None
+
+        if not os.path.isfile(cert):
+            return None, None, None, None, None
+
+        ctx = ssl.create_default_context()
+        
+        with open(cert, 'rb') as cert_file:
+            cert = x509.load_pem_x509_certificate(cert_file.read(), default_backend())
+
+        vendor_id = None
+        product_id = None
+        for attribute in cert.subject:
+            if ObjectIdentifier('1.3.6.1.4.1.37244.2.1') == attribute.oid:
+                vendor_id = int(attribute.value, 16)
+            if ObjectIdentifier('1.3.6.1.4.1.37244.2.2') == attribute.oid:
+                product_id = int(attribute.value, 16)
+
+        issue_date = cert.not_valid_before
+        expire_date = cert.not_valid_after
+
+        return vendor_id, product_id, issue_date, expire_date
+
+    def verify_certificates(chip_cert, paa_cert, pai_cert, dac_cert):
+
+        if not os.path.isfile(pai_cert) or not os.path.isfile(dac_cert):
+            raise Exception("PAI certificate or DAC certificate is not specified.")
+
+        with open(pai_cert, 'rb') as cert_file:
+            cert = x509.load_pem_x509_certificate(cert_file.read(), default_backend())
+        pai_public_key = cert.public_key()
+
+        with open(dac_cert, 'rb') as cert_file:
+            cert = x509.load_pem_x509_certificate(cert_file.read(), default_backend())
+
+        try:
+            pai_public_key.verify(cert.signature, cert.tbs_certificate_bytes, ec.ECDSA(hashes.SHA256()))
+        except Exception as e:
+            raise Exception("Failed to verify DAC signature with PAI certificate.")
+
+
+        if (pai_cert != TEST_PAI_CERT and paa_cert != TEST_PAA_CERT) or (pai_cert == TEST_PAI_CERT and paa_cert == TEST_PAA_CERT):
+            if os.path.isfile(paa_cert):
+                cmd = [chip_cert, "validate-att-cert", 
+                       "--dac", dac_cert,
+                       "--pai", pai_cert,
+                       "--paa", paa_cert,
+                      ]
+                log.info("Verify Certificate Chain: {}".format(" ".join(cmd)))
+                subprocess.run(cmd)
+
+    def gen_dac_certificate(chip_cert, device_name, vendor_id, product_id, pai_cert, pai_key, dac_cert, dac_key, pai_issue_date, pai_expire_date):
+        def gen_valid_times(issue_date, expire_date):
+            now = datetime.now() - timedelta(days=1)
+
+            if not (issue_date <= now <= expire_date):
+                raise Exception("Invalid time in test PAI to generate DAC.")
+
+            return now.strftime('%Y%m%d%H%M%SZ'), (expire_date - now).days
+
+        if not os.path.isfile(dac_cert) or not os.path.isfile(dac_key):
+            if not os.path.isfile(pai_cert) or not os.path.isfile(pai_key):
+                raise Exception("No test PAI certificate/key specified for test DAC generation.")
+
+            valid_from, lifetime = gen_valid_times(pai_issue_date, pai_expire_date)
+            cmd = [chip_cert, "gen-att-cert",
+                   "--type", "d", # device attestation certificate
+                   "--subject-cn", device_name + " Test DAC 0",
+                   "--subject-vid", hex(vendor_id),
+                   "--subject-pid", hex(product_id),
+                   "--ca-cert", pai_cert,
+                   "--ca-key", pai_key,
+                   "--out", dac_cert,
+                   "--out-key", dac_key,
+                   "--valid-from", valid_from,
+                   "--lifetime", str(lifetime),
+                   ]
+            log.info("Generate DAC: {}".format(" ".join(cmd)))
+            subprocess.run(cmd)
+
+    def convert_pem_to_der(chip_cert, action, pem):
+
+        if not os.path.isfile(pem):
+            raise Exception("File {} is not existed.".format(pem))
+
+        der = Path(pem).with_suffix(".der")
+        if not os.path.isfile(der):
+            cmd = [chip_cert, action, pem, der, "--x509-der", ]
+            subprocess.run(cmd)
+
+        return der
+
+    def gen_cd(chip_cert, dac_vendor_id, dac_product_id, vendor_id, product_id, cd_cert, cd_key, cd):
+
+        if os.path.isfile(cd):
+            return
+
+        cmd = [chip_cert, "gen-cd",
+               "--key", cd_key,
+               "--cert", cd_cert,
+               "--out", cd,
+               "--format-version",  "1",
+               "--vendor-id",  hex(vendor_id),
+               "--product-id",  hex(product_id),
+               "--device-type-id", "0x1234",
+               "--certificate-id", "ZIG20141ZB330001-24",
+               "--security-level",  "0",
+               "--security-info",  "0",
+               "--certification-type",  str(TEST_CD_TYPE),
+               "--version-number", "9876",
+               ]
+
+        if dac_vendor_id != vendor_id or dac_product_id != product_id:
+            cmd += ["--dac-origin-vendor-id", hex(dac_vendor_id),
+                    "--dac-origin-product-id", hex(dac_product_id),
+                   ]
+
+        log.info("Generate CD: {}".format(" ".join(cmd)))
+        subprocess.run(cmd)
+
+
+    pai_vendor_id, pai_product_id, pai_issue_date, pai_expire_date = parse_cert_file(pai_cert)
+
+    dac_vendor_id = pai_vendor_id if pai_vendor_id else vendor_id
+    dac_product_id = pai_product_id if pai_product_id else product_id
+    gen_dac_certificate(chip_cert, device_name, dac_vendor_id, dac_product_id, pai_cert, pai_key, dac_cert, dac_key, pai_issue_date, pai_expire_date)
+    
+    dac_cert_der = convert_pem_to_der(chip_cert, "convert-cert", dac_cert)
+    dac_key_der = convert_pem_to_der(chip_cert, "convert-key", dac_key)
+    pai_cert_der = convert_pem_to_der(chip_cert, "convert-cert", pai_cert)
+
+    dac_vendor_id, dac_product_id, *_ = parse_cert_file(dac_cert)
+    paa_vendor_id, paa_product_id, *_ = parse_cert_file(paa_cert)
+
+    verify_certificates(chip_cert, paa_cert, pai_cert, dac_cert)
+
+    gen_cd(chip_cert, dac_vendor_id, dac_product_id, vendor_id, product_id, cd_cert, cd_key, cd)
+
+    return cd, pai_cert_der, dac_cert_der, dac_key_der
+
+
+def gen_mfd_partition(args, mfd_output):
+
+    def int_to_2bytearray_l(intvalue):
+        src = bytearray(2)
+        src[1] = (intvalue >> 8) & 0xFF
+        src[0] = (intvalue >> 0) & 0xFF
+        return src
+
+    def int_to_4bytearray_l(intvalue):
+        src = bytearray(4)
+        src[3] = (intvalue >> 24) & 0xFF
+        src[2] = (intvalue >> 16) & 0xFF
+        src[1] = (intvalue >> 8) & 0xFF
+        src[0] = (intvalue >> 0) & 0xFF
+        return src
+
+    def gen_efuse_aes_iv():
+        return bytes(random.sample(range(0, 0xff), 12) + [0] * 4)
+
+    def read_file(rfile):
+        with open(rfile, 'rb') as _f:
+           return _f.read()
+
+    def get_private_key(der):
+        with open(der, 'rb') as file:
+            keys = load_der_private_key(file.read(), password=None, backend=default_backend())
+            private_key = keys.private_numbers().private_value.to_bytes(32, byteorder='big')
+
+            return private_key
+
+    def encrypt_data(data_bytearray, key_bytearray, iv_bytearray):
+        data_bytearray += bytes([0] * (16 - (len(data_bytearray) % 16) ))
+        cryptor = AES.new(key_bytearray, AES.MODE_CBC, iv_bytearray)
+        ciphertext = cryptor.encrypt(data_bytearray)
+        return ciphertext
+
+    def convert_to_bytes(data):
+        if isinstance(data, bytes) or isinstance(data, str):
+            if isinstance(data, str):
+                return data.encode()
+            else:
+                return data
+        elif isinstance(data, int):
+            byte_len = int((data.bit_length() + 7) / 8)
+            return data.to_bytes(byte_len, byteorder='little')
+        elif data is None:
+            return bytes([])
+        else:
+            raise Exception("Data {} is invalid type: {}".format(name, type(data)))
+
+    def gen_tlvs(mfdDict, need_sec):
+        MFD_ID_RAW_MASK = 0x8000
+
+        sec_tlvs = bytes([])
+        raw_tlvs = bytes([])
+
+        for name in mfdDict.keys():
+            d = mfdDict[name]
+            if d["sec"] and need_sec:
+                if d["len"] and d["len"] < len(d["data"]):
+                    raise Exception("Data size of {} is over {}".format(name, d["len"]))
+                sec_tlvs += int_to_2bytearray_l(d["id"])
+                sec_tlvs += int_to_2bytearray_l(len(d["data"]))
+                sec_tlvs += d["data"]
+
+        for name in mfdDict.keys():
+            d = mfdDict[name]
+            if not d["sec"] or not need_sec:
+                if d["len"] and d["len"] < len(d["data"]):
+                    raise Exception("Data size of {} is over {}".format(name, d["len"]))
+                raw_tlvs += int_to_2bytearray_l(d["id"] + MFD_ID_RAW_MASK)
+                raw_tlvs += int_to_2bytearray_l(len(d["data"]))
+                raw_tlvs += d["data"]
+
+        return sec_tlvs, raw_tlvs
+
+    mfdDict = {
+        "aes_iv": {'sec': False, "id": 1, "len": 16, "data": gen_efuse_aes_iv() if args.key else bytes([0] * 16)},
+        "dac_cert": {'sec': False, "id": 2, "len": None, "data": read_file(args.dac_cert)},
+        "dac_key": {'sec': True, "id": 3, "len": None, "data": get_private_key(args.dac_key)},
+        "passcode": {'sec': False, "id": 4, "len": 4, "data": convert_to_bytes(args.passcode)},
+        "pai_cert": {'sec': False, "id": 5, "len": None, "data": read_file(args.pai_cert)},
+        "cd": {'sec': False, "id": 6, "len": None, "data": read_file(args.cd)},
+        "sn": {'sec': False, "id": 7, "len": 32, "data": convert_to_bytes(args.sn)},
+        "discriminator": {'sec': False, "id": 8, "len": 2, "data": convert_to_bytes(args.discriminator)},
+        "uid": {'sec': False, "id": 9, "len": 32, "data": convert_to_bytes(args.unique_id)},
+        "spake2p_it": {'sec': False, "id": 10, "len": 4, "data": convert_to_bytes(args.spake2p_it)},
+        "spake2p_salt": {'sec': False, "id": 11, "len": 32, "data": convert_to_bytes(args.spake2p_salt)},
+        "spake2p_verifier": {'sec': False, "id": 12, "len": None, "data": convert_to_bytes(args.spake2p_verifier)},
+        "vendor_name": {'sec': False, "id": 13, "len": 32, "data": convert_to_bytes(args.vendor_name)},
+        "vendor_id": {'sec': False, "id": 14, "len": 2, "data": convert_to_bytes(args.vendor_id)},
+        "product_name": {'sec': False, "id": 15, "len": 32, "data": convert_to_bytes(args.product_name)},
+        "product_id": {'sec': False, "id": 16, "len": 2, "data": convert_to_bytes(args.product_id)},
+        "product_part_no": {'sec': False, "id": 17, "len": 32, "data": convert_to_bytes(args.product_part_no)},
+        "product_url": {'sec': False, "id": 18, "len": 256, "data": convert_to_bytes(args.product_url)},
+        "product_label": {'sec': False, "id": 19, "len": 64, "data": convert_to_bytes(args.product_label)},
+        "manufactoring_date": {'sec': False, "id": 20, "len": 16, "data": convert_to_bytes(args.manufactoring_date)},
+        "hardware_ver": {'sec': False, "id": 21, "len": 4, "data": convert_to_bytes(args.hardware_version)},
+        "hardware_ver_str": {'sec': False, "id": 22, "len": 64, "data": convert_to_bytes(args.hardware_version_string)},
+    }
+
+    sec_tlvs, raw_tlvs = gen_tlvs(mfdDict, args.key)
+
+    output = bytes([])
+
+    sec_tlvs = sec_tlvs and encrypt_data(sec_tlvs, args.key, mfdDict["aes_iv"]["data"])
+
+    output = int_to_4bytearray_l(len(sec_tlvs))
+    output += sec_tlvs
+    output += int_to_4bytearray_l(binascii.crc32(sec_tlvs))
+    output += int_to_4bytearray_l(len(raw_tlvs))
+    output += raw_tlvs
+    output += int_to_4bytearray_l(binascii.crc32(raw_tlvs))
+
+    with open(mfd_output, "wb+") as fp:
+        fp.write(output)
+
+
+def gen_onboarding_data(args, onboard_txt, onboard_png, rendez = 6):
+
+    try:
+        import qrcode
+        from SetupPayload import CommissioningFlow, SetupPayload
+    except ImportError:
+        sys.path.append(os.path.join(MATTER_ROOT, "src/setup_payload/python"))
+        try:
+            import qrcode
+            from SetupPayload import CommissioningFlow, SetupPayload
+        except Exception as e:
+            raise Exception("Please make sure qrcode has been installed.")
+    else:
+        raise Exception("Please make sure qrcode has been installed.")
+
+    setup_payload = SetupPayload(discriminator=args.discriminator,
+                                 pincode=args.passcode,
+                                 rendezvous=rendez,
+                                 flow=CommissioningFlow.Standard,
+                                 vid=args.vendor_id,
+                                 pid=args.product_id)
+    with open(onboard_txt, "w") as manual_code_file:
+        manual_code_file.write("Manualcode : " + setup_payload.generate_manualcode() + "\n")
+        manual_code_file.write("QRCode : " + setup_payload.generate_qrcode())
+    qr = qrcode.make(setup_payload.generate_qrcode())
+    qr.save(onboard_png)
+
+    return setup_payload.generate_manualcode(), setup_payload.generate_qrcode()
+
+
+def main():
+
+    def check_arg(args):
+
+        if not isinstance(args.output, str) or not os.path.exists(args.output):
+            raise Exception("output path is not specified.")
+        log.info("output path: {}".format(args.output))
+
+        if not isinstance(args.chip_cert, str) or not os.path.exists(args.chip_cert):
+            raise Exception("chip-cert should be built before and is specified.")
+        log.info("chip-cert path: {}".format(args.chip_cert))
+
+    def to_bytes(input):
+        if isinstance(input, str):
+            return bytearray.fromhex(input)
+        elif isinstance(input, bytes):
+            return input
+        else:
+            return None
+
+    parser = argparse.ArgumentParser(description="Bouffalo Lab Factory Data generator tool")
+
+    parser.add_argument("--dac_cert", type=str, help="DAC certificate file.")
+    parser.add_argument("--dac_key", type=str, help="DAC certificate privat key.")
+    parser.add_argument("--passcode", type=int, help="Setup pincode, optional.")
+    parser.add_argument("--pai_cert", type=str, default=TEST_PAI_CERT, help="PAI certificate file.")
+    parser.add_argument("--cd", type=str, help="Certificate Declaration file.")
+    parser.add_argument("--sn", type=str, default="Test SN", help="Serial Number, optional.")
+    parser.add_argument("--discriminator", type=int, help="Discriminator ID, optional.")
+    parser.add_argument("--unique_id", type=base64.b64decode, help="Rotating Unique ID in hex string, optional.")
+    parser.add_argument("--spake2p_it", type=int, default=None, help="Spake2+ iteration count, optional.")
+    parser.add_argument("--spake2p_salt", type=base64.b64decode, help="Spake2+ salt in hex string, optional.")
+    
+    parser.add_argument("--vendor_id", type=int, default=0x130D, help="Vendor Identification, mandatory.")
+    parser.add_argument("--vendor_name", type=str, default="Bouffalo Lab", help="Vendor Name string, optional.")
+    parser.add_argument("--product_id", type=int, default=0x1001, help="Product Identification, mandatory.")
+    parser.add_argument("--product_name", type=str, default="Test Product", help="Product Name string, optional.")
+
+    parser.add_argument("--product_part_no", type=str, help="Product Part number, optional.")
+    parser.add_argument("--product_url", type=str, help="Product Web URL, optional.")
+    parser.add_argument("--product_label", type=str, help="Product Web URL, optional.")
+    parser.add_argument("--manufactoring_date", type=str, help="Product Web URL, optional.")
+    parser.add_argument("--hardware_version", type=int, help="Product Web URL, optional.")
+    parser.add_argument("--hardware_version_string", type=str, help="Product Web URL, optional.")
+    parser.add_argument("--rendezvous", type=int, default=6, help="Rendezvous Mode for QR code generation")
+
+    parser.add_argument("--output", type=str, help="output path.")
+    parser.add_argument("--key", type=str, help="Encrypt private part in mfd.")
+
+    parser.add_argument("--cd_cert", type=str, default=TEST_CD_CERT, help="for test, to sign certificate declaration.")
+    parser.add_argument("--cd_key", type=str, default=TEST_CD_KEY, help="for test, to sign certificate declaration.")
+    parser.add_argument("--paa_cert", type=str, default=TEST_PAA_CERT, help="for test, to verify certificate chain.")
+    parser.add_argument("--paa_key", type=str, default=TEST_PAA_KEY, help="for test, to sign pai certificate.")
+    parser.add_argument("--pai_key", type=str, default=TEST_PAI_KEY, help="for test, to sign dac certificate.")
+    parser.add_argument("--chip_cert", type=str, default=TEST_CHIP_CERT, help="for test, the tool to issue dac certificate.")
+
+    args = parser.parse_args()
+
+    log.basicConfig(format='[%(levelname)s] %(message)s', level=log.INFO)
+
+    check_arg(args)
+
+    passcode = gen_test_passcode(args.passcode)
+    discriminator = gen_test_discriminator(args.discriminator)
+    unique_id = gen_test_unique_id(args.unique_id)
+    spake2p_it, spake2p_salt, spake2p_verifier = gen_test_spake2(passcode, args.spake2p_it, args.spake2p_salt)
+
+    vp_info = "{}_{}".format(hex(args.vendor_id), hex(args.product_id))
+    vp_disc_info = "{}_{}_{}".format(hex(args.vendor_id), hex(args.product_id), discriminator)
+    if args.dac_cert is None:
+        args.dac_cert = os.path.join(args.output, "out_{}_dac_cert.pem".format(vp_disc_info))
+        args.dac_key =  os.path.join(args.output, "out_{}_dac_key.pem".format(vp_disc_info))
+
+    if args.cd is None:
+        args.cd =  os.path.join(args.output, "out_{}_cd.der".format(vp_info))
+
+    cd, pai_cert_der, dac_cert_der, dac_key_der = gen_test_certs(args.chip_cert, 
+                                                                 args.output,
+                                                                 args.vendor_id,
+                                                                 args.product_id,
+                                                                 args.vendor_name,
+                                                                 args.cd_cert,
+                                                                 args.cd_key,
+                                                                 args.cd,
+                                                                 args.paa_cert,
+                                                                 args.paa_key,
+                                                                 args.pai_cert,
+                                                                 args.pai_key,
+                                                                 args.dac_cert,
+                                                                 args.dac_key)
+
+    mfd_output =  os.path.join(args.output, "out_{}_mfd.bin".format(vp_disc_info))
+    args.dac_cert = dac_cert_der
+    args.dac_key = dac_key_der
+    args.passcode = passcode
+    args.pai_cert = pai_cert_der
+    args.cd = cd
+    args.discriminator = discriminator
+    args.unique_id = unique_id
+    args.spake2p_it = spake2p_it
+    args.spake2p_salt = spake2p_salt
+    args.spake2p_verifier = spake2p_verifier
+    args.key = to_bytes(args.key)
+    gen_mfd_partition(args, mfd_output)
+
+    onboard_txt =  os.path.join(args.output, "out_{}_onboard.txt".format(vp_disc_info))
+    onboard_png =  os.path.join(args.output, "out_{}_onboard.png".format(vp_disc_info))
+    manualcode, qrcode = gen_onboarding_data(args, onboard_txt, onboard_png, args.rendezvous)
+
+    log.info("")
+    log.info("Output as below: ")
+    log.info("Passcode: {}".format(passcode))
+    log.info("Discriminator ID: {}".format(discriminator))
+    log.info("Rotating Unique ID: {}".format(unique_id.hex()))
+    log.info("Rotating Unique ID base64 code: {}".format(base64.b64encode(unique_id).decode()))
+    log.info("SPAKE2+ iteration: {}".format(spake2p_it))
+    log.info("SPAKE2+ slat: {}".format(spake2p_salt.hex()))
+    log.info("SPAKE2+ slat base code: {}".format(base64.b64encode(spake2p_salt).decode()))
+    log.info("Manual code: {}".format(manualcode))
+    log.info("QR code: {}".format(qrcode))
+
+    log.info("")
+    log.info("MFD partition file: {}".format(mfd_output))
+    log.info("QR code PNG file: {}".format(onboard_png))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tools/bouffalolab/generate_factory_data.py
+++ b/scripts/tools/bouffalolab/generate_factory_data.py
@@ -22,7 +22,6 @@ import logging as log
 import os
 import random
 import secrets
-import ssl
 import subprocess
 import sys
 from datetime import datetime, timedelta

--- a/scripts/tools/bouffalolab/generate_factory_data.py
+++ b/scripts/tools/bouffalolab/generate_factory_data.py
@@ -146,8 +146,6 @@ def gen_test_certs(chip_cert: str,
         if not os.path.isfile(cert):
             return None, None, None, None, None
 
-        ctx = ssl.create_default_context()
-
         with open(cert, 'rb') as cert_file:
             cert = x509.load_pem_x509_certificate(cert_file.read(), default_backend())
 
@@ -178,7 +176,7 @@ def gen_test_certs(chip_cert: str,
 
         try:
             pai_public_key.verify(cert.signature, cert.tbs_certificate_bytes, ec.ECDSA(hashes.SHA256()))
-        except Exception as e:
+        except Exception:
             raise Exception("Failed to verify DAC signature with PAI certificate.")
 
         if (pai_cert != TEST_PAI_CERT and paa_cert != TEST_PAA_CERT) or (pai_cert == TEST_PAI_CERT and paa_cert == TEST_PAA_CERT):
@@ -329,7 +327,7 @@ def gen_mfd_partition(args, mfd_output):
         elif data is None:
             return bytes([])
         else:
-            raise Exception("Data {} is invalid type: {}".format(name, type(data)))
+            raise Exception("Data is invalid type: {}".format(type(data)))
 
     def gen_tlvs(mfdDict, need_sec):
         MFD_ID_RAW_MASK = 0x8000
@@ -409,7 +407,7 @@ def gen_onboarding_data(args, onboard_txt, onboard_png, rendez=6):
         try:
             import qrcode
             from SetupPayload import CommissioningFlow, SetupPayload
-        except Exception as e:
+        except Exception:
             raise Exception("Please make sure qrcode has been installed.")
     else:
         raise Exception("Please make sure qrcode has been installed.")
@@ -434,7 +432,7 @@ def main():
     def check_arg(args):
 
         if not isinstance(args.output, str) or not os.path.exists(args.output):
-            raise Exception("output path is not specified.")
+            raise Exception("output path is not specified or not existed.")
         log.info("output path: {}".format(args.output))
 
         if not isinstance(args.chip_cert, str) or not os.path.exists(args.chip_cert):


### PR DESCRIPTION
MFD partition is a flash region for Matter-specific device unique data and normally be programed during device/module produce for Bouffalo Lab platform.
This MR contains a script and readme to demonstrate mfd partition generation.  data contains:
- DAC/PAI certificate, CD and  DAC private key. The private key could be encryted by security engine with hardware only access key.
- Discriminator ID/Pass Code/Spake2p it/salt/verifier
- Vendor ID/Name, Product ID/Name, and so on