### PR TITLE
[Tizen] Run tests from 9P-shared directory instead of ISO

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-79 : [NXP] Updating NXP docker image to include k32w0 platform
+80 : [NXP] Updating NXP docker image to include k32w0 platform

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-80 : [NXP] Updating NXP docker image to include k32w0 platform
+80 : [Tizen] Run tests from 9P-shared directory instead of ISO

--- a/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
@@ -151,7 +151,7 @@ RUN set -x \
     | guestfish --rw -a $TIZEN_IOT_IMAGE_ROOT -m /dev/sda upload - $SYSTEMD_UNIT_OPT_POST_MOUNT : \
     ln-sf $SYSTEMD_UNIT_OPT_POST_MOUNT $SYSTEMD_REQUIRES_LOCAL_FS \
     # Mount using 9P at /mnt/chip
-    && SYSTEMD_9P_MOUNT=$SYSTEMD_SYSTEM/mnt-chip.mount \
+    && SYSTEMD_UNIT_9P_MOUNT=$SYSTEMD_SYSTEM/mnt-chip.mount \
     && echo -n \
     "[Unit]\n" \
     "After=network.target\n" \
@@ -160,8 +160,8 @@ RUN set -x \
     "Where=/mnt/chip\n" \
     "Type=9p\n" \
     "Options=nofail,trans=virtio\n" \
-    | guestfish --rw -a $TIZEN_IOT_IMAGE_ROOT -m /dev/sda upload - $SYSTEMD_9P_MOUNT : \
-    ln-sf $SYSTEMD_9P_MOUNT $SYSTEMD_REQUIRES_LOCAL_FS : \
+    | guestfish --rw -a $TIZEN_IOT_IMAGE_ROOT -m /dev/sda upload - $SYSTEMD_UNIT_9P_MOUNT : \
+    ln-sf $SYSTEMD_UNIT_9P_MOUNT $SYSTEMD_REQUIRES_LOCAL_FS : \
     mkdir /mnt/chip \
     # Setup auto-login for root user
     && SYSTEMD_UNIT_SERIAL_GETTY=$SYSTEMD_SYSTEM/serial-getty@.service \

--- a/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
@@ -150,7 +150,7 @@ RUN set -x \
     "RemainAfterExit=yes\n" \
     | guestfish --rw -a $TIZEN_IOT_IMAGE_ROOT -m /dev/sda upload - $SYSTEMD_UNIT_OPT_POST_MOUNT : \
     ln-sf $SYSTEMD_UNIT_OPT_POST_MOUNT $SYSTEMD_REQUIRES_LOCAL_FS \
-    # Mount 9P at /mnt/chip
+    # Mount using 9P at /mnt/chip
     && SYSTEMD_9P_MOUNT=$SYSTEMD_SYSTEM/mnt-chip.mount \
     && echo -n \
     "[Unit]\n" \

--- a/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
@@ -16,7 +16,6 @@ RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
     bc \
-    genisoimage \
     libgmp-dev \
     libmpc-dev \
     patch \
@@ -57,8 +56,12 @@ RUN set -x \
     && ./scripts/config -e VIRTIO_NET -e VETH \
     && ./scripts/config -e IKCONFIG -e IKCONFIG_PROC \
     && ./scripts/config -e BT_HCIVHCI -e CRYPTO_USER_API_HASH -e CRYPTO_USER_API_SKCIPHER \
-    && ./scripts/config -e OVERLAY_FS -e ISO9660_FS \
+    && ./scripts/config -e OVERLAY_FS \
     && ./scripts/config -e SECURITY_SMACK_PERMISSIVE_MODE \
+    && ./scripts/config -e NET_9P -e NET_9P_VIRTIO \
+    && ./scripts/config -e INET \
+    && ./scripts/config -e 9P_FS -e 9P_FS_POSIX_ACL \
+    && ./scripts/config -e PCI_HOST_GENERIC \
     && make olddefconfig \
     && make -j$(nproc) zImage \
     && mv arch/arm/boot/zImage $TIZEN_IOT_QEMU_KERNEL \
@@ -147,17 +150,18 @@ RUN set -x \
     "RemainAfterExit=yes\n" \
     | guestfish --rw -a $TIZEN_IOT_IMAGE_ROOT -m /dev/sda upload - $SYSTEMD_UNIT_OPT_POST_MOUNT : \
     ln-sf $SYSTEMD_UNIT_OPT_POST_MOUNT $SYSTEMD_REQUIRES_LOCAL_FS \
