### PR TITLE
Stop VSCode from Formatting .gitmodules file on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,7 +50,7 @@
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "files.associations": {
-        ".gitmodules": "plaintext",
+        ".gitmodules": "ini",
         "*.mm": "cpp",
         "iostream": "cpp",
         "array": "cpp",
@@ -139,8 +139,7 @@
         "list": "cpp",
         "unordered_set": "cpp"
     },
-
-    "[plaintext]": {
+    "[ini]": {
         "editor.formatOnSave": false
     },
     // Configure paths or glob patterns to exclude from file watching.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,6 +50,7 @@
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "files.associations": {
+        ".gitmodules": "plaintext",
         "*.mm": "cpp",
         "iostream": "cpp",
         "array": "cpp",
@@ -137,6 +138,10 @@
         "future": "cpp",
         "list": "cpp",
         "unordered_set": "cpp"
+    },
+
+    "[plaintext]": {
+        "editor.formatOnSave": false
     },
     // Configure paths or glob patterns to exclude from file watching.
     "files.watcherExclude": {


### PR DESCRIPTION
VSCode formats .gitmodules files when we save in a way that changes it overall structure.

- Deactivate formatOnSave for .gitmodules by associating it with the formatting of `*.ini` file
