### PR TITLE
[Fabric-Admin] Update the last used nodeId to avoid conflict

### DIFF
--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -62,6 +62,7 @@ void FabricSyncAddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_E
         ChipLogProgress(NotSpecified, "Successfully paired bridge device: NodeId: " ChipLogFormatX64,
                         ChipLogValueX64(mBridgeNodeId));
 
+        DeviceMgr().UpdateLastUsedNodeId(mBridgeNodeId);
         DeviceMgr().SubscribeRemoteFabricBridge();
 
         if (DeviceMgr().IsLocalBridgeReady())
@@ -180,6 +181,7 @@ void FabricSyncAddLocalBridgeCommand::OnCommissioningComplete(NodeId deviceId, C
     if (err == CHIP_NO_ERROR)
     {
         DeviceMgr().SetLocalBridgeNodeId(mLocalBridgeNodeId);
+        DeviceMgr().UpdateLastUsedNodeId(mLocalBridgeNodeId);
         ChipLogProgress(NotSpecified, "Successfully paired local bridge device: NodeId: " ChipLogFormatX64,
                         ChipLogValueX64(mLocalBridgeNodeId));
     }

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -49,7 +49,8 @@ void DeviceManager::Init()
     mLastUsedNodeId = 1;
     mInitialized    = true;
 
-    ChipLogProgress(NotSpecified, "DeviceManager initialized: last used nodeId: 0x%" PRIx64, mLastUsedNodeId);
+    ChipLogProgress(NotSpecified, "DeviceManager initialized: last used nodeId " ChipLogFormatX64,
+                    ChipLogValueX64(mLastUsedNodeId));
 }
 
 NodeId DeviceManager::GetNextAvailableNodeId()

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -47,6 +47,9 @@ void DeviceManager::Init()
 {
     // TODO: (#34113) Init mLastUsedNodeId from chip config file
     mLastUsedNodeId = 1;
+    mInitialized    = true;
+
+    ChipLogProgress(NotSpecified, "DeviceManager initialized: last used nodeId: 0x%" PRIx64, mLastUsedNodeId);
 }
 
 NodeId DeviceManager::GetNextAvailableNodeId()
@@ -61,8 +64,8 @@ void DeviceManager::UpdateLastUsedNodeId(NodeId nodeId)
 {
     if (nodeId > mLastUsedNodeId)
     {
-        ChipLogProgress(NotSpecified, "Updating last used NodeId to " ChipLogFormatX64, ChipLogValueX64(nodeId));
         mLastUsedNodeId = nodeId;
+        ChipLogProgress(NotSpecified, "Updating last used NodeId to " ChipLogFormatX64, ChipLogValueX64(mLastUsedNodeId));
     }
 }
 


### PR DESCRIPTION
Dynamically allocated NodeIds for synced devices start from 1. If we add local and remote bridges with NodeIds 1 and 2, it will conflict with the next dynamically allocated NodeId. 

To prevent this, we should update the last used NodeId after adding the bridges.
