### PR TITLE
Enable MRP in WiFi-PAF commissioning

### DIFF
--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -158,8 +158,11 @@ public:
 
     bool IsCommissioningSession() const override;
 
-    bool AllowsMRP() const override { return ((GetPeerAddress().GetTransportType() == Transport::Type::kUdp) ||
-                                              (GetPeerAddress().GetTransportType() == Transport::Type::kWiFiPAF)); }
+    bool AllowsMRP() const override
+    {
+        return ((GetPeerAddress().GetTransportType() == Transport::Type::kUdp) ||
+                (GetPeerAddress().GetTransportType() == Transport::Type::kWiFiPAF));
+    }
 
     bool AllowsLargePayload() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kTcp; }
 

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -158,7 +158,8 @@ public:
 
     bool IsCommissioningSession() const override;
 
-    bool AllowsMRP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kUdp; }
+    bool AllowsMRP() const override { return ((GetPeerAddress().GetTransportType() == Transport::Type::kUdp) ||
+                                              (GetPeerAddress().GetTransportType() == Transport::Type::kWiFiPAF)); }
 
     bool AllowsLargePayload() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kTcp; }
 

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -84,8 +84,11 @@ public:
         return Access::SubjectDescriptor(); // return an empty ISD for unauthenticated session.
     }
 
-    bool AllowsMRP() const override { return ((GetPeerAddress().GetTransportType() == Transport::Type::kUdp) ||
-                                              (GetPeerAddress().GetTransportType() == Transport::Type::kWiFiPAF)); }
+    bool AllowsMRP() const override
+    {
+        return ((GetPeerAddress().GetTransportType() == Transport::Type::kUdp) ||
+                (GetPeerAddress().GetTransportType() == Transport::Type::kWiFiPAF));
+    }
 
     bool AllowsLargePayload() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kTcp; }
 

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -84,7 +84,8 @@ public:
         return Access::SubjectDescriptor(); // return an empty ISD for unauthenticated session.
     }
 
-    bool AllowsMRP() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kUdp; }
+    bool AllowsMRP() const override { return ((GetPeerAddress().GetTransportType() == Transport::Type::kUdp) ||
+                                              (GetPeerAddress().GetTransportType() == Transport::Type::kWiFiPAF)); }
 
     bool AllowsLargePayload() const override { return GetPeerAddress().GetTransportType() == Transport::Type::kTcp; }
 


### PR DESCRIPTION
Enable MRP so that WiFi-PAF commissioning can run well in the noisy environment.

