### PR TITLE
Test: TC-CNET-4-23 for switching network interface

### DIFF
--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -759,8 +759,7 @@ PyChipError pychip_DeviceController_EstablishPASESession(chip::Controller::Devic
 
 PyChipError pychip_DeviceController_Commission(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid)
 {
-    CommissioningParameters params;
-    return ToPyChipError(devCtrl->Commission(nodeid, params));
+    return ToPyChipError(devCtrl->Commission(nodeid, sCommissioningParameters));
 }
 
 PyChipError pychip_ScriptDevicePairingDelegate_SetOpenWindowCompleteCallback(

--- a/src/python_testing/TC_CNET_4_23.py
+++ b/src/python_testing/TC_CNET_4_23.py
@@ -112,9 +112,9 @@ class TC_CNET_4_23(MatterBaseTest):
         for endpoint, value in feature_map_response.items():
             feature_dict = value.get(Clusters.Objects.NetworkCommissioning, {})
             feature_map = feature_dict.get(Clusters.Objects.NetworkCommissioning.Attributes.FeatureMap, None)
-            if feature_map == kWiFiFeature:
+            if bool(feature_map & Clusters.NetworkCommissioning.Bitmaps.Feature.kWiFiNetworkInterface):
                 wifi_endpoint = endpoint
-            elif feature_map == kThreadFeature:
+            elif bool(feature_map & Clusters.NetworkCommissioning.Bitmaps.Feature.kThreadNetworkInterface):
                 thread_endpoint = endpoint
             else:
                 continue

--- a/src/python_testing/TC_CNET_4_23.py
+++ b/src/python_testing/TC_CNET_4_23.py
@@ -1,0 +1,221 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import logging
+import time
+
+import chip.clusters as Clusters
+from chip.exceptions import ChipStackError
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+
+kRootEndpointId = 0
+kInvalidEndpointId = 0xFFFF
+kWiFiFeature = 1
+kThreadFeature = 2
+kExpiryLengthSeconds = 900
+kChipErrorTimeout = 0x32
+kMaxCommissioningCompleteRetryTimes = 5
+
+
+class TC_CNET_4_23(MatterBaseTest):
+    """
+    [TC-CNET-4.23] [Wi-Fi and Thread] Verification for network interface switching between Wi-Fi and Thread [DUT-Server].
+    Example Usage:
+        To run the test case, use the following command:
+        ```bash
+        python src/python_testing/TC_CNET_4_23.py --commissioning-method ble-wifi -discriminator <discriminator> -passcode <passcode> \
+               --wifi-ssid <wifi_ssid> --wifi-passphrase <wifi_credentials> --hex-arg PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET:<thread_dataset>
+        ```
+        Where `<dataset_value>` should be replaced with the Thread Operational Dataset
+    """
+
+    def steps_TC_CNET_4_23(self):
+        return [TestStep("precondition", "TH is commissioned", is_commissioning=True),
+                TestStep(1, 'TH sends ArmFailSafe command to the DUT with ExpiryLengthSeconds set to 900. Verify that DUT sends ArmFailSafeResponse command to the TH'),
+                TestStep(2, 'TH reads Networks attribute on endpoint PIXIT.CNET.ENDPOINT_WIFI from the DUT. Verify that the Networks attribute list has an entry with the following fields: network_id matches the bytes in PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID, Connected is of type bool and is TRUE'),
+                TestStep(3, 'TH finds the index of the Networks list entry with network_id for PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID and saves it as `Userwifi_netidx`'),
+                TestStep(4, 'TH sends RemoveNetwork Command to the DUT PIXIT.CNET.ENDPOINT_WIFI endpoint with network_id field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID. Verify that DUT sends NetworkConfigResponse to command with the following fields: NetworkingStatus is Success, NetworkIndex matches previously saved `Userwifi_netidx`'),
+                TestStep(5, 'TH sends AddOrUpdateThreadNetwork command to the DUT PIXIT.CNET.ENDPOINT_THREAD endpoint with operational dataset field set to PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET. Verify that DUT sends the NetworkConfigResponse command to the TH with the following fields: NetworkingStatus is Success, DebugText is of type string with max length 512 or empty'),
+                TestStep(6, 'TH reads Networks attribute from the DUT PIXIT.CNET.ENDPOINT_THREAD endpoint. Verify that the Networks attribute list has an entry with the following fields: network_id is the extended PAN ID of PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET, Connected is of type bool and is FALSE'),
+                TestStep(7, 'TH sends ConnectNetwork command to the DUT PIXIT.CNET.ENDPOINT_THREAD endpoint with network_id field set to the extended PAN ID of PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET'),
+                TestStep(8, 'TH sends the CommissioningComplete command to the DUT. Verify that DUT sends CommissioningCompleteResponse with the ErrorCode field set to OK'),
+                TestStep(9, 'TH reads Networks attribute from the DUT PIXIT.CNET.ENDPOINT_THREAD endpoint. Verify that the Networks attribute list has an entry with the following values: network_id is the extended PAN ID of PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET, Connected is of type bool and is TRUE. TH saves the index of the Networks list entry as `Userth_netidx`'),
+                TestStep(10, 'TH sends ArmFailSafe command to the DUT with ExpiryLengthSeconds set to 900| Verify that DUT sends ArmFailSafeResponse command to the TH'),
+                TestStep(11, 'TH sends RemoveNetwork Command to the DUT PIXIT.CNET.ENDPOINT_THREAD endpoint with network_id field set to the extended PAN ID of PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET. Verify that DUT sends NetworkConfigResponse to command with the following response fields: NetworkingStatus is Success, NetworkIndex is `Userth_netidx`'),
+                TestStep(12, 'TH sends AddOrUpdateWiFiNetwork command to the DUT PIXIT.CNET.ENDPOINT_WIFI endpoint with SSID field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID, Credentials field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_CREDENTIALS. Verify that DUT sends the NetworkConfigResponse command to the TH with the following response fields: NetworkingStatus is Success, DebugText is of type string with max length 512 or empty'),
+                TestStep(13, 'TH sends ConnectNetwork command to the DUT PIXIT.CNET.ENDPOINT_WIFI endpoint with network_id field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID'),
+                TestStep(14, 'TH sends the CommissioningComplete command to the DUT. Verify that DUT sends CommissioningCompleteResponse with the ErrorCode field set to OK'),
+                TestStep(15, 'TH reads Networks attribute from the DUT PIXIT.CNET.ENDPOINT_WIFI endpoint. Verify that the Networks attribute list has an entry with the following fields: network_id matches the bytes in PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID, Connected is of type bool and is TRUE')]
+
+    def def_TC_CNET_4_23(self):
+        return '[TC-CNET-4.23] Verification for network interface switching between Wi-Fi and Thread [DUT-Server]'
+
+    def pics_TC_CNET_4_23(self):
+        return ["CNET.S.F00", "CNET.S.F01"]
+
+    # Override default timeout.
+    @property
+    def default_timeout(self) -> int:
+        return 200
+
+    async def SendConnectNetworkWithFailure(
+            self, networkID: int, endpoint: int):
+        try:
+            cmd = Clusters.NetworkCommissioning.Commands.ConnectNetwork(networkID=networkID)
+            await self.send_single_cmd(endpoint=endpoint, cmd=cmd)
+        except ChipStackError as e:
+            asserts.assert_equal(e.err, kChipErrorTimeout, "Unexpected error while trying to send ConnectNetwork command")
+            logging.exception(e)
+
+    async def SendCommissioningCompleteWithRetry(self):
+        commissioning_complete_cmd = Clusters.GeneralCommissioning.Commands.CommissioningComplete()
+        # After switching networks, it may resolve to an incorrect address. Implement a retry mechanism for failure recovery.
+        for i in range(kMaxCommissioningCompleteRetryTimes):
+            try:
+                commissioning_complete_results = await self.send_single_cmd(cmd=commissioning_complete_cmd)
+                asserts.assert_true(commissioning_complete_results.errorCode ==
+                                    Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk, "CommissioningComplete command failed")
+                break
+            except ChipStackError as e:
+                asserts.assert_equal(e.err, kChipErrorTimeout, "Unexpected error while trying to send CommissioningComplete")
+                time.sleep(10)
+                logging.exception(e)
+        else:
+            asserts.assert_true(False, "CommissioningComplete command failed")
+
+    @async_test_body
+    async def test_TC_CNET_4_23(self):
+        asserts.assert_true('PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET' in self.matter_test_config.global_test_params,
+                            "PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET must be included on the command line in "
+                            "the --hex-arg flag as PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET:<thread dataset in hex>")
+        self.step("precondition")
+        wifi_ssid = self.get_wifi_ssid().encode("utf-8")
+        wifi_credential = self.get_credentials().encode("utf-8")
+
+        feature_map_response = await self.default_controller.ReadAttribute(self.dut_node_id, [(Clusters.NetworkCommissioning.Attributes.FeatureMap)], fabricFiltered=True)
+        wifi_endpoint = kInvalidEndpointId
+        thread_endpoint = kInvalidEndpointId
+        for endpoint, value in feature_map_response.items():
+            feature_dict = value.get(Clusters.Objects.NetworkCommissioning, {})
+            feature_map = feature_dict.get(Clusters.Objects.NetworkCommissioning.Attributes.FeatureMap, None)
+            if feature_map == kWiFiFeature:
+                wifi_endpoint = endpoint
+            elif feature_map == kThreadFeature:
+                thread_endpoint = endpoint
+            else:
+                continue
+        if wifi_endpoint == kInvalidEndpointId or thread_endpoint == kInvalidEndpointId:
+            logging.info('Should support both Wi-Fi and Thread, skipping remaining steps')
+            self.skip_all_remaining_steps(1)
+            return
+
+        operational_dataset = self.matter_test_config.global_test_params['PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET']
+
+        self.step(1)
+        arm_failsafe_cmd = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=kExpiryLengthSeconds)
+        arm_fail_safe_results = await self.send_single_cmd(cmd=arm_failsafe_cmd)
+        asserts.assert_true(arm_fail_safe_results.errorCode ==
+                            Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk, "ArmFailSafe command failed")
+
+        self.step(2)
+        networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
+                                                                           attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=wifi_endpoint)
+        self.step(3)
+        index = 0
+        Userwifi_netidx = 0
+        verification = False
+        for network_info in networks_response:
+            if network_info.connected and network_info.networkID == wifi_ssid:
+                Userwifi_netidx = index
+                verification = True
+            index += 1
+        asserts.assert_true(verification, "There is no correct entry in Networks attribute list")
+
+        self.step(4)
+        remove_network_cmd = Clusters.NetworkCommissioning.Commands.RemoveNetwork(networkID=wifi_ssid)
+        remove_network_results = await self.send_single_cmd(endpoint=wifi_endpoint, cmd=remove_network_cmd)
+        asserts.assert_true(remove_network_results.networkIndex == Userwifi_netidx and remove_network_results.networkingStatus ==
+                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "RemoveNetwork command failed")
+
+        self.step(5)
+        add_thread_network_cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateThreadNetwork(
+            operationalDataset=operational_dataset)
+        add_network_results = await self.send_single_cmd(endpoint=thread_endpoint, cmd=add_thread_network_cmd)
+        asserts.assert_true(add_network_results.networkingStatus ==
+                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateNetwork command failed")
+
+        self.step(6)
+        networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
+                                                                           attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=thread_endpoint)
+
+        thread_extend_panid = None
+        for network in networks_response:
+            thread_extend_panid = network.networkID
+        asserts.assert_false(thread_extend_panid is None, "There is no networkID in Networks attribute")
+
+        self.step(7)
+        await self.SendConnectNetworkWithFailure(networkID=thread_extend_panid, endpoint=thread_endpoint)
+
+        self.step(8)
+        await self.SendCommissioningCompleteWithRetry()
+
+        self.step(9)
+        networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
+                                                                           attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=thread_endpoint)
+        verification = False
+        for network_info in networks_response:
+            if network_info.connected and network_info.networkID == thread_extend_panid:
+                verification = True
+        asserts.assert_true(verification, "There is no correct entry in Networks attribute list")
+
+        self.step(10)
+        arm_fail_safe_results = await self.send_single_cmd(cmd=arm_failsafe_cmd)
+        asserts.assert_true(arm_fail_safe_results.errorCode ==
+                            Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk, "ArmFailSafe command failed")
+
+        self.step(11)
+        remove_network_cmd = Clusters.NetworkCommissioning.Commands.RemoveNetwork(networkID=thread_extend_panid)
+        remove_network_results = await self.send_single_cmd(endpoint=thread_endpoint, cmd=remove_network_cmd)
+        asserts.assert_true(remove_network_results.networkingStatus ==
+                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "RemoveNetwork command failed")
+
+        self.step(12)
+        add_wifi_network_cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateWiFiNetwork(
+            ssid=wifi_ssid, credentials=wifi_credential)
+        add_network_results = await self.send_single_cmd(endpoint=wifi_endpoint, cmd=add_wifi_network_cmd)
+        asserts.assert_true(add_network_results.networkingStatus ==
+                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateNetwork command failed")
+
+        self.step(13)
+        await self.SendConnectNetworkWithFailure(networkID=wifi_ssid, endpoint=wifi_endpoint)
+
+        self.step(14)
+        await self.SendCommissioningCompleteWithRetry()
+
+        self.step(15)
+        networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
+                                                                           attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=wifi_endpoint)
+        verification = False
+        for network_info in networks_response:
+            if network_info.connected and network_info.networkID == wifi_ssid:
+                verification = True
+        asserts.assert_true(verification, "There is no correct entry in Networks attribute list")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_CNET_4_23.py
+++ b/src/python_testing/TC_CNET_4_23.py
@@ -38,35 +38,71 @@ class TC_CNET_4_23(MatterBaseTest):
     Example Usage:
         To run the test case, use the following command:
         ```bash
-        python src/python_testing/TC_CNET_4_23.py --commissioning-method ble-wifi -discriminator <discriminator> -passcode <passcode> \
-               --wifi-ssid <wifi_ssid> --wifi-passphrase <wifi_credentials> --hex-arg PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET:<thread_dataset>
+        python src/python_testing/TC_CNET_4_23.py --discriminator <discriminator> --passcode <passcode> \
+               --endpoint <endpoint_value> \
+               --string-arg PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID:<wifi_ssid> \
+               --string-arg PIXIT.CNET.WIFI_1ST_ACCESSPOINT_CREDENTIALS:<wifi_credentials> \
+               --string-arg PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET:<thread_dataset>
         ```
