### PR TITLE
update_cluster_revisions.py excludes updating no-unique-id example's BINFO cluster

### DIFF
--- a/scripts/tools/zap/update_cluster_revisions.py
+++ b/scripts/tools/zap/update_cluster_revisions.py
@@ -24,11 +24,15 @@ import subprocess
 import sys
 from pathlib import Path
 
+BASIC_INFORMATION_CLUSTER_ID = int("0x0039", 16)
 CHIP_ROOT_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), '../../..'))
+EXCLUDE_FROM_UPDATE_DICTIONARY = {
+    BASIC_INFORMATION_CLUSTER_ID: ["lighting-app-data-mode-no-unique-id"]
+}
 
 
-def getTargets():
+def getTargets(cluster_id: int):
     ROOTS_TO_SEARCH = [
         './examples',
         './src/controller/data_model',
@@ -39,6 +43,10 @@ def getTargets():
     for root in ROOTS_TO_SEARCH:
         for filepath in Path(root).rglob('*.zap'):
             targets.append(filepath)
+
+    if cluster_id in EXCLUDE_FROM_UPDATE_DICTIONARY:
+        for target_to_exclude in EXCLUDE_FROM_UPDATE_DICTIONARY[cluster_id]:
+            targets = [target for target in targets if target_to_exclude not in target.parts]
 
     return targets
 
@@ -130,7 +138,7 @@ def main():
 
     os.chdir(CHIP_ROOT_DIR)
 
-    targets = getTargets()
+    targets = getTargets(args.cluster_id)
 
     if args.dry_run:
         for target in targets:

--- a/scripts/tools/zap/update_cluster_revisions.py
+++ b/scripts/tools/zap/update_cluster_revisions.py
@@ -46,7 +46,7 @@ def getTargets(cluster_id: int):
 
     if cluster_id in EXCLUDE_FROM_UPDATE_DICTIONARY:
         for target_to_exclude in EXCLUDE_FROM_UPDATE_DICTIONARY[cluster_id]:
-            targets = [target for target in targets if target_to_exclude not in target.parts]
+            targets = [target for target in targets if target_to_exclude not in str(target)]
 
     return targets
 

--- a/scripts/tools/zap/update_cluster_revisions.py
+++ b/scripts/tools/zap/update_cluster_revisions.py
@@ -46,7 +46,7 @@ def getTargets(cluster_id: int):
 
     if cluster_id in EXCLUDE_FROM_UPDATE_DICTIONARY:
         for target_to_exclude in EXCLUDE_FROM_UPDATE_DICTIONARY[cluster_id]:
-            targets = [target for target in targets if target_to_exclude not in str(target)]
+            targets = [target for target in targets if target_to_exclude not in target.parts]
 
     return targets
 


### PR DESCRIPTION
`lighting-app-data-mode-no-unique-id` intentionally has a BINFO cluster revision set to 3 to be compliant with not providing a UniqueID that became mandatory in cluster revision 4.

Test:
* Run `python3 scripts/tools/zap/update_cluster_revisions.py --dry-run --cluster-id 0x0039 --new-revision 4 | grep no-unique`
  * confirm no output
* Run `python3 scripts/tools/zap/update_cluster_revisions.py --dry-run --cluster-id 0x0040 --new-revision 4 | grep no-unique`
  * output shows `Will try to update: examples/lighting-app-data-mode-no-unique-id/lighting-common/lighting-app.zap`

Fixes: https://github.com/project-chip/connectedhomeip/issues/35334