### PR TITLE
Updating XPC interfaces to pass along context, and fixing some retries

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDefines_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDefines_Internal.h
@@ -111,3 +111,56 @@ typedef struct {} variable_hidden_by_mtr_hide;
                                                                                                                     \
         return outValue;                                                                                            \
     }
+
+#ifndef MTR_OPTIONAL_ATTRIBUTE
+#if __has_feature(objc_arc)
+#define MTR_OPTIONAL_ATTRIBUTE(ATTRIBUTE, VALUE, DICTIONARY)                                                                                       \
+    {                                                                                                                                              \
+        id valueToAdd = VALUE;                                                                                                                     \
+        if (valueToAdd != nil) {                                                                                                                   \
+            CFDictionarySetValue((CFMutableDictionaryRef) DICTIONARY, (CFStringRef) (__bridge const void *) ATTRIBUTE, (const void *) valueToAdd); \
+        }                                                                                                                                          \
+    }
+#else
+#define MTR_OPTIONAL_ATTRIBUTE(ATTRIBUTE, VALUE, DICTIONARY)                                                                              \
+    {                                                                                                                                     \
+        id valueToAdd = VALUE;                                                                                                            \
+        if (valueToAdd != nil) {                                                                                                          \
+            CFDictionarySetValue((CFMutableDictionaryRef) DICTIONARY, (CFStringRef) (const void *) ATTRIBUTE, (const void *) valueToAdd); \
+        }                                                                                                                                 \
+    }
+#endif
+#endif
+
+#ifndef MTR_OPTIONAL_COLLECTION_ATTRIBUTE
+#define MTR_OPTIONAL_COLLECTION_ATTRIBUTE(ATTRIBUTE, COLLECTION, DICTIONARY)                                           \
+    if ([COLLECTION count] > 0) {                                                                                      \
+        CFDictionarySetValue((CFMutableDictionaryRef) DICTIONARY, (CFStringRef) ATTRIBUTE, (const void *) COLLECTION); \
+    }
+#endif
+
+#ifndef MTR_OPTIONAL_NUMBER_ATTRIBUTE
+#define MTR_OPTIONAL_NUMBER_ATTRIBUTE(ATTRIBUTE, NUMBER, DICTIONARY)                                               \
+    if ([NUMBER intValue] != 0) {                                                                                  \
+        CFDictionarySetValue((CFMutableDictionaryRef) DICTIONARY, (CFStringRef) ATTRIBUTE, (const void *) NUMBER); \
+    }
+#endif
+
+#ifndef MTR_REMOVE_ATTRIBUTE
+#define MTR_REMOVE_ATTRIBUTE(ATTRIBUTE, DICTIONARY)                                            \
+    if (ATTRIBUTE != nil && DICTIONARY) {                                                      \
+        CFDictionaryRemoveValue((CFMutableDictionaryRef) DICTIONARY, (CFStringRef) ATTRIBUTE); \
+    }
+#endif
+
+#ifndef MTR_REQUIRED_ATTRIBUTE
+#define MTR_REQUIRED_ATTRIBUTE(ATTRIBUTE, VALUE, DICTIONARY)                                                               \
+    {                                                                                                                      \
+        id valueToAdd = VALUE;                                                                                             \
+        if (valueToAdd != nil) {                                                                                           \
+            CFDictionarySetValue((CFMutableDictionaryRef) DICTIONARY, (CFStringRef) ATTRIBUTE, (const void *) valueToAdd); \
+        } else {                                                                                                           \
+            MTR_LOG_ERROR("Warning, missing %@ to add to %s", ATTRIBUTE, #DICTIONARY);                                     \
+        }                                                                                                                  \
+    }
+#endif

--- a/src/darwin/Framework/CHIP/MTRDeviceController+XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController+XPC.mm
@@ -34,7 +34,13 @@ static NSString * const kMaxIntervalKey = @"maxInterval";
 static NSSet * GetXPCAllowedClasses()
 {
     static NSSet * const sXPCAllowedClasses = [NSSet setWithArray:@[
-        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class], [NSDate class],
+        [NSString class],
+        [NSNumber class],
+        [NSData class],
+        [NSArray class],
+        [NSDictionary class],
+        [NSError class],
+        [NSDate class],
     ]];
     return sXPCAllowedClasses;
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceController+XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController+XPC.mm
@@ -34,7 +34,7 @@ static NSString * const kMaxIntervalKey = @"maxInterval";
 static NSSet * GetXPCAllowedClasses()
 {
     static NSSet * const sXPCAllowedClasses = [NSSet setWithArray:@[
-        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class]
+        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class], [NSDate class],
     ]];
     return sXPCAllowedClasses;
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.h
@@ -27,7 +27,7 @@ MTR_TESTABLE
 - (id)initWithUniqueIdentifier:(NSUUID *)UUID machServiceName:(NSString *)machServiceName options:(NSXPCConnectionOptions)options
 #endif
 
