### PR TITLE
Auto-commissioner: remove primary network config if failed in commissioning SecondaryNetworkInterface

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -502,8 +502,16 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStageInternal(Commissio
     case CommissioningStage::kEvictPreviousCaseSessions:
         return CommissioningStage::kFindOperationalForStayActive;
     case CommissioningStage::kPrimaryOperationalNetworkFailed:
-        return CommissioningStage::kDisablePrimaryNetworkInterface;
-    case CommissioningStage::kDisablePrimaryNetworkInterface:
+        if (mDeviceCommissioningInfo.network.wifi.endpoint == kRootEndpointId)
+        {
+            return CommissioningStage::kRemoveWiFiNetworkConfig;
+        }
+        else
+        {
+            return CommissioningStage::kRemoveThreadNetworkConfig;
+        }
+    case CommissioningStage::kRemoveWiFiNetworkConfig:
+    case CommissioningStage::kRemoveThreadNetworkConfig:
         return GetNextCommissioningStageNetworkSetup(currentStage, lastErr);
     case CommissioningStage::kFindOperationalForStayActive:
         return CommissioningStage::kICDSendStayActive;
@@ -567,7 +575,8 @@ EndpointId AutoCommissioner::GetEndpoint(const CommissioningStage & stage) const
     case CommissioningStage::kThreadNetworkSetup:
     case CommissioningStage::kThreadNetworkEnable:
         return mDeviceCommissioningInfo.network.thread.endpoint;
-    case CommissioningStage::kDisablePrimaryNetworkInterface:
+    case CommissioningStage::kRemoveWiFiNetworkConfig:
+    case CommissioningStage::kRemoveThreadNetworkConfig:
         return kRootEndpointId;
     default:
         return kRootEndpointId;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -980,8 +980,6 @@ private:
     OnICDManagementStayActiveResponse(void * context,
                                       const app::Clusters::IcdManagement::Commands::StayActiveResponse::DecodableType & data);
 
-    static void OnInterfaceEnableWriteSuccessResponse(void * context);
-
     /**
      * @brief
      *   This function processes the CSR sent by the device.

--- a/src/controller/CommissioningDelegate.cpp
+++ b/src/controller/CommissioningDelegate.cpp
@@ -139,8 +139,11 @@ const char * StageToString(CommissioningStage stage)
     case kPrimaryOperationalNetworkFailed:
         return "PrimaryOperationalNetworkFailed";
 
-    case kDisablePrimaryNetworkInterface:
-        return "DisablePrimaryNetworkInterface";
+    case kRemoveWiFiNetworkConfig:
+        return "RemoveWiFiNetworkConfig";
+
+    case kRemoveThreadNetworkConfig:
+        return "RemoveThreadNetworkConfig";
 
     default:
         return "???";

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -79,9 +79,10 @@ enum CommissioningStage : uint8_t
     /// Call CHIPDeviceController::NetworkCredentialsReady() when CommissioningParameters is populated with
     /// network credentials to use in kWiFiNetworkSetup or kThreadNetworkSetup steps.
     kNeedsNetworkCreds,
-    kPrimaryOperationalNetworkFailed, ///< Indicate that the primary operational network (on root endpoint) failed, should disable
-                                      ///< the primary network interface later.
-    kDisablePrimaryNetworkInterface,  ///< Send InterfaceEnabled write request to the device to disable network interface.
+    kPrimaryOperationalNetworkFailed, ///< Indicate that the primary operational network (on root endpoint) failed, should remove
+                                      ///< the primary network config later.
+    kRemoveWiFiNetworkConfig,         ///< Remove Wi-Fi network config.
+    kRemoveThreadNetworkConfig        ///< Remove Thread network config.
 };
 
 enum class ICDRegistrationStrategy : uint8_t


### PR DESCRIPTION
Ref to https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/10335, modified the steps during commissioning a SecondaryNetworkInterface device.

#### Change overview
- If the commissioner fails to configure a network interface, and want to configure another network interface, it SHALL remove the added network configuration before the next attempt.