### PR TITLE
[Silabs] Added new wifi BRD2605A board support in matter

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -128,6 +128,24 @@ jobs:
             /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out
+      - name: Build BRD2605A WiFi Soc variants
+        run: |
+          ./scripts/run_in_build_env.sh \
+             "./scripts/build/build_examples.py \
+                --enable-flashbundle \
+                --target efr32-brd2605a-light-skip-rps-generation \
+                --target efr32-brd2605a-lock-skip-rps-generation \
+                build \
+                --copy-artifacts-to out/artifacts \
+             "
+      - name: Prepare bloat report for brd2605a lock app
+        run: |
+          .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+            efr32 BRD2605a lock-app \
+            out/efr32-brd2605a-lock-skip-rps-generation/matter-silabs-lock-example.out \
+            /tmp/bloat_reports/
+      - name: Clean out build output
+        run: rm -rf ./out
       - name: Build EFR32 with WiFi NCP
         run: |
           ./scripts/run_in_build_env.sh \

--- a/examples/light-switch-app/silabs/build_for_wifi_gnfile.gn
+++ b/examples/light-switch-app/silabs/build_for_wifi_gnfile.gn
@@ -24,5 +24,6 @@ default_args = {
   target_cpu = "arm"
   target_os = "freertos"
   chip_enable_wifi = true
+  chip_device_platform = "SiWx917"
   import("//build_for_wifi_args.gni")
 }

--- a/examples/lighting-app/silabs/build_for_wifi_gnfile.gn
+++ b/examples/lighting-app/silabs/build_for_wifi_gnfile.gn
@@ -24,5 +24,6 @@ default_args = {
   target_cpu = "arm"
   target_os = "freertos"
   chip_enable_wifi = true
+  chip_device_platform = "SiWx917"
   import("//build_for_wifi_args.gni")
 }

--- a/examples/lock-app/silabs/build_for_wifi_gnfile.gn
+++ b/examples/lock-app/silabs/build_for_wifi_gnfile.gn
@@ -24,5 +24,6 @@ default_args = {
   target_cpu = "arm"
   target_os = "freertos"
   chip_enable_wifi = true
+  chip_device_platform = "SiWx917"
   import("//build_for_wifi_args.gni")
 }

--- a/examples/thermostat/silabs/build_for_wifi_gnfile.gn
+++ b/examples/thermostat/silabs/build_for_wifi_gnfile.gn
@@ -24,5 +24,6 @@ default_args = {
   target_cpu = "arm"
   target_os = "freertos"
   chip_enable_wifi = true
+  chip_device_platform = "SiWx917"
   import("//build_for_wifi_args.gni")
 }

--- a/examples/window-app/silabs/build_for_wifi_gnfile.gn
+++ b/examples/window-app/silabs/build_for_wifi_gnfile.gn
@@ -24,5 +24,6 @@ default_args = {
   target_cpu = "arm"
   target_os = "freertos"
   chip_enable_wifi = true
+  chip_device_platform = "SiWx917"
   import("//build_for_wifi_args.gni")
 }

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -253,6 +253,7 @@ def BuildEfr32Target():
         TargetPart('brd4186c', board=Efr32Board.BRD4186C),
         TargetPart('brd2703a', board=Efr32Board.BRD2703A),
         TargetPart('brd4338a', board=Efr32Board.BRD4338A, enable_wifi=True, enable_917_soc=True),
+        TargetPart('brd2605a', board=Efr32Board.BRD2605A, enable_wifi=True, enable_917_soc=True),
     ])
 
     # apps

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -104,6 +104,7 @@ class Efr32Board(Enum):
     BRD4186C = 10
     BRD4338A = 11
     BRD2703A = 12
+    BRD2605A = 13
 
     def GnArgName(self):
         if self == Efr32Board.BRD2704B:
@@ -130,6 +131,8 @@ class Efr32Board(Enum):
             return 'BRD4338A'
         elif self == Efr32Board.BRD2703A:
             return 'BRD2703A'
