### PR TITLE
Add a step timeout for Matter.framework unit tests.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -105,10 +105,9 @@ jobs:
               run: |
                   scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux out/debug/ota-requestor-app chip_config_network_layer_ble=false non_spec_compliant_ota_action_delay_floor=0
             - name: Run Framework Tests
-              # For now disable unguarded-availability-new warnings because we
-              # internally use APIs that we are annotating as only available on
-              # new enough versions.  Maybe we should change out deployment
-              # target versions instead?
+              # We want to ensure that our log upload runs on timeout, so use a timeout here shorter
+              # than the 6-hour overall job timeout.  4.5 hours should be plenty.
+              timeout-minutes: 270
               working-directory: src/darwin/Framework
               run: |
                   mkdir -p /tmp/darwin/framework-tests


### PR DESCRIPTION
If a test hangs, we end up running until job timeout after 6 hours.  But that skips later steps, including log uploads, which makes it harder to figure out why the hang happened.

The fix is to use a timeout on the test job that is somewhat shorter than the 6-hour job timeout, so we allow time for the log upload too.
