### PR TITLE
[ICD] Fix multiple check-in/peer node ids handling in icd client

### DIFF
--- a/examples/chip-tool/commands/icd/ICDCommand.cpp
+++ b/examples/chip-tool/commands/icd/ICDCommand.cpp
@@ -40,14 +40,17 @@ CHIP_ERROR ICDListCommand::RunCommand()
     fprintf(stderr, "  +------------------------------------------------------------------------------------------+\n");
     fprintf(stderr, "  | %-88s |\n", "Known ICDs:");
     fprintf(stderr, "  +------------------------------------------------------------------------------------------+\n");
-    fprintf(stderr, "  | %20s | %15s | %15s | %16s | %10s |\n", "Fabric Index:Node ID", "Start Counter", "Counter Offset",
-            "MonitoredSubject", "ClientType");
+    fprintf(stderr, "  | %20s | %20s | %15s | %15s | %16s | %10s |\n", "Fabric Index:Peer Node ID", "Fabric Index:CheckIn Node ID",
+            "Start Counter", "Counter Offset", "MonitoredSubject", "ClientType");
 
     while (iter->Next(info))
     {
         fprintf(stderr, "  +------------------------------------------------------------------------------------------+\n");
-        fprintf(stderr, "  | %3" PRIu32 ":" ChipLogFormatX64 " | %15" PRIu32 " | %15" PRIu32 " | " ChipLogFormatX64 " | %10u |\n",
+        fprintf(stderr,
+                "  | %3" PRIu32 ":" ChipLogFormatX64 " | %3" PRIu32 ":" ChipLogFormatX64 " | %15" PRIu32 " | %15" PRIu32
+                " | " ChipLogFormatX64 " | %10u |\n",
                 static_cast<uint32_t>(info.peer_node.GetFabricIndex()), ChipLogValueX64(info.peer_node.GetNodeId()),
+                static_cast<uint32_t>(info.check_in_node.GetFabricIndex()), ChipLogValueX64(info.check_in_node.GetNodeId()),
                 info.start_icd_counter, info.offset, ChipLogValueX64(info.monitored_subject),
                 static_cast<uint8_t>(info.client_type));
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -469,7 +469,8 @@ void PairingCommand::OnICDRegistrationComplete(ScopedNodeId nodeId, uint32_t icd
                                sizeof(icdSymmetricKeyHex), chip::Encoding::HexFlags::kNullTerminate);
 
     app::ICDClientInfo clientInfo;
-    clientInfo.peer_node         = chip::ScopedNodeId(mICDCheckInNodeId.Value(), nodeId.GetFabricIndex());
+    clientInfo.check_in_node     = chip::ScopedNodeId(mICDCheckInNodeId.Value(), nodeId.GetFabricIndex());
+    clientInfo.peer_node         = nodeId;
     clientInfo.monitored_subject = mICDMonitoredSubject.Value();
     clientInfo.start_icd_counter = icdCounter;
 

--- a/src/app/icd/client/DefaultICDClientStorage.cpp
+++ b/src/app/icd/client/DefaultICDClientStorage.cpp
@@ -235,16 +235,22 @@ CHIP_ERROR DefaultICDClientStorage::Load(FabricIndex fabricIndex, std::vector<IC
         ICDClientInfo clientInfo;
         TLV::TLVType ICDClientInfoType;
         NodeId nodeId;
+        NodeId checkInNodeId;
         FabricIndex fabric;
         ReturnErrorOnFailure(reader.EnterContainer(ICDClientInfoType));
         // Peer Node ID
         ReturnErrorOnFailure(reader.Next(TLV::ContextTag(ClientInfoTag::kPeerNodeId)));
         ReturnErrorOnFailure(reader.Get(nodeId));
 
+        ReturnErrorOnFailure(reader.Next(TLV::ContextTag(ClientInfoTag::kCheckInNodeId)));
+        ReturnErrorOnFailure(reader.Get(checkInNodeId));
+
         // Fabric Index
         ReturnErrorOnFailure(reader.Next(TLV::ContextTag(ClientInfoTag::kFabricIndex)));
         ReturnErrorOnFailure(reader.Get(fabric));
-        clientInfo.peer_node = ScopedNodeId(nodeId, fabric);
+
+        clientInfo.peer_node     = ScopedNodeId(nodeId, fabric);
+        clientInfo.check_in_node = ScopedNodeId(checkInNodeId, fabric);
 
         // Start ICD Counter
         ReturnErrorOnFailure(reader.Next(TLV::ContextTag(ClientInfoTag::kStartICDCounter)));
@@ -323,6 +329,7 @@ CHIP_ERROR DefaultICDClientStorage::SerializeToTlv(TLV::TLVWriter & writer, cons
         TLV::TLVType ICDClientInfoContainerType;
         ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, ICDClientInfoContainerType));
         ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kPeerNodeId), clientInfo.peer_node.GetNodeId()));