-    @property(atomic, retain, readwrite)NSXPCConnection * xpcConnection;
+@property(nullable, atomic, retain, readwrite) NSXPCConnection * xpcConnection;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.h
@@ -27,7 +27,7 @@ MTR_TESTABLE
 - (id)initWithUniqueIdentifier:(NSUUID *)UUID machServiceName:(NSString *)machServiceName options:(NSXPCConnectionOptions)options
 #endif
 
-@property(nullable, atomic, retain, readwrite) NSXPCConnection * xpcConnection;
+    @property(nullable, atomic, retain, readwrite)NSXPCConnection * xpcConnection;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -19,6 +19,7 @@
 #import "MTRDefines_Internal.h"
 #import "MTRDeviceController_Internal.h"
 #import "MTRDevice_XPC.h"
+#import "MTRDevice_XPC_Internal.h"
 #import "MTRLogging_Internal.h"
 #import "MTRXPCClientProtocol.h"
 #import "MTRXPCServerProtocol.h"
@@ -33,7 +34,10 @@
 
 @interface MTRDeviceController_XPC ()
 
-@property (nonatomic, retain, readwrite) NSUUID * uniqueIdentifier;
+@property (nonatomic, readwrite, retain) NSUUID * uniqueIdentifier;
+@property (nonnull, atomic, readwrite, retain) MTRXPCDeviceControllerParameters * xpcParameters;
+@property (atomic, readwrite, assign) NSTimeInterval xpcRetryTimeInterval;
+@property (atomic, readwrite, assign) BOOL xpcConnectedOrConnecting;
 
 @end
 
@@ -83,6 +87,114 @@
     return [self.uniqueIdentifier UUIDString];
 }
 
+- (void)_startXPCConnectionRetry
+{
+    if (!self.xpcConnectedOrConnecting) {
+        MTR_LOG("%@: XPC Connection retry - Starting retry for XPC Connection", self);
+        self.xpcRetryTimeInterval = 0.5;
+        mtr_weakify(self);
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (self.xpcRetryTimeInterval * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            mtr_strongify(self);
+            [self _xpcConnectionRetry];
+        });
+    } else {
+        MTR_LOG("%@: XPC Connection retry - Not starting retry for XPC Connection, already trying", self);
+    }
+}
+
+- (void)_xpcConnectionRetry
+{
+    MTR_LOG("%@: XPC Connection retry - timer hit", self);
+    if (!self.xpcConnectedOrConnecting) {
+        if (![self _setupXPCConnection]) {
+#if 0 // FIXME: Not sure why this retry is not working, but I will fix this later
+            MTR_LOG("%@: XPC Connection retry - Scheduling another retry", self);
+            self.xpcRetryTimeInterval = self.xpcRetryTimeInterval >= 1 ? self.xpcRetryTimeInterval * 2 : 1;
+            self.xpcRetryTimeInterval = MIN(60.0, self.xpcRetryTimeInterval);
+            mtr_weakify(self);
+
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.xpcRetryTimeInterval * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                mtr_strongify(self);
+                [self _xpcConnectionRetry];
+            });
+#else
+            MTR_LOG("%@: XPC Connection failed retry - bailing", self);
+#endif
+        } else {
+            MTR_LOG("%@: XPC Connection retry - connection attempt successful", self);
+        }
+    } else {
+        MTR_LOG("%@: XPC Connection retry - Mid retry, or connected, stopping retry timer", self);
+    }
+}
+
+- (BOOL)_setupXPCConnection
+{
+    self.xpcConnection = self.xpcParameters.xpcConnectionBlock();
+
+    MTR_LOG("%@ Set up XPC Connection: %@", self, self.xpcConnection);
+    if (self.xpcConnection) {
+        mtr_weakify(self);
+        self.xpcConnection.remoteObjectInterface = [self _interfaceForServerProtocol];
+
+        self.xpcConnection.exportedInterface = [self _interfaceForClientProtocol];
+        self.xpcConnection.exportedObject = self;
+
+        self.xpcConnection.interruptionHandler = ^{
+            mtr_strongify(self);
+            MTR_LOG_ERROR("XPC Connection for device controller interrupted: %@", self.xpcParameters.uniqueIdentifier);
+            self.xpcConnectedOrConnecting = NO;
+            self.xpcConnection = nil;
+            [self _startXPCConnectionRetry];
+        };
+
+        self.xpcConnection.invalidationHandler = ^{
+            mtr_strongify(self);
+            MTR_LOG_ERROR("XPC Connection for device controller invalidated: %@", self.xpcParameters.uniqueIdentifier);
+            self.xpcConnectedOrConnecting = NO;
+            self.xpcConnection = nil;
+            [self _startXPCConnectionRetry];
+        };
+
+        MTR_LOG("%@ Activating new XPC connection", self);
+        [self.xpcConnection activate];
+
+        [[self.xpcConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
+            MTR_LOG_ERROR("Checkin error: %@", error);
+        }] deviceController:self.uniqueIdentifier checkInWithContext:[NSDictionary dictionary]];
+
+        // FIXME: Trying to kick all the MTRDevices attached to this controller to re-establish connections
+        //        This state needs to be stored properly and re-established at connnection time
+
+        MTR_LOG("%@ Starting existing NodeID Registration", self);
+        for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
+            MTR_LOG("%@ => Registering nodeID: %@", self, nodeID);
+            mtr_weakify(self);
+
+            [[self.xpcConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
+                mtr_strongify(self);
+                MTR_LOG_ERROR("%@ Registration error for device nodeID: %@ : %@", self, nodeID, error);
+            }] deviceController:self.uniqueIdentifier registerNodeID:nodeID];
+        }
+
+        __block BOOL barrierComplete = NO;
+
+        [self.xpcConnection scheduleSendBarrierBlock:^{
+            barrierComplete = YES;
+            MTR_LOG("%@: Barrier complete: %d", self, barrierComplete);
+        }];
+
+        MTR_LOG("%@ Done existing NodeID Registration, barrierComplete: %d", self, barrierComplete);
+        self.xpcConnectedOrConnecting = barrierComplete;
+    } else {
+        MTR_LOG_ERROR("%@ Failed to set up XPC Connection", self);
+        self.xpcConnectedOrConnecting = NO;
+    }
+
+    return (self.xpcConnectedOrConnecting);
+}
+
 - (nullable instancetype)initWithParameters:(MTRDeviceControllerAbstractParameters *)parameters
                                       error:(NSError * __autoreleasing *)error
 {
@@ -110,30 +222,12 @@
             return nil;
         }
 
