### PR TITLE
Make fixes to match the test scripts to the test plan

### DIFF
--- a/src/app/tests/suites/certification/PICS.yaml
+++ b/src/app/tests/suites/certification/PICS.yaml
@@ -6497,7 +6497,8 @@ PICS:
     - label: "Does the device implement the Schedules attribute?"
       id: TSTAT.S.A0051
 
-    - label: "Does the device implement the SetpointHoldExpiryTimestamp attribute?"
+    - label:
+          "Does the device implement the SetpointHoldExpiryTimestamp attribute?"
       id: TSTAT.S.A0052
 
     #

--- a/src/app/tests/suites/certification/PICS.yaml
+++ b/src/app/tests/suites/certification/PICS.yaml
@@ -6494,6 +6494,12 @@ PICS:
     - label: "Does the device implement the Schedules attribute?"
       id: TSTAT.S.A0051
 
+    - label: "Does the device implement the Schedules attribute?"
+      id: TSTAT.S.A0051
+
+    - label: "Does the device implement the SetpointHoldExpiryTimestamp attribute?"
+      id: TSTAT.S.A0052
+
     #
     # server / commandsReceived
     #

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_1_1.yaml
@@ -606,17 +606,7 @@ tests:
               contains: [1, 2, 3]
 
     - label:
-          "Step 6c: TH reads the optional (GetRelayStatusLog) command in
-          AcceptedCommandList"
-      PICS: TSTAT.S.C04.Rsp
-      command: "readAttribute"
-      attribute: "AcceptedCommandList"
-      response:
-          constraints:
-              type: list
-              contains: [4]
-    - label:
-          "Step 6d: TH reads Feature dependent(TSTAT.S.F08(PRES)) commands in
+          "Step 6c: TH reads Feature dependent(TSTAT.S.F08(PRES)) commands in
           AcceptedCommandList"
       PICS: TSTAT.S.F08
       command: "readAttribute"
@@ -627,18 +617,7 @@ tests:
               contains: [6, 254]
 
     - label:
-          "Step 7a: TH reads Feature dependent(TSTAT.S.F08(PRES)) commands in
-          the GeneratedCommandList attribute."
-      PICS: TSTAT.S.Cfe.Rsp
-      command: "readAttribute"
-      attribute: "GeneratedCommandList"
-      response:
-          value: [0xFD] # AtomicResponse
-          constraints:
-              type: list
-
-    - label:
-          "Step 7b: TH reads Feature dependent(TSTAT.S.F03(SCH)) commands in
+          "Step 7a: TH reads Feature dependent(TSTAT.S.F03(SCH)) commands in
           GeneratedCommandList"
       PICS: TSTAT.S.F03
       command: "readAttribute"
@@ -649,12 +628,12 @@ tests:
               contains: [0]
 
     - label:
-          "Step 7c: TH reads optional command (GetRelayStatusLogResponse) in
-          GeneratedCommandList"
-      PICS: TSTAT.S.C04.Rsp
+          "Step 7b: TH reads Feature dependent(TSTAT.S.F08(PRES)) commands in
+          the GeneratedCommandList attribute."
+      PICS: TSTAT.S.F08 & TSTAT.S.Cfe.Rsp
       command: "readAttribute"
       attribute: "GeneratedCommandList"
       response:
+          value: [0xFD] # AtomicResponse
           constraints:
               type: list
-              contains: [1]

--- a/src/app/tests/suites/certification/ci-pics-values
+++ b/src/app/tests/suites/certification/ci-pics-values
@@ -1989,6 +1989,7 @@ TSTAT.S.A004a=1
 TSTAT.S.A004e=1
 TSTAT.S.A0050=1
 TSTAT.S.A0051=0
+TSTAT.S.A0052=0
 
 TSTAT.S.M.MinSetpointDeadBandWritable=1
 TSTAT.S.M.HVACSystemTypeConfigurationWritable=0


### PR DESCRIPTION
- Set the PICS code for SetpointHoldExpiryTimestamp to 0

- Remove the test cases for GetRelayLog and GetRelayLogResponse

- Update PICS code for Preset related commands

Fixes: #35264 

