### PR TITLE
[DNS-SD] Common Resolution Data such as the idle interval, active int…

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -409,7 +409,6 @@ void DnssdService::ToDiscoveredCommissionNodeData(const Span<Inet::IPAddress> & 
         ByteSpan key(reinterpret_cast<const uint8_t *>(mTextEntries[i].mKey), strlen(mTextEntries[i].mKey));
         ByteSpan val(mTextEntries[i].mData, mTextEntries[i].mDataSize);
         FillNodeDataFromTxt(key, val, discoveredData);
-        FillNodeDataFromTxt(key, val, discoveredData);
     }
 }
 

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -262,6 +262,7 @@ void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, CommissionN
         nodeData.supportsCommissionerGeneratedPasscode = Internal::GetCommissionerPasscode(val);
         break;
     default:
+        FillNodeDataFromTxt(key, val, static_cast<CommonResolutionData &>(nodeData));
         break;
     }
 }


### PR DESCRIPTION
…erval, etc... are ignored by the dnssd platform discovery code when a commissionable node is discovered

#### Problem

By altering the logs (#35649) used with the _ReliableMessageMgr_ I found out that https://github.com/project-chip/connectedhomeip/pull/33025 has regressed the discovery code such that the some of the values advertise by accessories are ignored.

The list of ignored values are:
 * Session Idle Interval
 * Session Active Interval
 * Session Active Threshold
 * TCP Supported
 * Long Idle Time ICD

Concretely it means the the _PBKDFParamRequest_ use to establish a **PASE** session defaults to the default **MRP** values defined in the spec, not the one advertised by the accessory.
