### PR TITLE
Added missing "is_commissioning=True" to step 1 in all DEM, EEVSE and EWATERHTR test scripts

### DIFF
--- a/src/python_testing/TC_DEM_2_10.py
+++ b/src/python_testing/TC_DEM_2_10.py
@@ -61,7 +61,8 @@ class TC_DEM_2_10(MatterBaseTest, DEMTestBase):
     def steps_TC_DEM_2_10(self) -> list[TestStep]:
         """Execute the test steps."""
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the FeatureMap",
                      "Verify that the DUT response contains the FeatureMap attribute. Store the value as FeatureMap."),
             TestStep("3", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",

--- a/src/python_testing/TC_DEM_2_2.py
+++ b/src/python_testing/TC_DEM_2_2.py
@@ -61,7 +61,8 @@ class TC_DEM_2_2(MatterBaseTest, DEMTestBase):
     def steps_TC_DEM_2_2(self) -> list[TestStep]:
         """Execute the test steps."""
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the _FeatureMap_ attribute",
                      "Verify that the DUT response contains the _FeatureMap_ attribute. Verify PowerAdjustment is supported."),
             TestStep("3", "Set up a subscription to all DeviceEnergyManagement cluster events"),

--- a/src/python_testing/TC_DEM_2_3.py
+++ b/src/python_testing/TC_DEM_2_3.py
@@ -54,7 +54,8 @@ class TC_DEM_2_3(MatterBaseTest, DEMTestBase):
 
     def steps_TC_DEM_2_3(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the _FeatureMap_ attribute",
                      "Verify that the DUT response contains the _FeatureMap_ attribute. Verify StartTimeAdjustment feature is supported on the cluster. Verify PowerForecastReporting or StateForecastReporting feature is supported on the cluster."),
             TestStep("3", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",

--- a/src/python_testing/TC_DEM_2_4.py
+++ b/src/python_testing/TC_DEM_2_4.py
@@ -55,7 +55,8 @@ class TC_DEM_2_4(MatterBaseTest, DEMTestBase):
 
     def steps_TC_DEM_2_4(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the _FeatureMap_ attribute",
                      "Verify that the DUT response contains the _FeatureMap_ attribute. Verify Pausable feature is supported on the cluster. Verify PowerForecastReporting or StateForecastReporting feature is supported on the cluster."),
             TestStep("3", "Set up a subscription to all DeviceEnergyManagement cluster events"),

--- a/src/python_testing/TC_DEM_2_5.py
+++ b/src/python_testing/TC_DEM_2_5.py
@@ -59,7 +59,8 @@ class TC_DEM_2_5(MatterBaseTest, DEMTestBase):
     def steps_TC_DEM_2_5(self) -> list[TestStep]:
         """Execute the test steps."""
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the _FeatureMap_ attribute",
                      "Verify that the DUT response contains the _FeatureMap_ attribute. Verify ForecastAdjustment feature is supported on the cluster. Verify PowerForecastReporting feature is supported on the cluster. Verify StateForecastReporting feature is not supported on the cluster."),
             TestStep("3", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",

--- a/src/python_testing/TC_DEM_2_6.py
+++ b/src/python_testing/TC_DEM_2_6.py
@@ -59,7 +59,8 @@ class TC_DEM_2_6(MatterBaseTest, DEMTestBase):
     def steps_TC_DEM_2_6(self) -> list[TestStep]:
         """Execute the test steps."""
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the _FeatureMap_ attribute",
                      "Verify that the DUT response contains the _FeatureMap_ attribute. Verify ForecastAdjustment feature is supported on the cluster. Verify StateForecastReporting feature is supported on the cluster. Verify PowerForecastReporting feature is not supported on the cluster."),
             TestStep("3", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",

--- a/src/python_testing/TC_DEM_2_7.py
+++ b/src/python_testing/TC_DEM_2_7.py
@@ -59,7 +59,8 @@ class TC_DEM_2_7(MatterBaseTest, DEMTestBase):
     def steps_TC_DEM_2_7(self) -> list[TestStep]:
         """Execute the test steps."""
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the _FeatureMap_ attribute",
                      "Verify that the DUT response contains the _FeatureMap_ attribute. Verify ConstraintBasedAdjustment feature is supported on the cluster. Verify PowerForecastReporting feature is supported on the cluster. Verify StateForecastReporting feature is not supported on the cluster."),
             TestStep("3", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",

--- a/src/python_testing/TC_DEM_2_8.py
+++ b/src/python_testing/TC_DEM_2_8.py
@@ -59,7 +59,8 @@ class TC_DEM_2_8(MatterBaseTest, DEMTestBase):
     def steps_TC_DEM_2_8(self) -> list[TestStep]:
         """Execute the test steps."""
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the _FeatureMap_ attribute",
                      "Verify that the DUT response contains the _FeatureMap_ attribute. Verify ConstraintBasedAdjustment feature is supported on the cluster. Verify StateForecastReporting feature is supported on the cluster. Verify PowerForecastReporting feature is not supported on the cluster."),
             TestStep("3", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",

--- a/src/python_testing/TC_DEM_2_9.py
+++ b/src/python_testing/TC_DEM_2_9.py
@@ -58,7 +58,8 @@ class TC_DEM_2_9(MatterBaseTest, DEMTestBase):
     def steps_TC_DEM_2_9(self) -> list[TestStep]:
         """Execute the test steps."""
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the _FeatureMap_ attribute",
                      "Verify that the DUT response contains the _FeatureMap_ attribute. Verify one of PowerForecastReporting or StateForecastReporting is supported but not both."),
             TestStep("3", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",

--- a/src/python_testing/TC_EEVSE_2_2.py
+++ b/src/python_testing/TC_EEVSE_2_2.py
@@ -52,7 +52,8 @@ class TC_EEVSE_2_2(MatterBaseTest, EEVSEBaseTestHelper):
 
     def steps_TC_EEVSE_2_2(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",
                      "Value has to be 1 (True)"),
             TestStep("3", "TH sends TestEventTrigger command to General Diagnostics Cluster on Endpoint 0 with EnableKey field set to PIXIT.EEVSE.TESTEVENT_TRIGGERKEY and EventTrigger field set to PIXIT.EEVSE.TESTEVENTTRIGGER for Basic Functionality Test Event",

--- a/src/python_testing/TC_EEVSE_2_3.py
+++ b/src/python_testing/TC_EEVSE_2_3.py
@@ -52,7 +52,8 @@ class TC_EEVSE_2_3(MatterBaseTest, EEVSEBaseTestHelper):
 
     def steps_TC_EEVSE_2_3(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",
                      "Value has to be 1 (True)"),
             TestStep("3", "TH sends TestEventTrigger command to General Diagnostics Cluster on Endpoint 0 with EnableKey field set to PIXIT.EEVSE.TESTEVENT_TRIGGERKEY and EventTrigger field set to PIXIT.EEVSE.TESTEVENTTRIGGER for Basic Functionality Test Event",

--- a/src/python_testing/TC_EEVSE_2_4.py
+++ b/src/python_testing/TC_EEVSE_2_4.py
@@ -50,7 +50,8 @@ class TC_EEVSE_2_4(MatterBaseTest, EEVSEBaseTestHelper):
 
     def steps_TC_EEVSE_2_4(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",
                      "Value has to be 1 (True)"),
             TestStep("3", "TH sends TestEventTrigger command to General Diagnostics Cluster on Endpoint 0 with EnableKey field set to PIXIT.EEVSE.TESTEVENT_TRIGGERKEY and EventTrigger field set to PIXIT.EEVSE.TESTEVENTTRIGGER for Basic Functionality Test Event",

--- a/src/python_testing/TC_EEVSE_2_5.py
+++ b/src/python_testing/TC_EEVSE_2_5.py
@@ -50,7 +50,8 @@ class TC_EEVSE_2_5(MatterBaseTest, EEVSEBaseTestHelper):
 
     def steps_TC_EEVSE_2_5(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",
                      "Value has to be 1 (True)"),
             TestStep("3", "TH sends TestEventTrigger command to General Diagnostics Cluster on Endpoint 0 with EnableKey field set to PIXIT.EEVSE.TESTEVENT_TRIGGERKEY and EventTrigger field set to PIXIT.EEVSE.TESTEVENTTRIGGER for Basic Functionality Test Event",

--- a/src/python_testing/TC_EEVSE_2_6.py
+++ b/src/python_testing/TC_EEVSE_2_6.py
@@ -52,7 +52,8 @@ class TC_EEVSE_2_6(MatterBaseTest, EEVSEBaseTestHelper):
 
     def steps_TC_EEVSE_2_6(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the FeatureMap",
                      "Verify that the DUT response contains the FeatureMap attribute. Store the value as FeatureMap."),
             TestStep("3", "Set up a subscription to all EnergyEVSE cluster events"),

--- a/src/python_testing/TC_EWATERHTR_2_1.py
+++ b/src/python_testing/TC_EWATERHTR_2_1.py
@@ -50,7 +50,8 @@ class TC_EWATERHTR_2_1(MatterBaseTest, EWATERHTRBase):
 
     def steps_TC_EWATERHTR_2_1(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)."),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the FeatureMap attribute.",
                      "Verify that the DUT response contains the FeatureMap attribute. Store the value as FeatureMap."),
             TestStep("3", "TH reads from the DUT the HeaterTypes attribute.",

--- a/src/python_testing/TC_EWATERHTR_2_2.py
+++ b/src/python_testing/TC_EWATERHTR_2_2.py
@@ -52,7 +52,8 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
 
     def steps_TC_EWATERHTR_2_2(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "Set up a subscription to all WaterHeaterManagement cluster events"),
             TestStep("3", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",
                      "Value has to be 1 (True)"),

--- a/src/python_testing/TC_EWATERHTR_2_3.py
+++ b/src/python_testing/TC_EWATERHTR_2_3.py
@@ -49,7 +49,8 @@ class TC_EWATERHTR_2_3(MatterBaseTest, EWATERHTRBase):
 
     def steps_TC_EWATERHTR_2_3(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)"),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)",
+                     is_commissioning=True),
             TestStep("2", "Set up a subscription to all WaterHeaterManagement cluster events"),
             TestStep("3", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",
                      "Value has to be 1 (True)"),


### PR DESCRIPTION
Helps to fix an issue in https://github.com/project-chip/certification-tool/issues/410

All of these scripts were missing the is_commissioning=True in the 1st test step:
 * TC_EEVSE_2_2
 * TC_EEVSE_2_3
 * TC_EEVSE_2_4
 * TC_EEVSE_2_5
 * TC_EEVSE_2_6 

 * TC_DEM_2_2
 * TC_DEM_2_3
 * TC_DEM_2_4
 * TC_DEM_2_5
 * TC_DEM_2_6
 * TC_DEM_2_7
 * TC_DEM_2_8
 * TC_DEM_2_9
 * TC_DEM_2_10

 * TC_EWATERHTR_2_1
 * TC_EWATERHTR_2_2
 * TC_EWATERHTR_2_3