-        self.xpcConnection = connectionBlock();
-        self.uniqueIdentifier = UUID;
+        self.xpcParameters = xpcParameters;
         self.chipWorkQueue = dispatch_queue_create("MTRDeviceController_XPC_queue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         self.nodeIDToDeviceMap = [NSMapTable strongToWeakObjectsMapTable];
+        self.uniqueIdentifier = UUID;
 
-        MTR_LOG("Set up XPC Connection: %@", self.xpcConnection);
-        if (self.xpcConnection) {
-            self.xpcConnection.remoteObjectInterface = [self _interfaceForServerProtocol];
-
-            self.xpcConnection.exportedInterface = [self _interfaceForClientProtocol];
-            self.xpcConnection.exportedObject = self;
-
-            self.xpcConnection.interruptionHandler = ^{
-                MTR_LOG_ERROR("XPC Connection for device controller interrupted: %@", UUID);
-            };
-
-            self.xpcConnection.invalidationHandler = ^{
-                MTR_LOG_ERROR("XPC Connection for device controller invalidated: %@", UUID);
-            };
-
-            MTR_LOG("Activating new XPC connection");
-            [self.xpcConnection activate];
-        } else {
-            MTR_LOG_ERROR("Failed to set up XPC Connection");
+        if (![self _setupXPCConnection]) {
             return nil;
         }
     }
@@ -159,7 +253,7 @@
             self.xpcConnection.exportedObject = self;
 
             MTR_LOG("%s: resuming new XPC connection");
-            [self.xpcConnection resume];
+            [self.xpcConnection activate];
         } else {
             MTR_LOG_ERROR("Failed to set up XPC Connection");
             return nil;
@@ -177,13 +271,7 @@
     os_unfair_lock_assert_owner(self.deviceMapLock);
 
     MTRDevice * deviceToReturn = [[MTRDevice_XPC alloc] initWithNodeID:nodeID controller:self];
-    // If we're not running, don't add the device to our map.  That would
-    // create a cycle that nothing would break.  Just return the device,
-    // which will be in exactly the state it would be in if it were created
-    // while we were running and then we got shut down.
-    if ([self isRunning]) {
-        [self.nodeIDToDeviceMap setObject:deviceToReturn forKey:nodeID];
-    }
+    [self.nodeIDToDeviceMap setObject:deviceToReturn forKey:nodeID];
     MTR_LOG("%s: returning XPC device for node id %@", __PRETTY_FUNCTION__, nodeID);
     return deviceToReturn;
 }
