### PR TITLE
[Silabs] Enabling brd4342a board support for matter

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -146,6 +146,24 @@ jobs:
             /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out
+      - name: Build BRD4342A WiFi Soc variants
+        run: |
+          ./scripts/run_in_build_env.sh \
+             "./scripts/build/build_examples.py \
+                --enable-flashbundle \
+                --target efr32-brd4342a-light-skip-rps-generation \
+                --target efr32-brd4342a-lock-skip-rps-generation \
+                build \
+                --copy-artifacts-to out/artifacts \
+             "
+      - name: Prepare bloat report for brd4342a lock app
+        run: |
+          .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+            efr32 BRD4342a lock-app \
+            out/efr32-brd4342a-lock-skip-rps-generation/matter-silabs-lock-example.out \
+            /tmp/bloat_reports/
+      - name: Clean out build output
+        run: rm -rf ./out
       - name: Build EFR32 with WiFi NCP
         run: |
           ./scripts/run_in_build_env.sh \

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -138,12 +138,6 @@ jobs:
                 build \
                 --copy-artifacts-to out/artifacts \
              "
-      - name: Prepare bloat report for brd2605a lock app
-        run: |
-          .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-            efr32 BRD2605a lock-app \
-            out/efr32-brd2605a-lock-skip-rps-generation/matter-silabs-lock-example.out \
-            /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out
       - name: Build BRD4342A WiFi Soc variants
@@ -156,12 +150,6 @@ jobs:
                 build \
                 --copy-artifacts-to out/artifacts \
              "
-      - name: Prepare bloat report for brd4342a lock app
-        run: |
-          .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-            efr32 BRD4342a lock-app \
-            out/efr32-brd4342a-lock-skip-rps-generation/matter-silabs-lock-example.out \
-            /tmp/bloat_reports/
       - name: Clean out build output
         run: rm -rf ./out
       - name: Build EFR32 with WiFi NCP

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -256,6 +256,7 @@ def BuildEfr32Target():
         TargetPart('brd2703a', board=Efr32Board.BRD2703A),
         TargetPart('brd4338a', board=Efr32Board.BRD4338A, enable_wifi=True, enable_917_soc=True),
         TargetPart('brd2605a', board=Efr32Board.BRD2605A, enable_wifi=True, enable_917_soc=True),
+        TargetPart('brd4342a', board=Efr32Board.BRD4342A, enable_wifi=True, enable_917_soc=True),
     ])
 
     # apps

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -105,7 +105,7 @@ class Efr32Board(Enum):
     BRD4338A = 11
     BRD2703A = 12
     BRD2605A = 13
-    BRD2605A = 14
+    BRD4342A = 14
 
     def GnArgName(self):
         if self == Efr32Board.BRD2704B:

--- a/scripts/build/builders/efr32.py
+++ b/scripts/build/builders/efr32.py
@@ -105,6 +105,7 @@ class Efr32Board(Enum):
     BRD4338A = 11
     BRD2703A = 12
     BRD2605A = 13
+    BRD2605A = 14
 
     def GnArgName(self):
         if self == Efr32Board.BRD2704B:
@@ -133,6 +134,8 @@ class Efr32Board(Enum):
             return 'BRD2703A'
         elif self == Efr32Board.BRD2605A:
             return 'BRD2605A'
+        elif self == Efr32Board.BRD4342A:
+            return 'BRD4342A'
         else:
             raise Exception('Unknown board #: %r' % self)
 

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -5,7 +5,7 @@ bouffalolab-{bl602dk,bl704ldk,bl706dk,bl602-night-light,bl706-night-light,bl602-
 cc32xx-{lock,air-purifier}
 ti-cc13x4_26x4-{lighting,lock,pump,pump-controller}[-mtd][-ftd]
 cyw30739-{cyw30739b2_p5_evk_01,cyw30739b2_p5_evk_02,cyw30739b2_p5_evk_03,cyw930739m2evb_01,cyw930739m2evb_02}-{light,light-switch,lock,thermostat}
-efr32-{brd2704b,brd4316a,brd4317a,brd4318a,brd4319a,brd4186a,brd4187a,brd2601b,brd4187c,brd4186c,brd2703a,brd4338a,brd2605a}-{window-covering,switch,unit-test,light,lock,thermostat,pump}[-rpc][-with-ota-requestor][-icd][-low-power][-shell][-no-logging][-openthread-mtd][-heap-monitoring][-no-openthread-cli][-show-qr-code][-wifi][-rs9116][-wf200][-siwx917][-ipv4][-additional-data-advertising][-use-ot-lib][-use-ot-coap-lib][-no-version][-skip-rps-generation]
+efr32-{brd2704b,brd4316a,brd4317a,brd4318a,brd4319a,brd4186a,brd4187a,brd2601b,brd4187c,brd4186c,brd2703a,brd4338a,brd2605a,brd4342a}-{window-covering,switch,unit-test,light,lock,thermostat,pump}[-rpc][-with-ota-requestor][-icd][-low-power][-shell][-no-logging][-openthread-mtd][-heap-monitoring][-no-openthread-cli][-show-qr-code][-wifi][-rs9116][-wf200][-siwx917][-ipv4][-additional-data-advertising][-use-ot-lib][-use-ot-coap-lib][-no-version][-skip-rps-generation]
 esp32-{m5stack,c3devkit,devkitc,qemu}-{all-clusters,all-clusters-minimal,energy-management,ota-provider,ota-requestor,shell,light,lock,bridge,temperature-measurement,ota-requestor,tests}[-rpc][-ipv6only][-tracing][-data-model-disabled][-data-model-enabled]
 genio-lighting-app
 linux-fake-tests[-mbedtls][-boringssl][-asan][-tsan][-ubsan][-libfuzzer][-ossfuzz][-pw-fuzztest][-coverage][-dmalloc][-clang]

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -297,7 +297,7 @@ else
     fi
 
     # 917 exception. TODO find a more generic way
-    if [ "$SILABS_BOARD" == "BRD4338A" ] || [ "$SILABS_BOARD" == "BRD2605A" ]; then
+    if [ "$SILABS_BOARD" == "BRD4338A" ] || [ "$SILABS_BOARD" == "BRD2605A" ] || [ "$SILABS_BOARD" == "BRD4342A" ]; then
         echo "Compiling for 917 WiFi SOC"
         USE_WIFI=true
     fi

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -62,7 +62,8 @@ if (silabs_board == "") {
 assert(silabs_board != "", "silabs_board must be specified")
 
 # Si917 WIFI board ----------
-if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A" || silabs_board == "BRD4342A") {
+if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A" ||
+    silabs_board == "BRD4342A") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
   wifi_soc = true

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -62,7 +62,7 @@ if (silabs_board == "") {
 assert(silabs_board != "", "silabs_board must be specified")
 
 # Si917 WIFI board ----------
-if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A") {
+if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A" || silabs_board == "BRD4342A") {
   silabs_family = "SiWx917-common"
   silabs_mcu = "SiWG917M111MGTBA"
   wifi_soc = true


### PR DESCRIPTION
Add BRD4342A board support in matter
Verified light, lock applications with BRD4342A board.

sdk_support PR: https://github.com/SiliconLabs/sdk_support/pull/226


