### PR TITLE
[Silabs][Wi-Fi] Updating the connection interval for the BLE 

### DIFF
--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -62,8 +62,8 @@ extern "C" {
 #include <setup_payload/AdditionalDataPayloadGenerator.h>
 #endif
 
-#define BLE_MIN_CONNECTION_INTERVAL_MS 45
-#define BLE_MAX_CONNECTION_INTERVAL_MS 45
+#define BLE_MIN_CONNECTION_INTERVAL_MS 24
+#define BLE_MAX_CONNECTION_INTERVAL_MS 40
 #define BLE_SLAVE_LATENCY_MS 0
 #define BLE_TIMEOUT_MS 400
 #define BLE_DEFAULT_TIMER_PERIOD_MS (1)


### PR DESCRIPTION
Description of Problem/Feature:
In busy environments (SQA environment with multiple wifi around) commissioning is failing because of the BLE connection interval timeout.

Description of Fix/Solution:
Set the correct commissioning interval for the BLE. 

Testing Done:
917 SOC
917 NCP + 418&C