### PR TITLE
[Darwin] Fix MTRDevice getAllAttributesReport return value

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -3500,8 +3500,8 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             // Construct response-value dictionary with the data-value dictionary returned by
             // _lockedAttributeValueDictionaryForAttributePath, to takes into consideration expected values as well.
             [attributeReport addObject:@{
-                MTRAttributePathKey: attributePath,
-                MTRDataKey: [self _lockedAttributeValueDictionaryForAttributePath:attributePath]
+                MTRAttributePathKey : attributePath,
+                MTRDataKey : [self _lockedAttributeValueDictionaryForAttributePath:attributePath]
             }];
         }
     }

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -3497,8 +3497,12 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                                                                        clusterID:clusterPath.cluster
                                                                      attributeID:attributeID];
 
-            // Using _lockedAttributeValueDictionaryForAttributePath because it takes into consideration expected values too
-            [attributeReport addObject:[self _lockedAttributeValueDictionaryForAttributePath:attributePath]];
+            // Construct response-value dictionary with the data-value dictionary returned by
+            // _lockedAttributeValueDictionaryForAttributePath, to takes into consideration expected values as well.
+            [attributeReport addObject:@{
+                MTRAttributePathKey: attributePath,
+                MTRDataKey: [self _lockedAttributeValueDictionaryForAttributePath:attributePath]
+            }];
         }
     }
 

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -4323,11 +4323,28 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     [self waitForExpectations:@[ gotReportEnd ] timeout:60];
 
-    XCTAssertEqual(attributesReceived, 36);
-
     NSArray * allAttributesReport = [device getAllAttributesReport];
 
-    XCTAssertEqual(allAttributesReport.count, 36);
+    XCTAssertEqual(allAttributesReport.count, attributeReport.count);
+
+    for (NSDictionary<NSString *, id> *newResponseValueDict in allAttributesReport) {
+        MTRAttributePath *newPath = newResponseValueDict[MTRAttributePathKey];
+        NSDictionary<NSString *, id> *newDataValueDict = newResponseValueDict[MTRDataKey];
+        NSNumber *newValue = newDataValueDict[MTRValueKey];
+        XCTAssertNotNil(newValue);
+
+        for (NSDictionary<NSString *, id> *originalResponseValueDict in attributeReport) {
+            MTRAttributePath *originalPath = originalResponseValueDict[MTRAttributePathKey];
+            // Find same attribute path and compare value
+            if ([newPath isEqual:originalPath]) {
+                NSDictionary<NSString *, id> *originalDataValueDict = originalResponseValueDict[MTRDataKey];
+                NSNumber *originalValue = originalDataValueDict[MTRValueKey];
+                XCTAssertNotNil(originalValue);
+                XCTAssertEqualObjects(newValue, originalValue);
+                continue;
+            }
+        }
+    }
 }
 
 @end

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -4327,18 +4327,18 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     XCTAssertEqual(allAttributesReport.count, attributeReport.count);
 
-    for (NSDictionary<NSString *, id> *newResponseValueDict in allAttributesReport) {
-        MTRAttributePath *newPath = newResponseValueDict[MTRAttributePathKey];
-        NSDictionary<NSString *, id> *newDataValueDict = newResponseValueDict[MTRDataKey];
-        NSNumber *newValue = newDataValueDict[MTRValueKey];
+    for (NSDictionary<NSString *, id> * newResponseValueDict in allAttributesReport) {
+        MTRAttributePath * newPath = newResponseValueDict[MTRAttributePathKey];
+        NSDictionary<NSString *, id> * newDataValueDict = newResponseValueDict[MTRDataKey];
+        NSNumber * newValue = newDataValueDict[MTRValueKey];
         XCTAssertNotNil(newValue);
 
-        for (NSDictionary<NSString *, id> *originalResponseValueDict in attributeReport) {
-            MTRAttributePath *originalPath = originalResponseValueDict[MTRAttributePathKey];
+        for (NSDictionary<NSString *, id> * originalResponseValueDict in attributeReport) {
+            MTRAttributePath * originalPath = originalResponseValueDict[MTRAttributePathKey];
             // Find same attribute path and compare value
             if ([newPath isEqual:originalPath]) {
-                NSDictionary<NSString *, id> *originalDataValueDict = originalResponseValueDict[MTRDataKey];
-                NSNumber *originalValue = originalDataValueDict[MTRValueKey];
+                NSDictionary<NSString *, id> * originalDataValueDict = originalResponseValueDict[MTRDataKey];
+                NSNumber * originalValue = originalDataValueDict[MTRValueKey];
                 XCTAssertNotNil(originalValue);
                 XCTAssertEqualObjects(newValue, originalValue);
                 continue;


### PR DESCRIPTION
The previous PR https://github.com/project-chip/connectedhomeip/pull/35463 returned an array of data-value dictionary instead of response-value dictionary. This patch fixes that so the returned attribute report has the right format.