### PR TITLE
remove icdm 4_1 from manual tests

### DIFF
--- a/src/app/tests/suites/manualTests.json
+++ b/src/app/tests/suites/manualTests.json
@@ -117,7 +117,7 @@
     "GeneralCommissioning": ["Test_TC_CGEN_2_2"],
     "GeneralDiagnostics": ["Test_TC_DGGEN_2_2"],
     "Identify": ["Test_TC_I_3_2"],
-    "IcdManagement": ["Test_TC_ICDM_4_1", "Test_TC_ICDM_5_1"],
+    "IcdManagement": ["Test_TC_ICDM_5_1"],
     "IlluminanceMeasurement": [],
     "InteractionDataModel": [
         "Test_TC_IDM_1_1",


### PR DESCRIPTION
somehow in previous PRs, we forgot to remove  icdm 4_1  from manual test https://github.com/project-chip/connectedhomeip/pull/34812/files
