### PR TITLE
Implement MTRDevice handling in controller suspend/resume.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -648,8 +648,9 @@ using namespace chip::Tracing::DarwinFramework;
 
 - (void)_delegateAdded
 {
-    // Nothing to do; this is a hook for subclasses.  If that ever changes for
-    // some reason, subclasses need to start calling this hook on their super.
+    os_unfair_lock_assert_owner(&self->_lock);
+
+    // Nothing to do for now. At the moment this is a hook for subclasses.
 }
 
 - (void)removeDelegate:(id<MTRDeviceDelegate>)delegate
@@ -1741,6 +1742,16 @@ using namespace chip::Tracing::DarwinFramework;
     }
 
     return result;
+}
+
+- (void)controllerSuspended
+{
+    // Nothing to do for now.
+}
+
+- (void)controllerResumed
+{
+    // Nothing to do for now.
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
@@ -150,6 +150,11 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
                 intermediateCertificate:(MTRCertificateDERBytes _Nullable)intermediateCertificate
                         rootCertificate:(MTRCertificateDERBytes)rootCertificate;
 
+/**
+ * The root certificate we were initialized with.
+ */
+@property (nonatomic, copy, readonly) MTRCertificateDERBytes rootCertificate MTR_NEWLY_AVAILABLE;
+
 @end
 
 MTR_NEWLY_AVAILABLE

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -338,6 +338,9 @@ constexpr NSUInteger kDefaultConcurrentSubscriptionPoolSize = 300;
 @end
 
 @implementation MTRDeviceControllerExternalCertificateParameters
+
+@dynamic rootCertificate;
+
 - (instancetype)initWithStorageDelegate:(id<MTRDeviceControllerStorageDelegate>)storageDelegate
                    storageDelegateQueue:(dispatch_queue_t)storageDelegateQueue
                        uniqueIdentifier:(NSUUID *)uniqueIdentifier

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDeviceController ()
 
-@property (nonatomic, readwrite, nullable) NSMapTable * nodeIDToDeviceMap;
+@property (nonatomic, readonly) NSMapTable<NSNumber *, MTRDevice *> * nodeIDToDeviceMap;
 @property (readonly, assign) os_unfair_lock_t deviceMapLock;
 
 // queue used to serialize all work performed by the MTRDeviceController

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -113,7 +113,6 @@
         self.xpcConnection = connectionBlock();
         self.uniqueIdentifier = UUID;
         self.chipWorkQueue = dispatch_queue_create("MTRDeviceController_XPC_queue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
-        self.nodeIDToDeviceMap = [NSMapTable strongToWeakObjectsMapTable];
 
         MTR_LOG("Set up XPC Connection: %@", self.xpcConnection);
         if (self.xpcConnection) {

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -196,6 +196,9 @@ MTR_DIRECT_MEMBERS
 
 - (BOOL)_delegateExists;
 
+// Must be called by subclasses or MTRDevice implementation only.
+- (void)_delegateAdded;
+
 #ifdef DEBUG
 // Only used for unit test purposes - normal delegate should not expect or handle being called back synchronously
 // Returns YES if a delegate is called
@@ -204,6 +207,10 @@ MTR_DIRECT_MEMBERS
 
 // Used to generate attribute report that contains all known attributes, taking into consideration expected values
 - (NSArray<NSDictionary<NSString *, id> *> *)getAllAttributesReport;
+
+// Hooks for controller suspend/resume.
+- (void)controllerSuspended;
+- (void)controllerResumed;
 
 @end
 

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -262,11 +262,8 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
                                                        nodeID:(NSNumber *)nodeID
                                                       storage:(MTRTestPerControllerStorage *)storage
                                         caseAuthenticatedTags:(NSSet * _Nullable)caseAuthenticatedTags
+                                               paramsModifier:(void (^_Nullable)(MTRDeviceControllerExternalCertificateParameters *))paramsModifier
                                                         error:(NSError * __autoreleasing *)error
-                                            certificateIssuer:
-                                                (MTRPerControllerStorageTestsCertificateIssuer * __autoreleasing *)certificateIssuer
-                               concurrentSubscriptionPoolSize:(NSUInteger)concurrentSubscriptionPoolSize
-                                 storageBehaviorConfiguration:(MTRDeviceStorageBehaviorConfiguration * _Nullable)storageBehaviorConfiguration
 {
     XCTAssertTrue(error != NULL);
 
@@ -295,31 +292,58 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
                                                                                      intermediateCertificate:nil
                                                                                              rootCertificate:root];
     XCTAssertNotNil(params);
-    // TODO: This is only used by testControllerServer.  If that moves
-    // elsewhere, take this back out again.
-    params.shouldAdvertiseOperational = YES;
 
-    __auto_type * ourCertificateIssuer = [[MTRPerControllerStorageTestsCertificateIssuer alloc] initWithRootCertificate:root
-                                                                                                intermediateCertificate:nil
-                                                                                                             signingKey:rootKeys
-                                                                                                               fabricID:fabricID];
-    XCTAssertNotNil(ourCertificateIssuer);
-
-    if (certificateIssuer) {
-        *certificateIssuer = ourCertificateIssuer;
-    }
-
-    [params setOperationalCertificateIssuer:ourCertificateIssuer queue:dispatch_get_main_queue()];
-
-    if (concurrentSubscriptionPoolSize > 0) {
-        params.concurrentSubscriptionEstablishmentsAllowedOnThread = concurrentSubscriptionPoolSize;
-    }
-
-    if (storageBehaviorConfiguration) {
-        params.storageBehaviorConfiguration = storageBehaviorConfiguration;
+    if (paramsModifier) {
+        paramsModifier(params);
     }
 
     return [[MTRDeviceController alloc] initWithParameters:params error:error];
+}
+
+- (nullable MTRDeviceController *)startControllerWithRootKeys:(MTRTestKeys *)rootKeys
+                                              operationalKeys:(MTRTestKeys *)operationalKeys
+                                                     fabricID:(NSNumber *)fabricID
+                                                       nodeID:(NSNumber *)nodeID
+                                                      storage:(MTRTestPerControllerStorage *)storage
+                                        caseAuthenticatedTags:(NSSet * _Nullable)caseAuthenticatedTags
+                                                        error:(NSError * __autoreleasing *)error
+                                            certificateIssuer:
+                                                (MTRPerControllerStorageTestsCertificateIssuer * __autoreleasing *)certificateIssuer
+                               concurrentSubscriptionPoolSize:(NSUInteger)concurrentSubscriptionPoolSize
+                                 storageBehaviorConfiguration:(MTRDeviceStorageBehaviorConfiguration * _Nullable)storageBehaviorConfiguration
+{
+    return [self startControllerWithRootKeys:rootKeys
+                             operationalKeys:operationalKeys
+                                    fabricID:fabricID
+                                      nodeID:nodeID
+                                     storage:storage
+                       caseAuthenticatedTags:caseAuthenticatedTags
+                              paramsModifier:^(MTRDeviceControllerExternalCertificateParameters * params) {
+                                  // TODO: This is only used by testControllerServer.  If that moves
+                                  // elsewhere, take this back out again.
+                                  params.shouldAdvertiseOperational = YES;
+
+                                  __auto_type * ourCertificateIssuer = [[MTRPerControllerStorageTestsCertificateIssuer alloc] initWithRootCertificate:params.rootCertificate
+                                                                                                                              intermediateCertificate:nil
+                                                                                                                                           signingKey:rootKeys
+                                                                                                                                             fabricID:fabricID];
+                                  XCTAssertNotNil(ourCertificateIssuer);
+
+                                  if (certificateIssuer) {
+                                      *certificateIssuer = ourCertificateIssuer;
+                                  }
+
+                                  [params setOperationalCertificateIssuer:ourCertificateIssuer queue:dispatch_get_main_queue()];
+
+                                  if (concurrentSubscriptionPoolSize > 0) {
+                                      params.concurrentSubscriptionEstablishmentsAllowedOnThread = concurrentSubscriptionPoolSize;
+                                  }
+
+                                  if (storageBehaviorConfiguration) {
+                                      params.storageBehaviorConfiguration = storageBehaviorConfiguration;
+                                  }
+                              }
+                                       error:error];
 }
 
 - (nullable MTRDeviceController *)startControllerWithRootKeys:(MTRTestKeys *)rootKeys
@@ -462,6 +486,7 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
     XCTAssertNil(error);
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
+    XCTAssertFalse(controller.suspended);
 
     XCTAssertEqualObjects(controller.controllerNodeID, nodeID);
 
@@ -1609,6 +1634,128 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
 - (void)test011_TestDataStoreMTRDeviceWithStorageBehaviorOptimizationDisabled
 {
     [self doDataStoreMTRDeviceTestWithStorageDelegate:[[MTRTestPerControllerStorage alloc] initWithControllerID:[NSUUID UUID]] disableStorageBehaviorOptimization:YES];
+}
+
+// TODO: Factor out startControllerWithRootKeys into a test helper, move these
+// suspension tests to a different file.
+- (void)test012_startSuspended
+{
+    NSError * error;
+    __auto_type * storageDelegate = [[MTRTestPerControllerStorage alloc] initWithControllerID:[NSUUID UUID]];
+    __auto_type * controller = [self startControllerWithRootKeys:[[MTRTestKeys alloc] init]
+                                                 operationalKeys:[[MTRTestKeys alloc] init]
+                                                        fabricID:@555
+                                                          nodeID:@888
+                                                         storage:storageDelegate
+                                           caseAuthenticatedTags:nil
+                                                  paramsModifier:^(MTRDeviceControllerExternalCertificateParameters * params) {
+                                                      params.startSuspended = YES;
+                                                  }
+                                                           error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(controller);
+    XCTAssertTrue(controller.running);
+    XCTAssertTrue(controller.suspended);
+    [controller shutdown];
+}
+
+- (void)test013_suspendDevices
+{
+    NSNumber * deviceID = @(17);
+    __auto_type * device = [self getMTRDevice:deviceID];
+    __auto_type * controller = device.deviceController;
+
+    XCTAssertFalse(controller.suspended);
+
+    __auto_type queue = dispatch_get_main_queue();
+    __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
+
+    XCTestExpectation * initialSubscriptionExpectation = [self expectationWithDescription:@"Subscription has been set up"];
+    XCTestExpectation * initialReachableExpectation = [self expectationWithDescription:@"Device initially became reachable"];
+    XCTestExpectation * initialUnreachableExpectation = [self expectationWithDescription:@"Device initially became unreachable"];
+    initialUnreachableExpectation.inverted = YES;
+
+    delegate.onReachable = ^{
+        [initialReachableExpectation fulfill];
+    };
+
+    delegate.onNotReachable = ^{
+        // We do not expect to land here.
+        [initialUnreachableExpectation fulfill];
+    };
+
+    delegate.onReportEnd = ^{
+        [initialSubscriptionExpectation fulfill];
+    };
+
+    [device setDelegate:delegate queue:queue];
+    [self waitForExpectations:@[ initialReachableExpectation, initialSubscriptionExpectation ] timeout:60];
+    // Separately wait for the unreachable bit, so we don't end up waiting 60
+    // seconds for it.
+    [self waitForExpectations:@[ initialUnreachableExpectation ] timeout:0];
+
+    // Test that sending a command works.  Clear the delegate's onReportEnd
+    // first, so reports from the command don't trigger it.
+    delegate.onReportEnd = nil;
+    XCTestExpectation * toggle1Expectation = [self expectationWithDescription:@"toggle 1"];
+    __auto_type * cluster = [[MTRClusterOnOff alloc] initWithDevice:device endpointID:@(1) queue:queue];
+    [cluster toggleWithExpectedValues:nil expectedValueInterval:nil completion:^(NSError * _Nullable error) {
+        XCTAssertNil(error);
+        [toggle1Expectation fulfill];
+    }];
+
+    [self waitForExpectations:@[ toggle1Expectation ] timeout:kTimeoutInSeconds];
+
+    XCTestExpectation * becameUnreachableExpectation = [self expectationWithDescription:@"Device became unreachable"];
+    delegate.onNotReachable = ^{
+        [becameUnreachableExpectation fulfill];
+    };
+
+    [controller suspend];
+    XCTAssertTrue(controller.suspended);
+
+    // Test that sending a command no longer works.
+    XCTestExpectation * toggle2Expectation = [self expectationWithDescription:@"toggle 2"];
+    [cluster toggleWithExpectedValues:nil expectedValueInterval:nil completion:^(NSError * _Nullable error) {
+        XCTAssertNotNil(error);
+        [toggle2Expectation fulfill];
+    }];
+
+    [self waitForExpectations:@[ becameUnreachableExpectation, toggle2Expectation ] timeout:kTimeoutInSeconds];
+
+    XCTestExpectation * newSubscriptionExpectation = [self expectationWithDescription:@"Subscription has been set up again"];
+    XCTestExpectation * newReachableExpectation = [self expectationWithDescription:@"Device became reachable again"];
+    delegate.onReachable = ^{
+        [newReachableExpectation fulfill];
+    };
+
+    delegate.onReportEnd = ^{
+        [newSubscriptionExpectation fulfill];
+    };
+
+    [controller resume];
+    XCTAssertFalse(controller.suspended);
+
+    [self waitForExpectations:@[ newSubscriptionExpectation, newReachableExpectation ] timeout:kTimeoutInSeconds];
+
+    // Test that sending a command works again.  Clear the delegate's onReportEnd
+    // first, so reports from the command don't trigger it.
+    delegate.onReportEnd = nil;
+    XCTestExpectation * toggle3Expectation = [self expectationWithDescription:@"toggle 3"];
+    [cluster toggleWithExpectedValues:nil expectedValueInterval:nil completion:^(NSError * _Nullable error) {
+        XCTAssertNil(error);
+        [toggle3Expectation fulfill];
+    }];
+
+    [self waitForExpectations:@[ toggle3Expectation ] timeout:kTimeoutInSeconds];
+
+    [controller removeDevice:device];
+    // Reset our commissionee.
+    __auto_type * baseDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];
+    ResetCommissionee(baseDevice, queue, self, kTimeoutInSeconds);
+
+    [controller shutdown];
 }
 
 // TODO: This might want to go in a separate test file, with some shared setup


### PR DESCRIPTION
Also blocks acquisition of CASE sessions on a suspended controller, which should ensure that new requests for MTRDevices and MTRBaseDevices associated with the controller do not hit the network.

Draft for now until https://github.com/project-chip/connectedhomeip/pull/35453 lands.