@@ -253,6 +341,14 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_COMMAND(shutdown, shutdownDeviceControlle
     MTR_LOG("Received deviceConfigurationChanged: %@ found device: %@", nodeID, device);
 
     [device deviceConfigurationChanged:nodeID];
+}
+
+- (oneway void)device:(NSNumber *)nodeID internalStateUpdated:(NSDictionary *)dictionary
+{
+    MTRDevice_XPC * device = (MTRDevice_XPC *) [self deviceForNodeID:nodeID];
+    MTR_LOG("Received internalStateUpdated: %@ found device: %@", nodeID, device);
+
+    [device device:nodeID internalStateUpdated:dictionary];
 }
 
 #pragma mark - MTRDeviceController Protocol Client

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -52,7 +52,7 @@
     NSXPCInterface * interface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCServerProtocol)];
 
     NSSet * allowedClasses = [NSSet setWithArray:@[
-        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class], [MTRCommandPath class], [MTRAttributePath class]
+        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class], [MTRCommandPath class], [MTRAttributePath class], [NSDate class],
     ]];
 
     [interface setClasses:allowedClasses
@@ -66,7 +66,7 @@
 {
     NSXPCInterface * interface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCClientProtocol)];
     NSSet * allowedClasses = [NSSet setWithArray:@[
-        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class], [MTRAttributePath class]
+        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class], [MTRAttributePath class], [NSDate class],
     ]];
     [interface setClasses:allowedClasses
               forSelector:@selector(device:receivedAttributeReport:)

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -52,7 +52,15 @@
     NSXPCInterface * interface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCServerProtocol)];
 
     NSSet * allowedClasses = [NSSet setWithArray:@[
-        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class], [MTRCommandPath class], [MTRAttributePath class], [NSDate class],
+        [NSString class],
+        [NSNumber class],
+        [NSData class],
+        [NSArray class],
+        [NSDictionary class],
+        [NSError class],
+        [MTRCommandPath class],
+        [MTRAttributePath class],
+        [NSDate class],
     ]];
 
     [interface setClasses:allowedClasses
@@ -66,7 +74,14 @@
 {
     NSXPCInterface * interface = [NSXPCInterface interfaceWithProtocol:@protocol(MTRXPCClientProtocol)];
     NSSet * allowedClasses = [NSSet setWithArray:@[
-        [NSString class], [NSNumber class], [NSData class], [NSArray class], [NSDictionary class], [NSError class], [MTRAttributePath class], [NSDate class],
+        [NSString class],
+        [NSNumber class],
+        [NSData class],
+        [NSArray class],
+        [NSDictionary class],
+        [NSError class],
+        [MTRAttributePath class],
+        [NSDate class],
     ]];
     [interface setClasses:allowedClasses
               forSelector:@selector(device:receivedAttributeReport:)

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -98,8 +98,8 @@ public:
         UnsolicitedMessageFromPublisherHandler unsolicitedMessageFromPublisherHandler, ReportBeginHandler reportBeginHandler,
         ReportEndHandler reportEndHandler)
         : MTRBaseSubscriptionCallback(attributeReportCallback, eventReportCallback, errorCallback, resubscriptionCallback,
-            subscriptionEstablishedHandler, onDoneHandler, unsolicitedMessageFromPublisherHandler, reportBeginHandler,
-            reportEndHandler)
+              subscriptionEstablishedHandler, onDoneHandler, unsolicitedMessageFromPublisherHandler, reportBeginHandler,
+              reportEndHandler)
     {
     }
 
@@ -466,24 +466,18 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
 - (NSDictionary *)_internalProperties
 {
-    id vidOrUnknown, pidOrUnknown;
+    NSMutableDictionary * properties = [NSMutableDictionary dictionary];
+    std::lock_guard lock(_descriptionLock);
 
-    {
-        std::lock_guard lock(_descriptionLock);
+    MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyKeyVendorID, _vid, properties);
+    MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyKeyProductID, _pid, properties);
+    MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyNetworkFeatures, _allNetworkFeatures, properties);
+    MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyDeviceState, [NSNumber numberWithUnsignedInteger: _internalDeviceStateForDescription], properties);
+    MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionAttemptWait, [NSNumber numberWithUnsignedInt: _lastSubscriptionAttemptWaitForDescription], properties);
+    MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyMostRecentReportTime, _mostRecentReportTimeForDescription, properties);
+    MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionFailureTime, _lastSubscriptionFailureTimeForDescription, properties);
 
