### PR TITLE
[libfuzzer] Cleaning shutdown of fuzzed all-clusters-app

### DIFF
--- a/examples/all-clusters-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-app/linux/fuzzing-main.cpp
@@ -31,6 +31,7 @@ LinuxCommissionableDataProvider gCommissionableDataProvider;
 
 void CleanShutdown()
 {
+    ApplicationShutdown();
     Server::GetInstance().Shutdown();
     PlatformMgr().Shutdown();
     // TODO: We don't Platform::MemoryShutdown because ~CASESessionManager calls


### PR DESCRIPTION
- Cleaning up shutdown of fuzzed All-clusters-app (libfuzzer version)
- this showed up as Error with AddressSanitized Fuzzing Run.
```cpp
[1726056512.002226][844963:844963] CHIP:DL: Inet Layer shutdown
[1726056512.002232][844963:844963] CHIP:DL: BLE Layer shutdown
[1726056512.002324][844963:844963] CHIP:DL: System Layer shutdown
[1726056512.002959][844963:844963] CHIP:SPT: VerifyOrDie failure at src/lib/support/IntrusiveList.h:290: Empty()
AddressSanitizer:DEADLYSIGNAL
=================================================================
==844963==ERROR: AddressSanitizer: ABRT on unknown address 0x0539000ce4a3 (pc 0x7a262374e00b bp 0x7ffe4ee661f0 sp 0x7ffe4ee65f70 T0)
SCARINESS: 10 (signal)
    #0 0x7a262374e00b in raise /build/glibc-LcI20x/glibc-2.31/sysdeps/unix/sysv/linux/raise.c:51:1
    #1 0x7a262372d858 in abort /build/glibc-LcI20x/glibc-2.31/stdlib/abort.c:79:7
    #2 0x5aa45dbe6dcc in chip::IntrusiveListBase::~IntrusiveListBase() connectedhomeip/src/lib/support/IntrusiveList.h:0
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: ABRT (/lib/x86_64-linux-gnu/libc.so.6+0x4300b) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
==844963==ABORTING
``` 

