### PR TITLE
Bugfix: packet buffer counter going negative and triggering UBSan Issue

### DIFF
--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -145,6 +145,7 @@ void PacketBufferHandle::InternalRightSize()
 
     const size_t blockSize   = usedSize + PacketBuffer::kStructureSize;
     PacketBuffer * newBuffer = reinterpret_cast<PacketBuffer *>(chip::Platform::MemoryAlloc(blockSize));
+    SYSTEM_STATS_INCREMENT(chip::System::Stats::kSystemLayer_NumPacketBufs);
     if (newBuffer == nullptr)
     {
         ChipLogError(chipSystemLayer, "PacketBuffer: pool EMPTY.");

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -145,12 +145,13 @@ void PacketBufferHandle::InternalRightSize()
 
     const size_t blockSize   = usedSize + PacketBuffer::kStructureSize;
     PacketBuffer * newBuffer = reinterpret_cast<PacketBuffer *>(chip::Platform::MemoryAlloc(blockSize));
-    SYSTEM_STATS_INCREMENT(chip::System::Stats::kSystemLayer_NumPacketBufs);
     if (newBuffer == nullptr)
     {
         ChipLogError(chipSystemLayer, "PacketBuffer: pool EMPTY.");
         return;
     }
+
+    SYSTEM_STATS_INCREMENT(chip::System::Stats::kSystemLayer_NumPacketBufs);
 
     uint8_t * const newStart = newBuffer->ReserveStart();
     newBuffer->next          = nullptr;


### PR DESCRIPTION
#### Problem
- On Linux apps (tested on all-clusters-app) the packet buffer counter at array index `sResourcesInUse[kSystemLayer_NumPacketBufs]` in `SystemStats` goes negative. 
- when fuzzing the all-clusters-app, sResourcesInUse[0]` underflows and triggers a UBSan (Undefined Behavior Sanitizer) Error.

#### Cause
- The counter`sResourcesInUse[0]` is incremented and decremented using the macros `SYSTEM_STATS_INCREMENT(kSystemLayer_NumPacketBufs)`  and `SYSTEM_STATS_DECREMENT(kSystemLayer_NumPacketBufs)` .

-  these Macros are being called in `PacketBufferHandle::New` and `PacketBuffer::Free` respectively.

- However, when `CHIP_SYSTEM_PACKETBUFFER_FROM_CHIP_HEAP` and `PacketBufferHandle::InternalRightSize()` is called, we Allocate Memory without using `PacketBufferHandle::New` but when freeing the memory, `PacketBuffer::Free` is still used.
- so we end up decrementing sResourcesInUse[0] without a corresponding Increment, and when fuzzing we keep going negative until it underflows (sResourcesInUse was defined as a signed int).

#### Possible Follow-up
- [ ] should we change sResourcesInUse to become an unsigned int?

#### Log of UBSan Error that uncovered issue
```cpp
[1726744635.412558][911757:911757] CHIP:EM: >>> [E:0i S:0 M:1811939340] (U) Msg RX from 0:0000000000000067 [0000] --- Type 676C:0C (----:----) (B:126)
[1726744635.413133][911757:911757] CHIP:EM: >>> [E:0i S:0 M:1811939340] (U) Msg RX from 0:0000000000000067 [0000] --- Type 676C:0C (----:----) (B:126)
../../src/system/SystemPacketBuffer.cpp:697:13: runtime error: implicit conversion from type 'int' of value -129 (32-bit, signed) to type 'count_t' (aka 'signed char') changed the value to 127 (8-bit, signed)
```
