### PR TITLE
[libfuzzer] Fuzzing different Transport Types for all-clusters-app

### DIFF
--- a/examples/all-clusters-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-app/linux/fuzzing-main.cpp
@@ -75,7 +75,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
     // the incoming data?
 
     // dumping payload with fuzzed transport types
-    constexpr uint8_t numberOfTypes = static_cast<int>(Transport::Type::kLast) + 1;
+    constexpr uint8_t numberOfTypes     = static_cast<int>(Transport::Type::kLast) + 1;
     Transport::Type fuzzedTransportType = static_cast<Transport::Type>(aData[0] % numberOfTypes);
     Transport::PeerAddress peerAddr(fuzzedTransportType);
 

--- a/examples/all-clusters-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-app/linux/fuzzing-main.cpp
@@ -74,12 +74,18 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
     // But maybe we should try to separately extract a PeerAddress and data from
     // the incoming data?
 
-    // dumping payload with random transport types
-    Transport::Type fuzzedTransportType = static_cast<Transport::Type>(*aData % 5);
+    // dumping payload with fuzzed transport types
+    constexpr uint8_t numberOfTypes = static_cast<int>(Transport::Type::kLast) + 1;
+    Transport::Type fuzzedTransportType = static_cast<Transport::Type>(aData[0] % numberOfTypes);
     Transport::PeerAddress peerAddr(fuzzedTransportType);
 
+    if (aSize < 1)
+    {
+        return 0;
+    }
+
     System::PacketBufferHandle buf =
-        System::PacketBufferHandle::NewWithData(aData, aSize, /* aAdditionalSize = */ 0, /* aReservedSize = */ 0);
+        System::PacketBufferHandle::NewWithData(&aData[1], aSize - 1, /* aAdditionalSize = */ 0, /* aReservedSize = */ 0);
     if (buf.IsNull())
     {
         // Too big; we couldn't represent this as a packetbuffer to start with.

--- a/examples/all-clusters-app/linux/fuzzing-main.cpp
+++ b/examples/all-clusters-app/linux/fuzzing-main.cpp
@@ -74,15 +74,16 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * aData, size_t aSize)
     // But maybe we should try to separately extract a PeerAddress and data from
     // the incoming data?
 
+    // To avoid out-of-bounds access when acessing aData[1]
+    if (aSize < 2)
+    {
+        return 0;
+    }
+
     // dumping payload with fuzzed transport types
     constexpr uint8_t numberOfTypes     = static_cast<int>(Transport::Type::kLast) + 1;
     Transport::Type fuzzedTransportType = static_cast<Transport::Type>(aData[0] % numberOfTypes);
     Transport::PeerAddress peerAddr(fuzzedTransportType);
-
-    if (aSize < 1)
-    {
-        return 0;
-    }
 
     System::PacketBufferHandle buf =
         System::PacketBufferHandle::NewWithData(&aData[1], aSize - 1, /* aAdditionalSize = */ 0, /* aReservedSize = */ 0);

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -54,6 +54,7 @@ enum class Type : uint8_t
     kBle,
     kTcp,
     kWiFiPAF,
+    kLast = kWiFiPAF, //This is not an actual transport type, it just refers to the last transport type
 };
 
 /**

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -54,7 +54,7 @@ enum class Type : uint8_t
     kBle,
     kTcp,
     kWiFiPAF,
-    kLast = kWiFiPAF, //This is not an actual transport type, it just refers to the last transport type
+    kLast = kWiFiPAF, // This is not an actual transport type, it just refers to the last transport type
 };
 
 /**


### PR DESCRIPTION
Fuzzing different Transport Types for all-clusters-app instead of just with `Transport::Type = kUndefined`

