### PR TITLE
Tracing: Create leading directories if they don't exist

### DIFF
--- a/src/controller/python/chip/tracing/TracingSetup.cpp
+++ b/src/controller/python/chip/tracing/TracingSetup.cpp
@@ -34,7 +34,7 @@ chip::Tracing::Perfetto::PerfettoBackend gPerfettoBackend;
 
 } // namespace
 
-extern "C" void pychip_tracing_start_json_log(const char * file_name)
+extern "C" void pychip_tracing_start_json_log()
 {
     chip::MainLoopWork::ExecuteInMainLoop([] {
         gJsonBackend.CloseFile(); // just in case, ensure no file output

--- a/src/controller/python/chip/tracing/__init__.py
+++ b/src/controller/python/chip/tracing/__init__.py
@@ -115,9 +115,6 @@ class TracingContext:
         else:
             raise ValueError("Invalid trace-to destination: %r", destination)
 
-    def __init__(self):
-        pass
-
     def __enter__(self):
         return self
 

--- a/src/tracing/json/json_tracing.cpp
+++ b/src/tracing/json/json_tracing.cpp
@@ -31,6 +31,7 @@
 
 #include <errno.h>
 
+#include <filesystem>
 #include <sstream>
 #include <string>
 
@@ -461,8 +462,16 @@ void JsonBackend::CloseFile()
 CHIP_ERROR JsonBackend::OpenFile(const char * path)
 {
     CloseFile();
-    mOutputFile.open(path, std::ios_base::out);
 
+    std::error_code ec;
+    std::filesystem::path filePath(path);
+    // Create directories if they don't exist
+    if (!std::filesystem::create_directories(filePath.remove_filename(), ec))
+    {
+        return CHIP_ERROR_POSIX(ec.value());
+    }
+
+    mOutputFile.open(path, std::ios_base::out);
     if (!mOutputFile)
     {
         return CHIP_ERROR_POSIX(errno);

--- a/src/tracing/perfetto/file_output.cpp
+++ b/src/tracing/perfetto/file_output.cpp
@@ -24,6 +24,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <filesystem>
 
 namespace chip {
 namespace Tracing {
@@ -36,6 +37,14 @@ CHIP_ERROR FileTraceOutput::Open(const char * file_name)
 
     // Close any existing files
     Close();
+
+    std::error_code ec;
+    std::filesystem::path filePath(file_name);
+    // Create directories if they don't exist
+    if (!std::filesystem::create_directories(filePath.remove_filename(), ec))
+    {
+        return CHIP_ERROR_POSIX(ec.value());
+    }
 
     // Create a trace file and start sending data to it
     mTraceFileId = open(file_name, O_RDWR | O_CREAT | O_TRUNC, 0640);


### PR DESCRIPTION
### Problem

When running `python3 ./src/python_testing/execute_python_tests.py --env-file test-env.yaml --search-directory src/python_testing` locally without creating `out/trace_data` everything hangs without any meaningful output. The problem is that the output from test scripts is silenced and in case of missing `out/trace_data` the tracing fails which hangs everything.

### Changes

- Create trace file leading directories if they do not exist

### Testing

Tested locally that now tests work without pre-creating `out/trace_data` directory.

