### PR TITLE
Mark setupDeviceForNodeID: on MTRDeviceController as abstract.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -1190,44 +1190,10 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     return [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:self];
 }
 
-// If prefetchedClusterData is not provided, load attributes individually from controller data store
 - (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData
 {
-    os_unfair_lock_assert_owner(self.deviceMapLock);
-
-    MTRDevice * deviceToReturn = [[MTRDevice_Concrete alloc] initWithNodeID:nodeID controller:self];
-    // If we're not running, don't add the device to our map.  That would
-    // create a cycle that nothing would break.  Just return the device,
-    // which will be in exactly the state it would be in if it were created
-    // while we were running and then we got shut down.
-    if ([self isRunning]) {
-        [_nodeIDToDeviceMap setObject:deviceToReturn forKey:nodeID];
-    }
-
-    if (prefetchedClusterData) {
-        if (prefetchedClusterData.count) {
-            [deviceToReturn setPersistedClusterData:prefetchedClusterData];
-        }
-    } else if (_controllerDataStore) {
-        // Load persisted cluster data if they exist.
-        NSDictionary * clusterData = [_controllerDataStore getStoredClusterDataForNodeID:nodeID];
-        MTR_LOG("%@ Loaded %lu cluster data from storage for %@", self, static_cast<unsigned long>(clusterData.count), deviceToReturn);
-        if (clusterData.count) {
-            [deviceToReturn setPersistedClusterData:clusterData];
-        }
-    }
-
-    // TODO: Figure out how to get the device data as part of our bulk-read bits.
-    if (_controllerDataStore) {
-        auto * deviceData = [_controllerDataStore getStoredDeviceDataForNodeID:nodeID];
-        if (deviceData.count) {
-            [deviceToReturn setPersistedDeviceData:deviceData];
-        }
-    }
-
-    [deviceToReturn setStorageBehaviorConfiguration:_storageBehaviorConfiguration];
-
-    return deviceToReturn;
+    MTR_ABSTRACT_METHOD();
+    return nil;
 }
 
 - (MTRDevice *)deviceForNodeID:(NSNumber *)nodeID

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerParameters.h
@@ -166,7 +166,7 @@ MTR_NEWLY_AVAILABLE
 /**
  * A controller created from this way will connect to a remote instance of an MTRDeviceController loaded in an XPC Service
  *
- * @param xpcConnectionBlock The XPC Connection block that will return an NSXPCConnection to the indended listener.
+ * @param xpcConnectionBlock The XPC Connection block that will return an NSXPCConnection to the intended listener.
  *
  * @param uniqueIdentifier The unique id to assign to the controller.
  *

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1193,30 +1193,6 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     return deviceToReturn;
 }
 
-- (MTRDevice *)deviceForNodeID:(NSNumber *)nodeID
-{
-    std::lock_guard lock(*self.deviceMapLock);
-    MTRDevice * deviceToReturn = [self.nodeIDToDeviceMap objectForKey:nodeID];
-    if (!deviceToReturn) {
-        deviceToReturn = [self _setupDeviceForNodeID:nodeID prefetchedClusterData:nil];
-    }
-
-    return deviceToReturn;
-}
-
-- (void)removeDevice:(MTRDevice *)device
-{
-    std::lock_guard lock(*self.deviceMapLock);
-    auto * nodeID = device.nodeID;
-    MTRDevice * deviceToRemove = [self.nodeIDToDeviceMap objectForKey:nodeID];
-    if (deviceToRemove == device) {
-        [deviceToRemove invalidate];
-        [self.nodeIDToDeviceMap removeObjectForKey:nodeID];
-    } else {
-        MTR_LOG_ERROR("%@ Error: Cannot remove device %p with nodeID %llu", self, device, nodeID.unsignedLongLongValue);
-    }
-}
-
 #ifdef DEBUG
 - (NSDictionary<NSNumber *, NSNumber *> *)unitTestGetDeviceAttributeCounts
 {

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -298,6 +298,10 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Device-specific data and SDK access
 // DeviceController will act as a central repository for this opaque dictionary that MTRDevice manages
 - (MTRDevice *)deviceForNodeID:(NSNumber *)nodeID;
+/**
+ * _setupDeviceForNodeID is a hook expected to be implemented by subclasses to
+ * actually allocate a device object of the right type.
+ */
 - (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(nullable NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData;
 - (void)removeDevice:(MTRDevice *)device;
 


### PR DESCRIPTION
This is overridden by the XPC and Concrete implementations.

Also, there is no need to override deviceForNodeID and removeDevice in MTRDeviceController_Concrete, so those overrides are removed.
