### PR TITLE
Attribute metadata attribute-type.h encapsulation

### DIFF
--- a/src/app/util/attribute-metadata.cpp
+++ b/src/app/util/attribute-metadata.cpp
@@ -18,6 +18,16 @@
 
 #include <app-common/zap-generated/attribute-type.h>
 
+bool EmberAfAttributeMetadata::IsBoolean() const
+{
+    return attributeType == ZCL_BOOLEAN_ATTRIBUTE_TYPE;
+}
+
+bool EmberAfAttributeMetadata::IsSignedIntegerAttribute() const
+{
+    return chip::app::IsSignedAttributeType(attributeType);
+}
+
 bool emberAfIsStringAttributeType(EmberAfAttributeType attributeType)
 {
     return (attributeType == ZCL_OCTET_STRING_ATTRIBUTE_TYPE || attributeType == ZCL_CHAR_STRING_ATTRIBUTE_TYPE);

--- a/src/app/util/attribute-metadata.h
+++ b/src/app/util/attribute-metadata.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <app-common/zap-generated/attribute-type.h>
 #include <app/util/basic-types.h>
 #include <cstdint>
 
@@ -161,12 +160,12 @@ struct EmberAfAttributeMetadata
     /**
      * Check wether this attribute is a boolean based on its type according to the spec.
      */
-    bool IsBoolean() const { return attributeType == ZCL_BOOLEAN_ATTRIBUTE_TYPE; }
+    bool IsBoolean() const;
 
     /**
      * Check wether this attribute is signed based on its type according to the spec.
      */
-    bool IsSignedIntegerAttribute() const { return chip::app::IsSignedAttributeType(attributeType); }
+    bool IsSignedIntegerAttribute() const;
 
     /**
      * Check whether this attribute has a define min and max.


### PR DESCRIPTION
Removed attribute-type.h from attribute-metadata and moved definitions inside of .cpp file to reduce the compilation dependencies of attribute-metadata.h


