### PR TITLE
Add GetNextAction API so that a caller that might want to implement a…

### DIFF
--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -134,6 +134,11 @@ void TransferSession::PollOutput(OutputEvent & event, System::Clock::Timestamp c
     mPendingOutput = OutputEventType::kNone;
 }
 
+void TransferSession::GetNextAction(OutputEvent & event)
+{
+    PollOutput(event, System::SystemClock().GetMonotonicTimestamp());
+}
+
 CHIP_ERROR TransferSession::StartTransfer(TransferRole role, const TransferInitData & initData, System::Clock::Timeout timeout)
 {
     VerifyOrReturnError(mState == TransferState::kUnitialized, CHIP_ERROR_INCORRECT_STATE);

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -172,7 +172,8 @@ public:
      *   the caller will get an event of type OutputEventType::kNone.
      *
      *   It is possible that consecutive calls to this method may emit different outputs depending on the state of the
-     *   TransferSession object.  The caller is generally expected to keep calling this method until it gets an event of type OutputEventType::kNone.
+     *   TransferSession object.  The caller is generally expected to keep calling this method until it gets an event of type
+     * OutputEventType::kNone.
      *
      *   If the output event type is kMsgToSend, the caller is expected to send the message immediately on the
      *   relevant exchange.  In this case the BDX session timeout timer will start when GetNextAction is called.

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -173,8 +173,10 @@ public:
      *   It is possible that consecutive calls to this method may emit different outputs depending on the state of the
      *   TransferSession object and so we need to call this until we get an event of type - OutputEventType::kNone
      *
-     *   Note that if the event type is kMsgToSend, the caller is expected to send the message immediately over the
-     *   exchange otherwise the caller is expected to pass the event to HandleTransferSessionOutput to handle the BDX
+     *   If the output event type is kMsgToSend, the caller is expected to send the message immediately on the
+     *   relevant exchange.  In this case the BDX session timeout timer will start when GetNextAction is called.
+     *
+     *   For all other event types, the caller is expected to pass the event to HandleTransferSessionOutput to handle the BDX
      *   message or any other TransferSession event.
      *
      *   See OutputEventType for all possible output event types.

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -167,6 +167,24 @@ public:
 
     /**
      * @brief
+     *   Gets the pending output event from the transfer session in the event param passed in by the caller.
+     *   The output event may contain some data for the caller to act upon.
+     *
+     *   It is possible that consecutive calls to this method may emit different outputs depending on the state of the
+     *   TransferSession object and so we need to call this until we get an event of type - OutputEventType::kNone
+     *
+     *   Note that if the event type is kMsgToSend, the caller is expected to send the message immediately over the
+     *   exchange otherwise the caller is expected to pass the event to HandleTransferSessionOutput to handle the BDX
+     *   message or any other TransferSession event.
+     *
+     *   See OutputEventType for all possible output event types.
+     *
+     * @param event     Reference to an OutputEvent struct that will be filled out with any pending output event data
+     */
+    void GetNextAction(OutputEvent & event);
+
+    /**
+     * @brief
      *   Initializes the TransferSession object and prepares a TransferInit message (emitted via PollOutput()).
      *
      *   A TransferSession object must be initialized with either StartTransfer() or WaitForTransfer().

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -169,10 +169,10 @@ public:
      * @brief
      *   Gets the pending output event from the transfer session in the event param passed in by the caller.
      *   The output event may contain some data for the caller to act upon. If there is no pending output event,
-     *   the caller will get an event of type - OutputEventType::kNone.
+     *   the caller will get an event of type OutputEventType::kNone.
      *
      *   It is possible that consecutive calls to this method may emit different outputs depending on the state of the
-     *   TransferSession object and the caller needs to call this until we get an event of type - OutputEventType::kNone
+     *   TransferSession object.  The caller is generally expected to keep calling this method until it gets an event of type OutputEventType::kNone.
      *
      *   If the output event type is kMsgToSend, the caller is expected to send the message immediately on the
      *   relevant exchange.  In this case the BDX session timeout timer will start when GetNextAction is called.

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -168,16 +168,14 @@ public:
     /**
      * @brief
      *   Gets the pending output event from the transfer session in the event param passed in by the caller.
-     *   The output event may contain some data for the caller to act upon.
+     *   The output event may contain some data for the caller to act upon. If there is no pending output event,
+     *   the caller will get an event of type - OutputEventType::kNone.
      *
      *   It is possible that consecutive calls to this method may emit different outputs depending on the state of the
-     *   TransferSession object and so we need to call this until we get an event of type - OutputEventType::kNone
+     *   TransferSession object and the caller needs to call this until we get an event of type - OutputEventType::kNone
      *
      *   If the output event type is kMsgToSend, the caller is expected to send the message immediately on the
      *   relevant exchange.  In this case the BDX session timeout timer will start when GetNextAction is called.
-     *
-     *   For all other event types, the caller is expected to pass the event to HandleTransferSessionOutput to handle the BDX
-     *   message or any other TransferSession event.
      *
      *   See OutputEventType for all possible output event types.
      *


### PR DESCRIPTION
…n event driven mechanism to drive the BDX transfer can get the next output event from the TransferSession on demand

Currently we have the PollOutput API where the expectation is the caller needs to poll frequently for the next output event from the TransferSession which introduces a delay based on the poll interval in handling every single BDX message or transfer session event handled by the caller.

Fixes: #35461 

