### PR TITLE
Fix Parsing Response Data in Content App Command Delegate

### DIFF
--- a/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
@@ -219,7 +219,12 @@ Status ContentAppCommandDelegate::InvokeCommand(EndpointId epId, ClusterId clust
 void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::HandlerContext & handlerContext, const char * response)
 {
     handlerContext.SetCommandHandled();
+    Json::Reader reader;
     Json::Value value;
+    if (!reader.parse(response, value))
+    {
+        return;
+    }
 
     // handle errors from platform-app
     if (!value[FAILURE_KEY].empty())


### PR DESCRIPTION
**Problem**
FormatResponseData inside ContentAppCommandDelegate is missing the actual parsing of the response data.

**Solution**
Add back the parsing logic that was accidentally removed in previous PR #34895

Tested on Prime Video casting from Android and iOS. Commissioning and casting control were successful.

