### PR TITLE
[NXP][Zephyr] Add experimental Ethernet support to NXP zephyr platforms

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -274,7 +274,7 @@ jobs:
               with:
                 platform-name: RW61X
     zephyr:
-        name: ZEPHYR_RW61X
+        name: ZEPHYR
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
@@ -290,12 +290,13 @@ jobs:
               with:
                 platform: nxp
 
-            - name: Build RW61x Zephyr examples
+            - name: Build NXP Zephyr examples
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
                       --target nxp-rw61x-zephyr-all-clusters \
                       --target nxp-rw61x-zephyr-thermostat \
                       --target nxp-rw61x-zephyr-laundry-washer-factory \
+                      --target nxp-rw61x_eth-zephyr-thermostat-ethernet \
                       build \
                   "

--- a/config/nxp/chip-module/CMakeLists.txt
+++ b/config/nxp/chip-module/CMakeLists.txt
@@ -123,7 +123,7 @@ endif()
 
 if (CONFIG_NET_L2_OPENTHREAD)
     matter_add_gn_arg_string("chip_mdns" "platform")
-elseif(CONFIG_WIFI_NXP)
+elseif(CONFIG_WIFI_NXP OR CONFIG_CHIP_ETHERNET)
     matter_add_gn_arg_string("chip_mdns" "minimal")
 else()
     matter_add_gn_arg_string("chip_mdns" "none")

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -252,10 +252,6 @@ choice SCHED_ALGORITHM
 	default SCHED_MULTIQ
 endchoice
 
-choice LIBC_IMPLEMENTATION
-	default NEWLIB_LIBC
-endchoice
-
 choice WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_CHOICE
 	default WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_INF
 endchoice
@@ -323,6 +319,22 @@ config HEAP_MEM_POOL_SIZE
 
 config CHIP_MALLOC_SYS_HEAP_SIZE
 	default 28672 # 28 kB
+
+endif
+
+if CHIP_ETHERNET || CHIP_WIFI
+
+choice LIBC_IMPLEMENTATION
+	default NEWLIB_LIBC
+endchoice
+
+endif
+
+if CHIP_ETHERNET
+
+choice NXP_ENET_DRIVER
+	default ETH_NXP_ENET
+endchoice
 
 endif
 

--- a/config/nxp/chip-module/Kconfig.features
+++ b/config/nxp/chip-module/Kconfig.features
@@ -76,4 +76,27 @@ config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
 	  a random jitter interval is added to it to avoid periodicity. The random jitter is selected
 	  within range [-JITTER; +JITTER].
 
+config CHIP_ETHERNET
+	bool "Enable NXP Ethernet support"
+	default n
+	depends on !CHIP_WIFI
+	select NET_MGMT_EVENT
+	select NET_MGMT_EVENT_INFO
+	select NET_L2_ETHERNET
+	select NET_L2_ETHERNET_MGMT
+	select NET_UDP
+	select NET_IP
+	select NET_CONFIG_SETTINGS
+	select NET_MGMT
+	select NET_IPV4
+	select NET_DHCPV4
+	select NET_NATIVE_IPV4
+	select NET_NATIVE
+	select NET_TCP
+	select DNS_RESOLVER
+	select MDNS_RESOLVER
+	select MBEDTLS_PKCS5_C
+	select MBEDTLS_HKDF_C
+	select MBEDTLS_ECDSA_C
+	select PSA_CRYPTO_ENABLE_ALL
 endif # CHIP