+        elif self == Efr32Board.BRD2605A:
+            return 'BRD2605A'
         else:
             raise Exception('Unknown board #: %r' % self)
 

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -5,7 +5,7 @@ bouffalolab-{bl602dk,bl704ldk,bl706dk,bl602-night-light,bl706-night-light,bl602-
 cc32xx-{lock,air-purifier}
 ti-cc13x4_26x4-{lighting,lock,pump,pump-controller}[-mtd][-ftd]
 cyw30739-{cyw30739b2_p5_evk_01,cyw30739b2_p5_evk_02,cyw30739b2_p5_evk_03,cyw930739m2evb_01,cyw930739m2evb_02}-{light,light-switch,lock,thermostat}
-efr32-{brd2704b,brd4316a,brd4317a,brd4318a,brd4319a,brd4186a,brd4187a,brd2601b,brd4187c,brd4186c,brd2703a,brd4338a}-{window-covering,switch,unit-test,light,lock,thermostat,pump}[-rpc][-with-ota-requestor][-icd][-low-power][-shell][-no-logging][-openthread-mtd][-heap-monitoring][-no-openthread-cli][-show-qr-code][-wifi][-rs9116][-wf200][-siwx917][-ipv4][-additional-data-advertising][-use-ot-lib][-use-ot-coap-lib][-no-version][-skip-rps-generation]
+efr32-{brd2704b,brd4316a,brd4317a,brd4318a,brd4319a,brd4186a,brd4187a,brd2601b,brd4187c,brd4186c,brd2703a,brd4338a,brd2605a}-{window-covering,switch,unit-test,light,lock,thermostat,pump}[-rpc][-with-ota-requestor][-icd][-low-power][-shell][-no-logging][-openthread-mtd][-heap-monitoring][-no-openthread-cli][-show-qr-code][-wifi][-rs9116][-wf200][-siwx917][-ipv4][-additional-data-advertising][-use-ot-lib][-use-ot-coap-lib][-no-version][-skip-rps-generation]
 esp32-{m5stack,c3devkit,devkitc,qemu}-{all-clusters,all-clusters-minimal,energy-management,ota-provider,ota-requestor,shell,light,lock,bridge,temperature-measurement,ota-requestor,tests}[-rpc][-ipv6only][-tracing]
 genio-lighting-app
 linux-fake-tests[-mbedtls][-boringssl][-asan][-tsan][-ubsan][-libfuzzer][-ossfuzz][-pw-fuzztest][-coverage][-dmalloc][-clang]

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -300,7 +300,6 @@ else
     if [ "$SILABS_BOARD" == "BRD4338A" ] || [ "$SILABS_BOARD" == "BRD2605A" ]; then
         echo "Compiling for 917 WiFi SOC"
         USE_WIFI=true
-        optArgs+="chip_device_platform =\"SiWx917\" is_debug=false "
     fi
 
     if [ "$USE_GIT_SHA_FOR_VERSION" == true ]; then

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -297,7 +297,7 @@ else
     fi
 
     # 917 exception. TODO find a more generic way
-    if [ "$SILABS_BOARD" == "BRD4338A" ]; then
+    if [ "$SILABS_BOARD" == "BRD4338A" ] || [ "$SILABS_BOARD" == "BRD2605A" ]; then
         echo "Compiling for 917 WiFi SOC"
         USE_WIFI=true
         optArgs+="chip_device_platform =\"SiWx917\" is_debug=false "

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -23,8 +23,10 @@
 
 #include <app/icd/server/ICDServerConfig.h>
 
+#include <lib/support/CodeUtils.h>
 #if SILABS_LOG_ENABLED
 #include "silabs_utils.h"
+
 #endif // SILABS_LOG_ENABLED
 
 // TODO add includes ?
@@ -48,6 +50,14 @@ void soc_pll_config(void);
 
 #if SILABS_LOG_OUT_UART || ENABLE_CHIP_SHELL
 #include "uart.h"
+#endif
+// TODO Remove this when SI91X-16606 is addressed
+#ifdef SI917_DEVKIT
+#define SL_LED_COUNT 1
+uint8_t ledPinArray[SL_LED_COUNT] = { SL_LED_LEDB_PIN };
+#else
+#define SL_LED_COUNT SL_SI91x_LED_COUNT
+uint8_t ledPinArray[SL_LED_COUNT] = { SL_LED_LED0_PIN, SL_LED_LED1_PIN };
 #endif
 
 namespace chip {
@@ -100,9 +110,8 @@ void SilabsPlatform::InitLed(void)
 
 CHIP_ERROR SilabsPlatform::SetLed(bool state, uint8_t led)
 {
-    // TODO add range check
-    (state) ? sl_si91x_led_set(led ? SL_LED_LED1_PIN : SL_LED_LED0_PIN)
-            : sl_si91x_led_clear(led ? SL_LED_LED1_PIN : SL_LED_LED0_PIN);
+    VerifyOrReturnError(led < SL_LED_COUNT, CHIP_ERROR_INVALID_ARGUMENT);
+    (state) ? sl_si91x_led_set(ledPinArray[led]) : sl_si91x_led_clear(ledPinArray[led]);
     return CHIP_NO_ERROR;
 }
 
@@ -114,8 +123,8 @@ bool SilabsPlatform::GetLedState(uint8_t led)
 
 CHIP_ERROR SilabsPlatform::ToggleLed(uint8_t led)
 {
-    // TODO add range check
-    sl_si91x_led_toggle(led ? SL_LED_LED1_PIN : SL_LED_LED0_PIN);
+    VerifyOrReturnError(led < SL_LED_COUNT, CHIP_ERROR_INVALID_ARGUMENT);
+    sl_si91x_led_toggle(ledPinArray[led]);
     return CHIP_NO_ERROR;
 }
 #endif // ENABLE_WSTK_LEDS

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -60,8 +60,8 @@ template("siwx917_sdk") {
       "${efr32_sdk_root}/platform/emdrv/nvm3/inc",
       "${efr32_sdk_root}/platform/emdrv/common/inc",
       "${efr32_sdk_root}/platform/service/device_init/inc",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/autogen",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/config",
+      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen",
+      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/config",
 
       "${chip_root}/src/platform/silabs/rs911x",
 
@@ -131,7 +131,7 @@ template("siwx917_sdk") {
       "${efr32_sdk_root}/platform/service/sleeptimer/inc",
       "${efr32_sdk_root}/platform/service/sleeptimer/config",
       "${efr32_sdk_root}/platform/service/sleeptimer/src",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/support/inc",
+      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/support/inc",
 
       "${efr32_sdk_root}/platform/service/iostream/inc",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/button/inc",
@@ -691,11 +691,11 @@ template("siwx917_sdk") {
       "${efr32_sdk_root}/util/third_party/freertos/kernel/stream_buffer.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/tasks.c",
       "${efr32_sdk_root}/util/third_party/freertos/kernel/timers.c",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/autogen/sl_event_handler.c",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/autogen/sl_si91x_button_instances.c",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/autogen/sl_si91x_led_instances.c",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/autogen/sl_ulp_timer_init.c",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/support/hal/rsi_hal_mcu_m4.c",
+      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_event_handler.c",
+      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_button_instances.c",
+      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_led_instances.c",
+      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_ulp_timer_init.c",
+      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/support/hal/rsi_hal_mcu_m4.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/button/src/sl_si91x_button.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/src/sl_si91x_led.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/nvm3/src/sl_si91x_nvm3_hal_flash.c",
@@ -713,7 +713,7 @@ template("siwx917_sdk") {
       # STARTUP FILES
       "${efr32_sdk_root}/platform/service/iostream/src/sl_iostream.c",
       "${efr32_sdk_root}/platform/service/iostream/src/sl_iostream_rtt.c",
-      "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/support/src/startup_common_RS1xxxx.c",
+      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/support/src/startup_common_RS1xxxx.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/nvm3/src/sl_si91x_common_flash_intf.c",
 
       # OTA
@@ -765,8 +765,8 @@ template("siwx917_sdk") {
 
     if (chip_enable_icd_server) {
       sources += [
-        "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/autogen/sl_si91x_power_manager_handler.c",
-        "${sdk_support_root}/matter/si91x/siwx917/BRD4338A/autogen/sl_si91x_power_manager_wakeup_handler.c",
+        "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_power_manager_handler.c",
+        "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_power_manager_wakeup_handler.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/peripheral_drivers/src/sl_si91x_m4_ps.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/power_manager/src/sl_si91x_power_manager.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/power_manager/src/sli_si91x_power_manager.c",

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -131,7 +131,7 @@ template("siwx917_sdk") {
       "${efr32_sdk_root}/platform/service/sleeptimer/inc",
       "${efr32_sdk_root}/platform/service/sleeptimer/config",
       "${efr32_sdk_root}/platform/service/sleeptimer/src",
-      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/support/inc",
+      "${sdk_support_root}/matter/si91x/support/inc",
 
       "${efr32_sdk_root}/platform/service/iostream/inc",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/button/inc",
@@ -695,7 +695,7 @@ template("siwx917_sdk") {
       "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_button_instances.c",
       "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_led_instances.c",
       "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_ulp_timer_init.c",
-      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/support/hal/rsi_hal_mcu_m4.c",
+      "${sdk_support_root}/matter/si91x/support/hal/rsi_hal_mcu_m4.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/button/src/sl_si91x_button.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/src/sl_si91x_led.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/nvm3/src/sl_si91x_nvm3_hal_flash.c",
@@ -713,7 +713,7 @@ template("siwx917_sdk") {
       # STARTUP FILES
       "${efr32_sdk_root}/platform/service/iostream/src/sl_iostream.c",
       "${efr32_sdk_root}/platform/service/iostream/src/sl_iostream_rtt.c",
-      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/support/src/startup_common_RS1xxxx.c",
+      "${sdk_support_root}/matter/si91x/support/src/startup_common_RS1xxxx.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/nvm3/src/sl_si91x_common_flash_intf.c",
 
       # OTA

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -62,7 +62,7 @@ if (silabs_board == "") {
 assert(silabs_board != "", "silabs_board must be specified")
 
 # Si917 WIFI board ----------
-if (silabs_board == "BRD4338A") {
+if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
   wifi_soc = true


### PR DESCRIPTION
**Description**: Add support for BRD2605A board support in matter
Verified build for brd2605A for light, lock and dishwasher apps.

Note: There is a sdk_support PR raised to support. This needs to be merged after the sdk_support PR will be merged.
https://github.com/SiliconLabs/sdk_support/pull/224
