### PR TITLE
[pw_fuzzer] Fix build failure + add coverage to payload decoder fuzztest

### DIFF
--- a/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsingPW.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/FuzzPacketParsingPW.cpp
@@ -96,7 +96,7 @@ void TxtResponderFuzz(const std::vector<std::uint8_t> & aRecord)
     auto equal_sign_pos     = aRecord.end();
 
     // This test is only giving a set of values, it can be gives more
-    vector<uint8_t> prefixedRecord{ static_cast<uint8_t>(aRecord.size()) };
+    std::vector<uint8_t> prefixedRecord{ static_cast<std::uint8_t>(aRecord.size()) };
 
     prefixedRecord.insert(prefixedRecord.end(), aRecord.begin(), aRecord.end());
 
@@ -126,6 +126,6 @@ void TxtResponderFuzz(const std::vector<std::uint8_t> & aRecord)
     }
 }
 
-FUZZ_TEST(MinimalmDNS, TxtResponderFuzz).WithDomains(Arbitrary<vector<uint8_t>>().WithMaxSize(254));
+FUZZ_TEST(MinimalmDNS, TxtResponderFuzz).WithDomains(Arbitrary<std::vector<std::uint8_t>>().WithMaxSize(254));
 
 } // namespace

--- a/src/lib/format/tests/FuzzPayloadDecoderPW.cpp
+++ b/src/lib/format/tests/FuzzPayloadDecoderPW.cpp
@@ -59,13 +59,17 @@ void RunDecodeFuzz(const std::vector<std::uint8_t> & bytes, chip::Protocols::Id 
     }
 }
 
-// This function allows us to fuzz using one of four protocols; by using FuzzTests's `ElementOf` API, we define an
+// This function allows us to fuzz using all existing protocols; by using FuzzTests's `ElementOf` API, we define an
 // input domain by explicitly enumerating the set of values in it More Info:
 // https://github.com/google/fuzztest/blob/main/doc/domains-reference.md#elementof-domains-element-of
 auto AnyProtocolID()
 {
+    // Adding an Invalid Protocol
+    static constexpr chip::Protocols::Id InvalidProtocolID(chip::VendorId::Common, 2121);
+
     return ElementOf({ chip::Protocols::SecureChannel::Id, chip::Protocols::InteractionModel::Id, chip::Protocols::BDX::Id,
-                       chip::Protocols::UserDirectedCommissioning::Id });
+                       chip::Protocols::UserDirectedCommissioning::Id, chip::Protocols::Echo::Id, chip::Protocols::NotSpecified,
+                       InvalidProtocolID });
 }
 
 FUZZ_TEST(PayloadDecoder, RunDecodeFuzz).WithDomains(Arbitrary<std::vector<std::uint8_t>>(), AnyProtocolID(), Arbitrary<uint8_t>());


### PR DESCRIPTION
#### Changes in PR:
1. fix for missing `std` namespace specifier in `FuzzPacketParsingPW.cpp`, that was newly triggered.

2. adding new protocol types (Echo and invalid Protocols) to `FuzzPayloadDecoderPW.cpp`