### PR TITLE
[OSS-Fuzz] Fix static library linking needed for OSS-Fuzz

### DIFF
--- a/build/config/linux/pkg-config.py
+++ b/build/config/linux/pkg-config.py
@@ -142,6 +142,8 @@ def main():
                       dest='dridriverdir')
     parser.add_option('--version-as-components', action='store_true',
                       dest='version_as_components')
+    parser.add_option('--static', action='store_true',
+                      dest='static')
     (options, args) = parser.parse_args()
 
     # Make a list of regular expressions to strip out.
@@ -203,7 +205,11 @@ def main():
         sys.stdout.write(dridriverdir.strip())
         return
 
-    cmd = [options.pkg_config, "--cflags", "--libs"] + args
+    if options.static:
+        cmd = [options.pkg_config, "--cflags", "--libs", "--static"] + args
+    else:
+        cmd = [options.pkg_config, "--cflags", "--libs"] + args
+
     if options.debug:
         sys.stderr.write('Running: %s\n' % ' '.join(cmd))
 

--- a/build/config/linux/pkg-config.py
+++ b/build/config/linux/pkg-config.py
@@ -205,10 +205,12 @@ def main():
         sys.stdout.write(dridriverdir.strip())
         return
 
+    cmd = [options.pkg_config, "--cflags", "--libs"]
+
     if options.static:
-        cmd = [options.pkg_config, "--cflags", "--libs", "--static"] + args
-    else:
-        cmd = [options.pkg_config, "--cflags", "--libs"] + args
+        cmd.append("--static")
+
+    cmd.extend(args)
 
     if options.debug:
         sys.stderr.write('Running: %s\n' % ' '.join(cmd))

