### PR TITLE
Fix mismatch in gn argument name between its declaration and usage.

### DIFF
--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -61,7 +61,7 @@ declare_args() {
   sl_active_mode_duration_ms = 1000  # 1s Active Mode Duration
   sl_active_mode_threshold_ms = 500  # 500ms Active Mode Threshold
   sl_icd_supported_clients_per_fabric = 2  # 2 registration slots per fabric
-  sl_use_subscription_synching = false
+  sl_use_subscription_syncing = false
 
   silabs_log_enabled = true
 
@@ -658,7 +658,7 @@ template("efr32_sdk") {
       ]
     }
 
-    if (sl_use_subscription_synching) {
+    if (sl_use_subscription_syncing) {
       defines += [ "CHIP_CONFIG_SYNCHRONOUS_REPORTS_ENABLED=1" ]
     }
 


### PR DESCRIPTION
The argument was named `sl_use_subscription_synching` but our apps were using sl_use_subscription_syncing.

for example
https://github.com/project-chip/connectedhomeip/blob/master/examples/light-switch-app/silabs/openthread.gni#L33

rename `sl_use_subscription_synching` and keep `sl_use_subscription_syncing`. 