### PR TITLE
[SVE][ICD] Bump MaxICDMonitoringEntrySize to reasonable size

### DIFF
--- a/src/app/icd/server/ICDMonitoringTable.cpp
+++ b/src/app/icd/server/ICDMonitoringTable.cpp
@@ -53,6 +53,7 @@ CHIP_ERROR ICDMonitoringEntry::Serialize(TLV::TLVWriter & writer) const
     ReturnErrorOnFailure(writer.Put(TLV::ContextTag(Fields::kClientType), clientType));
 
     ReturnErrorOnFailure(writer.EndContainer(outer));
+    ReturnErrorOnFailure(writer.Finalize());
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/icd/server/ICDMonitoringTable.h
+++ b/src/app/icd/server/ICDMonitoringTable.h
@@ -34,11 +34,21 @@ using SymmetricKeystore = SessionKeystore;
 
 namespace chip {
 
-inline constexpr size_t kICDMonitoringBufferSize = 60;
+static constexpr size_t MaxICDMonitoringEntrySize()
+{
+    // All the fields added together
+    return TLV::EstimateStructOverhead(
+        sizeof(NodeId) /*checkInNodeID*/, 
+        sizeof(uint64_t) /*monitoredSubject*/,
+        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*aes_key_handle*/,
+        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*hmac_key_handle*/, 
+        sizeof(uint8_t) /*client_type*/) * 3 / 2;
+}
+
+inline constexpr size_t kICDMonitoringBufferSize = MaxICDMonitoringEntrySize();
 
 struct ICDMonitoringEntry : public PersistentData<kICDMonitoringBufferSize>
 {
-
     ICDMonitoringEntry(FabricIndex fabric = kUndefinedFabricIndex, NodeId nodeId = kUndefinedNodeId)
     {
         this->fabricIndex      = fabric;

--- a/src/app/icd/server/ICDMonitoringTable.h
+++ b/src/app/icd/server/ICDMonitoringTable.h
@@ -41,10 +41,10 @@ static constexpr size_t MaxICDMonitoringEntrySize()
                                        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*aes_key_handle*/,
                                        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*hmac_key_handle*/,
                                        sizeof(uint8_t) /*client_type*/) *
-         // Provide 50% extra space to make a firmware upgrade that starts storing
-         // more data followed by a downgrade work easily and reliably.
-         // The 50% number is chosen fairly randomly; storage increases larger than that are
-         // possible but need to be staged carefully.
+        // Provide 50% extra space to make a firmware upgrade that starts storing
+        // more data followed by a downgrade work easily and reliably.
+        // The 50% number is chosen fairly randomly; storage increases larger than that are
+        // possible but need to be staged carefully.
         3 / 2;
 }
 

--- a/src/app/icd/server/ICDMonitoringTable.h
+++ b/src/app/icd/server/ICDMonitoringTable.h
@@ -41,7 +41,11 @@ static constexpr size_t MaxICDMonitoringEntrySize()
                                        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*aes_key_handle*/,
                                        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*hmac_key_handle*/,
                                        sizeof(uint8_t) /*client_type*/) *
-        3 / 2; // Expect to have at least 50% to make sure we can grow and then if there is a firmware upgrade/downgrade, it doesn't brick
+         // Provide 50% extra space to make a firmware upgrade that starts storing
+         // more data followed by a downgrade work easily and reliably.
+         // The 50% number is chosen fairly randomly; storage increases larger than that are
+         // possible but need to be staged carefully.
+        3 / 2;
 }
 
 inline constexpr size_t kICDMonitoringBufferSize = MaxICDMonitoringEntrySize();

--- a/src/app/icd/server/ICDMonitoringTable.h
+++ b/src/app/icd/server/ICDMonitoringTable.h
@@ -41,7 +41,7 @@ static constexpr size_t MaxICDMonitoringEntrySize()
                                        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*aes_key_handle*/,
                                        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*hmac_key_handle*/,
                                        sizeof(uint8_t) /*client_type*/) *
-        3 / 2;
+        3 / 2; // Expect to have at least 50% to make sure we can grow and then if there is a firmware upgrade/downgrade, it doesn't brick
 }
 
 inline constexpr size_t kICDMonitoringBufferSize = MaxICDMonitoringEntrySize();

