### PR TITLE
Go back to macos-13 for the Darwin framework tests.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -36,7 +36,7 @@ jobs:
     framework:
         name: Build framework
         if: github.actor != 'restyled-io[bot]'
-        runs-on: macos-14
+        runs-on: macos-13
         strategy:
             matrix:
                 options: # We don't need a full matrix
@@ -73,7 +73,7 @@ jobs:
         name: Run framework tests
         if: github.actor != 'restyled-io[bot]'
         needs: [framework] # serialize to avoid running to many parallel macos runners
-        runs-on: macos-14
+        runs-on: macos-13
         strategy:
             matrix:
                 options: # We don't need a full matrix


### PR DESCRIPTION
The macos-14 runners are random-failing a lot.  Rolling back to the previous runner version while we investigate that.
