### PR TITLE
TC-OPSTATE-2.5: Force expire session on reboot

### DIFF
--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -1112,10 +1112,11 @@ class TC_OPSTATE_BASE():
 
             # STEP 11: Restart DUT
             self.step(11)
-            # In CI environment, the STOP coommand (step 8) already resets the variables. Only ask for
+            # In CI environment, the STOP command (step 8) already resets the variables. Only ask for
             # reboot outside CI environment.
             if not self.is_ci:
                 self.wait_for_user_input(prompt_msg="Restart DUT. Press Enter when ready.\n")
+                self.default_controller.ExpireSessions(self.dut_node_id)
 
             # STEP 12: TH waits for {PIXIT.WAITTIME.REBOOT}
             self.step(12)


### PR DESCRIPTION
If the DUT has rebooted, the TH will need to establish the session again, which means expiring the current. In a real product, a fail on the case would trigger a retry, but it's not clear that we want that in the TH because it can paper over problems where the DUT is crashing. This is an intentional reboot, wihch is different.

Probably not caught in CI / QA because the CI app doesn't actually reboot.