### PR TITLE
Make at least on/off light chef have endpoint ID > 10

### DIFF
--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
@@ -2032,7 +2032,7 @@ endpoint 0 {
     ram      attribute clusterRevision default = 1;
   }
 }
-endpoint 1 {
+endpoint 13 {
   device type ma_onofflight = 256, version 1;
 
   binding cluster Binding;

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.zap
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.zap
@@ -3473,7 +3473,7 @@
       "endpointTypeName": "Anonymous Endpoint Type",
       "endpointTypeIndex": 1,
       "profileId": 259,
-      "endpointId": 1,
+      "endpointId": 13,
       "networkId": 0,
       "parentEndpointIdentifier": null
     }


### PR DESCRIPTION
- To test corner cases where tests assume the single application endpoint is endpoint 1, this makes the only application endpoint be 13 in at least one sample.
