### PR TITLE
Remove the accessedViaPublicAPI on MTRDevice.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -306,7 +306,6 @@ using namespace chip::Tracing::DarwinFramework;
         _delegates = [NSMutableSet set];
         _deviceController = controller;
         _nodeID = nodeID;
-        _accessedViaPublicAPI = NO;
         _state = MTRDeviceStateUnknown;
     }
 
@@ -322,7 +321,6 @@ using namespace chip::Tracing::DarwinFramework;
         _nodeID = [nodeID copy];
         _fabricIndex = controller.fabricIndex;
         _deviceController = controller;
-        _accessedViaPublicAPI = NO;
         _queue
             = dispatch_queue_create("org.csa-iot.matter.framework.device.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         _asyncWorkQueue = [[MTRAsyncWorkQueue alloc] initWithContext:self];
@@ -362,19 +360,9 @@ using namespace chip::Tracing::DarwinFramework;
     MTR_LOG("MTRDevice dealloc: %p", self);
 }
 
-+ (MTRDevice *)_deviceWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller
-{
-    return [controller deviceForNodeID:nodeID];
-}
-
 + (MTRDevice *)deviceWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller
 {
-    auto * device = [self _deviceWithNodeID:nodeID controller:controller];
-    if (device) {
-        std::lock_guard lock(device->_lock);
-        device->_accessedViaPublicAPI = YES;
-    }
-    return device;
+    return [controller deviceForNodeID:nodeID];
 }
 
 #pragma mark - Time Synchronization

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -2700,12 +2700,12 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     // 3. The attribute is not in the spec, and the read params asks to assume
     //    an unknown attribute has the Changes Omitted quality.
     //
-    // But all this only happens if this device has been accessed via the public
-    // API.  If it's a device we just created internally, don't do read-throughs.
+    // But all this only happens if this device is not suspended.  If it's suspended, read-throughs will fail
+    // anyway, so we should not bother trying.
     BOOL readThroughsAllowed;
     {
         std::lock_guard lock(_lock);
-        readThroughsAllowed = _accessedViaPublicAPI;
+        readThroughsAllowed = !self.suspended;
     }
     if (readThroughsAllowed && (![self _subscriptionAbleToReport] || hasChangesOmittedQuality)) {
         // Read requests container will be a mutable array of items, each being an array containing:

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -120,18 +120,7 @@ MTR_DIRECT_MEMBERS
     // Our controller.  Declared nullable because our property is, though in
     // practice it does not look like we ever set it to nil.
     MTRDeviceController * _Nullable _deviceController;
-
-    // Whether this device has been accessed via the public deviceWithNodeID API
-    // (as opposed to just via the internal _deviceWithNodeID).
-    BOOL _accessedViaPublicAPI;
 }
-
-/**
- * Internal way of creating an MTRDevice that does not flag the device as being
- * visible to external API consumers.
- */
-+ (MTRDevice *)_deviceWithNodeID:(NSNumber *)nodeID
-                      controller:(MTRDeviceController *)controller;
 
 - (instancetype)initForSubclassesWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;
 - (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;


### PR DESCRIPTION
Now that we have a concept of suspended devices, just use that to avoid wasting time on read-throughs which would fail anyway.
