### PR TITLE
Add a getter to AttributeValueDecoder for raw data.

### DIFF
--- a/src/app/AttributeValueDecoder.h
+++ b/src/app/AttributeValueDecoder.h
@@ -55,7 +55,8 @@ public:
     /**
      * Get the reader from the decoder for raw data. Calling this is considered to be tried decoding.
      */
-    TLV::TLVReader & GetReaderForDecoding() {
+    TLV::TLVReader & GetReaderForDecoding()
+    {
         mTriedDecode = true;
         return mReader;
     }

--- a/src/app/AttributeValueDecoder.h
+++ b/src/app/AttributeValueDecoder.h
@@ -52,6 +52,14 @@ public:
         return CHIP_NO_ERROR;
     }
 
+    /**
+     * Get the reader from the decoder for raw data. Calling this is considered to be tried decoding.
+     */
+    TLV::TLVReader & GetReaderForDecoding() {
+        mTriedDecode = true;
+        return mReader;
+    }
+
     bool TriedDecode() const { return mTriedDecode; }
 
     /**

--- a/src/app/tests/TestAttributeValueDecoder.cpp
+++ b/src/app/tests/TestAttributeValueDecoder.cpp
@@ -136,4 +136,34 @@ TEST(TestAttributeValueDecoder, TestOverwriteFabricIndexInListOfStructs)
     }
 }
 
+TEST(TestAttributeValueDecoder, TestGetReaderForDecoding)
+{
+    TestSetup setup;
+    CHIP_ERROR err;
+    Clusters::AccessControl::Structs::AccessControlExtensionStruct::Type item;
+    Access::SubjectDescriptor subjectDescriptor = { .fabricIndex = kTestFabricIndex };
+
+    item.fabricIndex = 0;
+
+    err = setup.Encode(item);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    TLV::TLVReader reader;
+    TLVType ignored;
+    reader.Init(setup.buf, setup.writer.GetLengthWritten());
+
+    err = reader.Next();
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = reader.EnterContainer(ignored);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = reader.Next();
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    AttributeValueDecoder decoder(reader, subjectDescriptor);
+    decoder.GetReaderForDecoding();
+    EXPECT_TRUE(decoder.TriedDecode());
+}
+
 } // anonymous namespace


### PR DESCRIPTION
Add a getter to AttributeValueDecoder which returns the reader from the decoder.

This is useful to get the copy of the raw data and pass it around (in multi-threaded case) instead of the decoder. Also the decoder is marked as mTriedDecoded after the call.

