### PR TITLE
Workaround fix for docker bloaty issue #35364

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -140,7 +140,13 @@ RUN set -x \
     && cd .. \
     && rm -rf gn \
     && : # last line
-
+#TODO Issue #35280: this is only added as a workaround to bloaty build failures, remove it once bloaty fixes issue
+# Clone and install abseil-cpp
+RUN git clone https://github.com/abseil/abseil-cpp.git /tmp/abseil-cpp \
+    && cd /tmp/abseil-cpp \
+    && cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build build --target install \
+    && rm -rf /tmp/abseil-cpp
 # Install bloat comparison tools
 RUN set -x \
     && git clone https://github.com/google/bloaty.git \


### PR DESCRIPTION
Fix #35364 

Fix is needed until  https://github.com/google/bloaty/pull/384 is ready and integrated. This is needed for Chip-Cert-Bins to be built for TH
