### PR TITLE
Add MinValue/MaxValue helpers on our NumericAttributeTraits.

### DIFF
--- a/src/app/util/attribute-storage-null-handling.h
+++ b/src/app/util/attribute-storage-null-handling.h
@@ -138,7 +138,7 @@ public:
 
         if (isNullable)
         {
-            // Smallest negative value is excluded for nullable types.
+            // Smallest negative value is excluded for nullable signed types.
             return static_cast<WorkingType>(std::numeric_limits<WorkingType>::min() + 1);
         }
 
@@ -154,7 +154,7 @@ public:
 
         if (isNullable)
         {
-            // Largest value is excluded for nullable types.
+            // Largest value is excluded for nullable unsigned types.
             return static_cast<WorkingType>(std::numeric_limits<WorkingType>::max() - 1);
         }
 

--- a/src/app/util/attribute-storage-null-handling.h
+++ b/src/app/util/attribute-storage-null-handling.h
@@ -127,6 +127,39 @@ public:
     // Utility that lets consumers treat a StorageType instance as a uint8_t*
     // for writing to the attribute store.
     static uint8_t * ToAttributeStoreRepresentation(StorageType & value) { return reinterpret_cast<uint8_t *>(&value); }
+
+    // Min and max values for the type.
+    static WorkingType MinValue(bool isNullable)
+    {
+        if constexpr (!std::is_signed_v<WorkingType>)
+        {
+            return 0;
+        }
+
+        if (isNullable)
+        {
+            // Smallest negative value is excluded for nullable types.
+            return static_cast<WorkingType>(std::numeric_limits<WorkingType>::min() + 1);
+        }
+
+        return std::numeric_limits<WorkingType>::min();
+    }
+
+    static WorkingType MaxValue(bool isNullable)
+    {
+        if constexpr (std::is_signed_v<WorkingType>)
+        {
+            return std::numeric_limits<WorkingType>::max();
+        }
+
+        if (isNullable)
+        {
+            // Largest value is excluded for nullable types.
+            return static_cast<WorkingType>(std::numeric_limits<WorkingType>::max() - 1);
+        }
+
+        return std::numeric_limits<WorkingType>::max();
+    }
 };
 
 template <typename T>
@@ -208,6 +241,10 @@ struct NumericAttributeTraits<bool>
     }
 
     static uint8_t * ToAttributeStoreRepresentation(StorageType & value) { return reinterpret_cast<uint8_t *>(&value); }
+
+    static uint8_t MinValue(bool isNullable) { return 0; }
+
+    static uint8_t MaxValue(bool isNullable) { return 1; }
 
 private:
     static constexpr StorageType kNullValue = 0xFF;

--- a/src/app/util/odd-sized-integers.h
+++ b/src/app/util/odd-sized-integers.h
@@ -221,7 +221,7 @@ struct NumericAttributeTraits<OddSizedInteger<ByteSize, IsSigned>, IsBigEndian> 
         constexpr WorkingType signedMin = -(static_cast<WorkingType>(1) << (8 * ByteSize - 1));
         if (isNullable)
         {
-            // We have one fewer value.
+            // Smallest negative value is excluded for nullable signed types.
             return signedMin + 1;
         }
 
@@ -237,10 +237,10 @@ struct NumericAttributeTraits<OddSizedInteger<ByteSize, IsSigned>, IsBigEndian> 
             return (static_cast<WorkingType>(1) << (8 * ByteSize - 1)) - 1;
         }
 
-        constexpr WorkingType unsignedMax = (static_cast<WorkingType>(1) << (8 * ByteSize));
+        constexpr WorkingType unsignedMax = (static_cast<WorkingType>(1) << (8 * ByteSize)) - 1;
         if (isNullable)
         {
-            // Largest value is excluded for nullable types.
+            // Largest value is excluded for nullable unsigned types.
             return unsignedMax - 1;
         }
 

--- a/src/app/util/odd-sized-integers.h
+++ b/src/app/util/odd-sized-integers.h
@@ -200,27 +200,7 @@ struct NumericAttributeTraits<OddSizedInteger<ByteSize, IsSigned>, IsBigEndian> 
 
     static constexpr bool CanRepresentValue(bool isNullable, WorkingType value)
     {
-        // Since WorkingType has at least one extra byte, none of our bitshifts
-        // overflow.
-        if (IsSigned)
-        {
-            WorkingType max = (static_cast<WorkingType>(1) << (8 * ByteSize - 1)) - 1;
-            WorkingType min = -max;
-            if (!isNullable)
-            {
-                // We have one more value.
-                min -= 1;
-            }
-            return value >= min && value <= max;
-        }
-
-        WorkingType max = (static_cast<WorkingType>(1) << (8 * ByteSize)) - 1;
-        if (isNullable)
-        {
-            // we have one less value
-            max -= 1;
-        }
-        return value <= max;
+        return MinValue(isNullable) <= value && value <= MaxValue(isNullable);
     }
 
     static CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, StorageType value)
@@ -229,6 +209,43 @@ struct NumericAttributeTraits<OddSizedInteger<ByteSize, IsSigned>, IsBigEndian> 
     }
 
     static uint8_t * ToAttributeStoreRepresentation(StorageType & value) { return value; }
+
+    static WorkingType MinValue(bool isNullable)
+    {
+        if constexpr (!IsSigned)
+        {
+            return 0;
+        }
+
+        // Since WorkingType has at least one extra byte, the bitshift cannot overflow.
+        constexpr WorkingType signedMin = -(static_cast<WorkingType>(1) << (8 * ByteSize - 1));
+        if (isNullable)
+        {
+            // We have one fewer value.
+            return signedMin + 1;
+        }
+
+        return signedMin;
+    }
+
+    static WorkingType MaxValue(bool isNullable)
+    {
+        // Since WorkingType has at least one extra byte, none of our bitshifts
+        // overflow.
+        if constexpr (IsSigned)
+        {
+            return (static_cast<WorkingType>(1) << (8 * ByteSize - 1)) - 1;
+        }
+
+        constexpr WorkingType unsignedMax = (static_cast<WorkingType>(1) << (8 * ByteSize));
+        if (isNullable)
+        {
+            // Largest value is excluded for nullable types.
+            return unsignedMax - 1;
+        }
+
+        return unsignedMax;
+    }
 };
 
 } // namespace app


### PR DESCRIPTION
Uses the new helpers in SceneHandlerImpl.

Fixes https://github.com/project-chip/connectedhomeip/issues/35328

Review note: git diff is a bit annoyingly confused on the odd-sized-integers bits.  The PR does not in fact change anything about Encode() or ToAttributeStoreRepresentation().