### PR TITLE
[Fabric-Admin] Fix compile errors when RPC is disabled

### DIFF
--- a/examples/fabric-admin/device_manager/DeviceSubscription.cpp
+++ b/examples/fabric-admin/device_manager/DeviceSubscription.cpp
@@ -17,7 +17,10 @@
  */
 
 #include "DeviceSubscription.h"
+
+#if defined(PW_RPC_ENABLED)
 #include "rpc/RpcClient.h"
+#endif
 
 #include <app/InteractionModelEngine.h>
 #include <app/server/Server.h>
@@ -61,11 +64,14 @@ void DeviceSubscription::OnAttributeData(const ConcreteDataAttributePath & path,
         CHIP_ERROR err = data->Get(windowStatus);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(NotSpecified, "Failed to read WindowStatus"));
         VerifyOrReturn(windowStatus != Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kUnknownEnumValue);
+#if defined(PW_RPC_ENABLED)        
         mCurrentAdministratorCommissioningAttributes.window_status = static_cast<uint32_t>(windowStatus);
+#endif        
         mChangeDetected                                            = true;
         break;
     }
     case Clusters::AdministratorCommissioning::Attributes::AdminFabricIndex::Id: {
+#if defined(PW_RPC_ENABLED)        
         FabricIndex fabricIndex;
         CHIP_ERROR err                                                       = data->Get(fabricIndex);
         mCurrentAdministratorCommissioningAttributes.has_opener_fabric_index = err == CHIP_NO_ERROR;
@@ -73,10 +79,12 @@ void DeviceSubscription::OnAttributeData(const ConcreteDataAttributePath & path,
         {
             mCurrentAdministratorCommissioningAttributes.opener_fabric_index = static_cast<uint32_t>(fabricIndex);
         }
+#endif        
         mChangeDetected = true;
         break;
     }
     case Clusters::AdministratorCommissioning::Attributes::AdminVendorId::Id: {
+#if defined(PW_RPC_ENABLED)              
         chip::VendorId vendorId;
         CHIP_ERROR err                                                    = data->Get(vendorId);
         mCurrentAdministratorCommissioningAttributes.has_opener_vendor_id = err == CHIP_NO_ERROR;
@@ -84,6 +92,7 @@ void DeviceSubscription::OnAttributeData(const ConcreteDataAttributePath & path,
         {
             mCurrentAdministratorCommissioningAttributes.opener_vendor_id = static_cast<uint32_t>(vendorId);
         }
+#endif        
         mChangeDetected = true;
         break;
     }
@@ -111,7 +120,7 @@ void DeviceSubscription::OnDone(ReadClient * apReadClient)
     // After calling mOnDoneCallback we are indicating that `this` is deleted and we shouldn't do anything else with
     // DeviceSubscription.
     MoveToState(State::AwaitingDestruction);
-    mOnDoneCallback(mCurrentAdministratorCommissioningAttributes.node_id);
+    mOnDoneCallback(mNodeId);
 }
 
 void DeviceSubscription::OnError(CHIP_ERROR error)
@@ -126,7 +135,7 @@ void DeviceSubscription::OnDeviceConnected(Messaging::ExchangeManager & exchange
         // After calling mOnDoneCallback we are indicating that `this` is deleted and we shouldn't do anything else with
         // DeviceSubscription.
         MoveToState(State::AwaitingDestruction);
-        mOnDoneCallback(mCurrentAdministratorCommissioningAttributes.node_id);
+        mOnDoneCallback(mNodeId);
         return;
     }
     VerifyOrDie(mState == State::Connecting);
@@ -151,7 +160,7 @@ void DeviceSubscription::OnDeviceConnected(Messaging::ExchangeManager & exchange
         // After calling mOnDoneCallback we are indicating that `this` is deleted and we shouldn't do anything else with
         // DeviceSubscription.
         MoveToState(State::AwaitingDestruction);
-        mOnDoneCallback(mCurrentAdministratorCommissioningAttributes.node_id);
+        mOnDoneCallback(mNodeId);
         return;
     }
     MoveToState(State::SubscriptionStarted);
@@ -194,7 +203,7 @@ void DeviceSubscription::OnDeviceConnectionFailure(const ScopedNodeId & peerId, 
     // After calling mOnDoneCallback we are indicating that `this` is deleted and we shouldn't do anything else with
     // DeviceSubscription.
     MoveToState(State::AwaitingDestruction);
-    mOnDoneCallback(mCurrentAdministratorCommissioningAttributes.node_id);
+    mOnDoneCallback(mNodeId);
 }
 
 CHIP_ERROR DeviceSubscription::StartSubscription(OnDoneCallback onDoneCallback, Controller::DeviceController & controller,
@@ -203,10 +212,14 @@ CHIP_ERROR DeviceSubscription::StartSubscription(OnDoneCallback onDoneCallback, 
     assertChipStackLockedByCurrentThread();
     VerifyOrDie(mState == State::Idle);
 
+    mNodeId = nodeId;
+
+#if defined(PW_RPC_ENABLED)    
     mCurrentAdministratorCommissioningAttributes         = chip_rpc_AdministratorCommissioningChanged_init_default;
     mCurrentAdministratorCommissioningAttributes.node_id = nodeId;
     mCurrentAdministratorCommissioningAttributes.window_status =
         static_cast<uint32_t>(Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
+#endif        
 
     mOnDoneCallback = onDoneCallback;
     MoveToState(State::Connecting);
@@ -243,5 +256,5 @@ void DeviceSubscription::StopSubscription()
     // After calling mOnDoneCallback we are indicating that `this` is deleted and we shouldn't do anything else with
     // DeviceSubscription.
     MoveToState(State::AwaitingDestruction);
-    mOnDoneCallback(mCurrentAdministratorCommissioningAttributes.node_id);
+    mOnDoneCallback(mNodeId);
 }

--- a/examples/fabric-admin/device_manager/DeviceSubscription.cpp
+++ b/examples/fabric-admin/device_manager/DeviceSubscription.cpp
@@ -67,7 +67,7 @@ void DeviceSubscription::OnAttributeData(const ConcreteDataAttributePath & path,
 #if defined(PW_RPC_ENABLED)
         mCurrentAdministratorCommissioningAttributes.window_status = static_cast<uint32_t>(windowStatus);
 #endif
-        mChangeDetected                                            = true;
+        mChangeDetected = true;
         break;
     }
     case Clusters::AdministratorCommissioning::Attributes::AdminFabricIndex::Id: {

--- a/examples/fabric-admin/device_manager/DeviceSubscription.cpp
+++ b/examples/fabric-admin/device_manager/DeviceSubscription.cpp
@@ -64,14 +64,14 @@ void DeviceSubscription::OnAttributeData(const ConcreteDataAttributePath & path,
         CHIP_ERROR err = data->Get(windowStatus);
         VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(NotSpecified, "Failed to read WindowStatus"));
         VerifyOrReturn(windowStatus != Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kUnknownEnumValue);
-#if defined(PW_RPC_ENABLED)        
+#if defined(PW_RPC_ENABLED)
         mCurrentAdministratorCommissioningAttributes.window_status = static_cast<uint32_t>(windowStatus);
-#endif        
+#endif
         mChangeDetected                                            = true;
         break;
     }
     case Clusters::AdministratorCommissioning::Attributes::AdminFabricIndex::Id: {
-#if defined(PW_RPC_ENABLED)        
+#if defined(PW_RPC_ENABLED)
         FabricIndex fabricIndex;
         CHIP_ERROR err                                                       = data->Get(fabricIndex);
         mCurrentAdministratorCommissioningAttributes.has_opener_fabric_index = err == CHIP_NO_ERROR;
@@ -79,12 +79,12 @@ void DeviceSubscription::OnAttributeData(const ConcreteDataAttributePath & path,
         {
             mCurrentAdministratorCommissioningAttributes.opener_fabric_index = static_cast<uint32_t>(fabricIndex);
         }
-#endif        
+#endif
         mChangeDetected = true;
         break;
     }
     case Clusters::AdministratorCommissioning::Attributes::AdminVendorId::Id: {
-#if defined(PW_RPC_ENABLED)              
+#if defined(PW_RPC_ENABLED)
         chip::VendorId vendorId;
         CHIP_ERROR err                                                    = data->Get(vendorId);
         mCurrentAdministratorCommissioningAttributes.has_opener_vendor_id = err == CHIP_NO_ERROR;
@@ -92,7 +92,7 @@ void DeviceSubscription::OnAttributeData(const ConcreteDataAttributePath & path,
         {
             mCurrentAdministratorCommissioningAttributes.opener_vendor_id = static_cast<uint32_t>(vendorId);
         }
-#endif        
+#endif
         mChangeDetected = true;
         break;
     }
@@ -214,12 +214,12 @@ CHIP_ERROR DeviceSubscription::StartSubscription(OnDoneCallback onDoneCallback, 
 
     mNodeId = nodeId;
 
-#if defined(PW_RPC_ENABLED)    
+#if defined(PW_RPC_ENABLED)
     mCurrentAdministratorCommissioningAttributes         = chip_rpc_AdministratorCommissioningChanged_init_default;
     mCurrentAdministratorCommissioningAttributes.node_id = nodeId;
     mCurrentAdministratorCommissioningAttributes.window_status =
         static_cast<uint32_t>(Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen);
-#endif        
+#endif
 
     mOnDoneCallback = onDoneCallback;
     MoveToState(State::Connecting);

--- a/examples/fabric-admin/device_manager/DeviceSubscription.h
+++ b/examples/fabric-admin/device_manager/DeviceSubscription.h
@@ -23,8 +23,10 @@
 
 #include <memory>
 
+#if defined(PW_RPC_ENABLED)
 #include "fabric_bridge_service/fabric_bridge_service.pb.h"
 #include "fabric_bridge_service/fabric_bridge_service.rpc.pb.h"
+#endif
 
 class DeviceSubscriptionManager;
 
@@ -32,7 +34,7 @@ class DeviceSubscriptionManager;
 /// via RPC when change has been identified.
 ///
 /// An instance of DeviceSubscription is intended to be used only once. Once a DeviceSubscription is
-/// terminal, either from an error or from subscriptions getting shut down, we expect the instance
+/// terminated, either from an error or from subscriptions getting shut down, we expect the instance
 /// to be deleted. Any new subscription should instantiate another instance of DeviceSubscription.
 class DeviceSubscription : public chip::app::ReadClient::Callback
 {
@@ -78,13 +80,18 @@ private:
     void MoveToState(const State aTargetState);
     const char * GetStateStr() const;
 
+    chip::NodeId mNodeId = chip::kUndefinedNodeId;
+
     OnDoneCallback mOnDoneCallback;
     std::unique_ptr<chip::app::ReadClient> mClient;
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
 
+#if defined(PW_RPC_ENABLED)
     chip_rpc_AdministratorCommissioningChanged mCurrentAdministratorCommissioningAttributes;
+#endif
+
     bool mChangeDetected = false;
     State mState         = State::Idle;
 };

--- a/examples/fabric-admin/device_manager/DeviceSubscriptionManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceSubscriptionManager.cpp
@@ -17,7 +17,10 @@
  */
 
 #include "DeviceSubscriptionManager.h"
+
+#if defined(PW_RPC_ENABLED)
 #include "rpc/RpcClient.h"
+#endif
 
 #include <app/InteractionModelEngine.h>
 #include <app/server/Server.h>

--- a/examples/fabric-admin/device_manager/DeviceSynchronization.h
+++ b/examples/fabric-admin/device_manager/DeviceSynchronization.h
@@ -25,8 +25,10 @@
 
 #include <memory>
 
+#if defined(PW_RPC_ENABLED)
 #include "fabric_bridge_service/fabric_bridge_service.pb.h"
 #include "fabric_bridge_service/fabric_bridge_service.rpc.pb.h"
+#endif
 
 /// Ensures that device data is synchronized to the remote fabric bridge.
 ///
@@ -92,6 +94,9 @@ private:
     // mController is expected to remain valid throughout the entire device synchronization process (i.e. when
     // mState != Idle).
     chip::Controller::DeviceController * mController = nullptr;
-    chip_rpc_SynchronizedDevice mCurrentDeviceData   = chip_rpc_SynchronizedDevice_init_default;
+    chip::NodeId mNodeId                             = chip::kUndefinedNodeId;
+#if defined(PW_RPC_ENABLED)
+    chip_rpc_SynchronizedDevice mCurrentDeviceData = chip_rpc_SynchronizedDevice_init_default;
+#endif
     UniqueIdGetter mUniqueIdGetter;
 };


### PR DESCRIPTION

We currently use two separate apps, Fabric-Admin and Fabric-Bridge, to implement the Fabric-Sync feature in the SDK. However, we are planning to integrate this feature into a single app that supports multiple nodes within a single CHIP stack.

RPC is only used in the case of separate apps.

