### PR TITLE
[Silabs] Add gn arg to configure NVM3 for efr32 platform

### DIFF
--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -39,6 +39,8 @@ declare_args() {
   enable_openthread_cli = !(use_rs9116 || use_wf200 || use_SiWx917)
   kvs_max_entries = 255
   sl_nvm3_max_object_size = 4092
+  sl_nvm3_nvm_size = 40960
+  sl_nvm3_cache_size = 200
 
   # Use Silabs factory data provider example.
   # Users can implement their own.
@@ -424,7 +426,8 @@ template("efr32_sdk") {
       "__STARTUP_CLEAR_BSS",
       "HARD_FAULT_LOG_ENABLE",
       "CORTEXM3_EFM32_MICRO",
-      "NVM3_DEFAULT_NVM_SIZE=40960",
+      "NVM3_DEFAULT_CACHE_SIZE=${sl_nvm3_cache_size}",
+      "NVM3_DEFAULT_NVM_SIZE=${sl_nvm3_nvm_size}",
       "NVM3_DEFAULT_MAX_OBJECT_SIZE=${sl_nvm3_max_object_size}",
       "KVS_MAX_ENTRIES=${kvs_max_entries}",
       "CORTEXM3=1",


### PR DESCRIPTION
Add two new gn arg(sl_nvm3_nvm_size and sl_nvm3_cache_size) to configure NVM3 for silabs efr32 platform.

Developers can analyze their storage needs to adjust these two parameters, which can improve storage efficiency.

Especially after https://github.com/project-chip/connectedhomeip/pull/35480, developers would like to adjust these two parameters.