### PR TITLE
[NXP] Adding pre/post-build process support for NXP RW61x platform

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -243,6 +243,7 @@ jobs:
                       --target nxp-rw61x-freertos-all-clusters-wifi \
                       --target nxp-rw61x-freertos-all-clusters-thread \
                       --target nxp-rw61x-freertos-all-clusters-thread-wifi \
+                      --target nxp-rw61x-freertos-all-clusters-wifi-ota-cmake \
                       build \
                       --copy-artifacts-to out/artifacts \
                   "

--- a/config/nxp/chip-cmake-freertos/CMakeLists.txt
+++ b/config/nxp/chip-cmake-freertos/CMakeLists.txt
@@ -20,16 +20,24 @@ if(NOT CHIP_ROOT)
     get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)
 endif()
 
-get_filename_component(GN_ROOT_TARGET ${CHIP_ROOT}/config/nxp/chip-gn-freertos REALPATH)
+if (NOT GN_ROOT_TARGET)
+    get_filename_component(GN_ROOT_TARGET ${CHIP_ROOT}/config/nxp/chip-gn-freertos REALPATH)
+endif()
+
+# Include common NXP helpers for build & pre/post-build process
+include(${CHIP_ROOT}/third_party/nxp/nxp_matter_support/cmake/build_helpers.cmake)
 
 include(${CHIP_ROOT}/config/nxp/cmake/common.cmake)
 include(${CHIP_ROOT}/src/app/chip_data_model.cmake)
 
+if(NOT CONFIG_CHIP_BUILD_APP_WITH_GN)
 # Prepare compiler flags
 matter_add_cflags(${CMAKE_C_FLAGS})
 matter_add_cxxflags(${CMAKE_CXX_FLAGS})
 
 matter_get_compiler_flags_from_targets("${CONFIG_CHIP_EXTERNAL_TARGETS}")
+endif()
+
 
 # ==============================================================================
 # Generate configuration for CHIP GN build system
@@ -39,6 +47,8 @@ matter_add_gn_arg_string("nxp_platform" ${CONFIG_CHIP_NXP_PLATFORM})
 matter_add_gn_arg("chip_with_factory_data" ${CONFIG_CHIP_FACTORY_DATA})
 matter_add_gn_arg("chip_enable_secure_dac_private_key_storage" ${CONFIG_CHIP_SECURE_DAC_PRIVATE_KEY_STORAGE})
 matter_add_gn_arg("chip_enable_secure_whole_factory_data" ${CONFIG_CHIP_ENABLE_SECURE_WHOLE_FACTORY_DATA})
+matter_add_gn_arg_bool("chip_enable_matter_cli" CONFIG_CHIP_LIB_SHELL)
+matter_add_gn_arg_bool("chip_enable_pairing_autostart" CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART)
 
 if (CONFIG_USE_CHIP_DATA_MODEL_INTERFACE)
     set(DATA_MODEL_INTERFACE "enabled")
@@ -46,24 +56,71 @@ else()
     set(DATA_MODEL_INTERFACE "disabled")
 endif()
 
-matter_common_gn_args(
-    DEBUG CONFIG_DEBUG
-    LIB_SHELL CONFIG_CHIP_LIB_SHELL
-    LIB_TESTS CONFIG_CHIP_BUILD_TESTS
-    PROJECT_CONFIG ${CONFIG_CHIP_PROJECT_CONFIG}
-    PROJECT_CONFIG_INC_DIR ${CONFIG_CHIP_PROJECT_CONFIG_INCLUDE_DIRS}
-    DEVICE_INFO_EXAMPLE_PROVIDER CONFIG_CHIP_EXAMPLE_DEVICE_INFO_PROVIDER
-    DATA_MODEL_INTERFACE ${DATA_MODEL_INTERFACE}
-)
+if(CONFIG_BOOTLOADER_MCUBOOT)
+    matter_add_gn_arg_bool("no_mcuboot" false)
+endif(CONFIG_BOOTLOADER_MCUBOOT)
+
+# Enable map file generation by default
+matter_add_gn_arg_bool("chip_generate_link_map_file" true)
+
+if(CONFIG_CHIP_BUILD_APP_WITH_GN)
+    include(${CHIP_ROOT}/third_party/nxp/nxp_matter_support/cmake/nxp_sdk_gn_build.cmake)
+else()
+    matter_common_gn_args(
+        DEBUG CONFIG_DEBUG
+        LIB_SHELL CONFIG_CHIP_LIB_SHELL
+        LIB_TESTS CONFIG_CHIP_BUILD_TESTS
+        PROJECT_CONFIG ${CONFIG_CHIP_PROJECT_CONFIG}
+        PROJECT_CONFIG_INC_DIR ${CONFIG_CHIP_PROJECT_CONFIG_INCLUDE_DIRS}
+        DEVICE_INFO_EXAMPLE_PROVIDER CONFIG_CHIP_EXAMPLE_DEVICE_INFO_PROVIDER
+        DATA_MODEL_INTERFACE ${DATA_MODEL_INTERFACE}
+    )
+endif()
 
 matter_generate_args_tmp_file()
 
 # ==============================================================================
 # Build chip library
 # ==============================================================================
