### PR TITLE
[Fabric-Sync] Improve the stability of test TC_MCORE_FS_1_4

### DIFF
--- a/src/python_testing/TC_MCORE_FS_1_4.py
+++ b/src/python_testing/TC_MCORE_FS_1_4.py
@@ -48,6 +48,31 @@ from matter_testing_support import MatterBaseTest, TestStep, async_test_body, de
 from mobly import asserts
 
 
+async def wait_for_server_initialization(server_port, timeout=5):
+    """Wait until the server is ready by checking if it opens the expected port."""
+    start_time = asyncio.get_event_loop().time()
+    elapsed_time = 0
+    retry_interval = 1
+
+    logging.info(f"Waiting for server to initialize on TCP port {server_port} for up to {timeout} seconds.")
+
+    while elapsed_time < timeout:
+        try:
+            # Try connecting to the server to check if it's ready
+            reader, writer = await asyncio.open_connection('::1', server_port)
+            writer.close()
+            await writer.wait_closed()
+            logging.info(f"TH_SERVER_NO_UID is initialized and ready on port {server_port}.")
+            return
+        except (ConnectionRefusedError, OSError) as e:
+            logging.warning(f"Connection to port {server_port} failed: {e}. Retrying in {retry_interval} seconds...")
+
+        await asyncio.sleep(retry_interval)
+        elapsed_time = asyncio.get_event_loop().time() - start_time
+
+    raise TimeoutError(f"Server on port {server_port} did not initialize within {timeout} seconds. "
+                       f"Total time waited: {elapsed_time} seconds.")
+
 # TODO: Make this class more generic. Issue #35348
 class Subprocess(threading.Thread):
 
@@ -240,7 +265,7 @@ class TC_MCORE_FS_1_4(MatterBaseTest):
 
         # Wait for TH_SERVER_NO_UID get initialized.
         try:
-            asyncio.run(self.wait_for_server_initialization(self.th_server_port))
+            asyncio.run(wait_for_server_initialization(self.th_server_port))
         except TimeoutError:
             asserts.fail(f"TH_SERVER_NO_UID server failed to open port {self.th_server_port}")
 
@@ -252,31 +277,6 @@ class TC_MCORE_FS_1_4(MatterBaseTest):
         if self.storage is not None:
             self.storage.cleanup()
         super().teardown_class()
-
-    async def wait_for_server_initialization(self, server_port, timeout=5):
-        """Wait until the server is ready by checking if it opens the expected port."""
-        start_time = asyncio.get_event_loop().time()
-        elapsed_time = 0
-        retry_interval = 1
-
-        logging.info(f"Waiting for server to initialize on port {server_port} for up to {timeout} seconds.")
-
-        while elapsed_time < timeout:
-            try:
-                # Try connecting to the server to check if it's ready
-                reader, writer = await asyncio.open_connection('::1', server_port)
-                writer.close()
-                await writer.wait_closed()
-                logging.info(f"TH_SERVER_NO_UID is initialized and ready on port {server_port}.")
-                return
-            except (ConnectionRefusedError, OSError) as e:
-                logging.warning(f"Connection to port {server_port} failed: {e}. Retrying in {retry_interval} seconds...")
-
-            await asyncio.sleep(retry_interval)
-            elapsed_time = asyncio.get_event_loop().time() - start_time
-
-        raise TimeoutError(f"Server on port {server_port} did not initialize within {timeout} seconds. "
-                           f"Total time waited: {elapsed_time} seconds.")
 
     def steps_TC_MCORE_FS_1_4(self) -> list[TestStep]:
         return [

--- a/src/python_testing/TC_MCORE_FS_1_4.py
+++ b/src/python_testing/TC_MCORE_FS_1_4.py
@@ -238,6 +238,12 @@ class TC_MCORE_FS_1_4(MatterBaseTest):
             discriminator=self.th_server_discriminator,
             passcode=self.th_server_passcode)
 
+        # Wait for TH_SERVER_NO_UID get initialized.
+        try:
+            asyncio.run(self.wait_for_server_initialization(self.th_server_port))
+        except TimeoutError:
+            asserts.fail(f"TH_SERVER_NO_UID server failed to open port {self.th_server_port}")
+
     def teardown_class(self):
         if self.th_fsa_controller is not None:
             self.th_fsa_controller.stop()
@@ -296,9 +302,6 @@ class TC_MCORE_FS_1_4(MatterBaseTest):
         self.step(1)
 
         th_server_th_node_id = 1
-
-        # Wait for TH_SERVER_NO_UID get initialized.
-        await self.wait_for_server_initialization(self.th_server_port)
 
         await self.default_controller.CommissionOnNetwork(
             nodeId=th_server_th_node_id,

--- a/src/python_testing/TC_MCORE_FS_1_4.py
+++ b/src/python_testing/TC_MCORE_FS_1_4.py
@@ -74,6 +74,8 @@ async def wait_for_server_initialization(server_port, timeout=5):
                        f"Total time waited: {elapsed_time} seconds.")
 
 # TODO: Make this class more generic. Issue #35348
+
+
 class Subprocess(threading.Thread):
 
     def __init__(self, args: list = [], stdout_cb=None, tag="", **kw):


### PR DESCRIPTION
I've noticed that MCORE_FS_1_4 is still quite flaky, though the other test cases seem stable.

It turn out there is race issue and the TH paired to FS_BRIDGE instead test SERVER.
