### PR TITLE
Move the operationalInstanceAdded/nodeMayBeAdvertisingOperational bits to concrete device/controller.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -432,13 +432,6 @@ using namespace chip::Tracing::DarwinFramework;
     [_delegates removeAllObjects];
 }
 
-- (void)nodeMayBeAdvertisingOperational
-{
-    assertChipStackLockedByCurrentThread();
-
-    MTR_LOG("%@ saw new operational advertisement", self);
-}
-
 - (BOOL)_delegateExists
 {
     os_unfair_lock_assert_owner(&self->_lock);

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -675,22 +675,6 @@ using namespace chip::Tracing::DarwinFramework;
     [self syncRunOnWorkQueue:block error:nil];
 }
 
-- (void)operationalInstanceAdded:(chip::NodeId)nodeID
-{
-    // Don't use deviceForNodeID here, because we don't want to create the
-    // device if it does not already exist.
-    os_unfair_lock_lock(self.deviceMapLock);
-    MTRDevice * device = [_nodeIDToDeviceMap objectForKey:@(nodeID)];
-    os_unfair_lock_unlock(self.deviceMapLock);
-
-    if (device == nil) {
-        return;
-    }
-
-    ChipLogProgress(Controller, "Notifying device about node 0x" ChipLogFormatX64 " advertising", ChipLogValueX64(nodeID));
-    [device nodeMayBeAdvertisingOperational];
-}
-
 - (void)downloadLogFromNodeWithID:(NSNumber *)nodeID
                              type:(MTRDiagnosticLogType)type
                           timeout:(NSTimeInterval)timeout

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -1132,7 +1132,7 @@ MTR_DIRECT_MEMBERS
         if (compressedFabricId != nil && compressedFabricId.unsignedLongLongValue == operationalID.GetCompressedFabricId()) {
             ChipLogProgress(Controller, "Notifying controller at fabric index %u about new operational node 0x" ChipLogFormatX64,
                 controller.fabricIndex, ChipLogValueX64(operationalID.GetNodeId()));
-            [controller operationalInstanceAdded:operationalID.GetNodeId()];
+            [controller operationalInstanceAdded:@(operationalID.GetNodeId())];
         }
 
         // Keep going: more than one controller might match a given compressed

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -117,6 +117,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)directlyGetSessionForNode:(chip::NodeId)nodeID completion:(MTRInternalDeviceConnectionCallback)completion;
 
+/**
+ * Notify the controller that a new operational instance with the given node id
+ * and a compressed fabric id that matches this controller has been observed.
+ */
+- (void)operationalInstanceAdded:(NSNumber *)nodeID;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -202,12 +202,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (MTRBaseDevice *)baseDeviceForNodeID:(NSNumber *)nodeID;
 
 /**
- * Notify the controller that a new operational instance with the given node id
- * and a compressed fabric id that matches this controller has been observed.
- */
-- (void)operationalInstanceAdded:(chip::NodeId)nodeID;
-
-/**
  * Download log of the desired type from the device.
  */
 - (void)downloadLogFromNodeWithID:(NSNumber *)nodeID

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.h
@@ -26,6 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController_Concrete *)controller;
 
+// Called by controller when a new operational advertisement for what we think
+// is this device's identity has been observed.  This could have
+// false-positives, for example due to compressed fabric id collisions.
+- (void)nodeMayBeAdvertisingOperational;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -128,11 +128,6 @@ MTR_DIRECT_MEMBERS
 // called by controller to clean up and shutdown
 - (void)invalidate;
 
-// Called by controller when a new operational advertisement for what we think
-// is this device's identity has been observed.  This could have
-// false-positives, for example due to compressed fabric id collisions.
-- (void)nodeMayBeAdvertisingOperational;
-
 - (BOOL)_callDelegatesWithBlock:(void (^)(id<MTRDeviceDelegate> delegate))block;
 
 // Called by MTRDevice_XPC to forward delegate callbacks


### PR DESCRIPTION
These are only used in the concrete case.
