### PR TITLE
[Raspi] Fix crash on RP4 when add-local-bridge

### DIFF
--- a/examples/fabric-admin/commands/pairing/PairingCommand.h
+++ b/examples/fabric-admin/commands/pairing/PairingCommand.h
@@ -272,15 +272,15 @@ private:
     TypedComplexArgument<chip::app::DataModel::List<chip::app::Clusters::TimeSynchronization::Structs::DSTOffsetStruct::Type>>
         mComplex_DSTOffsets;
 
-    uint16_t mRemotePort = 0;
+    uint16_t mRemotePort    = 0;
     uint16_t mDiscriminator = 0;
-    uint32_t mSetupPINCode = 0;
-    uint16_t mIndex = 0;
+    uint32_t mSetupPINCode  = 0;
+    uint16_t mIndex         = 0;
     chip::ByteSpan mOperationalDataset;
     chip::ByteSpan mSSID;
     chip::ByteSpan mPassword;
-    char * mOnboardingPayload = nullptr;
-    uint64_t mDiscoveryFilterCode = 0;
+    char * mOnboardingPayload           = nullptr;
+    uint64_t mDiscoveryFilterCode       = 0;
     char * mDiscoveryFilterInstanceName = nullptr;
 
     bool mDeviceIsICD = false;

--- a/examples/fabric-admin/commands/pairing/PairingCommand.h
+++ b/examples/fabric-admin/commands/pairing/PairingCommand.h
@@ -250,7 +250,7 @@ private:
     const PairingNetworkType mNetworkType;
     const chip::Dnssd::DiscoveryFilterType mFilterType;
     Command::AddressWithInterface mRemoteAddr;
-    NodeId mNodeId;
+    NodeId mNodeId = chip::kUndefinedNodeId;
     chip::Optional<uint16_t> mTimeout;
     chip::Optional<bool> mDiscoverOnce;
     chip::Optional<bool> mUseOnlyOnNetworkDiscovery;
@@ -272,18 +272,18 @@ private:
     TypedComplexArgument<chip::app::DataModel::List<chip::app::Clusters::TimeSynchronization::Structs::DSTOffsetStruct::Type>>
         mComplex_DSTOffsets;
 
-    uint16_t mRemotePort;
-    uint16_t mDiscriminator;
-    uint32_t mSetupPINCode;
-    uint16_t mIndex;
+    uint16_t mRemotePort = 0;
+    uint16_t mDiscriminator = 0;
+    uint32_t mSetupPINCode = 0;
+    uint16_t mIndex = 0;
     chip::ByteSpan mOperationalDataset;
     chip::ByteSpan mSSID;
     chip::ByteSpan mPassword;
-    char * mOnboardingPayload;
-    uint64_t mDiscoveryFilterCode;
-    char * mDiscoveryFilterInstanceName;
+    char * mOnboardingPayload = nullptr;
+    uint64_t mDiscoveryFilterCode = 0;
+    char * mDiscoveryFilterInstanceName = nullptr;
 
-    bool mDeviceIsICD;
+    bool mDeviceIsICD = false;
     uint8_t mRandomGeneratedICDSymmetricKey[chip::Crypto::kAES_CCM128_Key_Length];
 
     // For unpair


### PR DESCRIPTION
[NXP] Marian Chereji

Hey everyone! I just made a new attempt to run the basic FabricSync scenario on a setup made out of 2 x RaspberryPi and I'm still getting a crash after the first command (fabricsync add-local-bridge 1). The error reported in the fabric-admin log seems to be the same
CHIP:SPT: VerifyOrDie failure at src/lib/support/SetupDiscriminator.h:52: discriminator == (discriminator & kLongMask)
I used the CHIP baseline
[2cf028b7d5](https://github.com/project-chip/connectedhomeip/commit/2cf028b7d54be514547ccd37ee1077ad634b6d07) [ESP32] Support Thread and Wi-Fi network revert configuration
I just ran the run_fabric_sync.sh script and inputted the command "fabricsync add-local-bridge 1".

```
[1725685782.943] [11817:11822] [-] PushCommand: pairing already-discovered 1 20202021 ::1 5540
[1725685783.851] [11817:11817] [-] Command: pairing already-discovered 1 20202021 ::1 5540 
[1725685783.855] [11817:11822] [-] SetLongValue called with discriminator: 49732 (0xC244), masked value: 580 (0x244)

[1725685783.855] [11817:11822] [SPT] VerifyOrDie failure at src/lib/support/SetupDiscriminator.h:55: discriminator == (discriminator & kLongMask)
./run_fabric_sync.sh: line 118: 11817 Aborted                 (core dumped) "$FABRIC_ADMIN_PATH"
ubuntu@ubuntu:~$ 
```
On certain platforms like Raspberry Pi 4 (RPi4) or other embedded systems, uninitialized variables—especially in C++—can have unpredictable values, which could cause issues like unexpected behavior or crashes.

To avoid such issues, you need to ensure that all member variables of your class are explicitly initialized.