+if(NOT CONFIG_CHIP_BUILD_APP_WITH_GN)
 matter_build(chip
     LIB_SHELL ${CONFIG_CHIP_LIB_SHELL}
     LIB_TESTS ${CONFIG_CHIP_BUILD_TESTS}
     DEVICE_INFO_EXAMPLE_PROVIDER ${CONFIG_CHIP_EXAMPLE_DEVICE_INFO_PROVIDER}
     GN_DEPENDENCIES ${CONFIG_GN_DEPENDENCIES}
 )
+endif()
+
+
+#**************************************************************************************
+# Pre-build instructions
+#**************************************************************************************
+nxp_pre_build_process()
+
+#**************************************************************************************
+# Post-build instructions
+#**************************************************************************************
+if(CONFIG_CHIP_OTA_REQUESTOR)
+
+if (CONFIG_BOOTLOADER_MCUBOOT)
+    # Build mcuboot application
+    nxp_generate_mcuboot()
+
+    # Sign application binaries with mcuboot imgtool
+    nxp_sign_app_imgtool("${CONFIG_REMOVE_SECTIONS_FROM_BIN}")
+
+endif()
+
+    # Generate .ota file
+    nxp_generate_ota_file()
+
+endif(CONFIG_CHIP_OTA_REQUESTOR)
+
+if (CONFIG_CHIP_FACTORY_DATA_BUILD)
+    
+    set(OUTPUT_FILE_PATH ${gn_build}/factory_data)
+    
+    # Generate factory data binaries
+    nxp_generate_factory_data()
+
+endif(CONFIG_CHIP_FACTORY_DATA_BUILD)

--- a/config/nxp/chip-module/generate_factory_data.cmake
+++ b/config/nxp/chip-module/generate_factory_data.cmake
@@ -218,7 +218,9 @@ function(nxp_generate_factory_data)
     # Localize all scripts needed to generate factory data partition
     set(GENERATE_CERTS_SCRIPT_PATH ${CHIP_ROOT}/scripts/tools/nxp/generate_certs.py)
     set(GENERATE_FDATA_SCRIPT_PATH ${CHIP_ROOT}/scripts/tools/nxp/factory_data_generator/generate.py)
-    set(OUTPUT_FILE_PATH ${APPLICATION_BINARY_DIR}/zephyr)
+    if (NOT OUTPUT_FILE_PATH)
+        set(OUTPUT_FILE_PATH ${APPLICATION_BINARY_DIR}/zephyr)
+    endif()
 
     if(CONFIG_CHIP_FACTORY_DATA_CERT_SOURCE_GENERATED)
         # Generate certificates

--- a/examples/all-clusters-app/nxp/rt/rw61x/CMakeLists.txt
+++ b/examples/all-clusters-app/nxp/rt/rw61x/CMakeLists.txt
@@ -1,0 +1,38 @@
+#
+#   Copyright (c) 2024 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+project(chip-rw61x-all-cluster-example)
+
+if (NOT CHIP_ROOT)
+    get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../../../.. REALPATH)
+endif()
+
+# Define the GN root target for the application
+get_filename_component(GN_ROOT_TARGET ${CMAKE_CURRENT_LIST_DIR} REALPATH)
+
+# Include platform specific configs / variables
+include(${CHIP_ROOT}/examples/platform/nxp/rt/rw61x/platform_config.cmake)
+
+add_subdirectory(${CHIP_ROOT}/config/nxp/chip-cmake-freertos ./chip)
+
+#**************************************************************************************
+# Build example application
+#**************************************************************************************
+if(CONFIG_CHIP_BUILD_APP_WITH_GN)
+    nxp_build_app_with_gn()
+endif()

