### PR TITLE
Added a CopyCharSpanToMutableCharSpanTruncate function.

### DIFF
--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -392,11 +392,11 @@ inline CHIP_ERROR CopyCharSpanToMutableCharSpan(CharSpan cspan_to_copy, MutableC
 
 /**
  * Copies a CharSpan into a MutableCharSpan.
- * If the span_to_copy does not if in out_span, span_to_copy in truncated to fit in out_span.
+ * If the span_to_copy does not fit in out_span, span_to_copy in truncated to fit in out_span.
  * @param span_to_copy The CharSpan to copy.
  * @param out_span The MutableCharSpan in which span_to_copy is to be copied.
  */
-inline void CopyCharSpanToMutableCharSpanTruncate(CharSpan span_to_copy, MutableCharSpan & out_span)
+inline void CopyCharSpanToMutableCharSpanWithTruncation(CharSpan span_to_copy, MutableCharSpan & out_span)
 {
     size_t size_to_copy = std::min(span_to_copy.size(), out_span.size());
 

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -390,4 +390,18 @@ inline CHIP_ERROR CopyCharSpanToMutableCharSpan(CharSpan cspan_to_copy, MutableC
     return CHIP_NO_ERROR;
 }
 
+/**
+ * Copies a CharSpan into a MutableCharSpan.
+ * If the cspan_to_copy does not if in out_buf, cspan_to_copy in truncated to fit in out_buf.
+ * @param cspan_to_copy The CharSpan to copy.
+ * @param out_buf The MutableCharSpan in which cspan_to_copy is to be copied.
+ */
+inline void CopyCharSpanToMutableCharSpanTruncate(CharSpan cspan_to_copy, MutableCharSpan & out_buf)
+{
+    size_t size_to_copy = std::min(cspan_to_copy.size(), out_buf.size());
+
+    memcpy(out_buf.data(), cspan_to_copy.data(), size_to_copy);
+    out_buf.reduce_size(size_to_copy);
+}
+
 } // namespace chip

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -392,16 +392,16 @@ inline CHIP_ERROR CopyCharSpanToMutableCharSpan(CharSpan cspan_to_copy, MutableC
 
 /**
  * Copies a CharSpan into a MutableCharSpan.
- * If the cspan_to_copy does not if in out_buf, cspan_to_copy in truncated to fit in out_buf.
- * @param cspan_to_copy The CharSpan to copy.
- * @param out_buf The MutableCharSpan in which cspan_to_copy is to be copied.
+ * If the span_to_copy does not if in out_span, span_to_copy in truncated to fit in out_span.
+ * @param span_to_copy The CharSpan to copy.
+ * @param out_span The MutableCharSpan in which span_to_copy is to be copied.
  */
-inline void CopyCharSpanToMutableCharSpanTruncate(CharSpan cspan_to_copy, MutableCharSpan & out_buf)
+inline void CopyCharSpanToMutableCharSpanTruncate(CharSpan span_to_copy, MutableCharSpan & out_span)
 {
-    size_t size_to_copy = std::min(cspan_to_copy.size(), out_buf.size());
+    size_t size_to_copy = std::min(span_to_copy.size(), out_span.size());
 
-    memcpy(out_buf.data(), cspan_to_copy.data(), size_to_copy);
-    out_buf.reduce_size(size_to_copy);
+    memcpy(out_span.data(), span_to_copy.data(), size_to_copy);
+    out_span.reduce_size(size_to_copy);
 }
 
 } // namespace chip

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -392,7 +392,7 @@ inline CHIP_ERROR CopyCharSpanToMutableCharSpan(CharSpan cspan_to_copy, MutableC
 
 /**
  * Copies a CharSpan into a MutableCharSpan.
- * If the span_to_copy does not fit in out_span, span_to_copy in truncated to fit in out_span.
+ * If the span_to_copy does not fit in out_span, span_to_copy is truncated to fit in out_span.
  * @param span_to_copy The CharSpan to copy.
  * @param out_span The MutableCharSpan in which span_to_copy is to be copied.
  */


### PR DESCRIPTION
Fixes #35345.

Adds a new function that copies a `CharSpan` into a `MutableCharSpan` without the possibility of erroring. If the `CharSpan` does not fit, it is truncated.