### PR TITLE
TC-ACL-2.11: Add top level PICS

### DIFF
--- a/src/python_testing/TC_ACL_2_11.py
+++ b/src/python_testing/TC_ACL_2_11.py
@@ -74,6 +74,9 @@ class TC_ACL_2_11(MatterBaseTest):
         Clusters.Descriptor.Attributes.EventList.attribute_id
     ]
 
+    def pics_TC_ACL_2_11(self) -> list[str]:
+        return ['ACL.S.F01']
+
     def desc_TC_ACL_2_11(self) -> str:
         return "[TC-ACL-2.11] Verification of Managed Device feature"
 


### PR DESCRIPTION
Without this, the TH is going to select this test for every device and every device except the MACL devices will fail.

Test plan: https://github.com/CHIP-Specifications/chip-test-plans/pull/4634