--- a/examples/platform/nxp/rt/rw61x/platform_config.cmake
+++ b/examples/platform/nxp/rt/rw61x/platform_config.cmake
@@ -1,0 +1,110 @@
+
+#
+#   Copyright (c) 2024 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+#
+#   @file
+#     CMake file that defines cmake variables specific to this platform
+#
+
+# Board configs
+set(CONFIG_CORE_FOLDER "")
+
+if (CONFIG_BOARD_VARIANT STREQUAL "frdm")
+    set(CONFIG_BOARD_NAME "frdmrw612")
+else()
+    set(CONFIG_BOARD_NAME "rdrw612bga")
+endif()
+
+# MCUBoot OTA configs
+set(CONFIG_MCUBOOT_BUILD_TYPE "flash_release")
+set(CONFIG_CHIP_MCUBOOT_SLOT_SIZE 0x440000)
+set(CONFIG_CHIP_MCUBOOT_MAX_SECTORS 1088)
+set(CONFIG_CHIP_MCUBOOT_HEADER_SIZE 0x1000)
+
+# CHIP configs
+set(CONFIG_CHIP_DEVICE_VENDOR_ID 4151)
+set(CONFIG_CHIP_DEVICE_PRODUCT_ID 41510)
+
+set(CONFIG_CHIP_DEVICE_VENDOR_NAME "NXP Semiconductors")
+if (NOT CONFIG_CHIP_DEVICE_PRODUCT_NAME)
+    set(CONFIG_CHIP_DEVICE_PRODUCT_NAME "Thermostat")
+endif()
+if (NOT CONFIG_CHIP_DEVICE_TYPE)
+    set(CONFIG_CHIP_DEVICE_TYPE 769)
+endif()
+set(CONFIG_CHIP_DEVICE_SPAKE2_IT 10000)
+set(CONFIG_CHIP_DEVICE_SPAKE2_SALT "UXKLzwHdN3DZZLBaL2iVGhQi/OoQwIwJRQV4rpEalbA=")
+if (NOT CONFIG_CHIP_DEVICE_DISCRIMINATOR)
+    set(CONFIG_CHIP_DEVICE_DISCRIMINATOR 2560)
+endif()
+if (NOT CONFIG_CHIP_DEVICE_SPAKE2_PASSCODE)
+    set(CONFIG_CHIP_DEVICE_SPAKE2_PASSCODE 14014)
+endif()
+set(CONFIG_CHIP_DEVICE_HARDWARE_VERSION 1)
+set(CONFIG_CHIP_DEVICE_HARDWARE_VERSION_STRING "1.0")
+set(CONFIG_CHIP_DEVICE_SERIAL_NUMBER "12345678")
+set(CONFIG_CHIP_DEVICE_MANUFACTURING_DATE "2024-01-01")
+set(CONFIG_CHIP_DEVICE_ROTATING_DEVICE_UID "00112233445566778899aabbccddeeff")
+set(CONFIG_CHIP_DEVICE_PRODUCT_FINISH "Matte")
+set(CONFIG_CHIP_DEVICE_PRODUCT_COLOR "Green")
+set(CONFIG_CHIP_DEVICE_PRODUCT_URL "https://www.nxp.com/products/wireless/wi-fi-plus-bluetooth-plus-802-15-4/wireless-mcu-with-integrated-tri-radiobr1x1-wi-fi-6-plus-bluetooth-low-energy-5-3-802-15-4:RW612")
+set(CONFIG_CHIP_DEVICE_PRODUCT_LABEL "RW612")
+set(CONFIG_CHIP_DEVICE_PART_NUMBER "RW612")
+set(CONFIG_CHIP_ENCRYPTED_FACTORY_DATA_AES128_KEY "2B7E151628AED2A6ABF7158809CF4F3C")
+set(CONFIG_CHIP_FACTORY_DATA_CERT_SOURCE_GENERATED true)
+set(CONFIG_CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER true)
+set(CONFIG_CHIP_ENCRYPTED_FACTORY_DATA true)
+
+# build configs
+set(CONFIG_CHIP_NVM_COMPONENT "nvs")
+set(CONFIG_CHIP_RT_PLATFORM "rw61x")
+set(CONFIG_CHIP_NXP_PLATFORM "rt/${CONFIG_CHIP_RT_PLATFORM}")
+set(CONFIG_CHIP_FACTORY_DATA 1)
+set(CONFIG_CHIP_SECURE_DAC_PRIVATE_KEY_STORAGE false)
+set(CONFIG_CHIP_ENABLE_SECURE_WHOLE_FACTORY_DATA false)
+set(CONFIG_CHIP_BUILD_APP_WITH_GN true)
+set(CONFIG_LOG true)
+set(CONFIG_MATTER_LOG_LEVEL 4) # detail logs
+
+# BLE is enabled by default
+if (NOT DEFINED CONFIG_BT)
+    set(CONFIG_BT true)
+endif()
+
+if (NOT DEFINED CONFIG_CHIP_IPV4)
+    set(CONFIG_CHIP_IPV4 true)
+endif()
+
+if (NOT DEFINED CONFIG_CHIP_DEVICE_SOFTWARE_VERSION)
+    set(CONFIG_CHIP_DEVICE_SOFTWARE_VERSION 1)
+endif()
+
+if (NOT DEFINED CONFIG_CHIP_DEVICE_SOFTWARE_VERSION_STRING)
+    set(CONFIG_CHIP_DEVICE_SOFTWARE_VERSION_STRING "1.0")
+endif()
+
+if(NOT DEFINED CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART)
+    set(CONFIG_CHIP_ENABLE_PAIRING_AUTOSTART true)
+endif()
+
+
+# define sections to remove from the binary when converting the elf to bin with objcopy
+if (CONFIG_CHIP_OTA_REQUESTOR)
+    set(CONFIG_REMOVE_SECTIONS_FROM_BIN -R .flash_config -R .NVM)
+else()
+    set(CONFIG_REMOVE_SECTIONS_FROM_BIN -R .NVM)
+endif()

