### PR TITLE
[Tizen] Fix ConnectivityManager::GetWiFiBssId implementation

### DIFF
--- a/src/platform/Tizen/ConnectivityManagerImpl.cpp
+++ b/src/platform/Tizen/ConnectivityManagerImpl.cpp
@@ -254,17 +254,7 @@ bool ConnectivityManagerImpl::IsWiFiManagementStarted()
 
 CHIP_ERROR ConnectivityManagerImpl::GetWiFiBssId(MutableByteSpan & value)
 {
-    constexpr size_t bssIdSize = 6;
-    VerifyOrReturnError(value.size() >= bssIdSize, CHIP_ERROR_BUFFER_TOO_SMALL);
-
-    uint8_t * bssId = nullptr;
-    CHIP_ERROR err  = Internal::WiFiMgr().GetBssId(bssId);
-    ReturnErrorOnFailure(err);
-
-    memcpy(value.data(), bssId, bssIdSize);
-    value.reduce_size(bssIdSize);
-
-    return CHIP_NO_ERROR;
+    return Internal::WiFiMgr().GetBssId(value);
 }
 
 CHIP_ERROR ConnectivityManagerImpl::GetWiFiSecurityType(SecurityTypeEnum & securityType)

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -31,7 +31,9 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/GLibTypeDeleter.h>
 #include <platform/PlatformManager.h>
-#include <platform/Tizen/NetworkCommissioningDriver.h>
+
+#include "ErrorUtils.h"
+#include "NetworkCommissioningDriver.h"
 
 using namespace ::chip::DeviceLayer::NetworkCommissioning;
 
@@ -1095,34 +1097,23 @@ CHIP_ERROR WiFiManager::GetConnectionState(wifi_manager_connection_state_e * con
     return err;
 }
 
-CHIP_ERROR WiFiManager::GetBssId(uint8_t * bssId)
+CHIP_ERROR WiFiManager::GetBssId(MutableByteSpan & value)
 {
-    VerifyOrReturnError(bssId != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-
-    char * bssIdStr = nullptr;
-    std::unique_ptr<char, decltype(&::free)> _{ bssIdStr, &::free };
+    VerifyOrReturnError(value.size() >= kWiFiBSSIDLength, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     wifi_manager_ap_h connectedAp = _WiFiGetConnectedAP();
-    if (connectedAp == nullptr)
-    {
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
+    VerifyOrReturnError(connectedAp != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    int wifiErr = wifi_manager_ap_get_bssid(connectedAp, &bssIdStr);
-    if (wifiErr != WIFI_MANAGER_ERROR_NONE)
-    {
-        ChipLogError(DeviceLayer, "FAIL: get bssid [%s]", get_error_message(wifiErr));
-        return CHIP_ERROR_READ_FAILED;
-    }
+    GAutoPtr<char> bssIdStr;
+    int wifiErr = wifi_manager_ap_get_bssid(connectedAp, &bssIdStr.GetReceiver());
+    VerifyOrReturnError(wifiErr == WIFI_MANAGER_ERROR_NONE, TizenToChipError(wifiErr),
+                        ChipLogError(DeviceLayer, "FAIL: Get AP BSSID: %s", get_error_message(wifiErr)));
 
-    if (sscanf(bssIdStr, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &mWiFiBSSID[0], &mWiFiBSSID[1], &mWiFiBSSID[2], &mWiFiBSSID[3],
-               &mWiFiBSSID[4], &mWiFiBSSID[5]) != 6)
-    {
-        ChipLogError(DeviceLayer, "FAIL: parse bssid");
-        return CHIP_ERROR_READ_FAILED;
-    }
+    uint8_t * data = value.data();
+    int rv = sscanf(bssIdStr.get(), "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx", &data[0], &data[1], &data[2], &data[3], &data[4], &data[5]);
+    VerifyOrReturnError(rv == kWiFiBSSIDLength, CHIP_ERROR_READ_FAILED, ChipLogError(DeviceLayer, "FAIL: Parse AP BSSID"));
 
-    bssId = mWiFiBSSID;
+    value.reduce_size(kWiFiBSSIDLength);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/Tizen/WiFiManager.h
+++ b/src/platform/Tizen/WiFiManager.h
@@ -54,7 +54,7 @@ public:
     CHIP_ERROR SetDeviceState(wifi_manager_device_state_e deviceState);
     CHIP_ERROR GetModuleState(wifi_manager_module_state_e * moduleState);
     CHIP_ERROR GetConnectionState(wifi_manager_connection_state_e * connectionState);
-    CHIP_ERROR GetBssId(uint8_t * bssId);
+    CHIP_ERROR GetBssId(MutableByteSpan & value);
     CHIP_ERROR GetSecurityType(wifi_manager_security_type_e * securityType);
     CHIP_ERROR GetConfiguredNetwork(NetworkCommissioning::Network & network);
     bool IsWiFiStationConnected();
@@ -105,7 +105,6 @@ private:
     wifi_manager_module_state_e mModuleState;
     wifi_manager_connection_state_e mConnectionState;
 
-    uint8_t mWiFiBSSID[kWiFiBSSIDLength];
     char mWiFiSSID[kMaxWiFiSSIDLength + 1];
     char mWiFiKey[kMaxWiFiKeyLength + 1];
     char mInterestedSSID[kMaxWiFiSSIDLength + 1];


### PR DESCRIPTION
### Problem

Current implementation does not return BSSID because of a bug:

```
Tizen/ConnectivityManagerImpl.cpp:264:11: error: argument 2 null where non-null expected [-Werror=nonnull]
  264 |     memcpy(value.data(), bssId, bssIdSize);
```

### Changes

- change `Internal::WiFiMgr().GetBssId` signature to be less bug-prone

### Testing

Tested locally.