### PR TITLE
[Docker Image] remove workaround for bloaty build

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -123,14 +123,6 @@ RUN set -x \
     ruff \
     && : # last line
 
-#TODO Issue #35280: this is only added as a workaround to bloaty build failures, remove it once bloaty fixes issue
-# Clone and install abseil-cpp
-RUN git clone https://github.com/abseil/abseil-cpp.git /tmp/abseil-cpp \
-    && cd /tmp/abseil-cpp \
-    && cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
-    && cmake --build build --target install \
-    && rm -rf /tmp/abseil-cpp
-
 # Install bloat comparison tools
 RUN set -x \
     && git clone https://github.com/google/bloaty.git \

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-74 : Update Silabs docker SiSDK 2024.06.1 WiseConnect 3.3.1 Wiseconnect Wifi bt sdk 2.10.0
+75: remove workaround for bloaty build, workaround involved cloning and installing abseil


### PR DESCRIPTION
fixes #35280
- Bloaty integrated their PR that bumps  use thier abseil submodule; allowing us to use it instead of a system-based copy
