### PR TITLE
Attempt to fix TSan issues in Swift unit tests.

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRSwiftDeviceTests.swift
+++ b/src/darwin/Framework/CHIPTests/MTRSwiftDeviceTests.swift
@@ -414,12 +414,8 @@ class MTRSwiftDeviceTests : XCTestCase {
         
         wait(for: [ resubscriptionReachableExpectation, resubscriptionGotReportsExpectation ], timeout:60)
         
-        // Now make sure we ignore later tests.  Ideally we would just unsubscribe
-        // or remove the delegate, but there's no good way to do that.
-        delegate.onReachable = { () -> Void in }
-        delegate.onNotReachable = nil
-        delegate.onAttributeDataReceived = nil
-        delegate.onEventDataReceived = nil
+        // Now make sure we ignore later tests.
+        device.remove(_: delegate)
         
         // Make sure we got no updated reports (because we had a cluster state cache
         // with data versions) during the resubscribe.


### PR DESCRIPTION
The only reason we are messing with the delegate's fields is because we had no remove API, but we have that now.  And maybe this will fix the claimed thread race between us setting its fields and it being destroyed.
