### PR TITLE
[ESP32] Support total operational hours

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -181,7 +181,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     {
         // Start a timer which reloads every one hour and bumps the total operational hours
-        TickType_t reloadPeriod = (1000 * 60 * 60) / portTICK_PERIOD_MS;
+        TickType_t reloadPeriod   = (1000 * 60 * 60) / portTICK_PERIOD_MS;
         TimerHandle_t timerHandle = xTimerCreate("tOpHrs", reloadPeriod, pdPASS, nullptr, TotalOperationalHoursTimerCallback);
         if (timerHandle == nullptr)
         {

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -45,8 +45,6 @@ namespace DeviceLayer {
 
 using namespace ::chip::DeviceLayer::Internal;
 
-// TODO: Define a Singleton instance of CHIP Group Key Store here (#1266)
-
 ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 {
     static ConfigurationManagerImpl sInstance;
@@ -202,8 +200,6 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<ESP32Config>::Init();
     SuccessOrExit(err);
-
-    // TODO: Initialize the global GroupKeyStore object here (#1266)
 
     err = CHIP_NO_ERROR;
 

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -98,6 +98,9 @@ private:
     // ===== Private members reserved for use by this class only.
 
     static void DoFactoryReset(intptr_t arg);
+
+    static uint32_t mTotalOperationalHours;
+    static void TotalOperationalHoursTimerCallback(TimerHandle_t timer);
 };
 
 /**


### PR DESCRIPTION
- Added support for total operational hour attribute using FreeRTOs timer
- removed stale TODOs as #1266 is no longer needed

#### tests
Reduced the resolution to per minute for testing purpose and read the total-operational-hours attribute

```
./chip-tool generaldiagnostics read total-operational-hours 1 0
```