### PR TITLE
[Android][ICD]Fix invalid signature for ICD onRefresh

### DIFF
--- a/src/controller/java/AndroidCheckInDelegate.cpp
+++ b/src/controller/java/AndroidCheckInDelegate.cpp
@@ -92,7 +92,7 @@ RefreshKeySender * AndroidCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & cl
                           jniICDHmacKey)
 
         jmethodID onKeyRefreshNeededMethodID = nullptr;
-        err = chip::JniReferences::GetInstance().FindMethod(env, mCheckInDelegate.ObjectRef(), "onKeyRefreshNeeded", "(JJJJJ[B[B)V",
+        err = chip::JniReferences::GetInstance().FindMethod(env, mCheckInDelegate.ObjectRef(), "onKeyRefreshNeeded", "(JJJJJ[B[B)[B",
                                                             &onKeyRefreshNeededMethodID);
         VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr,
                             ChipLogProgress(ICD, "onKeyRefreshNeeded - FindMethod is failed! : %" CHIP_ERROR_FORMAT, err.Format()));
@@ -120,6 +120,12 @@ RefreshKeySender * AndroidCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & cl
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(ICD, "Generation of new key failed: %" CHIP_ERROR_FORMAT, err.Format());
+            return nullptr;
+        }
+        err = newKey.SetLength(newKey.Capacity());
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(ICD, "Fail to set new key length with error: %" CHIP_ERROR_FORMAT, err.Format());
             return nullptr;
         }
     }

--- a/src/controller/java/AndroidCheckInDelegate.cpp
+++ b/src/controller/java/AndroidCheckInDelegate.cpp
@@ -92,8 +92,8 @@ RefreshKeySender * AndroidCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & cl
                           jniICDHmacKey)
 
         jmethodID onKeyRefreshNeededMethodID = nullptr;
-        err = chip::JniReferences::GetInstance().FindMethod(env, mCheckInDelegate.ObjectRef(), "onKeyRefreshNeeded", "(JJJJJ[B[B)[B",
-                                                            &onKeyRefreshNeededMethodID);
+        err = chip::JniReferences::GetInstance().FindMethod(env, mCheckInDelegate.ObjectRef(), "onKeyRefreshNeeded",
+                                                            "(JJJJJ[B[B)[B", &onKeyRefreshNeededMethodID);
         VerifyOrReturnValue(err == CHIP_NO_ERROR, nullptr,
                             ChipLogProgress(ICD, "onKeyRefreshNeeded - FindMethod is failed! : %" CHIP_ERROR_FORMAT, err.Format()));
 

--- a/src/controller/java/src/chip/devicecontroller/ICDCheckInDelegateWrapper.java
+++ b/src/controller/java/src/chip/devicecontroller/ICDCheckInDelegateWrapper.java
@@ -67,7 +67,7 @@ class ICDCheckInDelegateWrapper {
   }
 
   @SuppressWarnings("unused")
-  private void onKeyRefreshDone(Long errorCode) {
+  private void onKeyRefreshDone(long errorCode) {
     delegate.onKeyRefreshDone(errorCode);
   }
 }

--- a/src/controller/java/src/chip/devicecontroller/ICDCheckInDelegateWrapper.java
+++ b/src/controller/java/src/chip/devicecontroller/ICDCheckInDelegateWrapper.java
@@ -67,7 +67,7 @@ class ICDCheckInDelegateWrapper {
   }
 
   @SuppressWarnings("unused")
-  private void onKeyRefreshDone(int errorCode) {
+  private void onKeyRefreshDone(Long errorCode) {
     delegate.onKeyRefreshDone(errorCode);
   }
 }


### PR DESCRIPTION
Fix the return type signature for ICD onKeyRefreshNeeded and input parameter signature for onKeyRefreshDone 

tests: locally validated using android chip-tool for ICD refresh bits