--- a/build/config/linux/pkg_config.gni
+++ b/build/config/linux/pkg_config.gni
@@ -137,13 +137,16 @@ template("pkg_config") {
 
       # Link libraries statically for OSS-Fuzz fuzzer build
       if (oss_fuzz) {
-        #outputs libs needed for static linking (direct + transitive/non-direct libs), we will re-execute the script to get those libs
+        # Output libs needed for static linking (direct + transitive/non-direct libs), we will re-execute the script to get those libs
         args += [ "--static" ]
         pkgresult_static = exec_script(pkg_config_script, args, "value")
         libs = []
         ldflags = [ "-Wl,-Bstatic" ]
         foreach(lib, pkgresult_static[3]) {
-          #dl(dynamic loading) lib is not needed for linking statically and its presence triggers errors.
+          # dl(dynamic loading) lib is not needed for linking statically and its presence triggers errors.
+          # example of errors:
+          #   ld.lld: error: undefined symbol: __dlsym
+          #   >>> referenced by dlsym.o:(dlsym) in archive /lib/x86_64-linux-gnu/libdl.a
           if (lib != "dl") {
             ldflags += [ "-l$lib" ]
           }

--- a/build/config/linux/pkg_config.gni
+++ b/build/config/linux/pkg_config.gni
@@ -122,13 +122,7 @@ template("pkg_config") {
     }
 
     # pkgresult = [present, includes, cflags, libs, lib_dirs]
-    args += [ "--static" ]
     pkgresult = exec_script(pkg_config_script, args, "value")
-    print(" ")
-    print("target_name $target_name")
-    print("pkgresult $pkgresult")
-    print(" ")
-
     if (pkgresult[0]) {
       cflags = pkgresult[2]
 
@@ -141,22 +135,15 @@ template("pkg_config") {
         lib_dirs = pkgresult[4]
       }
 
-      pkgresult_static = exec_script(pkg_config_script, args, "value")
-      print(" ")
-      print("target_name $target_name")
-      print("pkgresult_static $pkgresult_static")
-      print(" ")
-
       # Link libraries statically for OSS-Fuzz fuzzer build
       if (oss_fuzz) {
+        #outputs libs needed for static linking (direct + transitive/non-direct libs), we will re-execute the script to get those libs
+        args += [ "--static" ]
         pkgresult_static = exec_script(pkg_config_script, args, "value")
-        print(" ")
-        print("target_name $target_name")
-        print("pkgresult_static $pkgresult_static")
-        print(" ")
         libs = []
         ldflags = [ "-Wl,-Bstatic" ]
         foreach(lib, pkgresult_static[3]) {
+          #dl(dynamic loading) lib is not needed for linking statically and its presence triggers errors.
           if (lib != "dl") {
             ldflags += [ "-l$lib" ]
           }

--- a/build/config/linux/pkg_config.gni
+++ b/build/config/linux/pkg_config.gni
@@ -122,7 +122,13 @@ template("pkg_config") {
     }
 
     # pkgresult = [present, includes, cflags, libs, lib_dirs]
+    args += [ "--static" ]
     pkgresult = exec_script(pkg_config_script, args, "value")
+    print(" ")
+    print("target_name $target_name")
+    print("pkgresult $pkgresult")
+    print(" ")
+
     if (pkgresult[0]) {
       cflags = pkgresult[2]
 
@@ -135,12 +141,25 @@ template("pkg_config") {
         lib_dirs = pkgresult[4]
       }
 
+      pkgresult_static = exec_script(pkg_config_script, args, "value")
+      print(" ")
+      print("target_name $target_name")
+      print("pkgresult_static $pkgresult_static")
+      print(" ")
+
       # Link libraries statically for OSS-Fuzz fuzzer build
       if (oss_fuzz) {
+        pkgresult_static = exec_script(pkg_config_script, args, "value")
+        print(" ")
+        print("target_name $target_name")
+        print("pkgresult_static $pkgresult_static")
+        print(" ")
         libs = []
         ldflags = [ "-Wl,-Bstatic" ]
-        foreach(lib, pkgresult[3]) {
-          ldflags += [ "-l$lib" ]
+        foreach(lib, pkgresult_static[3]) {
+          if (lib != "dl") {
+            ldflags += [ "-l$lib" ]
+          }
         }
         ldflags += [ "-Wl,-Bdynamic" ]
         lib_dirs = pkgresult[4]


### PR DESCRIPTION
- This issue showed up after #35408
- It is related to linker errors due to missing libs

- OSS-Fuzz requires libraries to be linked statically.
- When building for OSS-Fuzz , `pkg-config.py` only outputs the direct dependencies and misses out the transitive libs that need to be explicitly linked (when linking statically).
- Fix involves  adding `--static` flag to pkg-config invocation, when we are building for OSS-Fuzz.

### Testing
- This was Tested on OSS-Fuzz Image.
- Actions Job can be seen: https://github.com/google/oss-fuzz/actions/runs/10798522931/job/29952211472?pr=12461


##### Output of `pkg-config.py` without `--static`

```python
$ python3 build/config/linux/pkg-config.py  gio-2.0
[true,
 ["/usr/include/libmount", "/usr/include/blkid", "/usr/include/glib-2.0", "/usr/lib/x86_64-linux-gnu/glib-2.0/include"], 
 [], 
 #Below is the list with libs
 ["gio-2.0", "gobject-2.0", "glib-2.0"], 
 []]
```

##### Output of `pkg-config` with `--static` 
```python
$ python3 build/config/linux/pkg-config.py --static gio-2.0
[true,
 ["/usr/include/libmount", "/usr/include/blkid", "/usr/include/glib-2.0", "/usr/lib/x86_64-linux-gnu/glib-2.0/include"], 
 [], 
  #Below is the list with libs that includes transitive libs
 ["gio-2.0", "gmodule-2.0", "z", "mount", "dl", "blkid", "selinux", "sepol", "pcre2-8", "gobject-2.0", "ffi", "glib-2.0", "m", "pcre"], 
 []]

```
