### PR TITLE
Use persistent and subscription resumption implementation of ShouldCheckInMsgsBeSentAtActiveModeFunction by setting chip_subscription_timeout_resumption=true for Linux reference lit-icd-app

### DIFF
--- a/examples/lit-icd-app/linux/args.gni
+++ b/examples/lit-icd-app/linux/args.gni
@@ -28,6 +28,6 @@ matter_enable_tracing_support = true
 
 # ICD configurations
 chip_enable_icd_server = true
-chip_subscription_timeout_resumption = false
+chip_subscription_timeout_resumption = true
 chip_icd_report_on_active_mode = true
 chip_enable_icd_lit = true


### PR DESCRIPTION
fixes https://github.com/project-chip/connectedhomeip/issues/34803
 
 The ICD manager has few different conditions implementation for when a check-in message should be sent depending on some configured features.
 See
 https://github.com/project-chip/connectedhomeip/blob/master/src/app/icd/server/ICDManager.cpp#L267
 
 Persistent subscription is enabled by default on most platforms and the ICD test plan and script were validated with both `CHIP_CONFIG_PERSIST_SUBSCRIPTIONS` and `CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION` enabled.

 Set `chip_subscription_timeout_resumption` to true as default for the Linux lit-icd-app so the `CHIP_CONFIG_PERSIST_SUBSCRIPTIONS` and `CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION` implementation of `ShouldCheckInMsgsBeSentAtActiveModeFunction` is used in the reference app for SVE