### PR TITLE
Fix Darwin CI random failures.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -114,7 +114,6 @@ jobs:
                   mkdir -p /tmp/darwin/framework-tests
                   echo "This is a simple log" > /tmp/darwin/framework-tests/end_user_support_log.txt
                   ../../../out/debug/all-clusters-app/chip-all-clusters-app --interface-id -1 --end_user_support_log /tmp/darwin/framework-tests/end_user_support_log.txt > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
-                  ../../../out/debug/all-clusters-app/chip-all-clusters-app --interface-id -1 --dac_provider ../../../credentials/development/commissioner_dut/struct_cd_origin_pid_vid_correct/test_case_vector.json --product-id 32768 --discriminator 3839 --secured-device-port 5539 --KVS /tmp/chip-all-clusters-app-kvs2 > >(tee /tmp/darwin/framework-tests/all-cluster-app-origin-vid.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-origin-vid-err.log >&2) &
 
                   export TEST_RUNNER_ASAN_OPTIONS=__CURRENT_VALUE__:detect_stack_use_after_return=1
 

--- a/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
@@ -30,12 +30,10 @@
 
 static const uint16_t kLocalPort = 5541;
 static const uint16_t kTestVendorId = 0xFFF1u;
-static const uint16_t kTestProductId1 = 0x8000u;
-static const uint16_t kTestProductId2 = 0x8001u;
-static const uint16_t kTestDiscriminator1 = 3840u;
-static const uint16_t kTestDiscriminator2 = 3839u;
+static const __auto_type kTestProductIds = @[ @(0x8001u) ];
+static const __auto_type kTestDiscriminators = @[ @(3840u) ];
 static const uint16_t kDiscoverDeviceTimeoutInSeconds = 10;
-static const uint16_t kExpectedDiscoveredDevicesCount = 2;
+static const uint16_t kExpectedDiscoveredDevicesCount = 1;
 
 // Singleton controller we use.
 static MTRDeviceController * sController = nil;
@@ -96,8 +94,8 @@ static MTRDeviceController * sController = nil;
 
     XCTAssertEqual(instanceName.length, 16); // The  instance name is random, so just ensure the len is right.
     XCTAssertEqualObjects(vendorId, @(kTestVendorId));
-    XCTAssertTrue([productId isEqual:@(kTestProductId1)] || [productId isEqual:@(kTestProductId2)]);
-    XCTAssertTrue([discriminator isEqual:@(kTestDiscriminator1)] || [discriminator isEqual:@(kTestDiscriminator2)]);
+    XCTAssertTrue([kTestProductIds containsObject:productId]);
+    XCTAssertTrue([kTestDiscriminators containsObject:discriminator]);
     XCTAssertEqual(commissioningMode, YES);
 
     NSLog(@"Found Device (%@) with discriminator: %@ (vendor: %@, product: %@)", instanceName, discriminator, vendorId, productId);

--- a/src/darwin/Framework/CHIPTests/MTRSwiftPairingTests.swift
+++ b/src/darwin/Framework/CHIPTests/MTRSwiftPairingTests.swift
@@ -1,12 +1,15 @@
 import Matter
 import XCTest
 
-// This more or less parallels the "no delegate" case in MTRPairingTests
+// This more or less parallels the "no delegate" case in MTRPairingTests, but uses the "normal"
+// all-clusters-app, since it does not do any of the "interesting" VID/PID notification so far.  If
+// it ever starts needing to do that, we should figure out a way to use MTRTestServerAppRunner from
+// here.
 
 struct PairingConstants {
     static let localPort = 5541
     static let vendorID = 0xFFF1
-    static let onboardingPayload = "MT:Y.K90SO527JA0648G00"
+    static let onboardingPayload = "MT:-24J0AFN00KA0648G00"
     static let deviceID = 0x12344321
     static let timeoutInSeconds : UInt16 = 3
 }

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
@@ -32,10 +32,6 @@
 #endif // HAVE_NSTASK
 }
 
-/**
- * Unfortunately, doing this in "+ (void)tearDown" (the global suite teardown)
- * does not trigger a test failure even if the XCTAssertEqual fails.
- */
 - (void)tearDown
 {
 #if defined(ENABLE_LEAK_DETECTION) && ENABLE_LEAK_DETECTION
@@ -43,12 +39,17 @@
         int pid = getpid();
         __auto_type * cmd = [NSString stringWithFormat:@"leaks %d", pid];
         int ret = system(cmd.UTF8String);
+        /**
+         * Unfortunately, doing this in "+ (void)tearDown" (the global suite teardown)
+         * does not trigger a test failure even if the XCTAssertEqual fails.
+         */
         XCTAssertEqual(ret, 0, "LEAKS DETECTED");
     }
 #endif
 
 #if HAVE_NSTASK
     for (NSTask * task in _runningTasks) {
+        NSLog(@"Terminating task %@", task);
         [task terminate];
     }
     _runningTasks = nil;

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestServerAppRunner.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestServerAppRunner.m
@@ -92,7 +92,7 @@ static const uint16_t kBasePort = 5542 - kMinDiscriminator;
 
     [testcase launchTask:_appTask];
 
-    NSLog(@"Started chip-%@-app with arguments %@ stdout=%@ and stderr=%@", name, allArguments, outFile, errorFile);
+    NSLog(@"Started chip-%@-app (%@) with arguments %@ stdout=%@ and stderr=%@", name, _appTask, allArguments, outFile, errorFile);
 
     return self;
 #endif // HAVE_NSTASK


### PR DESCRIPTION
We were starting an example app up front, then commissioning it when the test ran, but sometimes that takes longer than 15 minutes.

The fix is to start example apps as needed as parts of the pairing tests that need them.

The logging changes in MTRTestCase and MTRTestServerAppRunner are from trying to figure out why things were not being torn down right.  That's also what the added super-calls for setUp and tearDown fix.
