### PR TITLE
ESP32 Ethernet: Added new PHY support

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -768,6 +768,53 @@ menu "CHIP Device Layer"
             help
                 Set PHY address according your board schematic.
 
+        choice ETH_PHY_MODEL
+            prompt "Ethernet PHY Device"
+            default ETH_PHY_IP101
+            help
+                Select the Ethernet PHY device to use in the example.
+
+            config ETH_PHY_IP101
+                bool "IP101"
+                help
+                    IP101 is a single port 10/100 MII/RMII/TP/Fiber Fast Ethernet Transceiver.
+                    Goto http://www.icplus.com.tw/pp-IP101G.html for more information about it.
+
+            config ETH_PHY_RTL8201
+                bool "RTL8201/SR8201"
+                help
+                    RTL8201F/SR8201F is a single port 10/100Mb Ethernet Transceiver with auto MDIX.
+                    Goto http://www.corechip-sz.com/productsview.asp?id=22 for more information about it.
+
+            config ETH_PHY_LAN87XX
+                bool "LAN87xx"
+                help
+                    Below chips are supported:
+                    LAN8710A is a small footprint MII/RMII 10/100 Ethernet Transceiver with HP Auto-MDIX and
+                        flexPWR® Technology.
+                    LAN8720A is a small footprint RMII 10/100 Ethernet Transceiver with HP Auto-MDIX Support.
+                    LAN8740A/LAN8741A is a small footprint MII/RMII 10/100 Energy Efficient Ethernet Transceiver
+                        with HP Auto-MDIX and flexPWR® Technology.
+                    LAN8742A is a small footprint RMII 10/100 Ethernet Transceiver with HP Auto-MDIX and
+                        flexPWR® Technology.
+                    Goto https://www.microchip.com for more information about them.
+
+            config ETH_PHY_DP83848
+                bool "DP83848"
+                help
+                    DP83848 is a single port 10/100Mb/s Ethernet Physical Layer Transceiver.
+                    Goto http://www.ti.com/product/DP83848J for more information about it.
+
+            config ETH_PHY_KSZ80XX
+                bool "KSZ80xx"
+                help
+                    With the KSZ80xx series, Microchip offers single-chip 10BASE-T/100BASE-TX
+                    Ethernet Physical Layer Transceivers (PHY).
+                    The following chips are supported: KSZ8001, KSZ8021, KSZ8031, KSZ8041,
+                        KSZ8051, KSZ8061, KSZ8081, KSZ8091
+                    Goto https://www.microchip.com for more information about them.
+        endchoice # ETH_PHY_MODEL
+
     endmenu
 
     menu "Commissioning options"

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -768,25 +768,25 @@ menu "CHIP Device Layer"
             help
                 Set PHY address according your board schematic.
 
-        choice ETH_PHY_MODEL
+        choice ETH_PHY_TYPE
             prompt "Ethernet PHY Device"
-            default ETH_PHY_IP101
+            default ETH_PHY_TYPE_IP101
             help
                 Select the Ethernet PHY device to use in the example.
 
-            config ETH_PHY_IP101
+            config ETH_PHY_TYPE_IP101
                 bool "IP101"
                 help
                     IP101 is a single port 10/100 MII/RMII/TP/Fiber Fast Ethernet Transceiver.
                     Goto http://www.icplus.com.tw/pp-IP101G.html for more information about it.
 
-            config ETH_PHY_RTL8201
+            config ETH_PHY_TYPE_RTL8201
                 bool "RTL8201/SR8201"
                 help
                     RTL8201F/SR8201F is a single port 10/100Mb Ethernet Transceiver with auto MDIX.
                     Goto http://www.corechip-sz.com/productsview.asp?id=22 for more information about it.
 
-            config ETH_PHY_LAN87XX
+            config ETH_PHY_TYPE_LAN87XX
                 bool "LAN87xx"
                 help
                     Below chips are supported:
@@ -799,13 +799,13 @@ menu "CHIP Device Layer"
                         flexPWR® Technology.
                     Goto https://www.microchip.com for more information about them.
 
-            config ETH_PHY_DP83848
+            config ETH_PHY_TYPE_DP83848
                 bool "DP83848"
                 help
                     DP83848 is a single port 10/100Mb/s Ethernet Physical Layer Transceiver.
                     Goto http://www.ti.com/product/DP83848J for more information about it.
 
-            config ETH_PHY_KSZ80XX
+            config ETH_PHY_TYPE_KSZ80XX
                 bool "KSZ80xx"
                 help
                     With the KSZ80xx series, Microchip offers single-chip 10BASE-T/100BASE-TX

