### PR TITLE
tagging rootNode as a mandatory device type in zcl.json for ZAP 

### DIFF
--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -681,6 +681,7 @@
         ],
         "Service Area": ["CurrentArea", "EstimatedEndTime", "FeatureMap"]
     },
+    "mandatoryDeviceTypes": "0x0016",
     "defaultReportingPolicy": "mandatory",
     "ZCLDataTypes": ["ARRAY", "BITMAP", "ENUM", "NUMBER", "STRING", "STRUCT"],
     "fabricHandling": {

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -675,6 +675,7 @@
         ],
         "Service Area": ["CurrentArea", "EstimatedEndTime", "FeatureMap"]
     },
+    "mandatoryDeviceTypes": "0x0016",
     "defaultReportingPolicy": "mandatory",
     "ZCLDataTypes": ["ARRAY", "BITMAP", "ENUM", "NUMBER", "STRING", "STRUCT"],
     "fabricHandling": {


### PR DESCRIPTION
Adding Root Node Device Type's DeviceId to zcl.json indicating it is a "mandatoryDeviceType". 

The XML does not indicate root node being a requirement for any Matter application. That information needs to be recorded somewhere for ZAP to enable it by default. 

