### PR TITLE
Change some more internal MTRDeviceControllerFactory APIs to use MTRDeviceController_Concrete.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -975,9 +975,9 @@ MTR_DIRECT_MEMBERS
     return [_controllers copy];
 }
 
-- (nullable MTRDeviceController *)runningControllerForFabricIndex:(FabricIndex)fabricIndex
-                                      includeControllerStartingUp:(BOOL)includeControllerStartingUp
-                                    includeControllerShuttingDown:(BOOL)includeControllerShuttingDown
+- (nullable MTRDeviceController_Concrete *)runningControllerForFabricIndex:(FabricIndex)fabricIndex
+                                               includeControllerStartingUp:(BOOL)includeControllerStartingUp
+                                             includeControllerShuttingDown:(BOOL)includeControllerShuttingDown
 {
     assertChipStackLockedByCurrentThread();
 
@@ -1006,7 +1006,7 @@ MTR_DIRECT_MEMBERS
     return nil;
 }
 
-- (nullable MTRDeviceController *)runningControllerForFabricIndex:(chip::FabricIndex)fabricIndex
+- (nullable MTRDeviceController_Concrete *)runningControllerForFabricIndex:(chip::FabricIndex)fabricIndex
 {
     return [self runningControllerForFabricIndex:fabricIndex includeControllerStartingUp:YES includeControllerShuttingDown:YES];
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
@@ -57,21 +57,21 @@ MTR_DIRECT_MEMBERS
  * Get the list of running controllers.  This will include controllers that are
  * in the middle of starting up or shutting down.
  */
-- (NSArray<MTRDeviceController *> *)getRunningControllers;
+- (NSArray<MTRDeviceController_Concrete *> *)getRunningControllers;
 
 /**
  * Find a running controller, if any, for the given fabric index.
  */
-- (nullable MTRDeviceController *)runningControllerForFabricIndex:(chip::FabricIndex)fabricIndex;
+- (nullable MTRDeviceController_Concrete *)runningControllerForFabricIndex:(chip::FabricIndex)fabricIndex;
 
 /**
  * Find a running controller, if any, for the given fabric index.  Allows
  * controlling whether to include a controller that is in the middle of startup
  * or shutdown.
  */
-- (nullable MTRDeviceController *)runningControllerForFabricIndex:(chip::FabricIndex)fabricIndex
-                                      includeControllerStartingUp:(BOOL)includeControllerStartingUp
-                                    includeControllerShuttingDown:(BOOL)includeControllerShuttingDown;
+- (nullable MTRDeviceController_Concrete *)runningControllerForFabricIndex:(chip::FabricIndex)fabricIndex
+                                               includeControllerStartingUp:(BOOL)includeControllerStartingUp
+                                             includeControllerShuttingDown:(BOOL)includeControllerShuttingDown;
 
 /**
  * Notify the controller factory that a new operational instance with the given


### PR DESCRIPTION
These always return concrete controllers.

getRunningControllers was already claiming the right signature in the implementation, just not the header.
