### PR TITLE
[Darwin] Device controller should declare conformance to MTRDeviceControllerDelegate

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -22,6 +22,8 @@
 #import <Matter/MTRDeviceController.h>
 #import <Matter/MTROperationalCertificateIssuer.h>
 
+#import "MTRDeviceControllerDelegate.h"
+
 @class MTRBaseDevice;
 @class MTRServerEndpoint; // Defined in MTRServerEndpoint.h, which imports MTRAccessGrant.h, which imports MTRBaseClusters.h, which imports this file, so we can't import it.
 
@@ -36,9 +38,8 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 @class MTRCommissionableBrowserResult;
 @class MTRSetupPayload;
 @protocol MTRDevicePairingDelegate;
-@protocol MTRDeviceControllerDelegate;
 
-@interface MTRDeviceController_Concrete : MTRDeviceController
+@interface MTRDeviceController_Concrete : MTRDeviceController <MTRDeviceControllerDelegate>
 
 /**
  * Initialize a device controller with the provided parameters.  This will:

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -718,8 +718,7 @@ using namespace chip::Tracing::DarwinFramework;
         commissionerInitialized = YES;
 
         // Set self as delegate, which fans out delegate callbacks to all added delegates
-        id<MTRDeviceControllerDelegate> selfDelegate = static_cast<id<MTRDeviceControllerDelegate>>(self);
-        self->_deviceControllerDelegateBridge->setDelegate(self, selfDelegate, _chipWorkQueue);
+        self->_deviceControllerDelegateBridge->setDelegate(self, self, _chipWorkQueue);
 
         MTR_LOG("%@ startup succeeded for nodeID 0x%016llX", self, self->_cppCommissioner->GetNodeId());
     });


### PR DESCRIPTION
The proper way to declare a conformance to a protocol is at the interface or class extension. Given `MTRDeviceController_Concrete` sets itself as the delegate for the `MTRDeviceControllerDelegateBridge`, the conformance should be declared in the header.