-    # Mount Matter ISO image on startup
-    && SYSTEMD_UNIT_CHIP_MOUNT=$SYSTEMD_SYSTEM/mnt-chip.mount \
+    # Mount 9P at /mnt/chip
+    && SYSTEMD_9P_MOUNT=$SYSTEMD_SYSTEM/mnt-chip.mount \
     && echo -n \
     "[Unit]\n" \
-    "ConditionPathIsMountPoint=!/mnt/chip\n" \
+    "After=network.target\n" \
     "[Mount]\n" \
-    "What=/dev/disk/by-label/CHIP\n" \
+    "What=host0\n" \
     "Where=/mnt/chip\n" \
-    "Options=nofail\n" \
-    | guestfish --rw -a $TIZEN_IOT_IMAGE_ROOT -m /dev/sda upload - $SYSTEMD_UNIT_CHIP_MOUNT : \
-    ln-sf $SYSTEMD_UNIT_CHIP_MOUNT $SYSTEMD_REQUIRES_LOCAL_FS : \
+    "Type=9p\n" \
+    "Options=nofail,trans=virtio\n" \
+    | guestfish --rw -a $TIZEN_IOT_IMAGE_ROOT -m /dev/sda upload - $SYSTEMD_9P_MOUNT : \
+    ln-sf $SYSTEMD_9P_MOUNT $SYSTEMD_REQUIRES_LOCAL_FS : \
     mkdir /mnt/chip \
     # Setup auto-login for root user
     && SYSTEMD_UNIT_SERIAL_GETTY=$SYSTEMD_SYSTEM/serial-getty@.service \

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -6,7 +6,7 @@ FROM ghcr.io/project-chip/chip-build-android:${VERSION} AS android
 FROM ghcr.io/project-chip/chip-build-esp32-qemu:${VERSION} as esp32
 FROM ghcr.io/project-chip/chip-build-telink:${VERSION} AS telink
 FROM ghcr.io/project-chip/chip-build-infineon:${VERSION} AS psoc6
-FROM ghcr.io/project-chip/chip-build-tizen:${VERSION} AS tizen
+FROM ghcr.io/project-chip/chip-build-tizen-qemu:${VERSION} AS tizen
 FROM ghcr.io/project-chip/chip-build-crosscompile:${VERSION} AS crosscompile
 FROM ghcr.io/project-chip/chip-build-ameba:${VERSION} AS ameba
 FROM ghcr.io/project-chip/chip-build-nxp:${VERSION} AS nxp
@@ -139,10 +139,10 @@ ENV NXP_SDK_PATH=/opt/nxp
 # NOTE: This directory is NOT persistent.
 ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
 
-ENV TIZEN_VERSION 7.0
+ENV TIZEN_VERSION 8.0
 ENV TIZEN_SDK_ROOT /opt/tizen-sdk
 ENV TIZEN_SDK_TOOLCHAIN $TIZEN_SDK_ROOT/tools/arm-linux-gnueabi-gcc-9.2
-ENV TIZEN_SDK_SYSROOT $TIZEN_SDK_ROOT/platforms/tizen-$TIZEN_VERSION/mobile/rootstraps/mobile-$TIZEN_VERSION-device.core
+ENV TIZEN_SDK_SYSROOT $TIZEN_SDK_ROOT/platforms/tizen-$TIZEN_VERSION/tizen/rootstraps/tizen-$TIZEN_VERSION-device.core
 
 ENV FVP_CORSTONE_300_PATH=/opt/FVP_Corstone_SSE-300
 ENV BOUFFALOLAB_SDK_ROOT=/opt/bouffalolab_sdk


### PR DESCRIPTION
### Issue

Currently the way tests and runner are passed onto QEMU is by mounting an iso image containing these. The problem with this approach is that building the image is slow, and does not allow to share output files back with host which will be needed in a follow-up PR (#35786) adding code coverage for tests.


### Solution

Scalable and efficient method is to share tests directory between host and QEMU using virtfs with 9P. This approach involves copying adequate runner to `${root_out_dir}/tests` and then sharing it as `/mnt/chip` on QEMU side. This is highly configurable as the new option`tizen_qemu.py --share` takes a custom path. A service is added which performs the mounting.

### Testing

Tested locally using both interactive and non-interactive modes with and without customized shared directory.

### Extra notes
This PR contains only Dockerfile changes for the mentioned above issue and solution.