### PR TITLE
[Fabric-Admin] Fix crash when try to read UniqueId from a legacy device

### DIFF
--- a/examples/fabric-admin/device_manager/DeviceSynchronization.cpp
+++ b/examples/fabric-admin/device_manager/DeviceSynchronization.cpp
@@ -72,6 +72,13 @@ void DeviceSynchronizer::OnAttributeData(const ConcreteDataAttributePath & path,
     VerifyOrDie(path.mEndpointId == kRootEndpointId);
     VerifyOrDie(path.mClusterId == Clusters::BasicInformation::Id);
 
+    CHIP_ERROR error = status.ToChipError();
+    if (CHIP_NO_ERROR != error)
+    {
+        ChipLogError(NotSpecified, "Response Failure: %" CHIP_ERROR_FORMAT, error.Format());
+        return;
+    }
+
     switch (path.mAttributeId)
     {
     case Clusters::BasicInformation::Attributes::UniqueID::Id:


### PR DESCRIPTION
The DUT crash when running TC_MCORE_FS_1_3.py

When try to read the UniqueId attribute from a legacy device which does not have the UniqueId, we should not try to decode it if the status is not success. 

