### PR TITLE
[Darwin] Add internal method to get report of all attributes to MTRDevice

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1459,6 +1459,17 @@ using namespace chip::Tracing::DarwinFramework;
     }
 }
 
+- (NSArray<NSDictionary<NSString *, id> *> *)getAllAttributesReport
+{
+#define MTRDeviceErrorStr "MTRDevice getAllAttributesReport must be handled by subclasses that support it"
+    MTR_LOG_ERROR(MTRDeviceErrorStr);
+#ifdef DEBUG
+    NSAssert(NO, @MTRDeviceErrorStr);
+#endif // DEBUG
+#undef MTRDeviceErrorStr
+    return nil;
+}
+
 #ifdef DEBUG
 - (NSUInteger)unitTestAttributeCount
 {

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -202,6 +202,9 @@ MTR_DIRECT_MEMBERS
 - (void)_callFirstDelegateSynchronouslyWithBlock:(void (^)(id<MTRDeviceDelegate> delegate))block;
 #endif
 
+// Used to generate attribute report that contains all known attributes, taking into consideration expected values
+- (NSArray<NSDictionary<NSString *, id> *> *)getAllAttributesReport;
+
 @end
 
 #pragma mark - MTRDevice internal state monitoring


### PR DESCRIPTION
This adds an internal method to retrieve "the current view of all attributes" from the device.