### PR TITLE
Fixing UBSan issues that showed up in all-clusters app

### DIFF
--- a/src/lib/support/BufferWriter.cpp
+++ b/src/lib/support/BufferWriter.cpp
@@ -73,8 +73,9 @@ LittleEndian::BufferWriter & LittleEndian::BufferWriter::EndianPutSigned(int64_t
 
 BigEndian::BufferWriter & BigEndian::BufferWriter::EndianPut(uint64_t x, size_t size)
 {
-    while (size-- > 0)
+    while (size > 0)
     {
+        size--;
         Put(static_cast<uint8_t>((x >> (size * 8)) & 0xff));
     }
     return *this;
@@ -82,8 +83,9 @@ BigEndian::BufferWriter & BigEndian::BufferWriter::EndianPut(uint64_t x, size_t 
 
 BigEndian::BufferWriter & BigEndian::BufferWriter::EndianPutSigned(int64_t x, size_t size)
 {
-    while (size-- > 0)
+    while (size > 0)
     {
+        size--;
         Put(static_cast<uint8_t>((x >> (size * 8)) & 0xff));
     }
     return *this;

--- a/src/lib/support/CHIPMemString.h
+++ b/src/lib/support/CHIPMemString.h
@@ -82,12 +82,20 @@ inline void CopyString(char (&dest)[N], const char * source)
  */
 inline void CopyString(char * dest, size_t destLength, ByteSpan source)
 {
-    if (dest && destLength)
+    if ((dest == nullptr) || (destLength == 0))
     {
-        size_t maxChars = std::min(destLength - 1, source.size());
-        memcpy(dest, source.data(), maxChars);
-        dest[maxChars] = '\0';
+        return; // no space to copy anything, not even a null terminator
     }
+
+    if (source.empty())
+    {
+        *dest = '\0'; // just a null terminator, we are copying empty data
+        return;
+    }
+
+    size_t maxChars = std::min(destLength - 1, source.size());
+    memcpy(dest, source.data(), maxChars);
+    dest[maxChars] = '\0';
 }
 
 /**


### PR DESCRIPTION
- Fixing undefinedBehaviour Sanitizer issues showing up while running ubsan-sanitized all-clusters-app
- Fix for two issues in the PR:

1. `BufferWriter.cpp:76:16: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'size_t' (aka 'unsigned long')`

    - when `size` becomes 0 and we are in `while (size-- > 0)`, then size will become less than 0, which should be avoided since it is an unsigned (although technically it wraps around, UBSAN complains about it).
    - Fix: stop size from decrement past 0, by moving `size--` inside the loop
    
2. `CHIPMemString.h:88:22: runtime error: null pointer passed as argument 2, which is declared to never be null`
    - when `PI=` is in mDNS TXT record (its value is empty) ,  and `Dnssd::Internal::GetPairingInstruction` calls  `CopyString`, `source` is an empty bytespan and `source.data()` will return a null pointer, that will be passed to `memcpy`
    - Fix: avoid memcpy in that case.



### To Reproduce
```cpp
$ out/linux-x64-all-clusters-ubsan-clang/chip-all-clusters-app 
.
..
...
[1726243039.356984][104063:104063] CHIP:DIS: Responding with _L3840._sub._matterc._udp.local
[1726243039.356989][104063:104063] CHIP:DIS: Responding with _CM._sub._matterc._udp.local
[1726243039.357000][104063:104063] CHIP:DIS: Responding with C769D87C1A751176._matterc._udp.local
[1726243039.357004][104063:104063] CHIP:DIS: CHIP minimal mDNS configured as 'Commissionable node device'; instance name: C769D87C1A751176.
../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/lib/support/BufferWriter.cpp:76:16: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'size_t' (aka 'unsigned long')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/lib/support/BufferWriter.cpp:76:16 
[1726243039.359102][104063:104063] CHIP:DIS: mDNS service published: _matterc._udp
[1726243039.359121][104063:104063] CHIP:DIS: Updating services using commissioning mode 1
[1726243039.360108][104063:104063] CHIP:DIS: CHIP minimal mDNS started advertising.
.
..
...
[1726243039.365925][104063:104063] CHIP:DMG: Endpoint 1, Cluster 0x0000_005D update version to ab663630
[1726243039.365935][104063:104063] CHIP:DMG: Endpoint 1, Cluster 0x0000_005D update version to ab663631
[1726243039.365946][104063:104063] CHIP:DMG: Endpoint 1, Cluster 0x0000_005D update version to ab663632
[1726243039.365974][104063:104063] CHIP:EVL: LogEvent event number: 0x00000000000C0003 priority: 1, endpoint id:  0x1 cluster id: 0x0000_005D event id: 0x0 Epoch timestamp: 0x00000191EC1A6885
[1726243039.365987][104063:104063] CHIP:SVR: WaterHeaterManagementInstance::Init()
[1726243039.365996][104063:104063] CHIP:DMG: Endpoint 1, Cluster 0x0000_0094 update version to 30cc246a
../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/lib/support/CHIPMemString.h:88:22: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/lib/support/CHIPMemString.h:88:22 
[1726243039.373334][104063:104064] CHIP:DL: CREATE service object at /chipoble/967f/service
[1726243039.373482][104063:104064] CHIP:DL: Create characteristic object at /chipoble/967f/service/c1
[1726243039.373571][104063:104064] CHIP:DL: Create characteristic object at /chipoble/967f/service/c2
[1726243039.373607][104063:104064] CHIP:DL: CHIP BTP C1 /chipoble/967f/service


```

