### PR TITLE
[NXP] Migrate docker image to NXP Zephyr 3.7 downstream release

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-76 : [Telink] Update Docker image (Zephyr update)
+77 : [NXP] Migrate docker image to NXP Zephyr 3.7 downstream release

--- a/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
@@ -10,23 +10,23 @@ RUN set -x \
 
 WORKDIR /opt/nxp-zephyr
 RUN set -x \
-    && wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.5/zephyr-sdk-0.16.5_linux-x86_64_minimal.tar.xz \
-    && tar xvf zephyr-sdk-0.16.5_linux-x86_64_minimal.tar.xz \
-    && rm -rf zephyr-sdk-0.16.5_linux-x86_64_minimal.tar.xz \
-    && zephyr-sdk-0.16.5/setup.sh -t arm-zephyr-eabi \
+    && wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_linux-x86_64_minimal.tar.xz \
+    && tar xvf zephyr-sdk-0.16.8_linux-x86_64_minimal.tar.xz \
+    && rm -rf zephyr-sdk-0.16.8_linux-x86_64_minimal.tar.xz \
+    && zephyr-sdk-0.16.8/setup.sh -t arm-zephyr-eabi \
     && pip3 install --break-system-packages -U --no-cache-dir west \
-    && west init zephyrproject -m https://github.com/nxp-zephyr-ear/zephyr.git --mr zephyr_rw61x_v3.6_RFP \
-    && cd zephyrproject/zephyr \
+    && west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v3.7.0 \
+    && cd zephyrproject \
     && west update -o=--depth=1 -n \
     && west zephyr-export \
     && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}
 
-COPY --from=build /opt/nxp-zephyr/zephyr-sdk-0.16.5/ /opt/nxp-zephyr/zephyr-sdk-0.16.5/
+COPY --from=build /opt/nxp-zephyr/zephyr-sdk-0.16.8/ /opt/nxp-zephyr/zephyr-sdk-0.16.8/
 COPY --from=build /opt/nxp-zephyr/zephyrproject/ /opt/nxp-zephyr/zephyrproject/
 
 WORKDIR /opt/nxp-zephyr
 
 ENV ZEPHYR_NXP_BASE=/opt/nxp-zephyr/zephyrproject/zephyr
-ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-0.16.5
+ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-0.16.8

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -54,7 +54,7 @@ COPY --from=rw61x /opt/sdk /opt/nxp-sdk
 
 COPY --from=nxp /opt/nxp /opt/nxp
 
-COPY --from=nxpzephyr /opt/nxp-zephyr/zephyr-sdk-0.16.5/ /opt/nxp-zephyr/zephyr-sdk-0.16.5/
+COPY --from=nxpzephyr /opt/nxp-zephyr/zephyr-sdk-0.16.8/ /opt/nxp-zephyr/zephyr-sdk-0.16.8/
 COPY --from=nxpzephyr /opt/nxp-zephyr/zephyrproject/ /opt/nxp-zephyr/zephyrproject/
 
 COPY --from=imx /opt/fsl-imx-xwayland /opt/fsl-imx-xwayland
@@ -140,7 +140,7 @@ ENV ZEPHYR_BASE=/opt/NordicSemiconductor/nrfconnect/zephyr
 ENV ZEPHYR_SDK_INSTALL_DIR=/opt/NordicSemiconductor/nRF5_tools/zephyr-sdk-0.16.5
 ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
 ENV ZEPHYR_NXP_BASE=/opt/nxp-zephyr/zephyrproject/zephyr
-ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-0.16.5
+ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-0.16.8
 ENV NXP_UPDATE_SDK_SCRIPT_DOCKER=/opt/nxp/nxp_matter_support/scripts/update_nxp_sdk.py
 
 # Places bootstrap files there instead of the default one which is `.environment`.


### PR DESCRIPTION
Migrate NXP Zephyr docker image to NXP Zephyr 3.7 downstream release.
This is needed before merging the platform updates for this migration.

