### PR TITLE
Move some APIs that are only used on MTRDeviceController_Concrete to that interface.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -320,20 +320,6 @@ using namespace chip::Tracing::DarwinFramework;
     // Subclass hook; nothing to do.
 }
 
-- (BOOL)matchesPendingShutdownControllerWithOperationalCertificate:(nullable MTRCertificateDERBytes)operationalCertificate andRootCertificate:(nullable MTRCertificateDERBytes)rootCertificate
-{
-    // TODO: Once the factory knows it's dealing with MTRDeviceController_Concrete, this can be removed, and its
-    // declaration moved to MTRDeviceController_Concrete.
-    return NO;
-}
-
-- (void)clearPendingShutdown
-{
-    // TODO: Once the factory knows it's dealing with MTRDeviceController_Concrete, this can be removed, and its
-    // declaration moved to MTRDeviceController_Concrete.
-    MTR_ABSTRACT_METHOD();
-}
-
 - (void)shutdown
 {
     MTR_ABSTRACT_METHOD();
@@ -1083,36 +1069,6 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 {
     auto storedValue = _storedCompressedFabricID.load();
     return storedValue.has_value() ? @(storedValue.value()) : nil;
-}
-
-- (CHIP_ERROR)isRunningOnFabric:(chip::FabricTable *)fabricTable
-                    fabricIndex:(chip::FabricIndex)fabricIndex
-                      isRunning:(BOOL *)isRunning
-{
-    assertChipStackLockedByCurrentThread();
-
-    if (![self isRunning]) {
-        *isRunning = NO;
-        return CHIP_NO_ERROR;
-    }
-
-    const chip::FabricInfo * otherFabric = fabricTable->FindFabricWithIndex(fabricIndex);
-    if (!otherFabric) {
-        // Should not happen...
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    if (_cppCommissioner->GetFabricId() != otherFabric->GetFabricId()) {
-        *isRunning = NO;
-        return CHIP_NO_ERROR;
-    }
-
-    chip::Crypto::P256PublicKey ourRootPublicKey, otherRootPublicKey;
-    ReturnErrorOnFailure(_cppCommissioner->GetRootPublicKey(ourRootPublicKey));
-    ReturnErrorOnFailure(fabricTable->FetchRootPubkey(otherFabric->GetFabricIndex(), otherRootPublicKey));
-
-    *isRunning = (ourRootPublicKey.Matches(otherRootPublicKey));
-    return CHIP_NO_ERROR;
 }
 
 - (void)invalidateCASESessionForNode:(chip::NodeId)nodeID;

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -71,6 +71,21 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)deinitFromFactory;
 
 /**
+ * Check whether this controller is running on the given fabric, as represented
+ * by the provided FabricTable and fabric index.  The provided fabric table may
+ * not be the same as the fabric table this controller is using. This method
+ * MUST be called from the Matter work queue.
+ *
+ * Might return failure, in which case we don't know whether it's running on the
+ * given fabric.  Otherwise it will set *isRunning to the right boolean value.
+ *
+ * Only MTRDeviceControllerFactory should be calling this.
+ */
+- (CHIP_ERROR)isRunningOnFabric:(chip::FabricTable *)fabricTable
+                    fabricIndex:(chip::FabricIndex)fabricIndex
+                      isRunning:(BOOL *)isRunning;
+
+/**
  * Takes an assertion to keep the controller running. If `-[MTRDeviceController shutdown]` is called while an assertion
  * is held, the shutdown will be honored only after all assertions are released. Invoking this method multiple times increases
  * the number of assertions and needs to be matched with equal amount of '-[MTRDeviceController removeRunAssertion]` to release
@@ -83,6 +98,16 @@ NS_ASSUME_NONNULL_BEGIN
  * Invoking this method once all assertions have been released in a noop.
  */
 - (void)removeRunAssertion;
+
+/**
+ * This method returns TRUE if this controller matches the fabric reference and node ID as listed in the parameters.
+ */
+- (BOOL)matchesPendingShutdownControllerWithOperationalCertificate:(nullable MTRCertificateDERBytes)operationalCertificate andRootCertificate:(nullable MTRCertificateDERBytes)rootCertificate;
+
+/**
+ * Clear any pending shutdown request.
+ */
+- (void)clearPendingShutdown;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -122,21 +122,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, retain, nullable) NSData * rootPublicKey;
 
 /**
- * Check whether this controller is running on the given fabric, as represented
- * by the provided FabricTable and fabric index.  The provided fabric table may
- * not be the same as the fabric table this controller is using. This method
- * MUST be called from the Matter work queue.
- *
- * Might return failure, in which case we don't know whether it's running on the
- * given fabric.  Otherwise it will set *isRunning to the right boolean value.
- *
- * Only MTRDeviceControllerFactory should be calling this.
- */
-- (CHIP_ERROR)isRunningOnFabric:(chip::FabricTable *)fabricTable
-                    fabricIndex:(chip::FabricIndex)fabricIndex
-                      isRunning:(BOOL *)isRunning;
-
-/**
  * Ensure we have a CASE session to the given node ID and then call the provided
  * connection callback.  This may be called on any queue (including the Matter
  * event queue) and on success will always call the provided connection callback
@@ -264,16 +249,6 @@ NS_ASSUME_NONNULL_BEGIN
  * makes use of the subscription pool.
  */
 - (void)directlyGetSessionForNode:(chip::NodeId)nodeID completion:(MTRInternalDeviceConnectionCallback)completion;
-
-/**
- * This method returns TRUE if this controller matches the fabric reference and node ID as listed in the parameters.
- */
-- (BOOL)matchesPendingShutdownControllerWithOperationalCertificate:(nullable MTRCertificateDERBytes)operationalCertificate andRootCertificate:(nullable MTRCertificateDERBytes)rootCertificate;
-
-/**
- * Clear any pending shutdown request.
- */
-- (void)clearPendingShutdown;
 
 @end
 


### PR DESCRIPTION
Now that MTRDeviceControllerFactory only works with MTRDeviceController_Concrete, we can move some APIs from MTRDeviceController_Internal to MTRDeviceController_Concrete.
