### PR TITLE
MTRDeviceControllerOverXPC should inherit from MTRDeviceController_Concrete for now.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.h
@@ -16,7 +16,8 @@
  */
 
 #import <Matter/MTRDefines.h>
-#import <Matter/MTRDeviceController.h>
+
+#import "MTRDeviceController_Concrete.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -24,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef NSXPCConnection * _Nonnull (^MTRXPCConnectBlock)(void);
 
-@interface MTRDeviceControllerOverXPC : MTRDeviceController
+@interface MTRDeviceControllerOverXPC : MTRDeviceController_Concrete
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;


### PR DESCRIPTION
That's what it used to do, and for now we should just leave it be.  Longer-term, we need to figure out what should happen with MTRDeviceControllerOverXPC; whether it should inherit from the base MTRDeviceController, or just not exist, or what.
