### PR TITLE
Move StoreCurrentUpdateInfo() call from ApplyUpdate to DownloadUpdate

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -554,6 +554,8 @@ CHIP_ERROR DefaultOTARequestor::TriggerImmediateQuery(FabricIndex fabricIndex)
 void DefaultOTARequestor::DownloadUpdate()
 {
     RecordNewUpdateState(OTAUpdateStateEnum::kDownloading, OTAChangeReasonEnum::kSuccess);
+    // If image successfully downloads and is applied, the device will reboot so persist all relevant data
+    StoreCurrentUpdateInfo();
     ConnectToProvider(kDownload);
 }
 
@@ -565,10 +567,6 @@ void DefaultOTARequestor::DownloadUpdateDelayedOnUserConsent()
 void DefaultOTARequestor::ApplyUpdate()
 {
     RecordNewUpdateState(OTAUpdateStateEnum::kApplying, OTAChangeReasonEnum::kSuccess);
-
-    // If image is successfully applied, the device will reboot so persist all relevant data
-    StoreCurrentUpdateInfo();
-
     ConnectToProvider(kApplyUpdate);
 }
 


### PR DESCRIPTION
Update to DefaultOTARequestor.cpp where the API call to StoreCurrentUpdateInfo() is moved from ApplyUpdate() to DownloadUpdate(). 
