### PR TITLE
Remove mentions of client-side global attributes in the ZAP XML.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/global-attributes.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/global-attributes.xml
@@ -16,9 +16,7 @@ limitations under the License.
 -->
 <configurator>
   <global>
-    <attribute side="client" code="0xFFFD" define="CLUSTER_REVISION_CLIENT" type="int16u"   default="1">ClusterRevision</attribute>
     <attribute side="server" code="0xFFFD" define="CLUSTER_REVISION_SERVER" type="int16u"   default="1">ClusterRevision</attribute>
-    <attribute side="client" code="0xFFFC" define="FEATURE_MAP_CLIENT"      type="bitmap32" default="0">FeatureMap</attribute>
     <attribute side="server" code="0xFFFC" define="FEATURE_MAP_SERVER"      type="bitmap32" default="0">FeatureMap</attribute>
     <attribute side="server" code="0xFFFB" define="ATTRIBUTE_LIST_SERVER"   type="array" entryType="attrib_id">AttributeList</attribute>
     <attribute side="server" code="0xFFFA" define="EVENT_LIST"              type="array" entryType="event_id">EventList</attribute>


### PR DESCRIPTION
Client-side attributes do not exist in Matter.