--- a/examples/thermostat/nxp/rt/rw61x/CMakeLists.txt
+++ b/examples/thermostat/nxp/rt/rw61x/CMakeLists.txt
@@ -1,0 +1,38 @@
+#
+#   Copyright (c) 2024 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+
+project(chip-rw61x-thermostat-example)
+
+if (NOT CHIP_ROOT)
+    get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../../../.. REALPATH)
+endif()
+
+# Define the GN root target for the application
+get_filename_component(GN_ROOT_TARGET ${CMAKE_CURRENT_LIST_DIR} REALPATH)
+
+# Include platform specific configs / variables
+include(${CHIP_ROOT}/examples/platform/nxp/rt/rw61x/platform_config.cmake)
+
+add_subdirectory(${CHIP_ROOT}/config/nxp/chip-cmake-freertos ./chip)
+
+#**************************************************************************************
+# Build example application
+#**************************************************************************************
+if(CONFIG_CHIP_BUILD_APP_WITH_GN)
+    nxp_build_app_with_gn()
+endif()

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -28,7 +28,7 @@ from builders.mbed import MbedApp, MbedBoard, MbedBuilder, MbedProfile
 from builders.mw320 import MW320App, MW320Builder
 from builders.nrf import NrfApp, NrfBoard, NrfConnectBuilder
 from builders.nuttx import NuttXApp, NuttXBoard, NuttXBuilder
-from builders.nxp import NxpApp, NxpBoard, NxpBuilder, NxpBuildSystem, NxpOsUsed
+from builders.nxp import NxpApp, NxpBoard, NxpBoardVariant, NxpBuilder, NxpBuildSystem, NxpOsUsed
 from builders.openiotsdk import OpenIotSdkApp, OpenIotSdkBuilder, OpenIotSdkCryptoBackend
 from builders.qpg import QpgApp, QpgBoard, QpgBuilder
 from builders.stm32 import stm32App, stm32Board, stm32Builder
@@ -551,7 +551,7 @@ def BuildNxpTarget():
     target.AppendModifier('data-model-disabled', data_model_interface="disabled").ExceptIfRe('-data-model-enabled')
     target.AppendModifier('data-model-enabled', data_model_interface="enabled").ExceptIfRe('-data-model-disabled')
     target.AppendModifier(name="factory-build", enable_factory_data_build=True).OnlyIfRe('rw61x')
-    target.AppendModifier(name="frdm", board_variant="frdm").OnlyIfRe('rw61x')
+    target.AppendModifier(name="frdm", board_variant=NxpBoardVariant.FRDM).OnlyIfRe('rw61x')
     target.AppendModifier(name="cmake", build_system=NxpBuildSystem.CMAKE).OnlyIfRe('rw61x')
 
     return target

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -550,6 +550,8 @@ def BuildNxpTarget():
     target.AppendModifier(name="matter-shell", enable_shell=True).ExceptIfRe('k32w0|k32w1')
     target.AppendModifier('data-model-disabled', data_model_interface="disabled").ExceptIfRe('-data-model-enabled')
     target.AppendModifier('data-model-enabled', data_model_interface="enabled").ExceptIfRe('-data-model-disabled')
+    target.AppendModifier(name="factory-build", enable_factory_data_build=True).OnlyIfRe('rw61x')
+    target.AppendModifier(name="frdm", board_variant="frdm").OnlyIfRe('rw61x')
 
     return target
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -28,7 +28,7 @@ from builders.mbed import MbedApp, MbedBoard, MbedBuilder, MbedProfile
 from builders.mw320 import MW320App, MW320Builder
 from builders.nrf import NrfApp, NrfBoard, NrfConnectBuilder
 from builders.nuttx import NuttXApp, NuttXBoard, NuttXBuilder