-        vidOrUnknown = _vid ?: @"Unknown";
-        pidOrUnknown = _pid ?: @"Unknown";
-        //    id networkFeatures = _allNetworkFeatures;
-        //    id internalDeviceState = _internalDeviceStateForDescription;
-        //    id lastSubscriptionAttemptWait = _lastSubscriptionAttemptWaitForDescription;
-        //    id mostRecentReportTime = _mostRecentReportTimeForDescription;
-        //    id lastSubscriptionFailureTime = _lastSubscriptionFailureTimeForDescription;
-    }
-
-    return @{
-        kMTRDeviceInternalPropertyKeyVendorID : vidOrUnknown,
-        kMTRDeviceInternalPropertyKeyProductID : pidOrUnknown,
-    };
+    return properties;
 }
 
 - (void)_notifyDelegateOfPrivateInternalPropertiesChanges

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -98,8 +98,8 @@ public:
         UnsolicitedMessageFromPublisherHandler unsolicitedMessageFromPublisherHandler, ReportBeginHandler reportBeginHandler,
         ReportEndHandler reportEndHandler)
         : MTRBaseSubscriptionCallback(attributeReportCallback, eventReportCallback, errorCallback, resubscriptionCallback,
-              subscriptionEstablishedHandler, onDoneHandler, unsolicitedMessageFromPublisherHandler, reportBeginHandler,
-              reportEndHandler)
+            subscriptionEstablishedHandler, onDoneHandler, unsolicitedMessageFromPublisherHandler, reportBeginHandler,
+            reportEndHandler)
     {
     }
 
@@ -472,8 +472,8 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyKeyVendorID, _vid, properties);
     MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyKeyProductID, _pid, properties);
     MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyNetworkFeatures, _allNetworkFeatures, properties);
-    MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyDeviceState, [NSNumber numberWithUnsignedInteger: _internalDeviceStateForDescription], properties);
-    MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionAttemptWait, [NSNumber numberWithUnsignedInt: _lastSubscriptionAttemptWaitForDescription], properties);
+    MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyDeviceState, [NSNumber numberWithUnsignedInteger:_internalDeviceStateForDescription], properties);
+    MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionAttemptWait, [NSNumber numberWithUnsignedInt:_lastSubscriptionAttemptWaitForDescription], properties);
     MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyMostRecentReportTime, _mostRecentReportTimeForDescription, properties);
     MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionFailureTime, _lastSubscriptionFailureTimeForDescription, properties);
 

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -98,8 +98,8 @@ public:
         UnsolicitedMessageFromPublisherHandler unsolicitedMessageFromPublisherHandler, ReportBeginHandler reportBeginHandler,
         ReportEndHandler reportEndHandler)
         : MTRBaseSubscriptionCallback(attributeReportCallback, eventReportCallback, errorCallback, resubscriptionCallback,
-            subscriptionEstablishedHandler, onDoneHandler, unsolicitedMessageFromPublisherHandler, reportBeginHandler,
-            reportEndHandler)
+              subscriptionEstablishedHandler, onDoneHandler, unsolicitedMessageFromPublisherHandler, reportBeginHandler,
+              reportEndHandler)
     {
     }
 
@@ -253,8 +253,6 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
  */
 @property (nonatomic) ReadClient * currentReadClient;
 @property (nonatomic) SubscriptionCallback * currentSubscriptionCallback; // valid when and only when currentReadClient is valid
-
-@property (nonatomic, weak) id<MTRXPCClientProtocol_MTRDevice> privateInternalStateDelegate;
 
 @end
 
@@ -488,11 +486,14 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     };
 }
 
-- (void)_notifyPrivateInternalPropertiesDelegateOfChanges
+- (void)_notifyDelegateOfPrivateInternalPropertiesChanges
 {
-    if ([self.privateInternalStateDelegate respondsToSelector:@selector(device:internalStateUpdated:)]) {
-        [self.privateInternalStateDelegate device:self.nodeID internalStateUpdated:[self _internalProperties]];
-    }
+    os_unfair_lock_assert_owner(&self->_lock);
+    [self _callDelegatesWithBlock:^(id<MTRDeviceDelegate> delegate) {
+        if ([delegate respondsToSelector:@selector(device:internalStateUpdated:)]) {
+            [delegate performSelector:@selector(device:internalStateUpdated:) withObject:self withObject:[self _internalProperties]];
+        }
+    }];
 }
 
 #pragma mark - Time Synchronization
