### PR TITLE
[ESP32] Use the nvs generator from pypi instead from IDF_PATH

### DIFF
--- a/scripts/setup/requirements.esp32.txt
+++ b/scripts/setup/requirements.esp32.txt
@@ -14,3 +14,4 @@ python-socketio<5
 itsdangerous<2.1 ; python_version < "3.11"
 esp_idf_monitor==1.1.1
 esp-idf-kconfig==1.2.0
+esp_idf_nvs_partition_gen==0.1.2

--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -25,6 +25,7 @@ from enum import Enum
 from types import SimpleNamespace
 
 import cryptography.x509
+import esp_idf_nvs_partition_gen.nvs_partition_gen as nvs_partition_gen
 from esp_secure_cert.tlv_format import generate_partition_ds, generate_partition_no_ds, tlv_priv_key_t, tlv_priv_key_type_t
 
 CHIP_TOPDIR = os.path.dirname(os.path.realpath(__file__))[:-len(os.path.join('scripts', 'tools'))]
@@ -33,15 +34,6 @@ from spake2p import generate_verifier  # noqa: E402 isort:skip
 sys.path.insert(0, os.path.join(CHIP_TOPDIR, 'src', 'setup_payload', 'python'))
 from SetupPayload import CommissioningFlow, SetupPayload  # noqa: E402 isort:skip
 
-if os.getenv('IDF_PATH'):
-    sys.path.insert(0, os.path.join(os.getenv('IDF_PATH'),
-                                    'components',
-                                    'nvs_flash',
-                                    'nvs_partition_generator'))
-    import nvs_partition_gen
-else:
-    sys.stderr.write("Please set the IDF_PATH environment variable.")
-    exit(0)
 
 INVALID_PASSCODES = [00000000, 11111111, 22222222, 33333333, 44444444, 55555555,
                      66666666, 77777777, 88888888, 99999999, 12345678, 87654321]


### PR DESCRIPTION
start using [esp-idf-nvs-partition-gen](https://pypi.org/project/esp-idf-nvs-partition-gen) from PyPI, which reduces the dependency of esp-idf.

#### Tests
- Generated the partition containing the discriminator and passcode and verified the content.