### PR TITLE
[Silabs] Added log entry to signal provision mode enable.

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -230,13 +230,14 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 
     ReturnErrorOnFailure(PlatformMgr().InitChipStack());
 
+    chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(appName);
+
     // Provision Manager
     Silabs::Provision::Manager & provision = Silabs::Provision::Manager::GetInstance();
     ReturnErrorOnFailure(provision.Init());
     SetDeviceInstanceInfoProvider(&provision.GetStorage());
     SetCommissionableDataProvider(&provision.GetStorage());
-
-    chip::DeviceLayer::ConnectivityMgr().SetBLEDeviceName(appName);
+    ChipLogProgress(DeviceLayer, "Provision mode %s", provision.IsProvisionRequired() ? "ENABLED" : "disabled");
 
 #if CHIP_ENABLE_OPENTHREAD
     ReturnErrorOnFailure(InitOpenThread());


### PR DESCRIPTION
Added log to show the state of the provisioning mode.

Testes on EFR32MG24.
