### PR TITLE
[devcontainer] Version bump and enhanced UX.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,18 +24,17 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 ENV LANG en_US.utf8
 
-# TODO: remove these apt installs in the future as they will be in the base image from version 75+.
+
 RUN apt-get update \
     && apt-get install -y locales \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
-    && apt-get -fy install git vim emacs sudo \
+    && apt-get -fy install vim emacs sudo \
     apt-utils dialog zsh \
-    iproute2 procps lsb-release \
+    lsb-release \
     bash-completion \
-    build-essential cmake cppcheck valgrind \
-    wget curl telnet \
+    valgrind \
     docker.io \
-    iputils-ping net-tools \
+    iputils-ping \
     && :
 
 RUN groupadd -g $USER_GID $USERNAME \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,6 +25,8 @@ ARG USER_GID=$USER_UID
 ENV LANG en_US.utf8
 
 
+# These are installed for terminal/dev convenience. If more tooling for build is required, please
+# add them to chip-build (in integrations/docker/images/chip-build).
 RUN apt-get update \
     && apt-get install -y locales \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -51,13 +51,22 @@ RUN curl https://raw.githubusercontent.com/restyled-io/restyler/master/bin/resty
 RUN mkdir -p /opt/sdk/sdks/ \
     && chown -R $USERNAME:$USERNAME \
     /opt/sdk/sdks/ `# NXP uses a patch_sdk script to change SDK files` \
-    /opt/NordicSemiconductor/nrfconnect/ `# $USERNAME needs to own west configuration to build nRF Connect examples` \
-    $IDF_PATH `# $USERNAME needs to own the esp-idf and tools for the examples to build` \
+    $ANDROID_HOME \
     $IDF_TOOLS_PATH \
-    $SYSROOT_AARCH64 `# allow read/write access to header and libraries` \
-    $ANDROID_HOME `# allow licenses to be accepted` \
-    $AMEBA_PATH `# AmebaD requires access to change build_info.h` \
-    $IMX_SDK_ROOT \
+    && find $AMEBA_PATH -name "inc_lp" -print0 | xargs -0 chown -R $USERNAME:$USERNAME \
+    && find $AMEBA_PATH -name "inc_hp" -print0 | xargs -0 chown -R $USERNAME:$USERNAME \
+    && find $AMEBA_PATH -name "project_lp" -print0 | xargs -0 chown -R $USERNAME:$USERNAME \
+    && find $AMEBA_PATH -name "project_hp" -print0 | xargs -0 chown -R $USERNAME:$USERNAME \
+    && chmod -R +x \
+    $ANDROID_HOME/tools/bin `# sdkmanager for accepting licenses`\
+    && chmod -R +w \
+    $IDF_TOOLS_PATH \
+    && find $AMEBA_PATH -name "inc_lp" -print0 | xargs -0 chmod -R +w \
+    && find $AMEBA_PATH -name "inc_hp" -print0 | xargs -0 chmod -R +w \
+    && find $AMEBA_PATH -name "project_lp" -print0 | xargs -0 chmod -R +w \
+    && find $AMEBA_PATH -name "project_hp" -print0 | xargs -0 chmod -R +w \
+    # Safe directory is preffered over chown.
+    && git config --global --add safe.directory "*" \
     && :
 
 # Fix Tizen SDK paths for new user

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,9 +37,6 @@ RUN apt-get update \
     wget curl telnet \
     docker.io \
     iputils-ping net-tools \
-    libncurses5 \
-    libncursesw5 \
-    libpython2.7 \
     && :
 
 RUN groupadd -g $USER_GID $USERNAME \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,8 +24,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 ENV LANG en_US.utf8
 
