### PR TITLE
[Silabs] Update Silabs docker image to WiseConnect 3.3.2

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-77 : [NXP] Migrate docker image to NXP Zephyr 3.7 downstream release
+78 : [Silabs] Update Silabs docker WiseConnect 3.3.2

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -29,8 +29,8 @@ RUN git clone --depth=1 --single-branch --branch=2.10.0 https://github.com/Silic
     rm -rf .git \
     && : # last line
 
-# Clone WiSeConnect SDK v3.3.1 (841ea3f)
-RUN git clone --depth=1 --single-branch --branch=v3.3.1 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
+# Clone WiSeConnect SDK v3.3.2 (b5d6422)
+RUN git clone --depth=1 --single-branch --branch=v3.3.2 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
     cd /tmp/wifi_sdk && \
     rm -rf .git \
     && : # last line


### PR DESCRIPTION
This PR updates docker image to new WiseConnect version 3.3.2. The Silabs platform in CSA will be updated shortly to leverage this release: https://github.com/project-chip/connectedhomeip/pull/35439.