-from builders.nxp import NxpApp, NxpBoard, NxpBuilder, NxpOsUsed, NxpBuildSystem
+from builders.nxp import NxpApp, NxpBoard, NxpBuilder, NxpBuildSystem, NxpOsUsed
 from builders.openiotsdk import OpenIotSdkApp, OpenIotSdkBuilder, OpenIotSdkCryptoBackend
 from builders.qpg import QpgApp, QpgBoard, QpgBuilder
 from builders.stm32 import stm32App, stm32Board, stm32Builder

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -28,7 +28,7 @@ from builders.mbed import MbedApp, MbedBoard, MbedBuilder, MbedProfile
 from builders.mw320 import MW320App, MW320Builder
 from builders.nrf import NrfApp, NrfBoard, NrfConnectBuilder
 from builders.nuttx import NuttXApp, NuttXBoard, NuttXBuilder
-from builders.nxp import NxpApp, NxpBoard, NxpBuilder, NxpOsUsed
+from builders.nxp import NxpApp, NxpBoard, NxpBuilder, NxpOsUsed, NxpBuildSystem
 from builders.openiotsdk import OpenIotSdkApp, OpenIotSdkBuilder, OpenIotSdkCryptoBackend
 from builders.qpg import QpgApp, QpgBoard, QpgBuilder
 from builders.stm32 import stm32App, stm32Board, stm32Builder
@@ -552,6 +552,7 @@ def BuildNxpTarget():
     target.AppendModifier('data-model-enabled', data_model_interface="enabled").ExceptIfRe('-data-model-disabled')
     target.AppendModifier(name="factory-build", enable_factory_data_build=True).OnlyIfRe('rw61x')
     target.AppendModifier(name="frdm", board_variant="frdm").OnlyIfRe('rw61x')
+    target.AppendModifier(name="cmake", build_system=NxpBuildSystem.CMAKE).OnlyIfRe('rw61x')
 
     return target
 

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -262,7 +262,7 @@ class NxpBuilder(GnBuilder):
                 flags.append('-DFILE_SUFFIX=fdata')
             else:
                 flags.append("-DCONFIG_CHIP_FACTORY_DATA=true")
-        
+
         if self.enable_ethernet:
             if self.os_env == NxpOsUsed.ZEPHYR:
                 flags.append('-DEXTRA_CONF_FILE="prj_ethernet.conf"')

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -304,7 +304,7 @@ class NxpBuilder(GnBuilder):
             flag_board_variant = "-DCONFIG_BOARD_VARIANT=\"%s\"" % self.board_variant.BoardVariantName(self.board)
             flags.append(flag_board_variant)
 
-        build_flags = " ".join(flags) if len(flags) > 0 else ""
+        build_flags = " ".join(flags)
 
         return build_flags
 

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -140,11 +140,12 @@ class NxpBuilder(GnBuilder):
                  enable_thread: bool = False,
                  enable_wifi: bool = False,
                  enable_ethernet: bool = False,
-                 disable_ipv4: bool = False,
                  enable_shell: bool = False,
                  enable_ota: bool = False,
                  data_model_interface: Optional[str] = None,
-                 ):
+                 enable_factory_data_build: bool = False,
+                 disable_pairing_autostart: bool = False,
+                 board_variant: str = None):
         super(NxpBuilder, self).__init__(
             root=app.BuildRoot(root, board, os_env),
             runner=runner)
@@ -160,7 +161,6 @@ class NxpBuilder(GnBuilder):
         self.enable_lit = enable_lit
         self.enable_rotating_id = enable_rotating_id
         self.has_sw_version_2 = has_sw_version_2
-        self.disable_ipv4 = disable_ipv4
         self.disable_ble = disable_ble
         self.enable_thread = enable_thread
         self.enable_wifi = enable_wifi
@@ -168,6 +168,9 @@ class NxpBuilder(GnBuilder):
         self.enable_ota = enable_ota
         self.enable_shell = enable_shell
         self.data_model_interface = data_model_interface
+        self.enable_factory_data_build = enable_factory_data_build
+        self.disable_pairing_autostart = disable_pairing_autostart
+        self.board_variant = board_variant
 
     def GnBuildArgs(self):
         args = []
@@ -222,26 +225,63 @@ class NxpBuilder(GnBuilder):
 
         return args
 
-    def WestBuildArgs(self):
-        args = []
+    def CmakeBuildFlags(self):
+        flags = []
         if self.enable_factory_data:
-            args.append('-DFILE_SUFFIX=fdata')
-
+            if self.os_env == NxpOsUsed.ZEPHYR:
+                flags.append('-DFILE_SUFFIX=fdata')
+            else:
+                flags.append("-DCONFIG_CHIP_FACTORY_DATA=true")
+        
         if self.enable_ethernet:
-            args.append('-DEXTRA_CONF_FILE="prj_ethernet.conf"')
+            if self.os_env == NxpOsUsed.ZEPHYR:
+                flags.append('-DEXTRA_CONF_FILE="prj_ethernet.conf"')
 
         if self.has_sw_version_2:
