### PR TITLE
tv-casting-app cancel connection upon CancelPasscode CDC message from TV

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCEndpoint.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCEndpoint.mm
@@ -90,27 +90,67 @@
 - (MCCluster * _Nullable)clusterForType:(MCEndpointClusterType)type
 {
     switch (type) {
-    case MCEndpointClusterTypeApplicationBasic:
-        return [[MCApplicationBasicCluster alloc] initWithCppCluster:_cppEndpoint->GetCluster<matter::casting::clusters::application_basic::ApplicationBasicCluster>()];
+    case MCEndpointClusterTypeApplicationBasic: {
+        auto cppCluster = _cppEndpoint->GetCluster<matter::casting::clusters::application_basic::ApplicationBasicCluster>();
+        if (cppCluster == nullptr) {
+            ChipLogError(AppServer, "MCEndpoint::clusterForType() MCEndpointClusterTypeApplicationBasic, GetCluster() returned nullptr");
+            return nil;
+        }
+        return [[MCApplicationBasicCluster alloc] initWithCppCluster:cppCluster];
+    }
 
-    case MCEndpointClusterTypeApplicationLauncher:
-        return [[MCApplicationLauncherCluster alloc] initWithCppCluster:_cppEndpoint->GetCluster<matter::casting::clusters::application_launcher::ApplicationLauncherCluster>()];
+    case MCEndpointClusterTypeApplicationLauncher: {
+        auto cppCluster = _cppEndpoint->GetCluster<matter::casting::clusters::application_launcher::ApplicationLauncherCluster>();
+        if (cppCluster == nullptr) {
+            ChipLogError(AppServer, "MCEndpoint::clusterForType() MCEndpointClusterTypeApplicationLauncher GetCluster() returned nullptr");
+            return nil;
+        }
+        return [[MCApplicationLauncherCluster alloc] initWithCppCluster:cppCluster];
+    }
 
-    case MCEndpointClusterTypeContentLauncher:
-        return [[MCContentLauncherCluster alloc] initWithCppCluster:_cppEndpoint->GetCluster<matter::casting::clusters::content_launcher::ContentLauncherCluster>()];
+    case MCEndpointClusterTypeContentLauncher: {
+        auto cppCluster = _cppEndpoint->GetCluster<matter::casting::clusters::content_launcher::ContentLauncherCluster>();
+        if (cppCluster == nullptr) {
+            ChipLogError(AppServer, "MCEndpoint::clusterForType() MCEndpointClusterTypeContentLauncher GetCluster() returned nullptr");
+            return nil;
+        }
+        return [[MCContentLauncherCluster alloc] initWithCppCluster:cppCluster];
+    }
 
-    case MCEndpointClusterTypeKeypadInput:
-        return [[MCKeypadInputCluster alloc] initWithCppCluster:_cppEndpoint->GetCluster<matter::casting::clusters::keypad_input::KeypadInputCluster>()];
+    case MCEndpointClusterTypeKeypadInput: {
+        auto cppCluster = _cppEndpoint->GetCluster<matter::casting::clusters::keypad_input::KeypadInputCluster>();
+        if (cppCluster == nullptr) {
+            ChipLogError(AppServer, "MCEndpoint::clusterForType() MCEndpointClusterTypeKeypadInput GetCluster() returned nullptr");
+            return nil;
+        }
+        return [[MCKeypadInputCluster alloc] initWithCppCluster:cppCluster];
+    }
 
-    case MCEndpointClusterTypeMediaPlayback:
-        return [[MCMediaPlaybackCluster alloc] initWithCppCluster:_cppEndpoint->GetCluster<matter::casting::clusters::media_playback::MediaPlaybackCluster>()];
+    case MCEndpointClusterTypeMediaPlayback: {
+        auto cppCluster = _cppEndpoint->GetCluster<matter::casting::clusters::media_playback::MediaPlaybackCluster>();
+        if (cppCluster == nullptr) {
+            ChipLogError(AppServer, "MCEndpoint::clusterForType() MCEndpointClusterTypeMediaPlayback GetCluster() returned nullptr");
+            return nil;
+        }
+        return [[MCMediaPlaybackCluster alloc] initWithCppCluster:cppCluster];
+    }
 
-    case MCEndpointClusterTypeOnOff:
-        return [[MCOnOffCluster alloc] initWithCppCluster:_cppEndpoint->GetCluster<matter::casting::clusters::on_off::OnOffCluster>()];
-
-    case MCEndpointClusterTypeTargetNavigator:
-        return [[MCTargetNavigatorCluster alloc] initWithCppCluster:_cppEndpoint->GetCluster<matter::casting::clusters::target_navigator::TargetNavigatorCluster>()];
-
+    case MCEndpointClusterTypeOnOff: {
+        auto cppCluster = _cppEndpoint->GetCluster<matter::casting::clusters::on_off::OnOffCluster>();
+        if (cppCluster == nullptr) {
+            ChipLogError(AppServer, "MCEndpoint::clusterForType() MCEndpointClusterTypeOnOff GetCluster() returned nullptr");
+            return nil;
+        }
+        return [[MCOnOffCluster alloc] initWithCppCluster:cppCluster];
+    }
+    case MCEndpointClusterTypeTargetNavigator: {
+        auto cppCluster = _cppEndpoint->GetCluster<matter::casting::clusters::target_navigator::TargetNavigatorCluster>();
+        if (cppCluster == nullptr) {
+            ChipLogError(AppServer, "MCEndpoint::clusterForType() MCEndpointClusterTypeTargetNavigator GetCluster() returned nullptr");
+            return nil;
+        }
+        return [[MCTargetNavigatorCluster alloc] initWithCppCluster:cppCluster];
+    }
     default:
         ChipLogError(AppServer, "MCEndpointClusterType not found");
         break;

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCApplicationBasicReadVendorIDExampleViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCApplicationBasicReadVendorIDExampleViewModel.swift
@@ -47,7 +47,7 @@ class MCApplicationBasicReadVendorIDExampleViewModel: ObservableObject {
         // validate that the selected endpoint supports the ApplicationBasic cluster
         if(!endpoint.hasCluster(MCEndpointClusterTypeApplicationBasic))
         {
-            self.Log.error("No ApplicationBasic cluster supporting endpoint found")
+            self.Log.error("MCApplicationBasicReadVendorIDExampleViewModel.read() No ApplicationBasic cluster supporting endpoint found")
             DispatchQueue.main.async
             {
                 self.status = "No ApplicationBasic cluster supporting endpoint found"

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCContentLauncherLaunchURLExampleViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCContentLauncherLaunchURLExampleViewModel.swift
@@ -47,7 +47,7 @@ class MCContentLauncherLaunchURLExampleViewModel: ObservableObject {
         // validate that the selected endpoint supports the ContentLauncher cluster
         if(!endpoint.hasCluster(MCEndpointClusterTypeContentLauncher))
         {
-            self.Log.error("No ContentLauncher cluster supporting endpoint found")
+            self.Log.error("MCContentLauncherLaunchURLExampleViewModel.invokeCommand() No ContentLauncher cluster supporting endpoint found")
             DispatchQueue.main.async
             {
                 self.status = "No ContentLauncher cluster supporting endpoint found"

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCMediaPlaybackSubscribeToCurrentStateExampleViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCMediaPlaybackSubscribeToCurrentStateExampleViewModel.swift
@@ -47,7 +47,7 @@ class MCMediaPlaybackSubscribeToCurrentStateExampleViewModel: ObservableObject {
         // validate that the selected endpoint supports the MediaPlayback cluster
         if(!endpoint.hasCluster(MCEndpointClusterTypeMediaPlayback))
         {
-            self.Log.error("No MediaPlayback cluster supporting endpoint found")
+            self.Log.error("MCMediaPlaybackSubscribeToCurrentStateExampleViewModel.subscribe() No MediaPlayback cluster supporting endpoint found")
             DispatchQueue.main.async
             {
                 self.status = "No MediaPlayback cluster supporting endpoint found"

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -267,7 +267,7 @@ void ConnectionHandler(CHIP_ERROR err, matter::casting::core::CastingPlayer * ca
     // For a connection failure, called back with an error and nullptr.
     VerifyOrReturn(
         err == CHIP_NO_ERROR,
-        ChipLogProgress(
+        ChipLogError(
             AppServer,
             "simple-app-helper.cpp::ConnectionHandler(): Failed to connect to CastingPlayer (ID: %s) with err %" CHIP_ERROR_FORMAT,
             targetCastingPlayer->GetId(), err.Format()));

--- a/examples/tv-casting-app/tv-casting-common/core/BaseCluster.h
+++ b/examples/tv-casting-app/tv-casting-common/core/BaseCluster.h
@@ -58,12 +58,28 @@ public:
     /**
      * @return Pointer to the Attribute registered in this cluster, corresponding to attributeId
      */
-    void * GetAttribute(const chip::AttributeId attributeId) { return mAttributes[attributeId]; }
+    void * GetAttribute(const chip::AttributeId attributeId)
+    {
+        if (mAttributes.empty())
+        {
+            ChipLogError(AppServer, "BaseCluster::GetAttribute() mAttributes is empty");
+            return nullptr;
+        }
+        return mAttributes[attributeId];
+    }
 
     /**
      * @return Pointer to the Command registered in this cluster, corresponding to commandId
      */
-    void * GetCommand(const chip::CommandId commandId) { return mCommands[commandId]; }
+    void * GetCommand(const chip::CommandId commandId)
+    {
+        if (mCommands.empty())
+        {
+            ChipLogError(AppServer, "BaseCluster::GetCommand() mCommands is empty");
+            return nullptr;
+        }
+        return mCommands[commandId];
+    }
 
 protected:
     /**

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -109,6 +109,7 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
         // found the CastingPlayer in cache
         if (it != cachedCastingPlayers.end())
         {
+            ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() found this CastingPlayer in app cache");
             unsigned index = (unsigned int) std::distance(cachedCastingPlayers.begin(), it);
             if (ContainsDesiredTargetApp(&cachedCastingPlayers[index], idOptions.getTargetAppInfoList()))
             {

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -102,16 +102,11 @@ public:
      */
     static CastingPlayer * GetTargetCastingPlayer()
     {
-        ChipLogProgress(AppServer, "CastingPlayer::GetTargetCastingPlayer() called");
         std::shared_ptr<CastingPlayer> sharedPtr = mTargetCastingPlayer.lock();
         CastingPlayer * rawPtr                   = nullptr;
         if (sharedPtr)
         {
             rawPtr = sharedPtr.get();
-            ChipLogProgress(
-                AppServer,
-                "CastingPlayer::GetTargetCastingPlayer() Got rawPtr from mTargetCastingPlayer, sharedPtr reference count: %lu",
-                sharedPtr.use_count());
             sharedPtr.reset();
         }
         else

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
@@ -48,7 +48,7 @@ public:
     /**
      * @brief OnCommissionerDeclarationMessage() will call the CommissionerDeclarationCallback set by this function.
      */
-    void SetCommissionerDeclarationCallback(CommissionerDeclarationCallback callback, memory::Weak<CastingPlayer> castingPlayer);
+    void SetCommissionerDeclarationCallback(CommissionerDeclarationCallback callback);
 
     /**
      * @brief returns true if the CommissionerDeclarationHandler sigleton has a CommissionerDeclarationCallback set, false
@@ -59,7 +59,6 @@ public:
 private:
     static CommissionerDeclarationHandler * sCommissionerDeclarationHandler_;
     CommissionerDeclarationCallback mCmmissionerDeclarationCallback_;
-    memory::Weak<CastingPlayer> mTargetCastingPlayer;
 
     CommissionerDeclarationHandler() {}
     ~CommissionerDeclarationHandler() {}

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.h
@@ -48,7 +48,7 @@ public:
     /**
      * @brief OnCommissionerDeclarationMessage() will call the CommissionerDeclarationCallback set by this function.
      */
-    void SetCommissionerDeclarationCallback(CommissionerDeclarationCallback callback);
+    void SetCommissionerDeclarationCallback(CommissionerDeclarationCallback callback, memory::Weak<CastingPlayer> castingPlayer);
 
     /**
      * @brief returns true if the CommissionerDeclarationHandler sigleton has a CommissionerDeclarationCallback set, false
@@ -59,6 +59,7 @@ public:
 private:
     static CommissionerDeclarationHandler * sCommissionerDeclarationHandler_;
     CommissionerDeclarationCallback mCmmissionerDeclarationCallback_;
+    memory::Weak<CastingPlayer> mTargetCastingPlayer;
 
     CommissionerDeclarationHandler() {}
     ~CommissionerDeclarationHandler() {}

--- a/examples/tv-casting-app/tv-casting-common/core/Endpoint.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/Endpoint.cpp
@@ -28,6 +28,7 @@ void Endpoint::RegisterClusters(std::vector<chip::ClusterId> clusters)
 {
     for (chip::ClusterId clusterId : clusters)
     {
+        ChipLogProgress(AppServer, "Endpoint::RegisterClusters() Registering clusterId %d for endpointId %d", clusterId, GetId());
         switch (clusterId)
         {
         case chip::app::Clusters::ApplicationBasic::Id:
@@ -67,7 +68,8 @@ void Endpoint::RegisterClusters(std::vector<chip::ClusterId> clusters)
             break;
 
         default:
-            ChipLogProgress(AppServer, "Skipping registration of clusterId %d for endpointId %d", clusterId, GetId());
+            ChipLogProgress(AppServer, "Endpoint::RegisterClusters() Skipping registration of clusterId %d for endpointId %d",
+                            clusterId, GetId());
             break;
         }
     }

--- a/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
+++ b/examples/tv-casting-app/tv-casting-common/core/Endpoint.h
@@ -105,6 +105,7 @@ public:
      */
     std::vector<chip::ClusterId> GetServerList()
     {
+        ChipLogProgress(AppServer, "Endpoint::GetServerList() mClusters.size(): %d", static_cast<int>(mClusters.size()));
         std::vector<chip::ClusterId> serverList;
         for (auto const & cluster : mClusters)
         {
@@ -122,6 +123,7 @@ public:
     template <typename T>
     void RegisterCluster(const chip::ClusterId clusterId)
     {
+        ChipLogProgress(AppServer, "Endpoint::RegisterCluster() Registering clusterId %d for endpointId %d", clusterId, GetId());
         static_assert(std::is_base_of<BaseCluster, T>::value, "T must be derived from BaseCluster");
         auto cluster = std::make_shared<T>(shared_from_this());
         cluster->SetUp();
@@ -135,6 +137,7 @@ public:
     memory::Strong<T> GetCluster()
     {
         static_assert(std::is_base_of<BaseCluster, T>::value, "T must be derived from BaseCluster");
+        ChipLogProgress(AppServer, "Endpoint::GetCluster() mClusters.size(): %d", static_cast<int>(mClusters.size()));
         for (const auto & pair : mClusters)
         {
             auto cluster = std::dynamic_pointer_cast<T>(pair.second);

--- a/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
@@ -90,7 +90,8 @@ CHIP_ERROR EndpointListLoader::Load()
         if (binding.type == MATTER_UNICAST_BINDING && CastingPlayer::GetTargetCastingPlayer()->GetNodeId() == binding.nodeId)
         {
             // if we discovered a new Endpoint from the bindings, read its EndpointAttributes
-            chip::EndpointId endpointId                     = binding.remote;
+            chip::EndpointId endpointId = binding.remote;
+            ChipLogProgress(AppServer, "EndpointListLoader::Load() Found new endpointId: %d", endpointId);
             std::vector<memory::Strong<Endpoint>> endpoints = CastingPlayer::GetTargetCastingPlayer()->GetEndpoints();
             if (std::find_if(endpoints.begin(), endpoints.end(), [&endpointId](const memory::Strong<Endpoint> & endpoint) {
                     return endpoint->GetId() == endpointId;
@@ -128,17 +129,19 @@ void EndpointListLoader::Complete()
 
     if (mPendingAttributeReads == 0)
     {
-        ChipLogProgress(AppServer, "EndpointListLoader::Complete Loading %lu endpoint(s)", mNewEndpointsToLoad);
+        ChipLogProgress(AppServer, "EndpointListLoader::Complete() Loading %lu endpoint(s)", mNewEndpointsToLoad);
         for (unsigned long i = 0; i < mNewEndpointsToLoad; i++)
         {
             EndpointAttributes endpointAttributes = mEndpointAttributesList[i];
             std::shared_ptr<Endpoint> endpoint =
                 std::make_shared<Endpoint>(CastingPlayer::GetTargetCastingPlayer(), endpointAttributes);
+            ChipLogProgress(AppServer, "EndpointListLoader::Complete() mEndpointServerLists[i].size: %lu ",
+                            mEndpointServerLists[i].size());
             endpoint->RegisterClusters(mEndpointServerLists[i]);
             CastingPlayer::GetTargetCastingPlayer()->RegisterEndpoint(endpoint);
         }
 
-        ChipLogProgress(AppServer, "EndpointListLoader::Complete finished Loading %lu endpoints", mNewEndpointsToLoad);
+        ChipLogProgress(AppServer, "EndpointListLoader::Complete() Finished Loading %lu endpoints", mNewEndpointsToLoad);
 
         // TODO cleanup
         // delete mEndpointAttributesList;


### PR DESCRIPTION
Updated the common tv-casting-app Linux implementation to cancel connection attempt upon receiving CancelPasscode CDC message from CastingPlayer/Commissioner TV. This change corresponds to the following examples/tv-app change by @lazarkov: https://github.com/project-chip/connectedhomeip/pull/34507

**Change summary**

1.	Updated CastingPlayer.h/cpp and CommissionerDeclarationHandler.h/cpp. 
2.	CommissionerDeclarationHandler.h/cpp OnCommissionerDeclarationMessage(), upon receiving a CommissionerDeclaration message with CancelPasscode ==true from the CastingPlayer/Commissioner TV, calls the internal StopConnecting() API to cancel the current connection attempt.
3.	Implemented an internal version of the StopConnecting() API which can only be called by CommissionerDeclarationHandler. The public version of StopConnecting() API is unchanged and calls the internal StopConnecting() with shouldSendIdentificationDeclarationMessage set to true.
4. Updated /connectedhomeip/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCEndpoint.mm clusterForType() function to check for a null cppCluster object returned from GetCluster(). This prevents the Swift object from getting initialized with a  null cpp value. This was also the cause of an iOS app crash when trying to invoke a command or read attribute in the iOS sample app.

**Testing**

Verified and tested locally with the Linux, Android and iOS tv-casting-app example mobile apps, and the Linux tv-app (CastingPlayer). Able to build and commission with the example apps using both the commissionee and commissioner generated passcode flows. Cancelling the connection attempt on the TV-app using “controller ux cancel” sends a CommissionerDeclaration with CancelPasscode. The tv-casting-app reads the CommissionerDeclaration with CancelPasscode  and cancels the ongoing connection without replying to the TV-app. 

**Linux Test steps:**
1. Start Linux TV App: `./out/tv-app/chip-tv-app`
2. Start TV Casting App: `./out/tv-casting-app/chip-tv-casting-app`
3. TV App uninstall endpoint 4: `app uninstall 65521 32769`
4. TV Casting App: `cast request 0` or `cast request 0 commissioner-generated-passcode`
5. TV App: `controller ux ok`
6. TV App, to send CommissionerDeclaration with CancelPasscode flag: `controller ux cancel`
7. Observe TV Casting App logs. We reset the CastingPlayer state after receiving the CommissionerDeclaration with CancelPasscode set to true: "[1725057856.727] [3844:11750597] [SVR] CastingPlayer::StopConnecting() shouldSendIdentificationDeclarationMessage: false, User Directed Commissioning stopped by the CastingPlayer/Commissioner user."
8. TV Casting App: `cast request 0 commissioner-generated-passcode`
9. TV App: `controller ux ok`
10. TV Casting App: `cast setcommissionerpasscode 12345678`
11. Observe TV Casting App logs,  we successfully connected and started demo interactions.

**iOS Test steps:** 
1. Start Linux TV App: `./out/tv-app/chip-tv-app`
2. Start iOS TV Casting App from Xcode:
3. TV App uninstall endpoint 4: `app uninstall 65521 32769`
4.  iOS TV Casting App UX: short or long press on the CastingPlayer
5. TV App: `controller ux ok`
6. TV App, to send CommissionerDeclaration with CancelPasscode flag: `controller ux cancel`
7. Observe iOS TV Casting App  logs. We reset the CastingPlayer state after receiving the CommissionerDeclaration with CancelPasscode set to true: 
"
[0;32m[1725386754.362] [66107:12625175] [SVR] CastingPlayer::StopConnecting() shouldSendIdentificationDeclarationMessage: 0, User Directed Commissioning aborted by the CastingPlayer/Commissioner user.[0m
CastingPlayer::resetState()
"
8. Observe iOS TV Casting App UX. Since the mCmmissionerDeclarationCallback_ was not set, the mOnCompleted callback was called with the CHIP_ERROR_CONNECTION_ABORTED error. Note, if you long pressed in Step 4, you will need to press "Cancel" in the passcode input dialog. The UX screen will show a "Incorrect state" error since the "Cancel" button calls MCCastingPlayer.stopConnecting() after it has already been called once before. 
10.  iOS TV Casting App UX: press "Back". 
11.   iOS TV Casting App UX: long press on the CastingPlayer
12. TV App: `controller ux ok`
13.  iOS TV Casting App UX passcode input dialog press "Continue Connecting"
14. Observe iOS TV Casting App UX,  we successfully connected. Click "Next" and try the demo commands like Launch URL

**Android Test steps:**
1. Start Linux TV App on Raspberry PI: `./out/tv-app/chip-tv-app`
2. Start Android TV Casting App on Android phone.
3. TV App uninstall endpoint 4: `app uninstall 65521 32769`
4. Android TV Casting App UX: short or long press on the CastingPlayer
5. TV App:` controller ux ok`
6. TV App, to send CommissionerDeclaration with CancelPasscode flag: `controller ux cancel`
7. Observe Android TV Casting App logs. We reset the CastingPlayer state after receiving the CommissionerDeclaration with CancelPasscode set to true: 
"
2024-09-04 12:05:30.573 28756-28788 SVR                     com.chip.casting                     I  CastingPlayer::StopConnecting() shouldSendIdentificationDeclarationMessage: 0, User Directed Commissioning aborted by the CastingPlayer/Commissioner user.
2024-09-04 12:05:30.573 28756-28788 SVR                     com.chip.casting                     E  MatterCastingPlayer-JNI::verifyOrEstablishConnection() ConnectCallback() Connection error: examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp:263: CHIP Error 0x00000002: Connection aborted
"
8. Observe Android TV Casting App UX. Since the mCmmissionerDeclarationCallback_ was not set, the mOnCompleted callback was called with the CHIP_ERROR_CONNECTION_ABORTED error. Note, if you long pressed in Step 4, you will need to press "Cancel" in the passcode input dialog. The UX screen will show a "errorCode=3" error since the "Cancel" button calls MCCastingPlayer.stopConnecting() after it has already been called once before.
9. Android TV Casting App UX: press "Back".
10. Android TV Casting App UX: long press on the CastingPlayer
11. TV App: `controller ux ok`
12. Android TV Casting App UX passcode input dialog press "Continue Connecting"
13. Observe Android Casting App UX, we successfully connected. Click "Next" and try the demo commands like Launch URL


