### PR TITLE
Reactivate `function` and `vptr` UBSan checks

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -24,10 +24,40 @@ if (current_os == "mac" || current_os == "ios") {
   import("${build_root}/config/mac/mac_sdk.gni")
 }
 
+# To use different sanitizer options, use `gn args .` in the out folder and
+# use settings like:
+#
+#   is_clang=true
+#   is_debug=true
+#   optimize_for_size=false
+#   is_asan=true
+#   is_sanitize_fatal=false
+#
+
 declare_args() {
   # Enable -Werror. This can be disabled if using a different compiler
   # with unfixed or unsupported wanings.
   treat_warnings_as_errors = true
+
+  # Enable Thread sanitizer
+  is_tsan = false
+
+  # Enable memory sanitizer
+  is_msan = false
+
+  # enable undefined behavior sanitizer
+  is_ubsan = false
+
+  # Exit on sanitize error. Generally standard libraries may get errors
+  # so not stopping on the first error is often useful
+  is_sanitize_fatal = true
+
+  # Enable or disable Runtime Type Information (RTTI).
+  # Defaults true on darwin because Darwin.framework uses it.
+  enable_rtti = current_os == "mac" || current_os == "ios"
+
+  # Enable or disable support for C++ exceptions.
+  enable_exceptions = false
 }
 
 if (current_cpu == "arm" || current_cpu == "arm64") {
@@ -397,21 +427,6 @@ config("runtime_default") {
 #   is_sanitize_fatal=false
 #
 
-declare_args() {
-  # Enable Thread sanitizer
-  is_tsan = false
-
-  # Enable memory sanitizer
-  is_msan = false
-
-  # enable undefined behavior sanitizer
-  is_ubsan = false
-
-  # Exit on sanitize error. Generally standard libraries may get errors
-  # so not stopping on the first error is often useful
-  is_sanitize_fatal = true
-}
-
 config("sanitize_address") {
   defines = []
   cflags = [
@@ -524,15 +539,6 @@ config("coverage_default") {
   if (use_coverage) {
     configs += [ ":coverage" ]
   }
-}
-
-declare_args() {
-  # Enable or disable Runtime Type Information (RTTI).
-  # Defaults true on darwin because Darwin.framework uses it.
-  enable_rtti = current_os == "mac" || current_os == "ios"
-
-  # Enable or disable support for C++ exceptions.
-  enable_exceptions = false
 }
 
 config("no_rtti") {

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -455,6 +455,11 @@ config("sanitize_undefined_behavior") {
     ]
   }
 
+  #According to the LLVM UBSan documentation, sanitizing vptr is incompatible with the -fno-rtti flag.
+  if (!enable_rtti) {
+    cflags += [ "-fno-sanitize=vptr" ]
+  }
+
   ldflags = cflags
 }
 

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -452,7 +452,6 @@ config("sanitize_undefined_behavior") {
       "-fsanitize=unsigned-integer-overflow",
       "-fsanitize=implicit-conversion",
       "-fsanitize=nullability",
-      "-fno-sanitize=vptr,function",
     ]
   }
 


### PR DESCRIPTION
- This is a follow-up to #https://github.com/project-chip/connectedhomeip/pull/35777 which solves an issue uncovered by re-activating `function` UBSan check.
- we should re-activate the  `function` UBSan check to prevent similar errors.

#### In the PR
1. remove `-fno-sanitize` for `function` UBSan checks --> to re-activate it.

2. the `vptr` UBSan check should also be activated, EXCEPT when `-fno-rtti` flag is used (as indicated in [LLVM UBSan Documentation](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#available-checks) 

3. the `declare_arg` blocks in `build/config/compiler/BUILD.gn` were also regrouped to the top of the file.
 
#### Testing
1. CI Tests
2. Fuzzed all-clusters-app with UBSan activated, being run for 20 Minutes.
```
$ ./scripts/build/build_examples.py --target linux-x64-tests-libfuzzer-ubsan-clang build
$ out/linux-x64-tests-libfuzzer-ubsan-clang/tests/fuzz-chip-all-clusters-app 
```