-            args.append('-DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION=2')
-
+            flags.append("-DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION=2")
+            flags.append("-DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION_STRING=\"2.0\"")
+        
         if self.data_model_interface:
             # NOTE: this is not supporting "check"
             enabled = "y" if self.data_model_interface.lower() == "enabled" else "n"
-            args.append(f"-DCONFIG_USE_CHIP_DATA_MODEL_INTERFACE={enabled}")
+            flags.append(f"-DCONFIG_USE_CHIP_DATA_MODEL_INTERFACE={enabled}")
 
-        build_args = " -- " + " ".join(args) if len(args) > 0 else ""
-        return build_args
+        if self.enable_ota:
+            flags.append("-DCONFIG_CHIP_OTA_REQUESTOR=true")
+            if self.os_env == NxpOsUsed.FREERTOS and self.board == NxpBoard.RW61X:
+                flags.append("-DCONFIG_BOOTLOADER_MCUBOOT=true")
+
+        if self.disable_ble:
+            flags.append("-DCONFIG_BT=false")
+
+        if self.enable_wifi:
+            flags.append('-DCONFIG_CHIP_WIFI=true')
+
+        if self.enable_thread:
+            flags.append("-DCONFIG_NET_L2_OPENTHREAD=true -DCONFIG_CHIP_IPV4=false")
+
+        if self.enable_factory_data_build:
+            # Generate the factory data binary
+            flags.append("-DCONFIG_CHIP_FACTORY_DATA_BUILD=true -DCONFIG_CHIP_FACTORY_DATA=true")
+
+        if self.enable_shell:
+            flags.append("-DCONFIG_CHIP_LIB_SHELL=true")
+
+        if self.disable_pairing_autostart:
+            flags.append('-DCONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=false')
+
+        if self.board_variant:
+            if self.board == NxpBoard.RW61X:
+                flag_board_variant = "-DCONFIG_BOARD_VARIANT=\"%s\"" % self.board_variant
+            
+            flags.append(flag_board_variant)
+
+        build_flags = " ".join(flags) if len(flags) > 0 else ""    
+
+        return build_flags
 
     def generate(self):
+        build_flags = self.CmakeBuildFlags()
         if self.os_env == NxpOsUsed.ZEPHYR:
             if 'ZEPHYR_NXP_SDK_INSTALL_DIR' not in os.environ:
                 raise Exception("ZEPHYR_NXP_SDK_INSTALL_DIR need to be set")
@@ -253,11 +293,11 @@ class NxpBuilder(GnBuilder):
             cmd += '\nexport ZEPHYR_BASE="$ZEPHYR_NXP_BASE"'
             cmd += '\nunset ZEPHYR_TOOLCHAIN_VARIANT'
 
-            cmd += '\nwest build -p --cmake-only -b {board_name} -d {out_folder} {example_folder}{build_args}'.format(
+            cmd += '\nwest build -p --cmake-only -b {board_name} -d {out_folder} {example_folder} {build_flags}'.format(
                 board_name=self.board.Name(self.os_env),
                 out_folder=self.output_dir,
                 example_folder=self.app.BuildRoot(self.code_root, self.board, self.os_env),
-                build_args=self.WestBuildArgs())
+                build_flags=self.CmakeBuildFlags())
             self._Execute(['bash', '-c', cmd], title='Generating ' + self.identifier)
         else:
             cmd = ''
@@ -273,29 +313,40 @@ class NxpBuilder(GnBuilder):
                         cmd += 'export NXP_K32W0_SDK_ROOT="' + str(p.sdk_storage_location_abspath) + '" \n '
                     elif p.sdk_name == 'common':
                         cmd += 'export NXP_SDK_ROOT="' + str(p.sdk_storage_location_abspath) + '" \n '
-            # add empty space at the end to avoid concatenation issue when there is no --args
-            cmd += 'gn gen --check --fail-on-unused-args --export-compile-commands --root=%s ' % self.root
 
-            extra_args = []
+            if self.board == NxpBoard.RW61X:
+                cmd += '''
+                cmake -GNinja {build_flags} -H{example_folder} -B{out_folder}
+                '''.format(
+                    build_flags=build_flags,
+                    example_folder=self.app.BuildRoot(self.code_root, self.board, self.os_env),
+                    out_folder=self.output_dir).strip()
+                self._Execute(['bash', '-c', cmd], title='Generating ' + self.identifier)
 
-            if self.options.pw_command_launcher:
-                extra_args.append('pw_command_launcher="%s"' % self.options.pw_command_launcher)
+            else:
+                # add empty space at the end to avoid concatenation issue when there is no --args
+                cmd += 'gn gen --check --fail-on-unused-args --export-compile-commands --root=%s ' % self.root
 
