### PR TITLE
Clean up subscriptions from fabric sync tests

### DIFF
--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -123,6 +123,7 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         self.set_of_dut_endpoints_before_adding_device = set(root_part_list)
 
         super().setup_class()
+        self._active_change_event_subscription = None
         self.app_process = None
         self.app_process_paused = False
         app = self.user_params.get("th_icd_server_app_path", None)
@@ -156,6 +157,10 @@ class TC_BRBINFO_4_1(MatterBaseTest):
                                                          params.commissioningParameters.setupManualCode, params.commissioningParameters.setupQRCode)
 
     def teardown_class(self):
+        if self._active_change_event_subscription is not None:
+            self._active_change_event_subscription.Shutdown()
+            self._active_change_event_subscription = None
+
         # In case the th_icd_server_app_path does not exist, then we failed the test
         # and there is nothing to remove
         if self.app_process is not None:
@@ -239,8 +244,8 @@ class TC_BRBINFO_4_1(MatterBaseTest):
         self.q = queue.Queue()
         urgent = 1
         cb = SimpleEventCallback("ActiveChanged", event.cluster_id, event.event_id, self.q)
-        subscription = await self.default_controller.ReadEvent(nodeid=self.dut_node_id, events=[(dynamic_endpoint_id, event, urgent)], reportInterval=[1, 3])
-        subscription.SetEventUpdateCallback(callback=cb)
+        self._active_change_event_subscription = await self.default_controller.ReadEvent(nodeid=self.dut_node_id, events=[(dynamic_endpoint_id, event, urgent)], reportInterval=[1, 3])
+        self._active_change_event_subscription.SetEventUpdateCallback(callback=cb)
 
         self.step("3")
         stay_active_duration_ms = 1000

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -61,10 +61,20 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
     @async_test_body
     async def setup_class(self):
         super().setup_class()
+        self._partslist_subscription = None
+        self._cadmin_subscription = None
         self._app_th_server_process = None
         self._th_server_kvs = None
 
     def teardown_class(self):
+        if self._partslist_subscription is not None:
+            self._partslist_subscription.Shutdown()
+            self._partslist_subscription = None
+
+        if self._cadmin_subscription is not None:
+            self._cadmin_subscription.Shutdown()
+            self._cadmin_subscription = None
+
         if self._app_th_server_process is not None:
             logging.warning("Stopping app with SIGTERM")
             self._app_th_server_process.send_signal(signal.SIGTERM.value)
@@ -142,7 +152,7 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
         parts_list_subscription_contents = [
             (root_endpoint, Clusters.Descriptor.Attributes.PartsList)
         ]
-        parts_list_sub = await self.default_controller.ReadAttribute(
+        self._partslist_subscription = await self.default_controller.ReadAttribute(
             nodeid=self.dut_node_id,
             attributes=parts_list_subscription_contents,
             reportInterval=(min_report_interval_sec, max_report_interval_sec),
@@ -152,8 +162,8 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
         parts_list_queue = queue.Queue()
         parts_list_attribute_handler = AttributeChangeAccumulator(
             name=self.default_controller.name, expected_attribute=Clusters.Descriptor.Attributes.PartsList, output=parts_list_queue)
-        parts_list_sub.SetAttributeUpdateCallback(parts_list_attribute_handler)
-        parts_list_cached_attributes = parts_list_sub.GetAttributes()
+        self._partslist_subscription.SetAttributeUpdateCallback(parts_list_attribute_handler)
+        parts_list_cached_attributes = self._partslist_subscription.GetAttributes()
         step_1_dut_parts_list = parts_list_cached_attributes[root_endpoint][Clusters.Descriptor][Clusters.Descriptor.Attributes.PartsList]
 
         asserts.assert_true(type_matches(step_1_dut_parts_list, list), "PartsList is expected to be a list")
@@ -219,7 +229,7 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
         cadmin_subscription_contents = [
             (newly_added_endpoint, Clusters.AdministratorCommissioning)
         ]
-        cadmin_sub = await self.default_controller.ReadAttribute(
+        self._cadmin_subscription = await self.default_controller.ReadAttribute(
             nodeid=self.dut_node_id,
             attributes=cadmin_subscription_contents,
             reportInterval=(min_report_interval_sec, max_report_interval_sec),
@@ -230,7 +240,7 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
         # This AttributeChangeAccumulator is really just to let us know when new subscription came in
         cadmin_attribute_handler = AttributeChangeAccumulator(
             name=self.default_controller.name, expected_attribute=Clusters.AdministratorCommissioning.Attributes.WindowStatus, output=cadmin_queue)
-        cadmin_sub.SetAttributeUpdateCallback(cadmin_attribute_handler)
+        self._cadmin_subscription.SetAttributeUpdateCallback(cadmin_attribute_handler)
         time.sleep(1)
 
         self.step(7)


### PR DESCRIPTION
Previously there used to be a stack error for not properly cleaning up the subscriptions on TH after displaying message that the test passed. This gave testers some concern, but it wasn't an actual issue since test was correctly passing. This is simply cleaning up the subscriptions in the test teardown. The stack trace looked like this

```
DEBUG:chip.native.DMG:MoveToState ReadClient[0xffff9000dd30]: Moving to [      Idle]
Exception ignored on calling ctypes callback function: <function _OnReadDoneCallback at 0xffffa9cec4a0>
Traceback (most recent call last):
  File "/home/ubuntu/Aug7/connectedhomeip/no/lib/python3.12/site-packages/chip/clusters/Attribute.py", line 903, in _OnReadDoneCallback
    closure.handleDone()
  File "/home/ubuntu/Aug7/connectedhomeip/no/lib/python3.12/site-packages/chip/clusters/Attribute.py", line 786, in handleDone
    self._event_loop.call_soon_threadsafe(self._handleDone)
  File "/usr/lib/python3.12/asyncio/base_events.py", line 840, in call_soon_threadsafe
    self._check_closed()
  File "/usr/lib/python3.12/asyncio/base_events.py", line 541, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
DEBUG:chip.native.DMG:MoveToState ReadClient[0xffff90014000]: Moving to [      Idle]
Exception ignored on calling ctypes callback function: <function _OnReadDoneCallback at 0xffffa9cec4a0>
Traceback (most recent call last):
  File "/home/ubuntu/Aug7/connectedhomeip/no/lib/python3.12/site-packages/chip/clusters/Attribute.py", line 903, in _OnReadDoneCallback
    closure.handleDone()
  File "/home/ubuntu/Aug7/connectedhomeip/no/lib/python3.12/site-packages/chip/clusters/Attribute.py", line 786, in handleDone
    self._event_loop.call_soon_threadsafe(self._handleDone)
  File "/usr/lib/python3.12/asyncio/base_events.py", line 840, in call_soon_threadsafe
    self._check_closed()
  File "/usr/lib/python3.12/asyncio/base_events.py", line 541, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```

By calling shutdown on the subscriptions we no longer see this stack track