### PR TITLE
[ESP32] Add a configurable device type for commissionable advertising.

### DIFF
--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -209,6 +209,11 @@ FACTORY_DATA = {
         'encoding': 'string',
         'value': None,
     },
+    'device-type': {
+        'type': 'data',
+        'encoding': 'u32',
+        'value': None,
+    },
 }
 
 
@@ -372,6 +377,8 @@ def populate_factory_data(args, spake2p_params):
         FACTORY_DATA['product-url']['value'] = args.product_url
     if args.product_label:
         FACTORY_DATA['product-label']['value'] = args.product_label
+    if args.device_type  is not None:
+        FACTORY_DATA['device-type']['value'] = args.device_type
 
     # SupportedModes are stored as multiple entries
     #  - sm-sz/<ep>                 : number of supported modes for the endpoint
@@ -553,6 +560,8 @@ def get_args():
     parser.add_argument("--part-number", type=str, help='human readable product number')
     parser.add_argument("--product-label", type=str, help='human readable product label')
     parser.add_argument("--product-url", type=str, help='link to product specific web page')
+
+    parser.add_argument("--device-type", type=any_base_int, help='commissionable device type')
 
     parser.add_argument('-s', '--size', type=any_base_int, default=0x6000,
                         help='The size of the partition.bin, default: 0x6000')

--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -377,7 +377,7 @@ def populate_factory_data(args, spake2p_params):
         FACTORY_DATA['product-url']['value'] = args.product_url
     if args.product_label:
         FACTORY_DATA['product-label']['value'] = args.product_label
-    if args.device_type  is not None:
+    if args.device_type is not None:
         FACTORY_DATA['device-type']['value'] = args.device_type
 
     # SupportedModes are stored as multiple entries

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -271,24 +271,19 @@ CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
 
 CHIP_ERROR ConfigurationManagerImpl::GetDeviceTypeId(uint32_t & deviceType)
 {
-#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONABLE_DEVICE_TYPE
     uint32_t value = 0;
     CHIP_ERROR err = ReadConfigValue(ESP32Config::kConfigKey_PrimaryDeviceType, value);
 
-    if (err == CHIP_NO_ERROR)
-    {
-        deviceType = value;
-    }
-    else
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
     {
         deviceType = CHIP_DEVICE_CONFIG_DEVICE_TYPE;
     }
+    else
+    {
+        deviceType = value;
+    }
 
-    return err;
-#else
-    deviceType = 0;
     return CHIP_NO_ERROR;
-#endif // CONFIG_ENABLE_ESP32_LOCATIONCAPABILITY
 }
 
 CHIP_ERROR ConfigurationManagerImpl::StoreCountryCode(const char * code, size_t codeLen)

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -269,6 +269,28 @@ CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
 #endif // CONFIG_ENABLE_ESP32_LOCATIONCAPABILITY
 }
 
+CHIP_ERROR ConfigurationManagerImpl::GetDeviceTypeId(uint32_t & deviceType)
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONABLE_DEVICE_TYPE
+    uint32_t value = 0;
+    CHIP_ERROR err = ReadConfigValue(ESP32Config::kConfigKey_PrimaryDeviceType, value);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        deviceType = value;
+    }
+    else
+    {
+        deviceType = CHIP_DEVICE_CONFIG_DEVICE_TYPE;
+    }
+
+    return err;
+#else
+    deviceType = 0;
+    return CHIP_NO_ERROR;
+#endif // CONFIG_ENABLE_ESP32_LOCATIONCAPABILITY
+}
+
 CHIP_ERROR ConfigurationManagerImpl::StoreCountryCode(const char * code, size_t codeLen)
 {
     // As per spec, codeLen has to be 2

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -58,6 +58,7 @@ public:
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize);
     CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override;
     CHIP_ERROR GetLocationCapability(uint8_t & location) override;
+    CHIP_ERROR GetDeviceTypeId(uint32_t & deviceType) override;
     static ConfigurationManagerImpl & GetDefaultInstance();
 
     // Set the country code to esp_phy layer and also store it to NVS

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -81,6 +81,7 @@ const ESP32Config::Key ESP32Config::kConfigKey_ProductFinish         = { kConfig
 const ESP32Config::Key ESP32Config::kConfigKey_ProductColor          = { kConfigNamespace_ChipFactory, "product-color" };
 const ESP32Config::Key ESP32Config::kConfigKey_PartNumber            = { kConfigNamespace_ChipFactory, "part-number" };
 const ESP32Config::Key ESP32Config::kConfigKey_LocationCapability    = { kConfigNamespace_ChipFactory, "loc-capability" };
+const ESP32Config::Key ESP32Config::kConfigKey_PrimaryDeviceType     = { kConfigNamespace_ChipFactory, "device-type" };
 
 // Keys stored in the chip-config namespace
 const ESP32Config::Key ESP32Config::kConfigKey_ServiceConfig      = { kConfigNamespace_ChipConfig, "service-config" };

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -83,6 +83,7 @@ public:
     static const Key kConfigKey_ProductFinish;
     static const Key kConfigKey_ProductColor;
     static const Key kConfigKey_LocationCapability;
+    static const Key kConfigKey_PrimaryDeviceType;
 
     // CHIP Config keys
     static const Key kConfigKey_ServiceConfig;


### PR DESCRIPTION
For matter certify test case TC-SC-4.1, step 7, if we support advertise the device type when the commissioning window opened, we should provide the DUT's primary device type. 

So add the interface in esp32 to config the correct primary device type in flash. 

And update the generate_esp32_chip_factory_bin.py  tool to specify the device when generate the factory.bin.