### PR TITLE
Plumbing for CADMIN attribute updates from fabric-admin to fabric-bridge

### DIFF
--- a/examples/common/pigweed/protos/fabric_bridge_service.proto
+++ b/examples/common/pigweed/protos/fabric_bridge_service.proto
@@ -26,7 +26,7 @@ message KeepActiveChanged {
   uint32 promised_active_duration_ms = 2;
 }
 
-message AdministratorCommissioningChange {
+message AdministratorCommissioningChanged {
   uint64 node_id = 1;
   uint32 window_status = 2;
   optional uint32 opener_fabric_index = 3;
@@ -37,5 +37,5 @@ service FabricBridge {
   rpc AddSynchronizedDevice(SynchronizedDevice) returns (pw.protobuf.Empty){}
   rpc RemoveSynchronizedDevice(SynchronizedDevice) returns (pw.protobuf.Empty){}
   rpc ActiveChanged(KeepActiveChanged) returns (pw.protobuf.Empty){}
-  rpc AdminCommissioningAttributeChanged(AdministratorCommissioningChange) returns (pw.protobuf.Empty){}
+  rpc AdminCommissioningAttributeChanged(AdministratorCommissioningChanged) returns (pw.protobuf.Empty){}
 }

--- a/examples/common/pigweed/protos/fabric_bridge_service.proto
+++ b/examples/common/pigweed/protos/fabric_bridge_service.proto
@@ -26,8 +26,20 @@ message KeepActiveChanged {
   uint32 promised_active_duration_ms = 2;
 }
 
+message AdministratorCommissioningChange {
+  uint64 node_id = 1;
+  // TODO figure out the types we should use here
+  //uint8 window_status = 2;
+  //optional uint8 admin_fabric_index = 3;
+  //optional uint16 admin_vendor_id = 4;
+  uint32 window_status = 2;
+  optional uint32 opener_fabric_index = 3;
+  optional uint32 opener_vendor_id = 4;
+}
+
 service FabricBridge {
   rpc AddSynchronizedDevice(SynchronizedDevice) returns (pw.protobuf.Empty){}
   rpc RemoveSynchronizedDevice(SynchronizedDevice) returns (pw.protobuf.Empty){}
   rpc ActiveChanged(KeepActiveChanged) returns (pw.protobuf.Empty){}
+  rpc AdminCommissioningAttributeChanged(AdministratorCommissioningChange) returns (pw.protobuf.Empty){}
 }

--- a/examples/common/pigweed/protos/fabric_bridge_service.proto
+++ b/examples/common/pigweed/protos/fabric_bridge_service.proto
@@ -28,10 +28,6 @@ message KeepActiveChanged {
 
 message AdministratorCommissioningChange {
   uint64 node_id = 1;
-  // TODO figure out the types we should use here
-  //uint8 window_status = 2;
-  //optional uint8 admin_fabric_index = 3;
-  //optional uint16 admin_vendor_id = 4;
   uint32 window_status = 2;
   optional uint32 opener_fabric_index = 3;
   optional uint32 opener_vendor_id = 4;

--- a/examples/common/pigweed/rpc_services/FabricBridge.h
+++ b/examples/common/pigweed/rpc_services/FabricBridge.h
@@ -49,7 +49,7 @@ public:
         return pw::Status::Unimplemented();
     }
 
-    virtual pw::Status AdminCommissioningAttributeChanged (const chip_rpc_AdministratorCommissioningChange  & request, pw_protobuf_Empty & response)
+    virtual pw::Status AdminCommissioningAttributeChanged (const chip_rpc_AdministratorCommissioningChanged & request, pw_protobuf_Empty & response)
     {
         return pw::Status::Unimplemented();
     }

--- a/examples/common/pigweed/rpc_services/FabricBridge.h
+++ b/examples/common/pigweed/rpc_services/FabricBridge.h
@@ -48,6 +48,11 @@ public:
     {
         return pw::Status::Unimplemented();
     }
+
+    virtual pw::Status AdminCommissioningAttributeChanged (const chip_rpc_AdministratorCommissioningChange  & request, pw_protobuf_Empty & response)
+    {
+        return pw::Status::Unimplemented();
+    }
 };
 
 } // namespace rpc

--- a/examples/common/pigweed/rpc_services/FabricBridge.h
+++ b/examples/common/pigweed/rpc_services/FabricBridge.h
@@ -49,7 +49,8 @@ public:
         return pw::Status::Unimplemented();
     }
 
