### PR TITLE
[Android] Fix resolve exception issue

### DIFF
--- a/src/platform/android/java/chip/platform/NsdServiceFinderAndResolver.java
+++ b/src/platform/android/java/chip/platform/NsdServiceFinderAndResolver.java
@@ -41,6 +41,7 @@ class NsdServiceFinderAndResolver implements NsdManager.DiscoveryListener {
   private final ChipMdnsCallback chipMdnsCallback;
   private final MulticastLock multicastLock;
   private final ScheduledFuture<?> resolveTimeoutExecutor;
+  private NsdServiceInfo discoveredServiceInfo = null;
 
   @Nullable
   private final NsdManagerServiceResolver.NsdManagerResolverAvailState nsdManagerResolverAvailState;
@@ -94,14 +95,13 @@ class NsdServiceFinderAndResolver implements NsdManager.DiscoveryListener {
 
   @Override
   public void onServiceFound(NsdServiceInfo service) {
-    if (targetServiceInfo.getServiceName().equals(service.getServiceName())) {
+    if (discoveredServiceInfo == null && targetServiceInfo.getServiceName().equals(service.getServiceName())) {
       Log.d(TAG, "onServiceFound: found target service " + service);
 
       if (stopDiscoveryRunnable.cancel(false)) {
         nsdManager.stopServiceDiscovery(this);
       }
-
-      resolveService(service, callbackHandle, contextHandle, chipMdnsCallback);
+      discoveredServiceInfo = service;
     } else {
       Log.d(TAG, "onServiceFound: found service not a target for resolution, ignoring " + service);
     }
@@ -206,7 +206,11 @@ class NsdServiceFinderAndResolver implements NsdManager.DiscoveryListener {
 
   @Override
   public void onDiscoveryStopped(String serviceType) {
-    Log.i(TAG, "Discovery stopped: " + serviceType);
+    Log.i(TAG, "Discovery stopped: " + serviceType + ", discoveredServiceInfo: " + discoveredServiceInfo);
+    if (discoveredServiceInfo != null) {
+      resolveService(discoveredServiceInfo, callbackHandle, contextHandle, chipMdnsCallback);
+      discoveredServiceInfo = null;
+    }
   }
 
   @Override

--- a/src/platform/android/java/chip/platform/NsdServiceFinderAndResolver.java
+++ b/src/platform/android/java/chip/platform/NsdServiceFinderAndResolver.java
@@ -95,7 +95,8 @@ class NsdServiceFinderAndResolver implements NsdManager.DiscoveryListener {
 
   @Override
   public void onServiceFound(NsdServiceInfo service) {
-    if (discoveredServiceInfo == null && targetServiceInfo.getServiceName().equals(service.getServiceName())) {
+    if (discoveredServiceInfo == null
+        && targetServiceInfo.getServiceName().equals(service.getServiceName())) {
       Log.d(TAG, "onServiceFound: found target service " + service);
 
       if (stopDiscoveryRunnable.cancel(false)) {
@@ -206,7 +207,9 @@ class NsdServiceFinderAndResolver implements NsdManager.DiscoveryListener {
 
   @Override
   public void onDiscoveryStopped(String serviceType) {
-    Log.i(TAG, "Discovery stopped: " + serviceType + ", discoveredServiceInfo: " + discoveredServiceInfo);
+    Log.i(
+        TAG,
+        "Discovery stopped: " + serviceType + ", discoveredServiceInfo: " + discoveredServiceInfo);
     if (discoveredServiceInfo != null) {
       resolveService(discoveredServiceInfo, callbackHandle, contextHandle, chipMdnsCallback);
       discoveredServiceInfo = null;


### PR DESCRIPTION
Fix #35550 
If two instances of the same instanceName are called at the same time, the resolve method will be called twice. In this case, resolve will fail for similar reasons to the previously reported issue. (#31899 - Fix PR is #32459)

To prevent this, the first searched item is saved in a separate variable, and resolveService is called after discover is stopped.