--- a/src/app/icd/server/ICDMonitoringTable.h
+++ b/src/app/icd/server/ICDMonitoringTable.h
@@ -38,10 +38,10 @@ static constexpr size_t MaxICDMonitoringEntrySize()
 {
     // All the fields added together
     return TLV::EstimateStructOverhead(
-        sizeof(NodeId) /*checkInNodeID*/, 
+        sizeof(NodeId) /*checkInNodeID*/,
         sizeof(uint64_t) /*monitoredSubject*/,
         sizeof(Crypto::Symmetric128BitsKeyByteArray) /*aes_key_handle*/,
-        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*hmac_key_handle*/, 
+        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*hmac_key_handle*/,
         sizeof(uint8_t) /*client_type*/) * 3 / 2;
 }
 

--- a/src/app/icd/server/ICDMonitoringTable.h
+++ b/src/app/icd/server/ICDMonitoringTable.h
@@ -37,12 +37,11 @@ namespace chip {
 static constexpr size_t MaxICDMonitoringEntrySize()
 {
     // All the fields added together
-    return TLV::EstimateStructOverhead(
-        sizeof(NodeId) /*checkInNodeID*/,
-        sizeof(uint64_t) /*monitoredSubject*/,
-        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*aes_key_handle*/,
-        sizeof(Crypto::Symmetric128BitsKeyByteArray) /*hmac_key_handle*/,
-        sizeof(uint8_t) /*client_type*/) * 3 / 2;
+    return TLV::EstimateStructOverhead(sizeof(NodeId) /*checkInNodeID*/, sizeof(uint64_t) /*monitoredSubject*/,
+                                       sizeof(Crypto::Symmetric128BitsKeyByteArray) /*aes_key_handle*/,
+                                       sizeof(Crypto::Symmetric128BitsKeyByteArray) /*hmac_key_handle*/,
+                                       sizeof(uint8_t) /*client_type*/) *
+        3 / 2;
 }
 
 inline constexpr size_t kICDMonitoringBufferSize = MaxICDMonitoringEntrySize();

--- a/src/app/icd/server/tests/TestICDMonitoringTable.cpp
+++ b/src/app/icd/server/tests/TestICDMonitoringTable.cpp
@@ -43,6 +43,8 @@ constexpr uint64_t kClientNodeId13      = 0x100003;
 constexpr uint64_t kClientNodeId21      = 0x200001;
 constexpr uint64_t kClientNodeId22      = 0x200002;
 
+constexpr uint64_t kClientNodeMaxValue = std::numeric_limits<uint64_t>::max();
+
 constexpr uint8_t kKeyBuffer0a[] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
 constexpr uint8_t kKeyBuffer0b[] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                                      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
@@ -96,6 +98,20 @@ TEST(TestICDMonitoringTable, TestEntryAssignationOverload)
     EXPECT_EQ(entry.clientType, entry2.clientType);
 
     EXPECT_TRUE(entry2.IsKeyEquivalent(ByteSpan(kKeyBuffer1a)));
+}
+
+TEST(TestICDMonitoringTable, TestEntryMaximumSize)
+{
+    TestPersistentStorageDelegate storage;
+    TestSessionKeystoreImpl keystore;
+    ICDMonitoringTable table(storage, kTestFabricIndex1, kMaxTestClients1, &keystore);
+
+    ICDMonitoringEntry entry(&keystore);
+    entry.checkInNodeID    = kClientNodeMaxValue;
+    entry.monitoredSubject = kClientNodeMaxValue;
+    entry.clientType       = ClientTypeEnum::kPermanent;
+    EXPECT_EQ(CHIP_NO_ERROR, entry.SetKey(ByteSpan(kKeyBuffer1a)));
+    EXPECT_EQ(CHIP_NO_ERROR, table.Set(0, entry));
 }
 
 TEST(TestICDMonitoringTable, TestEntryKeyFunctions)


### PR DESCRIPTION
Previous MaxICDMonitoringEntrySize 60 cannot handle the "full width" node ID, for example, 0xffff000000000000 so that registerClient with the above nodeId would fail with too small buffer size error where size is 63, which is larger than 60
in this PR, we use EstimateStructOverhead *3/2 to calculate size.

we need slack of at least 50%  to make sure we can grow and then if there is a firmware upgrade/downgrade, that it doesn't brick


fixes https://github.com/project-chip/connectedhomeip/issues/35735
