### PR TITLE
Allow to specify run delay between app and test script

### DIFF
--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -638,6 +638,12 @@ markers must be present.
     -   Example:
         `--storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto`
 
+-   `test-runner-run/<run_identifier>/script-start-delay`: Specifies the number
+    of seconds to wait before starting the test script. By default, the delay
+    is 0 seconds.
+
+    -   Example: `10`
+
 This structured format ensures that all necessary configurations are clearly
 defined and easily understood, allowing for consistent and reliable test
 execution.

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -635,12 +635,13 @@ markers must be present.
 
 -   `test-runner-run/<run_identifier>/script-args`: Specifies the arguments to
     be passed to the test script.
+
     -   Example:
         `--storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto`
 
 -   `test-runner-run/<run_identifier>/script-start-delay`: Specifies the number
-    of seconds to wait before starting the test script. By default, the delay
-    is 0 seconds.
+    of seconds to wait before starting the test script. By default, the delay is
+    0 seconds.
 
     -   Example: `10`
 

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -640,8 +640,11 @@ markers must be present.
         `--storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto`
 
 -   `test-runner-run/<run_identifier>/script-start-delay`: Specifies the number
-    of seconds to wait before starting the test script. By default, the delay is
-    0 seconds.
+    of seconds to wait before starting the test script. This parameter can be
+    used to allow the application to initialize itself properly before the test
+    script will try to commission it (e.g. in case if the application needs to
+    be commissioned to some other controller first). By default, the delay is 0
+    seconds.
 
     -   Example: `10`
 

--- a/src/python_testing/matter_testing_infrastructure/metadata_parser/metadata.py
+++ b/src/python_testing/matter_testing_infrastructure/metadata_parser/metadata.py
@@ -33,6 +33,7 @@ class Metadata:
     app: str
     app_args: str
     script_args: str
+    script_start_delay: int = 0
     factoryreset: bool = False
     factoryreset_app_only: bool = False
     script_gdb: bool = False
@@ -59,6 +60,9 @@ class Metadata:
 
         if "script-args" in attr_dict:
             self.script_args = attr_dict["script-args"]
+
+        if "script-start-delay" in attr_dict:
+            self.script_start_delay = int(attr_dict["script-start-delay"])
 
         if "py_script_path" in attr_dict:
             self.py_script_path = attr_dict["py_script_path"]
@@ -187,6 +191,7 @@ class MetadataReader:
                 app=attr.get("app", ""),
                 app_args=attr.get("app_args", ""),
                 script_args=attr.get("script_args", ""),
+                script_start_delay=int(attr.get("script_start_delay", 0)),
                 factoryreset=bool(attr.get("factoryreset", False)),
                 factoryreset_app_only=bool(attr.get("factoryreset_app_only", False)),
                 script_gdb=bool(attr.get("script_gdb", False)),


### PR DESCRIPTION
### Problem

In the `TC-MCORE-FS-1.3` test it is required to properly setup application before the test script can be run. Application consists of `fabric-admin` and `fabric-bridge` where the `fabric-bridge` needs to be commissioned to `fabric-admin` as a part of app setup. If the test script runs without any delay, the fabric-bridge is commissioned to TH fabric instead.

### Testing

Tested locally when updating TC-MCORE-FS-1.3 test script.