### PR TITLE
[ICD] Increase ICD Monitoring buffer size to fit maximum sized entry

### DIFF
--- a/src/app/icd/server/ICDMonitoringTable.h
+++ b/src/app/icd/server/ICDMonitoringTable.h
@@ -34,7 +34,7 @@ using SymmetricKeystore = SessionKeystore;
 
 namespace chip {
 
-inline constexpr size_t kICDMonitoringBufferSize = 60;
+inline constexpr size_t kICDMonitoringBufferSize = 63;
 
 struct ICDMonitoringEntry : public PersistentData<kICDMonitoringBufferSize>
 {
@@ -129,8 +129,7 @@ struct ICDMonitoringTable
 {
     ICDMonitoringTable(PersistentStorageDelegate & storage, FabricIndex fabric, uint16_t limit,
                        Crypto::SymmetricKeystore * symmetricKeystore) :
-        mStorage(&storage),
-        mFabric(fabric), mLimit(limit), mSymmetricKeystore(symmetricKeystore)
+        mStorage(&storage), mFabric(fabric), mLimit(limit), mSymmetricKeystore(symmetricKeystore)
     {}
 
     /**

--- a/src/app/icd/server/ICDMonitoringTable.h
+++ b/src/app/icd/server/ICDMonitoringTable.h
@@ -129,7 +129,8 @@ struct ICDMonitoringTable
 {
     ICDMonitoringTable(PersistentStorageDelegate & storage, FabricIndex fabric, uint16_t limit,
                        Crypto::SymmetricKeystore * symmetricKeystore) :
-        mStorage(&storage), mFabric(fabric), mLimit(limit), mSymmetricKeystore(symmetricKeystore)
+        mStorage(&storage),
+        mFabric(fabric), mLimit(limit), mSymmetricKeystore(symmetricKeystore)
     {}
 
     /**

--- a/src/app/icd/server/tests/TestICDMonitoringTable.cpp
+++ b/src/app/icd/server/tests/TestICDMonitoringTable.cpp
@@ -43,6 +43,8 @@ constexpr uint64_t kClientNodeId13      = 0x100003;
 constexpr uint64_t kClientNodeId21      = 0x200001;
 constexpr uint64_t kClientNodeId22      = 0x200002;
 
+constexpr uint64_t kClientNodeMaxValue = std::numeric_limits<uint64_t>::max();
+
 constexpr uint8_t kKeyBuffer0a[] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 constexpr uint8_t kKeyBuffer0b[] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                                      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
@@ -96,6 +98,20 @@ TEST(TestICDMonitoringTable, TestEntryAssignationOverload)
     EXPECT_EQ(entry.clientType, entry2.clientType);
 
     EXPECT_TRUE(entry2.IsKeyEquivalent(ByteSpan(kKeyBuffer1a)));
+}
+
+TEST(TestICDMonitoringTable, TestEntryMaximumSize)
+{
+    TestPersistentStorageDelegate storage;
+    TestSessionKeystoreImpl keystore;
+    ICDMonitoringTable table(storage, kTestFabricIndex1, kMaxTestClients1, &keystore);
+
+    ICDMonitoringEntry entry(&keystore);
+    entry.checkInNodeID    = kClientNodeMaxValue;
+    entry.monitoredSubject = kClientNodeMaxValue;
+    entry.clientType       = ClientTypeEnum::kPermanent;
+    EXPECT_EQ(CHIP_NO_ERROR, entry.SetKey(ByteSpan(kKeyBuffer1a)));
+    EXPECT_EQ(CHIP_NO_ERROR, table.Set(0, entry));
 }
 
 TEST(TestICDMonitoringTable, TestEntryKeyFunctions)


### PR DESCRIPTION
#### Description
ICD Monitoring table buffer size was not large enough to fix a entry with each field at its maximum size. PR increases the buffer to fit an entry with all its max values.

#### Tests 
Added unit tests to validate the behavior change.