@@ -760,6 +761,8 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
             [self _setupSubscriptionWithReason:@"delegate is set and subscription is needed"];
         }
     }
+
+    [self _notifyDelegateOfPrivateInternalPropertiesChanges];
 }
 
 - (void)invalidate
@@ -983,7 +986,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         }];
         /* END DRAGONS */
 
-        [self _notifyPrivateInternalPropertiesDelegateOfChanges];
+        [self _notifyDelegateOfPrivateInternalPropertiesChanges];
     }
 }
 
@@ -1185,7 +1188,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         std::lock_guard lock(_descriptionLock);
         _lastSubscriptionFailureTimeForDescription = _lastSubscriptionFailureTime;
     }
-    [self _notifyPrivateInternalPropertiesDelegateOfChanges];
+    [self _notifyDelegateOfPrivateInternalPropertiesChanges];
     deviceUsesThread = [self _deviceUsesThread];
 
     // If a previous resubscription failed, remove the item from the subscription pool.
@@ -1236,7 +1239,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         _lastSubscriptionAttemptWaitForDescription = lastSubscriptionAttemptWait;
     }
 
-    [self _notifyPrivateInternalPropertiesDelegateOfChanges];
+    [self _notifyDelegateOfPrivateInternalPropertiesChanges];
 }
 
 - (void)_doHandleSubscriptionReset:(NSNumber * _Nullable)retryDelay
@@ -1252,7 +1255,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         std::lock_guard lock(_descriptionLock);
         _lastSubscriptionFailureTimeForDescription = _lastSubscriptionFailureTime;
     }
-    [self _notifyPrivateInternalPropertiesDelegateOfChanges];
+    [self _notifyDelegateOfPrivateInternalPropertiesChanges];
 
     // if there is no delegate then also do not retry
     if (![self _delegateExists]) {
@@ -1310,6 +1313,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         // For non-Thread-enabled devices, just call the resubscription block after the specified time
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, resubscriptionDelayNs), self.queue, resubscriptionBlock);
     }
+    [self _notifyDelegateOfPrivateInternalPropertiesChanges];
 }
 
 - (void)_reattemptSubscriptionNowIfNeededWithReason:(NSString *)reason
@@ -1507,7 +1511,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         std::lock_guard lock(_descriptionLock);
         _mostRecentReportTimeForDescription = [mostRecentReportTimes lastObject];
     }
-    [self _notifyPrivateInternalPropertiesDelegateOfChanges];
+    [self _notifyDelegateOfPrivateInternalPropertiesChanges];
 }
 #endif
 
@@ -1566,7 +1570,6 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         std::lock_guard lock(_descriptionLock);
         _mostRecentReportTimeForDescription = [_mostRecentReportTimes lastObject];
     }
-    [self _notifyPrivateInternalPropertiesDelegateOfChanges];
 
     // Calculate running average and update multiplier - need at least 2 items to calculate intervals
     if (_mostRecentReportTimes.count > 2) {
@@ -1613,6 +1616,8 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         }
     }
 
+    [self _notifyDelegateOfPrivateInternalPropertiesChanges];
+
     // Do not schedule persistence if device is reporting excessively
     if ([self _deviceIsReportingExcessively]) {
         return;
@@ -1637,7 +1642,6 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         std::lock_guard lock(_descriptionLock);
         _mostRecentReportTimeForDescription = nil;
     }
-    [self _notifyPrivateInternalPropertiesDelegateOfChanges];
 
     _deviceReportingExcessivelyStartTime = nil;
     _reportToPersistenceDelayCurrentMultiplier = 1;
@@ -1646,6 +1650,8 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     if ([self _dataStoreExists]) {
         [self _persistClusterData];
     }
+
+    [self _notifyDelegateOfPrivateInternalPropertiesChanges];
 }
 
 - (void)setStorageBehaviorConfiguration:(MTRDeviceStorageBehaviorConfiguration *)storageBehaviorConfiguration
@@ -1699,6 +1705,8 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         }
     }];
 #endif
