### PR TITLE
[Silabs] Enabling custom board support for matter

### DIFF
--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -18,7 +18,7 @@ declare_args() {
 
   # Silabs mcu family used
   silabs_family = ""
-  
+
   # Silabs mcu model used
   silabs_mcu = ""
 
@@ -162,8 +162,8 @@ if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A") {
   print("Using custom board configuration")
   print("silabs_family:", silabs_family)
   print("silabs_mcu:", silabs_mcu)
-  assert(silabs_family != "", "Must specify silabs_family to configure custom board")
-  assert(silabs_mcu != "", "Must specify silabs_mcu to configure custom board")
+  assert(silabs_family != "", "Must specify silabs_family to config custom board")
+  assert(silabs_mcu != "", "Must specify silabs_mcu to config custom board")
 } else {
   assert(
       false,

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -162,8 +162,8 @@ if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A") {
   print("Using custom board configuration")
   print("silabs_family:", silabs_family)
   print("silabs_mcu:", silabs_mcu)
-  assert(silabs_family != "", "Must specify silabs_family to config custom board")
-  assert(silabs_mcu != "", "Must specify silabs_mcu to config custom board")
+  assert(silabs_family != "", "Must specify silabs_family for custom board")
+  assert(silabs_mcu != "", "Must specify silabs_mcu for custom board")
 } else {
   assert(
       false,

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 declare_args() {
-  # Silabs wireless starter kit plug-in boards featuring specific mcu family and mcu model. 
+  # Silabs wireless starter kit plug-in boards featuring specific mcu family and mcu model.
   # Find more information at https://www.silabs.com/development-tools/wireless.
   # A board tailored for specific mcu family and mcu model can be created with "CUSTOM".
   silabs_board = ""

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 declare_args() {
-  # Silabs board used
+  # Silabs wireless starter kit plug-in boards featuring specific mcu family and mcu model. 
+  # Find more information at https://www.silabs.com/development-tools/wireless.
+  # A board tailored for specific mcu family and mcu model can be created with "CUSTOM".
   silabs_board = ""
 
   # Silabs mcu family used
@@ -162,8 +164,6 @@ if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A") {
   print("Using custom board configuration")
   print("silabs_family:", silabs_family)
   print("silabs_mcu:", silabs_mcu)
-  assert(silabs_family != "", "Must specify silabs_family for custom board")
-  assert(silabs_mcu != "", "Must specify silabs_mcu for custom board")
 } else {
   assert(
       false,
@@ -181,6 +181,10 @@ declare_args() {
   # Default true for the wifi soc and false for EFR32 boards
   sl_uart_log_output = wifi_soc
 }
+
+# Silabs mcu family and mcu model must be specified
+assert(silabs_family != "", "Must specify silabs_family")
+assert(silabs_mcu != "", "Must specify silabs_mcu")
 
 # qr code cannot be true if lcd is disabled
 assert(!(disable_lcd && show_qr_code))

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -13,8 +13,14 @@
 # limitations under the License.
 
 declare_args() {
-  # EFR32 board used
+  # Silabs board used
   silabs_board = ""
+
+  # Silabs mcu family used
+  silabs_family = ""
+  
+  # Silabs mcu model used
+  silabs_mcu = ""
 
   # LCD is enabled by default
   # Boards BRD4166A, BRD2601B, BRD2703A and BRD4319A do not have a LCD so they disable it explicitly
@@ -150,6 +156,14 @@ if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A") {
   # ThunderBoards don't have a LCD,
   show_qr_code = false
   disable_lcd = true
+
+  # Custom Board ----------
+} else if (silabs_board == "CUSTOM") {
+  print("Using custom board configuration")
+  print("silabs_family:", silabs_family)
+  print("silabs_mcu:", silabs_mcu)
+  assert(silabs_family != "", "Must specify silabs_family to configure custom board")
+  assert(silabs_mcu != "", "Must specify silabs_mcu to configure custom board")
 } else {
   assert(
       false,


### PR DESCRIPTION
Enable Custom Board Support:
- This enhancement allows for greater flexibility in selecting mcu models, leveraging the diverse range of mcu models provided by Silabs to cater to various application requirements.
- When integrating the connectedhomeip repo as a third-party submodule into developers' projects, the objective is to ensure a seamless downstream process. This involves leveraging `sl_pre_gen_path` to adapt flexibly to custom board configurations.
 ```
  ├── smart-plug-app
  │   ├── silabs
  │   │   ├── args.gni
  │   │   ├── BUILD.gn
  │   │   ├── slcp
  │   │   │   ├── CUSTOM
  │   │   │   │   ├── autogen
  │   │   │   │   └── config
  │   │   │   ├── gatt_configuration.btconf
  │   │   │   └── matter-platform.slcp
  │   │   ├── src
  │   └── smart-plug-common
  │       ├── BUILD.gn
  │       ├── smart-plug.matter
  │       └── smart-plug.zap
  └── third-party
      ├── connectedhomeip
 ```


Testing done:
```
./scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs out CUSTOM silabs_family=\"efr32mg24\" silabs_mcu=\"EFR32MG24A410F1536IM48\" sl_pre_gen_path=\"<PATH_TO_SLCP_GEN>\"
```




