### PR TITLE
Fix crash when running MCORE_FS_1_2

### DIFF
--- a/examples/fabric-admin/commands/pairing/PairingCommand.cpp
+++ b/examples/fabric-admin/commands/pairing/PairingCommand.cpp
@@ -45,6 +45,7 @@ namespace {
 
 CHIP_ERROR GetPayload(const char * setUpCode, SetupPayload & payload)
 {
+    VerifyOrReturnValue(setUpCode, CHIP_ERROR_INVALID_ARGUMENT);
     bool isQRCode = strncmp(setUpCode, kQRCodePrefix, strlen(kQRCodePrefix)) == 0;
     if (isQRCode)
     {


### PR DESCRIPTION
Test ran `python3 src/python_testing/TC_MCORE_FS_1_2.py --commissioning-method on-network --manual-code 34970112332 --string-arg th_server_app_path:"out/linux-x64-all-clusters-no-ble-clang/chip-all-clusters-app"`

Fixes: https://github.com/project-chip/connectedhomeip/issues/35316