--- a/config/nxp/cmake/common.cmake
+++ b/config/nxp/cmake/common.cmake
@@ -44,6 +44,7 @@ matter_add_gn_arg_bool  ("chip_detail_logging"                    CONFIG_MATTER_
 matter_add_gn_arg_bool  ("chip_automation_logging"                FALSE)
 matter_add_gn_arg_bool  ("chip_malloc_sys_heap"                   CONFIG_CHIP_MALLOC_SYS_HEAP)
 matter_add_gn_arg_bool  ("chip_enable_wifi"                       CONFIG_CHIP_WIFI)
+matter_add_gn_arg_bool  ("chip_enable_ethernet"                   CONFIG_CHIP_ETHERNET)
 matter_add_gn_arg_bool  ("chip_system_config_provide_statistics"  CONFIG_CHIP_STATISTICS)
 matter_add_gn_arg_bool  ("chip_enable_icd_server"                 CONFIG_CHIP_ENABLE_ICD_SUPPORT)
 matter_add_gn_arg_bool  ("enable_eventlist_attribute"             TRUE)

--- a/examples/all-clusters-app/nxp/zephyr/boards/rd_rw612_bga_ethernet.overlay
+++ b/examples/all-clusters-app/nxp/zephyr/boards/rd_rw612_bga_ethernet.overlay
@@ -1,0 +1,18 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http: //www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "rd_rw612_bga.overlay"

--- a/examples/all-clusters-app/nxp/zephyr/boards/rd_rw612_bga_ethernet_fdata.conf
+++ b/examples/all-clusters-app/nxp/zephyr/boards/rd_rw612_bga_ethernet_fdata.conf
@@ -1,0 +1,23 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=16
+
+# 0xA226
+CONFIG_CHIP_DEVICE_PRODUCT_ID=41510
+CONFIG_CHIP_DEVICE_PRODUCT_URL="https://www.nxp.com/products/wireless-connectivity/wi-fi-plus-bluetooth-plus-802-15-4/wireless-mcu-with-integrated-tri-radio-1x1-wi-fi-6-plus-bluetooth-low-energy-5-3-802-15-4:RW612"
+CONFIG_CHIP_DEVICE_PRODUCT_LABEL="RW612"
+CONFIG_CHIP_DEVICE_PART_NUMBER="RW612"

--- a/examples/all-clusters-app/nxp/zephyr/prj_ethernet.conf
+++ b/examples/all-clusters-app/nxp/zephyr/prj_ethernet.conf
@@ -1,0 +1,27 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Options needed for Ethernet are located in this file
+
+# ethernet discriminator
+CONFIG_CHIP_DEVICE_DISCRIMINATOR=0x700
+
+CONFIG_CHIP_WIFI=n
+CONFIG_CHIP_ETHERNET=y
+
+CONFIG_NET_DEFAULT_IF_WIFI=n
+CONFIG_BT=n
+CONFIG_BT_DEVICE_NAME=""

--- a/examples/laundry-washer-app/nxp/zephyr/boards/rd_rw612_bga_ethernet.overlay
+++ b/examples/laundry-washer-app/nxp/zephyr/boards/rd_rw612_bga_ethernet.overlay
@@ -1,0 +1,18 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http: //www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "rd_rw612_bga.overlay"

--- a/examples/laundry-washer-app/nxp/zephyr/boards/rd_rw612_bga_ethernet_fdata.conf
+++ b/examples/laundry-washer-app/nxp/zephyr/boards/rd_rw612_bga_ethernet_fdata.conf
@@ -1,0 +1,23 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=16
+
+# 0xA226
+CONFIG_CHIP_DEVICE_PRODUCT_ID=41510
+CONFIG_CHIP_DEVICE_PRODUCT_URL="https://www.nxp.com/products/wireless-connectivity/wi-fi-plus-bluetooth-plus-802-15-4/wireless-mcu-with-integrated-tri-radio-1x1-wi-fi-6-plus-bluetooth-low-energy-5-3-802-15-4:RW612"
+CONFIG_CHIP_DEVICE_PRODUCT_LABEL="RW612"
+CONFIG_CHIP_DEVICE_PART_NUMBER="RW612"

--- a/examples/laundry-washer-app/nxp/zephyr/prj_ethernet.conf
+++ b/examples/laundry-washer-app/nxp/zephyr/prj_ethernet.conf
@@ -1,0 +1,27 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Options needed for Ethernet are located in this file
+
+# ethernet discriminator
+CONFIG_CHIP_DEVICE_DISCRIMINATOR=0x700
+
+CONFIG_CHIP_WIFI=n
+CONFIG_CHIP_ETHERNET=y
+
+CONFIG_NET_DEFAULT_IF_WIFI=n
+CONFIG_BT=n
+CONFIG_BT_DEVICE_NAME=""

--- a/examples/platform/nxp/common/app_task/include/AppTaskBase.h
+++ b/examples/platform/nxp/common/app_task/include/AppTaskBase.h
@@ -149,6 +149,8 @@ public:
      */
 #if CONFIG_CHIP_WIFI || CHIP_DEVICE_CONFIG_ENABLE_WPA
     virtual chip::DeviceLayer::NetworkCommissioning::WiFiDriver * GetWifiDriverInstance(void) = 0;
+#elif CONFIG_CHIP_ETHERNET
+    virtual chip::DeviceLayer::NetworkCommissioning::EthernetDriver * GetEthernetDriverInstance(void) = 0;
 #endif
 
     /**

--- a/examples/platform/nxp/common/app_task/include/AppTaskZephyr.h
+++ b/examples/platform/nxp/common/app_task/include/AppTaskZephyr.h
@@ -51,6 +51,8 @@ public:
      */
 #if defined(CONFIG_CHIP_WIFI)
     virtual chip::DeviceLayer::NetworkCommissioning::WiFiDriver * GetWifiDriverInstance(void) override;
+#elif defined(CONFIG_CHIP_ETHERNET)
+    virtual chip::DeviceLayer::NetworkCommissioning::EthernetDriver * GetEthernetDriverInstance(void) override;
 #endif
 
     /**

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -115,6 +115,9 @@ chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 #if CONFIG_CHIP_WIFI || CHIP_DEVICE_CONFIG_ENABLE_WPA
 app::Clusters::NetworkCommissioning::Instance sNetworkCommissioningInstance(0,
                                                                             chip::NXP::App::GetAppTask().GetWifiDriverInstance());
+#elif CONFIG_CHIP_ETHERNET
+app::Clusters::NetworkCommissioning::Instance
+    sNetworkCommissioningInstance(0, chip::NXP::App::GetAppTask().GetEthernetDriverInstance());
 #endif
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER || (CONFIG_CHIP_TEST_EVENT && CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
@@ -288,6 +291,8 @@ CHIP_ERROR chip::NXP::App::AppTaskBase::Init()
 #ifdef ENABLE_CHIP_SHELL
     Shell::SetWiFiDriver(chip::NXP::App::GetAppTask().GetWifiDriverInstance());
 #endif
+#elif CONFIG_CHIP_ETHERNET
+    sNetworkCommissioningInstance.Init();
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
     if (err == CHIP_NO_ERROR)

--- a/examples/platform/nxp/common/app_task/source/AppTaskZephyr.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskZephyr.cpp
@@ -36,6 +36,10 @@
 #include "AppCLIBase.h"
 #endif
 
+#ifdef CONFIG_CHIP_ETHERNET
+#include <platform/nxp/zephyr/Ethernet/NxpEthDriver.h>
+#endif
+
 #if CONFIG_CHIP_FACTORY_DATA
 #include <platform/nxp/common/factory_data/FactoryDataProvider.h>
 #else
@@ -69,7 +73,13 @@ chip::DeviceLayer::NetworkCommissioning::WiFiDriver * chip::NXP::App::AppTaskZep
     return static_cast<chip::DeviceLayer::NetworkCommissioning::WiFiDriver *>(
         &(NetworkCommissioning::ZephyrWifiDriver::Instance()));
 }
-#endif // CONFIG_CHIP_WIFI
+#elif defined(CONFIG_CHIP_ETHERNET)
+chip::DeviceLayer::NetworkCommissioning::EthernetDriver * chip::NXP::App::AppTaskZephyr::GetEthernetDriverInstance()
+{
+    return static_cast<chip::DeviceLayer::NetworkCommissioning::EthernetDriver *>(
+        &(NetworkCommissioning::NxpEthDriver::Instance()));
+}
+#endif
 
 CHIP_ERROR chip::NXP::App::AppTaskZephyr::AppMatter_Register()
 {

--- a/examples/thermostat/nxp/zephyr/boards/rd_rw612_bga_ethernet.overlay
+++ b/examples/thermostat/nxp/zephyr/boards/rd_rw612_bga_ethernet.overlay
@@ -1,0 +1,18 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http: //www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "rd_rw612_bga.overlay"

--- a/examples/thermostat/nxp/zephyr/boards/rd_rw612_bga_ethernet_fdata.conf
+++ b/examples/thermostat/nxp/zephyr/boards/rd_rw612_bga_ethernet_fdata.conf
@@ -1,0 +1,23 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=16
+
+# 0xA226
+CONFIG_CHIP_DEVICE_PRODUCT_ID=41510
+CONFIG_CHIP_DEVICE_PRODUCT_URL="https://www.nxp.com/products/wireless-connectivity/wi-fi-plus-bluetooth-plus-802-15-4/wireless-mcu-with-integrated-tri-radio-1x1-wi-fi-6-plus-bluetooth-low-energy-5-3-802-15-4:RW612"
+CONFIG_CHIP_DEVICE_PRODUCT_LABEL="RW612"
+CONFIG_CHIP_DEVICE_PART_NUMBER="RW612"

--- a/examples/thermostat/nxp/zephyr/prj_ethernet.conf
+++ b/examples/thermostat/nxp/zephyr/prj_ethernet.conf
@@ -1,0 +1,27 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Options needed for Ethernet are located in this file
+
+# ethernet discriminator
+CONFIG_CHIP_DEVICE_DISCRIMINATOR=0x700
+
+CONFIG_CHIP_WIFI=n
+CONFIG_CHIP_ETHERNET=y
+
+CONFIG_NET_DEFAULT_IF_WIFI=n
+CONFIG_BT=n
+CONFIG_BT_DEVICE_NAME=""

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -515,6 +515,7 @@ def BuildNxpTarget():
         TargetPart('k32w0', board=NxpBoard.K32W0),
         TargetPart('k32w1', board=NxpBoard.K32W1),
         TargetPart('rw61x', board=NxpBoard.RW61X),
+        TargetPart('rw61x_eth', board=NxpBoard.RW61X_ETH),
         TargetPart('mcxw71', board=NxpBoard.MCXW71)
     ])
 
@@ -544,6 +545,7 @@ def BuildNxpTarget():
     target.AppendModifier(name="sw-v2", has_sw_version_2=True)
     target.AppendModifier(name="ota", enable_ota=True).ExceptIfRe('zephyr')
     target.AppendModifier(name="wifi", enable_wifi=True).OnlyIfRe('rw61x')
+    target.AppendModifier(name="ethernet", enable_ethernet=True).OnlyIfRe('rw61x_eth-zephyr')
     target.AppendModifier(name="thread", enable_thread=True).ExceptIfRe('zephyr')
     target.AppendModifier(name="matter-shell", enable_shell=True).ExceptIfRe('k32w0|k32w1')
     target.AppendModifier('data-model-disabled', data_model_interface="disabled").ExceptIfRe('-data-model-enabled')

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -39,6 +39,7 @@ class NxpBoard(Enum):
     K32W0 = auto()
     K32W1 = auto()
     RW61X = auto()
+    RW61X_ETH = auto()
     MCXW71 = auto()
 
     def Name(self, os_env):
@@ -46,9 +47,12 @@ class NxpBoard(Enum):
             return 'k32w0x'
         elif self == NxpBoard.K32W1:
             return 'k32w1'
-        elif self == NxpBoard.RW61X:
+        elif (self == NxpBoard.RW61X) or (self == NxpBoard.RW61X_ETH):
             if os_env == NxpOsUsed.ZEPHYR:
-                return 'rd_rw612_bga'
+                if self == NxpBoard.RW61X_ETH:
+                    return 'rd_rw612_bga/rw612/ethernet'
+                else:
+                    return 'rd_rw612_bga'
             else:
                 return 'rw61x'
         elif self == NxpBoard.MCXW71:
@@ -61,7 +65,7 @@ class NxpBoard(Enum):
             return 'k32w0'
         elif self == NxpBoard.K32W1:
             return 'k32w1'
-        elif self == NxpBoard.RW61X:
+        elif (self == NxpBoard.RW61X) or (self == NxpBoard.RW61X_ETH):
             if os_env == NxpOsUsed.ZEPHYR:
                 return 'zephyr'
             else:
@@ -135,6 +139,7 @@ class NxpBuilder(GnBuilder):
                  disable_ble: bool = False,
                  enable_thread: bool = False,
                  enable_wifi: bool = False,
+                 enable_ethernet: bool = False,
                  disable_ipv4: bool = False,
                  enable_shell: bool = False,
                  enable_ota: bool = False,
@@ -159,6 +164,7 @@ class NxpBuilder(GnBuilder):
         self.disable_ble = disable_ble
         self.enable_thread = enable_thread
         self.enable_wifi = enable_wifi
+        self.enable_ethernet = enable_ethernet
         self.enable_ota = enable_ota
         self.enable_shell = enable_shell
         self.data_model_interface = data_model_interface
@@ -220,6 +226,9 @@ class NxpBuilder(GnBuilder):
         args = []
         if self.enable_factory_data:
             args.append('-DFILE_SUFFIX=fdata')
+
+        if self.enable_ethernet:
+            args.append('-DEXTRA_CONF_FILE="prj_ethernet.conf"')
 
         if self.has_sw_version_2:
             args.append('-DCONFIG_CHIP_DEVICE_SOFTWARE_VERSION=2')

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -13,7 +13,7 @@ linux-{x64,arm64}-{rpc-console,all-clusters,all-clusters-minimal,chip-tool,therm
 linux-x64-efr32-test-runner[-clang]
 imx-{chip-tool,lighting-app,thermostat,all-clusters-app,all-clusters-minimal-app,ota-provider-app}[-release]
 infineon-psoc6-{lock,light,all-clusters,all-clusters-minimal}[-ota][-updateimage][-trustm]
-nxp-{k32w0,k32w1,rw61x,mcxw71}-{zephyr,freertos}-{lighting,contact-sensor,lock-app,all-clusters,laundry-washer,thermostat}[-factory][-low-power][-lit][-fro32k][-smu2][-dac-conversion][-rotating-id][-sw-v2][-ota][-wifi][-thread][-matter-shell][-data-model-disabled][-data-model-enabled]
+nxp-{k32w0,k32w1,rw61x,rw61x_eth,mcxw71}-{zephyr,freertos}-{lighting,contact-sensor,lock-app,all-clusters,laundry-washer,thermostat}[-factory][-low-power][-lit][-fro32k][-smu2][-dac-conversion][-rotating-id][-sw-v2][-ota][-wifi][-ethernet][-thread][-matter-shell][-data-model-disabled][-data-model-enabled]
 mbed-cy8cproto_062_4343w-{lock,light,all-clusters,all-clusters-minimal,pigweed,ota-requestor,shell}[-release][-develop][-debug][-data-model-disabled][-data-model-enabled]
 mw320-all-clusters-app
 nrf-{nrf5340dk,nrf52840dk,nrf52840dongle}-{all-clusters,all-clusters-minimal,lock,light,light-switch,shell,pump,pump-controller,window-covering}[-rpc][-data-model-disabled][-data-model-enabled]

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -227,8 +227,13 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI || CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     const net_if * const iface = InetUtils::GetWiFiInterface();
+#else
+    const net_if * const iface = InetUtils::GetInterface();
+#endif
+
     VerifyOrReturnError(iface != nullptr, CHIP_ERROR_INTERNAL);
 
     const auto linkAddrStruct = iface->if_dev->link_addr;

--- a/src/platform/nxp/zephyr/BUILD.gn
+++ b/src/platform/nxp/zephyr/BUILD.gn
@@ -23,9 +23,6 @@ static_library("nxp_zephyr") {
   defines = []
   sources = [
     "../../SingletonConfigurationManager.cpp",
-    "../../Zephyr/BLEAdvertisingArbiter.cpp",
-    "../../Zephyr/BLEAdvertisingArbiter.h",
-    "../../Zephyr/BLEManagerImpl.cpp",
     "../../Zephyr/ConfigurationManagerImpl.cpp",
     "../../Zephyr/DiagnosticDataProviderImpl.cpp",
     "../../Zephyr/DiagnosticDataProviderImpl.h",
@@ -37,8 +34,6 @@ static_library("nxp_zephyr") {
     "../../Zephyr/ZephyrConfig.h",
     "../common/CHIPDeviceNXPPlatformDefaultConfig.h",
     "../common/CHIPNXPPlatformDefaultConfig.h",
-    "BLEManagerImpl.h",
-    "BlePlatformConfig.h",
     "CHIPDevicePlatformConfig.h",
     "CHIPDevicePlatformEvent.h",
     "CHIPPlatformConfig.h",
@@ -81,11 +76,17 @@ static_library("nxp_zephyr") {
       "DeviceInstanceInfoProviderImpl.h",
     ]
   }
-
+  if (chip_config_network_layer_ble) {
+    sources += [
+      "../../Zephyr/BLEAdvertisingArbiter.cpp",
+      "../../Zephyr/BLEAdvertisingArbiter.h",
+      "../../Zephyr/BLEManagerImpl.cpp",
+      "BLEManagerImpl.h",
+      "BlePlatformConfig.h",
+    ]
+  }
   if (chip_enable_wifi) {
     sources += [
-      "../../Zephyr/InetUtils.cpp",
-      "../../Zephyr/InetUtils.h",
       "../../Zephyr/wifi/ConnectivityManagerImplWiFi.cpp",
       "../../Zephyr/wifi/ConnectivityManagerImplWiFi.h",
       "../../Zephyr/wifi/WiFiManager.cpp",
@@ -94,14 +95,29 @@ static_library("nxp_zephyr") {
       "../../Zephyr/wifi/ZephyrWifiDriver.h",
     ]
   }
-
+  if (chip_enable_ethernet) {
+    sources += [
+      "Ethernet/ConnectivityManagerImplEth.cpp",
+      "Ethernet/ConnectivityManagerImplEth.h",
+      "Ethernet/EthManager.cpp",
+      "Ethernet/EthManager.h",
+      "Ethernet/NxpEthDriver.cpp",
+      "Ethernet/NxpEthDriver.h",
+    ]
+  }
   if (chip_enable_ota_requestor) {
     sources += [
       "ota/OTAImageProcessorImpl.cpp",
       "ota/OTAImageProcessorImpl.h",
     ]
   }
-
+  if (chip_enable_wifi || chip_enable_ethernet)
+  {
+    sources += [
+      "../../Zephyr/InetUtils.cpp",
+      "../../Zephyr/InetUtils.h",
+    ]
+  }
   if (chip_malloc_sys_heap) {
     sources += [ "../../Zephyr/SysHeapMalloc.cpp" ]
   }

--- a/src/platform/nxp/zephyr/BUILD.gn
+++ b/src/platform/nxp/zephyr/BUILD.gn
@@ -111,8 +111,7 @@ static_library("nxp_zephyr") {
       "ota/OTAImageProcessorImpl.h",
     ]
   }
-  if (chip_enable_wifi || chip_enable_ethernet)
-  {
+  if (chip_enable_wifi || chip_enable_ethernet) {
     sources += [
       "../../Zephyr/InetUtils.cpp",
       "../../Zephyr/InetUtils.h",

--- a/src/platform/nxp/zephyr/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/zephyr/ConnectivityManagerImpl.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR JoinLeaveMulticastGroup(net_if * iface, const Inet::IPAddress & addre
     }
 #endif
 
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI || CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
     // The following code should also be valid for other interface types, such as Ethernet,
     // but they are not officially supported, so for now enable it for Wi-Fi only.
     const in6_addr in6Addr = InetUtils::ToZephyrAddr(address);
@@ -104,11 +104,14 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_Init();
 #endif
+
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     ReturnErrorOnFailure(InitWiFi());
+#elif CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+    ReturnErrorOnFailure(InitEth());
 #endif
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD || CHIP_DEVICE_CONFIG_ENABLE_WIFI
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD || CHIP_DEVICE_CONFIG_ENABLE_WIFI || CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
     UDPEndPointImplSockets::SetMulticastGroupHandler(
         [](InterfaceId interfaceId, const IPAddress & address, UDPEndPointImplSockets::MulticastOperation operation) {
             if (interfaceId.IsPresent())

--- a/src/platform/nxp/zephyr/ConnectivityManagerImpl.h
+++ b/src/platform/nxp/zephyr/ConnectivityManagerImpl.h
@@ -41,6 +41,10 @@
 #include <platform/internal/GenericConnectivityManagerImpl_NoWiFi.h>
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+#include "Ethernet/ConnectivityManagerImplEth.h"
+#endif
+
 #include <lib/support/logging/CHIPLogging.h>
 
 namespace chip {
@@ -70,6 +74,9 @@ class ConnectivityManagerImpl final : public ConnectivityManager,
                                       public Internal::GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>,
 #else
                                       public Internal::GenericConnectivityManagerImpl_NoThread<ConnectivityManagerImpl>,
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+                                      public ConnectivityManagerImplEth,
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
                                       public ConnectivityManagerImplWiFi

--- a/src/platform/nxp/zephyr/Ethernet/ConnectivityManagerImplEth.cpp
+++ b/src/platform/nxp/zephyr/Ethernet/ConnectivityManagerImplEth.cpp
@@ -1,0 +1,38 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "EthManager.h"
+
+#include <platform/CommissionableDataProvider.h>
+#include <platform/ConnectivityManager.h>
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+#include "ConnectivityManagerImplEth.h"
+
+#if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+using namespace ::chip;
+namespace chip {
+namespace DeviceLayer {
+CHIP_ERROR ConnectivityManagerImplEth::InitEth()
+{
+    return EthManager::Instance().Init();
+}
+} // namespace DeviceLayer
+} // namespace chip
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET

--- a/src/platform/nxp/zephyr/Ethernet/ConnectivityManagerImplEth.h
+++ b/src/platform/nxp/zephyr/Ethernet/ConnectivityManagerImplEth.h
@@ -1,0 +1,35 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/support/logging/CHIPLogging.h>
+#include <platform/ConnectivityManager.h>
+
+namespace chip {
+namespace DeviceLayer {
+class ConnectivityManagerImplEth
+{
+    friend class ConnectivityManager;
+    friend class EthManager;
+
+protected:
+    CHIP_ERROR InitEth();
+};
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nxp/zephyr/Ethernet/EthManager.cpp
+++ b/src/platform/nxp/zephyr/Ethernet/EthManager.cpp
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    Copyright 2024 NXP
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "EthManager.h"
+
+#include <inet/InetInterface.h>
+#include <inet/UDPEndPointImplSockets.h>
+
+#include <lib/support/logging/CHIPLogging.h>
+
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/Zephyr/InetUtils.h>
+
+#include <zephyr/net/net_if.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+CHIP_ERROR EthManager::Init()
+{
+    ChipLogDetail(DeviceLayer, "EthManager has been initialized");
+    return CHIP_NO_ERROR;
+}
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nxp/zephyr/Ethernet/EthManager.h
+++ b/src/platform/nxp/zephyr/Ethernet/EthManager.h
@@ -1,0 +1,40 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    Copyright 2024 NXP
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <system/SystemLayer.h>
+
+namespace chip {
+namespace DeviceLayer {
+class EthManager
+{
+public:
+    static EthManager & Instance()
+    {
+        static EthManager sInstance;
+        return sInstance;
+    }
+    CHIP_ERROR Init();
+};
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nxp/zephyr/Ethernet/NxpEthDriver.cpp
+++ b/src/platform/nxp/zephyr/Ethernet/NxpEthDriver.cpp
@@ -1,0 +1,36 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "NxpEthDriver.h"
+
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
+
+using namespace ::chip;
+namespace chip {
+namespace DeviceLayer {
+namespace NetworkCommissioning {
+
+CHIP_ERROR NxpEthDriver::Init(NetworkStatusChangeCallback * networkStatusChangeCallback)
+{
+    return CHIP_NO_ERROR;
+}
+
+} // namespace NetworkCommissioning
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nxp/zephyr/Ethernet/NxpEthDriver.h
+++ b/src/platform/nxp/zephyr/Ethernet/NxpEthDriver.h
@@ -1,0 +1,78 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    Copyright 2024 NXP
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "EthManager.h"
+
+#include <platform/NetworkCommissioning.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace NetworkCommissioning {
+class NxpEthDriver final : public EthernetDriver
+{
+public:
+    class EthernetNetworkIterator final : public NetworkIterator
+    {
+    public:
+        EthernetNetworkIterator(NxpEthDriver * aDriver) : mDriver(aDriver) {}
+        size_t Count() { return 1; }
+        bool Next(Network & item) override
+        {
+            if (exhausted)
+            {
+                return false;
+            }
+            exhausted = true;
+            memcpy(item.networkID, interfaceName, interfaceNameLen);
+            item.networkIDLen = interfaceNameLen;
+            item.connected    = true;
+            return true;
+        }
+        void Release() override { delete this; }
+        ~EthernetNetworkIterator() = default;
+
+        uint8_t interfaceName[kMaxNetworkIDLen];
+        uint8_t interfaceNameLen = 0;
+        bool exhausted           = false;
+
+    private:
+        NxpEthDriver * mDriver;
+    };
+
+    // BaseDriver
+    NetworkIterator * GetNetworks() override { return new EthernetNetworkIterator(this); };
+    uint8_t GetMaxNetworks() { return 1; }
+    CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
+    void Shutdown()
+    {
+        // TODO: This method can be implemented if Ethernet is used along with Wifi/Thread.
+    }
+
+    static NxpEthDriver & Instance()
+    {
+        static NxpEthDriver instance;
+        return instance;
+    }
+};
+
+} // namespace NetworkCommissioning
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nxp/zephyr/args.gni
+++ b/src/platform/nxp/zephyr/args.gni
@@ -17,6 +17,7 @@ declare_args() {
 
   # Enable factory data support
   chip_enable_factory_data = false
+
   # Enable Ethernet support
   chip_enable_ethernet = false
 }

--- a/src/platform/nxp/zephyr/args.gni
+++ b/src/platform/nxp/zephyr/args.gni
@@ -17,4 +17,6 @@ declare_args() {
 
   # Enable factory data support
   chip_enable_factory_data = false
+  # Enable Ethernet support
+  chip_enable_ethernet = false
 }

--- a/src/platform/telink/CHIPDevicePlatformConfig.h
+++ b/src/platform/telink/CHIPDevicePlatformConfig.h
@@ -103,6 +103,11 @@
 #define CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP 0
 #endif
 
+// telink platform does not support ethernet yet, but we need this config defined as we share the Zephyr platform
+#ifndef CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+#define CHIP_DEVICE_CONFIG_ENABLE_ETHERNET 0
+#endif // CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
+
 #ifdef CONFIG_BT
 #define CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE CONFIG_BT
 #else


### PR DESCRIPTION
* Enable Ethernet for RW61x platform
* Add ethernet support in following examples:
  * All-clusters-app
  * Laudry washer
  * Thermostat
* Support ethernet build with build_examples.py and add it to workflows