### PR TITLE
Fix Fabric Sync test script issues discovered on TH

### DIFF
--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -53,11 +53,14 @@ class TC_CCTRL_2_2(MatterBaseTest):
         self.port = 5543
         discriminator = random.randint(0, 4095)
         passcode = 20202021
-        app_args = f'--secured-device-port {self.port} --discriminator {discriminator} --passcode {passcode} --KVS {self.kvs}'
-        cmd = f'{app} {app_args}'
+        cmd = [app]
+        cmd.extend(['--secured-device-port', str(5543)])
+        cmd.extend(['--discriminator', str(discriminator)])
+        cmd.extend(['--passcode', str(passcode)])
+        cmd.extend(['--KVS', self.kvs])
         # TODO: Determine if we want these logs cooked or pushed to somewhere else
         logging.info("Starting TH_SERVER")
-        self.app_process = subprocess.Popen(cmd, bufsize=0, shell=True)
+        self.app_process = subprocess.Popen(cmd)
         logging.info("TH_SERVER started")
         time.sleep(3)
 

--- a/src/python_testing/TC_CCTRL_2_3.py
+++ b/src/python_testing/TC_CCTRL_2_3.py
@@ -52,11 +52,14 @@ class TC_CCTRL_2_3(MatterBaseTest):
         self.port = 5543
         discriminator = random.randint(0, 4095)
         passcode = 20202021
-        app_args = f'--secured-device-port {self.port} --discriminator {discriminator} --passcode {passcode} --KVS {self.kvs}'
-        cmd = f'{app} {app_args}'
+        cmd = [app]
+        cmd.extend(['--secured-device-port', str(5543)])
+        cmd.extend(['--discriminator', str(discriminator)])
+        cmd.extend(['--passcode', str(passcode)])
+        cmd.extend(['--KVS', self.kvs])
         # TODO: Determine if we want these logs cooked or pushed to somewhere else
         logging.info("Starting TH_SERVER")
-        self.app_process = subprocess.Popen(cmd, bufsize=0, shell=True)
+        self.app_process = subprocess.Popen(cmd)
         logging.info("TH_SERVER started")
         time.sleep(3)
 

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -45,11 +45,14 @@ class TC_MCORE_FS_1_1(MatterBaseTest):
         self.port = 5543
         discriminator = random.randint(0, 4095)
         passcode = 20202021
-        app_args = f'--secured-device-port {self.port} --discriminator {discriminator} --passcode {passcode} --KVS {self.kvs}'
-        cmd = f'{app} {app_args}'
+        cmd = [app]
+        cmd.extend(['--secured-device-port', str(5543)])
+        cmd.extend(['--discriminator', str(discriminator)])
+        cmd.extend(['--passcode', str(passcode)])
+        cmd.extend(['--KVS', self.kvs])
         # TODO: Determine if we want these logs cooked or pushed to somewhere else
         logging.info("Starting application to acts mock a server portion of TH_FSA")
-        self.app_process = subprocess.Popen(cmd, bufsize=0, shell=True)
+        self.app_process = subprocess.Popen(cmd)
         logging.info("Started application to acts mock a server portion of TH_FSA")
         time.sleep(3)
 


### PR DESCRIPTION
Back-to-back failures on TC-CCTRL-2.2, TC-CCTRL-2.3, TC-MCORE_FS_1_1 where TH reboot was required by GRL because the TH_SERVER subprocess remained running after the test completed because sub process was started in a seprate shell (due to `shell=True`).

This fix was confirmed to work on https://github.com/project-chip/connectedhomeip/pull/35257/ so now we are applying the fix to the rest of the test that had `Popen.*shell=True`

Fixes https://github.com/project-chip/connectedhomeip/issues/35252