### PR TITLE
[Tizen] Use valid QEMU binary

### DIFF
--- a/third_party/tizen/tizen_qemu.py
+++ b/third_party/tizen/tizen_qemu.py
@@ -19,9 +19,9 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
-import shutil
 
 # Absolute path to Tizen Studio CLI tool.
 tizen_sdk_root = os.environ.get("TIZEN_SDK_ROOT", "")

--- a/third_party/tizen/tizen_qemu.py
+++ b/third_party/tizen/tizen_qemu.py
@@ -76,7 +76,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 
-def all_binaries(binary_name):
+def whereis(binary_name):
     # Get the PATH environment variable.
     path_dirs = os.environ.get('PATH', '').split(os.pathsep)
 
@@ -94,7 +94,7 @@ def all_binaries(binary_name):
 
 # If qemu-system-arm binary is from Pigweed prefer the next one in PATH if there is one.
 if pw_install_dir != "" and qemu_system_arm.startswith(pw_install_dir):
-    binaries = all_binaries("qemu-system-arm")
+    binaries = whereis("qemu-system-arm")
     if len(binaries) > 1:
         qemu_system_arm = binaries[1]
 

--- a/third_party/tizen/tizen_qemu.py
+++ b/third_party/tizen/tizen_qemu.py
@@ -75,6 +75,7 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+
 def all_binaries(binary_name):
     # Get the PATH environment variable.
     path_dirs = os.environ.get('PATH', '').split(os.pathsep)
@@ -89,6 +90,7 @@ def all_binaries(binary_name):
             found_paths.append(binary_path)
 
     return found_paths
+
 
 # If qemu-system-arm binary is from Pigweed prefer the next one in PATH if there is one.
 if pw_install_dir != "" and qemu_system_arm.startswith(pw_install_dir):

--- a/third_party/tizen/tizen_qemu.py
+++ b/third_party/tizen/tizen_qemu.py
@@ -85,9 +85,8 @@ def whereis(binary_name):
 
     # Search for the binary in each directory.
     for directory in path_dirs:
-        binary_path = os.path.join(directory, binary_name)
-        if os.path.isfile(binary_path) and os.access(binary_path, os.X_OK):
-            found_paths.append(binary_path)
+        if found := shutil.which(binary_name, path=directory):
+            found_paths.append(found)
 
     return found_paths
 


### PR DESCRIPTION
### Issue

There are 2 `qemu-system-arm` binaries, one is in `/usr/bin` and the other one is in `$PW_PIGWEED_CIPD_INSTALL_DIR/bin`. The former is preferred over the latter because it's there specifically for this use case, but currently the latter is being used.

The exact error I've encountered with binary from pigweed: `'virtio-9p-pci' is not a valid device model name`.

### Solution

Modify `tizen_qemu.py` so that it finds the correct version of `qemu-system-arm`.

### Testing

Successfully compiled and ran locally.

### Extra notes

There will be a follow-up PR that needs the valid binary to work.