### PR TITLE
[Fabric-Sync] Allow RPC ports customization in example apps

### DIFF
--- a/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
+++ b/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
@@ -197,7 +197,7 @@ CHIP_ERROR InteractiveStartCommand::RunCommand()
     }
 
 #if defined(PW_RPC_ENABLED)
-    SetRpcClientPort(mFabricBridgeServerPort.Value());
+    SetRpcRemoteServerPort(mFabricBridgeServerPort.Value());
     InitRpcServer(mLocalServerPort.Value());
     ChipLogProgress(NotSpecified, "PW_RPC initialized.");
     DeviceLayer::PlatformMgr().ScheduleWork(ExecuteDeferredConnect, 0);

--- a/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
+++ b/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
@@ -31,6 +31,7 @@
 
 #if defined(PW_RPC_ENABLED)
 #include <rpc/RpcClient.h>
+#include <rpc/RpcServer.h>
 #endif
 
 using namespace chip;
@@ -116,7 +117,7 @@ void ENFORCE_FORMAT(3, 0) LoggingCallback(const char * module, uint8_t category,
 #if defined(PW_RPC_ENABLED)
 void AttemptRpcClientConnect(System::Layer * systemLayer, void * appState)
 {
-    if (InitRpcClient(kFabricBridgeServerPort) == CHIP_NO_ERROR)
+    if (StartRpcClient() == CHIP_NO_ERROR)
     {
         ChipLogProgress(NotSpecified, "Connected to Fabric-Bridge");
     }
@@ -196,6 +197,9 @@ CHIP_ERROR InteractiveStartCommand::RunCommand()
     }
 
 #if defined(PW_RPC_ENABLED)
+    SetRpcClientPort(mFabricBridgeServerPort.Value());
+    InitRpcServer(mLocalServerPort.Value());
+    ChipLogProgress(NotSpecified, "PW_RPC initialized.");
     DeviceLayer::PlatformMgr().ScheduleWork(ExecuteDeferredConnect, 0);
 #endif
 

--- a/examples/fabric-admin/commands/interactive/InteractiveCommands.h
+++ b/examples/fabric-admin/commands/interactive/InteractiveCommands.h
@@ -31,8 +31,7 @@ class InteractiveCommand : public CHIPCommand
 public:
     InteractiveCommand(const char * name, Commands * commandsHandler, const char * helpText,
                        CredentialIssuerCommands * credsIssuerConfig) :
-        CHIPCommand(name, credsIssuerConfig, helpText),
-        mHandler(commandsHandler)
+        CHIPCommand(name, credsIssuerConfig, helpText), mHandler(commandsHandler)
     {
         AddArgument("advertise-operational", 0, 1, &mAdvertiseOperational,
                     "Advertise operational node over DNS-SD and accept incoming CASE sessions.");
@@ -55,7 +54,14 @@ public:
     InteractiveStartCommand(Commands * commandsHandler, CredentialIssuerCommands * credsIssuerConfig) :
         InteractiveCommand("start", commandsHandler, "Start an interactive shell that can then run other commands.",
                            credsIssuerConfig)
-    {}
+    {
+#if defined(PW_RPC_ENABLED)
+        AddArgument("fabric-bridge-server-port", 0, UINT16_MAX, &mFabricBridgeServerPort,
+                    "The fabric-bridge RPC port number to connect to (default: 33002).");
+        AddArgument("local-server-port", 0, UINT16_MAX, &mLocalServerPort,
+                    "The port number for local RPC server (default: 33001).");
+#endif
+    }
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
@@ -63,6 +69,11 @@ public:
 private:
     char * GetCommand(char * command);
     std::string GetHistoryFilePath() const;
+
+#if defined(PW_RPC_ENABLED)
+    chip::Optional<uint16_t> mFabricBridgeServerPort{ 33002 };
+    chip::Optional<uint16_t> mLocalServerPort{ 33001 };
+#endif
 };
 
 void PushCommand(const std::string & command);

--- a/examples/fabric-admin/commands/interactive/InteractiveCommands.h
+++ b/examples/fabric-admin/commands/interactive/InteractiveCommands.h
@@ -31,7 +31,8 @@ class InteractiveCommand : public CHIPCommand
 public:
     InteractiveCommand(const char * name, Commands * commandsHandler, const char * helpText,
                        CredentialIssuerCommands * credsIssuerConfig) :
-        CHIPCommand(name, credsIssuerConfig, helpText), mHandler(commandsHandler)
+        CHIPCommand(name, credsIssuerConfig, helpText),
+        mHandler(commandsHandler)
     {
         AddArgument("advertise-operational", 0, 1, &mAdvertiseOperational,
                     "Advertise operational node over DNS-SD and accept incoming CASE sessions.");

--- a/examples/fabric-admin/commands/interactive/InteractiveCommands.h
+++ b/examples/fabric-admin/commands/interactive/InteractiveCommands.h
@@ -24,6 +24,9 @@
 
 #include <string>
 
+constexpr uint16_t kFabricBridgeServerPort = 33002;
+constexpr uint16_t kFabricLocalServerPort  = 33001;
+
 class Commands;
 
 class InteractiveCommand : public CHIPCommand
@@ -58,9 +61,8 @@ public:
     {
 #if defined(PW_RPC_ENABLED)
         AddArgument("fabric-bridge-server-port", 0, UINT16_MAX, &mFabricBridgeServerPort,
-                    "The fabric-bridge RPC port number to connect to (default: 33002).");
-        AddArgument("local-server-port", 0, UINT16_MAX, &mLocalServerPort,
-                    "The port number for local RPC server (default: 33001).");
+                    "The fabric-bridge RPC port number to connect to.");
+        AddArgument("local-server-port", 0, UINT16_MAX, &mLocalServerPort, "The port number for local RPC server.");
 #endif
     }
 
@@ -72,8 +74,8 @@ private:
     std::string GetHistoryFilePath() const;
 
 #if defined(PW_RPC_ENABLED)
-    chip::Optional<uint16_t> mFabricBridgeServerPort{ 33002 };
-    chip::Optional<uint16_t> mLocalServerPort{ 33001 };
+    chip::Optional<uint16_t> mFabricBridgeServerPort{ kFabricBridgeServerPort };
+    chip::Optional<uint16_t> mLocalServerPort{ kFabricLocalServerPort };
 #endif
 };
 