-            if self.options.enable_link_map_file:
-                extra_args.append('chip_generate_link_map_file=true')
+                extra_args = []
 
-            if self.options.pregen_dir:
-                extra_args.append('chip_code_pre_generated_directory="%s"' % self.options.pregen_dir)
+                if self.options.pw_command_launcher:
+                    extra_args.append('pw_command_launcher="%s"' % self.options.pw_command_launcher)
 
-            extra_args.extend(self.GnBuildArgs() or [])
-            if extra_args:
-                cmd += " --args='%s" % ' '.join(extra_args) + "' "
+                if self.options.enable_link_map_file:
+                    extra_args.append('chip_generate_link_map_file=true')
 
-            cmd += self.output_dir
+                if self.options.pregen_dir:
+                    extra_args.append('chip_code_pre_generated_directory="%s"' % self.options.pregen_dir)
 
-            title = 'Generating ' + self.identifier
+                extra_args.extend(self.GnBuildArgs() or [])
+                if extra_args:
+                    cmd += ' --args="%s' % ' '.join(extra_args) + '" '
 
-            self._Execute(['bash', '-c', cmd], title=title)
+                cmd += self.output_dir
+
+                title = 'Generating ' + self.identifier
+
+                self._Execute(['bash', '-c', cmd], title=title)
 
     def build_outputs(self):
         name = 'chip-%s-%s' % (self.board.Name(self.os_env), self.app.NameSuffix())

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -287,10 +287,10 @@ class NxpBuilder(GnBuilder):
         if self.board_variant:
             if self.board == NxpBoard.RW61X:
                 flag_board_variant = "-DCONFIG_BOARD_VARIANT=\"%s\"" % self.board_variant
-            
+
             flags.append(flag_board_variant)
 
-        build_flags = " ".join(flags) if len(flags) > 0 else ""    
+        build_flags = " ".join(flags) if len(flags) > 0 else ""
 
         return build_flags
 

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -325,7 +325,7 @@ class NxpBuilder(GnBuilder):
                 board_name=self.board.Name(self.os_env),
                 out_folder=self.output_dir,
                 example_folder=self.app.BuildRoot(self.code_root, self.board, self.os_env),
-                build_flags=self.CmakeBuildFlags())
+                build_flags=build_flags)
             self._Execute(['bash', '-c', cmd], title='Generating ' + self.identifier)
         else:
             cmd = ''

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -94,13 +94,13 @@ class NxpBoardVariant(Enum):
     FRDM = auto()
 
     def BoardVariantName(self, board):
-        if board == NxpBoard.RW61X:
-            if self == NxpBoardVariant.RD:
-                return "rdrw612bga"
-            elif self == NxpBoardVariant.FRDM:
-                return "frdm"
-        else:
-            raise Exception('Unkown board variant: %r' % self)
+        if board != NxpBoard.RW61X:
+            raise Exception('Board variants only supported for RW61X')
+
+        if self == NxpBoardVariant.RD:
+            return "rdrw612bga"
+        elif self == NxpBoardVariant.FRDM:
+            return "frdm"
 
 
 class NxpApp(Enum):

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -86,6 +86,18 @@ class NxpBoard(Enum):
         else:
             raise Exception('Unknown board type: %r' % self)
 
+class NxpBoardVariant(Enum):
+    RD = auto()
+    FRDM = auto()
+    
+    def BoardVariantName(self, board):
+        if board == NxpBoard.RW61X:
+            if self == NxpBoardVariant.RD:
+                return "rdrw612bga"
+            elif self == NxpBoardVariant.FRDM:
+                return "frdm"
+        else:
+            raise Exception('Unkown board variant: %r' % self)
 
 class NxpApp(Enum):
     LIGHTING = auto()
@@ -138,6 +150,7 @@ class NxpBuilder(GnBuilder):
                  runner,
                  app: NxpApp = NxpApp.LIGHTING,
                  board: NxpBoard = NxpBoard.K32W0,
+                 board_variant: NxpBoardVariant = None,
                  os_env: NxpOsUsed = NxpOsUsed.FREERTOS,
                  build_system: NxpBuildSystem = NxpBuildSystem.GN,
                  low_power: bool = False,
@@ -156,8 +169,7 @@ class NxpBuilder(GnBuilder):
                  enable_ota: bool = False,
                  data_model_interface: Optional[str] = None,
                  enable_factory_data_build: bool = False,
-                 disable_pairing_autostart: bool = False,
-                 board_variant: str = None):
+                 disable_pairing_autostart: bool = False):
         super(NxpBuilder, self).__init__(
             root=app.BuildRoot(root, board, os_env),
             runner=runner)
@@ -285,9 +297,7 @@ class NxpBuilder(GnBuilder):
             flags.append('-DCONFIG_CHIP_ENABLE_PAIRING_AUTOSTART=false')
 
         if self.board_variant:
