### PR TITLE
Ensure all derived clusters have the base enum values

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -2985,6 +2985,16 @@ cluster OvenMode = 73 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kBake = 16384;
     kConvection = 16385;
     kGrill = 16386;
@@ -3106,6 +3116,16 @@ cluster LaundryWasherMode = 81 {
   revision 2;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNormal = 16384;
     kDelicate = 16385;
     kHeavy = 16386;
@@ -3157,6 +3177,16 @@ cluster RefrigeratorAndTemperatureControlledCabinetMode = 82 {
   revision 2;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kRapidCool = 16384;
     kRapidFreeze = 16385;
   }
@@ -3234,6 +3264,16 @@ cluster RvcRunMode = 84 {
   revision 3;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kIdle = 16384;
     kCleaning = 16385;
     kMapping = 16386;
@@ -3293,6 +3333,16 @@ cluster RvcCleanMode = 85 {
   revision 3;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kDeepClean = 16384;
     kVacuum = 16385;
     kMop = 16386;
@@ -3403,6 +3453,16 @@ cluster DishwasherMode = 89 {
   revision 2;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNormal = 16384;
     kHeavy = 16385;
     kLight = 16386;
@@ -3644,6 +3704,16 @@ cluster MicrowaveOvenMode = 94 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNormal = 16384;
     kDefrost = 16385;
   }
@@ -3744,6 +3814,10 @@ cluster RvcOperationalState = 97 {
   revision 1;
 
   enum ErrorStateEnum : enum8 {
+    kNoError = 0;
+    kUnableToStartOrResume = 1;
+    kUnableToCompleteOperation = 2;
+    kCommandInvalidInState = 3;
     kFailedToFindChargingDock = 64;
     kStuck = 65;
     kDustBinMissing = 66;
@@ -3755,6 +3829,10 @@ cluster RvcOperationalState = 97 {
   }
 
   enum OperationalStateEnum : enum8 {
+    kStopped = 0;
+    kRunning = 1;
+    kPaused = 2;
+    kError = 3;
     kSeekingCharger = 64;
     kCharging = 65;
     kDocked = 66;
@@ -4903,6 +4981,16 @@ cluster EnergyEvseMode = 157 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kManual = 16384;
     kTimeOfUse = 16385;
     kSolarCharging = 16386;
@@ -4953,6 +5041,16 @@ cluster WaterHeaterMode = 158 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kOff = 16384;
     kManual = 16385;
     kTimed = 16386;
@@ -5003,6 +5101,16 @@ provisional cluster DeviceEnergyManagementMode = 159 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNoOptimization = 16384;
     kDeviceOptimization = 16385;
     kLocalOptimization = 16386;

--- a/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.matter
+++ b/examples/chef/devices/rootnode_laundrywasher_fb10d238c8.matter
@@ -1303,6 +1303,16 @@ cluster LaundryWasherMode = 81 {
   revision 2;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNormal = 16384;
     kDelicate = 16385;
     kHeavy = 16386;

--- a/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
+++ b/examples/chef/devices/rootnode_roboticvacuumcleaner_1807ff0c49.matter
@@ -1583,6 +1583,16 @@ cluster RvcRunMode = 84 {
   revision 3;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kIdle = 16384;
     kCleaning = 16385;
     kMapping = 16386;
@@ -1642,6 +1652,16 @@ cluster RvcCleanMode = 85 {
   revision 3;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kDeepClean = 16384;
     kVacuum = 16385;
     kMop = 16386;
@@ -1694,6 +1714,10 @@ cluster RvcOperationalState = 97 {
   revision 1;
 
   enum ErrorStateEnum : enum8 {
+    kNoError = 0;
+    kUnableToStartOrResume = 1;
+    kUnableToCompleteOperation = 2;
+    kCommandInvalidInState = 3;
     kFailedToFindChargingDock = 64;
     kStuck = 65;
     kDustBinMissing = 66;
@@ -1705,6 +1729,10 @@ cluster RvcOperationalState = 97 {
   }
 
   enum OperationalStateEnum : enum8 {
+    kStopped = 0;
+    kRunning = 1;
+    kPaused = 2;
+    kError = 3;
     kSeekingCharger = 64;
     kCharging = 65;
     kDocked = 66;

--- a/examples/energy-management-app/energy-management-common/energy-management-app.matter
+++ b/examples/energy-management-app/energy-management-common/energy-management-app.matter
@@ -2222,6 +2222,16 @@ cluster EnergyEvseMode = 157 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kManual = 16384;
     kTimeOfUse = 16385;
     kSolarCharging = 16386;
@@ -2272,6 +2282,16 @@ cluster WaterHeaterMode = 158 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kOff = 16384;
     kManual = 16385;
     kTimed = 16386;
@@ -2322,6 +2342,16 @@ provisional cluster DeviceEnergyManagementMode = 159 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNoOptimization = 16384;
     kDeviceOptimization = 16385;
     kLocalOptimization = 16386;

--- a/examples/laundry-washer-app/nxp/zap/laundry-washer-app.matter
+++ b/examples/laundry-washer-app/nxp/zap/laundry-washer-app.matter
@@ -1963,6 +1963,16 @@ cluster LaundryWasherMode = 81 {
   revision 2;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNormal = 16384;
     kDelicate = 16385;
     kHeavy = 16386;

--- a/examples/microwave-oven-app/microwave-oven-common/microwave-oven-app.matter
+++ b/examples/microwave-oven-app/microwave-oven-common/microwave-oven-app.matter
@@ -1321,6 +1321,16 @@ cluster MicrowaveOvenMode = 94 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNormal = 16384;
     kDefrost = 16385;
   }

--- a/examples/rvc-app/rvc-common/rvc-app.matter
+++ b/examples/rvc-app/rvc-common/rvc-app.matter
@@ -1247,6 +1247,16 @@ cluster RvcRunMode = 84 {
   revision 3;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kIdle = 16384;
     kCleaning = 16385;
     kMapping = 16386;
@@ -1306,6 +1316,16 @@ cluster RvcCleanMode = 85 {
   revision 3;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kDeepClean = 16384;
     kVacuum = 16385;
     kMop = 16386;
@@ -1358,6 +1378,10 @@ cluster RvcOperationalState = 97 {
   revision 1;
 
   enum ErrorStateEnum : enum8 {
+    kNoError = 0;
+    kUnableToStartOrResume = 1;
+    kUnableToCompleteOperation = 2;
+    kCommandInvalidInState = 3;
     kFailedToFindChargingDock = 64;
     kStuck = 65;
     kDustBinMissing = 66;
@@ -1369,6 +1393,10 @@ cluster RvcOperationalState = 97 {
   }
 
   enum OperationalStateEnum : enum8 {
+    kStopped = 0;
+    kRunning = 1;
+    kPaused = 2;
+    kError = 3;
     kSeekingCharger = 64;
     kCharging = 65;
     kDocked = 66;

--- a/src/app/zap-templates/zcl/data-model/chip/device-energy-management-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/device-energy-management-mode-cluster.xml
@@ -19,8 +19,23 @@ limitations under the License.
 
   <enum name="ModeTag" type="enum16">
     <cluster code="0x009F"/>
+    <!-- These are the base values (see `enum class ModeTag`
+         in src/app/clusters/mode-base-server/mode-base-cluster-objects.h for the namespace source of truth
+         until it is possible to auto-include these without duplication in codegen. -->
+    <item value="0x0000" name="Auto"/>
+    <item value="0x0001" name="Quick"/>
+    <item value="0x0002" name="Quiet"/>
+    <item value="0x0003" name="LowNoise"/>
+    <item value="0x0004" name="LowEnergy"/>
+    <item value="0x0005" name="Vacation"/>
+    <item value="0x0006" name="Min"/>
+    <item value="0x0007" name="Max"/>
+    <item value="0x0008" name="Night"/>
+    <item value="0x0009" name="Day"/>
+
+    <!-- Derived cluster-specific values -->
     <item value="0x4000" name="No Optimization"/>
-    <item value="0x4001" name="Device Optimization"/>    
+    <item value="0x4001" name="Device Optimization"/>
     <item value="0x4002" name="Local Optimization"/>
     <item value="0x4003" name="Grid Optimization"/>
   </enum>

--- a/src/app/zap-templates/zcl/data-model/chip/dishwasher-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/dishwasher-mode-cluster.xml
@@ -19,6 +19,22 @@ limitations under the License.
 
   <enum name="ModeTag" type="enum16">
     <cluster code="0x0059"/>
+    <!-- These are the base values (see `enum class ModeTag`
+         in src/app/clusters/mode-base-server/mode-base-cluster-objects.h for the namespace source of truth
+         until it is possible to auto-include these without duplication in codegen. -->
+    <item value="0x0000" name="Auto"/>
+    <item value="0x0001" name="Quick"/>
+    <item value="0x0002" name="Quiet"/>
+    <item value="0x0003" name="LowNoise"/>
+    <item value="0x0004" name="LowEnergy"/>
+    <item value="0x0005" name="Vacation"/>
+    <item value="0x0006" name="Min"/>
+    <item value="0x0007" name="Max"/>
+    <item value="0x0008" name="Night"/>
+    <item value="0x0009" name="Day"/>
+
+    <!-- Derived cluster-specific values -->
+
     <item value="0x4000" name="Normal"/>
     <item value="0x4001" name="Heavy"/>
     <item value="0x4002" name="Light"/>
@@ -39,7 +55,7 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-    
+
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/energy-evse-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/energy-evse-mode-cluster.xml
@@ -19,6 +19,21 @@ limitations under the License.
 
   <enum name="ModeTag" type="enum16">
     <cluster code="0x009D"/>
+    <!-- These are the base values (see `enum class ModeTag`
+          in src/app/clusters/mode-base-server/mode-base-cluster-objects.h for the namespace source of truth
+          until it is possible to auto-include these without duplication in codegen. -->
+    <item value="0x0000" name="Auto"/>
+    <item value="0x0001" name="Quick"/>
+    <item value="0x0002" name="Quiet"/>
+    <item value="0x0003" name="LowNoise"/>
+    <item value="0x0004" name="LowEnergy"/>
+    <item value="0x0005" name="Vacation"/>
+    <item value="0x0006" name="Min"/>
+    <item value="0x0007" name="Max"/>
+    <item value="0x0008" name="Night"/>
+    <item value="0x0009" name="Day"/>
+
+    <!-- Derived cluster-specific values -->
     <item value="0x4000" name="Manual"/>
     <item value="0x4001" name="TimeOfUse"/>
     <item value="0x4002" name="SolarCharging"/>

--- a/src/app/zap-templates/zcl/data-model/chip/laundry-washer-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/laundry-washer-mode-cluster.xml
@@ -19,6 +19,22 @@ limitations under the License.
 
   <enum name="ModeTag" type="enum16">
     <cluster code="0x0051"/>
+
+    <!-- These are the base values (see `enum class ModeTag`
+         in src/app/clusters/mode-base-server/mode-base-cluster-objects.h for the namespace source of truth
+         until it is possible to auto-include these without duplication in codegen. -->
+    <item value="0x0000" name="Auto"/>
+    <item value="0x0001" name="Quick"/>
+    <item value="0x0002" name="Quiet"/>
+    <item value="0x0003" name="LowNoise"/>
+    <item value="0x0004" name="LowEnergy"/>
+    <item value="0x0005" name="Vacation"/>
+    <item value="0x0006" name="Min"/>
+    <item value="0x0007" name="Max"/>
+    <item value="0x0008" name="Night"/>
+    <item value="0x0009" name="Day"/>
+
+    <!-- Derived cluster-specific values -->
     <item value="0x4000" name="Normal"/>
     <item value="0x4001" name="Delicate"/>
     <item value="0x4002" name="Heavy"/>
@@ -40,7 +56,7 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-    
+
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/microwave-oven-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/microwave-oven-mode-cluster.xml
@@ -19,6 +19,21 @@ limitations under the License.
 
   <enum name="ModeTag" type="enum16">
     <cluster code="0x005E"/>
+    <!-- These are the base values (see `enum class ModeTag`
+         in src/app/clusters/mode-base-server/mode-base-cluster-objects.h for the namespace source of truth
+         until it is possible to auto-include these without duplication in codegen. -->
+    <item value="0x0000" name="Auto"/>
+    <item value="0x0001" name="Quick"/>
+    <item value="0x0002" name="Quiet"/>
+    <item value="0x0003" name="LowNoise"/>
+    <item value="0x0004" name="LowEnergy"/>
+    <item value="0x0005" name="Vacation"/>
+    <item value="0x0006" name="Min"/>
+    <item value="0x0007" name="Max"/>
+    <item value="0x0008" name="Night"/>
+    <item value="0x0009" name="Day"/>
+
+    <!-- Derived cluster-specific values -->
     <item value="0x4000" name="Normal"/>
     <item value="0x4001" name="Defrost"/>
   </enum>

--- a/src/app/zap-templates/zcl/data-model/chip/mode-base-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/mode-base-cluster.xml
@@ -21,6 +21,8 @@ limitations under the License.
 The generic enum values for the StatusCode and ModeTag enums are defined within the ModeBase namespace
 in the mode-base-server source code. See mode-base-cluster-objects.h.
 This is because zap does not currently support generating code for clusters that do not have a cluster ID.
+
+Each of these enum values is also listed/copied in the derived clusters.
 -->
 
   <struct name="ModeTagStruct">

--- a/src/app/zap-templates/zcl/data-model/chip/operational-state-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-state-cluster.xml
@@ -19,7 +19,6 @@ limitations under the License.
 
   <enum name="OperationalStateEnum" type="enum8">
     <cluster code="0x0060"/>
-    <cluster code="0x0048"/>
     <item name="Stopped" value="0x00"/>
     <item name="Running" value="0x01"/>
     <item name="Paused"  value="0x02"/>
@@ -28,7 +27,6 @@ limitations under the License.
 
   <enum name="ErrorStateEnum" type="enum8">
     <cluster code="0x0060"/>
-    <cluster code="0x0048"/>
     <item name="NoError"                    value="0x00"/>
     <item name="UnableToStartOrResume"      value="0x01"/>
     <item name="UnableToCompleteOperation"  value="0x02"/>

--- a/src/app/zap-templates/zcl/data-model/chip/operational-state-oven-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-state-oven-cluster.xml
@@ -16,6 +16,33 @@ limitations under the License.
 -->
 <configurator>
   <domain name="CHIP"/>
+
+  <enum name="OperationalStateEnum" type="enum8">
+    <cluster code="0x0048"/>
+    <!-- These are the base values from the OperationalStateCluster, which have to
+         be copied in each derived cluster, due to ZAP XML constraints, until it
+         is possible to auto-include these without duplication in codegen. -->
+    <item name="Stopped" value="0x00"/>
+    <item name="Running" value="0x01"/>
+    <item name="Paused"  value="0x02"/>
+    <item name="Error"   value="0x03"/>
+
+    <!-- Derived cluster-specific values start below at 0x40 -->
+  </enum>
+
+  <enum name="ErrorStateEnum" type="enum8">
+    <cluster code="0x0048"/>
+    <!-- These are the base values from the OperationalStateCluster, which have to
+         be copied in each derived cluster, due to ZAP XML constraints, until it
+         is possible to auto-include these without duplication in codegen. -->
+    <item name="NoError"                    value="0x00"/>
+    <item name="UnableToStartOrResume"      value="0x01"/>
+    <item name="UnableToCompleteOperation"  value="0x02"/>
+    <item name="CommandInvalidInState"      value="0x03"/>
+
+    <!-- Derived cluster-specific values start below at 0x40 -->
+  </enum>
+
   <cluster>
     <domain>Appliances</domain>
     <name>Oven Cavity Operational State</name>

--- a/src/app/zap-templates/zcl/data-model/chip/operational-state-rvc-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-state-rvc-cluster.xml
@@ -19,6 +19,16 @@ limitations under the License.
 
   <enum name="OperationalStateEnum" type="enum8">
     <cluster code="0x0061"/>
+
+    <!-- These are the base values from the OperationalStateCluster, which have to
+          be copied in each derived cluster, due to ZAP XML constraints, until it
+          is possible to auto-include these without duplication in codegen. -->
+    <item name="Stopped" value="0x00"/>
+    <item name="Running" value="0x01"/>
+    <item name="Paused"  value="0x02"/>
+    <item name="Error"   value="0x03"/>
+
+    <!-- Derived cluster-specific values start below at 0x40 -->
     <item name="SeekingCharger" value="0x40"/>
     <item name="Charging"       value="0x41"/>
     <item name="Docked"         value="0x42"/>
@@ -26,6 +36,16 @@ limitations under the License.
 
   <enum name="ErrorStateEnum" type="enum8">
     <cluster code="0x0061"/>
+
+    <!-- These are the base values from the OperationalStateCluster, which have to
+         be copied in each derived cluster, due to ZAP XML constraints, until it
+         is possible to auto-include these without duplication in codegen. -->
+    <item name="NoError"                    value="0x00"/>
+    <item name="UnableToStartOrResume"      value="0x01"/>
+    <item name="UnableToCompleteOperation"  value="0x02"/>
+    <item name="CommandInvalidInState"      value="0x03"/>
+
+    <!-- Derived cluster-specific values start below at 0x40 -->
     <item name="FailedToFindChargingDock"   value="0x40"/>
     <item name="Stuck"                      value="0x41"/>
     <item name="DustBinMissing"             value="0x42"/>

--- a/src/app/zap-templates/zcl/data-model/chip/oven-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/oven-mode-cluster.xml
@@ -19,6 +19,21 @@ limitations under the License.
 
   <enum name="ModeTag" type="enum16">
     <cluster code="0x0049"/>
+    <!-- These are the base values (see `enum class ModeTag`
+      in src/app/clusters/mode-base-server/mode-base-cluster-objects.h for the namespace source of truth
+      until it is possible to auto-include these without duplication in codegen. -->
+    <item value="0x0000" name="Auto"/>
+    <item value="0x0001" name="Quick"/>
+    <item value="0x0002" name="Quiet"/>
+    <item value="0x0003" name="LowNoise"/>
+    <item value="0x0004" name="LowEnergy"/>
+    <item value="0x0005" name="Vacation"/>
+    <item value="0x0006" name="Min"/>
+    <item value="0x0007" name="Max"/>
+    <item value="0x0008" name="Night"/>
+    <item value="0x0009" name="Day"/>
+
+    <!-- Derived cluster-specific values -->
     <item value="0x4000" name="Bake"/>
     <item value="0x4001" name="Convection"/>
     <item value="0x4002" name="Grill"/>

--- a/src/app/zap-templates/zcl/data-model/chip/refrigerator-and-temperature-controlled-cabinet-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/refrigerator-and-temperature-controlled-cabinet-mode-cluster.xml
@@ -19,6 +19,22 @@ limitations under the License.
 
   <enum name="ModeTag" type="enum16">
     <cluster code="0x0052"/>
+
+    <!-- These are the base values (see `enum class ModeTag`
+         in src/app/clusters/mode-base-server/mode-base-cluster-objects.h for the namespace source of truth
+         until it is possible to auto-include these without duplication in codegen. -->
+    <item value="0x0000" name="Auto"/>
+    <item value="0x0001" name="Quick"/>
+    <item value="0x0002" name="Quiet"/>
+    <item value="0x0003" name="LowNoise"/>
+    <item value="0x0004" name="LowEnergy"/>
+    <item value="0x0005" name="Vacation"/>
+    <item value="0x0006" name="Min"/>
+    <item value="0x0007" name="Max"/>
+    <item value="0x0008" name="Night"/>
+    <item value="0x0009" name="Day"/>
+
+    <!-- Derived cluster-specific values -->
     <item value="0x4000" name="RapidCool"/>
     <item value="0x4001" name="RapidFreeze"/>
   </enum>
@@ -38,7 +54,7 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-    
+
     <!-- Base data types -->
     <attribute side="server" code="0x0000" define="SUPPORTED_MODES"  type="array" entryType="ModeOptionStruct" writable="false" optional="false" isNullable="false" length="255">SupportedModes</attribute>
     <attribute side="server" code="0x0001" define="CURRENT_MODE"     type="int8u"                              writable="false" optional="false" isNullable="false" reportable="true">CurrentMode</attribute>

--- a/src/app/zap-templates/zcl/data-model/chip/rvc-clean-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/rvc-clean-mode-cluster.xml
@@ -24,6 +24,22 @@ limitations under the License.
 
   <enum name="ModeTag" type="enum16">
     <cluster code="0x0055"/>
+
+    <!-- These are the base values (see `enum class ModeTag`
+         in src/app/clusters/mode-base-server/mode-base-cluster-objects.h for the namespace source of truth
+         until it is possible to auto-include these without duplication in codegen. -->
+    <item value="0x0000" name="Auto"/>
+    <item value="0x0001" name="Quick"/>
+    <item value="0x0002" name="Quiet"/>
+    <item value="0x0003" name="LowNoise"/>
+    <item value="0x0004" name="LowEnergy"/>
+    <item value="0x0005" name="Vacation"/>
+    <item value="0x0006" name="Min"/>
+    <item value="0x0007" name="Max"/>
+    <item value="0x0008" name="Night"/>
+    <item value="0x0009" name="Day"/>
+
+    <!-- Derived cluster-specific values -->
     <item value="0x4000" name="DeepClean"/>
     <item value="0x4001" name="Vacuum"/>
     <item value="0x4002" name="Mop"/>
@@ -38,7 +54,7 @@ limitations under the License.
     <server init="false" tick="false">true</server>
     <description>Attributes and commands for selecting a mode from a list of supported options.</description>
     <globalAttribute side="either" code="0xFFFD" value="3"/>
-  
+
     <features>
       <!-- TODO: ZAP still generates feature bits for things with disallowConform!
            Tracked in https://github.com/project-chip/zap/issues/1413 -->

--- a/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/rvc-run-mode-cluster.xml
@@ -31,6 +31,21 @@ limitations under the License.
 
   <enum name="ModeTag" type="enum16">
     <cluster code="0x0054"/>
+    <!-- These are the base values (see `enum class ModeTag`
+         in src/app/clusters/mode-base-server/mode-base-cluster-objects.h for the namespace source of truth
+         until it is possible to auto-include these without duplication in codegen. -->
+    <item value="0x0000" name="Auto"/>
+    <item value="0x0001" name="Quick"/>
+    <item value="0x0002" name="Quiet"/>
+    <item value="0x0003" name="LowNoise"/>
+    <item value="0x0004" name="LowEnergy"/>
+    <item value="0x0005" name="Vacation"/>
+    <item value="0x0006" name="Min"/>
+    <item value="0x0007" name="Max"/>
+    <item value="0x0008" name="Night"/>
+    <item value="0x0009" name="Day"/>
+
+    <!-- Derived cluster-specific values -->
     <item value="0x4000" name="Idle"/>
     <item value="0x4001" name="Cleaning"/>
     <item value="0x4002" name="Mapping"/>

--- a/src/app/zap-templates/zcl/data-model/chip/water-heater-mode-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/water-heater-mode-cluster.xml
@@ -19,6 +19,22 @@ limitations under the License.
 
   <enum name="ModeTag" type="enum16">
     <cluster code="0x009E"/>
+
+    <!-- These are the base values (see `enum class ModeTag`
+         in src/app/clusters/mode-base-server/mode-base-cluster-objects.h for the namespace source of truth
+         until it is possible to auto-include these without duplication in codegen. -->
+    <item value="0x0000" name="Auto"/>
+    <item value="0x0001" name="Quick"/>
+    <item value="0x0002" name="Quiet"/>
+    <item value="0x0003" name="LowNoise"/>
+    <item value="0x0004" name="LowEnergy"/>
+    <item value="0x0005" name="Vacation"/>
+    <item value="0x0006" name="Min"/>
+    <item value="0x0007" name="Max"/>
+    <item value="0x0008" name="Night"/>
+    <item value="0x0009" name="Day"/>
+
+    <!-- Derived cluster-specific values -->
     <item value="0x4000" name="Off"/>
     <item value="0x4001" name="Manual"/>
     <item value="0x4002" name="Timed"/>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -3206,6 +3206,16 @@ cluster OvenMode = 73 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kBake = 16384;
     kConvection = 16385;
     kGrill = 16386;
@@ -3324,6 +3334,16 @@ cluster LaundryWasherMode = 81 {
   revision 2;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNormal = 16384;
     kDelicate = 16385;
     kHeavy = 16386;
@@ -3375,6 +3395,16 @@ cluster RefrigeratorAndTemperatureControlledCabinetMode = 82 {
   revision 2;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kRapidCool = 16384;
     kRapidFreeze = 16385;
   }
@@ -3452,6 +3482,16 @@ cluster RvcRunMode = 84 {
   revision 3;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kIdle = 16384;
     kCleaning = 16385;
     kMapping = 16386;
@@ -3511,6 +3551,16 @@ cluster RvcCleanMode = 85 {
   revision 3;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kDeepClean = 16384;
     kVacuum = 16385;
     kMop = 16386;
@@ -3621,6 +3671,16 @@ cluster DishwasherMode = 89 {
   revision 2;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNormal = 16384;
     kHeavy = 16385;
     kLight = 16386;
@@ -3862,6 +3922,16 @@ cluster MicrowaveOvenMode = 94 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNormal = 16384;
     kDefrost = 16385;
   }
@@ -4006,6 +4076,10 @@ cluster RvcOperationalState = 97 {
   revision 1;
 
   enum ErrorStateEnum : enum8 {
+    kNoError = 0;
+    kUnableToStartOrResume = 1;
+    kUnableToCompleteOperation = 2;
+    kCommandInvalidInState = 3;
     kFailedToFindChargingDock = 64;
     kStuck = 65;
     kDustBinMissing = 66;
@@ -4017,6 +4091,10 @@ cluster RvcOperationalState = 97 {
   }
 
   enum OperationalStateEnum : enum8 {
+    kStopped = 0;
+    kRunning = 1;
+    kPaused = 2;
+    kError = 3;
     kSeekingCharger = 64;
     kCharging = 65;
     kDocked = 66;
@@ -5454,6 +5532,16 @@ cluster EnergyEvseMode = 157 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kManual = 16384;
     kTimeOfUse = 16385;
     kSolarCharging = 16386;
@@ -5504,6 +5592,16 @@ cluster WaterHeaterMode = 158 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kOff = 16384;
     kManual = 16385;
     kTimed = 16386;
@@ -5554,6 +5652,16 @@ provisional cluster DeviceEnergyManagementMode = 159 {
   revision 1;
 
   enum ModeTag : enum16 {
+    kAuto = 0;
+    kQuick = 1;
+    kQuiet = 2;
+    kLowNoise = 3;
+    kLowEnergy = 4;
+    kVacation = 5;
+    kMin = 6;
+    kMax = 7;
+    kNight = 8;
+    kDay = 9;
     kNoOptimization = 16384;
     kDeviceOptimization = 16385;
     kLocalOptimization = 16386;

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -16030,6 +16030,16 @@ class OvenMode(Cluster):
 
     class Enums:
         class ModeTag(MatterIntEnum):
+            kAuto = 0x00
+            kQuick = 0x01
+            kQuiet = 0x02
+            kLowNoise = 0x03
+            kLowEnergy = 0x04
+            kVacation = 0x05
+            kMin = 0x06
+            kMax = 0x07
+            kNight = 0x08
+            kDay = 0x09
             kBake = 0x4000
             kConvection = 0x4001
             kGrill = 0x4002
@@ -16043,7 +16053,7 @@ class OvenMode(Cluster):
             # to kUnknownEnumValue. This is a helper enum value that should only
             # be used by code to process how it handles receiving an unknown
             # enum value. This specific value should never be transmitted.
-            kUnknownEnumValue = 0,
+            kUnknownEnumValue = 10,
 
     class Bitmaps:
         class Feature(IntFlag):
@@ -16756,6 +16766,16 @@ class LaundryWasherMode(Cluster):
 
     class Enums:
         class ModeTag(MatterIntEnum):
+            kAuto = 0x00
+            kQuick = 0x01
+            kQuiet = 0x02
+            kLowNoise = 0x03
+            kLowEnergy = 0x04
+            kVacation = 0x05
+            kMin = 0x06
+            kMax = 0x07
+            kNight = 0x08
+            kDay = 0x09
             kNormal = 0x4000
             kDelicate = 0x4001
             kHeavy = 0x4002
@@ -17029,6 +17049,16 @@ class RefrigeratorAndTemperatureControlledCabinetMode(Cluster):
 
     class Enums:
         class ModeTag(MatterIntEnum):
+            kAuto = 0x00
+            kQuick = 0x01
+            kQuiet = 0x02
+            kLowNoise = 0x03
+            kLowEnergy = 0x04
+            kVacation = 0x05
+            kMin = 0x06
+            kMax = 0x07
+            kNight = 0x08
+            kDay = 0x09
             kRapidCool = 0x4000
             kRapidFreeze = 0x4001
             # kUnknownEnumValue intentionally not defined. This enum never goes
@@ -17506,6 +17536,16 @@ class RvcRunMode(Cluster):
 
     class Enums:
         class ModeTag(MatterIntEnum):
+            kAuto = 0x00
+            kQuick = 0x01
+            kQuiet = 0x02
+            kLowNoise = 0x03
+            kLowEnergy = 0x04
+            kVacation = 0x05
+            kMin = 0x06
+            kMax = 0x07
+            kNight = 0x08
+            kDay = 0x09
             kIdle = 0x4000
             kCleaning = 0x4001
             kMapping = 0x4002
@@ -17757,6 +17797,16 @@ class RvcCleanMode(Cluster):
 
     class Enums:
         class ModeTag(MatterIntEnum):
+            kAuto = 0x00
+            kQuick = 0x01
+            kQuiet = 0x02
+            kLowNoise = 0x03
+            kLowEnergy = 0x04
+            kVacation = 0x05
+            kMin = 0x06
+            kMax = 0x07
+            kNight = 0x08
+            kDay = 0x09
             kDeepClean = 0x4000
             kVacuum = 0x4001
             kMop = 0x4002
@@ -18464,6 +18514,16 @@ class DishwasherMode(Cluster):
 
     class Enums:
         class ModeTag(MatterIntEnum):
+            kAuto = 0x00
+            kQuick = 0x01
+            kQuiet = 0x02
+            kLowNoise = 0x03
+            kLowEnergy = 0x04
+            kVacation = 0x05
+            kMin = 0x06
+            kMax = 0x07
+            kNight = 0x08
+            kDay = 0x09
             kNormal = 0x4000
             kHeavy = 0x4001
             kLight = 0x4002
@@ -19789,13 +19849,23 @@ class MicrowaveOvenMode(Cluster):
 
     class Enums:
         class ModeTag(MatterIntEnum):
+            kAuto = 0x00
+            kQuick = 0x01
+            kQuiet = 0x02
+            kLowNoise = 0x03
+            kLowEnergy = 0x04
+            kVacation = 0x05
+            kMin = 0x06
+            kMax = 0x07
+            kNight = 0x08
+            kDay = 0x09
             kNormal = 0x4000
             kDefrost = 0x4001
             # All received enum values that are not listed above will be mapped
             # to kUnknownEnumValue. This is a helper enum value that should only
             # be used by code to process how it handles receiving an unknown
             # enum value. This specific value should never be transmitted.
-            kUnknownEnumValue = 0,
+            kUnknownEnumValue = 10,
 
     class Bitmaps:
         class Feature(IntFlag):
@@ -20720,6 +20790,10 @@ class RvcOperationalState(Cluster):
 
     class Enums:
         class ErrorStateEnum(MatterIntEnum):
+            kNoError = 0x00
+            kUnableToStartOrResume = 0x01
+            kUnableToCompleteOperation = 0x02
+            kCommandInvalidInState = 0x03
             kFailedToFindChargingDock = 0x40
             kStuck = 0x41
             kDustBinMissing = 0x42
@@ -20735,6 +20809,10 @@ class RvcOperationalState(Cluster):
             # src/app/common/templates/config-data.yaml.
 
         class OperationalStateEnum(MatterIntEnum):
+            kStopped = 0x00
+            kRunning = 0x01
+            kPaused = 0x02
+            kError = 0x03
             kSeekingCharger = 0x40
             kCharging = 0x41
             kDocked = 0x42
@@ -27374,6 +27452,16 @@ class EnergyEvseMode(Cluster):
 
     class Enums:
         class ModeTag(MatterIntEnum):
+            kAuto = 0x00
+            kQuick = 0x01
+            kQuiet = 0x02
+            kLowNoise = 0x03
+            kLowEnergy = 0x04
+            kVacation = 0x05
+            kMin = 0x06
+            kMax = 0x07
+            kNight = 0x08
+            kDay = 0x09
             kManual = 0x4000
             kTimeOfUse = 0x4001
             kSolarCharging = 0x4002
@@ -27646,6 +27734,16 @@ class WaterHeaterMode(Cluster):
 
     class Enums:
         class ModeTag(MatterIntEnum):
+            kAuto = 0x00
+            kQuick = 0x01
+            kQuiet = 0x02
+            kLowNoise = 0x03
+            kLowEnergy = 0x04
+            kVacation = 0x05
+            kMin = 0x06
+            kMax = 0x07
+            kNight = 0x08
+            kDay = 0x09
             kOff = 0x4000
             kManual = 0x4001
             kTimed = 0x4002
@@ -27918,6 +28016,16 @@ class DeviceEnergyManagementMode(Cluster):
 
     class Enums:
         class ModeTag(MatterIntEnum):
+            kAuto = 0x00
+            kQuick = 0x01
+            kQuiet = 0x02
+            kLowNoise = 0x03
+            kLowEnergy = 0x04
+            kVacation = 0x05
+            kMin = 0x06
+            kMax = 0x07
+            kNight = 0x08
+            kDay = 0x09
             kNoOptimization = 0x4000
             kDeviceOptimization = 0x4001
             kLocalOptimization = 0x4002

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
@@ -169,20 +169,6 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::DegradationDire
         return EnumType::kUnknownEnumValue;
     }
 }
-static auto __attribute__((unused)) EnsureKnownEnumValue(detail::ErrorStateEnum val)
-{
-    using EnumType = detail::ErrorStateEnum;
-    switch (val)
-    {
-    case EnumType::kNoError:
-    case EnumType::kUnableToStartOrResume:
-    case EnumType::kUnableToCompleteOperation:
-    case EnumType::kCommandInvalidInState:
-        return val;
-    default:
-        return EnumType::kUnknownEnumValue;
-    }
-}
 static auto __attribute__((unused)) EnsureKnownEnumValue(Globals::FloorSurfaceTag val)
 {
     using EnumType = Globals::FloorSurfaceTag;
@@ -346,20 +332,6 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(detail::MeasurementUnit
     case EnumType::kNgm3:
     case EnumType::kPm3:
     case EnumType::kBqm3:
-        return val;
-    default:
-        return EnumType::kUnknownEnumValue;
-    }
-}
-static auto __attribute__((unused)) EnsureKnownEnumValue(detail::OperationalStateEnum val)
-{
-    using EnumType = detail::OperationalStateEnum;
-    switch (val)
-    {
-    case EnumType::kStopped:
-    case EnumType::kRunning:
-    case EnumType::kPaused:
-    case EnumType::kError:
         return val;
     default:
         return EnumType::kUnknownEnumValue;
@@ -1651,11 +1623,50 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(Timer::TimerStatusEnum 
     }
 }
 
+static auto __attribute__((unused)) EnsureKnownEnumValue(OvenCavityOperationalState::ErrorStateEnum val)
+{
+    using EnumType = OvenCavityOperationalState::ErrorStateEnum;
+    switch (val)
+    {
+    case EnumType::kNoError:
+    case EnumType::kUnableToStartOrResume:
+    case EnumType::kUnableToCompleteOperation:
+    case EnumType::kCommandInvalidInState:
+        return val;
+    default:
+        return EnumType::kUnknownEnumValue;
+    }
+}
+static auto __attribute__((unused)) EnsureKnownEnumValue(OvenCavityOperationalState::OperationalStateEnum val)
+{
+    using EnumType = OvenCavityOperationalState::OperationalStateEnum;
+    switch (val)
+    {
+    case EnumType::kStopped:
+    case EnumType::kRunning:
+    case EnumType::kPaused:
+    case EnumType::kError:
+        return val;
+    default:
+        return EnumType::kUnknownEnumValue;
+    }
+}
+
 static auto __attribute__((unused)) EnsureKnownEnumValue(OvenMode::ModeTag val)
 {
     using EnumType = OvenMode::ModeTag;
     switch (val)
     {
+    case EnumType::kAuto:
+    case EnumType::kQuick:
+    case EnumType::kQuiet:
+    case EnumType::kLowNoise:
+    case EnumType::kLowEnergy:
+    case EnumType::kVacation:
+    case EnumType::kMin:
+    case EnumType::kMax:
+    case EnumType::kNight:
+    case EnumType::kDay:
     case EnumType::kBake:
     case EnumType::kConvection:
     case EnumType::kGrill:
@@ -1808,8 +1819,47 @@ static auto __attribute__((unused)) EnsureKnownEnumValue(MicrowaveOvenMode::Mode
     using EnumType = MicrowaveOvenMode::ModeTag;
     switch (val)
     {
+    case EnumType::kAuto:
+    case EnumType::kQuick:
+    case EnumType::kQuiet:
+    case EnumType::kLowNoise:
+    case EnumType::kLowEnergy:
+    case EnumType::kVacation:
+    case EnumType::kMin:
+    case EnumType::kMax:
+    case EnumType::kNight:
+    case EnumType::kDay:
     case EnumType::kNormal:
     case EnumType::kDefrost:
+        return val;
+    default:
+        return EnumType::kUnknownEnumValue;
+    }
+}
+
+static auto __attribute__((unused)) EnsureKnownEnumValue(OperationalState::ErrorStateEnum val)
+{
+    using EnumType = OperationalState::ErrorStateEnum;
+    switch (val)
+    {
+    case EnumType::kNoError:
+    case EnumType::kUnableToStartOrResume:
+    case EnumType::kUnableToCompleteOperation:
+    case EnumType::kCommandInvalidInState:
+        return val;
+    default:
+        return EnumType::kUnknownEnumValue;
+    }
+}
+static auto __attribute__((unused)) EnsureKnownEnumValue(OperationalState::OperationalStateEnum val)
+{
+    using EnumType = OperationalState::OperationalStateEnum;
+    switch (val)
+    {
+    case EnumType::kStopped:
+    case EnumType::kRunning:
+    case EnumType::kPaused:
+    case EnumType::kError:
         return val;
     default:
         return EnumType::kUnknownEnumValue;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -53,20 +53,6 @@ enum class DegradationDirectionEnum : uint8_t
     kUnknownEnumValue = 2,
 };
 
-// Enum for ErrorStateEnum
-enum class ErrorStateEnum : uint8_t
-{
-    kNoError                   = 0x00,
-    kUnableToStartOrResume     = 0x01,
-    kUnableToCompleteOperation = 0x02,
-    kCommandInvalidInState     = 0x03,
-    // All received enum values that are not listed above will be mapped
-    // to kUnknownEnumValue. This is a helper enum value that should only
-    // be used by code to process how it handles receiving and unknown
-    // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 4,
-};
-
 // Enum for LevelValueEnum
 enum class LevelValueEnum : uint8_t
 {
@@ -136,20 +122,6 @@ enum class MeasurementUnitEnum : uint8_t
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
     kUnknownEnumValue = 8,
-};
-
-// Enum for OperationalStateEnum
-enum class OperationalStateEnum : uint8_t
-{
-    kStopped = 0x00,
-    kRunning = 0x01,
-    kPaused  = 0x02,
-    kError   = 0x03,
-    // All received enum values that are not listed above will be mapped
-    // to kUnknownEnumValue. This is a helper enum value that should only
-    // be used by code to process how it handles receiving and unknown
-    // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 4,
 };
 
 // Enum for ProductIdentifierTypeEnum
@@ -1992,9 +1964,33 @@ enum class Feature : uint32_t
 
 namespace OvenCavityOperationalState {
 
-using ErrorStateEnum = Clusters::detail::ErrorStateEnum;
+// Enum for ErrorStateEnum
+enum class ErrorStateEnum : uint8_t
+{
+    kNoError                   = 0x00,
+    kUnableToStartOrResume     = 0x01,
+    kUnableToCompleteOperation = 0x02,
+    kCommandInvalidInState     = 0x03,
+    // All received enum values that are not listed above will be mapped
+    // to kUnknownEnumValue. This is a helper enum value that should only
+    // be used by code to process how it handles receiving and unknown
+    // enum value. This specific should never be transmitted.
+    kUnknownEnumValue = 4,
+};
 
-using OperationalStateEnum = Clusters::detail::OperationalStateEnum;
+// Enum for OperationalStateEnum
+enum class OperationalStateEnum : uint8_t
+{
+    kStopped = 0x00,
+    kRunning = 0x01,
+    kPaused  = 0x02,
+    kError   = 0x03,
+    // All received enum values that are not listed above will be mapped
+    // to kUnknownEnumValue. This is a helper enum value that should only
+    // be used by code to process how it handles receiving and unknown
+    // enum value. This specific should never be transmitted.
+    kUnknownEnumValue = 4,
+};
 } // namespace OvenCavityOperationalState
 
 namespace OvenMode {
@@ -2002,6 +1998,16 @@ namespace OvenMode {
 // Enum for ModeTag
 enum class ModeTag : uint16_t
 {
+    kAuto            = 0x00,
+    kQuick           = 0x01,
+    kQuiet           = 0x02,
+    kLowNoise        = 0x03,
+    kLowEnergy       = 0x04,
+    kVacation        = 0x05,
+    kMin             = 0x06,
+    kMax             = 0x07,
+    kNight           = 0x08,
+    kDay             = 0x09,
     kBake            = 0x4000,
     kConvection      = 0x4001,
     kGrill           = 0x4002,
@@ -2015,7 +2021,7 @@ enum class ModeTag : uint16_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 10,
 };
 
 // Bitmap for Feature
@@ -2056,10 +2062,20 @@ namespace LaundryWasherMode {
 // Enum for ModeTag
 enum class ModeTag : uint16_t
 {
-    kNormal   = 0x4000,
-    kDelicate = 0x4001,
-    kHeavy    = 0x4002,
-    kWhites   = 0x4003,
+    kAuto      = 0x00,
+    kQuick     = 0x01,
+    kQuiet     = 0x02,
+    kLowNoise  = 0x03,
+    kLowEnergy = 0x04,
+    kVacation  = 0x05,
+    kMin       = 0x06,
+    kMax       = 0x07,
+    kNight     = 0x08,
+    kDay       = 0x09,
+    kNormal    = 0x4000,
+    kDelicate  = 0x4001,
+    kHeavy     = 0x4002,
+    kWhites    = 0x4003,
     // kUnknownEnumValue intentionally not defined. This enum never goes
     // through DataModel::Decode, likely because it is a part of a derived
     // cluster. As a result having kUnknownEnumValue in this enum is error
@@ -2079,6 +2095,16 @@ namespace RefrigeratorAndTemperatureControlledCabinetMode {
 // Enum for ModeTag
 enum class ModeTag : uint16_t
 {
+    kAuto        = 0x00,
+    kQuick       = 0x01,
+    kQuiet       = 0x02,
+    kLowNoise    = 0x03,
+    kLowEnergy   = 0x04,
+    kVacation    = 0x05,
+    kMin         = 0x06,
+    kMax         = 0x07,
+    kNight       = 0x08,
+    kDay         = 0x09,
     kRapidCool   = 0x4000,
     kRapidFreeze = 0x4001,
     // kUnknownEnumValue intentionally not defined. This enum never goes
@@ -2124,9 +2150,19 @@ namespace RvcRunMode {
 // Enum for ModeTag
 enum class ModeTag : uint16_t
 {
-    kIdle     = 0x4000,
-    kCleaning = 0x4001,
-    kMapping  = 0x4002,
+    kAuto      = 0x00,
+    kQuick     = 0x01,
+    kQuiet     = 0x02,
+    kLowNoise  = 0x03,
+    kLowEnergy = 0x04,
+    kVacation  = 0x05,
+    kMin       = 0x06,
+    kMax       = 0x07,
+    kNight     = 0x08,
+    kDay       = 0x09,
+    kIdle      = 0x4000,
+    kCleaning  = 0x4001,
+    kMapping   = 0x4002,
     // kUnknownEnumValue intentionally not defined. This enum never goes
     // through DataModel::Decode, likely because it is a part of a derived
     // cluster. As a result having kUnknownEnumValue in this enum is error
@@ -2164,6 +2200,16 @@ namespace RvcCleanMode {
 // Enum for ModeTag
 enum class ModeTag : uint16_t
 {
+    kAuto      = 0x00,
+    kQuick     = 0x01,
+    kQuiet     = 0x02,
+    kLowNoise  = 0x03,
+    kLowEnergy = 0x04,
+    kVacation  = 0x05,
+    kMin       = 0x06,
+    kMax       = 0x07,
+    kNight     = 0x08,
+    kDay       = 0x09,
     kDeepClean = 0x4000,
     kVacuum    = 0x4001,
     kMop       = 0x4002,
@@ -2217,9 +2263,19 @@ namespace DishwasherMode {
 // Enum for ModeTag
 enum class ModeTag : uint16_t
 {
-    kNormal = 0x4000,
-    kHeavy  = 0x4001,
-    kLight  = 0x4002,
+    kAuto      = 0x00,
+    kQuick     = 0x01,
+    kQuiet     = 0x02,
+    kLowNoise  = 0x03,
+    kLowEnergy = 0x04,
+    kVacation  = 0x05,
+    kMin       = 0x06,
+    kMax       = 0x07,
+    kNight     = 0x08,
+    kDay       = 0x09,
+    kNormal    = 0x4000,
+    kHeavy     = 0x4001,
+    kLight     = 0x4002,
     // kUnknownEnumValue intentionally not defined. This enum never goes
     // through DataModel::Decode, likely because it is a part of a derived
     // cluster. As a result having kUnknownEnumValue in this enum is error
@@ -2381,13 +2437,23 @@ namespace MicrowaveOvenMode {
 // Enum for ModeTag
 enum class ModeTag : uint16_t
 {
-    kNormal  = 0x4000,
-    kDefrost = 0x4001,
+    kAuto      = 0x00,
+    kQuick     = 0x01,
+    kQuiet     = 0x02,
+    kLowNoise  = 0x03,
+    kLowEnergy = 0x04,
+    kVacation  = 0x05,
+    kMin       = 0x06,
+    kMax       = 0x07,
+    kNight     = 0x08,
+    kDay       = 0x09,
+    kNormal    = 0x4000,
+    kDefrost   = 0x4001,
     // All received enum values that are not listed above will be mapped
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 10,
 };
 
 // Bitmap for Feature
@@ -2410,9 +2476,33 @@ enum class Feature : uint32_t
 
 namespace OperationalState {
 
-using ErrorStateEnum = Clusters::detail::ErrorStateEnum;
+// Enum for ErrorStateEnum
+enum class ErrorStateEnum : uint8_t
+{
+    kNoError                   = 0x00,
+    kUnableToStartOrResume     = 0x01,
+    kUnableToCompleteOperation = 0x02,
+    kCommandInvalidInState     = 0x03,
+    // All received enum values that are not listed above will be mapped
+    // to kUnknownEnumValue. This is a helper enum value that should only
+    // be used by code to process how it handles receiving and unknown
+    // enum value. This specific should never be transmitted.
+    kUnknownEnumValue = 4,
+};
 
-using OperationalStateEnum = Clusters::detail::OperationalStateEnum;
+// Enum for OperationalStateEnum
+enum class OperationalStateEnum : uint8_t
+{
+    kStopped = 0x00,
+    kRunning = 0x01,
+    kPaused  = 0x02,
+    kError   = 0x03,
+    // All received enum values that are not listed above will be mapped
+    // to kUnknownEnumValue. This is a helper enum value that should only
+    // be used by code to process how it handles receiving and unknown
+    // enum value. This specific should never be transmitted.
+    kUnknownEnumValue = 4,
+};
 } // namespace OperationalState
 
 namespace RvcOperationalState {
@@ -2420,14 +2510,18 @@ namespace RvcOperationalState {
 // Enum for ErrorStateEnum
 enum class ErrorStateEnum : uint8_t
 {
-    kFailedToFindChargingDock = 0x40,
-    kStuck                    = 0x41,
-    kDustBinMissing           = 0x42,
-    kDustBinFull              = 0x43,
-    kWaterTankEmpty           = 0x44,
-    kWaterTankMissing         = 0x45,
-    kWaterTankLidOpen         = 0x46,
-    kMopCleaningPadMissing    = 0x47,
+    kNoError                   = 0x00,
+    kUnableToStartOrResume     = 0x01,
+    kUnableToCompleteOperation = 0x02,
+    kCommandInvalidInState     = 0x03,
+    kFailedToFindChargingDock  = 0x40,
+    kStuck                     = 0x41,
+    kDustBinMissing            = 0x42,
+    kDustBinFull               = 0x43,
+    kWaterTankEmpty            = 0x44,
+    kWaterTankMissing          = 0x45,
+    kWaterTankLidOpen          = 0x46,
+    kMopCleaningPadMissing     = 0x47,
     // kUnknownEnumValue intentionally not defined. This enum never goes
     // through DataModel::Decode, likely because it is a part of a derived
     // cluster. As a result having kUnknownEnumValue in this enum is error
@@ -2438,6 +2532,10 @@ enum class ErrorStateEnum : uint8_t
 // Enum for OperationalStateEnum
 enum class OperationalStateEnum : uint8_t
 {
+    kStopped        = 0x00,
+    kRunning        = 0x01,
+    kPaused         = 0x02,
+    kError          = 0x03,
     kSeekingCharger = 0x40,
     kCharging       = 0x41,
     kDocked         = 0x42,
@@ -3092,6 +3190,16 @@ namespace EnergyEvseMode {
 // Enum for ModeTag
 enum class ModeTag : uint16_t
 {
+    kAuto          = 0x00,
+    kQuick         = 0x01,
+    kQuiet         = 0x02,
+    kLowNoise      = 0x03,
+    kLowEnergy     = 0x04,
+    kVacation      = 0x05,
+    kMin           = 0x06,
+    kMax           = 0x07,
+    kNight         = 0x08,
+    kDay           = 0x09,
     kManual        = 0x4000,
     kTimeOfUse     = 0x4001,
     kSolarCharging = 0x4002,
@@ -3114,9 +3222,19 @@ namespace WaterHeaterMode {
 // Enum for ModeTag
 enum class ModeTag : uint16_t
 {
-    kOff    = 0x4000,
-    kManual = 0x4001,
-    kTimed  = 0x4002,
+    kAuto      = 0x00,
+    kQuick     = 0x01,
+    kQuiet     = 0x02,
+    kLowNoise  = 0x03,
+    kLowEnergy = 0x04,
+    kVacation  = 0x05,
+    kMin       = 0x06,
+    kMax       = 0x07,
+    kNight     = 0x08,
+    kDay       = 0x09,
+    kOff       = 0x4000,
+    kManual    = 0x4001,
+    kTimed     = 0x4002,
     // kUnknownEnumValue intentionally not defined. This enum never goes
     // through DataModel::Decode, likely because it is a part of a derived
     // cluster. As a result having kUnknownEnumValue in this enum is error
@@ -3136,6 +3254,16 @@ namespace DeviceEnergyManagementMode {
 // Enum for ModeTag
 enum class ModeTag : uint16_t
 {
+    kAuto               = 0x00,
+    kQuick              = 0x01,
+    kQuiet              = 0x02,
+    kLowNoise           = 0x03,
+    kLowEnergy          = 0x04,
+    kVacation           = 0x05,
+    kMin                = 0x06,
+    kMax                = 0x07,
+    kNight              = 0x08,
+    kDay                = 0x09,
     kNoOptimization     = 0x4000,
     kDeviceOptimization = 0x4001,
     kLocalOptimization  = 0x4002,


### PR DESCRIPTION
- OperationalState and ModeBase cluster enum values did not include the base enums values. This causes all sorts of pain for anything based on .matter files or code-gened enum values.
- This PR fixes the situation in the short term by having the ZAP XML include the necessary values

Testing done:

- No changes of values, only added values
