### PR TITLE
Replace 0x8000 with correct BIT mask for DirectModeChange feature

### DIFF
--- a/src/python_testing/TC_RVCCLEANM_2_2.py
+++ b/src/python_testing/TC_RVCCLEANM_2_2.py
@@ -95,9 +95,7 @@ class TC_RVCCLEANM_2_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_RVCCLEANM_2_2(self):
-        # TODO Replace 0x8000 with python object of RVCCLEAN FEATURE bit map when implemented
-        # 0x8000 corresponds to 16 bit DIRECTMODECH Feature map
-        self.directmodech_bit_mask = 0x8000
+        self.directmodech_bit_mask = Clusters.RvcCleanMode.Bitmaps.Feature.kDirectModeChange
         self.endpoint = self.matter_test_config.endpoint
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         if self.is_ci:

--- a/src/python_testing/TC_RVCRUNM_2_2.py
+++ b/src/python_testing/TC_RVCRUNM_2_2.py
@@ -122,9 +122,7 @@ class TC_RVCRUNM_2_2(MatterBaseTest):
                          "PIXIT.RVCRUNM.MODE_A:<mode id> \n"
                          "PIXIT.RVCRUNM.MODE_B:<mode id>")
 
-        # TODO Replace 0x8000 with python object of RVCRUN FEATURE bit when implemented
-        # 0x8000 corresponds to 16 bit DIRECTMODECH Feature map
-        self.directmodech_bit_mask = 0x8000
+        self.directmodech_bit_mask = Clusters.RvcRunMode.Bitmaps.Feature.kDirectModeChange
         self.endpoint = self.matter_test_config.endpoint
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         self.mode_a = self.matter_test_config.global_test_params['PIXIT.RVCRUNM.MODE_A']


### PR DESCRIPTION
In TC_RVCRUNM_2_2.py and TC_RVCCLEANM_2_2.py, we were using 0x8000 for direct_mode_change_bit_mask, since it is incorrect, code will now use `chip.clusters.RvcCleanMode.Bitmaps.Feature.kDirectModeChange `  and `chip.clusters.RvcRunMode.Bitmaps.Feature.kDirectModeChange ` 
FIX for https://github.com/project-chip/connectedhomeip/issues/35315