-            if self.board == NxpBoard.RW61X:
-                flag_board_variant = "-DCONFIG_BOARD_VARIANT=\"%s\"" % self.board_variant
-
+            flag_board_variant = "-DCONFIG_BOARD_VARIANT=\"%s\"" % self.board_variant.BoardVariantName(self.board)
             flags.append(flag_board_variant)
 
         build_flags = " ".join(flags) if len(flags) > 0 else ""

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -34,6 +34,7 @@ class NxpOsUsed(Enum):
         else:
             raise Exception('Unknown OS type: %r' % self)
 
+
 class NxpBuildSystem(Enum):
     GN = auto()
     CMAKE = auto()
@@ -45,6 +46,7 @@ class NxpBuildSystem(Enum):
             return 'cmake'
         else:
             raise Exception('Unknown build system: %r' % self)
+
 
 class NxpBoard(Enum):
     K32W0 = auto()
@@ -86,10 +88,11 @@ class NxpBoard(Enum):
         else:
             raise Exception('Unknown board type: %r' % self)
 
+
 class NxpBoardVariant(Enum):
     RD = auto()
     FRDM = auto()
-    
+
     def BoardVariantName(self, board):
         if board == NxpBoard.RW61X:
             if self == NxpBoardVariant.RD:
@@ -98,6 +101,7 @@ class NxpBoardVariant(Enum):
                 return "frdm"
         else:
             raise Exception('Unkown board variant: %r' % self)
+
 
 class NxpApp(Enum):
     LIGHTING = auto()
@@ -266,7 +270,7 @@ class NxpBuilder(GnBuilder):
         if self.has_sw_version_2:
             flags.append("-DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION=2")
             flags.append("-DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION_STRING=\"2.0\"")
-        
+
         if self.data_model_interface:
             # NOTE: this is not supporting "check"
             enabled = "y" if self.data_model_interface.lower() == "enabled" else "n"

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -13,7 +13,7 @@ linux-{x64,arm64}-{rpc-console,all-clusters,all-clusters-minimal,chip-tool,therm
 linux-x64-efr32-test-runner[-clang]
 imx-{chip-tool,lighting-app,thermostat,all-clusters-app,all-clusters-minimal-app,ota-provider-app}[-release]
 infineon-psoc6-{lock,light,all-clusters,all-clusters-minimal}[-ota][-updateimage][-trustm]
-nxp-{k32w0,k32w1,rw61x,rw61x_eth,mcxw71}-{zephyr,freertos}-{lighting,contact-sensor,lock-app,all-clusters,laundry-washer,thermostat}[-factory][-low-power][-lit][-fro32k][-smu2][-dac-conversion][-rotating-id][-sw-v2][-ota][-wifi][-ethernet][-thread][-matter-shell][-data-model-disabled][-data-model-enabled]
+nxp-{k32w0,k32w1,rw61x,rw61x_eth,mcxw71}-{zephyr,freertos}-{lighting,contact-sensor,lock-app,all-clusters,laundry-washer,thermostat}[-factory][-low-power][-lit][-fro32k][-smu2][-dac-conversion][-rotating-id][-sw-v2][-ota][-wifi][-ethernet][-thread][-matter-shell][-data-model-disabled][-data-model-enabled][-factory-build][-frdm][-cmake]
 mbed-cy8cproto_062_4343w-{lock,light,all-clusters,all-clusters-minimal,pigweed,ota-requestor,shell}[-release][-develop][-debug][-data-model-disabled][-data-model-enabled]
 mw320-all-clusters-app
 nrf-{nrf5340dk,nrf52840dk,nrf52840dongle}-{all-clusters,all-clusters-minimal,lock,light,light-switch,shell,pump,pump-controller,window-covering}[-rpc][-data-model-disabled][-data-model-enabled]

--- a/scripts/setup/requirements.nxp.txt
+++ b/scripts/setup/requirements.nxp.txt
@@ -1,3 +1,6 @@
 crc>=7.0.0
 jsonschema>=4.17.0
 pycryptodome>=3.20.0
+intelhex
+cbor
+cbor2


### PR DESCRIPTION
The aim of this Pull Request is to introduce the pre-build and post-build steps to automatize the generation of required pre/post-build files, and reduce the manual efforts for testing our applications.

Key changes : 
- Added CMake files for NXP RW61x examples, where cmake is utilized for executing the pre- and post- build tasks, and GN continues to handle the actual build of the applications.
- Added the pre- and post-build steps in the common "config/nxp/chip-cmake-freertos/CMakeLists.txt"
- Updated the NXP builder to utilize the build_examples framework for building RW61x applications with cmake (while GN build is also still supported)