### PR TITLE
Fixed check in step 5 of TC-SEAR-1.2

### DIFF
--- a/src/python_testing/TC_SEAR_1_2.py
+++ b/src/python_testing/TC_SEAR_1_2.py
@@ -158,7 +158,8 @@ class TC_SEAR_1_2(MatterBaseTest):
         if self.current_area is NullValue:
             asserts.assert_true(estimated_end_time is NullValue,
                                 "EstimatedEndTime should be null if CurrentArea is null.")
-        else:
+
+        if estimated_end_time is not NullValue:
             # allow for some clock skew
             asserts.assert_true(estimated_end_time >= read_time - 3*60,
                                 f"EstimatedEndTime({estimated_end_time}) should be greater than the time when it was read({read_time})")

--- a/src/python_testing/TC_SEAR_1_2.py
+++ b/src/python_testing/TC_SEAR_1_2.py
@@ -140,10 +140,10 @@ class TC_SEAR_1_2(MatterBaseTest):
             endpoint=self.endpoint, attribute=Clusters.ServiceArea.Attributes.CurrentArea)
         logging.info(f"CurrentArea {current_area}")
 
-        asserts.assert_true((len(self.selareaid_list) == 0 and current_area is NullValue)
-                            or
-                            current_area in self.selareaid_list,
-                            f"CurrentArea {current_area} is invalid. SelectedAreas is {self.selareaid_list}.")
+        if current_area is not NullValue:
+            asserts.assert_true(current_area in self.areaid_list,
+                                f"CurrentArea {current_area} is not in SupportedAreas: {self.areaid_list}.")
+
         # save so other methods can use this if needed
         self.current_area = current_area
 


### PR DESCRIPTION
Fixes #35196.

Step 5 reads the `CurrentArea` and request that this value is verified as follows.

> - {DUTreply} null, or a uint32 value
> - If supported_areas is empty, verify that the attribute is null
> - If the value is not null, verify that it matches the AreaID field of an entry in the supported_areas list
