### PR TITLE
Docker Image build fix: adding abseil as system lib

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -123,6 +123,14 @@ RUN set -x \
     ruff \
     && : # last line
 
+#TODO: this is only added as a workaround to bloaty build failures, remove it once not needed
+# Clone and install abseil-cpp
+RUN git clone https://github.com/abseil/abseil-cpp.git /tmp/abseil-cpp \
+    && cd /tmp/abseil-cpp \
+    && cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build build --target install \
+    && rm -rf /tmp/abseil-cpp
+
 # Install bloat comparison tools
 RUN set -x \
     && git clone https://github.com/google/bloaty.git \

--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -123,7 +123,7 @@ RUN set -x \
     ruff \
     && : # last line
 
-#TODO: this is only added as a workaround to bloaty build failures, remove it once not needed
+#TODO Issue #35280: this is only added as a workaround to bloaty build failures, remove it once bloaty fixes issue
 # Clone and install abseil-cpp
 RUN git clone https://github.com/abseil/abseil-cpp.git /tmp/abseil-cpp \
     && cd /tmp/abseil-cpp \


### PR DESCRIPTION
- fix/workaround for https://github.com/project-chip/connectedhomeip/issues/35269 and CI job failure https://github.com/project-chip/connectedhomeip/actions/runs/10600741039/job/29378930344?pr=35261 

#### Cause of Failure
- failure is related to bloaty failing to build.
- Bloaty's CMake is outputting 
```
#9 1.098 -- Could NOT find absl (missing: absl_DIR)
#9 1.098 -- System absl not found, using bundled version
```

- Issue seen after bloaty's PR: https://github.com/google/bloaty/pull/347, it seems bloaty's bundled abseil-cpp is missing some dependency which is triggering the failure.

- as a workaround, abseil-cpp is being cloned and installed so that bloaty's CMake can find it as a system library.

#### Failure Log (part of it)
```
[ 51%] Building CXX object third_party/protobuf/cmake/CMakeFiles/libprotobuf.dir/__/src/google/protobuf/extension_set_heavy.cc.o
In file included from /bloaty/third_party/abseil-cpp/absl/strings/internal/str_format/extension.cc:16:
/bloaty/third_party/abseil-cpp/absl/strings/internal/str_format/extension.h:34:6: warning: elaborated-type-specifier for a scoped enum must not use the 'class' keyword
   34 | enum class FormatConversionChar : uint8_t;
      | ~~~~ ^~~~~
      |      -----
/bloaty/third_party/abseil-cpp/absl/strings/internal/str_format/extension.h:34:33: error: found ':' in nested-name-specifier, expected '::'
   34 | enum class FormatConversionChar : uint8_t;
      |                                 ^
      |                                 ::
/bloaty/third_party/abseil-cpp/absl/strings/internal/str_format/extension.h:34:12: error: 'FormatConversionChar' has not been declared
   34 | enum class FormatConversionChar : uint8_t;

```