+        ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kCheckInNodeId), clientInfo.check_in_node.GetNodeId()));
         ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kFabricIndex), clientInfo.peer_node.GetFabricIndex()));
         ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kStartICDCounter), clientInfo.start_icd_counter));
         ReturnErrorOnFailure(writer.Put(TLV::ContextTag(ClientInfoTag::kOffset), clientInfo.offset));

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -124,13 +124,14 @@ protected:
     enum class ClientInfoTag : uint8_t
     {
         kPeerNodeId       = 1,
-        kFabricIndex      = 2,
-        kStartICDCounter  = 3,
-        kOffset           = 4,
-        kMonitoredSubject = 5,
-        kAesKeyHandle     = 6,
-        kHmacKeyHandle    = 7,
-        kClientType       = 8,
+        kCheckInNodeId    = 2,
+        kFabricIndex      = 3,
+        kStartICDCounter  = 4,
+        kOffset           = 5,
+        kMonitoredSubject = 6,
+        kAesKeyHandle     = 7,
+        kHmacKeyHandle    = 8,
+        kClientType       = 9,
     };
 
     enum class CounterTag : uint8_t
@@ -158,8 +159,9 @@ protected:
     {
         // All the fields added together
         return TLV::EstimateStructOverhead(
-            sizeof(NodeId), sizeof(FabricIndex), sizeof(uint32_t) /*start_icd_counter*/, sizeof(uint32_t) /*offset*/,
-            sizeof(uint64_t) /*monitored_subject*/, sizeof(Crypto::Symmetric128BitsKeyByteArray) /*aes_key_handle*/,
+            sizeof(NodeId), sizeof(NodeId), sizeof(FabricIndex), sizeof(uint32_t) /*start_icd_counter*/,
+            sizeof(uint32_t) /*offset*/, sizeof(uint64_t) /*monitored_subject*/,
+            sizeof(Crypto::Symmetric128BitsKeyByteArray) /*aes_key_handle*/,
             sizeof(Crypto::Symmetric128BitsKeyByteArray) /*hmac_key_handle*/, sizeof(uint8_t) /*client_type*/);
     }
 

