### PR TITLE
Update spacing error for docker versioning

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-75: remove workaround for bloaty build, workaround involved cloning and installing abseil
+75 : remove workaround for bloaty build, workaround involved cloning and installing abseil


### PR DESCRIPTION
Without this we seem to get an 'invalid version' error

