### PR TITLE
Update Chef Dockerfile to use trixie for latest ssl and lib versions

### DIFF
--- a/examples/chef/dockerfile
+++ b/examples/chef/dockerfile
@@ -1,10 +1,12 @@
-FROM debian:bullseye
+FROM debian:trixie
 
 ARG DEVICE_NAME
 
 RUN apt-get update && \
     apt-get install -y \
-    libglib2.0-0 && \
+    libglib2.0-0 \
+    libc6 \
+    libssl3 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
These updates are required to run the dockerized versions of chef examples. 

