### PR TITLE
Clean up fabric sync log files upon exit to ensure a new log file is generated during the next run.

### DIFF
--- a/examples/fabric-admin/scripts/stop_fabric_sync.sh
+++ b/examples/fabric-admin/scripts/stop_fabric_sync.sh
@@ -25,4 +25,3 @@ echo "Removed /tmp/chip_* files and directories."
 rm /tmp/fabric_admin.log
 rm /tmp/fabric_bridge_app.log
 echo "Removed fabric sync log files."
-

--- a/examples/fabric-admin/scripts/stop_fabric_sync.sh
+++ b/examples/fabric-admin/scripts/stop_fabric_sync.sh
@@ -21,5 +21,8 @@ fi
 
 # Remove /tmp/chip_* files and directories
 rm -rf /tmp/chip_*
-rm -rf /tmp/*.log
-echo "Removed /tmp/chip_* files and directories"
+echo "Removed /tmp/chip_* files and directories."
+rm /tmp/fabric_admin.log
+rm /tmp/fabric_bridge_app.log
+echo "Removed fabric sync log files."
+

--- a/examples/fabric-admin/scripts/stop_fabric_sync.sh
+++ b/examples/fabric-admin/scripts/stop_fabric_sync.sh
@@ -21,4 +21,5 @@ fi
 
 # Remove /tmp/chip_* files and directories
 rm -rf /tmp/chip_*
+rm -rf /tmp/*.log
 echo "Removed /tmp/chip_* files and directories"


### PR DESCRIPTION
Clean up fabric sync log files upon exit to ensure a new log file is generated during the next run.

