### PR TITLE
Remove usage of a separate `python.json` environment.

### DIFF
--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -141,7 +141,8 @@ _bootstrap_or_activate() {
     $_CHIP_ROOT/scripts/setup/gen_pigweed_cipd_json.py \
         -i $_PIGWEED_CIPD_JSON                         \
         -o $_GENERATED_PIGWEED_CIPD_JSON               \
-        -e darwin:$_PYTHON_CIPD_JSON
+        -e darwin:$_PYTHON_CIPD_JSON                   \
+        -e windows:$_PYTHON_CIPD_JSON
 
     if test -n "$GITHUB_ACTION"; then
         tee <<EOF >"${_PW_ACTUAL_ENVIRONMENT_ROOT}/pip.conf"

--- a/scripts/setup/environment.json
+++ b/scripts/setup/environment.json
@@ -1,7 +1,6 @@
 {
     "cipd_package_files": [
         "third_party/pigweed/repo/pw_env_setup/py/pw_env_setup/cipd_setup/arm.json",
-        "scripts/setup/python.json",
         "scripts/setup/zap.json"
     ],
     "virtualenv": {

--- a/scripts/setup/gen_pigweed_cipd_json.py
+++ b/scripts/setup/gen_pigweed_cipd_json.py
@@ -51,6 +51,7 @@ def generate_new_cipd_package_json(input, output, extra):
     logging.info("LOADING EXTRA PACKAGES FOR %s", my_platform)
     logging.info("Mappings: %r", extra)
 
+    # Odd "," because extra items are list entries
     for item, in extra:
         inject_platform, path = item.split(':', 1)
 

--- a/scripts/setup/gen_pigweed_cipd_json.py
+++ b/scripts/setup/gen_pigweed_cipd_json.py
@@ -48,12 +48,14 @@ def generate_new_cipd_package_json(input, output, extra):
     # Filter it for the given platform and append any resulting packages
     my_platform = platform.system().lower()
 
-    logging.info("LADING EXTRA PACKAGES FOR %s", my_platform)
+    logging.info("LOADING EXTRA PACKAGES FOR %s", my_platform)
+    logging.info("Mappings: %r", extra)
 
     for item in extra:
         inject_platform, path = item.split(':', 1)
 
         if inject_platform.lower() != my_platform:
+            logging.info("Skipping: %s (i.e. %s)", inject_platform.lower(), path)
             continue
 
         logging.info("Appending: %s", path)

--- a/scripts/setup/gen_pigweed_cipd_json.py
+++ b/scripts/setup/gen_pigweed_cipd_json.py
@@ -63,7 +63,7 @@ def generate_new_cipd_package_json(input, output, extra):
     with open(output, 'w') as f:
         json.dump(new_packages, f, indent=2)
 
-     logging.info("PACKAGES:\n%s\n", json.dump(new_packages, f, indent=2))
+     logging.info("PACKAGES:\n%s\n", json.dumps(new_packages, indent=2))
 
 
 def main():

--- a/scripts/setup/gen_pigweed_cipd_json.py
+++ b/scripts/setup/gen_pigweed_cipd_json.py
@@ -19,7 +19,10 @@ import json
 import logging
 import platform
 
-_LIST_OF_PACKAGES_TO_EXCLUDE = ['fuchsia/third_party/rust/']
+_LIST_OF_PACKAGES_TO_EXCLUDE = {
+   'fuchsia/third_party/rust/',
+   'infra/3pp/tools/renode',
+}
 
 
 def include_package(package: dict) -> bool:

--- a/scripts/setup/gen_pigweed_cipd_json.py
+++ b/scripts/setup/gen_pigweed_cipd_json.py
@@ -63,7 +63,7 @@ def generate_new_cipd_package_json(input, output, extra):
     with open(output, 'w') as f:
         json.dump(new_packages, f, indent=2)
 
-     logging.info("PACKAGES:\n%s\n", json.dumps(new_packages, indent=2))
+    logging.info("PACKAGES:\n%s\n", json.dumps(new_packages, indent=2))
 
 
 def main():

--- a/scripts/setup/gen_pigweed_cipd_json.py
+++ b/scripts/setup/gen_pigweed_cipd_json.py
@@ -51,7 +51,6 @@ def generate_new_cipd_package_json(input, output, extra):
 
     logging.info("Loading extra packages for %s", my_platform)
 
-    
     # Extra chain because extra is a list of lists like:
     # [['darwin:path1'], ['windows:path2']]
     for item in itertools.chain.from_iterable(extra):

--- a/scripts/setup/gen_pigweed_cipd_json.py
+++ b/scripts/setup/gen_pigweed_cipd_json.py
@@ -16,6 +16,7 @@
 
 import argparse
 import json
+import logging
 import platform
 
 _LIST_OF_PACKAGES_TO_EXCLUDE = ['fuchsia/third_party/rust/']
@@ -43,11 +44,16 @@ def generate_new_cipd_package_json(input, output, extra):
     # Extra is a list of platform:json.
     # Filter it for the given platform and append any resulting packages
     my_platform = platform.system().lower()
+
+    logging.info("LADING EXTRA PACKAGES FOR %s", my_platform)
+
     for item in extra:
         inject_platform, path = item.split(':', 1)
 
         if inject_platform.lower() != my_platform:
             continue
+
+        logging.info("Appending: %s", path)
 
         with open(path) as ins:
             for package in json.load(ins).get('packages'):
@@ -56,6 +62,8 @@ def generate_new_cipd_package_json(input, output, extra):
     new_packages = {'packages': new_file_packages}
     with open(output, 'w') as f:
         json.dump(new_packages, f, indent=2)
+
+     logging.info("PACKAGES:\n%s\n", json.dump(new_packages, f, indent=2))
 
 
 def main():

--- a/scripts/setup/gen_pigweed_cipd_json.py
+++ b/scripts/setup/gen_pigweed_cipd_json.py
@@ -82,6 +82,7 @@ def main():
         help="Inject extra packages for specific platforms. Format is <platform>:<path_to_json>"
     )
 
+    logging.basicConfig(format= '%(asctime)s %(message)s', level=logging.INFO)
     generate_new_cipd_package_json(**vars(parser.parse_args()))
 
 

--- a/scripts/setup/gen_pigweed_cipd_json.py
+++ b/scripts/setup/gen_pigweed_cipd_json.py
@@ -51,7 +51,7 @@ def generate_new_cipd_package_json(input, output, extra):
     logging.info("LOADING EXTRA PACKAGES FOR %s", my_platform)
     logging.info("Mappings: %r", extra)
 
-    for item in extra:
+    for item, in extra:
         inject_platform, path = item.split(':', 1)
 
         if inject_platform.lower() != my_platform:
@@ -83,7 +83,7 @@ def main():
         '--output', '-o', required=True
     )
     parser.add_argument(
-        '--extra', '-e', nargs='*', default=[],
+        '--extra', '-e', nargs='*', action="append",
         help="Inject extra packages for specific platforms. Format is <platform>:<path_to_json>"
     )
 

--- a/scripts/setup/gen_pigweed_cipd_json.py
+++ b/scripts/setup/gen_pigweed_cipd_json.py
@@ -20,8 +20,8 @@ import logging
 import platform
 
 _LIST_OF_PACKAGES_TO_EXCLUDE = {
-   'fuchsia/third_party/rust/',
-   'infra/3pp/tools/renode',
+    'fuchsia/third_party/rust/',
+    'infra/3pp/tools/renode',
 }
 
 
@@ -85,7 +85,7 @@ def main():
         help="Inject extra packages for specific platforms. Format is <platform>:<path_to_json>"
     )
 
-    logging.basicConfig(format= '%(asctime)s %(message)s', level=logging.INFO)
+    logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
     generate_new_cipd_package_json(**vars(parser.parse_args()))
 
 

--- a/scripts/setup/python.json
+++ b/scripts/setup/python.json
@@ -1,9 +1,0 @@
-{
-    "packages": [
-        {
-            "path": "infra/3pp/tools/cpython3/${platform}",
-            "platforms": ["mac-amd64", "windows-amd64"],
-            "tags": ["version:2@3.9.5.chromium.19"]
-        }
-    ]
-}


### PR DESCRIPTION
We instead now pull the python according to pigweed setup (so that version is maintained and uniform).

This moves windows to also use python 3.11 (because 3.9 will not work) and removes the mac-amd64 pull of a python3.9 as that is redundant.

### Changes

- remove python3.9 checkout for windows and darwin amd64
- pull python 3.11 for windows
- Fix argument repeat bug in `gen_pigweed_cipd_json.py`
- Add some logging to `gen_pigweed_cipd_json.py` to be able to see what it does
- remove `renode` cipd pull since we do not seem to use that one
