### PR TITLE
[Python] Avoid InvalidStateError on cancel

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -1062,6 +1062,8 @@ class ChipDeviceControllerBase():
                 self._future = future
 
             def _deviceAvailable(self):
+                if self._future.cancelled():
+                    return
                 if self._returnDevice.value is not None:
                     self._future.set_result(self._returnDevice)
                 else:


### PR DESCRIPTION
When the co-routine `GetConnectedDevice()` gets cancelled, the `asyncio.wait_for()` call will cancel the future we are waiting for. However, the SDK still calls the _DeviceAvailableCallback with an error (CHIP Error 0x00000074: The operation has been cancelled). But at this point we can't set the future result as the co-routine is already cancelled.

Simply check the future state before setting the result.
