### PR TITLE
Fixing 32-bit vs  64-bit size() log format issue

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
@@ -135,8 +135,8 @@ void EndpointListLoader::Complete()
             EndpointAttributes endpointAttributes = mEndpointAttributesList[i];
             std::shared_ptr<Endpoint> endpoint =
                 std::make_shared<Endpoint>(CastingPlayer::GetTargetCastingPlayer(), endpointAttributes);
-            ChipLogProgress(AppServer, "EndpointListLoader::Complete() mEndpointServerLists[i].size: %lu ",
-                            mEndpointServerLists[i].size());
+            ChipLogProgress(AppServer, "EndpointListLoader::Complete() mEndpointServerLists[i].size: %lu",
+                            static_cast<unsigned long>(mEndpointServerLists[i].size()));
             endpoint->RegisterClusters(mEndpointServerLists[i]);
             CastingPlayer::GetTargetCastingPlayer()->RegisterEndpoint(endpoint);
         }


### PR DESCRIPTION
Fixing 32-bit vs  64-bit size() log format issue from this PR: https://github.com/project-chip/connectedhomeip/pull/35331

Per comment form @andy31415:
https://github.com/project-chip/connectedhomeip/pull/35331#discussion_r1745955671