### PR TITLE
cleanup cmake data model build rules / remove ARG_INCLUDE_SERVER

### DIFF
--- a/config/openiotsdk/cmake/chip.cmake
+++ b/config/openiotsdk/cmake/chip.cmake
@@ -74,7 +74,6 @@ function(chip_add_data_model target scope model_name)
     include(${CHIP_ROOT}/src/app/chip_data_model.cmake)
     chip_configure_data_model(${target}
         SCOPE ${scope}
-        INCLUDE_SERVER
         ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../${model_name}-common/${model_name}-app.zap
     )
 endfunction()

--- a/examples/air-purifier-app/ameba/chip_main.cmake
+++ b/examples/air-purifier-app/ameba/chip_main.cmake
@@ -162,7 +162,6 @@ add_library(
 )
 
 chip_configure_data_model(chip_main
-    INCLUDE_SERVER
     ZAP_FILE ${matter_example_path}/../air-purifier-common/air-purifier-app.zap
 )
 

--- a/examples/air-quality-sensor-app/telink/CMakeLists.txt
+++ b/examples/air-quality-sensor-app/telink/CMakeLists.txt
@@ -53,7 +53,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../air-quality-sensor-common/air-quality-sensor-app.zap
 )
 

--- a/examples/all-clusters-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-app/ameba/chip_main.cmake
@@ -212,7 +212,6 @@ add_library(
 )
 
 chip_configure_data_model(chip_main
-    INCLUDE_SERVER
     ZAP_FILE ${matter_example_path}/../all-clusters-common/all-clusters-app.zap
 )
 

--- a/examples/all-clusters-app/mbed/CMakeLists.txt
+++ b/examples/all-clusters-app/mbed/CMakeLists.txt
@@ -87,7 +87,6 @@ target_sources(${APP_TARGET} PRIVATE
 )
 
 chip_configure_data_model(${APP_TARGET}
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../all-clusters-common/all-clusters-app.zap
 )
 

--- a/examples/all-clusters-app/nrfconnect/CMakeLists.txt
+++ b/examples/all-clusters-app/nrfconnect/CMakeLists.txt
@@ -77,7 +77,6 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${ALL_CLUSTERS_COMMON_DIR}/all-clusters-app.zap
 )
 

--- a/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/all-clusters-app/nxp/zephyr/CMakeLists.txt
@@ -82,7 +82,6 @@ if(CONFIG_CHIP_OTA_REQUESTOR)
 endif()
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${ALL_CLUSTERS_COMMON_DIR}/all-clusters-app.zap
 )
 

--- a/examples/all-clusters-app/telink/CMakeLists.txt
+++ b/examples/all-clusters-app/telink/CMakeLists.txt
@@ -76,7 +76,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${ALL_CLUSTERS_COMMON_DIR}/all-clusters-app.zap
 )
 

--- a/examples/all-clusters-minimal-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-minimal-app/ameba/chip_main.cmake
@@ -147,7 +147,6 @@ add_library(
 )
 
 chip_configure_data_model(chip_main
-    INCLUDE_SERVER
     ZAP_FILE ${matter_example_path}/../all-clusters-common/all-clusters-minimal-app.zap
 )
 

--- a/examples/all-clusters-minimal-app/mbed/CMakeLists.txt
+++ b/examples/all-clusters-minimal-app/mbed/CMakeLists.txt
@@ -65,7 +65,6 @@ target_sources(${APP_TARGET} PRIVATE
 )
 
 chip_configure_data_model(${APP_TARGET}
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../all-clusters-common/all-clusters-minimal-app.zap
 )
 

--- a/examples/all-clusters-minimal-app/nrfconnect/CMakeLists.txt
+++ b/examples/all-clusters-minimal-app/nrfconnect/CMakeLists.txt
@@ -55,7 +55,6 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../all-clusters-common/all-clusters-minimal-app.zap
 )
 

--- a/examples/all-clusters-minimal-app/telink/CMakeLists.txt
+++ b/examples/all-clusters-minimal-app/telink/CMakeLists.txt
@@ -55,7 +55,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../all-clusters-common/all-clusters-minimal-app.zap
 )
 

