### PR TITLE
[Logging] Use the ephemeral initiator node id in the logging message …

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -332,6 +332,10 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
 #if CHIP_PROGRESS_LOGGING
         destination = kUndefinedNodeId;
         fabricIndex = kUndefinedFabricIndex;
+        if (session->GetSessionRole() == Transport::UnauthenticatedSession::SessionRole::kResponder)
+        {
+            destination = session->GetEphemeralInitiatorNodeID();
+        }
 #endif // CHIP_PROGRESS_LOGGING
     }
     break;


### PR DESCRIPTION
…when the responder transmit a message

#### Problem

When logging _TX_ unauthenticated messages in https://github.com/project-chip/connectedhomeip/blob/2396bb429a9d81ccb542d1acbb4837a5e5ea7e87/src/transport/SessionManager.cpp#L388 the `destination` is set to `kUndefinedNodeId` but the responder normally set the destination to the _ephemeral initiator node id_ 

When messages are received  (_RX_ logs) the ephemeral initial node id is printed correctly but not when they are transmitted. 