### PR TITLE
Remove unused time update code from MTRDevice.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -245,8 +245,6 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
 @property (nonatomic) NSDate * estimatedStartTimeFromGeneralDiagnosticsUpTime;
 
-@property (nonatomic) NSMutableDictionary * temporaryMetaDataCache;
-
 /**
  * If currentReadClient is non-null, that means that we successfully
  * called SendAutoResubscribeRequest on the ReadClient and have not yet gotten


### PR DESCRIPTION
_scheduleNextUpdate is only called from _updateDeviceTimeAndScheduleNextUpdate.

__updateDeviceTimeAndScheduleNextUpdate is only called from _performScheduledTimeUpdate.

_performScheduledTimeUpdate is only called from _scheduleNextUpdate.

So all three are unused in practice and can be removed.

At that point, timeUpdateScheduled, timeSyncLock, and _setTimeOnDevice become unused and can be removed.

Then _endpointsWithTimeSyncClusterServer, _setUTCTime, and _setDSTOffsets become unused and can be removed.

temporaryMetaDataCache was just unused on both MTRDevice and MTRDevice_Concrete.

_getInternalState is only used on MTRDevice_Concrete, and then _internalDeviceState is unused on MTRDevice and can be removed.
