### PR TITLE
[zap] Add Windows support for ZAP generate and download scripts

### DIFF
--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -16,7 +16,6 @@
 #
 
 import argparse
-import fcntl
 import json
 import os
 import shutil
@@ -338,15 +337,29 @@ class LockFileSerializer:
             return
 
         self.lock_file = open(self.lock_file_path, 'wb')
-        fcntl.lockf(self.lock_file, fcntl.LOCK_EX)
+        self._lock()
 
     def __exit__(self, *args):
         if not self.lock_file:
             return
 
-        fcntl.lockf(self.lock_file, fcntl.LOCK_UN)
+        self._unlock()
         self.lock_file.close()
         self.lock_file = None
+
+    def _lock(self):
+        if sys.platform == 'linux' or sys.platform == 'darwin':
+            import fcntl
+            fcntl.lockf(self.lock_file, fcntl.LOCK_EX)
+        else:
+            print(f"Warning: lock does nothing on {sys.platform} platform")
+
+    def _unlock(self):
+        if sys.platform == 'linux' or sys.platform == 'darwin':
+            import fcntl
+            fcntl.lockf(self.lock_file, fcntl.LOCK_UN)
+        else:
+            print(f"Warning: unlock does nothing on {sys.platform} platform")
 
 
 def main():

--- a/scripts/tools/zap/zap_download.py
+++ b/scripts/tools/zap/zap_download.py
@@ -106,15 +106,21 @@ def _SetupReleaseZap(install_directory: str, zap_version: str):
 
     if sys.platform == 'linux':
         zap_platform = 'linux'
+        arch = os.uname().machine
     elif sys.platform == 'darwin':
         zap_platform = 'mac'
+        arch = os.uname().machine
+    elif sys.platform == 'win32':
+        zap_platform = 'win'
+        # os.uname is not implemented on Windows, so use an alternative instead.
+        import platform
+        arch = platform.uname().machine
     else:
         raise Exception('Unknown platform - do not know what zip file to download.')
 
-    arch = os.uname().machine
     if arch == 'arm64':
         zap_arch = 'arm64'
-    elif arch == 'x86_64':
+    elif arch == 'x86_64' or arch == 'AMD64':
         zap_arch = 'x64'
     else:
         raise Exception(f'Unknown architecture "${arch}" - do not know what zip file to download.')
@@ -228,17 +234,21 @@ def main(log_level: str, sdk_root: str, extract_root: str, zap_version: Optional
 
     install_directory = os.path.join(extract_root, f"zap-{zap_version}")
 
+    export_cmd = "export"
+    if sys.platform == 'win32':
+        export_cmd = "set"
+
     if zap == DownloadType.SOURCE:
         install_directory = install_directory + "-src"
         _SetupSourceZap(install_directory, zap_version)
 
         # Make sure the results can be used in scripts
-        print(f"export ZAP_DEVELOPMENT_PATH={shlex.quote(install_directory)}")
+        print(f"{export_cmd} ZAP_DEVELOPMENT_PATH={shlex.quote(install_directory)}")
     else:
         _SetupReleaseZap(install_directory, zap_version)
 
         # Make sure the results can be used in scripts
-        print(f"export ZAP_INSTALL_PATH={shlex.quote(install_directory)}")
+        print(f"{export_cmd} ZAP_INSTALL_PATH={shlex.quote(install_directory)}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These changes are a prerequisite for compiling on Windows using a custom bootstrap script. The changes should not affect the scripts behavior on other platforms.