--- a/examples/fabric-admin/main.cpp
+++ b/examples/fabric-admin/main.cpp
@@ -28,19 +28,10 @@
 #include <string>
 #include <vector>
 
-#if defined(PW_RPC_ENABLED)
-#include <rpc/RpcServer.h>
-#endif
-
 using namespace chip;
 
 void ApplicationInit()
 {
-#if defined(PW_RPC_ENABLED)
-    InitRpcServer(kFabricAdminServerPort);
-    ChipLogProgress(NotSpecified, "PW_RPC initialized.");
-#endif
-
     DeviceMgr().Init();
 }
 

--- a/examples/fabric-admin/rpc/RpcClient.cpp
+++ b/examples/fabric-admin/rpc/RpcClient.cpp
@@ -117,7 +117,7 @@ void RpcCompletedWithEmptyResponse(const pw_protobuf_Empty & response, pw::Statu
 
 } // namespace
 
-void SetRpcClientPort(uint16_t port)
+void SetRpcRemoteServerPort(uint16_t port)
 {
     rpc::client::SetRpcServerPort(port);
 }

--- a/examples/fabric-admin/rpc/RpcClient.cpp
+++ b/examples/fabric-admin/rpc/RpcClient.cpp
@@ -117,9 +117,13 @@ void RpcCompletedWithEmptyResponse(const pw_protobuf_Empty & response, pw::Statu
 
 } // namespace
 
-CHIP_ERROR InitRpcClient(uint16_t rpcServerPort)
+void SetRpcClientPort(uint16_t port)
 {
-    rpc::client::SetRpcServerPort(rpcServerPort);
+    rpc::client::SetRpcServerPort(port);
+}
+
+CHIP_ERROR StartRpcClient()
+{
     return rpc::client::StartPacketProcessing();
 }
 

--- a/examples/fabric-admin/rpc/RpcClient.h
+++ b/examples/fabric-admin/rpc/RpcClient.h
@@ -27,7 +27,7 @@
  *
  * @param port The port number.
  */
-void SetRpcClientPort(uint16_t port);
+void SetRpcRemoteServerPort(uint16_t port);
 
 /**
  * @brief Starts packet processing for the RPC client.

--- a/examples/fabric-admin/rpc/RpcClient.h
+++ b/examples/fabric-admin/rpc/RpcClient.h
@@ -22,17 +22,19 @@
 
 #include "fabric_bridge_service/fabric_bridge_service.rpc.pb.h"
 
-constexpr uint16_t kFabricBridgeServerPort = 33002;
+/**
+ * @brief Sets the RPC server port to which the RPC client will connect.
+ *
+ * @param port The port number.
+ */
+void SetRpcClientPort(uint16_t port);
 
 /**
- * @brief Initializes the RPC client with the specified server port.
+ * @brief Starts packet processing for the RPC client.
  *
- * This function sets the RPC server port and starts packet processing for the RPC client.
- *
- * @param rpcServerPort The port number on which the RPC server is running.
- * @return CHIP_NO_ERROR on successful initialization, or an appropriate CHIP_ERROR on failure.
+ * @return CHIP_NO_ERROR on successful start, or an appropriate CHIP_ERROR on failure.
  */
