### PR TITLE
[nrfconnect] Link updates in documentation

### DIFF
--- a/docs/guides/nrfconnect_examples_configuration.md
+++ b/docs/guides/nrfconnect_examples_configuration.md
@@ -25,7 +25,7 @@ Regardless of the option, you will need to rebuild your application. This will
 require you to provide the build target name of the kit you are using. You can
 find the build target names in the Requirements section of the example you are
 building or on the
-[Board support](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/app_dev/board_support/index.html)
+[Board support](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/board_support/index.html)
 page in the nRF Connect SDK documentation.
 
 ### Temporary changes to configuration
@@ -97,7 +97,7 @@ them values of proper type. Few examples:
     `CONFIG_SAMPLE_STRING_OPTION="some_text"`
 
 For more detailed information, read about
-[setting Kconfig values](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/kconfig/setting.html#setting-configuration-values)
+[setting Kconfig values](https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/build/kconfig/setting.html)
 in the nRF Connect SDK documentation.
 
 Because Kconfig configuration files are used in the building process, make sure
@@ -150,7 +150,7 @@ from your perspective:
           $ west build -b build-target -- -DOVERLAY_CONFIG=overlay_file_name
 
 Read the
-[Kconfig](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/kconfig/index.html#kconfig)
+[Kconfig](https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/build/kconfig/index.html)
 guide in the nRF Connect SDK's Zephyr documentation if you are interested in
 getting more advanced and detailed information about the configuration
 structure.
@@ -214,7 +214,7 @@ performance in case it has been polluted with unwanted entries.
 #### Logging
 
 You can enable logging for both the stack and Zephyr’s
-[Logging](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/reference/logging/index.html#logging-api)
+[Logging](https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/services/logging/index.html)
 API by setting the `CONFIG_LOG` option.
 
 Zephyr allows you to configure log levels of different software modules

--- a/docs/guides/nrfconnect_examples_software_update.md
+++ b/docs/guides/nrfconnect_examples_software_update.md
@@ -6,7 +6,7 @@ protocols:
 
 -   Matter-compliant OTA update protocol that uses the Matter operational
     network for querying and downloading a new firmware image.
--   [Simple Management Protocol](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/services/device_mgmt/smp_protocol.html)
+-   [Simple Management Protocol](https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/services/device_mgmt/smp_protocol.html)
     over Bluetooth LE. In this case, the DFU can be done either using a
     smartphone application or a PC command line tool. Note that this protocol is
     not part of the Matter specification.
@@ -125,11 +125,8 @@ rebooted to apply the update.
 To upgrade your device firmware over Bluetooth LE using a smartphone, complete
 the following steps:
 
-1. Install _one_ of the following applications on your smartphone:
-
-    - [nRF Connect for Mobile](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Connect-for-mobile)
-    - [nRF Toolbox](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Toolbox)
-
+1. Install the [nRF Connect Device Manager](https://www.nordicsemi.com/Products/Development-tools/nrf-connect-device-manager)
+   application on your smartphone.
 2. Push the appropriate button on the device to enable the software update
    functionality (if it is not enabled by default) and start the Bluetooth LE
    advertising of the SMP service. See the user interface section in the example
@@ -138,8 +135,8 @@ the following steps:
    advertising. See the user interface section in the example documentation to
    check the button number.
 4. Follow the instructions about downloading the new image to a device on the
-   [FOTA upgrades](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/working_with_nrf/nrf52/developing.html#fota-updates)
-   page in the nRF Connect SDK documentation.
+   FOTA updates page for either [nRF52 Series devices](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/device_guides/nrf52/fota_update.html)
+   or the [nRF5340 DK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/device_guides/nrf53/fota_update_nrf5340.html).
 
 <hr>
 
@@ -171,7 +168,7 @@ Complete the following steps to perform DFU using mcumgr:
 > (for example, `MatterLock`).
 
 1.  Install the tool by following the
-    [mcumgr command line tool installation instructions](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/device_mgmt/index.html#command-line-tool).
+    [mcumgr command line tool installation instructions](https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/services/device_mgmt/mcumgr.html#command-line_tool).
 2.  Push the appropriate button on the device to enable the software update
     functionality (if it is not enabled by default) and start the Bluetooth LE
     advertising of SMP service. See the user interface section in the example
@@ -342,6 +339,6 @@ Swapping operation can take some time, and after it completes, the new firmware
 is booted.
 
 Visit the
-[mcumgr image management](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/device_mgmt/indexhtml#image-management)
+[mcumgr image management](https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/services/device_mgmt/mcumgr.html#image_management)
 section to get familiar with all image management commands supported by the
 tool.

--- a/docs/guides/nrfconnect_examples_software_update.md
+++ b/docs/guides/nrfconnect_examples_software_update.md
@@ -125,7 +125,8 @@ rebooted to apply the update.
 To upgrade your device firmware over Bluetooth LE using a smartphone, complete
 the following steps:
 
-1. Install the [nRF Connect Device Manager](https://www.nordicsemi.com/Products/Development-tools/nrf-connect-device-manager)
+1. Install the
+   [nRF Connect Device Manager](https://www.nordicsemi.com/Products/Development-tools/nrf-connect-device-manager)
    application on your smartphone.
 2. Push the appropriate button on the device to enable the software update
    functionality (if it is not enabled by default) and start the Bluetooth LE
@@ -135,8 +136,10 @@ the following steps:
    advertising. See the user interface section in the example documentation to
    check the button number.
 4. Follow the instructions about downloading the new image to a device on the
-   FOTA updates page for either [nRF52 Series devices](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/device_guides/nrf52/fota_update.html)
-   or the [nRF5340 DK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/device_guides/nrf53/fota_update_nrf5340.html).
+   FOTA updates page for either
+   [nRF52 Series devices](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/device_guides/nrf52/fota_update.html)
+   or the
+   [nRF5340 DK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/device_guides/nrf53/fota_update_nrf5340.html).
 
 <hr>
 

--- a/docs/guides/nrfconnect_factory_data_configuration.md
+++ b/docs/guides/nrfconnect_factory_data_configuration.md
@@ -24,7 +24,7 @@ data secure by applying hardware write protection.
 
 > **Note:** Due to hardware limitations, in the nRF Connect platform, protection
 > against writing can be applied only to the internal memory partition. The
-> [Fprotect](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/fprotect.html)
+> [Fprotect](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/security/bootloader/fprotect.html)
 > is the hardware flash protection driver, and we used it to ensure write
 > protection of the factory data partition in internal flash memory.
 
@@ -643,7 +643,7 @@ $ west build -b nrf52840dk_nrf52840 -- \
 
 The factory data partition is an area in the device's persistent storage where a
 factory data set is stored. This area is configured using the
-[Partition Manager](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/scripts/partition_manager/partition_manager.html),
+[Partition Manager](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/scripts/partition_manager/partition_manager.html),
 within which all partitions are declared in the `pm_static.yml` file.
 
 To prepare an example that supports factory data, add a partition called
@@ -845,7 +845,7 @@ snippet:
 
 > **Note:** To get more information about how to use the interactive Kconfig
 > interfaces, read the
-> [Kconfig documentation](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/build/kconfig/menuconfig.html).
+> [Kconfig documentation](https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/build/kconfig/menuconfig.html).
 
 ### Default Kconfig values and developing aspects
 

--- a/docs/guides/nrfconnect_platform_overview.md
+++ b/docs/guides/nrfconnect_platform_overview.md
@@ -18,7 +18,7 @@ communication purposes:
 ## nRF Connect SDK
 
 Nordic Semiconductor's
-[nRF Connect SDK](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/index.html)
+[nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html)
 allows to build a range of applications, including cellular IoT (LTE-M and
 NB-IoT), Bluetooth Low Energy, Thread, Zigbee, and Bluetooth mesh. The SDK
 contains samples, libraries and a full set of drivers for Nordic Semiconductor's
@@ -57,8 +57,8 @@ Bluetooth LE concurrently with other stacks on the same radio chip.
 
 Read more in the nRF Connect SDK documentation:
 
--   [SoftDevice Controller](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrfxlib/softdevice_controller/README.html)
--   [Multiprotocol Service Layer](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrfxlib/mpsl/README.html)
+-   [SoftDevice Controller](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrfxlib/softdevice_controller/README.html)
+-   [Multiprotocol Service Layer](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrfxlib/mpsl/README.html)
 
 <hr>
 
@@ -72,9 +72,9 @@ network layer functionalities provided by the Zephyr.
 
 Read more in the nRF Connect SDK documentation:
 
--   [Multiprotocol Service Layer](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrfxlib/mpsl/README.html)
--   [nRF 802.15.4 Radio Driver](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrfxlib/nrf_802154/README.html)
--   [OpenThread integration](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/protocols/thread/overview/ot_integration.html)
+-   [Multiprotocol Service Layer](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrfxlib/mpsl/README.html)
+-   [nRF 802.15.4 Radio Driver](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrfxlib/nrf_802154/README.html)
+-   [OpenThread integration](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/thread/overview/ot_integration.html)
 
 <hr>
 
@@ -105,7 +105,7 @@ agnostic interfaces and no additional platform-related actions are needed to
 perform communication through the Matter stack.
 
 For more information, see the
-[Matter integration in the nRF Connect SDK](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/protocols/matter/overview/integration.html)
+[Matter integration in the nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/matter/overview/integration.html)
 page in the SDK documentation.
 
 <hr>
@@ -126,5 +126,5 @@ library file is imported during the compilation process.
 
 For more information about the build system in Zephyr and the nRF Connect SDK,
 see the
-[Build and configuration system](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/app_dev/build_and_config_system/index.html)
+[Build and configuration system](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/app_dev/config_and_build/config_and_build_system.html)
 page in the SDK documentation.

--- a/docs/guides/openthread_rcp_nrf_dongle.md
+++ b/docs/guides/openthread_rcp_nrf_dongle.md
@@ -13,14 +13,14 @@ Once programmed, the dongle can be used for
 ## Requirements
 
 You need to set up the
-[nRF Connect SDK](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/index.html)
+[nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html)
 to build and program the OpenThread Radio Co-Processor to the nRF52840 Dongle.
 Read the
-[nRF Connect SDK Getting started](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html)
+[nRF Connect SDK installation](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/installation.html)
 documentation for more information.
 
 ## Building and programming the RCP firmware onto an nRF52840 Dongle
 
 After you set up the nRF Connect SDK, follow the steps in the
-[Configuring a radio co-processor](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_thread_tools.html#configuring-a-radio-co-processor)
+[Configuring a radio co-processor](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/thread/tools.html#configuring_a_radio_co-processor)
 section for the nRF52840 Dongle (USB transport).


### PR DESCRIPTION
The nRF Connect documentation has changed to a new address. This updates all existing links to point there.
Also fixes one instance where information was outdated.