### PR TITLE
[Fabric-Admin] Show connect to bridge info to console

### DIFF
--- a/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
+++ b/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
@@ -119,11 +119,13 @@ void AttemptRpcClientConnect(System::Layer * systemLayer, void * appState)
 {
     if (StartRpcClient() == CHIP_NO_ERROR)
     {
-        ChipLogProgress(NotSpecified, "Connected to Fabric-Bridge");
+        // print to console
+        fprintf(stderr, "Connected to Fabric-Bridge\n");
     }
     else
     {
-        ChipLogError(NotSpecified, "Failed to connect to Fabric-Bridge, retry in %d seconds....", kRetryIntervalS);
+        // print to console
+        fprintf(stderr, "Failed to connect to Fabric-Bridge, retry in %d seconds....\n", kRetryIntervalS);
         systemLayer->StartTimer(System::Clock::Seconds16(kRetryIntervalS), AttemptRpcClientConnect, nullptr);
     }
 }


### PR DESCRIPTION
```
Failed to connect to Fabric-Bridge, retry in 5 seconds....
>>> Connected to Fabric-Bridge

>>> 
```
Print the above info to console so that user know when to input the command
