### PR TITLE
Fix fabric sync test timeouts

### DIFF
--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -47,7 +47,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
     async def _read_attribute_expect_success(self, endpoint, cluster, attribute, node_id):
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute, node_id=node_id)
 
-    # This test has some manual steps and also multiple sleeps for up to 30 seconds. Test typically runs under 3 mins,
+    # This test has some manual steps and also multiple sleeps >= 30 seconds. Test typically runs under 3 mins,
     # so 6 minutes is more than enough.
     @property
     def default_timeout(self) -> int:

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -47,7 +47,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
     async def _read_attribute_expect_success(self, endpoint, cluster, attribute, node_id):
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute, node_id=node_id)
 
-    # This test has some manual steps and also multiple sleeps for over 30 seconds. Test typically runs under 3 mins,
+    # This test has some manual steps and also multiple sleeps for up to 30 seconds. Test typically runs under 3 mins,
     # so 6 minutes is more than enough.
     @property
     def default_timeout(self) -> int:

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -48,10 +48,10 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute, node_id=node_id)
 
     # This test has some manual steps and also multiple sleeps for over 30 seconds. Test typically runs under 3 mins,
-    # so 5 minutes is more than enough.
+    # so 6 minutes is more than enough.
     @property
     def default_timeout(self) -> int:
-        return 5*60
+        return 6*60
 
     def desc_TC_BRBINFO_4_1(self) -> str:
         """Returns a description of this test"""

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -47,10 +47,11 @@ class TC_BRBINFO_4_1(MatterBaseTest):
     async def _read_attribute_expect_success(self, endpoint, cluster, attribute, node_id):
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute, node_id=node_id)
 
-    # Override default timeout to support a 60 min wait
+    # This test has some manual steps and also multiple sleeps for over 30 seconds. Test typically runs under 3 mins,
+    # so 5 minutes is more than enough.
     @property
     def default_timeout(self) -> int:
-        return 63*60
+        return 5*60
 
     def desc_TC_BRBINFO_4_1(self) -> str:
         """Returns a description of this test"""

--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -119,6 +119,14 @@ class TC_CCTRL_2_2(MatterBaseTest):
 
         return steps
 
+    # TODO(#35229) Once optimization has been completed, we should no longer need to wait for 4
+    # minutes and can drop this to something lower.
+    # This test has some manual steps and also multiple sleeps for 30 seconds. Test typically runs
+    # under 2 mins, so 4 minutes is more than enough.
+    @property
+    def default_timeout(self) -> int:
+        return 4*60
+
     @run_if_endpoint_matches(has_cluster(Clusters.CommissionerControl))
     async def test_TC_CCTRL_2_2(self):
         self.is_ci = self.check_pics('PICS_SDK_CI_ONLY')

--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -119,9 +119,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
 
         return steps
 
-    # TODO(#35229) Once optimization has been completed, we should no longer need to wait for 4
-    # minutes and can drop this to something lower.
-    # This test has some manual steps and also multiple sleeps for 30 seconds. Test typically runs
+    # This test has some manual steps and also multiple sleeps for up to 30 seconds. Test typically runs
     # under 2 mins, so 4 minutes is more than enough.
     @property
     def default_timeout(self) -> int:

--- a/src/python_testing/TC_CCTRL_2_3.py
+++ b/src/python_testing/TC_CCTRL_2_3.py
@@ -103,6 +103,14 @@ class TC_CCTRL_2_3(MatterBaseTest):
 
         return steps
 
+    # TODO(#35229) Once optimization has been completed, we should no longer need to wait for 3
+    # minutes and can drop this to something lower.
+    # This test has some manual steps and one sleep for 30 seconds. Test typically
+    # runs under 1 mins, so 3 minutes is more than enough.
+    @property
+    def default_timeout(self) -> int:
+        return 3*60
+
     @per_endpoint_test(has_cluster(Clusters.CommissionerControl))
     async def test_TC_CCTRL_2_3(self):
         self.is_ci = self.check_pics('PICS_SDK_CI_ONLY')

--- a/src/python_testing/TC_CCTRL_2_3.py
+++ b/src/python_testing/TC_CCTRL_2_3.py
@@ -103,9 +103,7 @@ class TC_CCTRL_2_3(MatterBaseTest):
 
         return steps
 
-    # TODO(#35229) Once optimization has been completed, we should no longer need to wait for 3
-    # minutes and can drop this to something lower.
-    # This test has some manual steps and one sleep for 30 seconds. Test typically
+    # This test has some manual steps and one sleep for up to 30 seconds. Test typically
     # runs under 1 mins, so 3 minutes is more than enough.
     @property
     def default_timeout(self) -> int:

--- a/src/python_testing/TC_ECOINFO_2_2.py
+++ b/src/python_testing/TC_ECOINFO_2_2.py
@@ -42,6 +42,12 @@ class TC_ECOINFO_2_2(MatterBaseTest):
 
         return steps
 
