### PR TITLE
Work around random "leaks" failures in CI.

### DIFF
--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
@@ -65,15 +65,26 @@ static void ClearTaskSet(NSMutableSet<NSTask *> * __strong & tasks)
 - (void)tearDown
 {
 #if defined(ENABLE_LEAK_DETECTION) && ENABLE_LEAK_DETECTION
+    /**
+     * Unfortunately, doing this in "+ (void)tearDown" (the global suite teardown)
+     * does not trigger a test failure even if the XCTAssertEqual below fails.
+     */
     if (_detectLeaks) {
         int pid = getpid();
         __auto_type * cmd = [NSString stringWithFormat:@"leaks %d", pid];
         int ret = system(cmd.UTF8String);
-        /**
-         * Unfortunately, doing this in "+ (void)tearDown" (the global suite teardown)
-         * does not trigger a test failure even if the XCTAssertEqual fails.
-         */
-        XCTAssertEqual(ret, 0, "LEAKS DETECTED");
+        if (WIFEXITED(ret)) {
+            // leaks ran to completion.
+            XCTAssertEqual(WEXITSTATUS(ret), 0, "LEAKS DETECTED");
+        } else {
+            // leaks failed to actually run to completion (e.g. crashed or ran
+            // into some other sort of failure trying to do its work).  Ideally
+            // we would fail our tests in that case, but this seems to be
+            // happening a fair amount, and randomly, on the ARM GitHub runners.
+            // Just log and ignore for now.
+            XCTAssertFalse(WIFSTOPPED(ret), "Not expecting a stopped leaks");
+            NSLog(@"Stopped by signal %d", WTERMSIG(ret));
+        }
     }
 #endif
 


### PR DESCRIPTION
It seems that "leaks" randomly fails on the new (ARM) Darwin runners.  For now, just ignore failures and only fail the test suite if "leaks" ran to completion but detected leaks.
