### PR TITLE
Push down the deviceController ivar into MTRDevice subclasses.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -272,6 +272,8 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 #endif
 
 @implementation MTRDevice_Concrete {
+    MTRDeviceController_Concrete * _deviceController;
+
 #ifdef DEBUG
     NSUInteger _unitTestAttributesReportedSinceLastCheck;
 #endif
@@ -365,6 +367,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 {
     // `super` was NSObject, is now MTRDevice.  MTRDevice hides its `init`
     if (self = [super initForSubclassesWithNodeID:nodeID controller:controller]) {
+        _deviceController = controller;
         _timeSyncLock = OS_UNFAIR_LOCK_INIT;
         _descriptionLock = OS_UNFAIR_LOCK_INIT;
         _fabricIndex = controller.fabricIndex;
@@ -463,6 +466,11 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
     return [NSString
         stringWithFormat:@"<%@: %p, node: %016llX-%016llX (%llu), VID: %@, PID: %@, WiFi: %@, Thread: %@, state: %@, last subscription attempt wait: %lus, queued work: %lu, last report: %@%@, last subscription failure: %@%@, controller: %@>", NSStringFromClass(self.class), self, _deviceController.compressedFabricID.unsignedLongLongValue, _nodeID.unsignedLongLongValue, _nodeID.unsignedLongLongValue, vid, pid, wifi, thread, InternalDeviceStateString(internalDeviceState), static_cast<unsigned long>(lastSubscriptionAttemptWait), static_cast<unsigned long>(_asyncWorkQueue.itemCount), mostRecentReportTime, reportAge, lastSubscriptionFailureTime, subscriptionFailureAge, _deviceController.uniqueIdentifier];
+}
+
+- (nullable MTRDeviceController *)deviceController
+{
+    return _deviceController;
 }
 
 - (NSDictionary *)_internalProperties

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -116,10 +116,6 @@ MTR_DIRECT_MEMBERS
     // Our node ID, with the ivar declared explicitly so it's accessible to
     // subclasses.
     NSNumber * _nodeID;
-
-    // Our controller.  Declared nullable because our property is, though in
-    // practice it does not look like we ever set it to nil.
-    MTRDeviceController * _Nullable _deviceController;
 }
 
 - (instancetype)initForSubclassesWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -80,14 +80,16 @@
                                   : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
                                   : [self nodeID])
 
-@implementation MTRDevice_XPC
+@implementation MTRDevice_XPC {
+    MTRDeviceController_XPC * _deviceController;
+}
 
 @synthesize _internalState;
 
 - (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController_XPC *)controller
 {
     if (self = [super initForSubclassesWithNodeID:nodeID controller:controller]) {
-        // Nothing else to do, all set.
+        _deviceController = controller;
     }
 
     return self;
@@ -129,6 +131,11 @@
         wifi,
         thread,
         _deviceController.uniqueIdentifier];
+}
+
+- (nullable MTRDeviceController *)deviceController
+{
+    return _deviceController;
 }
 
 #pragma mark - Client Callbacks (MTRDeviceDelegate)


### PR DESCRIPTION
This allows them to store the specific controller types they are associated with, which will allow us to move APIs that only make sense for a particular type to that type.