-CHIP_ERROR InitRpcClient(uint16_t rpcServerPort);
+CHIP_ERROR StartRpcClient();
 
 /**
  * @brief Adds a synchronized device to the RPC client.

--- a/examples/fabric-admin/rpc/RpcServer.h
+++ b/examples/fabric-admin/rpc/RpcServer.h
@@ -18,6 +18,4 @@
 
 #pragma once
 
-constexpr uint16_t kFabricAdminServerPort = 33001;
-
 void InitRpcServer(uint16_t rpcServerPort);

--- a/examples/fabric-bridge-app/linux/RpcClient.cpp
+++ b/examples/fabric-bridge-app/linux/RpcClient.cpp
@@ -107,9 +107,13 @@ void RpcCompletedWithEmptyResponse(const pw_protobuf_Empty & response, pw::Statu
 
 } // namespace
 
-CHIP_ERROR InitRpcClient(uint16_t rpcServerPort)
+void SetRpcClientPort(uint16_t port)
 {
-    rpc::client::SetRpcServerPort(rpcServerPort);
+    rpc::client::SetRpcServerPort(port);
+}
+
+CHIP_ERROR StartRpcClient()
+{
     return rpc::client::StartPacketProcessing();
 }
 

--- a/examples/fabric-bridge-app/linux/RpcClient.cpp
+++ b/examples/fabric-bridge-app/linux/RpcClient.cpp
@@ -107,7 +107,7 @@ void RpcCompletedWithEmptyResponse(const pw_protobuf_Empty & response, pw::Statu
 
 } // namespace
 
-void SetRpcClientPort(uint16_t port)
+void SetRpcRemoteServerPort(uint16_t port)
 {
     rpc::client::SetRpcServerPort(port);
 }

--- a/examples/fabric-bridge-app/linux/include/RpcClient.h
+++ b/examples/fabric-bridge-app/linux/include/RpcClient.h
@@ -26,7 +26,7 @@
  *
  * @param port The port number.
  */
-void SetRpcClientPort(uint16_t port);
+void SetRpcRemoteServerPort(uint16_t port);
 
 /**
  * Starts packet processing for the RPC client.

--- a/examples/fabric-bridge-app/linux/include/RpcClient.h
+++ b/examples/fabric-bridge-app/linux/include/RpcClient.h
@@ -21,17 +21,21 @@
 #include <controller/CommissioningWindowParams.h>
 #include <platform/CHIPDeviceLayer.h>
 
-constexpr uint16_t kFabricAdminServerPort = 33001;
+/**
+ * Sets the RPC server port to which the RPC client will connect.
+ *
+ * @param port The port number.
+ */
+void SetRpcClientPort(uint16_t port);
 
 /**
- * Initializes the RPC client by setting the server port and starting packet processing.
+ * Starts packet processing for the RPC client.
  *
- * @param rpcServerPort The port number of the RPC server.
  * @return CHIP_ERROR An error code indicating the success or failure of the initialization process.
  * - CHIP_NO_ERROR: Initialization was successful.
  * - Other error codes indicating specific failure reasons.
  */
-CHIP_ERROR InitRpcClient(uint16_t rpcServerPort);
+CHIP_ERROR StartRpcClient();
 
 /**
  * Opens a commissioning window for a specified node using setup PIN (passcode).

--- a/examples/fabric-bridge-app/linux/include/RpcServer.h
+++ b/examples/fabric-bridge-app/linux/include/RpcServer.h
@@ -18,6 +18,4 @@
 
 #pragma once
 
-constexpr uint16_t kFabricBridgeServerPort = 33002;
-
 void InitRpcServer(uint16_t rpcServerPort);

--- a/examples/fabric-bridge-app/linux/main.cpp
+++ b/examples/fabric-bridge-app/linux/main.cpp
@@ -293,7 +293,7 @@ void ApplicationInit()
     AttributeAccessInterfaceRegistry::Instance().Register(&gBridgedDeviceBasicInformationAttributes);
 
 #if defined(PW_RPC_FABRIC_BRIDGE_SERVICE) && PW_RPC_FABRIC_BRIDGE_SERVICE
-    SetRpcClientPort(gFabricAdminServerPort);
+    SetRpcRemoteServerPort(gFabricAdminServerPort);
     InitRpcServer(gLocalServerPort);
     AttemptRpcClientConnect(&DeviceLayer::SystemLayer(), nullptr);
 #endif


### PR DESCRIPTION
### Problem

It's not possible to run more than one set of fabric-admin+fabric-bridge on a single host.

### Changes

- optionally get RPC server ports from program arguments

### Testing

Tested locally while working on TC-MCORE-FS-1.3 update.