+
+    [self _notifyDelegateOfPrivateInternalPropertiesChanges];
 }
 
 - (BOOL)_interestedPaths:(NSArray * _Nullable)interestedPaths includesAttributePath:(MTRAttributePath *)attributePath

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -98,8 +98,8 @@ public:
         UnsolicitedMessageFromPublisherHandler unsolicitedMessageFromPublisherHandler, ReportBeginHandler reportBeginHandler,
         ReportEndHandler reportEndHandler)
         : MTRBaseSubscriptionCallback(attributeReportCallback, eventReportCallback, errorCallback, resubscriptionCallback,
-              subscriptionEstablishedHandler, onDoneHandler, unsolicitedMessageFromPublisherHandler, reportBeginHandler,
-              reportEndHandler)
+            subscriptionEstablishedHandler, onDoneHandler, unsolicitedMessageFromPublisherHandler, reportBeginHandler,
+            reportEndHandler)
     {
     }
 

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -225,6 +225,10 @@ static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribe
 // Concrete to XPC internal state property dictionary keys
 static NSString * const kMTRDeviceInternalPropertyKeyVendorID = @"MTRDeviceInternalStateKeyVendorID";
 static NSString * const kMTRDeviceInternalPropertyKeyProductID = @"MTRDeviceInternalStateKeyProductID";
-// TODO:  more internal properties
+static NSString * const kMTRDeviceInternalPropertyNetworkFeatures = @"MTRDeviceInternalPropertyNetworkFeatures";
+static NSString * const kMTRDeviceInternalPropertyDeviceState = @"MTRDeviceInternalPropertyDeviceState";
+static NSString * const kMTRDeviceInternalPropertyLastSubscriptionAttemptWait = @"kMTRDeviceInternalPropertyLastSubscriptionAttemptWait";
+static NSString * const kMTRDeviceInternalPropertyMostRecentReportTime = @"MTRDeviceInternalPropertyMostRecentReportTime";
+static NSString * const kMTRDeviceInternalPropertyLastSubscriptionFailureTime = @"MTRDeviceInternalPropertyLastSubscriptionFailureTime";
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -106,7 +106,7 @@
     NSString * wifi;
     NSString * thread;
     NSNumber * networkFeatures = [self._internalState objectForKey: kMTRDeviceInternalPropertyNetworkFeatures];
-    
+
     if (networkFeatures == nil) {
         wifi = @"NO";
         thread = @"NO";

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -187,8 +187,9 @@
     }];
 }
 
-- (oneway void)device:(NSNumber *)nodeID internalStateUpdated:(NSDictionary *)dictionary {
-    [self _setInternalState: dictionary];
+- (oneway void)device:(NSNumber *)nodeID internalStateUpdated:(NSDictionary *)dictionary
+{
+    [self _setInternalState:dictionary];
     MTR_LOG("%@ internal state updated", self);
 }
 

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -187,6 +187,11 @@
     }];
 }
 
