### PR TITLE
[Python] Process attribute cache updates in Python thread

### DIFF
--- a/docs/guides/repl/Matter_Basic_Interactions.ipynb
+++ b/docs/guides/repl/Matter_Basic_Interactions.ipynb
@@ -3504,7 +3504,7 @@
    "source": [
     "#### Read Events:\n",
     "\n",
-    "A `ReadEvents` API exists that behaves similarly to the `ReadAttributes` API. It permits the same degrees of wildcard expression as its counterpart and follows the same format for expressing all wildcard permutations."
+    "A `ReadEvent` API exists that behaves similarly to the `ReadAttribute` API. It permits the same degrees of wildcard expression as its counterpart and follows the same format for expressing all wildcard permutations."
    ]
   },
   {
@@ -3609,7 +3609,7 @@
    "source": [
     "### Subscription Interaction\n",
     "\n",
-    "To subscribe to a Node, the same `ReadAttributes` API is used to trigger a subscription, with a valid `reportInterval` tuple passed in being used as a way to indicate the request to create a subscription."
+    "To subscribe to a Node, the same `ReadAttribute` API is used to trigger a subscription, with a valid `reportInterval` tuple passed in being used as a way to indicate the request to create a subscription."
    ]
   },
   {

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -216,12 +216,12 @@ class ClusterObjectTests:
         sub.SetAttributeUpdateCallback(subUpdate)
 
         try:
-            data = sub.GetAttributes()
             req = Clusters.OnOff.Commands.On()
             await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=req)
 
             await asyncio.wait_for(event.wait(), timeout=11)
 
+            data = sub.GetAttributes()
             if (data[1][Clusters.OnOff][Clusters.OnOff.Attributes.OnOff] != 1):
                 raise ValueError("Current On/Off state should be 1")
 
@@ -232,6 +232,7 @@ class ClusterObjectTests:
 
             await asyncio.wait_for(event.wait(), timeout=11)
 
+            data = sub.GetAttributes()
             if (data[1][Clusters.OnOff][Clusters.OnOff.Attributes.OnOff] != 0):
                 raise ValueError("Current On/Off state should be 0")
 
@@ -254,13 +255,12 @@ class ClusterObjectTests:
         sub.SetAttributeUpdateCallback(subUpdate)
 
         try:
-            data = sub.GetAttributes()
-
             req = Clusters.OnOff.Commands.On()
             await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=req)
 
             await asyncio.wait_for(event.wait(), timeout=11)
 
+            data = sub.GetAttributes()
             cluster: Clusters.OnOff = data[1][Clusters.OnOff]
             if (not cluster.onOff):
                 raise ValueError("Current On/Off state should be True")
@@ -272,6 +272,7 @@ class ClusterObjectTests:
 
             await asyncio.wait_for(event.wait(), timeout=11)
 
+            data = sub.GetAttributes()
             cluster: Clusters.OnOff = data[1][Clusters.OnOff]
             if (cluster.onOff):
                 raise ValueError("Current On/Off state should be False")
@@ -298,7 +299,6 @@ class ClusterObjectTests:
         logger.info("Test Subscription With MinInterval of 0")
         sub = await devCtrl.ReadAttribute(nodeid=NODE_ID,
                                           attributes=[Clusters.OnOff, Clusters.LevelControl], reportInterval=(0, 60))
-        data = sub.GetAttributes()
 
         logger.info("Sending off command")
 
@@ -315,6 +315,7 @@ class ClusterObjectTests:
 
         logger.info("Checking read back value is indeed 254")
 
+        data = sub.GetAttributes()
         if (data[1][Clusters.LevelControl][Clusters.LevelControl.Attributes.CurrentLevel] != 254):
             raise ValueError("Current Level should have been 254")
 


### PR DESCRIPTION
Instead of processing the attribute update in the SDK thread, process them on request in the Python thread. This avoids acks being sent back too late to the device  after the last DataReport if there are many attribute updates sent at once.

Currently still the same data model and processing is done. There is certainly also room for optimization to make this more efficient.

This also removes some obsolete/unused functions and cleans up the Read function argument list.