### PR TITLE
Fix typo flag in targets.py arguments: this was supposed to be a chip die flag instead of enabling DM interface

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -196,7 +196,7 @@ def BuildHostTarget():
     target.AppendModifier('data-model-check', data_model_interface="check").ExceptIfRe('-data-model-(enabled|disabled)')
     target.AppendModifier('data-model-disabled', data_model_interface="disabled").ExceptIfRe('-data-model-(check|enabled)')
     target.AppendModifier('data-model-enabled', data_model_interface="enabled").ExceptIfRe('-data-model-(check|disabled)')
-    target.AppendModifier('check-failure-die', data_model_interface="enabled").OnlyIfRe('-data-model-check')
+    target.AppendModifier('check-failure-die', chip_data_model_check_die_on_failure=True).OnlyIfRe('-data-model-check')
 
     return target
 


### PR DESCRIPTION
Updated flags. CI should still pass.