### PR TITLE
Basic comp tests: add fix for pre-commissioned devices

### DIFF
--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -19,7 +19,7 @@
 # for details about the block below.
 #
 # === BEGIN CI TEST ARGUMENTS ===
-# test-runner-runs: run1 run2 run3 run4 run5 run6 run7
+# test-runner-runs: run1 run2 run3 run4 run5 run6 run7 run8
 # test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
 # test-runner-run/run1/factoryreset: True
 # test-runner-run/run1/quiet: True
@@ -61,6 +61,12 @@
 # test-runner-run/run7/quiet: True
 # test-runner-run/run7/app-args: --discriminator 1234 --KVS kvs1
 # test-runner-run/run7/script-args: --storage-path admin_storage.json --discriminator 1234 --passcode 20202021 --commissioning-method on-network
+#
+# test-runner-run/run8/app: ${CHIP_LOCK_APP}
+# test-runner-run/run8/factoryreset: False
+# test-runner-run/run8/quiet: True
+# test-runner-run/run8/app-args: --discriminator 1234 --KVS kvs1
+# test-runner-run/run8/script-args: --storage-path admin_storage.json
 # === END CI TEST ARGUMENTS ===
 
 # Run 1: runs through all tests

--- a/src/python_testing/basic_composition_support.py
+++ b/src/python_testing/basic_composition_support.py
@@ -104,6 +104,8 @@ class BasicCompositionTests:
             created_codes.append(dev_ctrl.CreateManualCode(discriminator, self.matter_test_config.setup_passcodes[idx]))
 
         setup_codes = self.matter_test_config.qr_code_content + self.matter_test_config.manual_code + created_codes
+        if not setup_codes:
+            return None
         asserts.assert_equal(len(setup_codes), 1,
                              "Require exactly one of either --qr-code, --manual-code or (--discriminator and --passcode).")
         return setup_codes[0]
@@ -132,7 +134,7 @@ class BasicCompositionTests:
         node_id = self.dut_node_id
 
         task_list = []
-        if allow_pase:
+        if allow_pase and self.get_code(dev_ctrl):
             setup_code = self.get_code(dev_ctrl)
             pase_future = dev_ctrl.EstablishPASESession(setup_code, self.dut_node_id)
             task_list.append(asyncio.create_task(pase_future))

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -1744,6 +1744,12 @@ def populate_commissioning_args(args: argparse.Namespace, config: MatterTestConf
 
     device_descriptors = config.qr_code_content + config.manual_code + config.discriminators
 
+    if not config.dut_node_ids:
+        config.dut_node_ids = [_DEFAULT_DUT_NODE_ID]
+
+    if args.commissioning_method is None:
+        return True
+
     if len(config.dut_node_ids) > len(device_descriptors):
         print("error: More node IDs provided than discriminators")
         return False
@@ -1751,8 +1757,6 @@ def populate_commissioning_args(args: argparse.Namespace, config: MatterTestConf
     if len(config.dut_node_ids) < len(device_descriptors):
         # We generate new node IDs sequentially from the last one seen for all
         # missing NodeIDs when commissioning many nodes at once.
-        if not config.dut_node_ids:
-            config.dut_node_ids = [_DEFAULT_DUT_NODE_ID]
         missing = len(device_descriptors) - len(config.dut_node_ids)
         for i in range(missing):
             config.dut_node_ids.append(config.dut_node_ids[-1] + 1)
@@ -1764,9 +1768,6 @@ def populate_commissioning_args(args: argparse.Namespace, config: MatterTestConf
     if len(config.discriminators) != len(set(config.discriminators)):
         print("error: Duplicate value in discriminator list")
         return False
-
-    if args.commissioning_method is None:
-        return True
 
     if args.discriminators == [] and (args.qr_code == [] and args.manual_code == []):
         print("error: Missing --discriminator when no --qr-code/--manual-code present!")


### PR DESCRIPTION
prior update to support pase and case on the basic information tests accidentally imposed a restriction where node id could not be specified without a discriminator. node id is required with no discriminator for previously commissioned devices. Also adds a CI run to run this test on the previously commissioned device from the prior run.