-# these are installed for terminal/dev convenience.  If more tooling for build is required, please
-#  add them to chip-build (in integrations/docker/images/chip-build)
+# TODO: remove these apt installs in the future as they will be in the base image from version 75+.
 RUN apt-get update \
     && apt-get install -y locales \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
     "image": "matter-dev-environment:local",
     "remoteUser": "vscode",
     "containerEnv": {
-        "PW_ENVIRONMENT_ROOT": "/workspaces/connectedhomeip/.environment-vscode"
+        "PW_ENVIRONMENT_ROOT": "${containerWorkspaceFolder}/.environment-vscode"
     },
     "customizations": {
         "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,9 @@
     "initializeCommand": "bash .devcontainer/build.sh --tag matter-dev-environment:local --version 74",
     "image": "matter-dev-environment:local",
     "remoteUser": "vscode",
+    "containerEnv": {
+        "PW_ENVIRONMENT_ROOT": "/workspaces/connectedhomeip/.environment-vscode"
+    },
     "customizations": {
         "vscode": {
             // Add the IDs of extensions you want installed when the container is created in the array below.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
     ],
-    "initializeCommand": "bash .devcontainer/build.sh --tag matter-dev-environment:local --version 22",
+    "initializeCommand": "bash .devcontainer/build.sh --tag matter-dev-environment:local --version 74",
     "image": "matter-dev-environment:local",
     "remoteUser": "vscode",
     "customizations": {

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ out/
 /src/darwin/Framework/build/
 
 # Pigweed Environment
-.environment/
+.environment*/
 build_overrides/pigweed_environment.gni
 
 # Temporary Directories
@@ -84,4 +84,3 @@ examples/*/esp32/dependencies.lock
 
 # jupyter temporary files
 .ipynb_checkpoints
-

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -106,16 +106,6 @@ RUN set -x \
     telnet \
     srecord \
     openjdk-8-jdk \
-    git vim emacs sudo \
-    apt-utils dialog zsh \
-    iproute2 procps lsb-release \
-    bash-completion \
-    build-essential cmake cppcheck valgrind \
-    wget curl telnet \
-    docker.io \
-    iputils-ping net-tools \
-    locales \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line
@@ -152,6 +142,10 @@ ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
 ENV ZEPHYR_NXP_BASE=/opt/nxp-zephyr/zephyrproject/zephyr
 ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-0.16.5
 ENV NXP_UPDATE_SDK_SCRIPT_DOCKER=/opt/nxp/nxp_matter_support/scripts/update_nxp_sdk.py
+
+# Places bootstrap files there instead of the default one which is `.environment`.
+# NOTE: This directory is NOT persistent.
+ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
 
 ENV TIZEN_VERSION 7.0
 ENV TIZEN_SDK_ROOT /opt/tizen-sdk

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -130,7 +130,6 @@ ENV NXP_K32W0_SDK_ROOT=/opt/k32w/core
 ENV NXP_K32W1_SDK_ROOT=/opt/k32w/k32w1
 ENV NXP_SDK_ROOT=/opt/nxp-sdk/rw61x
 ENV OPENOCD_PATH=/opt/openocd/
-ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
 ENV QEMU_ESP32=/opt/espressif/qemu/qemu-system-xtensa
 ENV QEMU_ESP32_DIR=/opt/espressif/qemu
 ENV SYSROOT_AARCH64=/opt/ubuntu-22.04.1-aarch64-sysroot

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -106,6 +106,16 @@ RUN set -x \
     telnet \
     srecord \
     openjdk-8-jdk \
+    git vim emacs sudo \
+    apt-utils dialog zsh \
+    iproute2 procps lsb-release \
+    bash-completion \
+    build-essential cmake cppcheck valgrind \
+    wget curl telnet \
+    docker.io \
+    iputils-ping net-tools \
+    locales \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line


### PR DESCRIPTION
### Issue

1. The current devcontainer image version is **22**, while the latest available version is **74**. Upgrading to the latest version will resolve several compatibility issues.

2. The directory of bootstrap files is hardcoded in the base image but it should be *visibly* configurable.

3. The devcontainer build process is inefficient, with a significant amount of time spent on recursively `chown`ing unnecessary files.

### Proposed Solution

1. Update the `devcontainer.json` to use the latest image version. Additionally, remove some unnecessary dependencies in `Dockerfile`.

2. Move the declaration of `PW_ENVIRONMENT_ROOT` environment variable from base image to `devcontainer.json`.

3. Eliminate certain `chown` operations, as `git config --global --add safe.directory "*"` with other minor changes provide a faster and sufficient alternative.

### Extra notes

apt installs from the `.devcontainer/Dockerfile` should be moved to the base image. This PR adds these apt installs to the base image and flags the ones in `.devcontainer/Dockerfile` to be removed in the next version when this gets merged.

### Testing

Successfully compiled a subset of examples for the affected build targets.