### PR TITLE
Switch to macos-14 for some of the Darwin runners.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -36,7 +36,7 @@ jobs:
     framework:
         name: Build framework
         if: github.actor != 'restyled-io[bot]'
-        runs-on: macos-13
+        runs-on: macos-14
         strategy:
             matrix:
                 options: # We don't need a full matrix
@@ -73,7 +73,7 @@ jobs:
         name: Run framework tests
         if: github.actor != 'restyled-io[bot]'
         needs: [framework] # serialize to avoid running to many parallel macos runners
-        runs-on: macos-13
+        runs-on: macos-14
         strategy:
             matrix:
                 options: # We don't need a full matrix

--- a/.github/workflows/example-tv-casting-darwin.yaml
+++ b/.github/workflows/example-tv-casting-darwin.yaml
@@ -36,7 +36,7 @@ jobs:
     tv-casting-bridge:
         name: Build TV Casting Bridge example
         if: github.actor != 'restyled-io[bot]'
-        runs-on: macos-13
+        runs-on: macos-14
         steps:
             - name: Checkout
               uses: actions/checkout@v4


### PR DESCRIPTION
macos-14 runners are ARM, and should be much faster than the macos-13 runners.

The YAML tests are not passing on macos-14 for some reason (being sorted out in https://github.com/project-chip/connectedhomeip/pull/35704), but other workflows can be switched, which is what this does.

