### PR TITLE
[ICD] refreshKey needs to be set with length

### DIFF
--- a/src/app/icd/client/DefaultCheckInDelegate.cpp
+++ b/src/app/icd/client/DefaultCheckInDelegate.cpp
@@ -42,7 +42,7 @@ void DefaultCheckInDelegate::OnCheckInComplete(const ICDClientInfo & clientInfo)
 CHIP_ERROR DefaultCheckInDelegate::GenerateRefreshKey(RefreshKeySender::RefreshKeyBuffer & newKey)
 {
     ReturnErrorOnFailure(Crypto::DRBG_get_bytes(newKey.Bytes(), newKey.Capacity()));
-    return newKey.SetLength(Crypto::kAES_CCM128_Key_Length);
+    return newKey.SetLength(newKey.Capacity());
 }
 
 RefreshKeySender * DefaultCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & clientInfo, ICDClientStorage * clientStorage)

--- a/src/app/icd/client/DefaultCheckInDelegate.cpp
+++ b/src/app/icd/client/DefaultCheckInDelegate.cpp
@@ -41,7 +41,8 @@ void DefaultCheckInDelegate::OnCheckInComplete(const ICDClientInfo & clientInfo)
 
 CHIP_ERROR DefaultCheckInDelegate::GenerateRefreshKey(RefreshKeySender::RefreshKeyBuffer & newKey)
 {
-    return Crypto::DRBG_get_bytes(newKey.Bytes(), newKey.Capacity());
+    ReturnErrorOnFailure(Crypto::DRBG_get_bytes(newKey.Bytes(), newKey.Capacity()));
+    return newKey.SetLength(Crypto::kAES_CCM128_Key_Length);
 }
 
 RefreshKeySender * DefaultCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & clientInfo, ICDClientStorage * clientStorage)


### PR DESCRIPTION
We need setLength after putting data inside SensitiveDataBuffer, otherwise, the key is 0 bytes
verified locally and confirm refreshKey works
fixes https://github.com/project-chip/connectedhomeip/issues/35347