### PR TITLE
[Darwin] Find cached controllers when creating existing controller fabric as well

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -331,14 +331,14 @@ using namespace chip::Tracing::DarwinFramework;
     return _cppCommissioner != nullptr;
 }
 
-- (BOOL)matchesPendingShutdownWithParams:(MTRDeviceControllerParameters *)parameters
+- (BOOL)matchesPendingShutdownControllerWithOperationalCertificate:(nullable MTRCertificateDERBytes)operationalCertificate andRootCertificate:(nullable MTRCertificateDERBytes)rootCertificate
 {
-    if (!parameters.operationalCertificate || !parameters.rootCertificate) {
+    if (!operationalCertificate || !rootCertificate) {
         return FALSE;
     }
-    NSNumber * nodeID = [MTRDeviceControllerParameters nodeIDFromNOC:parameters.operationalCertificate];
-    NSNumber * fabricID = [MTRDeviceControllerParameters fabricIDFromNOC:parameters.operationalCertificate];
-    NSData * publicKey = [MTRDeviceControllerParameters publicKeyFromCertificate:parameters.rootCertificate];
+    NSNumber * nodeID = [MTRDeviceControllerParameters nodeIDFromNOC:operationalCertificate];
+    NSNumber * fabricID = [MTRDeviceControllerParameters fabricIDFromNOC:operationalCertificate];
+    NSData * publicKey = [MTRDeviceControllerParameters publicKeyFromCertificate:rootCertificate];
 
     std::lock_guard lock(_assertionLock);
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -322,7 +322,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * This method returns TRUE if this controller matches the fabric reference and node ID as listed in the parameters.
  */
-- (BOOL)matchesPendingShutdownWithParams:(MTRDeviceControllerParameters *)parameters;
+- (BOOL)matchesPendingShutdownControllerWithOperationalCertificate:(nullable MTRCertificateDERBytes)operationalCertificate andRootCertificate:(nullable MTRCertificateDERBytes)rootCertificate;
 
 /**
  * Clear any pending shutdown request.


### PR DESCRIPTION

- Missed another call site in #35148