--- a/examples/bridge-app/telink/CMakeLists.txt
+++ b/examples/bridge-app/telink/CMakeLists.txt
@@ -52,7 +52,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../bridge-common/bridge-app.zap
 )
 

--- a/examples/chef/ameba/chip_main.cmake
+++ b/examples/chef/ameba/chip_main.cmake
@@ -51,7 +51,6 @@ add_library(
 )
 
 chip_configure_data_model(chip_main
-    INCLUDE_SERVER
     ZAP_FILE ${matter_example_path}/../devices/${SAMPLE_NAME}.zap
 )
 

--- a/examples/chef/nrfconnect/CMakeLists.txt
+++ b/examples/chef/nrfconnect/CMakeLists.txt
@@ -106,7 +106,6 @@ target_sources(app PRIVATE
 
 message(STATUS ${CHEF}/devices/${CONFIG_CHEF_DEVICE_TYPE}.zap)
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CHEF}/devices/${CONFIG_CHEF_DEVICE_TYPE}.zap
 )
 

--- a/examples/chef/telink/CMakeLists.txt
+++ b/examples/chef/telink/CMakeLists.txt
@@ -77,7 +77,6 @@ target_sources(app PRIVATE
 message(STATUS ${CHEF}/devices/${SAMPLE_NAME}.zap)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CHEF}/devices/${SAMPLE_NAME}.zap
 )
 

--- a/examples/contact-sensor-app/telink/CMakeLists.txt
+++ b/examples/contact-sensor-app/telink/CMakeLists.txt
@@ -51,7 +51,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../contact-sensor-common/contact-sensor-app.zap
 )
 

--- a/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
+++ b/examples/laundry-washer-app/nxp/zephyr/CMakeLists.txt
@@ -84,7 +84,6 @@ if(CONFIG_CHIP_OTA_REQUESTOR)
 endif()
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${ALL_CLUSTERS_COMMON_DIR}/../../laundry-washer-app/nxp/zap/laundry-washer-app.zap
 )
 

--- a/examples/light-switch-app/ameba/chip_main.cmake
+++ b/examples/light-switch-app/ameba/chip_main.cmake
@@ -173,7 +173,6 @@ add_library(
 )
 
 chip_configure_data_model(chip_main
-    INCLUDE_SERVER
     ZAP_FILE ${matter_example_path}/../light-switch-common/light-switch-app.zap
 )
 

--- a/examples/light-switch-app/nrfconnect/CMakeLists.txt
+++ b/examples/light-switch-app/nrfconnect/CMakeLists.txt
@@ -64,6 +64,5 @@ if(CONFIG_MCUMGR_TRANSPORT_BT)
 endif()
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../light-switch-common/light-switch-app.zap
 )

--- a/examples/light-switch-app/telink/CMakeLists.txt
+++ b/examples/light-switch-app/telink/CMakeLists.txt
@@ -52,7 +52,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../light-switch-common/light-switch-app.zap
 )
 

--- a/examples/lighting-app/ameba/chip_main.cmake
+++ b/examples/lighting-app/ameba/chip_main.cmake
@@ -166,7 +166,6 @@ add_library(
 )
 
 chip_configure_data_model(chip_main
-    INCLUDE_SERVER
     ZAP_FILE ${matter_example_path}/../lighting-common/lighting-app.zap
 )
 

--- a/examples/lighting-app/mbed/CMakeLists.txt
+++ b/examples/lighting-app/mbed/CMakeLists.txt
@@ -62,7 +62,6 @@ target_sources(${APP_TARGET} PRIVATE
 )
 
 chip_configure_data_model(${APP_TARGET}
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lighting-common/lighting-app.zap
 )
 

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -55,7 +55,6 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/PWMDevice.cpp)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lighting-common/lighting-app.zap
 )
 

--- a/examples/lighting-app/telink/CMakeLists.txt
+++ b/examples/lighting-app/telink/CMakeLists.txt
@@ -52,7 +52,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lighting-common/lighting-app.zap
 )
 

