### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-80 : [Tizen] Run tests from 9P-shared directory instead of ISO
+81 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=666326aabcb1b0c1c8d5ef9bd3c9588fd7dbaaf1
+ARG ZEPHYR_REVISION=3ed7686a9378de6be1368c912f9a42f998bbfb18
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=9ea364fd3b48c97f7cea6d69935f1fa630e30fb7
+ARG ZEPHYR_REVISION=666326aabcb1b0c1c8d5ef9bd3c9588fd7dbaaf1
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- soc: riscv: telink_b9x: MCUBoot platform extensions
- soc: riscv: telink_b9x: mcu_boot_startup.c: Print chip ID
- driver: yaml: dtsi: kconfig: add spi driver
- kconfig: update N22 binary revision
- soc: riscv: telink_b9x: mcu_boot_startup.c: Continue boot
- soc: riscv: telink_b9x: Add config to run MCUBoot vendor code
- kconfig: update N22 binary revision
- kconfig: update N22 binary revision
- telink_b9x: Simplify MbedTLS HW acceleration
- kconfig: update N22 binary revision
- kconfig: update N22 binary revision
- dts: Telink W91 v2.1 board layout changes
- soc: riscv: telink_b9x: mcu_boot_startup.c: Calculate chip_id CRC16
- soc: riscv: telink_w91: Matter dual core OTA adaptation:
    - change N22 Image offset & size for Matter OTA
    - add check of n22_partition overlaps
    - download optionally Matter MCUboot files
    - use 4m flash as default
    - add check start core with switch
    - use offset and size from DTS for sctool
    - set correct reset vector & more optimizations
    - kconfig: update N22 binary revision

**Changes of N22 binary:**

- sync with SCM-1.2.5
- Add SPI driver
- Update to build FreeRTOS native examples correctly
- Wrapping changes for ipc-zephyr app
- drivers: add ADC APIs
- Fix build issues with SCM-1.2.5
- Add D25_ZEPHYR config
- Use D25_ZEPHYR config instead of IPC_ZEPHYR config
- Publish Zephyr binaries from master branch
- Adopt BL and app for Matter dual core OTA

Testing
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully