### PR TITLE
Remove some more unused bits in MTRDeviceController.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -1099,7 +1099,7 @@ MTR_DIRECT_MEMBERS
 }
 
 - (void)downloadLogFromNodeWithID:(NSNumber *)nodeID
-                       controller:(MTRDeviceController *)controller
+                       controller:(MTRDeviceController_Concrete *)controller
                              type:(MTRDiagnosticLogType)type
                           timeout:(NSTimeInterval)timeout
                             queue:(dispatch_queue_t)queue

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
@@ -83,7 +83,7 @@ MTR_DIRECT_MEMBERS
  * Download log of the desired type from the device.
  */
 - (void)downloadLogFromNodeWithID:(NSNumber *)nodeID
-                       controller:(MTRDeviceController *)controller
+                       controller:(MTRDeviceController_Concrete *)controller
                              type:(MTRDiagnosticLogType)type
                           timeout:(NSTimeInterval)timeout
                             queue:(dispatch_queue_t)queue

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -19,6 +19,7 @@
 
 #import <Matter/Matter.h>
 
+#import "MTRDeviceConnectionBridge.h"
 #import "MTRDeviceControllerStartupParams_Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -108,6 +109,13 @@ NS_ASSUME_NONNULL_BEGIN
  * Clear any pending shutdown request.
  */
 - (void)clearPendingShutdown;