--- a/examples/lit-icd-app/nrfconnect/CMakeLists.txt
+++ b/examples/lit-icd-app/nrfconnect/CMakeLists.txt
@@ -50,7 +50,6 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lit-icd-common/lit-icd-server-app.zap
 )
 

--- a/examples/lock-app/mbed/CMakeLists.txt
+++ b/examples/lock-app/mbed/CMakeLists.txt
@@ -62,7 +62,6 @@ target_sources(${APP_TARGET} PRIVATE
 )
 
 chip_configure_data_model(${APP_TARGET}
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lock-common/lock-app.zap
 )
 

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -52,7 +52,6 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lock-common/lock-app.zap
 )
 

--- a/examples/lock-app/telink/CMakeLists.txt
+++ b/examples/lock-app/telink/CMakeLists.txt
@@ -53,7 +53,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lock-common/lock-app.zap
 )
 

--- a/examples/ota-requestor-app/ameba/chip_main.cmake
+++ b/examples/ota-requestor-app/ameba/chip_main.cmake
@@ -39,7 +39,6 @@ add_library(
 )
 
 chip_configure_data_model(chip_main
-    INCLUDE_SERVER
     ZAP_FILE ${matter_example_path}/../ota-requestor-common/ota-requestor-app.zap
 )
 

--- a/examples/ota-requestor-app/mbed/CMakeLists.txt
+++ b/examples/ota-requestor-app/mbed/CMakeLists.txt
@@ -60,7 +60,6 @@ target_sources(${APP_TARGET} PRIVATE
 )
 
 chip_configure_data_model(${APP_TARGET}
-    INCLUDE_SERVER
     ZAP_FILE ${CHIP_ROOT}/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.zap
 )
 

--- a/examples/ota-requestor-app/telink/CMakeLists.txt
+++ b/examples/ota-requestor-app/telink/CMakeLists.txt
@@ -51,7 +51,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../ota-requestor-common/ota-requestor-app.zap
 )
 

--- a/examples/pump-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-app/nrfconnect/CMakeLists.txt
@@ -52,7 +52,6 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../pump-common/pump-app.zap
 )
 

--- a/examples/pump-app/telink/CMakeLists.txt
+++ b/examples/pump-app/telink/CMakeLists.txt
@@ -50,7 +50,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../pump-common/pump-app.zap
 )
 

--- a/examples/pump-controller-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-controller-app/nrfconnect/CMakeLists.txt
@@ -52,7 +52,6 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../pump-controller-common/pump-controller-app.zap
 )
 

--- a/examples/pump-controller-app/telink/CMakeLists.txt
+++ b/examples/pump-controller-app/telink/CMakeLists.txt
@@ -50,7 +50,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../pump-controller-common/pump-controller-app.zap
 )
 

--- a/examples/smoke-co-alarm-app/telink/CMakeLists.txt
+++ b/examples/smoke-co-alarm-app/telink/CMakeLists.txt
@@ -51,7 +51,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../smoke-co-alarm-common/smoke-co-alarm-app.zap
 )
 

--- a/examples/temperature-measurement-app/telink/CMakeLists.txt
+++ b/examples/temperature-measurement-app/telink/CMakeLists.txt
@@ -53,7 +53,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../temperature-measurement-common/temperature-measurement.zap
 )
 

--- a/examples/thermostat/nxp/zephyr/CMakeLists.txt
+++ b/examples/thermostat/nxp/zephyr/CMakeLists.txt
@@ -84,7 +84,6 @@ if(CONFIG_CHIP_OTA_REQUESTOR)
 endif()
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${ALL_CLUSTERS_COMMON_DIR}/../../thermostat/nxp/zap/thermostat_matter_wifi.zap
 )
 

--- a/examples/thermostat/telink/CMakeLists.txt
+++ b/examples/thermostat/telink/CMakeLists.txt
@@ -53,7 +53,6 @@ target_sources(app PRIVATE
                ${TELINK_COMMON}/zephyr_ext/zephyr_ws2812.c)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../thermostat-common/thermostat.zap
 )
 

