### PR TITLE
[Fabric-Sync] Enhance the startup script for improved diagnostics.

### DIFF
--- a/examples/fabric-admin/scripts/run_fabric_sync.sh
+++ b/examples/fabric-admin/scripts/run_fabric_sync.sh
@@ -14,7 +14,9 @@ DEFAULT_BRIDGE_CHOICES=(
     "./fabric-bridge-app"
     "out/debug/standalone/fabric-bridge-app"
     "out/linux-x64-fabric-bridge-rpc/fabric-bridge-app"
+    "out/linux-x64-fabric-bridge-rpc-no-ble/fabric-bridge-app"    
     "out/darwin-arm64-fabric-bridge-rpc/fabric-bridge-app"
+    "out/darwin-arm64-fabric-bridge-rpc-no-ble/fabric-bridge-app"    
 )
 FABRIC_ADMIN_LOG="/tmp/fabric_admin.log"
 FABRIC_BRIDGE_APP_LOG="/tmp/fabric_bridge_app.log"

--- a/examples/fabric-admin/scripts/run_fabric_sync.sh
+++ b/examples/fabric-admin/scripts/run_fabric_sync.sh
@@ -14,9 +14,9 @@ DEFAULT_BRIDGE_CHOICES=(
     "./fabric-bridge-app"
     "out/debug/standalone/fabric-bridge-app"
     "out/linux-x64-fabric-bridge-rpc/fabric-bridge-app"
-    "out/linux-x64-fabric-bridge-rpc-no-ble/fabric-bridge-app"    
+    "out/linux-x64-fabric-bridge-rpc-no-ble/fabric-bridge-app"
     "out/darwin-arm64-fabric-bridge-rpc/fabric-bridge-app"
-    "out/darwin-arm64-fabric-bridge-rpc-no-ble/fabric-bridge-app"    
+    "out/darwin-arm64-fabric-bridge-rpc-no-ble/fabric-bridge-app"
 )
 FABRIC_ADMIN_LOG="/tmp/fabric_admin.log"
 FABRIC_BRIDGE_APP_LOG="/tmp/fabric_bridge_app.log"

--- a/examples/fabric-bridge-app/linux/README.md
+++ b/examples/fabric-bridge-app/linux/README.md
@@ -92,7 +92,7 @@ defined:
 
     ```
     source scripts/activate.sh
-    ./scripts/build/build_examples.py --target linux-x64-fabric-bridge-rpc build
+    ./scripts/build/build_examples.py --target linux-x64-fabric-bridge-rpc-no-ble build
     ```
 
     ### For Raspberry Pi 4 example:


### PR DESCRIPTION
Since we use IP to pair Fabric-Bridge, we have disable the BLE when building Fabric-Bridge image in CI.

Update the startup script for improved diagnostics.  

