### PR TITLE
[HVAC] Set thermostat delegate in thermostat app

### DIFF
--- a/examples/thermostat/linux/main.cpp
+++ b/examples/thermostat/linux/main.cpp
@@ -21,6 +21,9 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/CommandHandler.h>
 #include <app/clusters/identify-server/identify-server.h>
+#include <app/clusters/thermostat-server/thermostat-server.h>
+
+#include "thermostat-delegate-impl.h"
 
 using namespace chip;
 using namespace chip::app;
@@ -77,4 +80,13 @@ int main(int argc, char * argv[])
     VerifyOrDie(ChipLinuxAppInit(argc, argv) == 0);
     ChipLinuxAppMainLoop();
     return 0;
+}
+
+using namespace chip::app::Clusters::Thermostat;
+void emberAfThermostatClusterInitCallback(EndpointId endpoint)
+{
+    // Register the delegate for the Thermostat
+    auto & delegate = ThermostatDelegate::GetInstance();
+
+    SetDefaultDelegate(endpoint, &delegate);
 }


### PR DESCRIPTION
The thermostat app doesn't initialize the thermostat delegate properly, which causes some test cases to fail.
