### PR TITLE
[Silabs] Added [[maybe_unused]] to remove errors when disable detail logging

### DIFF
--- a/src/platform/silabs/multi-ota/OTAHooks.cpp
+++ b/src/platform/silabs/multi-ota/OTAHooks.cpp
@@ -30,7 +30,7 @@
 
 CHIP_ERROR chip::OTAMultiImageProcessorImpl::ProcessDescriptor(void * descriptor)
 {
-    auto desc = static_cast<chip::OTAFirmwareProcessor::Descriptor *>(descriptor);
+    [[maybe_unused]] auto desc = static_cast<chip::OTAFirmwareProcessor::Descriptor *>(descriptor);
     ChipLogDetail(SoftwareUpdate, "Descriptor: %ld, %s, %s", desc->version, desc->versionString, desc->buildDate);
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
Description of Problem:
Unused variable errors when disable detail logging

Testing Done:
./scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs out BRD4187C chip_enable_multi_ota_requestor=true chip_enable_ota_requestor=true chip_detail_logging=false

