### PR TITLE
Add force send parameter to setOnOffValue and send it on matter start

### DIFF
--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -341,7 +341,8 @@ Status OnOffServer::getOnOffValue(chip::EndpointId endpoint, bool * currentOnOff
  * @param command   Ver.: always
  * @param initiatedByLevelChange   Ver.: always
  * @param forceSend Send value of the On/Off even when it is the same as current On/Off value.
- * This parameter is useful at the start when you try to determine startup state of On/Off relay that does not store state after losing power
+ * This parameter is useful at the start when you try to determine startup state of On/Off relay that does not store state after
+ * losing power
  */
 Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId command, bool initiatedByLevelChange, bool forceSend)
 {
@@ -366,7 +367,6 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
         else if (command == Commands::On::Id)
         {
             newValue = true;
-
         }
         // I guess that, I can only get ON/OFF at startup
     }

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -64,7 +64,7 @@ public:
     void updateOnOffTimeCommand(chip::EndpointId endpoint);
     chip::Protocols::InteractionModel::Status getOnOffValue(chip::EndpointId endpoint, bool * currentOnOffValue);
     chip::Protocols::InteractionModel::Status setOnOffValue(chip::EndpointId endpoint, chip::CommandId command,
-                                                            bool initiatedByLevelChange, bool forceSend=false);
+                                                            bool initiatedByLevelChange, bool forceSend = false);
     chip::Protocols::InteractionModel::Status getOnOffValueForStartUp(chip::EndpointId endpoint, bool & onOffValueForStartUp);
 
     bool HasFeature(chip::EndpointId endpoint, Feature feature);

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -64,7 +64,7 @@ public:
     void updateOnOffTimeCommand(chip::EndpointId endpoint);
     chip::Protocols::InteractionModel::Status getOnOffValue(chip::EndpointId endpoint, bool * currentOnOffValue);
     chip::Protocols::InteractionModel::Status setOnOffValue(chip::EndpointId endpoint, chip::CommandId command,
-                                                            bool initiatedByLevelChange);
+                                                            bool initiatedByLevelChange, bool forceSend=false);
     chip::Protocols::InteractionModel::Status getOnOffValueForStartUp(chip::EndpointId endpoint, bool & onOffValueForStartUp);
 
     bool HasFeature(chip::EndpointId endpoint, Feature feature);


### PR DESCRIPTION
I sent this PR based on matter implementation for esp-matter it might work differently in other SDKs. 
This change is useful and required for an onoff device controlled via NC/NO relay. 
Since matter controls the startup parameter via "onoff write start-up-on-off" parameter. Connectedhomeip is the only place where the startup relay state can be determined. The current implementation's problem is that it only provides information about the startup relay state when it is different from the last known state before restart e.g. 
start-up-on-off is set to On when the last state of OnOff parameter is Off CHIP sends information about state change, 
start-up-on-off is set to On when the last state of OnOff parameter is On CHIP won't send information about the state of OnOff parameter

I think this makes it inconsistent and for me sending the state of OnOff parameter always at the start is the best way to go about it, so information about the startup state always comes from on/off server

