### PR TITLE
[Silabs] Fix SLC (non-gn) build when disabling matter ota

### DIFF
--- a/examples/platform/silabs/OTAConfig.h
+++ b/examples/platform/silabs/OTAConfig.h
@@ -29,7 +29,7 @@
 #include <platform/silabs/OTAImageProcessorImpl.h>
 #endif
 
-#if (SL_MATTER_GN_BUILD == 0)
+#if (SL_MATTER_GN_BUILD == 0) && defined(SILABS_OTA_ENABLED)
 #include "sl_matter_ota_config.h"
 #endif
 


### PR DESCRIPTION
Add a condition to the already conditional include of `sl_matter_ota_config.h` for our SLC build offering when the matter ota mechanism is disabled.



