### PR TITLE
[Darwin] Implement delegate add/remove for device controller

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDefines_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDefines_Internal.h
@@ -150,3 +150,7 @@ typedef struct {} variable_hidden_by_mtr_hide;
         }                                                                                                                  \
     }
 #endif
+
+#ifndef YES_NO
+#define YES_NO(x) ((x) ? @"YES" : @"NO")
+#endif

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -186,7 +186,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 - (void)preWarmCommissioningSession MTR_DEPRECATED("-[MTRDeviceControllerFactory preWarmCommissioningSession]", ios(16.4, 17.6), macos(13.3, 14.6), watchos(9.4, 10.6), tvos(16.4, 17.6));
 
 /**
- * Set the Delegate for the device controller  as well as the Queue on which the Delegate callbacks will be triggered
+ * Set the Delegate for the device controller as well as the Queue on which the Delegate callbacks will be triggered
  *
  * @param[in] delegate The delegate the commissioning process should use
  *
@@ -194,6 +194,23 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  */
 - (void)setDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate
                               queue:(dispatch_queue_t)queue MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+
+/**
+ * Adds a Delegate to the device controller as well as the Queue on which the Delegate callbacks will be triggered
+ *
+ * @param[in] delegate The delegate the commissioning process should use
+ *
+ * @param[in] queue The queue on which the callbacks will be delivered
+ */
+- (void)addDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate
+                              queue:(dispatch_queue_t)queue MTR_NEWLY_AVAILABLE;
+
+/**
+ * Removes a Delegate from the device controller
+ *
+ * @param[in] delegate The delegate to be removed
+ */
+- (void)removeDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate MTR_NEWLY_AVAILABLE;
 
 /**
  * Start scanning for commissionable devices.

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -1779,6 +1779,11 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 {
     @synchronized(self) {
         if (_strongDelegateForSetDelegateAPI) {
+            if (_strongDelegateForSetDelegateAPI == delegate) {
+                MTR_LOG("%@ setDeviceControllerDelegate: delegate %p is already set", self, delegate);
+                return;
+            }
+
             MTR_LOG("%@ setDeviceControllerDelegate: replacing %p with %p", self, _strongDelegateForSetDelegateAPI, delegate);
             [self removeDeviceControllerDelegate:_strongDelegateForSetDelegateAPI];
         }
@@ -1799,6 +1804,10 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 - (void)removeDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate
 {
     @synchronized(self) {
+        if (_strongDelegateForSetDelegateAPI == delegate) {
+            _strongDelegateForSetDelegateAPI = nil;
+        }
+
         __block MTRDeviceControllerDelegateInfo * delegateInfoToRemove = nil;
         [self _iterateDelegateInfoWithBlock:^(MTRDeviceControllerDelegateInfo * delegateInfo) {
             if (delegateInfo.delegate == delegate) {
@@ -1864,6 +1873,13 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
     MTR_LOG("%@ %lu delegates called for %s", self, static_cast<unsigned long>(delegatesCalled), logString);
 }
+
+#if DEBUG
+- (NSUInteger)unitTestDelegateCount
+{
+    return [self _iterateDelegateInfoWithBlock:nil];
+}
+#endif
 
 - (void)controller:(MTRDeviceController *)controller statusUpdate:(MTRCommissioningStatus)status
 {

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -112,6 +112,27 @@ typedef BOOL (^SyncWorkQueueBlockWithBoolReturnValue)(void);
 
 using namespace chip::Tracing::DarwinFramework;
 
+@interface MTRDeviceControllerDelegateInfo : NSObject
+- (instancetype)initWithDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue;
+@property(nonatomic, weak, readonly) id<MTRDeviceControllerDelegate> delegate;
+@property(nonatomic, readonly) dispatch_queue_t queue;
+@end
+
+@implementation MTRDeviceControllerDelegateInfo
+@synthesize delegate = _delegate, queue = _queue;
+- (instancetype)initWithDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue
+{
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    _delegate = delegate;
+    _queue = queue;
+
+    return self;
+}
+@end
+
 @implementation MTRDeviceController {
     chip::Controller::DeviceCommissioner * _cppCommissioner;
     chip::Credentials::PartialDACVerifier * _partialDACVerifier;
@@ -139,6 +160,9 @@ using namespace chip::Tracing::DarwinFramework;
     NSUInteger _keepRunningAssertionCounter;
     BOOL _shutdownPending;
     os_unfair_lock _assertionLock;
+
+    NSMutableSet<MTRDeviceControllerDelegateInfo *> *_delegates;
+    id<MTRDeviceControllerDelegate> _strongDelegateForSetDelegateAPI;
 }
 
 @synthesize uniqueIdentifier = _uniqueIdentifier;
@@ -167,6 +191,8 @@ using namespace chip::Tracing::DarwinFramework;
     _suspended = startSuspended;
 
     _nodeIDToDeviceMap = [NSMapTable strongToWeakObjectsMapTable];
+
+    _delegates = [NSMutableSet set];
 
     return self;
 }
@@ -567,6 +593,10 @@ using namespace chip::Tracing::DarwinFramework;
     if (_deviceControllerDelegateBridge) {
         delete _deviceControllerDelegateBridge;
         _deviceControllerDelegateBridge = nullptr;
+        @synchronized (self) {
+            _strongDelegateForSetDelegateAPI = nil;
+            [_delegates removeAllObjects];
+        }
     }
 }
 
@@ -1243,15 +1273,6 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 }
 #endif
 
-- (void)setDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue
-{
-    [self
-        asyncDispatchToMatterQueue:^() {
-            self->_deviceControllerDelegateBridge->setDelegate(self, delegate, queue);
-        }
-                      errorHandler:nil];
-}
-
 - (BOOL)setOperationalCertificateIssuer:(nullable id<MTROperationalCertificateIssuer>)operationalCertificateIssuer
                                   queue:(nullable dispatch_queue_t)queue
 {
@@ -1750,6 +1771,138 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     chip::app::DnssdServer::Instance().SetInterfaceId(interfaceId);
 }
 #endif // DEBUG
+
+#pragma mark - MTRDeviceControllerDelegate management
+
+// Note these are implemented in the base class so that XPC subclass can use it as well when it
+- (void)setDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue
+{
+    @synchronized (self) {
+        _strongDelegateForSetDelegateAPI = delegate;
+        [self addDeviceControllerDelegate:delegate queue:queue];
+    }
+}
+
+- (void)addDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue
+{
+    @synchronized (self) {
+        MTRDeviceControllerDelegateInfo *newDelegateInfo = [[MTRDeviceControllerDelegateInfo alloc] initWithDelegate:delegate queue:queue];
+        [_delegates addObject:newDelegateInfo];
+        MTR_LOG("%@ addDeviceControllerDelegate: added %p total %lu", self, delegate, static_cast<unsigned long>(_delegates.count));
+    }
+}
+
+- (void)removeDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate
+{
+    @synchronized (self) {
+        __block MTRDeviceControllerDelegateInfo *delegateInfoToRemove = nil;
+        [self _iterateDelegateInfoWithBlock:^(MTRDeviceControllerDelegateInfo *delegateInfo) {
+            if (delegateInfo.delegate == delegate) {
+                delegateInfoToRemove = delegateInfo;
+            }
+        }];
+
+        if (delegateInfoToRemove) {
+            [_delegates removeObject:delegateInfoToRemove];
+            if (_strongDelegateForSetDelegateAPI == delegate) {
+                _strongDelegateForSetDelegateAPI = nil;
+            }
+            MTR_LOG("%@ removeDeviceControllerDelegate: removed %p remaining %lu", self, delegate, static_cast<unsigned long>(_delegates.count));
+        } else {
+            MTR_LOG("%@ removeDeviceControllerDelegate: delegate %p not found in %lu", self, delegate, static_cast<unsigned long>(_delegates.count));
+        }
+    }
+}
+
+// Iterates the delegates, and remove delegate info objects if the delegate object has dealloc'ed
+// Returns number of delegates called
+- (NSUInteger)_iterateDelegateInfoWithBlock:(void(^ _Nullable)(MTRDeviceControllerDelegateInfo * delegateInfo))block
+{
+    @synchronized (self) {
+        if (!_delegates.count) {
+            MTR_LOG("%@ No delegates to iterate", self);
+            return 0;
+        }
+
+        // Opportunistically remove defunct delegate references on every iteration
+        NSMutableSet *delegatesToRemove = nil;
+        for (MTRDeviceControllerDelegateInfo *delegateInfo in _delegates) {
+            id<MTRDeviceControllerDelegate> strongDelegate = delegateInfo.delegate;
+            if (strongDelegate) {
+                if (block) {
+                    block(delegateInfo);
+                }
+            } else {
+                if (!delegatesToRemove) {
+                    delegatesToRemove = [NSMutableSet set];
+                }
+                [delegatesToRemove addObject:delegateInfo];
+            }
+        }
+
+        if (delegatesToRemove.count) {
+            [_delegates minusSet:delegatesToRemove];
+            MTR_LOG("%@ _iterateDelegatesWithBlock: removed %lu remaining %lu", self, static_cast<unsigned long>(delegatesToRemove.count), static_cast<unsigned long>(_delegates.count));
+        }
+
+        return _delegates.count;
+    }
+}
+
+- (void)_callDelegatesWithBlock:(void(^ _Nullable)(id<MTRDeviceControllerDelegate> delegate))block logString:(const char *)logString;
+{
+    NSUInteger delegatesCalled = [self _iterateDelegateInfoWithBlock:^(MTRDeviceControllerDelegateInfo *delegateInfo) {
+        id<MTRDeviceControllerDelegate> strongDelegate = delegateInfo.delegate;
+        dispatch_async(delegateInfo.queue, ^{
+            block(strongDelegate);
+        });
+    }];
+
+    MTR_LOG("%@ %lu delegates called for %s", self, static_cast<unsigned long>(delegatesCalled), logString);
+}
+
+- (void)controller:(MTRDeviceController *)controller statusUpdate:(MTRCommissioningStatus)status
+{
+    [self _callDelegatesWithBlock:^(id<MTRDeviceControllerDelegate> delegate) {
+        if ([delegate respondsToSelector:@selector(controller:statusUpdate:)]) {
+            [delegate controller:controller statusUpdate:status];
+        }
+    } logString:__PRETTY_FUNCTION__];
+}
+
+- (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError * _Nullable)error
+{
+    [self _callDelegatesWithBlock:^(id<MTRDeviceControllerDelegate> delegate) {
+        if ([delegate respondsToSelector:@selector(controller:commissioningSessionEstablishmentDone:)]) {
+            [delegate controller:controller commissioningSessionEstablishmentDone:error];
+        }
+    } logString:__PRETTY_FUNCTION__];
+}
+
+- (void)controller:(MTRDeviceController *)controller
+commissioningComplete:(NSError * _Nullable)error
+            nodeID:(NSNumber * _Nullable)nodeID
+           metrics:(MTRMetrics *)metrics
+{
+    [self _callDelegatesWithBlock:^(id<MTRDeviceControllerDelegate> delegate) {
+        if ([delegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {
+            [delegate controller:controller commissioningComplete:error nodeID:nodeID metrics:metrics];
+        } else if ([delegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:)]) {
+            [delegate controller:controller commissioningComplete:error nodeID:nodeID];
+        } else if ([delegate respondsToSelector:@selector(controller:commissioningComplete:)]) {
+            [delegate controller:controller commissioningComplete:error];
+        }
+    } logString:__PRETTY_FUNCTION__];
+}
+
+- (void)controller:(MTRDeviceController *)controller readCommissioningInfo:(MTRProductIdentity *)info
+{
+    [self _callDelegatesWithBlock:^(id<MTRDeviceControllerDelegate> delegate) {
+        if ([delegate respondsToSelector:@selector(controller:readCommissioningInfo:)]) {
+            [delegate controller:controller readCommissioningInfo:info];
+        }
+    } logString:__PRETTY_FUNCTION__];
+}
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -1778,6 +1778,10 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 - (void)setDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue
 {
     @synchronized(self) {
+        if (_strongDelegateForSetDelegateAPI) {
+            MTR_LOG("%@ setDeviceControllerDelegate: replacing %p with %p", self, _strongDelegateForSetDelegateAPI, delegate);
+            [self removeDeviceControllerDelegate:_strongDelegateForSetDelegateAPI];
+        }
         _strongDelegateForSetDelegateAPI = delegate;
         [self addDeviceControllerDelegate:delegate queue:queue];
     }

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -114,8 +114,8 @@ using namespace chip::Tracing::DarwinFramework;
 
 @interface MTRDeviceControllerDelegateInfo : NSObject
 - (instancetype)initWithDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue;
-@property(nonatomic, weak, readonly) id<MTRDeviceControllerDelegate> delegate;
-@property(nonatomic, readonly) dispatch_queue_t queue;
+@property (nonatomic, weak, readonly) id<MTRDeviceControllerDelegate> delegate;
+@property (nonatomic, readonly) dispatch_queue_t queue;
 @end
 
 @implementation MTRDeviceControllerDelegateInfo
@@ -161,7 +161,7 @@ using namespace chip::Tracing::DarwinFramework;
     BOOL _shutdownPending;
     os_unfair_lock _assertionLock;
 
-    NSMutableSet<MTRDeviceControllerDelegateInfo *> *_delegates;
+    NSMutableSet<MTRDeviceControllerDelegateInfo *> * _delegates;
     id<MTRDeviceControllerDelegate> _strongDelegateForSetDelegateAPI;
 }
 
@@ -593,7 +593,7 @@ using namespace chip::Tracing::DarwinFramework;
     if (_deviceControllerDelegateBridge) {
         delete _deviceControllerDelegateBridge;
         _deviceControllerDelegateBridge = nullptr;
-        @synchronized (self) {
+        @synchronized(self) {
             _strongDelegateForSetDelegateAPI = nil;
             [_delegates removeAllObjects];
         }
@@ -1777,7 +1777,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 // Note these are implemented in the base class so that XPC subclass can use it as well when it
 - (void)setDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue
 {
-    @synchronized (self) {
+    @synchronized(self) {
         _strongDelegateForSetDelegateAPI = delegate;
         [self addDeviceControllerDelegate:delegate queue:queue];
     }
@@ -1785,8 +1785,8 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
 - (void)addDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue
 {
-    @synchronized (self) {
-        MTRDeviceControllerDelegateInfo *newDelegateInfo = [[MTRDeviceControllerDelegateInfo alloc] initWithDelegate:delegate queue:queue];
+    @synchronized(self) {
+        MTRDeviceControllerDelegateInfo * newDelegateInfo = [[MTRDeviceControllerDelegateInfo alloc] initWithDelegate:delegate queue:queue];
         [_delegates addObject:newDelegateInfo];
         MTR_LOG("%@ addDeviceControllerDelegate: added %p total %lu", self, delegate, static_cast<unsigned long>(_delegates.count));
     }
@@ -1794,9 +1794,9 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
 - (void)removeDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate
 {
-    @synchronized (self) {
-        __block MTRDeviceControllerDelegateInfo *delegateInfoToRemove = nil;
-        [self _iterateDelegateInfoWithBlock:^(MTRDeviceControllerDelegateInfo *delegateInfo) {
+    @synchronized(self) {
+        __block MTRDeviceControllerDelegateInfo * delegateInfoToRemove = nil;
+        [self _iterateDelegateInfoWithBlock:^(MTRDeviceControllerDelegateInfo * delegateInfo) {
             if (delegateInfo.delegate == delegate) {
                 delegateInfoToRemove = delegateInfo;
             }
@@ -1816,17 +1816,17 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
 // Iterates the delegates, and remove delegate info objects if the delegate object has dealloc'ed
 // Returns number of delegates called
-- (NSUInteger)_iterateDelegateInfoWithBlock:(void(^ _Nullable)(MTRDeviceControllerDelegateInfo * delegateInfo))block
+- (NSUInteger)_iterateDelegateInfoWithBlock:(void (^_Nullable)(MTRDeviceControllerDelegateInfo * delegateInfo))block
 {
-    @synchronized (self) {
+    @synchronized(self) {
         if (!_delegates.count) {
             MTR_LOG("%@ No delegates to iterate", self);
             return 0;
         }
 
         // Opportunistically remove defunct delegate references on every iteration
-        NSMutableSet *delegatesToRemove = nil;
-        for (MTRDeviceControllerDelegateInfo *delegateInfo in _delegates) {
+        NSMutableSet * delegatesToRemove = nil;
+        for (MTRDeviceControllerDelegateInfo * delegateInfo in _delegates) {
             id<MTRDeviceControllerDelegate> strongDelegate = delegateInfo.delegate;
             if (strongDelegate) {
                 if (block) {
@@ -1849,9 +1849,9 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     }
 }
 
-- (void)_callDelegatesWithBlock:(void(^ _Nullable)(id<MTRDeviceControllerDelegate> delegate))block logString:(const char *)logString;
+- (void)_callDelegatesWithBlock:(void (^_Nullable)(id<MTRDeviceControllerDelegate> delegate))block logString:(const char *)logString;
 {
-    NSUInteger delegatesCalled = [self _iterateDelegateInfoWithBlock:^(MTRDeviceControllerDelegateInfo *delegateInfo) {
+    NSUInteger delegatesCalled = [self _iterateDelegateInfoWithBlock:^(MTRDeviceControllerDelegateInfo * delegateInfo) {
         id<MTRDeviceControllerDelegate> strongDelegate = delegateInfo.delegate;
         dispatch_async(delegateInfo.queue, ^{
             block(strongDelegate);
@@ -1880,9 +1880,9 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 }
 
 - (void)controller:(MTRDeviceController *)controller
-commissioningComplete:(NSError * _Nullable)error
-            nodeID:(NSNumber * _Nullable)nodeID
-           metrics:(MTRMetrics *)metrics
+    commissioningComplete:(NSError * _Nullable)error
+                   nodeID:(NSNumber * _Nullable)nodeID
+                  metrics:(MTRMetrics *)metrics
 {
     [self _callDelegatesWithBlock:^(id<MTRDeviceControllerDelegate> delegate) {
         if ([delegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:metrics:)]) {

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -168,15 +168,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 
 - (void)preWarmCommissioningSession MTR_DEPRECATED("-[MTRDeviceControllerFactory preWarmCommissioningSession]", ios(16.4, 17.6), macos(13.3, 14.6), watchos(9.4, 10.6), tvos(16.4, 17.6));
 
-/**
- * Set the Delegate for the device controller  as well as the Queue on which the Delegate callbacks will be triggered
- *
- * @param[in] delegate The delegate the commissioning process should use
- *
- * @param[in] queue The queue on which the callbacks will be delivered
- */
-- (void)setDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate
-                              queue:(dispatch_queue_t)queue MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4));
+// Use super class implementation for -setDeviceControllerDelegate:queue:
 
 /**
  * Start scanning for commissionable devices.

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -717,6 +717,10 @@ using namespace chip::Tracing::DarwinFramework;
 
         commissionerInitialized = YES;
 
+        // Set self as delegate, which fans out delegate callbacks to all added delegates
+        id<MTRDeviceControllerDelegate> selfDelegate = static_cast<id<MTRDeviceControllerDelegate>>(self);
+        self->_deviceControllerDelegateBridge->setDelegate(self, selfDelegate, dispatch_get_main_queue());
+
         MTR_LOG("%@ startup succeeded for nodeID 0x%016llX", self, self->_cppCommissioner->GetNodeId());
     });
 
@@ -1184,15 +1188,6 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     return deviceAttributeCounts;
 }
 #endif
-
-- (void)setDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue
-{
-    [self
-        asyncDispatchToMatterQueue:^() {
-            self->_deviceControllerDelegateBridge->setDelegate(self, delegate, queue);
-        }
-                      errorHandler:nil];
-}
 
 - (BOOL)setOperationalCertificateIssuer:(nullable id<MTROperationalCertificateIssuer>)operationalCertificateIssuer
                                   queue:(nullable dispatch_queue_t)queue

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -719,7 +719,7 @@ using namespace chip::Tracing::DarwinFramework;
 
         // Set self as delegate, which fans out delegate callbacks to all added delegates
         id<MTRDeviceControllerDelegate> selfDelegate = static_cast<id<MTRDeviceControllerDelegate>>(self);
-        self->_deviceControllerDelegateBridge->setDelegate(self, selfDelegate, dispatch_get_main_queue());
+        self->_deviceControllerDelegateBridge->setDelegate(self, selfDelegate, _chipWorkQueue);
 
         MTR_LOG("%@ startup succeeded for nodeID 0x%016llX", self, self->_cppCommissioner->GetNodeId());
     });

--- a/src/darwin/Framework/CHIP/MTRError_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRError_Internal.h
@@ -26,10 +26,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#ifndef YES_NO
-#define YES_NO(x) ((x) ? @"YES" : @"NO")
-#endif
-
 MTR_DIRECT_MEMBERS
 @interface MTRError : NSObject
 + (NSError *)errorWithCode:(MTRErrorCode)code;

--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -134,10 +134,10 @@ static MTRTestKeys * sTestKeys = nil;
 @end
 
 @interface MTRPairingTestMonitoringControllerDelegate : NSObject <MTRDeviceControllerDelegate>
-@property(nonatomic, readonly) BOOL statusUpdateCalled;
-@property(nonatomic, readonly) BOOL commissioningSessionEstablishmentDoneCalled;
-@property(nonatomic, readonly) BOOL commissioningCompleteCalled;
-@property(nonatomic, readonly) BOOL readCommissioningInfoCalled;
+@property (nonatomic, readonly) BOOL statusUpdateCalled;
+@property (nonatomic, readonly) BOOL commissioningSessionEstablishmentDoneCalled;
+@property (nonatomic, readonly) BOOL commissioningCompleteCalled;
+@property (nonatomic, readonly) BOOL readCommissioningInfoCalled;
 @end
 
 @implementation MTRPairingTestMonitoringControllerDelegate

--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -134,10 +134,10 @@ static MTRTestKeys * sTestKeys = nil;
 @end
 
 @interface MTRPairingTestMonitoringControllerDelegate : NSObject <MTRDeviceControllerDelegate>
-@property (nonatomic, readonly) BOOL statusUpdateCalled;
-@property (nonatomic, readonly) BOOL commissioningSessionEstablishmentDoneCalled;
-@property (nonatomic, readonly) BOOL commissioningCompleteCalled;
-@property (nonatomic, readonly) BOOL readCommissioningInfoCalled;
+@property (atomic, readwrite) BOOL statusUpdateCalled;
+@property (atomic, readwrite) BOOL commissioningSessionEstablishmentDoneCalled;
+@property (atomic, readwrite) BOOL commissioningCompleteCalled;
+@property (atomic, readwrite) BOOL readCommissioningInfoCalled;
 @end
 
 @implementation MTRPairingTestMonitoringControllerDelegate
@@ -147,12 +147,12 @@ static MTRTestKeys * sTestKeys = nil;
 }
 - (void)controller:(MTRDeviceController *)controller statusUpdate:(MTRCommissioningStatus)status
 {
-    _statusUpdateCalled = YES;
+    self.statusUpdateCalled = YES;
 }
 
 - (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError * _Nullable)error
 {
-    _commissioningSessionEstablishmentDoneCalled = YES;
+    self.commissioningSessionEstablishmentDoneCalled = YES;
 }
 
 - (void)controller:(MTRDeviceController *)controller
@@ -160,12 +160,12 @@ static MTRTestKeys * sTestKeys = nil;
                    nodeID:(NSNumber * _Nullable)nodeID
                   metrics:(MTRMetrics *)metrics
 {
-    _commissioningCompleteCalled = YES;
+    self.commissioningCompleteCalled = YES;
 }
 
 - (void)controller:(MTRDeviceController *)controller readCommissioningInfo:(MTRProductIdentity *)info
 {
-    _readCommissioningInfoCalled = YES;
+    self.readCommissioningInfoCalled = YES;
 }
 @end
 

--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -18,9 +18,11 @@
 // module headers
 #import <Matter/Matter.h>
 
+#import "MTRDefines_Internal.h"
 #import "MTRErrorTestUtils.h"
 #import "MTRTestCase+ServerAppRunner.h"
 #import "MTRTestCase.h"
+#import "MTRTestDeclarations.h"
 #import "MTRTestKeys.h"
 #import "MTRTestStorage.h"
 
@@ -131,6 +133,42 @@ static MTRTestKeys * sTestKeys = nil;
 
 @end
 
+@interface MTRPairingTestMonitoringControllerDelegate : NSObject <MTRDeviceControllerDelegate>
+@property(nonatomic, readonly) BOOL statusUpdateCalled;
+@property(nonatomic, readonly) BOOL commissioningSessionEstablishmentDoneCalled;
+@property(nonatomic, readonly) BOOL commissioningCompleteCalled;
+@property(nonatomic, readonly) BOOL readCommissioningInfoCalled;
+@end
+
+@implementation MTRPairingTestMonitoringControllerDelegate
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<MTRPairingTestMonitoringControllerDelegate: %p statusUpdateCalled %@ commissioningSessionEstablishmentDoneCalled %@ commissioningCompleteCalled %@ readCommissioningInfoCalled %@>", self, YES_NO(_statusUpdateCalled), YES_NO(_commissioningSessionEstablishmentDoneCalled), YES_NO(_commissioningCompleteCalled), YES_NO(_readCommissioningInfoCalled)];
+}
+- (void)controller:(MTRDeviceController *)controller statusUpdate:(MTRCommissioningStatus)status
+{
+    _statusUpdateCalled = YES;
+}
+
+- (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError * _Nullable)error
+{
+    _commissioningSessionEstablishmentDoneCalled = YES;
+}
+
+- (void)controller:(MTRDeviceController *)controller
+    commissioningComplete:(NSError * _Nullable)error
+                   nodeID:(NSNumber * _Nullable)nodeID
+                  metrics:(MTRMetrics *)metrics
+{
+    _commissioningCompleteCalled = YES;
+}
+
+- (void)controller:(MTRDeviceController *)controller readCommissioningInfo:(MTRProductIdentity *)info
+{
+    _readCommissioningInfoCalled = YES;
+}
+@end
+
 @interface MTRPairingTests : MTRTestCase
 @property (nullable) MTRPairingTestControllerDelegate * controllerDelegate;
 @end
@@ -219,6 +257,19 @@ static MTRTestKeys * sTestKeys = nil;
     [sController setDeviceControllerDelegate:controllerDelegate queue:callbackQueue];
     self.controllerDelegate = controllerDelegate;
 
+    // Test that a monitoring delegate works
+    __auto_type * monitoringControllerDelegate = [[MTRPairingTestMonitoringControllerDelegate alloc] init];
+    [sController addDeviceControllerDelegate:monitoringControllerDelegate queue:callbackQueue];
+    XCTAssertEqual([sController unitTestDelegateCount], 2);
+
+    // Test that the addDeviceControllerDelegate delegate is held weakly by the controller
+    @autoreleasepool {
+        __auto_type * monitoringControllerDelegate = [[MTRPairingTestMonitoringControllerDelegate alloc] init];
+        [sController addDeviceControllerDelegate:monitoringControllerDelegate queue:callbackQueue];
+        XCTAssertEqual([sController unitTestDelegateCount], 3);
+    }
+    XCTAssertEqual([sController unitTestDelegateCount], 2);
+
     NSError * error;
     __auto_type * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:kOnboardingPayload error:&error];
     XCTAssertNotNil(payload);
@@ -229,6 +280,13 @@ static MTRTestKeys * sTestKeys = nil;
 
     [self waitForExpectations:@[ expectation ] timeout:kPairingTimeoutInSeconds];
     XCTAssertNil(controllerDelegate.commissioningCompleteError);
+
+    // Test that the monitoring delegate got all the callbacks
+    XCTAssertTrue(monitoringControllerDelegate.statusUpdateCalled);
+    XCTAssertTrue(monitoringControllerDelegate.commissioningSessionEstablishmentDoneCalled);
+    XCTAssertTrue(monitoringControllerDelegate.commissioningCompleteCalled);
+    XCTAssertTrue(monitoringControllerDelegate.readCommissioningInfoCalled);
+    [sController removeDeviceControllerDelegate:monitoringControllerDelegate];
 }
 
 - (void)test001_PairWithoutAttestationDelegate

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -18,6 +18,9 @@
 #import <Foundation/Foundation.h>
 #import <Matter/Matter.h>
 
+// For MTRDeviceDataValueDictionary:
+#import "MTRDevice_Internal.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Declarations for internal methods
@@ -55,6 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 #ifdef DEBUG
 @interface MTRDeviceController (TestDebug)
 - (NSDictionary<NSNumber *, NSNumber *> *)unitTestGetDeviceAttributeCounts;
+- (NSUInteger)unitTestDelegateCount;
 @end
 
 @interface MTRBaseDevice (TestDebug)


### PR DESCRIPTION
This PR implements add/remove semantics for MTRDeviceController delegate.

The add/remove delegates will be weak references but will keep a strong reference for delegates set from the existing setDeviceControllerDelegate API, to keep old behavior.