### PR TITLE
Add chip-lighting-data-model-no-unique-id-app to TH

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -195,6 +195,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-rvc-ipv6only \
     --target linux-x64-fabric-bridge-rpc-ipv6only \
     --target linux-x64-fabric-admin-rpc-ipv6only \
+    --target linux-x64-light-data-model-no-unique-id \
     --target linux-x64-network-manager-ipv6only \
     build \
     && mv out/linux-x64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
@@ -218,6 +219,7 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-x64-rvc-ipv6only/chip-rvc-app out/chip-rvc-app \
     && mv out/linux-x64-fabric-bridge-rpc-ipv6only/fabric-bridge-app out/fabric-bridge-app \
     && mv out/linux-x64-fabric-admin-rpc-ipv6only/fabric-admin out/fabric-admin \
+    && mv out/linux-x64-light-data-model-no-unique-id/chip-lighting-app out/chip-lighting-data-model-no-unique-id-app \
     && mv out/linux-x64-network-manager-ipv6only/matter-network-manager-app out/matter-network-manager-app \
     ;; \
     "linux/arm64")\
@@ -245,6 +247,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-arm64-rvc-ipv6only \
     --target linux-arm64-fabric-bridge-rpc-ipv6only \
     --target linux-arm64-fabric-admin-rpc-ipv6only \
+    --target linux-arm64-light-data-model-no-unique-id \
     --target linux-arm64-network-manager-ipv6only \
     build \
     && mv out/linux-arm64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
@@ -268,6 +271,7 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-arm64-rvc-ipv6only/chip-rvc-app out/chip-rvc-app \
     && mv out/linux-arm64-fabric-bridge-rpc-ipv6only/fabric-bridge-app out/fabric-bridge-app \
     && mv out/linux-arm64-fabric-admin-rpc-ipv6only/fabric-admin out/fabric-admin \
+    && mv out/linux-arm64-light-data-model-no-unique-id/chip-lighting-app out/chip-lighting-data-model-no-unique-id-app \
     && mv out/linux-arm64-network-manager-ipv6only/matter-network-manager-app out/matter-network-manager-app \
     ;; \
     *) ;; \
@@ -304,6 +308,7 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-microwave-oven-a
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-rvc-app chip-rvc-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/fabric-bridge-app fabric-bridge-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/fabric-admin fabric-admin
+COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-lighting-data-model-no-unique-id-app chip-lighting-data-model-no-unique-id-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/matter-network-manager-app matter-network-manager-app
 
 # Stage 3.1: Setup the Matter Python environment


### PR DESCRIPTION
chip-lighting-data-model-no-unique-id-app is needed by the TH for MCORE_FS_1_3, and MCORE_FS_1_4.

Fixes: https://github.com/CHIP-Specifications/chip-test-plans/issues/4511