### PR TITLE
Disallow read-through on internally-created MTRDevice instances.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -37,13 +37,11 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- * TODO: Document usage better
+ * Get an MTRDevice object representing a device with a specific node ID
+ * associated with a specific controller.
  *
- * Directly instantiate a MTRDevice with a MTRDeviceController as a shim.
- *
- * All device-specific information would be stored on the device controller, and
- * retrieved when performing actions using a combination of MTRBaseDevice
- * and MTRAsyncCallbackQueue.
+ * MTRDevice objects are stateful, and callers should hold on to the MTRDevice
+ * while they are using it.
  */
 + (MTRDevice *)deviceWithNodeID:(NSNumber *)nodeID
                      controller:(MTRDeviceController *)controller MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -120,7 +120,18 @@ MTR_DIRECT_MEMBERS
     // Our controller.  Declared nullable because our property is, though in
     // practice it does not look like we ever set it to nil.
     MTRDeviceController * _Nullable _deviceController;
+
+    // Whether this device has been accessed via the public deviceWithNodeID API
+    // (as opposed to just via the internal _deviceWithNodeID).
+    BOOL _accessedViaPublicAPI;
 }
+
+/**
+ * Internal way of creating an MTRDevice that does not flag the device as being
+ * visible to external API consumers.
+ */
++ (MTRDevice *)_deviceWithNodeID:(NSNumber *)nodeID
+                      controller:(MTRDeviceController *)controller;
 
 - (instancetype)initForSubclassesWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;
 - (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;

--- a/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.mm
+++ b/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.mm
@@ -16,10 +16,13 @@
  */
 
 #import "MTRDiagnosticLogsDownloader.h"
+#import <Matter/Matter.h>
 
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/LockTracker.h>
 #include <protocols/bdx/BdxTransferServerDelegate.h>
+#include <protocols/bdx/DiagnosticLogs.h>
 
-#import "MTRDeviceControllerFactory_Internal.h"
 #import "MTRDeviceController_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTRLogging_Internal.h"
@@ -425,15 +428,15 @@ private:
         [download checkInteractionModelResponse:response error:error];
     };
 
-    auto * device = [controller deviceForNodeID:nodeID];
-    auto * cluster = [[MTRClusterDiagnosticLogs alloc] initWithDevice:device endpointID:@(kDiagnosticLogsEndPoint) queue:queue];
+    auto * device = [MTRBaseDevice deviceWithNodeID:nodeID controller:controller];
+    auto * cluster = [[MTRBaseClusterDiagnosticLogs alloc] initWithDevice:device endpointID:@(kDiagnosticLogsEndPoint) queue:queue];
 
     auto * params = [[MTRDiagnosticLogsClusterRetrieveLogsRequestParams alloc] init];
     params.intent = @(type);
     params.requestedProtocol = @(MTRDiagnosticLogsTransferProtocolBDX);
     params.transferFileDesignator = download.fileDesignator;
 
-    [cluster retrieveLogsRequestWithParams:params expectedValues:nil expectedValueInterval:nil completion:interactionModelDone];
+    [cluster retrieveLogsRequestWithParams:params completion:interactionModelDone];
 
     if (timeoutInSeconds > 0) {
         auto err = _bridge->StartBDXTransferTimeout(download, timeoutInSeconds);


### PR DESCRIPTION
We want to be able to instantiate an MTRDevice and readAttibute to get its cached state without ever triggering read-throughs.

The MTRDiagnosticLogsDownloader.mm changes were because it was using internal APIs to create an MTRDevice when it does not need an MTRDevice at all.
