### PR TITLE
Allow TestAccessControl to run with ARL

### DIFF
--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -817,7 +817,7 @@ struct CheckData
     bool allow;
 };
 
-constexpr CheckData checkData1[] = {
+CheckData checkData1[] = {
     // Checks for implicit PASE
     { .subjectDescriptor = { .fabricIndex = 0, .authMode = AuthMode::kPase, .subject = kPaseVerifier0 },
       .requestPath       = { .cluster = 1, .endpoint = 2 },
@@ -1749,9 +1749,12 @@ TEST_F(TestAccessControl, TestAclValidateTarget)
 TEST_F(TestAccessControl, TestCheck)
 {
     LoadAccessControl(accessControl, entryData1, entryData1Count);
-    for (const auto & checkData : checkData1)
+    for (auto & checkData : checkData1)
     {
         CHIP_ERROR expectedResult = checkData.allow ? CHIP_NO_ERROR : CHIP_ERROR_ACCESS_DENIED;
+#if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
+        checkData.requestPath.requestType = Access::RequestType::kAttributeReadRequest;
+#endif
         EXPECT_EQ(accessControl.Check(checkData.subjectDescriptor, checkData.requestPath, checkData.privilege), expectedResult);
     }
 }

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -817,7 +817,7 @@ struct CheckData
     bool allow;
 };
 
-CheckData checkData1[] = {
+constexpr CheckData checkData1[] = {
     // Checks for implicit PASE
     { .subjectDescriptor = { .fabricIndex = 0, .authMode = AuthMode::kPase, .subject = kPaseVerifier0 },
       .requestPath       = { .cluster = 1, .endpoint = 2 },
@@ -1749,13 +1749,14 @@ TEST_F(TestAccessControl, TestAclValidateTarget)
 TEST_F(TestAccessControl, TestCheck)
 {
     LoadAccessControl(accessControl, entryData1, entryData1Count);
-    for (auto & checkData : checkData1)
+    for (const auto & checkData : checkData1)
     {
         CHIP_ERROR expectedResult = checkData.allow ? CHIP_NO_ERROR : CHIP_ERROR_ACCESS_DENIED;
+        auto requestPath          = checkData.requestPath;
 #if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
-        checkData.requestPath.requestType = Access::RequestType::kAttributeReadRequest;
+        requestPath.requestType = Access::RequestType::kAttributeReadRequest;
 #endif
-        EXPECT_EQ(accessControl.Check(checkData.subjectDescriptor, checkData.requestPath, checkData.privilege), expectedResult);
+        EXPECT_EQ(accessControl.Check(checkData.subjectDescriptor, requestPath, checkData.privilege), expectedResult);
     }
 }
 


### PR DESCRIPTION
Since RequestType is required, set each test data entry to some value that will pass AccessRestrictionProvider checks (since the focus is on AccessControl for these tests).


