### PR TITLE
Enhance Android Logging with setLogCallback API

### DIFF
--- a/src/platform/android/AndroidChipPlatform-JNI.cpp
+++ b/src/platform/android/AndroidChipPlatform-JNI.cpp
@@ -304,13 +304,13 @@ static void ENFORCE_FORMAT(3, 0) logRedirectCallback(const char * module, uint8_
 
     jint jPriority = static_cast<jint>(priority);
     jobject jModule;
-    JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString(module), jModule);
+    VerifyOrReturn(JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString(module), jModule) == CHIP_NO_ERROR);
     VerifyOrReturn(jModule != nullptr);
 
     char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
     vsnprintf(buffer, sizeof(buffer), msg, args);
     jobject jMsg;
-    JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString(buffer), jMsg);
+    VerifyOrReturn(JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString(buffer), jMsg) == CHIP_NO_ERROR);
     VerifyOrReturn(jMsg != nullptr);
 
     env->CallVoidMethod(sJavaLogCallbackObject.ObjectRef(), sOnLogMessageMethod, static_cast<jstring>(jModule), jPriority,

--- a/src/platform/android/AndroidChipPlatform-JNI.cpp
+++ b/src/platform/android/AndroidChipPlatform-JNI.cpp
@@ -302,16 +302,19 @@ static void ENFORCE_FORMAT(3, 0) logRedirectCallback(const char * module, uint8_
         break;
     }
 
-    jint jPriority  = static_cast<jint>(priority);
-    jstring jModule = env->NewStringUTF(module);
+    jint jPriority = static_cast<jint>(priority);
+    jobject jModule;
+    JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString(module), jModule);
     VerifyOrReturn(jModule != nullptr);
 
     char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
     vsnprintf(buffer, sizeof(buffer), msg, args);
-    jstring jMsg = env->NewStringUTF(buffer);
+    jobject jMsg;
+    JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString(buffer), jMsg);
     VerifyOrReturn(jMsg != nullptr);
 
-    env->CallVoidMethod(sJavaLogCallbackObject.ObjectRef(), sOnLogMessageMethod, jModule, jPriority, jMsg);
+    env->CallVoidMethod(sJavaLogCallbackObject.ObjectRef(), sOnLogMessageMethod, static_cast<jstring>(jModule), jPriority,
+                        static_cast<jstring>(jMsg));
 }
 
 JNI_LOGGING_METHOD(void, setLogCallback)(JNIEnv * env, jclass clazz, jobject callback)

--- a/src/platform/android/AndroidChipPlatform-JNI.cpp
+++ b/src/platform/android/AndroidChipPlatform-JNI.cpp
@@ -283,6 +283,7 @@ static void ENFORCE_FORMAT(3, 0) logRedirectCallback(const char * module, uint8_
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr);
+    JniLocalReferenceScope scope(env);
     int priority = ANDROID_LOG_DEBUG;
     switch (category)
     {
@@ -301,24 +302,14 @@ static void ENFORCE_FORMAT(3, 0) logRedirectCallback(const char * module, uint8_
 
     jint jPriority  = static_cast<jint>(priority);
     jstring jModule = env->NewStringUTF(module);
-    if (jModule == nullptr)
-    {
-        return;
-    }
+    VerifyOrReturn(jModule != nullptr);
 
     char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
     vsnprintf(buffer, sizeof(buffer), msg, args);
     jstring jMsg = env->NewStringUTF(buffer);
-    if (jMsg == nullptr)
-    {
-        env->DeleteLocalRef(jModule);
-        return;
-    }
+    VerifyOrReturn(jMsg != nullptr);
 
     env->CallVoidMethod(sJavaLogCallbackObject, sOnLogMessageMethod, jModule, jPriority, jMsg);
-
-    env->DeleteLocalRef(jModule);
-    env->DeleteLocalRef(jMsg);
 }
 
 JNI_LOGGING_METHOD(void, setLogCallback)(JNIEnv * env, jclass clazz, jobject callback)

--- a/src/platform/android/AndroidChipPlatform-JNI.cpp
+++ b/src/platform/android/AndroidChipPlatform-JNI.cpp
@@ -282,6 +282,7 @@ static void ENFORCE_FORMAT(3, 0) logRedirectCallback(const char * module, uint8_
     using namespace chip::Logging;
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != nullptr);
     int priority = ANDROID_LOG_DEBUG;
     switch (category)
     {

--- a/src/platform/android/AndroidChipPlatform-JNI.cpp
+++ b/src/platform/android/AndroidChipPlatform-JNI.cpp
@@ -298,12 +298,21 @@ static void ENFORCE_FORMAT(3, 0) logRedirectCallback(const char * module, uint8_
         break;
     }
 
-    jstring jModule = env->NewStringUTF(module);
     jint jPriority  = static_cast<jint>(priority);
+    jstring jModule = env->NewStringUTF(module);
+    if (jModule == nullptr)
+    {
+        return;
+    }
 
     char buffer[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
     vsnprintf(buffer, sizeof(buffer), msg, args);
     jstring jMsg = env->NewStringUTF(buffer);
+    if (jMsg == nullptr)
+    {
+        env->DeleteLocalRef(jModule);
+        return;
+    }
 
     env->CallVoidMethod(sJavaLogCallbackObject, sOnLogMessageMethod, jModule, jPriority, jMsg);
 

--- a/src/platform/android/java/chip/platform/AndroidChipLogging.java
+++ b/src/platform/android/java/chip/platform/AndroidChipLogging.java
@@ -20,4 +20,11 @@ package chip.platform;
 public class AndroidChipLogging {
   // logging level is in android.util.Log class
   public static native void setLogFilter(int level);
+
+  // This must be called after System.loadLibrary
+  public static native void setLogCallback(LogCallback callback);
+
+  public interface LogCallback {
+    void onLogMessage(String module, int priority, String message);
+  }
 }


### PR DESCRIPTION
This change adds the setLogCallback API to the AndroidChipLogging class of the Matter SDK, enhancing its logging capabilities. With this API, developers can customize logging behavior and integrate it with Android's logging system, allowing for more flexible and comprehensive logging.

An example of usage in Kotlin is as follows:

```kt
ChipDeviceController.loadJni()
AndroidChipLogging.setLogCallback { module, priority, message ->
    when (priority) {
        Log.ERROR -> Log.e(module, message)
        Log.INFO -> Log.i(module, message)
        Log.DEBUG -> Log.d(module, message)
    }
}
```