### PR TITLE
[Fabric-Admin] Update the Fabric Sync guide to explain the confusion

### DIFF
--- a/docs/guides/fabric_synchronization_guide.md
+++ b/docs/guides/fabric_synchronization_guide.md
@@ -96,6 +96,10 @@ Run the Fabric Synchronization script:
 
 ### Fabric Sync Setup
 
+Fabric Sync Setup is the process of enabling two ecosystems that support the Fabric
+Synchronization feature to commission each other's Fabric Bridge nodes into their 
+respective private fabrics.
+
 In Ecosystem 1 Fabric-Admin console:
 
 Pair the local bridge of Ecosystem 1 with node ID 1:

--- a/docs/guides/fabric_synchronization_guide.md
+++ b/docs/guides/fabric_synchronization_guide.md
@@ -96,9 +96,9 @@ Run the Fabric Synchronization script:
 
 ### Fabric Sync Setup
 
-Fabric Sync Setup is the process of enabling two ecosystems that support the Fabric
-Synchronization feature to commission each other's Fabric Bridge nodes into their 
-respective private fabrics.
+Fabric Sync Setup is the process of enabling two ecosystems that support the
+Fabric Synchronization feature to commission each other's Fabric Bridge nodes
+into their respective private fabrics.
 
 In Ecosystem 1 Fabric-Admin console:
 

--- a/docs/guides/fabric_synchronization_guide.md
+++ b/docs/guides/fabric_synchronization_guide.md
@@ -118,6 +118,11 @@ of Ecosystem 1 has successfully paired with Ecosystem 2 on Endpoint 2:
 >>> A new device is added on Endpoint 2.
 ```
 
+Note: We only need to add the local bridge to the ecosystem to trigger the
+Fabric Sync Setup process. In the example above, the Fabric Sync Setup process
+is initiated by the command 'add-bridge' from Ecosystem 1. Adding the local
+bridge on the other side is optional.
+
 ### Pair Light Example to Ecosystem 2
 
 Since Fabric-Bridge also functions as a Matter server, running it alongside the

--- a/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
+++ b/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
@@ -43,7 +43,7 @@ constexpr char kInteractiveModeHistoryFileName[] = "chip_tool_history";
 constexpr char kInteractiveModeStopCommand[]     = "quit()";
 
 #if defined(PW_RPC_ENABLED)
-constexpr uint16_t kRetryIntervalS = 5;
+constexpr uint16_t kRetryIntervalS = 3;
 #endif
 
 // File pointer for the log file


### PR DESCRIPTION
1. Received a question about why the local bridge only needs to be added on one side and not the other. Update the documentation to explain this.

2. Decrease the RCP connection retry interval from 5s to 3s.


