### PR TITLE
[Darwin] Fix CI failure in MTRDeviceTests - test036_TestStorageBehaviorConfiguration

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -1505,6 +1505,8 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         std::lock_guard lock(_descriptionLock);
         _mostRecentReportTimeForDescription = [mostRecentReportTimes lastObject];
     }
+
+    std::lock_guard lock(_lock);
     [self _notifyDelegateOfPrivateInternalPropertiesChanges];
 }
 #endif


### PR DESCRIPTION
This test has been failing because of a unit test calling lock assert outside of locking.