### PR TITLE
[Darwin] Darwin CI TSAN test failure fix

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -350,7 +350,7 @@ using namespace chip::Tracing::DarwinFramework;
 
 - (BOOL)isSuspended
 {
-    @synchronized (self) {
+    @synchronized(self) {
         return _suspended;
     }
 }
@@ -359,10 +359,10 @@ using namespace chip::Tracing::DarwinFramework;
 {
     MTR_LOG("%@ suspending", self);
 
-    @synchronized (self) {
+    @synchronized(self) {
         _suspended = YES;
 
-        NSMutableArray *devicesToSuspend = [NSMutableArray array];
+        NSMutableArray * devicesToSuspend = [NSMutableArray array];
         {
             std::lock_guard lock(*self.deviceMapLock);
             NSEnumerator * devices = [self.nodeIDToDeviceMap objectEnumerator];
@@ -387,10 +387,10 @@ using namespace chip::Tracing::DarwinFramework;
 {
     MTR_LOG("%@ resuming", self);
 
-    @synchronized (self) {
+    @synchronized(self) {
         _suspended = NO;
 
-        NSMutableArray *devicesToResume = [NSMutableArray array];
+        NSMutableArray * devicesToResume = [NSMutableArray array];
         {
             std::lock_guard lock(*self.deviceMapLock);
             NSEnumerator * devices = [self.nodeIDToDeviceMap objectEnumerator];

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -352,6 +352,7 @@ using namespace chip::Tracing::DarwinFramework;
 
 - (BOOL)isSuspended
 {
+    std::lock_guard lock(_suspensionLock);
     return _suspended;
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -362,9 +362,16 @@ using namespace chip::Tracing::DarwinFramework;
     @synchronized (self) {
         _suspended = YES;
 
-        std::lock_guard lock(*self.deviceMapLock);
-        NSEnumerator * devices = [self.nodeIDToDeviceMap objectEnumerator];
-        for (MTRDevice * device in devices) {
+        NSMutableArray *devicesToSuspend = [NSMutableArray array];
+        {
+            std::lock_guard lock(*self.deviceMapLock);
+            NSEnumerator * devices = [self.nodeIDToDeviceMap objectEnumerator];
+            for (MTRDevice * device in devices) {
+                [devicesToSuspend addObject:device];
+            }
+        }
+
+        for (MTRDevice * device in devicesToSuspend) {
             [device controllerSuspended];
         }
 
@@ -383,9 +390,16 @@ using namespace chip::Tracing::DarwinFramework;
     @synchronized (self) {
         _suspended = NO;
 
-        std::lock_guard lock(*self.deviceMapLock);
-        NSEnumerator * devices = [self.nodeIDToDeviceMap objectEnumerator];
-        for (MTRDevice * device in devices) {
+        NSMutableArray *devicesToResume = [NSMutableArray array];
+        {
+            std::lock_guard lock(*self.deviceMapLock);
+            NSEnumerator * devices = [self.nodeIDToDeviceMap objectEnumerator];
+            for (MTRDevice * device in devices) {
+                [devicesToResume addObject:device];
+            }
+        }
+
+        for (MTRDevice * device in devicesToResume) {
             [device controllerResumed];
         }
     }

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -720,7 +720,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     os_unfair_lock_assert_owner(&self->_lock);
 
     // We should not allow a subscription for suspended controllers or device controllers over XPC.
-    return _deviceController.suspended == NO && ![_deviceController isKindOfClass:MTRDeviceControllerOverXPC.class];
+    return _deviceController.isSuspended == NO && ![_deviceController isKindOfClass:MTRDeviceControllerOverXPC.class];
 }
 
 - (void)_delegateAdded
@@ -1249,7 +1249,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 {
     os_unfair_lock_assert_owner(&_lock);
 
-    if (_deviceController.suspended) {
+    if (_deviceController.isSuspended) {
         MTR_LOG("%@ ignoring expected subscription reset on controller suspend", self);
         return;
     }


### PR DESCRIPTION
TSAN complained about accessing isSuspended while not holding the _suspensionLock lock. This is the change that should fix the intermittent failures.