### PR TITLE
[nrfconnect] Added BT reassembly config as default for SMP DFU samples

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -162,6 +162,7 @@ config CHIP_DFU_OVER_BT_SMP
 	# Enable custom SMP request to erase settings partition.
 	select MCUMGR_GRP_ZBASIC
 	select MCUMGR_GRP_ZBASIC_STORAGE_ERASE
+	select MCUMGR_TRANSPORT_BT_REASSEMBLY
 	help
 	  Enables Device Firmware Upgrade over Bluetooth LE with SMP and configures
 	  the set of options related to that feature.


### PR DESCRIPTION
This PR adds BT reassembly config as default for nrfconnect SMP DFU samples
