### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-75 : remove workaround for bloaty build, workaround involved cloning and installing abseil
+76 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=446337fb7b31cd9751720a57d0add62da89c962a
+ARG ZEPHYR_REVISION=9ea364fd3b48c97f7cea6d69935f1fa630e30fb7
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- drivers: console: Add Telink W91 console
- kconfig: update N22 binary revision
- shell: backends: Add Telink W91 shell back-end
- soc: kconfig: update ipc send data macro
- soc: yaml: fix ipc warning and update build examples
- zephyr: drivers: watchdog: telink_w91: Add watchdog driver
- drivers: kconfig: soc: yaml: update blocking module
- kconfig: update N22 binary revision
- boards: doc: index.rst: Update Flash Tool link
- telink: blobs: Update blobs location.
- telink: b92: update hal and lib.
- telink: b92: update hal commit.
- kconfig: update N22 binary revision
- kconfig: update N22 binary revision
- net: lib: sockets: sockets.c: SO_REUSEPORT ignore
- drivers: wifi: telink: wifi_w91.c: Fix scanning
- soc: riscv: telink_w91: Kconfig.n22: Update N22
- telink: b92: update hal commit
- .github: workflows: telink-b9x-build: Update B9x CI

Changes of N22 binary:
- Expand the heap size
- Add support printk logging
- Add except handler and heap overflow check
- update ipc proccessing, send data macros and read flash function
- Telink w91 watchdog driver
- Update priority of flash processing thread
- Fix issue of incorrect sent ipc data length
- Add stack overflow and optimase tasks stack usage
- Fix WiFi scan result.

Testing
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully