### PR TITLE
MTRDevice should remember new DataVersion values even if the attribute value did not change.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -3533,6 +3533,8 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             NSNumber * dataVersion = attributeDataValue[MTRDataVersionKey];
             MTRClusterPath * clusterPath = [MTRClusterPath clusterPathWithEndpointID:attributePath.endpoint clusterID:attributePath.cluster];
             if (dataVersion) {
+                [self _noteDataVersion:dataVersion forClusterPath:clusterPath];
+
                 // Remove data version from what we cache in memory
                 attributeDataValue = [self _dataValueWithoutDataVersion:attributeDataValue];
             }
@@ -3545,10 +3547,6 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 #endif
             // Now that we have grabbed previousValue, update our cache with the attribute value.
             if (readCacheValueChanged) {
-                if (dataVersion) {
-                    [self _noteDataVersion:dataVersion forClusterPath:clusterPath];
-                }
-
                 [self _pruneStoredDataForPath:attributePath missingFrom:attributeDataValue];
 
                 if (!_deviceConfigurationChanged) {


### PR DESCRIPTION
We used to ignore "same value but new DataVersion" because some devices would spam reports that looked like that and we were constantly hitting storage for the DataVersion updates.  But now that we have backoffs on the storage of our cluster data, we can go ahead and just note the new DataVersion and rely on that backoff to prevent hitting storage too much.

The test update verifies that:

1) Reports with same value but new DataVersion do get persisted but are subject
   to the persistence backoff settings.
2) Reports with the same value and same DataVersion do not lead to any storage
   traffic.

Review note: The test changes are best reviewed in a whitespace-insensitive diff.