### PR TITLE
[Silabs] Wi-fi: Add wpa wpa2 mixed security for rs9116

### DIFF
--- a/examples/platform/silabs/efr32/rs911x/rsi_if.c
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.c
@@ -481,7 +481,6 @@ static void wfx_rsi_save_ap_info() // translation
     wfx_rsi.sec.security = WFX_SEC_UNSPECIFIED;
     wfx_rsi.ap_chan      = rsp.scan_info->rf_channel;
     memcpy(&wfx_rsi.ap_mac.octet[0], &rsp.scan_info->bssid[0], BSSID_LEN);
-
     switch (rsp.scan_info->security_mode)
     {
     case SME_OPEN:
@@ -494,6 +493,9 @@ static void wfx_rsi_save_ap_info() // translation
     case SME_WPA2:
     case SME_WPA2_ENTERPRISE:
         wfx_rsi.sec.security = WFX_SEC_WPA2;
+        break;
+    case SME_WPA_WPA2_MIXED_MODE:
+        wfx_rsi.sec.security =  WPA_WPA2_MIXED;
         break;
     case SME_WEP:
         wfx_rsi.sec.security = WFX_SEC_WEP;
@@ -541,6 +543,7 @@ static void wfx_rsi_do_join(void)
             break;
         case WFX_SEC_WPA:
         case WFX_SEC_WPA2:
+        case WPA_WPA2_MIXED:
             connect_security_mode = RSI_WPA_WPA2_MIXED;
             break;
 #if WIFI_ENABLE_SECURITY_WPA3_TRANSITION

--- a/src/platform/silabs/efr32/wifi/wfx_host_events.h
+++ b/src/platform/silabs/efr32/wifi/wfx_host_events.h
@@ -249,6 +249,7 @@ typedef enum
     WFX_SEC_WPA         = 3,
     WFX_SEC_WPA2        = 4,
     WFX_SEC_WPA3        = 5,
+    WPA_WPA2_MIXED      = 6,
 } wfx_sec_t;
 
 typedef struct


### PR DESCRIPTION
Added wpa_wpa2_mixed security type for rs9116.
Verified commissioning on brd4187C + rs9116 board and it is working fine.

