### PR TITLE
[AddressResolver] Add a check in shutdown to avoid some crashes if so…

### DIFF
--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -248,6 +248,8 @@ CHIP_ERROR Resolver::Init(System::Layer * systemLayer)
 
 void Resolver::Shutdown()
 {
+    // mSystemLayer is set in ::Init, so if it's null that means the resolver
+    // has not been initialized or has already been shut down.
     VerifyOrReturn(mSystemLayer != nullptr);
 
     while (mActiveLookups.begin() != mActiveLookups.end())

--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -248,6 +248,8 @@ CHIP_ERROR Resolver::Init(System::Layer * systemLayer)
 
 void Resolver::Shutdown()
 {
+    VerifyOrReturn(mSystemLayer != nullptr);
+
     while (mActiveLookups.begin() != mActiveLookups.end())
     {
         auto current = mActiveLookups.begin();


### PR DESCRIPTION
…meone calls it multiple times

#### Problem

Some apps calls multiple times `Shutdown` on the resolver and it crashes a bit after since it tries to access a null pointer. It won't hurt much to just null check `mSystemLayer` and prevent doing the shutdown twice.