--- a/examples/window-app/nrfconnect/CMakeLists.txt
+++ b/examples/window-app/nrfconnect/CMakeLists.txt
@@ -55,7 +55,6 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/PWMDevice.cpp)
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${WIN_APP_COMMON_DIR}/window-app.zap
 )
 

--- a/examples/window-app/telink/CMakeLists.txt
+++ b/examples/window-app/telink/CMakeLists.txt
@@ -53,7 +53,6 @@ target_sources(app PRIVATE
                )
 
 chip_configure_data_model(app
-    INCLUDE_SERVER
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../common/window-app.zap
 )
 

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -119,6 +119,27 @@ function(chip_configure_data_model APP_TARGET)
         set(APP_GEN_FILES)
     endif()
 
+    # These are:
+    #   //src/app/icd/server:notfier
+    #   //src/app/icd/server:monitoring-table
+    #   //src/app/icd/server:configuration-data
+    #
+    # TODO: ideally we would avoid duplication and would link gn-built items. In this case
+    #       it may be slightly harder because these are source_sets rather than libraries.
+    target_sources(${APP_TARGET} ${SCOPE}
+        ${CHIP_APP_BASE_DIR}/icd/server/ICDMonitoringTable.cpp
+│       ${CHIP_APP_BASE_DIR}/icd/server/ICDNotifier.cpp
+│       ${CHIP_APP_BASE_DIR}/icd/server/ICDConfigurationData.cpp
+    )
+
+    # This is:
+    #    //src/app/common:cluster-objects
+    #
+    # TODO: ideally we would avoid duplication and would link gn-built items
+    target_sources(${APP_TARGET} ${SCOPE}
+        ${CHIP_APP_BASE_DIR}/../../zzz_generated/app-common/app-common/zap-generated/attributes/cluster-objects.cpp
+    )
+
     chip_zapgen(${APP_TARGET}-zapgen
         INPUT "${ARG_ZAP_FILE}"
         GENERATOR "app-templates"
@@ -133,18 +154,12 @@ function(chip_configure_data_model APP_TARGET)
     target_include_directories(${APP_TARGET} ${SCOPE} "${APP_TEMPLATES_GEN_DIR}")
     add_dependencies(${APP_TARGET} ${APP_TARGET}-zapgen)
 
-    # TODO: source for codedgen_data_model ???
-
     target_sources(${APP_TARGET} ${SCOPE}
         ${CHIP_APP_BASE_DIR}/../../zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
-        ${CHIP_APP_BASE_DIR}/../../zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
         ${CHIP_APP_BASE_DIR}/reporting/reporting.cpp
         ${CHIP_APP_BASE_DIR}/util/attribute-storage.cpp
         ${CHIP_APP_BASE_DIR}/util/attribute-table.cpp
         ${CHIP_APP_BASE_DIR}/util/binding-table.cpp
-        ${CHIP_APP_BASE_DIR}/icd/server/ICDMonitoringTable.cpp
-        ${CHIP_APP_BASE_DIR}/icd/server/ICDNotifier.cpp
-        ${CHIP_APP_BASE_DIR}/icd/server/ICDConfigurationData.cpp
         ${CHIP_APP_BASE_DIR}/util/DataModelHandler.cpp
         ${CHIP_APP_BASE_DIR}/util/ember-compatibility-functions.cpp
         ${CHIP_APP_BASE_DIR}/util/ember-global-attribute-access-interface.cpp

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -60,7 +60,6 @@ endfunction()
 # Available options are:
 # SCOPE             CMake scope keyword that defines the scope of included sources.
 # The default is PRIVATE scope.
-# INCLUDE_SERVER    Include source files from src/app/server directory.
 # ZAP_FILE          Path to the ZAP file, used to determine the list of clusters
 # supported by the application.
 # IDL               .matter IDL file to use for codegen. Inferred from ZAP_FILE
@@ -71,27 +70,26 @@ endfunction()
 #
 function(chip_configure_data_model APP_TARGET)
     set(SCOPE PRIVATE)
-    cmake_parse_arguments(ARG "INCLUDE_SERVER" "SCOPE;ZAP_FILE;IDL" "EXTERNAL_CLUSTERS" ${ARGN})
+    cmake_parse_arguments(ARG "" "SCOPE;ZAP_FILE;IDL" "EXTERNAL_CLUSTERS" ${ARGN})
 
     if(ARG_SCOPE)
         set(SCOPE ${ARG_SCOPE})
     endif()
 
-    if(ARG_INCLUDE_SERVER)
-        target_sources(${APP_TARGET} ${SCOPE}
-            ${CHIP_APP_BASE_DIR}/server/AclStorage.cpp
-            ${CHIP_APP_BASE_DIR}/server/DefaultAclStorage.cpp
-            ${CHIP_APP_BASE_DIR}/server/CommissioningWindowManager.cpp
-            ${CHIP_APP_BASE_DIR}/server/Dnssd.cpp
-            ${CHIP_APP_BASE_DIR}/server/EchoHandler.cpp
-            ${CHIP_APP_BASE_DIR}/server/OnboardingCodesUtil.cpp
-            ${CHIP_APP_BASE_DIR}/server/Server.cpp
-        )
+    # CMAKE data model auto-includes the server side implementation
+    target_sources(${APP_TARGET} ${SCOPE}
+        ${CHIP_APP_BASE_DIR}/server/AclStorage.cpp
+        ${CHIP_APP_BASE_DIR}/server/DefaultAclStorage.cpp
+        ${CHIP_APP_BASE_DIR}/server/CommissioningWindowManager.cpp
+        ${CHIP_APP_BASE_DIR}/server/Dnssd.cpp
+        ${CHIP_APP_BASE_DIR}/server/EchoHandler.cpp
+        ${CHIP_APP_BASE_DIR}/server/OnboardingCodesUtil.cpp
+        ${CHIP_APP_BASE_DIR}/server/Server.cpp
+    )
 
-        target_compile_options(${APP_TARGET} ${SCOPE}
-            "-DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>"
-        )
-    endif()
+    target_compile_options(${APP_TARGET} ${SCOPE}
+        "-DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>"
+    )
 
     if(ARG_ZAP_FILE)
         chip_configure_zap_file(${APP_TARGET} ${ARG_ZAP_FILE} "${ARG_EXTERNAL_CLUSTERS}")
@@ -128,8 +126,8 @@ function(chip_configure_data_model APP_TARGET)
     #       it may be slightly harder because these are source_sets rather than libraries.
     target_sources(${APP_TARGET} ${SCOPE}
         ${CHIP_APP_BASE_DIR}/icd/server/ICDMonitoringTable.cpp
-│       ${CHIP_APP_BASE_DIR}/icd/server/ICDNotifier.cpp
-│       ${CHIP_APP_BASE_DIR}/icd/server/ICDConfigurationData.cpp
+        ${CHIP_APP_BASE_DIR}/icd/server/ICDNotifier.cpp
+        ${CHIP_APP_BASE_DIR}/icd/server/ICDConfigurationData.cpp
     )
 
     # This is:
@@ -137,7 +135,7 @@ function(chip_configure_data_model APP_TARGET)
     #
     # TODO: ideally we would avoid duplication and would link gn-built items
     target_sources(${APP_TARGET} ${SCOPE}
-        ${CHIP_APP_BASE_DIR}/../../zzz_generated/app-common/app-common/zap-generated/attributes/cluster-objects.cpp
+        ${CHIP_APP_BASE_DIR}/../../zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
     )
 
     chip_zapgen(${APP_TARGET}-zapgen


### PR DESCRIPTION
The data model seems to do a lot more than just data mode as it includes more source files that are generally defaults within apps. For now make things more consistent:

### Changes

- remove (default to true) ARG_INCLUDE_SERVER as virtually every single CMakeLists.txt would set this and the places where it is not used seems to be some mbed and ameba where it likely will be without sideffects (extra files built only). 
- Separate out the ICD and cluster-object dependencies as they are separate in GN. Ideally we should separate out cmake targets/gn targets from code-generator dependent targets.