### PR TITLE
Update BUILDING.md to include Java JRE

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -94,7 +94,8 @@ satisfied with the following command:
 ```
 sudo apt-get install git gcc g++ pkg-config libssl-dev libdbus-1-dev \
      libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev \
-     python3-pip unzip libgirepository1.0-dev libcairo2-dev libreadline-dev
+     python3-pip unzip libgirepository1.0-dev libcairo2-dev libreadline-dev \
+     default-jre
 ```
 
 #### UI builds


### PR DESCRIPTION
- Installed a new PC for work. Could not run zap_regen_all.py successfully, as the Java dependency was not installed, but this was not stated in the manual.

