### PR TITLE
IDM-10.2: Fix provisional check

### DIFF
--- a/src/python_testing/spec_parsing_support.py
+++ b/src/python_testing/spec_parsing_support.py
@@ -216,8 +216,9 @@ class ClusterParser:
         except (KeyError, StopIteration):
             self._derived = None
 
-        if list(cluster.iter('provisionalConform')):
-            self._is_provisional = True
+        for id in cluster.iter('clusterIds'):
+            if list(id.iter('provisionalConform')):
+                self._is_provisional = True
 
         try:
             classification = next(cluster.iter('classification'))


### PR DESCRIPTION
Previously, the cluster was marked provisional if there were any provisional elements. This limits it to the cluster ID.
