### PR TITLE
Update ECOINFO cluster to reflect latest spec text

### DIFF
--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
@@ -34,9 +34,6 @@ constexpr size_t kUniqueLocationIdMaxSize       = 64;
 constexpr size_t kUniqueLocationIdsListMaxSize  = 64;
 constexpr size_t kLocationDescriptorNameMaxSize = 128;
 
-constexpr size_t kDeviceDirectoryMaxSize   = 256;
-constexpr size_t kLocationDirectoryMaxSize = 64;
-
 class AttrAccess : public AttributeAccessInterface
 {
 public:
@@ -264,7 +261,6 @@ CHIP_ERROR EcosystemInformationServer::AddDeviceInfo(EndpointId aEndpoint, std::
     VerifyOrReturnError((aEndpoint != kRootEndpointId && aEndpoint != kInvalidEndpointId), CHIP_ERROR_INVALID_ARGUMENT);
 
     auto & deviceInfo = mDevicesMap[aEndpoint];
-    VerifyOrReturnError((deviceInfo.mDeviceDirectory.size() < kDeviceDirectoryMaxSize), CHIP_ERROR_NO_MEMORY);
     deviceInfo.mDeviceDirectory.push_back(std::move(aDevice));
     return CHIP_NO_ERROR;
 }
@@ -282,7 +278,6 @@ CHIP_ERROR EcosystemInformationServer::AddLocationInfo(EndpointId aEndpoint, con
     EcosystemLocationKey key = { .mUniqueLocationId = aLocationId, .mFabricIndex = aFabricIndex };
     VerifyOrReturnError((deviceInfo.mLocationDirectory.find(key) == deviceInfo.mLocationDirectory.end()),
                         CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError((deviceInfo.mLocationDirectory.size() < kLocationDirectoryMaxSize), CHIP_ERROR_NO_MEMORY);
     deviceInfo.mLocationDirectory[key] = std::move(aLocation);
     return CHIP_NO_ERROR;
 }

--- a/src/app/zap-templates/zcl/data-model/chip/ecosystem-information-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/ecosystem-information-cluster.xml
@@ -44,11 +44,11 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <!-- cluster revision -->
     <globalAttribute code="0xFFFD" side="either" value="1"/>
-    <attribute code="0x0000" side="server" define="DEVICE_DIRECTORY" type="array" entryType="EcosystemDeviceStruct" length="256" minLength="1">
+    <attribute code="0x0000" side="server" define="DEVICE_DIRECTORY" type="array" entryType="EcosystemDeviceStruct">
       <description>DeviceDirectory</description>
       <access op="read" privilege="manage"/>
     </attribute>
-    <attribute code="0x0001" side="server" define="LOCATION_DIRECTORY" type="array" entryType="EcosystemLocationStruct" length="64" minLength="1">
+    <attribute code="0x0001" side="server" define="LOCATION_DIRECTORY" type="array" entryType="EcosystemLocationStruct">
       <description>LocationDirectory</description>
       <access op="read" privilege="manage"/>
     </attribute>

--- a/src/python_testing/TC_ECOINFO_2_1.py
+++ b/src/python_testing/TC_ECOINFO_2_1.py
@@ -25,9 +25,21 @@ from mobly import asserts
 
 class TC_ECOINFO_2_1(MatterBaseTest):
 
-    def _validate_device_directory(self, device_directory):
+    def _validate_device_directory(self, current_fabric_index, device_directory):
         for device in device_directory:
-            # TODO do fabric index check first
+            if current_fabric_index != device.fabricIndex:
+                # Fabric sensitve field still exist in python, just that they have default values
+                asserts.assert_equal(device.deviceName, None, "Unexpected value in deviceName")
+                asserts.assert_equal(device.deviceNameLastEdit, None, "Unexpected value in deviceNameLastEdit")
+                asserts.assert_equal(device.bridgedEndpoint, 0, "Unexpected value in bridgedEndpoint")
+                asserts.assert_equal(device.originalEndpoint, 0, "Unexpected value in originalEndpoint")
+                asserts.assert_true(type_matches(device.deviceTypes, list), "DeviceTypes should be a list")
+                asserts.assert_equal(len(device.deviceTypes), 0, "DeviceTypes list should be empty")
+                asserts.assert_true(type_matches(device.uniqueLocationIDs, list), "UniqueLocationIds should be a list")
+                asserts.assert_equal(len(device.uniqueLocationIDs), 0, "uniqueLocationIDs list should be empty")
+                asserts.assert_equal(device.uniqueLocationIDsLastEdit, 0, "Unexpected value in uniqueLocationIDsLastEdit")
+                continue
+
             if device.deviceName is not None:
                 asserts.assert_true(type_matches(device.deviceName, str), "DeviceName should be a string")
                 asserts.assert_less_equal(len(device.deviceName), 64, "DeviceName should be <= 64")
@@ -70,8 +82,17 @@ class TC_ECOINFO_2_1(MatterBaseTest):
             if num_of_unique_location_ids:
                 asserts.assert_greater(device.uniqueLocationIDsLastEdit, 0, "UniqueLocationIdsLastEdit must be non-zero")
 
-    def _validate_location_directory(self, location_directory):
+    def _validate_location_directory(self, current_fabric_index, location_directory):
         for location in location_directory:
+            if current_fabric_index != location.fabricIndex:
+                # Fabric sensitve field still exist in python, just that they have default values
+                asserts.assert_equal(location.uniqueLocationID, "", "Unexpected value in uniqueLocationID")
+                asserts.assert_equal(location.locationDescriptor.locationName, "", "Unexpected value in locationDescriptor.locationName")
+                asserts.assert_equal(location.locationDescriptor.floorNumber, NullValue, "Unexpected value in locationDescriptor.floorNumber")
+                asserts.assert_equal(location.locationDescriptor.areaType, NullValue, "Unexpected value in locationDescriptor.areaType")
+                asserts.assert_equal(location.locationDescriptorLastEdit, 0, "Unexpected value in locationDescriptorLastEdit")
+                continue
+
             asserts.assert_true(type_matches(location.uniqueLocationID, str), "UniqueLocationId should be a string")
             location_id_string_length = len(location.uniqueLocationID)
             asserts.assert_greater_equal(location_id_string_length, 1,
@@ -116,6 +137,7 @@ class TC_ECOINFO_2_1(MatterBaseTest):
             self.wait_for_user_input(
                 "Paused test to allow for manufacturer to satisfy precondition where one or more bridged devices of a supported type is connected to DUT")
 
+        current_fabric_index = await self.read_single_attribute_check_success(cluster=Clusters.OperationalCredentials, attribute=Clusters.OperationalCredentials.Attributes.CurrentFabricIndex)
         self.step(1)
         endpoint_wild_card_read = await dev_ctrl.ReadAttribute(dut_node_id, [(Clusters.EcosystemInformation.Attributes.ClusterRevision)])
         list_of_endpoints = list(endpoint_wild_card_read.keys())
@@ -130,7 +152,7 @@ class TC_ECOINFO_2_1(MatterBaseTest):
                 attribute=Clusters.EcosystemInformation.Attributes.DeviceDirectory,
                 fabricFiltered=False)
 
-            self._validate_device_directory(device_directory)
+            self._validate_device_directory(current_fabric_index, device_directory)
 
             if idx == 0:
                 self.step(3)
@@ -141,7 +163,7 @@ class TC_ECOINFO_2_1(MatterBaseTest):
                 attribute=Clusters.EcosystemInformation.Attributes.LocationDirectory,
                 fabricFiltered=False)
 
-            self._validate_location_directory(location_directory)
+            self._validate_location_directory(current_fabric_index, location_directory)
 
             if idx == 0:
                 self.step(4)

--- a/src/python_testing/TC_ECOINFO_2_1.py
+++ b/src/python_testing/TC_ECOINFO_2_1.py
@@ -87,9 +87,12 @@ class TC_ECOINFO_2_1(MatterBaseTest):
             if current_fabric_index != location.fabricIndex:
                 # Fabric sensitve field still exist in python, just that they have default values
                 asserts.assert_equal(location.uniqueLocationID, "", "Unexpected value in uniqueLocationID")
-                asserts.assert_equal(location.locationDescriptor.locationName, "", "Unexpected value in locationDescriptor.locationName")
-                asserts.assert_equal(location.locationDescriptor.floorNumber, NullValue, "Unexpected value in locationDescriptor.floorNumber")
-                asserts.assert_equal(location.locationDescriptor.areaType, NullValue, "Unexpected value in locationDescriptor.areaType")
+                asserts.assert_equal(location.locationDescriptor.locationName, "",
+                                     "Unexpected value in locationDescriptor.locationName")
+                asserts.assert_equal(location.locationDescriptor.floorNumber, NullValue,
+                                     "Unexpected value in locationDescriptor.floorNumber")
+                asserts.assert_equal(location.locationDescriptor.areaType, NullValue,
+                                     "Unexpected value in locationDescriptor.areaType")
                 asserts.assert_equal(location.locationDescriptorLastEdit, 0, "Unexpected value in locationDescriptorLastEdit")
                 continue
 

--- a/src/python_testing/TC_ECOINFO_2_1.py
+++ b/src/python_testing/TC_ECOINFO_2_1.py
@@ -26,8 +26,6 @@ from mobly import asserts
 class TC_ECOINFO_2_1(MatterBaseTest):
 
     def _validate_device_directory(self, device_directory):
-        num_of_devices = len(device_directory)
-        asserts.assert_less_equal(num_of_devices, 256, "Too many device entries")
         for device in device_directory:
             # TODO do fabric index check first
             if device.deviceName is not None:
@@ -73,8 +71,6 @@ class TC_ECOINFO_2_1(MatterBaseTest):
                 asserts.assert_greater(device.uniqueLocationIDsLastEdit, 0, "UniqueLocationIdsLastEdit must be non-zero")
 
     def _validate_location_directory(self, location_directory):
-        num_of_locations = len(location_directory)
-        asserts.assert_less_equal(num_of_locations, 64, "Too many location entries")
         for location in location_directory:
             asserts.assert_true(type_matches(location.uniqueLocationID, str), "UniqueLocationId should be a string")
             location_id_string_length = len(location.uniqueLocationID)


### PR DESCRIPTION
Updates now that https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/10342/ spec test as updated

No need to wait for test plan update as in fact the test of max size was actually missing for test plan (it would have been removed if it were there)
