### PR TITLE
Stop hardcoding the list of signed integer attribute types.

### DIFF
--- a/src/app/util/attribute-metadata.h
+++ b/src/app/util/attribute-metadata.h
@@ -166,11 +166,7 @@ struct EmberAfAttributeMetadata
     /**
      * Check wether this attribute is signed based on its type according to the spec.
      */
-    bool IsSignedIntegerAttribute() const
-    {
-        return (attributeType >= ZCL_INT8S_ATTRIBUTE_TYPE && attributeType <= ZCL_INT64S_ATTRIBUTE_TYPE) ||
-            attributeType == ZCL_TEMPERATURE_ATTRIBUTE_TYPE;
-    }
+    bool IsSignedIntegerAttribute() const { return chip::app::IsSignedAttributeType(attributeType); }
 
     /**
      * Check whether this attribute has a define min and max.

--- a/src/app/zap-templates/templates/app/attribute-type.zapt
+++ b/src/app/zap-templates/templates/app/attribute-type.zapt
@@ -3,9 +3,29 @@
 // Prevent multiple inclusion
 #pragma once
 
+#include <cstdint>
+
 // ZCL attribute types
 enum {
 {{#zcl_atomics}}
 {{ident}}ZCL_{{asDelimitedMacro name}}_ATTRIBUTE_TYPE = {{asHex atomicId 2}}, // {{description}}
 {{/zcl_atomics}}
 };
+
+namespace chip {
+namespace app {
+inline bool IsSignedAttributeType(uint8_t attributeType)
+{
+    switch (attributeType) {
+    {{#zcl_atomics}}
+    {{#if isSigned}}
+        case ZCL_{{asDelimitedMacro name}}_ATTRIBUTE_TYPE:
+            return true;
+    {{/if}}
+    {{/zcl_atomics}}
+        default:
+            return false;
+    }
+}
+} // namespace app
+} // namespace chip

--- a/zzz_generated/app-common/app-common/zap-generated/attribute-type.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attribute-type.h
@@ -20,6 +20,8 @@
 // Prevent multiple inclusion
 #pragma once
 
+#include <cstdint>
+
 // ZCL attribute types
 enum
 {
@@ -99,3 +101,42 @@ enum
     ZCL_HWADR_ATTRIBUTE_TYPE             = 0xF6, // Hardware Address
     ZCL_UNKNOWN_ATTRIBUTE_TYPE           = 0xFF, // Unknown
 };
+
+namespace chip {
+namespace app {
+inline bool IsSignedAttributeType(uint8_t attributeType)
+{
+    switch (attributeType)
+    {
+    case ZCL_INT8S_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_INT16S_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_INT24S_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_INT32S_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_INT40S_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_INT48S_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_INT56S_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_INT64S_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_TEMPERATURE_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_POWER_MW_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_AMPERAGE_MA_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_VOLTAGE_MV_ATTRIBUTE_TYPE:
+        return true;
+    case ZCL_ENERGY_MWH_ATTRIBUTE_TYPE:
+        return true;
+    default:
+        return false;
+    }
+}
+} // namespace app
+} // namespace chip


### PR DESCRIPTION
ZAP has this information.  We should just use that instead of duplicating it.

Fixes https://github.com/project-chip/connectedhomeip/issues/35147
