### PR TITLE
Add a way to dynamically change whether a node identity should be advertised.

### DIFF
--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -2164,4 +2164,17 @@ CHIP_ERROR FabricTable::SetFabricIndexForNextAddition(FabricIndex fabricIndex)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR FabricTable::SetShouldAdvertiseIdentity(FabricIndex fabricIndex, AdvertiseIdentity advertiseIdentity)
+{
+    VerifyOrReturnError(IsValidFabricIndex(fabricIndex), CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    FabricInfo * fabricInfo  = GetMutableFabricByIndex(fabricIndex);
+    bool fabricIsInitialized = (fabricInfo != nullptr) && fabricInfo->IsInitialized();
+    VerifyOrReturnError(fabricIsInitialized, CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    fabricInfo->SetShouldAdvertiseIdentity(advertiseIdentity == AdvertiseIdentity::Yes);
+
+    return CHIP_NO_ERROR;
+}
+
 } // namespace chip

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -212,6 +212,8 @@ private:
         mNodeId      = kUndefinedNodeId;
     }
 
+    void SetShouldAdvertiseIdentity(bool advertiseIdentity) { mShouldAdvertiseIdentity = advertiseIdentity; }
+
     static constexpr size_t MetadataTLVMaxSize()
     {
         return TLV::EstimateStructOverhead(sizeof(uint16_t), kFabricLabelMaxLengthInBytes);
@@ -1026,6 +1028,18 @@ public:
      * Returns an error if the |fabricIndex| is already in use.
      */
     CHIP_ERROR SetFabricIndexForNextAddition(FabricIndex fabricIndex);
+
+    /**
+     * @brief Set the advertising behavior for the fabric identified by `fabricIndex`.
+     *
+     * It is the caller's responsibility to actually restart DNS-SD advertising
+     * as needed after updating this state.
+     *
+     * @param fabricIndex - Fabric Index for which to set the label
+     * @param advertiseIdentity - whether the identity for this fabric should be advertised.
+     * @retval CHIP_ERROR_INVALID_FABRIC_INDEX if fabricIndex does not refer to a fabric in the table
+     */
+    CHIP_ERROR SetShouldAdvertiseIdentity(FabricIndex fabricIndex, AdvertiseIdentity advertiseIdentity);
 
 private:
     enum class StateFlags : uint16_t


### PR DESCRIPTION
In some cases, a node may need to stop or restart advertising its identity without actually tearing down the relevant CHIPDeviceController.
