### PR TITLE
Controller suspend/resume should stop/start operational advertising as needed.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -1244,6 +1244,22 @@ MTR_DIRECT_MEMBERS
     return _operationalBrowser.get();
 }
 
+- (FabricTable * _Nullable)fabricTable
+{
+    assertChipStackLockedByCurrentThread();
+
+    if (_controllerFactory == nullptr) {
+        return nullptr;
+    }
+
+    auto systemState = _controllerFactory->GetSystemState();
+    if (systemState == nullptr) {
+        return nullptr;
+    }
+
+    return systemState->Fabrics();
+}
+
 @end
 
 @interface MTRDummyStorage : NSObject <MTRStorage>

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
@@ -32,6 +32,7 @@
 #import "MTRDeviceControllerFactory.h"
 #import "MTROperationalBrowser.h"
 
+#include <credentials/FabricTable.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/PeerId.h>
@@ -110,6 +111,13 @@ MTR_DIRECT_MEMBERS
 @property (readonly) chip::PersistentStorageDelegate * storageDelegate;
 @property (readonly) chip::Credentials::GroupDataProvider * groupDataProvider;
 @property (readonly, assign) MTROperationalBrowser * operationalBrowser;
+
+// fabricTable must be gotten on the Matter queue.  May return null if there are
+// no controllers running.
+@property (readonly, nullable, assign) chip::FabricTable * fabricTable;
+
+// resetOperationalAdvertising must happen on the Matter queue.
+- (void)resetOperationalAdvertising;
 
 @end
 

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -16,6 +16,7 @@
 
 #import <Matter/Matter.h>
 
+#import <dns_sd.h>
 #import <os/lock.h>
 
 #import "MTRDeviceControllerLocalTestStorage.h"
@@ -203,6 +204,109 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
                                                                                      rootCertificate:self.rootCertificate
                                                                                         adminSubject:nil];
     completion(certChain, nil);
+}
+
+@end
+
+@interface MTRPerControllerStorageTestsOperationalBrowser : NSObject
+
+// expectedNodeID should be a 16-char uppercase hex string encoding the 64-bit
+// node ID.
+- (instancetype)initWithNodeID:(NSString *)expectedNodeID;
+- (void)shutdown;
+
+@property (nonatomic, readwrite) NSString * expectedNodeID;
+@property (nonatomic, readwrite, nullable) XCTestExpectation * addedExpectation;
+@property (nonatomic, readwrite, nullable) XCTestExpectation * removedExpectation;
+
+- (void)onBrowse:(DNSServiceFlags)flags error:(DNSServiceErrorType)error instanceName:(const char *)instanceName;
+
+@end
+
+static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t interfaceId,
+    DNSServiceErrorType error, const char * name, const char * type, const char * domain, void * context)
+{
+    __auto_type * self = (__bridge MTRPerControllerStorageTestsOperationalBrowser *) context;
+    [self onBrowse:flags error:error instanceName:name];
+}
+
+@implementation MTRPerControllerStorageTestsOperationalBrowser {
+    DNSServiceRef _browseRef;
+}
+
+- (instancetype)initWithNodeID:(NSString *)expectedNodeID
+{
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    _expectedNodeID = expectedNodeID;
+
+    __auto_type queue = dispatch_get_main_queue();
+
+    __auto_type err = DNSServiceBrowse(&_browseRef, /* DNSServiceFlags = */ 0, kDNSServiceInterfaceIndexAny, "_matter._tcp", "local.", OnBrowse, (__bridge void *) self);
+    XCTAssertEqual(err, kDNSServiceErr_NoError);
+    if (err != kDNSServiceErr_NoError) {
+        return nil;
+    }
+
+    err = DNSServiceSetDispatchQueue(_browseRef, queue);
+    XCTAssertEqual(err, kDNSServiceErr_NoError);
+    if (err != kDNSServiceErr_NoError) {
+        DNSServiceRefDeallocate(_browseRef);
+        _browseRef = nil;
+        return nil;
+    }
+
+    return self;
+}
+
+- (void)shutdown
+{
+    if (_browseRef) {
+        DNSServiceRefDeallocate(_browseRef);
+        _browseRef = nil;
+    }
+}
+
+- (void)onBrowse:(DNSServiceFlags)flags error:(DNSServiceErrorType)error instanceName:(const char *)instanceName
+{
+    XCTAssertEqual(error, kDNSServiceErr_NoError);
+    if (error != kDNSServiceErr_NoError) {
+        DNSServiceRefDeallocate(_browseRef);
+        _browseRef = nil;
+        return;
+    }
+
+    __auto_type len = strlen(instanceName);
+    XCTAssertEqual(len, 33); // Matter instance names are 33 chars.
+
+    if (len != 33) {
+        return;
+    }
+
+    // Skip over compressed fabric id and dash.
+    // TODO: Consider checking the compressed fabric ID?  That's a bit hard to
+    // do, in general, since it depends on our keys.
+    const char * nodeID = &instanceName[17];
+    NSString * browsedNode = [NSString stringWithUTF8String:nodeID];
+    if (![browsedNode isEqual:self.expectedNodeID]) {
+        return;
+    }
+
+    if (flags & kDNSServiceFlagsAdd) {
+        if (self.addedExpectation) {
+            XCTestExpectation * expectation = self.addedExpectation;
+            self.addedExpectation = nil;
+            [expectation fulfill];
+        }
+    } else {
+        if (self.removedExpectation) {
+            XCTestExpectation * expectation = self.removedExpectation;
+            self.removedExpectation = nil;
+            [expectation fulfill];
+        }
+    }
 }
 
 @end