-        Where `<dataset_value>` should be replaced with the Thread Operational Dataset
+        Where `<endpoint_value>` should be replaced with the actual endpoint
+        number under test for the Network Commissioning cluster on the DUT.
     """
 
     def steps_TC_CNET_4_23(self):
-        return [TestStep("precondition", "TH is commissioned", is_commissioning=True),
-                TestStep(1, 'TH sends ArmFailSafe command to the DUT with ExpiryLengthSeconds set to 900. Verify that DUT sends ArmFailSafeResponse command to the TH'),
-                TestStep(2, 'TH reads Networks attribute on endpoint PIXIT.CNET.ENDPOINT_WIFI from the DUT. Verify that the Networks attribute list has an entry with the following fields: network_id matches the bytes in PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID, Connected is of type bool and is TRUE'),
-                TestStep(3, 'TH finds the index of the Networks list entry with network_id for PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID and saves it as `Userwifi_netidx`'),
-                TestStep(4, 'TH sends RemoveNetwork Command to the DUT PIXIT.CNET.ENDPOINT_WIFI endpoint with network_id field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID. Verify that DUT sends NetworkConfigResponse to command with the following fields: NetworkingStatus is Success, NetworkIndex matches previously saved `Userwifi_netidx`'),
-                TestStep(5, 'TH sends AddOrUpdateThreadNetwork command to the DUT PIXIT.CNET.ENDPOINT_THREAD endpoint with operational dataset field set to PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET. Verify that DUT sends the NetworkConfigResponse command to the TH with the following fields: NetworkingStatus is Success, DebugText is of type string with max length 512 or empty'),
-                TestStep(6, 'TH reads Networks attribute from the DUT PIXIT.CNET.ENDPOINT_THREAD endpoint. Verify that the Networks attribute list has an entry with the following fields: network_id is the extended PAN ID of PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET, Connected is of type bool and is FALSE'),
-                TestStep(7, 'TH sends ConnectNetwork command to the DUT PIXIT.CNET.ENDPOINT_THREAD endpoint with network_id field set to the extended PAN ID of PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET'),
-                TestStep(8, 'TH sends the CommissioningComplete command to the DUT. Verify that DUT sends CommissioningCompleteResponse with the ErrorCode field set to OK'),
-                TestStep(9, 'TH reads Networks attribute from the DUT PIXIT.CNET.ENDPOINT_THREAD endpoint. Verify that the Networks attribute list has an entry with the following values: network_id is the extended PAN ID of PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET, Connected is of type bool and is TRUE. TH saves the index of the Networks list entry as `Userth_netidx`'),
-                TestStep(10, 'TH sends ArmFailSafe command to the DUT with ExpiryLengthSeconds set to 900| Verify that DUT sends ArmFailSafeResponse command to the TH'),
-                TestStep(11, 'TH sends RemoveNetwork Command to the DUT PIXIT.CNET.ENDPOINT_THREAD endpoint with network_id field set to the extended PAN ID of PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET. Verify that DUT sends NetworkConfigResponse to command with the following response fields: NetworkingStatus is Success, NetworkIndex is `Userth_netidx`'),
-                TestStep(12, 'TH sends AddOrUpdateWiFiNetwork command to the DUT PIXIT.CNET.ENDPOINT_WIFI endpoint with SSID field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID, Credentials field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_CREDENTIALS. Verify that DUT sends the NetworkConfigResponse command to the TH with the following response fields: NetworkingStatus is Success, DebugText is of type string with max length 512 or empty'),
-                TestStep(13, 'TH sends ConnectNetwork command to the DUT PIXIT.CNET.ENDPOINT_WIFI endpoint with network_id field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID'),
-                TestStep(14, 'TH sends the CommissioningComplete command to the DUT. Verify that DUT sends CommissioningCompleteResponse with the ErrorCode field set to OK'),
-                TestStep(15, 'TH reads Networks attribute from the DUT PIXIT.CNET.ENDPOINT_WIFI endpoint. Verify that the Networks attribute list has an entry with the following fields: network_id matches the bytes in PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID, Connected is of type bool and is TRUE')]
+        return [TestStep("precondition", "DUT is not commissioned and is in commissioning mode ", is_commissioning=False),
+                TestStep(1, 'TH establishes a PASE session with the DUT over BLE. Verify that the PASE session is established successfully'),
+                TestStep(2, 'TH reads the Network Commissioning Cluster FeatureMap from the DUT on all available endpoints. '
+                            'Store the response as `FeatureMapResponse'),
+                TestStep(3, 'If `FeatureMapResponse` does not include the endpoint with WI flag (bit 0) and the endpoint with TH flag (bit 1), skip the remaining steps'),
+                TestStep(4, 'If the endpoint under test is PIXIT.CNET.ENDPOINT_WIFI, set `commissioning_network` to "Wi-Fi", `network_id` to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID, and `operating_endpoint_id` to PIXIT.CNET.ENDPOINT_WIFI. '
+                            'If current endpoint is PIXIT.CNET.ENDPOINT_THREAD, set `commissioning_network` to "Thread", `network_id` to th_xpan_1, and `operating_endpoint_id` to PIXIT.CNET.ENDPOINT_THREAD. '
+                            'Otherwise, skip the remaining steps'),
+                TestStep(5, 'TH commissions the DUT over the selected `commissioning_network`. '
+                            'Verify that the DUT is commissioned'),
+                TestStep(6, 'TH sends ArmFailSafe command to the DUT with ExpiryLengthSeconds set to 900. '
+                            'Verify that DUT sends ArmFailSafeResponse command to the TH'),
+                TestStep(7, 'TH reads Networks attribute on `operating_endpoint_id` endpoint from the DUT. '
+                            'Verify that the Networks attribute list has an entry with the following fields: NetworkID matches `network_id` in bytes, Connected is of type bool and is TRUE. '
+                            'Save the index of the Networks list entry as `network_index`'),
+                TestStep(8, 'TH sends RemoveNetwork Command to the DUT `operating_endpoint_id` endpoint with NetworkID field set to `network_id`. '
+                            'Verify that DUT sends NetworkConfigResponse to command with the following fields: NetworkingStatus is Success, NetworkIndex matches previously saved `network_index`'),
+                TestStep(9, 'If `commissioning_network` is "Wi-Fi", set `network_id` to th_xpan_1 and `operating_endpoint_id` to PIXIT.CNET.ENDPOINT_THREAD, '
+                             'otherwise set `network_id` to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID and `operating_endpoint_id` to PIXIT.CNET.ENDPOINT_WIFI. '
+                             'If `commissioning_network` is "Thread", skip step 10a'),
+                TestStep("10a", 'TH sends AddOrUpdateThreadNetwork command to the DUT `operating_endpoint_id` endpoint with operational dataset field set to PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET. '
+                                'Skip step 10b. '
+                                'Verify that DUT sends the NetworkConfigResponse command to the TH with the following fields: NetworkingStatus is Success, DebugText is of type string with max length 512 or empty'),
+                TestStep("10b", 'TH sends AddOrUpdateWiFiNetwork command to the DUT `operating_endpoint_id` endpoint with SSID field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID, Credentials field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_CREDENTIALS. '
+                                'Verify that DUT sends the NetworkConfigResponse command to the TH with the following fields: NetworkingStatus is Success, DebugText is of type string with max length 512 or empty'),
+                TestStep(11, 'TH sends ConnectNetwork command to the DUT `operating_endpoint_id` endpoint with NetworkID field set to `network_id`'),
+                TestStep(12, 'TH sends the CommissioningComplete command to the DUT. '
+                             'Verify that DUT sends CommissioningCompleteResponse with the ErrorCode field set to OK'),
+                TestStep(13, 'TH reads Networks attribute from the DUT `operating_endpoint_id` endpoint. '
+                             'Verify that the Networks attribute list has an entry with the following values: NetworkID matches `network_id` in bytes, Connected is of type bool and is TRUE. '
+                             'Save the index of the Networks list entry as `network_index`'),
+                TestStep(14, 'TH sends ArmFailSafe command to the DUT with ExpiryLengthSeconds set to 900. '
+                             'Verify that DUT sends ArmFailSafeResponse command to the TH'),
+                TestStep(15, 'TH sends RemoveNetwork Command to the DUT `operating_endpoint_id` endpoint with NetworkID field set to `network_id`. '
+                             'Verify that DUT sends NetworkConfigResponse to command with the following response fields: NetworkingStatus is Success, NetworkIndex is `network_index`'),
+                TestStep(16, 'If `commissioning_network` is "Wi-Fi", set `network_id` to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID and `operating_endpoint_id` to PIXIT.CNET.ENDPOINT_WIFI, '
+                             'otherwise set `network_id` to th_xpan_1 and `operating_endpoint_id` to PIXIT.CNET.ENDPOINT_THREAD. '
+                             'If `commissioning_network` is "Thread", skip step 17a'),
+                TestStep("17a", 'TH sends AddOrUpdateWiFiNetwork command to the DUT `operating_endpoint_id` endpoint with SSID field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID, Credentials field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_CREDENTIALS. '
+                                'Skip step 17b. '
+                                'Verify that DUT sends the NetworkConfigResponse command to the TH with the following fields: NetworkingStatus is Success, DebugText is of type string with max length 512 or empty'),
+                TestStep("17b", 'TH sends AddOrUpdateThreadNetwork command to the DUT `operating_endpoint_id` endpoint with operational dataset field set to PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET. '
+                                'Verify that DUT sends the NetworkConfigResponse command to the TH with the following fields: NetworkingStatus is Success, DebugText is of type string with max length 512 or empty'),
+                TestStep(18, 'TH sends ConnectNetwork command to the DUT `operating_endpoint_id` endpoint with NetworkID field set to `network_id`'),
+                TestStep(19, 'TH sends the CommissioningComplete command to the DUT. '
+                             'Verify that DUT sends CommissioningCompleteResponse with the ErrorCode field set to OK'),
+                TestStep(20, 'TH reads Networks attribute from the DUT `operating_endpoint_id` endpoint. '
+                             'Verify that the Networks attribute list has an entry with the following fields: NetworkID matches `network_id` in bytes, Connected is of type bool and is TRUE')]
 
     def def_TC_CNET_4_23(self):
         return '[TC-CNET-4.23] Verification for network interface switching between Wi-Fi and Thread [DUT-Server]'
 
     def pics_TC_CNET_4_23(self):
-        return ["CNET.S.F00", "CNET.S.F01"]
+        return ["CNET.S"]
 
     # Override default timeout.
     @property
@@ -86,7 +122,7 @@ class TC_CNET_4_23(MatterBaseTest):
         # Implement a retry mechanism for timeout failure.
         for i in range(kMaxCommissioningCompleteRetryTimes):
             try:
-                commissioning_complete_results = await self.send_single_cmd(cmd=commissioning_complete_cmd)
+                commissioning_complete_results = await self.send_single_cmd(endpoint=kRootEndpointId, cmd=commissioning_complete_cmd)
                 asserts.assert_true(commissioning_complete_results.errorCode ==
                                     Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk, "CommissioningComplete command failed")
                 break
@@ -99,14 +135,43 @@ class TC_CNET_4_23(MatterBaseTest):
 
     @async_test_body
     async def test_TC_CNET_4_23(self):
-        asserts.assert_true('PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET' in self.matter_test_config.global_test_params,
-                            "PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET must be included on the command line in "
-                            "the --hex-arg flag as PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET:<thread dataset in hex>")
         self.step("precondition")
-        wifi_ssid = self.get_wifi_ssid().encode("utf-8")
-        wifi_credential = self.get_credentials().encode("utf-8")
+        test_endpoint = self.get_endpoint()
+        wifi_ssid_str = self.user_params.get('PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID')
+        wifi_credential_str = self.user_params.get('PIXIT.CNET.WIFI_1ST_ACCESSPOINT_CREDENTIALS')
+        operational_dataset_str = self.user_params.get('PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET')
 
+        asserts.assert_true(test_endpoint is not None, "Missing params: --endpoint <endpoint_value>")
+        asserts.assert_true(wifi_ssid_str is not None and isinstance(wifi_ssid_str, str), "Missing params: --string-arg PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID:<wifi_ssid>")
+        asserts.assert_true(wifi_credential_str is not None and isinstance(wifi_credential_str, str), "Missing params: --string-arg PIXIT.CNET.WIFI_1ST_ACCESSPOINT_CREDENTIALS:<wifi_credential>")
+        # TC_CNET_4_12.py sets Thread dataset as string-arg, keep consistent with that.
+        asserts.assert_true(operational_dataset_str is not None and isinstance(operational_dataset_str, str), "Missing params: --string-arg PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET:<thread_dataset>")
+
+        setup_payload = self.get_setup_payload_info()
+        if not setup_payload:
+            asserts.fail("Missing params: --discriminator <discriminator> --passcode <passcode>")
+
+        wifi_ssid = wifi_ssid_str.encode("utf-8")
+        wifi_credential = wifi_credential_str.encode("utf-8")
+        operational_dataset = bytes.fromhex(operational_dataset_str)
+
+        ext_pan_id_marker = b'\x02\x08'
+        marker_index = operational_dataset.find(ext_pan_id_marker)
+        asserts.assert_true(
+            marker_index != -1 and len(operational_dataset) >= marker_index + len(ext_pan_id_marker) + 8,
+            f"Could not find ExtPANID marker in PIXIT dataset or dataset too short in PIXIT bytes."
+        )
+        ext_pan_id_start = marker_index + len(ext_pan_id_marker)
+        th_xpan_1 = operational_dataset[ext_pan_id_start: ext_pan_id_start + 8]
+        asserts.assert_equal(len(th_xpan_1), 8, f"Extracted ExtPANID must be 8 bytes long.")
+
+        self.step(1)
+        await self.default_controller.EstablishPASESessionBLE(setup_payload[0].passcode, setup_payload[0].filter_value, self.dut_node_id);
+
+        self.step(2)
         feature_map_response = await self.default_controller.ReadAttribute(self.dut_node_id, [(Clusters.NetworkCommissioning.Attributes.FeatureMap)], fabricFiltered=True)
+
+        self.step(3)
         wifi_endpoint = kInvalidEndpointId
         thread_endpoint = kInvalidEndpointId
         for endpoint, value in feature_map_response.items():
@@ -120,99 +185,147 @@ class TC_CNET_4_23(MatterBaseTest):
                 continue
         if wifi_endpoint == kInvalidEndpointId or thread_endpoint == kInvalidEndpointId:
             logging.info('Should support both Wi-Fi and Thread, skipping remaining steps')
-            self.skip_all_remaining_steps(1)
+            self.mark_all_remaining_steps_skipped(4)
             return
 
-        operational_dataset = self.matter_test_config.global_test_params['PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET']
+        self.step(4)
+        commissioning_network = None
+        operating_endpoint_id = None
+        network_id = None
+        if wifi_endpoint == test_endpoint:
+            commissioning_network = "Wi-Fi"
+            network_id = wifi_ssid
+            operating_endpoint_id = wifi_endpoint
+            self.default_controller.SetWiFiCredentials(wifi_ssid.decode("utf-8"), wifi_credential.decode("utf-8"));
+        elif thread_endpoint == test_endpoint:
+            commissioning_network = "Thread"
+            network_id = th_xpan_1
+            operating_endpoint_id = thread_endpoint
+            self.default_controller.SetThreadOperationalDataset(operational_dataset)
+        else:
+            logging.info('Test endpoint should be PIXIT.CNET.ENDPOINT_WIFI or PIXIT.CNET.ENDPOINT_THREAD')
+            self.mark_all_remaining_steps_skipped(5)
+            return
 
-        self.step(1)
+        self.step(5)
+        await self.default_controller.Commission(self.dut_node_id)
+
+        self.step(6)
         arm_failsafe_cmd = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=kExpiryLengthSeconds)
-        arm_fail_safe_results = await self.send_single_cmd(cmd=arm_failsafe_cmd)
+        arm_fail_safe_results = await self.send_single_cmd(endpoint=kRootEndpointId, cmd=arm_failsafe_cmd)
         asserts.assert_true(arm_fail_safe_results.errorCode ==
                             Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk, "ArmFailSafe command failed")
 
-        self.step(2)
+        self.step(7)
         networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
-                                                                           attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=wifi_endpoint)
-        self.step(3)
+                                                                           attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=operating_endpoint_id)
         index = 0
-        Userwifi_netidx = 0
+        network_index = 0
         verification = False
         for network_info in networks_response:
-            if network_info.connected and network_info.networkID == wifi_ssid:
-                Userwifi_netidx = index
+            if network_info.connected and network_info.networkID == network_id:
+                network_index = index
                 verification = True
+                break
             index += 1
         asserts.assert_true(verification, "There is no correct entry in Networks attribute list")
 
-        self.step(4)
-        remove_network_cmd = Clusters.NetworkCommissioning.Commands.RemoveNetwork(networkID=wifi_ssid)
-        remove_network_results = await self.send_single_cmd(endpoint=wifi_endpoint, cmd=remove_network_cmd)
-        asserts.assert_true(remove_network_results.networkIndex == Userwifi_netidx and remove_network_results.networkingStatus ==
+        self.step(8)
+        remove_network_cmd = Clusters.NetworkCommissioning.Commands.RemoveNetwork(networkID=network_id)
+        remove_network_results = await self.send_single_cmd(endpoint=operating_endpoint_id, cmd=remove_network_cmd)
+        asserts.assert_true(remove_network_results.networkIndex == network_index and remove_network_results.networkingStatus ==
                             Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "RemoveNetwork command failed")
 
-        self.step(5)
-        add_thread_network_cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateThreadNetwork(
-            operationalDataset=operational_dataset)
-        add_network_results = await self.send_single_cmd(endpoint=thread_endpoint, cmd=add_thread_network_cmd)
-        asserts.assert_true(add_network_results.networkingStatus ==
-                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateNetwork command failed")
+        self.step(9)
+        if commissioning_network == "Wi-Fi":
+            operating_endpoint_id = thread_endpoint
+            network_id = th_xpan_1
+        else:
+            operating_endpoint_id = wifi_endpoint
+            network_id = wifi_ssid
 
-        self.step(6)
-        networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
-                                                                           attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=thread_endpoint)
+        if commissioning_network == "Wi-Fi":
+            self.step("10a")
+            cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateThreadNetwork(operationalDataset=operational_dataset)
+            add_network_results = await self.send_single_cmd(endpoint=operating_endpoint_id, cmd=cmd)
+            asserts.assert_true(add_network_results.networkingStatus ==
+                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateThreadNetwork command failed")
+            self.skip_step("10b")
+        else:
+            self.skip_step("10a")
+            self.step("10b")
+            cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateWiFiNetwork(ssid=wifi_ssid, credentials=wifi_credential)
+            add_network_results = await self.send_single_cmd(endpoint=operating_endpoint_id, cmd=cmd)
+            asserts.assert_true(add_network_results.networkingStatus ==
+                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateWiFiNetwork command failed")
 
-        thread_extend_panid = None
-        for network in networks_response:
-            thread_extend_panid = network.networkID
-        asserts.assert_false(thread_extend_panid is None, "There is no networkID in Networks attribute")
+        self.step(11)
+        await self.SendConnectNetworkWithFailure(networkID=network_id, endpoint=operating_endpoint_id)
 
-        self.step(7)
-        await self.SendConnectNetworkWithFailure(networkID=thread_extend_panid, endpoint=thread_endpoint)
-
-        self.step(8)
+        self.step(12)
         await self.SendCommissioningCompleteWithRetry()
 
-        self.step(9)
+        self.step(13)
         networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
-                                                                           attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=thread_endpoint)
+                                                                           attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=operating_endpoint_id)
         verification = False
+        index = 0
         for network_info in networks_response:
-            if network_info.connected and network_info.networkID == thread_extend_panid:
+            if network_info.connected and network_info.networkID == network_id:
+                network_index = index
                 verification = True
+                break
+            index += 1
         asserts.assert_true(verification, "There is no correct entry in Networks attribute list")
 
-        self.step(10)
-        arm_fail_safe_results = await self.send_single_cmd(cmd=arm_failsafe_cmd)
+        self.step(14)
+        arm_fail_safe_results = await self.send_single_cmd(endpoint=kRootEndpointId, cmd=arm_failsafe_cmd)
         asserts.assert_true(arm_fail_safe_results.errorCode ==
                             Clusters.GeneralCommissioning.Enums.CommissioningErrorEnum.kOk, "ArmFailSafe command failed")
 
-        self.step(11)
-        remove_network_cmd = Clusters.NetworkCommissioning.Commands.RemoveNetwork(networkID=thread_extend_panid)
-        remove_network_results = await self.send_single_cmd(endpoint=thread_endpoint, cmd=remove_network_cmd)
-        asserts.assert_true(remove_network_results.networkingStatus ==
+        self.step(15)
+        cmd = Clusters.NetworkCommissioning.Commands.RemoveNetwork(networkID=network_id)
+        remove_network_results = await self.send_single_cmd(endpoint=operating_endpoint_id, cmd=cmd)
+        asserts.assert_true(remove_network_results.networkIndex == network_index and remove_network_results.networkingStatus ==
                             Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "RemoveNetwork command failed")
 
-        self.step(12)
-        add_wifi_network_cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateWiFiNetwork(
-            ssid=wifi_ssid, credentials=wifi_credential)
-        add_network_results = await self.send_single_cmd(endpoint=wifi_endpoint, cmd=add_wifi_network_cmd)
-        asserts.assert_true(add_network_results.networkingStatus ==
-                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateNetwork command failed")
+        self.step(16)
+        if commissioning_network == "Wi-Fi":
+            operating_endpoint_id = wifi_endpoint
+            network_id = wifi_ssid
+        else:
+            operating_endpoint_id = thread_endpoint
+            network_id = th_xpan_1
 
-        self.step(13)
-        await self.SendConnectNetworkWithFailure(networkID=wifi_ssid, endpoint=wifi_endpoint)
+        if commissioning_network == "Wi-Fi":
+            self.step("17a")
+            cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateWiFiNetwork(ssid=wifi_ssid, credentials=wifi_credential)
+            add_network_results = await self.send_single_cmd(endpoint=operating_endpoint_id, cmd=cmd)
+            asserts.assert_true(add_network_results.networkingStatus ==
+                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateWiFiNetwork command failed")
+            self.skip_step("17b")
+        else:
+            self.skip_step("17a")
+            self.step("17b")
+            cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateThreadNetwork(operationalDataset=operational_dataset)
+            add_network_results = await self.send_single_cmd(endpoint=operating_endpoint_id, cmd=cmd)
+            asserts.assert_true(add_network_results.networkingStatus ==
+                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateThreadNetwork command failed")
 
-        self.step(14)
+        self.step(18)
+        await self.SendConnectNetworkWithFailure(networkID=network_id, endpoint=operating_endpoint_id)
+
+        self.step(19)
         await self.SendCommissioningCompleteWithRetry()
 
-        self.step(15)
+        self.step(20)
         networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
-                                                                           attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=wifi_endpoint)
+                                                                           attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=operating_endpoint_id)
         verification = False
         for network_info in networks_response:
-            if network_info.connected and network_info.networkID == wifi_ssid:
+            if network_info.connected and network_info.networkID == network_id:
                 verification = True
+                break
         asserts.assert_true(verification, "There is no correct entry in Networks attribute list")
 
 

--- a/src/python_testing/TC_CNET_4_23.py
+++ b/src/python_testing/TC_CNET_4_23.py
@@ -162,11 +162,11 @@ class TC_CNET_4_23(MatterBaseTest):
         marker_index = operational_dataset.find(ext_pan_id_marker)
         asserts.assert_true(
             marker_index != -1 and len(operational_dataset) >= marker_index + len(ext_pan_id_marker) + 8,
-            f"Could not find ExtPANID marker in PIXIT dataset or dataset too short in PIXIT bytes."
+            "Could not find ExtPANID marker in PIXIT dataset or dataset too short in PIXIT bytes."
         )
         ext_pan_id_start = marker_index + len(ext_pan_id_marker)
         th_xpan_1 = operational_dataset[ext_pan_id_start: ext_pan_id_start + 8]
-        asserts.assert_equal(len(th_xpan_1), 8, f"Extracted ExtPANID must be 8 bytes long.")
+        asserts.assert_equal(len(th_xpan_1), 8, "Extracted ExtPANID must be 8 bytes long.")
 
         self.step(1)
         await self.default_controller.EstablishPASESessionBLE(setup_payload[0].passcode, setup_payload[0].filter_value, self.dut_node_id)
@@ -222,16 +222,8 @@ class TC_CNET_4_23(MatterBaseTest):
         self.step(7)
         networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
                                                                            attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=operating_endpoint_id)
-        index = 0
-        network_index = 0
-        verification = False
-        for network_info in networks_response:
-            if network_info.connected and network_info.networkID == network_id:
-                network_index = index
-                verification = True
-                break
-            index += 1
-        asserts.assert_true(verification, "There is no correct entry in Networks attribute list")
+        network_index = next((i for i, info in enumerate(networks_response) if info.connected and info.networkID == network_id), None)
+        asserts.assert_true(network_index != None, "There is no correct entry in Networks attribute list")
 
         self.step(8)
         remove_network_cmd = Clusters.NetworkCommissioning.Commands.RemoveNetwork(networkID=network_id)
@@ -271,15 +263,8 @@ class TC_CNET_4_23(MatterBaseTest):
         self.step(13)
         networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
                                                                            attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=operating_endpoint_id)
-        verification = False
-        index = 0
-        for network_info in networks_response:
-            if network_info.connected and network_info.networkID == network_id:
-                network_index = index
-                verification = True
-                break
-            index += 1
-        asserts.assert_true(verification, "There is no correct entry in Networks attribute list")
+        network_index = next((i for i, info in enumerate(networks_response) if info.connected and info.networkID == network_id), None)
+        asserts.assert_true(network_index != None, "There is no correct entry in Networks attribute list")
 
         self.step(14)
         arm_fail_safe_results = await self.send_single_cmd(endpoint=kRootEndpointId, cmd=arm_failsafe_cmd)
@@ -324,11 +309,7 @@ class TC_CNET_4_23(MatterBaseTest):
         self.step(20)
         networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
                                                                            attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=operating_endpoint_id)
-        verification = False
-        for network_info in networks_response:
-            if network_info.connected and network_info.networkID == network_id:
-                verification = True
-                break
+        verification = any(info.connected and info.networkID == network_id for info in networks_response)
         asserts.assert_true(verification, "There is no correct entry in Networks attribute list")
 
 

--- a/src/python_testing/TC_CNET_4_23.py
+++ b/src/python_testing/TC_CNET_4_23.py
@@ -222,8 +222,9 @@ class TC_CNET_4_23(MatterBaseTest):
         self.step(7)
         networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
                                                                            attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=operating_endpoint_id)
-        network_index = next((i for i, info in enumerate(networks_response) if info.connected and info.networkID == network_id), None)
-        asserts.assert_true(network_index != None, "There is no correct entry in Networks attribute list")
+        network_index = next((i for i, info in enumerate(networks_response)
+                             if info.connected and info.networkID == network_id), None)
+        asserts.assert_true(network_index is not None, "There is no correct entry in Networks attribute list")
 
         self.step(8)
         remove_network_cmd = Clusters.NetworkCommissioning.Commands.RemoveNetwork(networkID=network_id)
@@ -263,8 +264,9 @@ class TC_CNET_4_23(MatterBaseTest):
         self.step(13)
         networks_response = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning,
                                                                            attribute=Clusters.NetworkCommissioning.Attributes.Networks, endpoint=operating_endpoint_id)
-        network_index = next((i for i, info in enumerate(networks_response) if info.connected and info.networkID == network_id), None)
-        asserts.assert_true(network_index != None, "There is no correct entry in Networks attribute list")
+        network_index = next((i for i, info in enumerate(networks_response)
+                             if info.connected and info.networkID == network_id), None)
+        asserts.assert_true(network_index is not None, "There is no correct entry in Networks attribute list")
 
         self.step(14)
         arm_fail_safe_results = await self.send_single_cmd(endpoint=kRootEndpointId, cmd=arm_failsafe_cmd)

--- a/src/python_testing/TC_CNET_4_23.py
+++ b/src/python_testing/TC_CNET_4_23.py
@@ -67,8 +67,8 @@ class TC_CNET_4_23(MatterBaseTest):
                 TestStep(8, 'TH sends RemoveNetwork Command to the DUT `operating_endpoint_id` endpoint with NetworkID field set to `network_id`. '
                             'Verify that DUT sends NetworkConfigResponse to command with the following fields: NetworkingStatus is Success, NetworkIndex matches previously saved `network_index`'),
                 TestStep(9, 'If `commissioning_network` is "Wi-Fi", set `network_id` to th_xpan_1 and `operating_endpoint_id` to PIXIT.CNET.ENDPOINT_THREAD, '
-                             'otherwise set `network_id` to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID and `operating_endpoint_id` to PIXIT.CNET.ENDPOINT_WIFI. '
-                             'If `commissioning_network` is "Thread", skip step 10a'),
+                         'otherwise set `network_id` to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID and `operating_endpoint_id` to PIXIT.CNET.ENDPOINT_WIFI. '
+                         'If `commissioning_network` is "Thread", skip step 10a'),
                 TestStep("10a", 'TH sends AddOrUpdateThreadNetwork command to the DUT `operating_endpoint_id` endpoint with operational dataset field set to PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET. '
                                 'Skip step 10b. '
                                 'Verify that DUT sends the NetworkConfigResponse command to the TH with the following fields: NetworkingStatus is Success, DebugText is of type string with max length 512 or empty'),
@@ -142,10 +142,13 @@ class TC_CNET_4_23(MatterBaseTest):
         operational_dataset_str = self.user_params.get('PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET')
 
         asserts.assert_true(test_endpoint is not None, "Missing params: --endpoint <endpoint_value>")
-        asserts.assert_true(wifi_ssid_str is not None and isinstance(wifi_ssid_str, str), "Missing params: --string-arg PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID:<wifi_ssid>")
-        asserts.assert_true(wifi_credential_str is not None and isinstance(wifi_credential_str, str), "Missing params: --string-arg PIXIT.CNET.WIFI_1ST_ACCESSPOINT_CREDENTIALS:<wifi_credential>")
+        asserts.assert_true(wifi_ssid_str is not None and isinstance(wifi_ssid_str, str),
+                            "Missing params: --string-arg PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID:<wifi_ssid>")
+        asserts.assert_true(wifi_credential_str is not None and isinstance(wifi_credential_str, str),
+                            "Missing params: --string-arg PIXIT.CNET.WIFI_1ST_ACCESSPOINT_CREDENTIALS:<wifi_credential>")
         # TC_CNET_4_12.py sets Thread dataset as string-arg, keep consistent with that.
-        asserts.assert_true(operational_dataset_str is not None and isinstance(operational_dataset_str, str), "Missing params: --string-arg PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET:<thread_dataset>")
+        asserts.assert_true(operational_dataset_str is not None and isinstance(operational_dataset_str, str),
+                            "Missing params: --string-arg PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET:<thread_dataset>")
 
         setup_payload = self.get_setup_payload_info()
         if not setup_payload:
@@ -166,7 +169,7 @@ class TC_CNET_4_23(MatterBaseTest):
         asserts.assert_equal(len(th_xpan_1), 8, f"Extracted ExtPANID must be 8 bytes long.")
 
         self.step(1)
-        await self.default_controller.EstablishPASESessionBLE(setup_payload[0].passcode, setup_payload[0].filter_value, self.dut_node_id);
+        await self.default_controller.EstablishPASESessionBLE(setup_payload[0].passcode, setup_payload[0].filter_value, self.dut_node_id)
 
         self.step(2)
         feature_map_response = await self.default_controller.ReadAttribute(self.dut_node_id, [(Clusters.NetworkCommissioning.Attributes.FeatureMap)], fabricFiltered=True)
@@ -196,7 +199,7 @@ class TC_CNET_4_23(MatterBaseTest):
             commissioning_network = "Wi-Fi"
             network_id = wifi_ssid
             operating_endpoint_id = wifi_endpoint
-            self.default_controller.SetWiFiCredentials(wifi_ssid.decode("utf-8"), wifi_credential.decode("utf-8"));
+            self.default_controller.SetWiFiCredentials(wifi_ssid.decode("utf-8"), wifi_credential.decode("utf-8"))
         elif thread_endpoint == test_endpoint:
             commissioning_network = "Thread"
             network_id = th_xpan_1
@@ -249,7 +252,7 @@ class TC_CNET_4_23(MatterBaseTest):
             cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateThreadNetwork(operationalDataset=operational_dataset)
             add_network_results = await self.send_single_cmd(endpoint=operating_endpoint_id, cmd=cmd)
             asserts.assert_true(add_network_results.networkingStatus ==
-                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateThreadNetwork command failed")
+                                Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateThreadNetwork command failed")
             self.skip_step("10b")
         else:
             self.skip_step("10a")
@@ -257,7 +260,7 @@ class TC_CNET_4_23(MatterBaseTest):
             cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateWiFiNetwork(ssid=wifi_ssid, credentials=wifi_credential)
             add_network_results = await self.send_single_cmd(endpoint=operating_endpoint_id, cmd=cmd)
             asserts.assert_true(add_network_results.networkingStatus ==
-                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateWiFiNetwork command failed")
+                                Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateWiFiNetwork command failed")
 
         self.step(11)
         await self.SendConnectNetworkWithFailure(networkID=network_id, endpoint=operating_endpoint_id)
@@ -302,7 +305,7 @@ class TC_CNET_4_23(MatterBaseTest):
             cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateWiFiNetwork(ssid=wifi_ssid, credentials=wifi_credential)
             add_network_results = await self.send_single_cmd(endpoint=operating_endpoint_id, cmd=cmd)
             asserts.assert_true(add_network_results.networkingStatus ==
-                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateWiFiNetwork command failed")
+                                Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateWiFiNetwork command failed")
             self.skip_step("17b")
         else:
             self.skip_step("17a")
@@ -310,7 +313,7 @@ class TC_CNET_4_23(MatterBaseTest):
             cmd = Clusters.NetworkCommissioning.Commands.AddOrUpdateThreadNetwork(operationalDataset=operational_dataset)
             add_network_results = await self.send_single_cmd(endpoint=operating_endpoint_id, cmd=cmd)
             asserts.assert_true(add_network_results.networkingStatus ==
-                            Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateThreadNetwork command failed")
+                                Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess, "AddOrUpdateThreadNetwork command failed")
 
         self.step(18)
         await self.SendConnectNetworkWithFailure(networkID=network_id, endpoint=operating_endpoint_id)

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -20,7 +20,7 @@ not_automated:
     - name: TC_CNET_4_22.py
       reason: It has no CI execution block, is not executed in CI
     - name: TC_CNET_4_23.py
-      reason: It has no CI execution block, is not executed in CI
+      reason: test requires a real wifi and thread network connection, which is not available in the CI
     - name: TC_DGGEN_3_2.py
       reason:
           src/python_testing/test_testing/test_TC_DGGEN_3_2.py is the Unit test

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -19,6 +19,8 @@ not_automated:
       reason: It has no CI execution block, is not executed in CI
     - name: TC_CNET_4_22.py
       reason: It has no CI execution block, is not executed in CI
+    - name: TC_CNET_4_23.py
+      reason: It has no CI execution block, is not executed in CI
     - name: TC_DGGEN_3_2.py
       reason:
           src/python_testing/test_testing/test_TC_DGGEN_3_2.py is the Unit test

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -20,7 +20,9 @@ not_automated:
     - name: TC_CNET_4_22.py
       reason: It has no CI execution block, is not executed in CI
     - name: TC_CNET_4_23.py
-      reason: test requires a real wifi and thread network connection, which is not available in the CI
+      reason:
+          test requires a real wifi and thread network connection, which is not
+          available in the CI
     - name: TC_DGGEN_3_2.py
       reason:
           src/python_testing/test_testing/test_TC_DGGEN_3_2.py is the Unit test


### PR DESCRIPTION
Ref to https://github.com/CHIP-Specifications/chip-test-plans/pull/4598, add tests for switching network interface.

### Testing:
Test lighting-app with `SecondaryNetworkInterface` device type on esp32c6.

Run test:
```
python src/python_testing/TC_CNET_4_23.py --discriminator <discriminator> --passcode <passcode> \
               --endpoint <endpoint_value> \
               --string-arg PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID:<wifi_ssid> \
               --string-arg PIXIT.CNET.WIFI_1ST_ACCESSPOINT_CREDENTIALS:<wifi_credentials> \
               --string-arg PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET:<thread_dataset>
```
Where `<endpoint_value>` should be replaced with the actual endpoint number under test for the Network Commissioning cluster on the DUT.