### PR TITLE
Fix fabric sync tests after name update

### DIFF
--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -141,7 +141,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
         events = await self.default_controller.ReadEvent(nodeid=self.dut_node_id, events=event_path)
 
         self.step(5)
-        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=1, responseTimeoutSeconds=30)
+        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestID=1, responseTimeoutSeconds=30)
         try:
             await self.send_single_cmd(cmd)
             asserts.fail("Unexpected success on CommissionNode")
@@ -162,7 +162,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
         self.step(8)
         good_request_id = 0x1234567887654321
         cmd = Clusters.CommissionerControl.Commands.RequestCommissioningApproval(
-            requestId=good_request_id, vendorId=th_server_vid, productId=th_server_pid)
+            requestID=good_request_id, vendorID=th_server_vid, productID=th_server_pid)
         try:
             await self.send_single_cmd(cmd=cmd, node_id=pase_nodeid)
             asserts.fail("Unexpected success on RequestCommissioningApproval over PASE")
@@ -187,7 +187,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
         not_th_server_vid = 0x6006
         asserts.assert_not_equal(not_th_server_vid, th_server_vid, "Test implementation assumption incorrect")
         cmd = Clusters.CommissionerControl.Commands.RequestCommissioningApproval(
-            requestId=good_request_id, vendorId=not_th_server_vid, productId=th_server_pid)
+            requestID=good_request_id, vendorID=not_th_server_vid, productID=th_server_pid)
         # If no exception is raised, this is success
         await self.send_single_cmd(cmd)
 
@@ -203,13 +203,13 @@ class TC_CCTRL_2_2(MatterBaseTest):
             new_event = await self.default_controller.ReadEvent(nodeid=self.dut_node_id, events=event_path, eventNumberFilter=max(event_nums)+1)
         asserts.assert_equal(len(new_event), 1, "Unexpected event list len")
         asserts.assert_equal(new_event[0].Data.statusCode, 0, "Unexpected status code")
-        asserts.assert_equal(new_event[0].Data.clientNodeId,
+        asserts.assert_equal(new_event[0].Data.clientNodeID,
                              self.matter_test_config.controller_node_id, "Unexpected client node id")
-        asserts.assert_equal(new_event[0].Data.requestId, good_request_id, "Unexpected request ID")
+        asserts.assert_equal(new_event[0].Data.requestID, good_request_id, "Unexpected request ID")
 
         self.step(14)
         bad_request_id = 0x1234567887654322
-        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=bad_request_id, responseTimeoutSeconds=30)
+        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestID=bad_request_id, responseTimeoutSeconds=30)
         try:
             await self.send_single_cmd(cmd=cmd)
             asserts.fail("Unexpected success on CommissionNode")
@@ -217,7 +217,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
             asserts.assert_equal(e.status, Status.Failure, "Incorrect error returned")
 
         self.step(15)
-        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=good_request_id, responseTimeoutSeconds=29)
+        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestID=good_request_id, responseTimeoutSeconds=29)
         try:
             await self.send_single_cmd(cmd=cmd)
             asserts.fail("Unexpected success on CommissionNode")
@@ -225,7 +225,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
             asserts.assert_equal(e.status, Status.ConstraintError, "Incorrect error returned")
 
         self.step(16)
-        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=good_request_id, responseTimeoutSeconds=121)
+        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestID=good_request_id, responseTimeoutSeconds=121)
         try:
             await self.send_single_cmd(cmd=cmd)
             asserts.fail("Unexpected success on CommissionNode")
@@ -233,7 +233,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
             asserts.assert_equal(e.status, Status.ConstraintError, "Incorrect error returned")
 
         self.step(17)
-        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=good_request_id, responseTimeoutSeconds=30)
+        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestID=good_request_id, responseTimeoutSeconds=30)
         resp: Clusters.CommissionerControl.Commands.ReverseOpenCommissioningWindow = await self.send_single_cmd(cmd)
         asserts.assert_equal(type(resp), Clusters.CommissionerControl.Commands.ReverseOpenCommissioningWindow,
                              "Incorrect response type")
@@ -263,7 +263,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
         self.step(22)
         good_request_id = 0x1234567812345678
         cmd = Clusters.CommissionerControl.Commands.RequestCommissioningApproval(
-            requestId=good_request_id, vendorId=th_server_vid, productId=th_server_pid, label="Test Ecosystem")
+            requestID=good_request_id, vendorID=th_server_vid, productID=th_server_pid, label="Test Ecosystem")
         await self.send_single_cmd(cmd)
 
         self.step(23)