--- a/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
@@ -57,7 +57,21 @@ CHIP_ERROR ESPEthernetDriver::Init(NetworkStatusChangeCallback * networkStatusCh
     esp32_emac_config.smi_mdc_gpio_num        = CONFIG_ETH_MDC_GPIO;
     esp32_emac_config.smi_mdio_gpio_num       = CONFIG_ETH_MDIO_GPIO;
     esp_eth_mac_t * mac                       = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
-    esp_eth_phy_t * phy                       = esp_eth_phy_new_ip101(&phy_config);
+
+    // Based on https://github.com/espressif/esp-idf/tree/master/examples/ethernet/basic/components/ethernet_init
+#if CONFIG_ETH_PHY_IP101
+    esp_eth_phy_t *phy = esp_eth_phy_new_ip101(&phy_config);
+#elif CONFIG_ETH_PHY_RTL8201
+    esp_eth_phy_t *phy = esp_eth_phy_new_rtl8201(&phy_config);
+#elif CONFIG_ETH_PHY_LAN87XX
+    esp_eth_phy_t *phy = esp_eth_phy_new_lan87xx(&phy_config);
+#elif CONFIG_ETH_PHY_DP83848
+    esp_eth_phy_t *phy = esp_eth_phy_new_dp83848(&phy_config);
+#elif CONFIG_ETH_PHY_KSZ80XX
+    esp_eth_phy_t *phy = esp_eth_phy_new_ksz80xx(&phy_config);
+#else
+#error "Ethernet PHY not selected"
+#endif
 
     esp_eth_config_t config     = ETH_DEFAULT_CONFIG(mac, phy);
     esp_eth_handle_t eth_handle = NULL;

--- a/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
@@ -59,15 +59,15 @@ CHIP_ERROR ESPEthernetDriver::Init(NetworkStatusChangeCallback * networkStatusCh
     esp_eth_mac_t * mac                       = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
 
     // Based on https://github.com/espressif/esp-idf/tree/master/examples/ethernet/basic/components/ethernet_init
-#if CONFIG_ETH_PHY_IP101
+#if defined(CONFIG_ETH_PHY_IP101)
     esp_eth_phy_t * phy = esp_eth_phy_new_ip101(&phy_config);
-#elif CONFIG_ETH_PHY_RTL8201
+#elif defined(CONFIG_ETH_PHY_RTL8201)
     esp_eth_phy_t * phy = esp_eth_phy_new_rtl8201(&phy_config);
-#elif CONFIG_ETH_PHY_LAN87XX
+#elif defined(CONFIG_ETH_PHY_LAN87XX)
     esp_eth_phy_t * phy = esp_eth_phy_new_lan87xx(&phy_config);
-#elif CONFIG_ETH_PHY_DP83848
+#elif defined(CONFIG_ETH_PHY_DP83848)
     esp_eth_phy_t * phy = esp_eth_phy_new_dp83848(&phy_config);
-#elif CONFIG_ETH_PHY_KSZ80XX
+#elif defined(CONFIG_ETH_PHY_KSZ80XX)
     esp_eth_phy_t * phy = esp_eth_phy_new_ksz80xx(&phy_config);
 #else
 #error "Ethernet PHY not selected"

--- a/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
@@ -60,15 +60,15 @@ CHIP_ERROR ESPEthernetDriver::Init(NetworkStatusChangeCallback * networkStatusCh
 
     // Based on https://github.com/espressif/esp-idf/tree/master/examples/ethernet/basic/components/ethernet_init
 #if CONFIG_ETH_PHY_IP101
-    esp_eth_phy_t *phy = esp_eth_phy_new_ip101(&phy_config);
+    esp_eth_phy_t * phy = esp_eth_phy_new_ip101(&phy_config);
 #elif CONFIG_ETH_PHY_RTL8201
-    esp_eth_phy_t *phy = esp_eth_phy_new_rtl8201(&phy_config);
+    esp_eth_phy_t * phy = esp_eth_phy_new_rtl8201(&phy_config);
 #elif CONFIG_ETH_PHY_LAN87XX
-    esp_eth_phy_t *phy = esp_eth_phy_new_lan87xx(&phy_config);
+    esp_eth_phy_t * phy = esp_eth_phy_new_lan87xx(&phy_config);
 #elif CONFIG_ETH_PHY_DP83848
-    esp_eth_phy_t *phy = esp_eth_phy_new_dp83848(&phy_config);
+    esp_eth_phy_t * phy = esp_eth_phy_new_dp83848(&phy_config);
 #elif CONFIG_ETH_PHY_KSZ80XX
-    esp_eth_phy_t *phy = esp_eth_phy_new_ksz80xx(&phy_config);
+    esp_eth_phy_t * phy = esp_eth_phy_new_ksz80xx(&phy_config);
 #else
 #error "Ethernet PHY not selected"
 #endif

--- a/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
@@ -59,15 +59,15 @@ CHIP_ERROR ESPEthernetDriver::Init(NetworkStatusChangeCallback * networkStatusCh
     esp_eth_mac_t * mac                       = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
 
     // Based on https://github.com/espressif/esp-idf/tree/master/examples/ethernet/basic/components/ethernet_init
-#if defined(CONFIG_ETH_PHY_IP101)
+#if defined(CONFIG_ETH_PHY_TYPE_IP101)
     esp_eth_phy_t * phy = esp_eth_phy_new_ip101(&phy_config);
-#elif defined(CONFIG_ETH_PHY_RTL8201)
+#elif defined(CONFIG_ETH_PHY_TYPE_RTL8201)
     esp_eth_phy_t * phy = esp_eth_phy_new_rtl8201(&phy_config);
-#elif defined(CONFIG_ETH_PHY_LAN87XX)
+#elif defined(CONFIG_ETH_PHY_TYPE_LAN87XX)
     esp_eth_phy_t * phy = esp_eth_phy_new_lan87xx(&phy_config);
-#elif defined(CONFIG_ETH_PHY_DP83848)
+#elif defined(CONFIG_ETH_PHY_TYPE_DP83848)
     esp_eth_phy_t * phy = esp_eth_phy_new_dp83848(&phy_config);
-#elif defined(CONFIG_ETH_PHY_KSZ80XX)
+#elif defined(CONFIG_ETH_PHY_TYPE_KSZ80XX)
     esp_eth_phy_t * phy = esp_eth_phy_new_ksz80xx(&phy_config);
 #else
 #error "Ethernet PHY not selected"


### PR DESCRIPTION
ESP32 Ethernet: Added new PHY support

- RTL8201/SR8201
- LAN87xx
- DP83848
- KSZ80xx

Based on https://github.com/espressif/esp-idf/tree/master/examples/ethernet/basic/components/ethernet_init
