### PR TITLE
[nrfconnect] Fix the case when the Wi-Fi info cannot be retrieved

### DIFF
--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
@@ -143,7 +143,7 @@ void NrfWiFiDriver::OnNetworkConnStatusChanged(const wifi_conn_status & connStat
             ssid    = WiFiManager::Instance().GetWantedNetwork().ssid;
             ssidLen = WiFiManager::Instance().GetWantedNetwork().ssidLen;
         }
-        mpNetworkStatusChangeCallback->OnNetworkingStatusChange(status, MakeOptional(ByteSpan(wifiInfo.mSsid, wifiInfo.mSsidLen)),
+        mpNetworkStatusChangeCallback->OnNetworkingStatusChange(status, MakeOptional(ByteSpan(ssid, ssidLen)),
                                                                 connStatus ? MakeOptional(static_cast<int32_t>(connStatus))
                                                                            : NullOptional);
     }


### PR DESCRIPTION
Don't pass uninitialized WiFiInfo object to the
OnNetworkingStatusChange() callback in case the GetWiFiInfo() fails. 
Use GetWantedNetwork() return value as a fallback.


