### PR TITLE
Abort BDX transfers as needed on controller shutdown.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -403,6 +403,9 @@ void DeviceController::Shutdown()
         // assume that all sessions for our fabric belong to us here.
         mSystemState->CASESessionMgr()->ReleaseSessionsForFabric(mFabricIndex);
 
+        // Shut down any bdx transfers we're acting as the server for.
+        mSystemState->BDXTransferServer()->AbortTransfersForFabric(mFabricIndex);
+
         // TODO: The CASE session manager does not shut down existing CASE
         // sessions.  It just shuts down any ongoing CASE session establishment
         // we're in the middle of as initiator.  Maybe it should shut down

--- a/src/protocols/bdx/BdxTransferDiagnosticLog.cpp
+++ b/src/protocols/bdx/BdxTransferDiagnosticLog.cpp
@@ -18,6 +18,8 @@
 
 #include "BdxTransferDiagnosticLog.h"
 
+#include <protocols/bdx/BdxTransferDiagnosticLogPool.h>
+
 namespace chip {
 namespace bdx {
 
@@ -199,6 +201,24 @@ void BdxTransferDiagnosticLog::OnExchangeClosing(Messaging::ExchangeContext * ec
     VerifyOrReturn(!mIsExchangeClosing);
     mExchangeCtx = nullptr;
     LogErrorOnFailure(OnTransferSessionEnd(CHIP_ERROR_INTERNAL));
+}
+
+bool BdxTransferDiagnosticLog::IsForFabric(FabricIndex fabricIndex) const
+{
+    if (mExchangeCtx == nullptr || !mExchangeCtx->HasSessionHandle())
+    {
+        return false;
+    }
+
+    auto session = mExchangeCtx->GetSessionHandle();
+    return session->GetFabricIndex() == fabricIndex;
+}
+
+void BdxTransferDiagnosticLog::AbortTransfer()
+{
+    // No need to mTransfer.AbortTransfer() here, since that just tries to async
+    // send a StatusReport to the other side, but we are going away here.
+    Reset();
 }
 
 } // namespace bdx

--- a/src/protocols/bdx/BdxTransferDiagnosticLog.h
+++ b/src/protocols/bdx/BdxTransferDiagnosticLog.h
@@ -18,13 +18,16 @@
 
 #pragma once
 
-#include <protocols/bdx/BdxTransferDiagnosticLogPool.h>
+#include <lib/core/DataModelTypes.h>
 #include <protocols/bdx/BdxTransferProxyDiagnosticLog.h>
+#include <protocols/bdx/BdxTransferServerDelegate.h>
 #include <protocols/bdx/TransferFacilitator.h>
 #include <system/SystemLayer.h>
 
 namespace chip {
 namespace bdx {
+
+class BdxTransferDiagnosticLogPoolDelegate;
 
 class BdxTransferDiagnosticLog : public Responder
 {
@@ -44,6 +47,13 @@ public:
     void HandleTransferSessionOutput(TransferSession::OutputEvent & event) override;
 
     void OnExchangeClosing(Messaging::ExchangeContext * ec) override;
+
+    /**
+     * Lifetime management, to allow us to abort transfers when a fabric
+     * identity is being shut down.
+     */
+    bool IsForFabric(FabricIndex fabricIndex) const;
+    void AbortTransfer();
 
 protected:
     /**

--- a/src/protocols/bdx/BdxTransferDiagnosticLogPool.h
+++ b/src/protocols/bdx/BdxTransferDiagnosticLogPool.h
@@ -18,14 +18,14 @@
 
 #pragma once
 
+#include <lib/core/DataModelTypes.h>
 #include <lib/support/Pool.h>
+#include <protocols/bdx/BdxTransferDiagnosticLog.h>
 #include <protocols/bdx/BdxTransferServerDelegate.h>
 #include <system/SystemLayer.h>
 
 namespace chip {
 namespace bdx {
-
-class BdxTransferDiagnosticLog;
 
 class BdxTransferDiagnosticLogPoolDelegate
 {
@@ -49,6 +49,17 @@ public:
     }
 
     void Release(BdxTransferDiagnosticLog * transfer) override { mTransferPool.ReleaseObject(transfer); }
+
+    void AbortTransfersForFabric(FabricIndex fabricIndex)
+    {
+        mTransferPool.ForEachActiveObject([fabricIndex](BdxTransferDiagnosticLog * transfer) {
+            if (transfer->IsForFabric(fabricIndex))
+            {
+                transfer->AbortTransfer();
+            }
+            return Loop::Continue;
+        });
+    }
 
 private:
     ObjectPool<BdxTransferDiagnosticLog, N> mTransferPool;

--- a/src/protocols/bdx/BdxTransferServer.h
+++ b/src/protocols/bdx/BdxTransferServer.h
@@ -20,6 +20,7 @@
 
 #include <protocols/bdx/BdxTransferDiagnosticLogPool.h>
 
+#include <lib/core/DataModelTypes.h>
 #include <messaging/ExchangeDelegate.h>
 #include <messaging/ExchangeMgr.h>
 #include <protocols/bdx/BdxTransferDiagnosticLog.h>
@@ -41,6 +42,8 @@ public:
     void Shutdown();
 
     void SetDelegate(BDXTransferServerDelegate * delegate) { mDelegate = delegate; }
+
+    void AbortTransfersForFabric(FabricIndex fabricIndex) { mPoolDelegate.AbortTransfersForFabric(fabricIndex); }
 
 protected:
     CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader,


### PR DESCRIPTION
If we're acting as a BDX transfer server, we should shut down transfers for a fabric index when the corresponding DeviceController shuts down.
