### PR TITLE
[Android] Fix DNSSD interupped system call issue

### DIFF
--- a/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
@@ -27,6 +27,7 @@ import androidx.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -44,6 +45,8 @@ public class NsdManagerServiceResolver implements ServiceResolver {
   private final CopyOnWriteArrayList<String> mMFServiceName = new CopyOnWriteArrayList<>();
   @Nullable private final NsdManagerResolverAvailState nsdManagerResolverAvailState;
   private final long timeout;
+
+  private ExecutorService mResolveExecutorService;
 
   /**
    * @param context application context
@@ -69,6 +72,8 @@ public class NsdManagerServiceResolver implements ServiceResolver {
 
     this.nsdManagerResolverAvailState = nsdManagerResolverAvailState;
     this.timeout = timeout;
+
+    mResolveExecutorService = Executors.newSingleThreadExecutor();
   }
 
   public NsdManagerServiceResolver(Context context) {
@@ -116,7 +121,7 @@ public class NsdManagerServiceResolver implements ServiceResolver {
           }
         };
 
-    new Thread(
+    mResolveExecutorService.execute(
             () -> {
               if (nsdManagerResolverAvailState != null) {
                 nsdManagerResolverAvailState.acquireResolver();
@@ -137,8 +142,7 @@ public class NsdManagerServiceResolver implements ServiceResolver {
                       resolveTimeoutExecutor,
                       nsdManagerResolverAvailState);
               serviceFinderResolver.start();
-            })
-        .start();
+            });
   }
 
   @Override

--- a/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
@@ -122,27 +122,27 @@ public class NsdManagerServiceResolver implements ServiceResolver {
         };
 
     mResolveExecutorService.execute(
-            () -> {
-              if (nsdManagerResolverAvailState != null) {
-                nsdManagerResolverAvailState.acquireResolver();
-              }
+        () -> {
+          if (nsdManagerResolverAvailState != null) {
+            nsdManagerResolverAvailState.acquireResolver();
+          }
 
-              ScheduledFuture<?> resolveTimeoutExecutor =
-                  Executors.newSingleThreadScheduledExecutor()
-                      .schedule(timeoutRunnable, timeout, TimeUnit.MILLISECONDS);
+          ScheduledFuture<?> resolveTimeoutExecutor =
+              Executors.newSingleThreadScheduledExecutor()
+                  .schedule(timeoutRunnable, timeout, TimeUnit.MILLISECONDS);
 
-              NsdServiceFinderAndResolver serviceFinderResolver =
-                  new NsdServiceFinderAndResolver(
-                      this.nsdManager,
-                      serviceInfo,
-                      callbackHandle,
-                      contextHandle,
-                      chipMdnsCallback,
-                      multicastLock,
-                      resolveTimeoutExecutor,
-                      nsdManagerResolverAvailState);
-              serviceFinderResolver.start();
-            });
+          NsdServiceFinderAndResolver serviceFinderResolver =
+              new NsdServiceFinderAndResolver(
+                  this.nsdManager,
+                  serviceInfo,
+                  callbackHandle,
+                  contextHandle,
+                  chipMdnsCallback,
+                  multicastLock,
+                  resolveTimeoutExecutor,
+                  nsdManagerResolverAvailState);
+          serviceFinderResolver.start();
+        });
   }
 
   @Override


### PR DESCRIPTION
Fix #35363 
Many threads are created and deleted, and while waiting, an interrupted system call crash occurs. To fix this, the method used has been changed to SingleThreadExecutor.