### PR TITLE
Add a new build directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ out/
 /examples/virtual-device-app/android/App/buildSrc/build/
 /src/test_driver/nrfconnect/build/
 /src/darwin/Framework/build/
-src/python_testing/matter_testing_infrastructure/build/
+/src/python_testing/matter_testing_infrastructure/build/
 
 # Pigweed Environment
 .environment*/

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out/
 /examples/virtual-device-app/android/App/buildSrc/build/
 /src/test_driver/nrfconnect/build/
 /src/darwin/Framework/build/
+src/python_testing/matter_testing_infrastructure/build/
 
 # Pigweed Environment
 .environment*/


### PR DESCRIPTION
- `src/python_testing/matter_testing_infrastructure/build/` is recent and the result of bootstrap. It should not appear to dirty the tree.