--- a/src/app/icd/client/ICDClientInfo.h
+++ b/src/app/icd/client/ICDClientInfo.h
@@ -31,6 +31,7 @@ namespace app {
 struct ICDClientInfo
 {
     ScopedNodeId peer_node;
+    ScopedNodeId check_in_node;
     uint32_t start_icd_counter                          = 0;
     uint32_t offset                                     = 0;
     Clusters::IcdManagement::ClientTypeEnum client_type = Clusters::IcdManagement::ClientTypeEnum::kPermanent;
@@ -44,6 +45,7 @@ struct ICDClientInfo
     ICDClientInfo & operator=(const ICDClientInfo & other)
     {
         peer_node         = other.peer_node;
+        check_in_node     = other.check_in_node;
         start_icd_counter = other.start_icd_counter;
         offset            = other.offset;
         client_type       = other.client_type;

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -77,7 +77,7 @@ CHIP_ERROR RefreshKeySender::RegisterClientWithNewKey(Messaging::ExchangeManager
     EndpointId endpointId = 0;
 
     Clusters::IcdManagement::Commands::RegisterClient::Type registerClientCommand;
-    registerClientCommand.checkInNodeID    = mICDClientInfo.peer_node.GetNodeId();
+    registerClientCommand.checkInNodeID    = mICDClientInfo.check_in_node.GetNodeId();
     registerClientCommand.monitoredSubject = mICDClientInfo.monitored_subject;
     registerClientCommand.key              = mNewKey.Span();
     return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, endpointId, registerClientCommand, onSuccess, onFailure);

--- a/src/controller/java/AndroidCheckInDelegate.cpp
+++ b/src/controller/java/AndroidCheckInDelegate.cpp
@@ -23,17 +23,17 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/logging/CHIPLogging.h>
 
-#define PARSE_CLIENT_INFO(_clientInfo, _peerNodeId, _checkInNodeId, _startCounter, _offset, _monitoredSubject, _jniICDAesKey,       \
-                          _jniICDHmacKey)                                                                                           \
-    jlong _peerNodeId = static_cast<jlong>(_clientInfo.peer_node.GetNodeId());                                                      \
-    jlong _checkInNodeId    = static_cast<jlong>(_clientInfo.check_in_node.GetNodeId());                                            \
-    jlong _startCounter     = static_cast<jlong>(_clientInfo.start_icd_counter);                                                    \
-    jlong _offset           = static_cast<jlong>(_clientInfo.offset);                                                               \
-    jlong _monitoredSubject = static_cast<jlong>(_clientInfo.monitored_subject);                                                    \
-    chip::ByteSpan aes_buf(_clientInfo.aes_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());                                  \
-    chip::ByteSpan hmac_buf(_clientInfo.hmac_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());                                \
-    chip::ByteArray _jniICDAesKey(env, aes_buf);                                                                                    \
-    chip::ByteArray _jniICDHmacKey(env, hmac_buf);                                                                                  \
+#define PARSE_CLIENT_INFO(_clientInfo, _peerNodeId, _checkInNodeId, _startCounter, _offset, _monitoredSubject, _jniICDAesKey,      \
+                          _jniICDHmacKey)                                                                                          \
+    jlong _peerNodeId       = static_cast<jlong>(_clientInfo.peer_node.GetNodeId());                                               \
+    jlong _checkInNodeId    = static_cast<jlong>(_clientInfo.check_in_node.GetNodeId());                                           \
+    jlong _startCounter     = static_cast<jlong>(_clientInfo.start_icd_counter);                                                   \
+    jlong _offset           = static_cast<jlong>(_clientInfo.offset);                                                              \
+    jlong _monitoredSubject = static_cast<jlong>(_clientInfo.monitored_subject);                                                   \
+    chip::ByteSpan aes_buf(_clientInfo.aes_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());                                 \
+    chip::ByteSpan hmac_buf(_clientInfo.hmac_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());                               \
+    chip::ByteArray _jniICDAesKey(env, aes_buf);                                                                                   \
+    chip::ByteArray _jniICDHmacKey(env, hmac_buf);
 
 namespace chip {
 namespace app {

--- a/src/controller/java/AndroidCheckInDelegate.cpp
+++ b/src/controller/java/AndroidCheckInDelegate.cpp
@@ -23,15 +23,17 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/logging/CHIPLogging.h>
 
-#define PARSE_CLIENT_INFO(_clientInfo, _peerNodeId, _startCounter, _offset, _monitoredSubject, _jniICDAesKey, _jniICDHmacKey)      \
-    jlong _peerNodeId       = static_cast<jlong>(_clientInfo.peer_node.GetNodeId());                                               \
-    jlong _startCounter     = static_cast<jlong>(_clientInfo.start_icd_counter);                                                   \
-    jlong _offset           = static_cast<jlong>(_clientInfo.offset);                                                              \
-    jlong _monitoredSubject = static_cast<jlong>(_clientInfo.monitored_subject);                                                   \
-    chip::ByteSpan aes_buf(_clientInfo.aes_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());                                 \
-    chip::ByteSpan hmac_buf(_clientInfo.hmac_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());                               \
-    chip::ByteArray _jniICDAesKey(env, aes_buf);                                                                                   \
-    chip::ByteArray _jniICDHmacKey(env, hmac_buf);
+#define PARSE_CLIENT_INFO(_clientInfo, _peerNodeId, _checkInNodeId, _startCounter, _offset, _monitoredSubject, _jniICDAesKey,       \
+                          _jniICDHmacKey)                                                                                           \
+    jlong _peerNodeId = static_cast<jlong>(_clientInfo.peer_node.GetNodeId());                                                      \
+    jlong _checkInNodeId    = static_cast<jlong>(_clientInfo.check_in_node.GetNodeId());                                            \
+    jlong _startCounter     = static_cast<jlong>(_clientInfo.start_icd_counter);                                                    \
+    jlong _offset           = static_cast<jlong>(_clientInfo.offset);                                                               \
+    jlong _monitoredSubject = static_cast<jlong>(_clientInfo.monitored_subject);                                                    \
+    chip::ByteSpan aes_buf(_clientInfo.aes_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());                                  \
+    chip::ByteSpan hmac_buf(_clientInfo.hmac_key_handle.As<Crypto::Symmetric128BitsKeyByteArray>());                                \
+    chip::ByteArray _jniICDAesKey(env, aes_buf);                                                                                    \
+    chip::ByteArray _jniICDHmacKey(env, hmac_buf);                                                                                  \
 
 namespace chip {
 namespace app {
@@ -53,24 +55,26 @@ CHIP_ERROR AndroidCheckInDelegate::SetDelegate(jobject checkInDelegateObj)
 
 void AndroidCheckInDelegate::OnCheckInComplete(const ICDClientInfo & clientInfo)
 {
-    ChipLogProgress(
-        ICD, "Check In Message processing complete: start_counter=%" PRIu32 " offset=%" PRIu32 " nodeid=" ChipLogFormatScopedNodeId,
-        clientInfo.start_icd_counter, clientInfo.offset, ChipLogValueScopedNodeId(clientInfo.peer_node));
+    ChipLogProgress(ICD,
+                    "Check In Message processing complete: start_counter=%" PRIu32 " offset=%" PRIu32
+                    " peernodeid=" ChipLogFormatScopedNodeId " checkinnodeid=" ChipLogFormatScopedNodeId,
+                    clientInfo.start_icd_counter, clientInfo.offset, ChipLogValueScopedNodeId(clientInfo.peer_node),
+                    ChipLogValueScopedNodeId(clientInfo.check_in_node));
 
     VerifyOrReturn(mCheckInDelegate.HasValidObjectRef(), ChipLogProgress(ICD, "check-in delegate is not implemented!"));
 
     JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturn(env != nullptr, ChipLogError(Controller, "JNIEnv is null!"));
-    PARSE_CLIENT_INFO(clientInfo, peerNodeId, startCounter, offset, monitoredSubject, jniICDAesKey, jniICDHmacKey)
+    PARSE_CLIENT_INFO(clientInfo, peerNodeId, checkInNodeId, startCounter, offset, monitoredSubject, jniICDAesKey, jniICDHmacKey)
 
     jmethodID onCheckInCompleteMethodID = nullptr;
     CHIP_ERROR err = chip::JniReferences::GetInstance().FindMethod(env, mCheckInDelegate.ObjectRef(), "onCheckInComplete",
-                                                                   "(JJJJ[B[B)V", &onCheckInCompleteMethodID);
+                                                                   "(JJJJJ[B[B)V", &onCheckInCompleteMethodID);
     VerifyOrReturn(err == CHIP_NO_ERROR,
                    ChipLogProgress(ICD, "onCheckInComplete - FindMethod is failed! : %" CHIP_ERROR_FORMAT, err.Format()));
 
-    env->CallVoidMethod(mCheckInDelegate.ObjectRef(), onCheckInCompleteMethodID, peerNodeId, startCounter, offset, monitoredSubject,
-                        jniICDAesKey.jniValue(), jniICDHmacKey.jniValue());
+    env->CallVoidMethod(mCheckInDelegate.ObjectRef(), onCheckInCompleteMethodID, peerNodeId, checkInNodeId, startCounter, offset,
+                        monitoredSubject, jniICDAesKey.jniValue(), jniICDHmacKey.jniValue());
 }
 
 RefreshKeySender * AndroidCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & clientInfo, ICDClientStorage * clientStorage)
@@ -84,17 +88,18 @@ RefreshKeySender * AndroidCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & cl
         JNIEnv * env = chip::JniReferences::GetInstance().GetEnvForCurrentThread();
         VerifyOrReturnValue(env != nullptr, nullptr, ChipLogError(Controller, "JNIEnv is null!"));
 
-        PARSE_CLIENT_INFO(clientInfo, peerNodeId, startCounter, offset, monitoredSubject, jniICDAesKey, jniICDHmacKey)
+        PARSE_CLIENT_INFO(clientInfo, peerNodeId, checkInNodeId, startCounter, offset, monitoredSubject, jniICDAesKey,
+                          jniICDHmacKey)
 
         jmethodID onKeyRefreshNeededMethodID = nullptr;
-        err = chip::JniReferences::GetInstance().FindMethod(env, mCheckInDelegate.ObjectRef(), "onKeyRefreshNeeded", "(JJJJ[B[B)V",
+        err = chip::JniReferences::GetInstance().FindMethod(env, mCheckInDelegate.ObjectRef(), "onKeyRefreshNeeded", "(JJJJJ[B[B)V",
                                                             &onKeyRefreshNeededMethodID);
         VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr,
                             ChipLogProgress(ICD, "onKeyRefreshNeeded - FindMethod is failed! : %" CHIP_ERROR_FORMAT, err.Format()));
 
-        jbyteArray key = static_cast<jbyteArray>(env->CallObjectMethod(mCheckInDelegate.ObjectRef(), onKeyRefreshNeededMethodID,
-                                                                       peerNodeId, startCounter, offset, monitoredSubject,
-                                                                       jniICDAesKey.jniValue(), jniICDHmacKey.jniValue()));
+        jbyteArray key = static_cast<jbyteArray>(
+            env->CallObjectMethod(mCheckInDelegate.ObjectRef(), onKeyRefreshNeededMethodID, peerNodeId, checkInNodeId, startCounter,
+                                  offset, monitoredSubject, jniICDAesKey.jniValue(), jniICDHmacKey.jniValue()));
 
         if (key != nullptr)
         {

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -1014,9 +1014,9 @@ void AndroidDeviceControllerWrapper::OnICDRegistrationComplete(chip::ScopedNodeI
 
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::app::ICDClientInfo clientInfo;
-    clientInfo.peer_node = icdNodeId;
-    clientInfo.check_in_node =
-        chip::ScopedNodeId(mAutoCommissioner.GetCommissioningParameters().GetICDCheckInNodeId().Value(), icdNodeId.GetFabricIndex());
+    clientInfo.peer_node         = icdNodeId;
+    clientInfo.check_in_node     = chip::ScopedNodeId(mAutoCommissioner.GetCommissioningParameters().GetICDCheckInNodeId().Value(),
+                                                      icdNodeId.GetFabricIndex());
     clientInfo.monitored_subject = mAutoCommissioner.GetCommissioningParameters().GetICDMonitoredSubject().Value();
     clientInfo.start_icd_counter = icdCounter;
 
@@ -1072,7 +1072,8 @@ void AndroidDeviceControllerWrapper::OnICDRegistrationComplete(chip::ScopedNodeI
         icdDeviceInfoClass, icdDeviceInfoStructCtor, jSymmetricKey, static_cast<jint>(mUserActiveModeTriggerHint.Raw()),
         jUserActiveModeTriggerInstruction, static_cast<jlong>(mIdleModeDuration), static_cast<jlong>(mActiveModeDuration),
         static_cast<jint>(mActiveModeThreshold), static_cast<jlong>(icdNodeId.GetNodeId()),
-        static_cast<jlong>(mAutoCommissioner.GetCommissioningParameters().GetICDCheckInNodeId().Value()), static_cast<jlong>(icdCounter),
+        static_cast<jlong>(mAutoCommissioner.GetCommissioningParameters().GetICDCheckInNodeId().Value()),
+        static_cast<jlong>(icdCounter),
         static_cast<jlong>(mAutoCommissioner.GetCommissioningParameters().GetICDMonitoredSubject().Value()),
         static_cast<jlong>(Controller()->GetFabricId()), static_cast<jint>(Controller()->GetFabricIndex()));
 

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -1014,7 +1014,9 @@ void AndroidDeviceControllerWrapper::OnICDRegistrationComplete(chip::ScopedNodeI
 
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::app::ICDClientInfo clientInfo;
-    clientInfo.peer_node         = icdNodeId;
+    clientInfo.peer_node = icdNodeId;
+    clientInfo.check_in_node =
+        chip::ScopedNodeId(mAutoCommissioner.GetCommissioningParameters().GetICDCheckInNodeId().Value(), icdNodeId.GetFabricIndex());
     clientInfo.monitored_subject = mAutoCommissioner.GetCommissioningParameters().GetICDMonitoredSubject().Value();
     clientInfo.start_icd_counter = icdCounter;
 
@@ -1056,7 +1058,7 @@ void AndroidDeviceControllerWrapper::OnICDRegistrationComplete(chip::ScopedNodeI
     methodErr = chip::JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/ICDDeviceInfo", icdDeviceInfoClass);
     VerifyOrReturn(methodErr == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find class ICDDeviceInfo"));
 
-    icdDeviceInfoStructCtor = env->GetMethodID(icdDeviceInfoClass, "<init>", "([BILjava/lang/String;JJIJJJJI)V");
+    icdDeviceInfoStructCtor = env->GetMethodID(icdDeviceInfoClass, "<init>", "([BILjava/lang/String;JJIJJJJJI)V");
     VerifyOrReturn(icdDeviceInfoStructCtor != nullptr, ChipLogError(Controller, "Could not find ICDDeviceInfo constructor"));
 
     methodErr =
@@ -1069,7 +1071,8 @@ void AndroidDeviceControllerWrapper::OnICDRegistrationComplete(chip::ScopedNodeI
     icdDeviceInfoObj = env->NewObject(
         icdDeviceInfoClass, icdDeviceInfoStructCtor, jSymmetricKey, static_cast<jint>(mUserActiveModeTriggerHint.Raw()),
         jUserActiveModeTriggerInstruction, static_cast<jlong>(mIdleModeDuration), static_cast<jlong>(mActiveModeDuration),
-        static_cast<jint>(mActiveModeThreshold), static_cast<jlong>(icdNodeId.GetNodeId()), static_cast<jlong>(icdCounter),
+        static_cast<jint>(mActiveModeThreshold), static_cast<jlong>(icdNodeId.GetNodeId()),
+        static_cast<jlong>(mAutoCommissioner.GetCommissioningParameters().GetICDCheckInNodeId().Value()), static_cast<jlong>(icdCounter),
         static_cast<jlong>(mAutoCommissioner.GetCommissioningParameters().GetICDMonitoredSubject().Value()),
         static_cast<jlong>(Controller()->GetFabricId()), static_cast<jint>(Controller()->GetFabricIndex()));
 

--- a/src/controller/java/AndroidICDClient.cpp
+++ b/src/controller/java/AndroidICDClient.cpp
@@ -58,7 +58,7 @@ jobject getICDClientInfo(JNIEnv * env, const char * icdClientInfoSign, jint jFab
                         ChipLogError(Controller, "Find ICDClientInfo class: %" CHIP_ERROR_FORMAT, err.Format()));
 
     env->ExceptionClear();
-    constructor = env->GetMethodID(infoClass, "<init>", "(JJJJ[B[B)V");
+    constructor = env->GetMethodID(infoClass, "<init>", "(JJJJJ[B[B)V");
     VerifyOrReturnValue(constructor != nullptr, nullptr, ChipLogError(Controller, "Find GetMethodID error!"));
 
     while (iter->Next(info))
@@ -84,9 +84,10 @@ jobject getICDClientInfo(JNIEnv * env, const char * icdClientInfoSign, jint jFab
         VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr,
                             ChipLogError(Controller, "ICD HMAC KEY N2J_ByteArray error!: %" CHIP_ERROR_FORMAT, err.Format()));
 
-        jICDClientInfo = (jobject) env->NewObject(infoClass, constructor, static_cast<jlong>(info.peer_node.GetNodeId()),
-                                                  static_cast<jlong>(info.start_icd_counter), static_cast<jlong>(info.offset),
-                                                  static_cast<jlong>(info.monitored_subject), jIcdAesKey, jIcdHmacKey);
+        jICDClientInfo = static_cast<jobject>(env->NewObject(
+            infoClass, constructor, static_cast<jlong>(info.peer_node.GetNodeId()),
+            static_cast<jlong>(info.check_in_node.GetNodeId()), static_cast<jlong>(info.start_icd_counter),
+            static_cast<jlong>(info.offset), static_cast<jlong>(info.monitored_subject), jIcdAesKey, jIcdHmacKey));
 
         err = chip::JniReferences::GetInstance().AddToList(jInfo, jICDClientInfo);
         VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr,
@@ -154,6 +155,7 @@ CHIP_ERROR ParseICDClientInfo(JNIEnv * env, jint jFabricIndex, jobject jIcdClien
     VerifyOrReturnError(jIcdClientInfo != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     jmethodID getPeerNodeIdMethod       = nullptr;
+    jmethodID getCheckInNodeIdMethod    = nullptr;
     jmethodID getStartCounterMethod     = nullptr;
     jmethodID getOffsetMethod           = nullptr;
     jmethodID getMonitoredSubjectMethod = nullptr;
@@ -162,6 +164,8 @@ CHIP_ERROR ParseICDClientInfo(JNIEnv * env, jint jFabricIndex, jobject jIcdClien
 
     ReturnErrorOnFailure(
         chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getPeerNodeId", "()J", &getPeerNodeIdMethod));
+    ReturnErrorOnFailure(
+        chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getCheckInNodeId", "()J", &getCheckInNodeIdMethod));
     ReturnErrorOnFailure(
         chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getStartCounter", "()J", &getStartCounterMethod));
     ReturnErrorOnFailure(chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getOffset", "()J", &getOffsetMethod));
@@ -173,17 +177,20 @@ CHIP_ERROR ParseICDClientInfo(JNIEnv * env, jint jFabricIndex, jobject jIcdClien
         chip::JniReferences::GetInstance().FindMethod(env, jIcdClientInfo, "getIcdHmacKey", "()[B", &getIcdHmacKeyMethod));
 
     jlong jPeerNodeId       = env->CallLongMethod(jIcdClientInfo, getPeerNodeIdMethod);
+    jlong jCheckInNodeId    = env->CallLongMethod(jIcdClientInfo, getCheckInNodeIdMethod);
     jlong jStartCounter     = env->CallLongMethod(jIcdClientInfo, getStartCounterMethod);
     jlong jOffset           = env->CallLongMethod(jIcdClientInfo, getOffsetMethod);
     jlong jMonitoredSubject = env->CallLongMethod(jIcdClientInfo, getMonitoredSubjectMethod);
     jbyteArray jIcdAesKey   = static_cast<jbyteArray>(env->CallObjectMethod(jIcdClientInfo, getIcdAesKeyMethod));
     jbyteArray jIcdHmacKey  = static_cast<jbyteArray>(env->CallObjectMethod(jIcdClientInfo, getIcdHmacKeyMethod));
 
-    chip::ScopedNodeId scopedNodeId(static_cast<chip::NodeId>(jPeerNodeId), static_cast<chip::FabricIndex>(jFabricIndex));
-    chip::JniByteArray jniIcdAesKey(env, jIcdAesKey);
+    chip::ScopedNodeId peerNodeId(static_cast<chip::NodeId>(jPeerNodeId), static_cast<chip::FabricIndex>(jFabricIndex));
+    chip::ScopedNodeId checkInNodeId(static_cast<chip::NodeId>(jCheckInNodeId), static_cast<chip::FabricIndex>(jFabricIndex));
+    chip::JniByteArray jniIcdAesKey(env,jIcdAesKey);
     chip::JniByteArray jniIcdHmacKey(env, jIcdHmacKey);
 
-    icdClientInfo.peer_node         = scopedNodeId;
+    icdClientInfo.peer_node         = peerNodeId;
+    icdClientInfo.check_in_node     = checkInNodeId;
     icdClientInfo.start_icd_counter = static_cast<uint32_t>(jStartCounter);
     icdClientInfo.offset            = static_cast<uint32_t>(jOffset);
     icdClientInfo.monitored_subject = static_cast<uint64_t>(jMonitoredSubject);

--- a/src/controller/java/AndroidICDClient.cpp
+++ b/src/controller/java/AndroidICDClient.cpp
@@ -84,10 +84,10 @@ jobject getICDClientInfo(JNIEnv * env, const char * icdClientInfoSign, jint jFab
         VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr,
                             ChipLogError(Controller, "ICD HMAC KEY N2J_ByteArray error!: %" CHIP_ERROR_FORMAT, err.Format()));
 
-        jICDClientInfo = static_cast<jobject>(env->NewObject(
-            infoClass, constructor, static_cast<jlong>(info.peer_node.GetNodeId()),
-            static_cast<jlong>(info.check_in_node.GetNodeId()), static_cast<jlong>(info.start_icd_counter),
-            static_cast<jlong>(info.offset), static_cast<jlong>(info.monitored_subject), jIcdAesKey, jIcdHmacKey));
+        jICDClientInfo = static_cast<jobject>(
+            env->NewObject(infoClass, constructor, static_cast<jlong>(info.peer_node.GetNodeId()),
+                           static_cast<jlong>(info.check_in_node.GetNodeId()), static_cast<jlong>(info.start_icd_counter),
+                           static_cast<jlong>(info.offset), static_cast<jlong>(info.monitored_subject), jIcdAesKey, jIcdHmacKey));
 
         err = chip::JniReferences::GetInstance().AddToList(jInfo, jICDClientInfo);
         VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr,
@@ -186,7 +186,7 @@ CHIP_ERROR ParseICDClientInfo(JNIEnv * env, jint jFabricIndex, jobject jIcdClien
 
     chip::ScopedNodeId peerNodeId(static_cast<chip::NodeId>(jPeerNodeId), static_cast<chip::FabricIndex>(jFabricIndex));
     chip::ScopedNodeId checkInNodeId(static_cast<chip::NodeId>(jCheckInNodeId), static_cast<chip::FabricIndex>(jFabricIndex));
-    chip::JniByteArray jniIcdAesKey(env,jIcdAesKey);
+    chip::JniByteArray jniIcdAesKey(env, jIcdAesKey);
     chip::JniByteArray jniIcdHmacKey(env, jIcdHmacKey);
 
     icdClientInfo.peer_node         = peerNodeId;

--- a/src/controller/java/src/chip/devicecontroller/ICDCheckInDelegateWrapper.java
+++ b/src/controller/java/src/chip/devicecontroller/ICDCheckInDelegateWrapper.java
@@ -29,6 +29,7 @@ class ICDCheckInDelegateWrapper {
   @SuppressWarnings("unused")
   private void onCheckInComplete(
       long peerNodeId,
+      long checkInNodeId,
       long startCounter,
       long offset,
       long monitoredSubject,
@@ -36,12 +37,19 @@ class ICDCheckInDelegateWrapper {
       byte[] icdHmacKey) {
     delegate.onCheckInComplete(
         new ICDClientInfo(
-            peerNodeId, startCounter, offset, monitoredSubject, icdAesKey, icdHmacKey));
+            peerNodeId,
+            checkInNodeId,
+            startCounter,
+            offset,
+            monitoredSubject,
+            icdAesKey,
+            icdHmacKey));
   }
 
   @SuppressWarnings("unused")
   private byte[] onKeyRefreshNeeded(
       long peerNodeId,
+      long checkInNodeId,
       long startCounter,
       long offset,
       long monitoredSubject,
@@ -49,7 +57,13 @@ class ICDCheckInDelegateWrapper {
       byte[] icdHmacKey) {
     return delegate.onKeyRefreshNeeded(
         new ICDClientInfo(
-            peerNodeId, startCounter, offset, monitoredSubject, icdAesKey, icdHmacKey));
+            peerNodeId,
+            checkInNodeId,
+            startCounter,
+            offset,
+            monitoredSubject,
+            icdAesKey,
+            icdHmacKey));
   }
 
   @SuppressWarnings("unused")

--- a/src/controller/java/src/chip/devicecontroller/ICDClientInfo.java
+++ b/src/controller/java/src/chip/devicecontroller/ICDClientInfo.java
@@ -20,6 +20,7 @@ package chip.devicecontroller;
 /** Class for holding ICD Client information. */
 public class ICDClientInfo {
   private final long peerNodeId;
+  private final long checkInNodeId;
   private final long startCounter;
   private final long offset;
   private final long monitoredSubject;
@@ -28,12 +29,14 @@ public class ICDClientInfo {
 
   public ICDClientInfo(
       long peerNodeId,
+      long checkInNodeId,
       long startCounter,
       long offset,
       long monitoredSubject,
       byte[] icdAesKey,
       byte[] icdHmacKey) {
     this.peerNodeId = peerNodeId;
+    this.checkInNodeId = checkInNodeId;
     this.startCounter = startCounter;
     this.offset = offset;
     this.monitoredSubject = monitoredSubject;
@@ -41,9 +44,14 @@ public class ICDClientInfo {
     this.icdHmacKey = icdHmacKey;
   }
 
-  /** Returns the check in peer node ID. */
+  /** Returns the peer node ID. */
   public long getPeerNodeId() {
     return peerNodeId;
+  }
+
+  /** Returns the check in node ID. */
+  public long getCheckInNodeId() {
+    return checkInNodeId;
   }
 
   /** Returns the Start Counter. */
@@ -76,6 +84,8 @@ public class ICDClientInfo {
     return "ICDClientInfo{"
         + "\n\tpeerNodeId="
         + peerNodeId
+        + "\n\tcheckInNodeId="
+        + checkInNodeId
         + "\n\t, startCounter="
         + startCounter
         + "\n\t, offset="

--- a/src/controller/java/src/matter/controller/ICDClientInfo.kt
+++ b/src/controller/java/src/matter/controller/ICDClientInfo.kt
@@ -21,11 +21,12 @@ package matter.controller
 /** Class for holding ICD Client information. */
 data class ICDClientInfo(
   val peerNodeId: Long,
+  val checkInNodeId: Long
   val startCounter: Long,
   val offset: Long,
   val monitoredSubject: Long,
   val icdAesKey: ByteArray,
   val icdHmacKey: ByteArray
 ) {
-  override fun toString(): String = "$peerNodeId/$startCounter/$offset/$monitoredSubject"
+  override fun toString(): String = "$peerNodeId/$checkInNodeId/$startCounter/$offset/$monitoredSubject"
 }

--- a/src/controller/java/src/matter/controller/ICDClientInfo.kt
+++ b/src/controller/java/src/matter/controller/ICDClientInfo.kt
@@ -21,7 +21,7 @@ package matter.controller
 /** Class for holding ICD Client information. */
 data class ICDClientInfo(
   val peerNodeId: Long,
-  val checkInNodeId: Long
+  val checkInNodeId: Long,
   val startCounter: Long,
   val offset: Long,
   val monitoredSubject: Long,

--- a/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptDevicePairingDelegate.cpp
@@ -188,7 +188,8 @@ ScriptDevicePairingDelegate::GetOpenWindowCallback(Controller::CommissioningWind
 void ScriptDevicePairingDelegate::OnICDRegistrationComplete(ScopedNodeId nodeId, uint32_t icdCounter)
 {
     app::ICDClientInfo clientInfo;
-    clientInfo.peer_node         = nodeId;
+    clientInfo.peer_node     = nodeId;
+    clientInfo.check_in_node = chip::ScopedNodeId(sCommissioningParameters.GetICDCheckInNodeId().Value(), nodeId.GetFabricIndex());
     clientInfo.monitored_subject = sCommissioningParameters.GetICDMonitoredSubject().Value();
     clientInfo.start_icd_counter = icdCounter;
     clientInfo.client_type       = sCommissioningParameters.GetICDClientType().Value();


### PR DESCRIPTION
When running icd registration and refresh key, we have problematically store check-in nodeId in peer nodeId. In order to resolve this issue, we add a new check_in_node in icdClientInfo, and update the code from bottom to up across android/python/c++ chiptool.

Tests:
Validate using chip-tool
./out/linux-x64-chip-tool/chip-tool interactive start
pairing onnetwork-long  1 20202021 3840
icdmanagement register-client 112233 1 hex:abcdef1234567890abcdef1234567890 0 1 0
icd wait-for-device 1 30

pairing onnetwork-long  1 20202021 3840 --icd-registration=true
icd wait-for-device 1 30

fixes: https://github.com/project-chip/connectedhomeip/issues/34799