+    # This test has some manual steps, so we need a longer timeout. Test typically runs under 1 mins so 2 mins should
+    # be enough time for test to run
+    @property
+    def default_timeout(self) -> int:
+        return 2*60
+
     @async_test_body
     async def test_TC_ECOINFO_2_2(self):
         dev_ctrl = self.default_controller

--- a/src/python_testing/TC_ECOINFO_2_2.py
+++ b/src/python_testing/TC_ECOINFO_2_2.py
@@ -42,11 +42,11 @@ class TC_ECOINFO_2_2(MatterBaseTest):
 
         return steps
 
-    # This test has some manual steps, so we need a longer timeout. Test typically runs under 1 mins so 2 mins should
+    # This test has some manual steps, so we need a longer timeout. Test typically runs under 1 mins so 3 mins should
     # be enough time for test to run
     @property
     def default_timeout(self) -> int:
-        return 2*60
+        return 3*60
 
     @async_test_body
     async def test_TC_ECOINFO_2_2(self):

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -87,6 +87,14 @@ class TC_MCORE_FS_1_1(MatterBaseTest):
                  TestStep("3c", "DUT_FSA commissions TH_FSA")]
         return steps
 
+    # TODO(#35229) Once optimization has been completed, we should no longer need to wait for 3
+    # minutes and can drop this to something lower.
+    # This test has some manual steps and one sleep for 30 seconds. Test typically
+    # runs under 1 mins, so 3 minutes is more than enough.
+    @property
+    def default_timeout(self) -> int:
+        return 3*60
+
     @async_test_body
     async def test_TC_MCORE_FS_1_1(self):
         self.is_ci = self.check_pics('PICS_SDK_CI_ONLY')

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -87,9 +87,7 @@ class TC_MCORE_FS_1_1(MatterBaseTest):
                  TestStep("3c", "DUT_FSA commissions TH_FSA")]
         return steps
 
-    # TODO(#35229) Once optimization has been completed, we should no longer need to wait for 3
-    # minutes and can drop this to something lower.
-    # This test has some manual steps and one sleep for 30 seconds. Test typically
+    # This test has some manual steps and one sleep for up to 30 seconds. Test typically
     # runs under 1 mins, so 3 minutes is more than enough.
     @property
     def default_timeout(self) -> int:

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -117,11 +117,11 @@ class TC_MCORE_FS_1_2(MatterBaseTest):
                  TestStep(7, "TH reads all attributes in the Bridged Device Basic Information cluster on new endpoint identified in step 3 from the DUT_FSA")]
         return steps
 
-    # This test has some manual steps, so we need a longer timeout. Test typically runs under 1 mins so 2 mins should
+    # This test has some manual steps, so we need a longer timeout. Test typically runs under 1 mins so 3 mins should
     # be enough time for test to run
     @property
     def default_timeout(self) -> int:
-        return 2*60
+        return 3*60
 
     @async_test_body
     async def test_TC_MCORE_FS_1_2(self):

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -117,9 +117,11 @@ class TC_MCORE_FS_1_2(MatterBaseTest):
                  TestStep(7, "TH reads all attributes in the Bridged Device Basic Information cluster on new endpoint identified in step 3 from the DUT_FSA")]
         return steps
 
+    # This test has some manual steps, so we need a longer timeout. Test typically runs under 1 mins so 2 mins should
+    # be enough time for test to run
     @property
     def default_timeout(self) -> int:
-        return self.user_params.get("report_waiting_timeout_delay_sec", 10)*2 + 60
+        return 2*60
 
     @async_test_body
     async def test_TC_MCORE_FS_1_2(self):

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -117,11 +117,11 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
                  TestStep(10, "TH waits up to 10 seconds for subscription report from the AdministratorCommissioning attribute (from step 6) to reflect values from previous step")]
         return steps
 
-    # This test has some manual steps, so we need a longer timeout. Test typically runs under 1 mins so 2 mins should
+    # This test has some manual steps, so we need a longer timeout. Test typically runs under 1 mins so 3 mins should
     # be enough time for test to run
     @property
     def default_timeout(self) -> int:
-        return 2*60
+        return 3*60
 
     @async_test_body
     async def test_TC_MCORE_FS_1_5(self):

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -117,9 +117,11 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
                  TestStep(10, "TH waits up to 10 seconds for subscription report from the AdministratorCommissioning attribute (from step 6) to reflect values from previous step")]
         return steps
 
+    # This test has some manual steps, so we need a longer timeout. Test typically runs under 1 mins so 2 mins should
+    # be enough time for test to run
     @property
     def default_timeout(self) -> int:
-        return self.user_params.get("report_waiting_timeout_delay_sec", 10)*2 + 60
+        return 2*60
 
     @async_test_body
     async def test_TC_MCORE_FS_1_5(self):


### PR DESCRIPTION
Increase the default timeout of various fabric sync tests that involve user interaction or sleep >= 30 seconds

The large drop for BRBINFO_4_1 was related to a spec change where the timeout could be provided by the client and wasn't defaulted to 60 mins. An earlier PR reduced the time of the wait, but didn't modify the default time to match the new reality

Fixes: https://github.com/project-chip/matter-test-scripts/issues/329
