### PR TITLE
Initialize MTRDevice_XPC and MTRDevice_Concrete with the corresponding controller types.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.h
@@ -18,9 +18,13 @@
 #import <Foundation/Foundation.h>
 #import <Matter/MTRDevice.h>
 
+#import "MTRDeviceController_Concrete.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDevice_Concrete : MTRDevice
+
+- (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController_Concrete *)controller;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -361,7 +361,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 //@synthesize lock = _lock;
 //@synthesize persistedClusterData = _persistedClusterData;
 
-- (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller
+- (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController_Concrete *)controller
 {
     // `super` was NSObject, is now MTRDevice.  MTRDevice hides its `init`
     if (self = [super initForSubclassesWithNodeID:nodeID controller:controller]) {

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -123,7 +123,6 @@ MTR_DIRECT_MEMBERS
 }
 
 - (instancetype)initForSubclassesWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;
-- (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;
 
 // called by controller to clean up and shutdown
 - (void)invalidate;

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.h
@@ -17,9 +17,13 @@
 
 #import <Matter/Matter.h>
 
+#import "MTRDeviceController_XPC.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDevice_XPC : MTRDevice <MTRXPCClientProtocol_MTRDevice>
+
+- (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController_XPC *)controller;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -84,10 +84,8 @@
 
 @synthesize _internalState;
 
-- (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller
+- (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController_XPC *)controller
 {
-    // TODO: Verify that this is a valid MTRDeviceController_XPC?
-
     if (self = [super initForSubclassesWithNodeID:nodeID controller:controller]) {
         // Nothing else to do, all set.
     }


### PR DESCRIPTION
Removes the unreached/unused initWithNodeID:controller: on MTRDevice.

unitTestSetMostRecentReportTimes is only used on MTRDevice_Concrete instances, and is already implemented there, so can be removed from MTRDevice.