+
+/**
+ * Since getSessionForNode now enqueues by the subscription pool for Thread
+ * devices, MTRDevice_Concrete needs a direct non-queued access because it already
+ * makes use of the subscription pool.
+ */
+- (void)directlyGetSessionForNode:(chip::NodeId)nodeID completion:(MTRInternalDeviceConnectionCallback)completion;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -243,13 +243,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(nullable NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData;
 - (void)removeDevice:(MTRDevice *)device;
 
-/**
- * Since getSessionForNode now enqueues by the subscription pool for Thread
- * devices, MTRDevice needs a direct non-queued access because it already
- * makes use of the subscription pool.
- */
-- (void)directlyGetSessionForNode:(chip::NodeId)nodeID completion:(MTRInternalDeviceConnectionCallback)completion;
-
 @end
 
 /**

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -2388,7 +2388,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     MATTER_LOG_METRIC_BEGIN(kMetricMTRDeviceInitialSubscriptionSetup);
 
     // Call directlyGetSessionForNode because the subscription setup already goes through the subscription pool queue
-    [_deviceController
+    [[self _concreteController]
         directlyGetSessionForNode:_nodeID.unsignedLongLongValue
                        completion:^(chip::Messaging::ExchangeManager * _Nullable exchangeManager,
                            const chip::Optional<chip::SessionHandle> & session, NSError * _Nullable error,
@@ -4136,6 +4136,14 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     // Use _ensureSubscriptionForExistingDelegates so that the subscriptions
     // will go through the pool as needed, not necessarily happen immediately.
     [self _ensureSubscriptionForExistingDelegates:@"Controller resumed"];
+}
+
+// nullable because technically _deviceController is nullable.
+- (nullable MTRDeviceController_Concrete *)_concreteController
+{
+    // We know our _deviceController is actually an MTRDeviceController_Concrete, since that's what
+    // gets passed to initWithNodeID.
+    return static_cast<MTRDeviceController_Concrete *>(_deviceController);
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -118,7 +118,8 @@ MTR_DIRECT_MEMBERS
     NSNumber * _nodeID;
 
     // Our controller.  Declared nullable because our property is, though in
-    // practice it does not look like we ever set it to nil.
+    // practice it does not look like we ever set it to nil.  If this changes,
+    // fix _concreteController on MTRDevice_Concrete accordingly.
     MTRDeviceController * _Nullable _deviceController;
 }
 

--- a/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.h
+++ b/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.h
@@ -20,6 +20,8 @@
 #import <Matter/MTRDeviceController.h>
 #import <Matter/MTRDiagnosticLogsType.h>
 
+#import "MTRDeviceController_Concrete.h"
+
 namespace chip {
 namespace bdx {
     class BDXTransferServerDelegate;
@@ -33,14 +35,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Must be called on Matter queue
 - (void)downloadLogFromNodeWithID:(NSNumber *)nodeID
-                       controller:(MTRDeviceController *)controller
+                       controller:(MTRDeviceController_Concrete *)controller
                              type:(MTRDiagnosticLogType)type
                           timeout:(NSTimeInterval)timeout
                             queue:(dispatch_queue_t)queue
                        completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
 // Must be called on Matter queue
-- (void)abortDownloadsForController:(MTRDeviceController *)controller;
+- (void)abortDownloadsForController:(MTRDeviceController_Concrete *)controller;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.mm
+++ b/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.mm
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
                     completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
                           done:(void (^)(MTRDownload * finishedDownload))done;
 
-- (void)abortDownloadsForController:(MTRDeviceController *)controller;
+- (void)abortDownloadsForController:(MTRDeviceController_Concrete *)controller;
 
 @end
 
@@ -354,7 +354,7 @@ private:
     return download;
 }
 
-- (void)abortDownloadsForController:(MTRDeviceController *)controller
+- (void)abortDownloadsForController:(MTRDeviceController_Concrete *)controller
 {
     assertChipStackLockedByCurrentThread();
 
@@ -408,7 +408,7 @@ private:
 }
 
 - (void)downloadLogFromNodeWithID:(NSNumber *)nodeID
-                       controller:(MTRDeviceController *)controller
+                       controller:(MTRDeviceController_Concrete *)controller
                              type:(MTRDiagnosticLogType)type
                           timeout:(NSTimeInterval)timeout
                             queue:(dispatch_queue_t)queue
@@ -462,7 +462,7 @@ private:
     }
 }
 
-- (void)abortDownloadsForController:(MTRDeviceController *)controller;
+- (void)abortDownloadsForController:(MTRDeviceController_Concrete *)controller;
 {
     assertChipStackLockedByCurrentThread();
 


### PR DESCRIPTION
Controller's downloadLogFromNodeWithID is only used from MTRBaseDevice, which is not expected to be used with a non-concrete controller.  Unfortunately, nothing actually prevents an MTRBaseDevice beign created against a non-concrete controller, so we can't just move this API to MTRDeviceController_Concrete.

With the implementation of downloadLogFromNodeWithID removed, _factory is unused and can be removed.

Also, with this implementation removed the factory's downloadLogFromNodeWithID can take MTRDeviceController_Concrete, as can the diagnostic log downloader.

Similarly, getSessionFromNode is only used from MTRBaseDevice and MTRCallbackBridgeBase's ActionWithNodeID.  And ActionWithNodeID is only used from DispatchAction, which is only called from MTRBaseClusters and MTRBaseDevice, none of which is expected to work with a non-concrete controller.  So this implementation can also be removed.

At that point directlyGetSessionForNode is only used from MTRDevice_Concrete, so we can just move it to MTRDeviceController_Concrete.

getSessionForCommissioneeDevice is only used from ActionWithPASEDevice, which is only used from DispatchAction, like getSessionFromNode.  So this implementation can also be removed.

At this point asyncDispatchToMatterQueue is only used from:

* MTRBaseDevice
* MTRClusterStateCacheContainer, where it's used on a controller coming from MTRBaseDevice.
* MTRDevice_Concrete, where it's being used on a concrete controller.
* MTRDiagnosticLogsDownloader, where it's being used on a concrete controller.
* MTRServerAttribute/MTRServerCluster/MTRServerEndpoint, which are not usable with non-concrete controllers as things stand.
* MTROTAProviderDelegateBridge, where its being used on a concrete controller.

So the MTRDeviceController implementation of asyncDispatchToMatterQueue can also be removed.