@@ -276,12 +276,12 @@ class TC_CCTRL_2_2(MatterBaseTest):
         new_event = await self.default_controller.ReadEvent(nodeid=self.dut_node_id, events=event_path, eventNumberFilter=max(event_nums)+1)
         asserts.assert_equal(len(new_event), 1, "Unexpected event list len")
         asserts.assert_equal(new_event[0].Data.statusCode, 0, "Unexpected status code")
-        asserts.assert_equal(new_event[0].Data.clientNodeId,
+        asserts.assert_equal(new_event[0].Data.clientNodeID,
                              self.matter_test_config.controller_node_id, "Unexpected client node id")
-        asserts.assert_equal(new_event[0].Data.requestId, good_request_id, "Unexpected request ID")
+        asserts.assert_equal(new_event[0].Data.requestID, good_request_id, "Unexpected request ID")
 
         self.step(25)
-        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=good_request_id, responseTimeoutSeconds=30)
+        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestID=good_request_id, responseTimeoutSeconds=30)
         resp = await self.send_single_cmd(cmd)
         asserts.assert_equal(type(resp), Clusters.CommissionerControl.Commands.ReverseOpenCommissioningWindow,
                              "Incorrect response type")

--- a/src/python_testing/TC_CCTRL_2_3.py
+++ b/src/python_testing/TC_CCTRL_2_3.py
@@ -125,7 +125,7 @@ class TC_CCTRL_2_3(MatterBaseTest):
         self.step(4)
         good_request_id = 0x1234567812345678
         cmd = Clusters.CommissionerControl.Commands.RequestCommissioningApproval(
-            requestId=good_request_id, vendorId=th_server_vid, productId=th_server_pid, label="Test Ecosystem")
+            requestID=good_request_id, vendorID=th_server_vid, productID=th_server_pid, label="Test Ecosystem")
         await self.send_single_cmd(cmd=cmd)
 
         self.step(5)
@@ -137,13 +137,13 @@ class TC_CCTRL_2_3(MatterBaseTest):
         events = await self.default_controller.ReadEvent(nodeid=self.dut_node_id, events=event_path)
         asserts.assert_equal(len(events), 1, "Unexpected event list len")
         asserts.assert_equal(events[0].Data.statusCode, 0, "Unexpected status code")
-        asserts.assert_equal(events[0].Data.clientNodeId,
+        asserts.assert_equal(events[0].Data.clientNodeID,
                              self.matter_test_config.controller_node_id, "Unexpected client node id")
-        asserts.assert_equal(events[0].Data.requestId, good_request_id, "Unexpected request ID")
+        asserts.assert_equal(events[0].Data.requestID, good_request_id, "Unexpected request ID")
 
         self.step(7)
         cmd = Clusters.CommissionerControl.Commands.RequestCommissioningApproval(
-            requestId=good_request_id, vendorId=th_server_vid, productId=th_server_pid)
+            requestID=good_request_id, vendorID=th_server_vid, productID=th_server_pid)
         try:
             await self.send_single_cmd(cmd=cmd)
             asserts.fail("Unexpected success on CommissionNode")
@@ -151,13 +151,13 @@ class TC_CCTRL_2_3(MatterBaseTest):
             asserts.assert_equal(e.status, Status.Failure, "Incorrect error returned")
 
         self.step(8)
-        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=good_request_id, responseTimeoutSeconds=30)
+        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestID=good_request_id, responseTimeoutSeconds=30)
         resp = await self.send_single_cmd(cmd)
         asserts.assert_equal(type(resp), Clusters.CommissionerControl.Commands.ReverseOpenCommissioningWindow,
                              "Incorrect response type")
 
         self.step(9)
-        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=good_request_id, responseTimeoutSeconds=30)
+        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestID=good_request_id, responseTimeoutSeconds=30)
         try:
             await self.send_single_cmd(cmd=cmd)
             asserts.fail("Unexpected success on CommissionNode")

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -111,7 +111,7 @@ class TC_MCORE_FS_1_1(MatterBaseTest):
         self.step("3a")
         good_request_id = 0x1234567812345678
         cmd = Clusters.CommissionerControl.Commands.RequestCommissioningApproval(
-            requestId=good_request_id, vendorId=th_fsa_server_vid, productId=th_fsa_server_pid, label="Test Ecosystem")
+            requestID=good_request_id, vendorID=th_fsa_server_vid, productID=th_fsa_server_pid, label="Test Ecosystem")
         await self.send_single_cmd(cmd, endpoint=dut_commissioning_control_endpoint)
 
         if not self.is_ci:
