### PR TITLE
Fix intermittent falure in Darwin browsing test.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissionableBrowser.mm
@@ -268,9 +268,14 @@ public:
         // If there is nothing else to resolve for the given instance name, just remove it
         // too and informs the delegate that it is gone.
         if ([interfaces count] == 0) {
-            dispatch_async(mDispatchQueue, ^{
-                [mDelegate controller:mController didRemoveCommissionableDevice:result];
-            });
+            // If result.instanceName is nil, that means we never notified our
+            // delegate about this result (because we did not get that far in
+            // resolving it), so don't bother notifying about the removal either.
+            if (result.instanceName != nil) {
+                dispatch_async(mDispatchQueue, ^{
+                    [mDelegate controller:mController didRemoveCommissionableDevice:result];
+                });
+            }
 
             mDiscoveredResults[key] = nil;
         }
@@ -325,7 +330,7 @@ public:
         MATTER_LOG_METRIC(kMetricBLEDevicesRemoved, ++mBLEDevicesRemoved);
 
         dispatch_async(mDispatchQueue, ^{
-            [mDelegate controller:mController didFindCommissionableDevice:result];
+            [mDelegate controller:mController didRemoveCommissionableDevice:result];
         });
     }
 


### PR DESCRIPTION
We are running the test against Matter applications that are starting up, and during startup we do some silly unregistering/re-registering of DNS-SD advertisements.  The test was counting all the registrations, not subtracting the un-registrations, and asserting that the resulting count was not too high. But sometimes it is, if we get a "unregister/re-register" pair in there.

The fix:

1) Fixes the test to better track un-registration bits. 2) Fixes the OnBleScanRemove code to call the right delegate method. 3) Fixes OnBrowseRemove to not call the delegate if we have not notified about
   the add for the relevant result.  We could have just worked around this in
   the test, but notifying "removed" about an object with all fields set to nil
   just doesn't make much sense.
