### PR TITLE
Implementation of UniqueID attribute in Bridge app

### DIFF
--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -20,15 +20,18 @@
 #include "Device.h"
 
 #include <cstdio>
+#include <crypto/RandUtils.h>
 #include <platform/CHIPDeviceLayer.h>
 
 #include <string>
 
+using namespace chip;
 using namespace chip::app::Clusters::Actions;
 
 Device::Device(const char * szDeviceName, std::string szLocation)
 {
     chip::Platform::CopyString(mName, szDeviceName);
+    chip::Platform::CopyString(mUniqueId, "");
     mLocation   = szLocation;
     mReachable  = false;
     mEndpointId = 0;
@@ -74,6 +77,12 @@ void Device::SetName(const char * szName)
     }
 }
 
+void Device::SetUniqueId(const char * szDeviceUniqueId)
+{
+    chip::Platform::CopyString(mUniqueId, szDeviceUniqueId);
+    ChipLogProgress(DeviceLayer, "Device[%s]: New UniqueId=\"%s\"", mName, mUniqueId);
+}
+
 void Device::SetLocation(std::string szLocation)
 {
     bool changed = (mLocation.compare(szLocation) != 0);
@@ -86,6 +95,23 @@ void Device::SetLocation(std::string szLocation)
     {
         HandleDeviceChange(this, kChanged_Location);
     }
+}
+
+void Device::GenerateUniqueId()
+{
+    // Ensure the buffer is zeroed out
+    memset(mUniqueId, 0, kDeviceUniqueIdSize+1);
+
+    static const char kRandCharChoices[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    // Prefix the generated value with "GEN-"
+    memcpy(mUniqueId, "GEN-", 4);
+    for (unsigned idx = 4; idx < kDeviceUniqueIdSize; idx++)
+    {
+        mUniqueId[idx] = kRandCharChoices[Crypto::GetRandU8() % (sizeof(kRandCharChoices) - 1)];
+    }
+
+    mUniqueId[kDeviceUniqueIdSize] = '\0'; // Ensure null-termination
 }
 
 DeviceOnOff::DeviceOnOff(const char * szDeviceName, std::string szLocation) : Device(szDeviceName, szLocation)

--- a/examples/bridge-app/linux/Device.cpp
+++ b/examples/bridge-app/linux/Device.cpp
@@ -19,8 +19,8 @@
 
 #include "Device.h"
 
-#include <cstdio>
 #include <crypto/RandUtils.h>
+#include <cstdio>
 #include <platform/CHIPDeviceLayer.h>
 
 #include <string>
@@ -100,7 +100,7 @@ void Device::SetLocation(std::string szLocation)
 void Device::GenerateUniqueId()
 {
     // Ensure the buffer is zeroed out
-    memset(mUniqueId, 0, kDeviceUniqueIdSize+1);
+    memset(mUniqueId, 0, kDeviceUniqueIdSize + 1);
 
     static const char kRandCharChoices[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -30,7 +30,8 @@
 class Device
 {
 public:
-    static const int kDeviceNameSize = 32;
+    static const int kDeviceNameSize     = 32;
+    static const int kDeviceUniqueIdSize = 32;
 
     enum Changed_t
     {
@@ -46,12 +47,15 @@ public:
     bool IsReachable();
     void SetReachable(bool aReachable);
     void SetName(const char * szDeviceName);
+    void SetUniqueId(const char * szDeviceUniqueId);
     void SetLocation(std::string szLocation);
+    void GenerateUniqueId();
     inline void SetEndpointId(chip::EndpointId id) { mEndpointId = id; };
     inline chip::EndpointId GetEndpointId() { return mEndpointId; };
     inline void SetParentEndpointId(chip::EndpointId id) { mParentEndpointId = id; };
     inline chip::EndpointId GetParentEndpointId() { return mParentEndpointId; };
     inline char * GetName() { return mName; };
+    inline char * GetUniqueId() { return mUniqueId; };
     inline std::string GetLocation() { return mLocation; };
     inline std::string GetZone() { return mZone; };
     inline void SetZone(std::string zone) { mZone = zone; };
@@ -61,7 +65,8 @@ private:
 
 protected:
     bool mReachable;
-    char mName[kDeviceNameSize];
+    char mName[kDeviceNameSize + 1];
+    char mUniqueId[kDeviceUniqueIdSize + 1];
     std::string mLocation;
     chip::EndpointId mEndpointId;
     chip::EndpointId mParentEndpointId;

--- a/examples/bridge-app/linux/include/Device.h
+++ b/examples/bridge-app/linux/include/Device.h
@@ -64,9 +64,9 @@ private:
     virtual void HandleDeviceChange(Device * device, Device::Changed_t changeMask) = 0;
 
 protected:
-    bool mReachable;
-    char mName[kDeviceNameSize + 1];
-    char mUniqueId[kDeviceUniqueIdSize + 1];
+    bool mReachable                         = false;
+    char mName[kDeviceNameSize + 1]         = { 0 };
+    char mUniqueId[kDeviceUniqueIdSize + 1] = { 0 };
     std::string mLocation;
     chip::EndpointId mEndpointId;
     chip::EndpointId mParentEndpointId;


### PR DESCRIPTION
Test Case
TC-BRBINFO-2.1

Below mentioned attribute has to be enabled in Bridge-app as it is Mandatory in SPEC :
UniqueID
Spec Reference: https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/data_model/bridge-clusters.adoc#attributes

Fixes #34366