@@ -125,12 +125,12 @@ class TC_MCORE_FS_1_1(MatterBaseTest):
 
         asserts.assert_equal(len(new_event), 1, "Unexpected event list len")
         asserts.assert_equal(new_event[0].Data.statusCode, 0, "Unexpected status code")
-        asserts.assert_equal(new_event[0].Data.clientNodeId,
+        asserts.assert_equal(new_event[0].Data.clientNodeID,
                              self.matter_test_config.controller_node_id, "Unexpected client node id")
-        asserts.assert_equal(new_event[0].Data.requestId, good_request_id, "Unexpected request ID")
+        asserts.assert_equal(new_event[0].Data.requestID, good_request_id, "Unexpected request ID")
 
         self.step("3b")
-        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestId=good_request_id, responseTimeoutSeconds=30)
+        cmd = Clusters.CommissionerControl.Commands.CommissionNode(requestID=good_request_id, responseTimeoutSeconds=30)
         resp = await self.send_single_cmd(cmd, endpoint=dut_commissioning_control_endpoint)
         asserts.assert_equal(type(resp), Clusters.CommissionerControl.Commands.ReverseOpenCommissioningWindow,
                              "Incorrect response type")

--- a/src/python_testing/TC_MCORE_FS_1_3.py
+++ b/src/python_testing/TC_MCORE_FS_1_3.py
@@ -170,9 +170,9 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
         await self.send_single_cmd(
             node_id=controller_node_id,
             cmd=Clusters.CommissionerControl.Commands.RequestCommissioningApproval(
-                requestId=request_id,
-                vendorId=vendor_id,
-                productId=product_id,
+                requestID=request_id,
+                vendorID=vendor_id,
+                productID=product_id,
             ),
         )
 
@@ -182,7 +182,7 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
         resp = await self.send_single_cmd(
             node_id=controller_node_id,
             cmd=Clusters.CommissionerControl.Commands.CommissionNode(
-                requestId=request_id,
+                requestID=request_id,
                 responseTimeoutSeconds=30,
             ),
         )

--- a/src/python_testing/test_testing/test_TC_CCNTL_2_2.py
+++ b/src/python_testing/test_testing/test_TC_CCNTL_2_2.py
@@ -94,14 +94,14 @@ def dynamic_event_return(*args, **argv):
         header = Attribute.EventHeader(EndpointId=0, ClusterId=Clusters.CommissionerControl.id,
                                        EventId=Clusters.CommissionerControl.Events.CommissioningRequestResult.event_id, EventNumber=1)
         data = Clusters.CommissionerControl.Events.CommissioningRequestResult(
-            requestId=0x1234567887654321, clientNodeId=112233, statusCode=0)
+            requestID=0x1234567887654321, clientNodeID=112233, statusCode=0)
         result = Attribute.EventReadResult(Header=header, Status=Status.Success, Data=data)
         return [result]
     elif event_call_count == 4:  # returned event with new request
         header = Attribute.EventHeader(EndpointId=0, ClusterId=Clusters.CommissionerControl.id,
                                        EventId=Clusters.CommissionerControl.Events.CommissioningRequestResult.event_id, EventNumber=1)
         data = Clusters.CommissionerControl.Events.CommissioningRequestResult(
-            requestId=0x1234567812345678, clientNodeId=112233, statusCode=0)
+            requestID=0x1234567812345678, clientNodeID=112233, statusCode=0)
         result = Attribute.EventReadResult(Header=header, Status=Status.Success, Data=data)
         return [result]
     else:

--- a/src/python_testing/test_testing/test_TC_MCORE_FS_1_1.py
+++ b/src/python_testing/test_testing/test_TC_MCORE_FS_1_1.py
@@ -72,7 +72,7 @@ def dynamic_event_return(*args, **argv):
         header = Attribute.EventHeader(EndpointId=0, ClusterId=Clusters.CommissionerControl.id,
                                        EventId=Clusters.CommissionerControl.Events.CommissioningRequestResult.event_id, EventNumber=1)
         data = Clusters.CommissionerControl.Events.CommissioningRequestResult(
-            requestId=0x1234567812345678, clientNodeId=112233, statusCode=0)
+            requestID=0x1234567812345678, clientNodeID=112233, statusCode=0)
         result = Attribute.EventReadResult(Header=header, Status=Status.Success, Data=data)
         return [result]
     else:


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/35381/ broke fabric sync tests of tip-of-tree. This updates tests to use the updated names