### PR TITLE
Disable the new data model interface code across the board for now.

### DIFF
--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -27,7 +27,9 @@ declare_args() {
   #   - check:    runs BOTH datamodel and non-data-model (if possible) functionality and compares results
   #   - enabled:  runs only the data model interface (does not use the legacy code)
   if (current_os == "linux") {
-    chip_use_data_model_interface = "check"
+    # "check" is broken, see https://github.com/project-chip/connectedhomeip/issues/35306
+    #chip_use_data_model_interface = "check"
+    chip_use_data_model_interface = "disabled"
   } else {
     chip_use_data_model_interface = "disabled"
   }


### PR DESCRIPTION
On Linux we were using the "check" mode, but it's buggy in ways that cause app crashes (see https://github.com/project-chip/connectedhomeip/issues/35306). Just disabling it for now so this is not an issue for SVE.