+- (oneway void)device:(NSNumber *)nodeID internalStateUpdated:(NSDictionary *)dictionary {
+    [self _setInternalState: dictionary];
+    MTR_LOG("%@ internal state updated", self);
+}
+
 #pragma mark - Remote Commands
 
 MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(state, MTRDeviceState, MTRDeviceStateUnknown, getStateWithReply)

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -105,7 +105,7 @@
 {
     NSString * wifi;
     NSString * thread;
-    NSNumber * networkFeatures = [self._internalState objectForKey: kMTRDeviceInternalPropertyNetworkFeatures];
+    NSNumber * networkFeatures = [self._internalState objectForKey:kMTRDeviceInternalPropertyNetworkFeatures];
 
     if (networkFeatures == nil) {
         wifi = @"NO";
@@ -123,15 +123,15 @@
 
     return [NSString
         stringWithFormat:@"<%@: %p, node: %016llX-%016llX (%llu), VID: %@, PID: %@, WiFi: %@, Thread: %@, controller: %@>",
-            NSStringFromClass(self.class), self,
-            _deviceController.compressedFabricID.unsignedLongLongValue,
-            _nodeID.unsignedLongLongValue,
-            _nodeID.unsignedLongLongValue,
-            [self._internalState objectForKey: kMTRDeviceInternalPropertyKeyVendorID],
-            [self._internalState objectForKey: kMTRDeviceInternalPropertyKeyProductID],
-            wifi,
-            thread,
-            _deviceController.uniqueIdentifier];
+        NSStringFromClass(self.class), self,
+        _deviceController.compressedFabricID.unsignedLongLongValue,
+        _nodeID.unsignedLongLongValue,
+        _nodeID.unsignedLongLongValue,
+        [self._internalState objectForKey:kMTRDeviceInternalPropertyKeyVendorID],
+        [self._internalState objectForKey:kMTRDeviceInternalPropertyKeyProductID],
+        wifi,
+        thread,
+        _deviceController.uniqueIdentifier];
 }
 
 #pragma mark - Client Callbacks (MTRDeviceDelegate)

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -103,32 +103,35 @@
 
 - (NSString *)description
 {
-    // TODO: Figure out whether, and if so how, to log: VID, PID, WiFi, Thread,
-    // internalDeviceState (do we even have such a thing here?), last
-    // subscription attempt wait (does that apply to us?) queued work (do we
-    // have any?), last report, last subscription failure (does that apply to us?).
-    return [NSString
-        stringWithFormat:@"<%@: %p, node: %016llX-%016llX (%llu), VID: %@, PID: %@, controller: %@>", NSStringFromClass(self.class), self, _deviceController.compressedFabricID.unsignedLongLongValue, _nodeID.unsignedLongLongValue, _nodeID.unsignedLongLongValue, [self _vid], [self _pid], _deviceController.uniqueIdentifier];
-}
-
-- (nullable NSNumber *)_internalStateNumberOrNilForKey:(NSString *)key
-{
-    if ([_internalState[key] isKindOfClass:NSNumber.class]) {
-        NSNumber * number = _internalState[key];
-        return number;
+    NSString * wifi;
+    NSString * thread;
+    NSNumber * networkFeatures = [self._internalState objectForKey: kMTRDeviceInternalPropertyNetworkFeatures];
+    
+    if (networkFeatures == nil) {
+        wifi = @"NO";
+        thread = @"NO";
     } else {
-        return nil;
+        wifi = YES_NO(networkFeatures.unsignedLongLongValue & MTRNetworkCommissioningFeatureWiFiNetworkInterface);
+        thread = YES_NO(networkFeatures.unsignedLongLongValue & MTRNetworkCommissioningFeatureThreadNetworkInterface);
     }
-}
 
-- (nullable NSNumber *)_vid
-{
-    return [self _internalStateNumberOrNilForKey:kMTRDeviceInternalPropertyKeyVendorID];
-}
+    // TODO: Add these to the description
+    // MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyDeviceState, _internalDeviceStateForDescription, properties);
+    // MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionAttemptWait, _lastSubscriptionAttemptWaitForDescription, properties);
+    // MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyMostRecentReportTime, _mostRecentReportTimeForDescription, properties);
+    // MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionFailureTime, _lastSubscriptionFailureTimeForDescription, properties);
 
-- (nullable NSNumber *)_pid
-{
-    return [self _internalStateNumberOrNilForKey:kMTRDeviceInternalPropertyKeyProductID];
+    return [NSString
+        stringWithFormat:@"<%@: %p, node: %016llX-%016llX (%llu), VID: %@, PID: %@, WiFi: %@, Thread: %@, controller: %@>",
+            NSStringFromClass(self.class), self,
+            _deviceController.compressedFabricID.unsignedLongLongValue,
+            _nodeID.unsignedLongLongValue,
+            _nodeID.unsignedLongLongValue,
+            [self._internalState objectForKey: kMTRDeviceInternalPropertyKeyVendorID],
+            [self._internalState objectForKey: kMTRDeviceInternalPropertyKeyProductID],
+            wifi,
+            thread,
+            _deviceController.uniqueIdentifier];
 }
 
 #pragma mark - Client Callbacks (MTRDeviceDelegate)

--- a/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCClientProtocol.h
+++ b/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCClientProtocol.h
@@ -27,9 +27,6 @@ MTR_NEWLY_AVAILABLE
 - (oneway void)deviceBecameActive:(NSNumber *)nodeID;
 - (oneway void)deviceCachePrimed:(NSNumber *)nodeID;
 - (oneway void)deviceConfigurationChanged:(NSNumber *)nodeID;
-
-@optional
-// temporarily optional to avoid lockstep needs
 - (oneway void)device:(NSNumber *)nodeID internalStateUpdated:(NSDictionary *)dictionary;
 @end
 

--- a/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
+++ b/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
@@ -70,9 +70,6 @@ MTR_NEWLY_AVAILABLE
 //- (oneway void)deviceController:(NSUUID *)controller removeServerEndpoint:(MTRServerEndpoint *)endpoint;
 
 - (oneway void)deviceController:(NSUUID *)controller shutdownDeviceController:(NSUUID *)controller;
-
-@optional
-// register / unregister temporarily optional to avoid lockstep needs
 - (oneway void)deviceController:(NSUUID *)controller registerNodeID:(NSNumber *)nodeID;
 - (oneway void)deviceController:(NSUUID *)controller unregisterNodeID:(NSNumber *)nodeID;
 


### PR DESCRIPTION
• XPC clients were not retrying, there is still an issue, but moving forward with this for now.
• Internal state was not propagating 
• New delegate was being used, going back to normal one

