### PR TITLE
Additional socket checks for socket inet implementations

### DIFF
--- a/src/inet/TCPEndPointImplSockets.cpp
+++ b/src/inet/TCPEndPointImplSockets.cpp
@@ -69,7 +69,7 @@ namespace Inet {
 
 CHIP_ERROR TCPEndPointImplSockets::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr)
 {
-  CHIP_ERROR res = GetSocket(addrType);
+    CHIP_ERROR res = GetSocket(addrType);
 
     if (res == CHIP_NO_ERROR && reuseAddr)
     {
@@ -809,7 +809,7 @@ void TCPEndPointImplSockets::HandlePendingIO(System::SocketEvents events)
 #else  // __MBED__
        // On Mbed OS, connect blocks and never returns EINPROGRESS
        // The socket option SO_ERROR is not available.
-            int osConRes     = 0;
+            int osConRes = 0;
 #endif // !__MBED__
             CHIP_ERROR conRes = CHIP_ERROR_POSIX(osConRes);
 

--- a/src/inet/TCPEndPointImplSockets.cpp
+++ b/src/inet/TCPEndPointImplSockets.cpp
@@ -162,6 +162,9 @@ CHIP_ERROR TCPEndPointImplSockets::ConnectImpl(const IPAddress & addr, uint16_t 
 
     ReturnErrorOnFailure(GetSocket(addrType));
 
+    // have to have a valid socket to send something with. Generally GetSocket ensures that
+    VerifyOrReturnValue(mSocket >= 0, CHIP_ERROR_INCORRECT_STATE);
+
     if (!intfId.IsPresent())
     {
         // The behavior when connecting to an IPv6 link-local address without specifying an outbound

--- a/src/inet/TCPEndPointImplSockets.cpp
+++ b/src/inet/TCPEndPointImplSockets.cpp
@@ -809,7 +809,7 @@ void TCPEndPointImplSockets::HandlePendingIO(System::SocketEvents events)
 #else  // __MBED__
        // On Mbed OS, connect blocks and never returns EINPROGRESS
        // The socket option SO_ERROR is not available.
-            int osConRes = 0;
+            int osConRes     = 0;
 #endif // !__MBED__
             CHIP_ERROR conRes = CHIP_ERROR_POSIX(osConRes);
 

--- a/src/inet/TCPEndPointImplSockets.cpp
+++ b/src/inet/TCPEndPointImplSockets.cpp
@@ -71,9 +71,6 @@ CHIP_ERROR TCPEndPointImplSockets::BindImpl(IPAddressType addrType, const IPAddr
 {
     ReturnErrorOnFailure(GetSocket(addrType));
 
-    // need to be in a connected state to be able to bind
-    VerifyOrReturnError(mSocket >= 0, CHIP_ERROR_INCORRECT_STATE);
-
     if (reuseAddr)
     {
         int n = 1;
@@ -126,6 +123,7 @@ CHIP_ERROR TCPEndPointImplSockets::BindImpl(IPAddressType addrType, const IPAddr
         return INET_ERROR_WRONG_ADDRESS_TYPE;
     }
 
+    // NOLINTNEXTLINE(clang-analyzer-unix.StdCLibraryFunctions): GetSocket calls ensure mSocket is valid
     if (bind(mSocket, &sa.any, sockaddrsize) != 0)
     {
         return CHIP_ERROR_POSIX(errno);
@@ -161,9 +159,6 @@ CHIP_ERROR TCPEndPointImplSockets::ConnectImpl(const IPAddress & addr, uint16_t 
     IPAddressType addrType = addr.Type();
 
     ReturnErrorOnFailure(GetSocket(addrType));
-
-    // have to have a valid socket to send something with. Generally GetSocket ensures that
-    VerifyOrReturnValue(mSocket >= 0, CHIP_ERROR_INCORRECT_STATE);
 
     if (!intfId.IsPresent())
     {
@@ -248,6 +243,7 @@ CHIP_ERROR TCPEndPointImplSockets::ConnectImpl(const IPAddress & addr, uint16_t 
         return INET_ERROR_WRONG_ADDRESS_TYPE;
     }
 
+    // NOLINTNEXTLINE(clang-analyzer-unix.StdCLibraryFunctions): GetSocket calls ensure mSocket is valid
     int conRes = connect(mSocket, &sa.any, sockaddrsize);
 
     if (conRes == -1 && errno != EINPROGRESS)

--- a/src/inet/TCPEndPointImplSockets.cpp
+++ b/src/inet/TCPEndPointImplSockets.cpp
@@ -69,9 +69,12 @@ namespace Inet {
 
 CHIP_ERROR TCPEndPointImplSockets::BindImpl(IPAddressType addrType, const IPAddress & addr, uint16_t port, bool reuseAddr)
 {
-    CHIP_ERROR res = GetSocket(addrType);
+    ReturnErrorOnFailure(GetSocket(addrType));
 
-    if (res == CHIP_NO_ERROR && reuseAddr)
+    // need to be in a connected state to be able to bind
+    VerifyOrReturnError(mSocket >= 0, CHIP_ERROR_INCORRECT_STATE);
+
+    if (reuseAddr)
     {
         int n = 1;
         setsockopt(mSocket, SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n));
@@ -94,47 +97,41 @@ CHIP_ERROR TCPEndPointImplSockets::BindImpl(IPAddressType addrType, const IPAddr
 #endif // defined(SO_REUSEPORT)
     }
 
-    if (res == CHIP_NO_ERROR)
+    SockAddr sa;
+    memset(&sa, 0, sizeof(sa));
+    socklen_t sockaddrsize = 0;
+
+    if (addrType == IPAddressType::kIPv6)
     {
-        SockAddr sa;
-        memset(&sa, 0, sizeof(sa));
-        socklen_t sockaddrsize = 0;
+        sa.in6.sin6_family   = AF_INET6;
+        sa.in6.sin6_port     = htons(port);
+        sa.in6.sin6_flowinfo = 0;
+        sa.in6.sin6_addr     = addr.ToIPv6();
+        sa.in6.sin6_scope_id = 0;
 
-        if (addrType == IPAddressType::kIPv6)
-        {
-            sa.in6.sin6_family   = AF_INET6;
-            sa.in6.sin6_port     = htons(port);
-            sa.in6.sin6_flowinfo = 0;
-            sa.in6.sin6_addr     = addr.ToIPv6();
-            sa.in6.sin6_scope_id = 0;
-
-            sockaddrsize = sizeof(sa.in6);
-        }
+        sockaddrsize = sizeof(sa.in6);
+    }
 #if INET_CONFIG_ENABLE_IPV4
-        else if (addrType == IPAddressType::kIPv4)
-        {
-            sa.in.sin_family = AF_INET;
-            sa.in.sin_port   = htons(port);
-            sa.in.sin_addr   = addr.ToIPv4();
+    else if (addrType == IPAddressType::kIPv4)
+    {
+        sa.in.sin_family = AF_INET;
+        sa.in.sin_port   = htons(port);
+        sa.in.sin_addr   = addr.ToIPv4();
 
-            sockaddrsize = sizeof(sa.in);
-        }
+        sockaddrsize = sizeof(sa.in);
+    }
 #endif // INET_CONFIG_ENABLE_IPV4
-        else
-        {
-            res = INET_ERROR_WRONG_ADDRESS_TYPE;
-        }
-
-        if (res == CHIP_NO_ERROR)
-        {
-            if (bind(mSocket, &sa.any, sockaddrsize) != 0)
-            {
-                res = CHIP_ERROR_POSIX(errno);
-            }
-        }
+    else
+    {
+        return INET_ERROR_WRONG_ADDRESS_TYPE;
     }
 
-    return res;
+    if (bind(mSocket, &sa.any, sockaddrsize) != 0)
+    {
+        return CHIP_ERROR_POSIX(errno);
+    }
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR TCPEndPointImplSockets::ListenImpl(uint16_t backlog)

--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -286,12 +286,12 @@ CHIP_ERROR UDPEndPointImplSockets::SendMsgImpl(const IPPacketInfo * aPktInfo, Sy
     // Ensure packet buffer is not null
     VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
 
-    // have to have a valid socket to send something with
-    VerifyOrReturnValue(mSocket >= 0, CHIP_ERROR_INCORRECT_STATE);
-
     // Make sure we have the appropriate type of socket based on the
     // destination address.
     ReturnErrorOnFailure(GetSocket(aPktInfo->DestAddress.Type()));
+
+    // have to have a valid socket to send something with. Generally GetSocket ensures that
+    VerifyOrReturnValue(mSocket >= 0, CHIP_ERROR_INCORRECT_STATE);
 
     // Ensure the destination address type is compatible with the endpoint address type.
     VerifyOrReturnError(mAddrType == aPktInfo->DestAddress.Type(), CHIP_ERROR_INVALID_ARGUMENT);

--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -93,8 +93,6 @@ namespace {
 
 CHIP_ERROR IPv6Bind(int socket, const IPAddress & address, uint16_t port, InterfaceId interface)
 {
-    VerifyOrReturnValue(socket >= 0, CHIP_ERROR_INVALID_ARGUMENT);
-
     struct sockaddr_in6 sa;
     memset(&sa, 0, sizeof(sa));
     sa.sin6_family                        = AF_INET6;
@@ -108,6 +106,8 @@ CHIP_ERROR IPv6Bind(int socket, const IPAddress & address, uint16_t port, Interf
     sa.sin6_scope_id = static_cast<decltype(sa.sin6_scope_id)>(interfaceId);
 
     CHIP_ERROR status = CHIP_NO_ERROR;
+
+    // NOLINTNEXTLINE(clang-analyzer-unix.StdCLibraryFunctions): Function called only with valid socket after GetSocket
     if (bind(socket, reinterpret_cast<const sockaddr *>(&sa), static_cast<unsigned>(sizeof(sa))) != 0)
     {
         status = CHIP_ERROR_POSIX(errno);
@@ -134,8 +134,6 @@ CHIP_ERROR IPv6Bind(int socket, const IPAddress & address, uint16_t port, Interf
 #if INET_CONFIG_ENABLE_IPV4
 CHIP_ERROR IPv4Bind(int socket, const IPAddress & address, uint16_t port)
 {
-    VerifyOrReturnValue(socket >= 0, CHIP_ERROR_INVALID_ARGUMENT);
-
     struct sockaddr_in sa;
     memset(&sa, 0, sizeof(sa));
     sa.sin_family = AF_INET;
@@ -143,6 +141,8 @@ CHIP_ERROR IPv4Bind(int socket, const IPAddress & address, uint16_t port)
     sa.sin_addr   = address.ToIPv4();
 
     CHIP_ERROR status = CHIP_NO_ERROR;
+
+    // NOLINTNEXTLINE(clang-analyzer-unix.StdCLibraryFunctions): Function called only with valid socket after GetSocket
     if (bind(socket, reinterpret_cast<const sockaddr *>(&sa), static_cast<unsigned>(sizeof(sa))) != 0)
     {
         status = CHIP_ERROR_POSIX(errno);
@@ -290,9 +290,6 @@ CHIP_ERROR UDPEndPointImplSockets::SendMsgImpl(const IPPacketInfo * aPktInfo, Sy
     // destination address.
     ReturnErrorOnFailure(GetSocket(aPktInfo->DestAddress.Type()));
 
-    // have to have a valid socket to send something with. Generally GetSocket ensures that
-    VerifyOrReturnValue(mSocket >= 0, CHIP_ERROR_INCORRECT_STATE);
-
     // Ensure the destination address type is compatible with the endpoint address type.
     VerifyOrReturnError(mAddrType == aPktInfo->DestAddress.Type(), CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -417,6 +414,7 @@ CHIP_ERROR UDPEndPointImplSockets::SendMsgImpl(const IPPacketInfo * aPktInfo, Sy
 #endif // INET_CONFIG_UDP_SOCKET_PKTINFO
 
     // Send IP packet.
+    // NOLINTNEXTLINE(clang-analyzer-unix.StdCLibraryFunctions): GetSocket calls ensure mSocket is valid
     const ssize_t lenSent = sendmsg(mSocket, &msgHeader, 0);
     if (lenSent == -1)
     {

--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -93,6 +93,8 @@ namespace {
 
 CHIP_ERROR IPv6Bind(int socket, const IPAddress & address, uint16_t port, InterfaceId interface)
 {
+    VerifyOrReturnValue(socket >= 0, CHIP_ERROR_INVALID_ARGUMENT);
+
     struct sockaddr_in6 sa;
     memset(&sa, 0, sizeof(sa));
     sa.sin6_family                        = AF_INET6;
@@ -132,6 +134,8 @@ CHIP_ERROR IPv6Bind(int socket, const IPAddress & address, uint16_t port, Interf
 #if INET_CONFIG_ENABLE_IPV4
 CHIP_ERROR IPv4Bind(int socket, const IPAddress & address, uint16_t port)
 {
+    VerifyOrReturnValue(socket >= 0, CHIP_ERROR_INVALID_ARGUMENT);
+
     struct sockaddr_in sa;
     memset(&sa, 0, sizeof(sa));
     sa.sin_family = AF_INET;
@@ -281,6 +285,9 @@ CHIP_ERROR UDPEndPointImplSockets::SendMsgImpl(const IPPacketInfo * aPktInfo, Sy
 {
     // Ensure packet buffer is not null
     VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
+
+    // have to have a valid socket to send something with
+    VerifyOrReturnValue(mSocket >= 0, CHIP_ERROR_INCORRECT_STATE);
 
     // Make sure we have the appropriate type of socket based on the
     // destination address.


### PR DESCRIPTION
#35644 pulled in a new pigweed which complains that bind/sendmsg should never be passed in negative arguments.

clang-tidy is unable to validate that GetSocket() is either an error or mSocket is valid. It thinks it can return something that `IsSuccess` while leaving mSocket invalid.

As a result, I added several `NOLINTNEXTLINE` entries.