-    virtual pw::Status AdminCommissioningAttributeChanged (const chip_rpc_AdministratorCommissioningChanged & request, pw_protobuf_Empty & response)
+    virtual pw::Status AdminCommissioningAttributeChanged(const chip_rpc_AdministratorCommissioningChanged & request,
+                                                          pw_protobuf_Empty & response)
     {
         return pw::Status::Unimplemented();
     }

--- a/examples/fabric-admin/rpc/RpcClient.cpp
+++ b/examples/fabric-admin/rpc/RpcClient.cpp
@@ -180,3 +180,20 @@ CHIP_ERROR ActiveChanged(chip::NodeId nodeId, uint32_t promisedActiveDurationMs)
 
     return WaitForResponse(call);
 }
+
+CHIP_ERROR AdminCommissioningAttributeChanged(const chip_rpc_AdministratorCommissioningChanged & data)
+{
+    ChipLogProgress(NotSpecified, "AdminCommissioningAttributeChanged");
+
+    // The RPC call is kept alive until it completes. When a response is received, it will be logged by the handler
+    // function and the call will complete.
+    auto call = fabricBridgeClient.AdminCommissioningAttributeChanged(data, RpcCompletedWithEmptyResponse);
+
+    if (!call.active())
+    {
+        // The RPC call was not sent. This could occur due to, for example, an invalid channel ID. Handle if necessary.
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    return WaitForResponse(call);
+}

--- a/examples/fabric-admin/rpc/RpcClient.h
+++ b/examples/fabric-admin/rpc/RpcClient.h
@@ -55,7 +55,7 @@ CHIP_ERROR AddSynchronizedDevice(const chip_rpc_SynchronizedDevice & data);
  * It logs the progress and checks if a `RemoveSynchronizedDevice` operation is already in progress.
  * If an operation is in progress, it returns `CHIP_ERROR_BUSY`.
  *
- * @param data The Node ID of the device to be removed.
+ * @param nodeId The Node ID of the device to be removed.
  * @return CHIP_ERROR An error code indicating the success or failure of the operation.
  * - CHIP_NO_ERROR: The RPC command was successfully processed.
  * - CHIP_ERROR_BUSY: Another operation is currently in progress.

--- a/examples/fabric-admin/rpc/RpcClient.h
+++ b/examples/fabric-admin/rpc/RpcClient.h
@@ -55,7 +55,7 @@ CHIP_ERROR AddSynchronizedDevice(const chip_rpc_SynchronizedDevice & data);
  * It logs the progress and checks if a `RemoveSynchronizedDevice` operation is already in progress.
  * If an operation is in progress, it returns `CHIP_ERROR_BUSY`.
  *
- * @param nodeId The Node ID of the device to be removed.
+ * @param data The Node ID of the device to be removed.
  * @return CHIP_ERROR An error code indicating the success or failure of the operation.
  * - CHIP_NO_ERROR: The RPC command was successfully processed.
  * - CHIP_ERROR_BUSY: Another operation is currently in progress.
@@ -74,3 +74,14 @@ CHIP_ERROR RemoveSynchronizedDevice(chip::NodeId nodeId);
  * - CHIP_ERROR_INTERNAL: An internal error occurred while activating the RPC call.
  */
 CHIP_ERROR ActiveChanged(chip::NodeId nodeId, uint32_t promisedActiveDurationMs);
+
+/**
+ * @brief CADMIN attribute has changed of one of the bridged devices that was previously added.
+ *
+ * @param data information regarding change in AdministratorCommissioning attributes
+ * @return CHIP_ERROR An error code indicating the success or failure of the operation.
+ * - CHIP_NO_ERROR: The RPC command was successfully processed.
+ * - CHIP_ERROR_BUSY: Another operation is currently in progress.
+ * - CHIP_ERROR_INTERNAL: An internal error occurred while activating the RPC call.
+ */
+CHIP_ERROR AdminCommissioningAttributeChanged(const chip_rpc_AdministratorCommissioningChanged & data);

--- a/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedDevice.h
+++ b/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedDevice.h
@@ -68,7 +68,8 @@ public:
 
     [[nodiscard]] const BridgedAttributes & GetBridgedAttributes() const { return mAttributes; }
     void SetBridgedAttributes(const BridgedAttributes & value) { mAttributes = value; }
-    // TODO(#35077): Need to allow mAdminCommissioningAttributes to be set from fabric-admin.
+
+    void SetAdminCommissioningAttributes(const AdminCommissioningAttributes & aAdminCommissioningAttributes);
     const AdminCommissioningAttributes & GetAdminCommissioningAttributes() const { return mAdminCommissioningAttributes; }
 
     /// Convenience method to set just the unique id of a bridged device as it

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedAdministratorCommissioning.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedAdministratorCommissioning.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR BridgedAdministratorCommissioning::Read(const ConcreteReadAttributePa
     switch (aPath.mAttributeId)
     {
     case Attributes::WindowStatus::Id: {
-        return aEncoder.Encode(attr.commissioningWindowStatus );
+        return aEncoder.Encode(attr.commissioningWindowStatus);
     }
     case Attributes::AdminFabricIndex::Id: {
         DataModel::Nullable<FabricIndex> encodeableFabricIndex = DataModel::NullNullable;

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedAdministratorCommissioning.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedAdministratorCommissioning.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR BridgedAdministratorCommissioning::Read(const ConcreteReadAttributePa
     switch (aPath.mAttributeId)
     {
     case Attributes::WindowStatus::Id: {
-        return aEncoder.Encode(attr.commissioningWindowStatus);
+        return aEncoder.Encode(attr.commissioningWindowStatus );
     }
     case Attributes::AdminFabricIndex::Id: {
         DataModel::Nullable<FabricIndex> encodeableFabricIndex = DataModel::NullNullable;

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDevice.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDevice.cpp
@@ -21,6 +21,7 @@
 #include <cstdio>
 
 #include <app/EventLogging.h>
+#include <app/reporting/reporting.h>
 #include <platform/CHIPDeviceLayer.h>
 
 namespace {
@@ -78,5 +79,31 @@ void BridgedDevice::SetReachable(bool reachable)
     else
     {
         ChipLogProgress(NotSpecified, "BridgedDevice[%s]: OFFLINE", mAttributes.uniqueId.c_str());
+    }
+}
+
+void BridgedDevice::SetAdminCommissioningAttributes(const AdminCommissioningAttributes & aAdminCommissioningAttributes)
+{
+    bool window_changed = (aAdminCommissioningAttributes.commissioningWindowStatus != mAdminCommissioningAttributes.commissioningWindowStatus);
+    bool fabric_index_changed = (aAdminCommissioningAttributes.openerFabricIndex != mAdminCommissioningAttributes.openerFabricIndex);
+    bool vendor_changed = (aAdminCommissioningAttributes.openerVendorId != mAdminCommissioningAttributes.openerVendorId);
+
+    mAdminCommissioningAttributes = aAdminCommissioningAttributes;
+
+    if (window_changed)
+    {
+        MatterReportingAttributeChangeCallback(mEndpointId, chip::app::Clusters::AdministratorCommissioning::Id,
+                                               chip::app::Clusters::AdministratorCommissioning::Attributes::WindowStatus::Id);
+    }
+    if (fabric_index_changed)
+    {
+        MatterReportingAttributeChangeCallback(mEndpointId, chip::app::Clusters::AdministratorCommissioning::Id,
+                                               chip::app::Clusters::AdministratorCommissioning::Attributes::AdminFabricIndex::Id);
+    }
+
+    if (vendor_changed)
+    {
+        MatterReportingAttributeChangeCallback(mEndpointId, chip::app::Clusters::AdministratorCommissioning::Id,
+                                               chip::app::Clusters::AdministratorCommissioning::Attributes::AdminVendorId::Id);
     }
 }

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDevice.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDevice.cpp
@@ -84,8 +84,10 @@ void BridgedDevice::SetReachable(bool reachable)
 
 void BridgedDevice::SetAdminCommissioningAttributes(const AdminCommissioningAttributes & aAdminCommissioningAttributes)
 {
-    bool window_changed = (aAdminCommissioningAttributes.commissioningWindowStatus != mAdminCommissioningAttributes.commissioningWindowStatus);
-    bool fabric_index_changed = (aAdminCommissioningAttributes.openerFabricIndex != mAdminCommissioningAttributes.openerFabricIndex);
+    bool window_changed =
+        (aAdminCommissioningAttributes.commissioningWindowStatus != mAdminCommissioningAttributes.commissioningWindowStatus);
+    bool fabric_index_changed =
+        (aAdminCommissioningAttributes.openerFabricIndex != mAdminCommissioningAttributes.openerFabricIndex);
     bool vendor_changed = (aAdminCommissioningAttributes.openerVendorId != mAdminCommissioningAttributes.openerVendorId);
 
     mAdminCommissioningAttributes = aAdminCommissioningAttributes;

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDevice.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDevice.cpp
@@ -35,9 +35,9 @@ struct ActiveChangeEventWorkData
 struct ReportAttributeChangedWorkData
 {
     chip::EndpointId mEndpointId;
-    bool mWindowChanged = false;
+    bool mWindowChanged      = false;
     bool mFabricIndexChanged = false;
-    bool mVendorChanged = false;
+    bool mVendorChanged      = false;
 };
 
 void ActiveChangeEventWork(intptr_t arg)
@@ -114,7 +114,7 @@ void BridgedDevice::SetReachable(bool reachable)
 
 void BridgedDevice::SetAdminCommissioningAttributes(const AdminCommissioningAttributes & aAdminCommissioningAttributes)
 {
-    ReportAttributeChangedWorkData  * workdata = chip::Platform::New<ReportAttributeChangedWorkData>();
+    ReportAttributeChangedWorkData * workdata = chip::Platform::New<ReportAttributeChangedWorkData>();
 
     workdata->mEndpointId = mEndpointId;
     workdata->mWindowChanged =

--- a/examples/fabric-bridge-app/linux/RpcServer.cpp
+++ b/examples/fabric-bridge-app/linux/RpcServer.cpp
@@ -189,19 +189,11 @@ pw::Status FabricBridge::AdminCommissioningAttributeChanged(const chip_rpc_Admin
         VerifyOrReturnValue(request.opener_fabric_index <= chip::kMaxValidFabricIndex, pw::Status::InvalidArgument());
         adminCommissioningAttributes.openerFabricIndex = static_cast<FabricIndex>(request.opener_fabric_index);
     }
-    else
-    {
-        adminCommissioningAttributes.openerFabricIndex.reset();
-    }
 
     if (request.has_opener_vendor_id)
     {
         VerifyOrReturnValue(request.opener_vendor_id != chip::VendorId::NotSpecified, pw::Status::InvalidArgument());
         adminCommissioningAttributes.openerVendorId = static_cast<chip::VendorId>(request.opener_vendor_id);
-    }
-    else
-    {
-        adminCommissioningAttributes.openerVendorId.reset();
     }
 
     device->SetAdminCommissioningAttributes(adminCommissioningAttributes);

--- a/examples/fabric-bridge-app/linux/RpcServer.cpp
+++ b/examples/fabric-bridge-app/linux/RpcServer.cpp
@@ -46,7 +46,7 @@ public:
     pw::Status AddSynchronizedDevice(const chip_rpc_SynchronizedDevice & request, pw_protobuf_Empty & response) override;
     pw::Status RemoveSynchronizedDevice(const chip_rpc_SynchronizedDevice & request, pw_protobuf_Empty & response) override;
     pw::Status ActiveChanged(const chip_rpc_KeepActiveChanged & request, pw_protobuf_Empty & response) override;
-    pw::Status AdminCommissioningAttributeChanged (const chip_rpc_AdministratorCommissioningChange  & request, pw_protobuf_Empty & response) override;
+    pw::Status AdminCommissioningAttributeChanged (const chip_rpc_AdministratorCommissioningChanged & request, pw_protobuf_Empty & response) override;
 };
 
 pw::Status FabricBridge::AddSynchronizedDevice(const chip_rpc_SynchronizedDevice & request, pw_protobuf_Empty & response)
@@ -161,7 +161,7 @@ pw::Status FabricBridge::ActiveChanged(const chip_rpc_KeepActiveChanged & reques
     return pw::OkStatus();
 }
 
-pw::Status FabricBridge::AdminCommissioningAttributeChanged(const chip_rpc_AdministratorCommissioningChange  & request, pw_protobuf_Empty & response)
+pw::Status FabricBridge::AdminCommissioningAttributeChanged(const chip_rpc_AdministratorCommissioningChanged & request, pw_protobuf_Empty & response)
 {
     NodeId nodeId = request.node_id;
     ChipLogProgress(NotSpecified, "Received CADMIN attribut change: " ChipLogFormatX64, ChipLogValueX64(nodeId));

--- a/examples/fabric-bridge-app/linux/RpcServer.cpp
+++ b/examples/fabric-bridge-app/linux/RpcServer.cpp
@@ -46,7 +46,8 @@ public:
     pw::Status AddSynchronizedDevice(const chip_rpc_SynchronizedDevice & request, pw_protobuf_Empty & response) override;
     pw::Status RemoveSynchronizedDevice(const chip_rpc_SynchronizedDevice & request, pw_protobuf_Empty & response) override;
     pw::Status ActiveChanged(const chip_rpc_KeepActiveChanged & request, pw_protobuf_Empty & response) override;
-    pw::Status AdminCommissioningAttributeChanged (const chip_rpc_AdministratorCommissioningChanged & request, pw_protobuf_Empty & response) override;
+    pw::Status AdminCommissioningAttributeChanged(const chip_rpc_AdministratorCommissioningChanged & request,
+                                                  pw_protobuf_Empty & response) override;
 };
 
 pw::Status FabricBridge::AddSynchronizedDevice(const chip_rpc_SynchronizedDevice & request, pw_protobuf_Empty & response)
@@ -161,7 +162,8 @@ pw::Status FabricBridge::ActiveChanged(const chip_rpc_KeepActiveChanged & reques
     return pw::OkStatus();
 }
 
-pw::Status FabricBridge::AdminCommissioningAttributeChanged(const chip_rpc_AdministratorCommissioningChanged & request, pw_protobuf_Empty & response)
+pw::Status FabricBridge::AdminCommissioningAttributeChanged(const chip_rpc_AdministratorCommissioningChanged & request,
+                                                            pw_protobuf_Empty & response)
 {
     NodeId nodeId = request.node_id;
     ChipLogProgress(NotSpecified, "Received CADMIN attribut change: " ChipLogFormatX64, ChipLogValueX64(nodeId));
@@ -176,9 +178,11 @@ pw::Status FabricBridge::AdminCommissioningAttributeChanged(const chip_rpc_Admin
 
     BridgedDevice::AdminCommissioningAttributes adminCommissioningAttributes;
 
-    uint32_t max_window_status_value = static_cast<uint32_t>(chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kUnknownEnumValue);
+    uint32_t max_window_status_value =
+        static_cast<uint32_t>(chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kUnknownEnumValue);
     VerifyOrReturnValue(request.window_status < max_window_status_value, pw::Status::InvalidArgument());
-    adminCommissioningAttributes.commissioningWindowStatus = static_cast<chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum>(request.window_status);
+    adminCommissioningAttributes.commissioningWindowStatus =
+        static_cast<chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum>(request.window_status);
     if (request.has_opener_fabric_index)
     {
         VerifyOrReturnValue(request.opener_fabric_index >= chip::kMinValidFabricIndex, pw::Status::InvalidArgument());
@@ -190,7 +194,8 @@ pw::Status FabricBridge::AdminCommissioningAttributeChanged(const chip_rpc_Admin
         adminCommissioningAttributes.openerFabricIndex.reset();
     }
 
-    if (request.has_opener_vendor_id) {
+    if (request.has_opener_vendor_id)
+    {
         VerifyOrReturnValue(request.opener_vendor_id != chip::VendorId::NotSpecified, pw::Status::InvalidArgument());
         adminCommissioningAttributes.openerVendorId = static_cast<chip::VendorId>(request.opener_vendor_id);
     }

--- a/examples/fabric-bridge-app/linux/RpcServer.cpp
+++ b/examples/fabric-bridge-app/linux/RpcServer.cpp
@@ -176,22 +176,27 @@ pw::Status FabricBridge::AdminCommissioningAttributeChanged(const chip_rpc_Admin
 
     BridgedDevice::AdminCommissioningAttributes adminCommissioningAttributes;
 
-    // TODO these casts are all hacks just place holder until I figure out proto types
+    uint32_t max_window_status_value = static_cast<uint32_t>(chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kUnknownEnumValue);
+    VerifyOrReturnValue(request.window_status < max_window_status_value, pw::Status::InvalidArgument());
     adminCommissioningAttributes.commissioningWindowStatus = static_cast<chip::app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum>(request.window_status);
-    if (request.has_opener_fabric_index) {
+    if (request.has_opener_fabric_index)
+    {
+        VerifyOrReturnValue(request.opener_fabric_index >= chip::kMinValidFabricIndex, pw::Status::InvalidArgument());
+        VerifyOrReturnValue(request.opener_fabric_index <= chip::kMaxValidFabricIndex, pw::Status::InvalidArgument());
         adminCommissioningAttributes.openerFabricIndex = static_cast<FabricIndex>(request.opener_fabric_index);
     }
     else
     {
-        adminCommissioningAttributes.openerFabricIndex = std::nullopt;
+        adminCommissioningAttributes.openerFabricIndex.reset();
     }
 
     if (request.has_opener_vendor_id) {
+        VerifyOrReturnValue(request.opener_vendor_id != chip::VendorId::NotSpecified, pw::Status::InvalidArgument());
         adminCommissioningAttributes.openerVendorId = static_cast<chip::VendorId>(request.opener_vendor_id);
     }
     else
     {
-        adminCommissioningAttributes.openerVendorId = std::nullopt;
+        adminCommissioningAttributes.openerVendorId.reset();
     }
 
     device->SetAdminCommissioningAttributes(adminCommissioningAttributes);


### PR DESCRIPTION
usage of fabric-admin calling `AdminCommissioningAttributeChanged` will be done in a follow up PR. This allows this PR to focus on plumbing of data from fabric-admin to fabric-bridge

This code is not yet heavily tested as fabric-admin still needs to subscribe to the attribute and properly populate the values. This will be completed in a follow up and any issues identified in the plumbing in this PR will be addressed in a follow up.