### PR TITLE
Remove ipaddr and port from CommisssionNode command in CCTRL_2_2

### DIFF
--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -136,7 +136,6 @@ class TC_CCTRL_2_2(MatterBaseTest):
         events = await self.default_controller.ReadEvent(nodeid=self.dut_node_id, events=event_path)
 
         self.step(5)
-        ipaddr = ipaddress.IPv6Address('::1')
         cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=1, responseTimeoutSeconds=30)
         try:
             await self.send_single_cmd(cmd)

--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -137,8 +137,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
 
         self.step(5)
         ipaddr = ipaddress.IPv6Address('::1')
-        cmd = Clusters.CommissionerControl.Commands.CommissionNode(
-            requestId=1, responseTimeoutSeconds=30, ipAddress=ipaddr.packed, port=self.port)
+        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=1, responseTimeoutSeconds=30)
         try:
             await self.send_single_cmd(cmd)
             asserts.fail("Unexpected success on CommissionNode")

--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -22,7 +22,6 @@
 
 # This test requires a TH_SERVER application. Please specify with --string-arg th_server_app_path:<path_to_app>
 
-import ipaddress
 import logging
 import os
 import random


### PR DESCRIPTION
https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/10342/files removed these command parameters. This was left over that still needs to be removed from the SDK

Fixes: https://github.com/project-chip/connectedhomeip/issues/35312