### PR TITLE
Add apps to chip cert bins image

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -182,7 +182,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-all-clusters-minimal-ipv6only \
     --target linux-x64-bridge-ipv6only \
     --target linux-x64-tv-app-ipv6only \
-    --target linux-x64-tv-casting-app-ipv6only \
+    --target linux-x64-tv-casting-app-ipv6only \  
     --target linux-x64-light-ipv6only \
     --target linux-x64-thermostat-ipv6only \
     --target linux-x64-ota-provider-ipv6only \
@@ -193,6 +193,9 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-energy-management-ipv6only \
     --target linux-x64-microwave-oven-ipv6only \
     --target linux-x64-rvc-ipv6only \
+    --target linux-x64-fabric-bridge-rpc-ipv6only \
+    --target linux-x64-fabric-admin-rpc-ipv6only \
+    --target linux-x64-network-manager-ipv6only \
     build \
     && mv out/linux-x64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
     && mv out/linux-x64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
@@ -213,6 +216,9 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-x64-energy-management-ipv6only/chip-energy-management-app out/chip-energy-management-app \
     && mv out/linux-x64-microwave-oven-ipv6only/chip-microwave-oven-app out/chip-microwave-oven-app \
     && mv out/linux-x64-rvc-ipv6only/chip-rvc-app out/chip-rvc-app \
+    && mv out/linux-x64-fabric-bridge-rpc-ipv6only/fabric-bridge-app out/fabric-bridge-app \
+    && mv out/linux-x64-fabric-admin-rpc-ipv6only/fabric-admin out/fabric-admin \
+    && mv out/linux-x64-network-manager-ipv6only/matter-network-manager-app out/matter-network-manager-app \
     ;; \
     "linux/arm64")\
     set -x \
@@ -237,6 +243,9 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-arm64-energy-management-ipv6only \
     --target linux-arm64-microwave-oven-ipv6only \
     --target linux-arm64-rvc-ipv6only \
+    --target linux-arm64-fabric-bridge-rpc-ipv6only \
+    --target linux-arm64-fabric-admin-rpc-ipv6only \
+    --target linux-arm64-network-manager-ipv6only \
     build \
     && mv out/linux-arm64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
     && mv out/linux-arm64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
@@ -257,6 +266,9 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-arm64-energy-management-ipv6only/chip-energy-management-app out/chip-energy-management-app \
     && mv out/linux-arm64-microwave-oven-ipv6only/chip-microwave-oven-app out/chip-microwave-oven-app \
     && mv out/linux-arm64-rvc-ipv6only/chip-rvc-app out/chip-rvc-app \
+    && mv out/linux-arm64-fabric-bridge-rpc-ipv6only/fabric-bridge-app out/fabric-bridge-app \
+    && mv out/linux-arm64-fabric-admin-rpc-ipv6only/fabric-admin out/fabric-admin \
+    && mv out/linux-arm64-network-manager-ipv6only/matter-network-manager-app out/matter-network-manager-app \
     ;; \
     *) ;; \
     esac
@@ -290,6 +302,9 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/out/lit-icd-app lit-icd-a
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-energy-management-app chip-energy-management-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-microwave-oven-app chip-microwave-oven-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-rvc-app chip-rvc-app
+COPY --from=chip-build-cert-bins /root/connectedhomeip/out/fabric-bridge-app fabric-bridge-app
+COPY --from=chip-build-cert-bins /root/connectedhomeip/out/fabric-admin fabric-admin
+COPY --from=chip-build-cert-bins /root/connectedhomeip/out/matter-network-manager-app matter-network-manager-app
 
 # Stage 3.1: Setup the Matter Python environment
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/python_lib python_lib
@@ -304,6 +319,7 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/src/python_testing/requir
 RUN pip install --break-system-packages -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 # PIP requires MASON package compilation, which seems to require a JDK
-RUN set -x && DEBIAN_FRONTEND=noninteractive apt-get install -fy openjdk-8-jdk
+# RUN apt-get update
+RUN set -x && DEBIAN_FRONTEND=noninteractive apt-get update; apt-get install -fy openjdk-8-jdk
 
 RUN pip install --break-system-packages --no-cache-dir python_lib/controller/python/chip*.whl

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -182,7 +182,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-all-clusters-minimal-ipv6only \
     --target linux-x64-bridge-ipv6only \
     --target linux-x64-tv-app-ipv6only \
-    --target linux-x64-tv-casting-app-ipv6only \  
+    --target linux-x64-tv-casting-app-ipv6only \
     --target linux-x64-light-ipv6only \
     --target linux-x64-thermostat-ipv6only \
     --target linux-x64-ota-provider-ipv6only \
@@ -319,7 +319,6 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/src/python_testing/requir
 RUN pip install --break-system-packages -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 # PIP requires MASON package compilation, which seems to require a JDK
-# RUN apt-get update
 RUN set -x && DEBIAN_FRONTEND=noninteractive apt-get update; apt-get install -fy openjdk-8-jdk
 
 RUN pip install --break-system-packages --no-cache-dir python_lib/controller/python/chip*.whl


### PR DESCRIPTION
Added the fabric-bridge-app, fabric-admin, network-manager-app apps to chip-cert-bins docker image as requested in the following issue:
https://github.com/project-chip/certification-tool/issues/334