@@ -1665,6 +1769,12 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
 // suspension tests to a different file.
 - (void)test012_startSuspended
 {
+    // Needs to match the 888 == 0x378 for the node ID below.
+    __auto_type * operationalBrowser = [[MTRPerControllerStorageTestsOperationalBrowser alloc] initWithNodeID:@"0000000000000378"];
+    XCTestExpectation * initialAdvertisingExpectation = [self expectationWithDescription:@"Controller advertising initially"];
+    operationalBrowser.addedExpectation = initialAdvertisingExpectation;
+    initialAdvertisingExpectation.inverted = YES; // We should not in fact advertise, since we are suspended.
+
     NSError * error;
     __auto_type * storageDelegate = [[MTRTestPerControllerStorage alloc] initWithControllerID:[NSUUID UUID]];
     __auto_type * controller = [self startControllerWithRootKeys:[[MTRTestKeys alloc] init]
@@ -1675,6 +1785,7 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
                                            caseAuthenticatedTags:nil
                                                   paramsModifier:^(MTRDeviceControllerExternalCertificateParameters * params) {
                                                       params.startSuspended = YES;
+                                                      params.shouldAdvertiseOperational = YES;
                                                   }
                                                            error:&error];
 
@@ -1691,16 +1802,27 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
     [controller setupCommissioningSessionWithPayload:payload newNodeID:@(17) error:&error];
     XCTAssertNotNil(error);
 
+    [self waitForExpectations:@[ initialAdvertisingExpectation ] timeout:kTimeoutInSeconds];
+
     [controller shutdown];
+
+    [operationalBrowser shutdown];
 }
 
 - (void)test013_suspendDevices
 {
+    // getMTRDevice uses "123" for the node ID of the controller, which is hex 0x7B
+    __auto_type * operationalBrowser = [[MTRPerControllerStorageTestsOperationalBrowser alloc] initWithNodeID:@"000000000000007B"];
+    XCTestExpectation * initialAdvertisingExpectation = [self expectationWithDescription:@"Controller advertising initially"];
+    operationalBrowser.addedExpectation = initialAdvertisingExpectation;
+
     NSNumber * deviceID = @(17);
     __auto_type * device = [self getMTRDevice:deviceID];
     __auto_type * controller = device.deviceController;
 
     XCTAssertFalse(controller.suspended);
+
+    [self waitForExpectations:@[ initialAdvertisingExpectation ] timeout:kTimeoutInSeconds];
 
     __auto_type queue = dispatch_get_main_queue();
     __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
@@ -1757,6 +1879,9 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
         }
     });
 
+    XCTestExpectation * advertisingStoppedExpectation = [self expectationWithDescription:@"Controller stopped advertising"];
+    operationalBrowser.removedExpectation = advertisingStoppedExpectation;
+
     [controller suspend];
     XCTAssertTrue(controller.suspended);
 
@@ -1767,7 +1892,7 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
         [toggle2Expectation fulfill];
     }];
 
-    [self waitForExpectations:@[ becameUnreachableExpectation, toggle2Expectation, suspendedExpectation, browseStoppedExpectation ] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ becameUnreachableExpectation, toggle2Expectation, suspendedExpectation, browseStoppedExpectation, advertisingStoppedExpectation ] timeout:kTimeoutInSeconds];
 
     XCTestExpectation * newSubscriptionExpectation = [self expectationWithDescription:@"Subscription has been set up again"];
     XCTestExpectation * newReachableExpectation = [self expectationWithDescription:@"Device became reachable again"];
@@ -1790,10 +1915,13 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
         }
     });
 
+    XCTestExpectation * advertisingResumedExpectation = [self expectationWithDescription:@"Controller resumed advertising"];
+    operationalBrowser.addedExpectation = advertisingResumedExpectation;
+
     [controller resume];
     XCTAssertFalse(controller.suspended);
 
-    [self waitForExpectations:@[ newSubscriptionExpectation, newReachableExpectation, resumedExpectation, browseRestartedExpectation ] timeout:kSubscriptionTimeoutInSeconds];
+    [self waitForExpectations:@[ newSubscriptionExpectation, newReachableExpectation, resumedExpectation, browseRestartedExpectation, advertisingResumedExpectation ] timeout:kSubscriptionTimeoutInSeconds];
 
     MTRSetLogCallback(MTRLogTypeProgress, nil);
 
@@ -1814,6 +1942,8 @@ static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
     ResetCommissionee(baseDevice, queue, self, kTimeoutInSeconds);
 
     [controller shutdown];
+
+    [operationalBrowser shutdown];
 }
 
 // TODO: This might want to go in a separate test file, with some shared setup


### PR DESCRIPTION
Draft until https://github.com/project-chip/connectedhomeip/pull/35634 merges.