### PR TITLE
ESP32: add an api to disconnect Wi-Fi driver

### DIFF
--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -236,6 +236,17 @@ CHIP_ERROR ESPWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen,
     return ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Enabled);
 }
 
+CHIP_ERROR ESPWiFiDriver::DisconnectDriver()
+{
+    if (chip::DeviceLayer::Internal::ESP32Utils::IsStationProvisioned())
+    {
+        ReturnErrorOnFailure(BackupConfiguration());
+        // Attaching to an empty network will disconnect the network.
+        ReturnErrorOnFailure(ConnectWiFiNetwork(nullptr, 0, nullptr, 0));
+    }
+    return CHIP_NO_ERROR;
+}
+
 void ESPWiFiDriver::OnConnectWiFiNetwork()
 {
     if (mpConnectCallback)

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -103,6 +103,7 @@ public:
 
     CHIP_ERROR CommitConfiguration() override;
     CHIP_ERROR RevertConfiguration() override;
+    CHIP_ERROR DisconnectDriver() override;
 
     Status RemoveNetwork(ByteSpan networkId, MutableCharSpan & outDebugText, uint8_t & outNetworkIndex) override;
     Status ReorderNetwork(ByteSpan networkId, uint8_t index, MutableCharSpan & outDebugText) override;


### PR DESCRIPTION
Ref to https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/10335, add an API to disconnect ESP32 Wi-Fi driver.

#### Required
- [ ] https://github.com/project-chip/connectedhomeip/pull/35256
- [ ] https://github.com/project-chip/connectedhomeip/pull/33745

