### PR TITLE
WaterHeater example fails TC_DEM_2.1 - ESAType not initialised 

### DIFF
--- a/examples/energy-management-app/energy-management-common/energy-evse/src/EVSEManufacturerImpl.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/EVSEManufacturerImpl.cpp
@@ -70,6 +70,7 @@ CHIP_ERROR EVSEManufacturer::Init()
 
     /* For Device Energy Management we need the ESA to be Online and ready to accept commands */
     dem->SetESAState(ESAStateEnum::kOnline);
+    dem->SetESAType(ESATypeEnum::kEvse);
 
     // Set the abs min and max power
     dem->SetAbsMinPower(1200000); // 1.2KW

--- a/examples/energy-management-app/energy-management-common/water-heater/src/WaterHeaterMain.cpp
+++ b/examples/energy-management-app/energy-management-common/water-heater/src/WaterHeaterMain.cpp
@@ -73,6 +73,7 @@ void FullWhmApplicationInit()
     /* For Device Energy Management we need the ESA to be Online and ready to accept commands */
 
     GetDEMDelegate()->SetESAState(ESAStateEnum::kOnline);
+    GetDEMDelegate()->SetESAType(ESATypeEnum::kWaterHeating);
     GetDEMDelegate()->SetDEMManufacturerDelegate(*GetWhmManufacturer());
 
     // Set the abs min and max power


### PR DESCRIPTION
Fixes #35687 - Added missing initialization of ESAType to allow WaterHeater to pass TC_DEM_2.1
