### PR TITLE
Make the log download test self-contained.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -111,8 +111,7 @@ jobs:
               working-directory: src/darwin/Framework
               run: |
                   mkdir -p /tmp/darwin/framework-tests
-                  echo "This is a simple log" > /tmp/darwin/framework-tests/end_user_support_log.txt
-                  ../../../out/debug/all-clusters-app/chip-all-clusters-app --interface-id -1 --end_user_support_log /tmp/darwin/framework-tests/end_user_support_log.txt > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
+                  ../../../out/debug/all-clusters-app/chip-all-clusters-app --interface-id -1 > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
 
                   export TEST_RUNNER_ASAN_OPTIONS=__CURRENT_VALUE__:detect_stack_use_after_return=1
 

--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -419,6 +419,7 @@ static const uint16_t kPairingTimeoutInSeconds = 30;
 static const uint16_t kTimeoutInSeconds = 3;
 static const uint64_t kDeviceId = 0x12344321;
 static NSString * kOnboardingPayload = @"MT:Y.K90SO527JA0648G00";
+static NSString * _Nullable sLogContentFilePath;
 static NSString * kSimpleLogContent = @"This is a simple log\n";
 static const uint16_t kLocalPort = 5541;
 
@@ -516,14 +517,14 @@ static BOOL sStackInitRan = NO;
     [super setUp];
 
     __auto_type * uniqueName = [[NSUUID UUID] UUIDString];
-    __auto_type * uniquePath = [NSTemporaryDirectory() stringByAppendingPathComponent:uniqueName];
-    [[NSFileManager defaultManager] createFileAtPath:uniquePath
+    sLogContentFilePath = [NSTemporaryDirectory() stringByAppendingPathComponent:uniqueName];
+    [[NSFileManager defaultManager] createFileAtPath:sLogContentFilePath
                                             contents:[kSimpleLogContent dataUsingEncoding:NSUTF8StringEncoding]
                                           attributes:nil];
     BOOL started = [self startAppWithName:@"all-clusters"
                                 arguments:@[
                                     @"--end_user_support_log",
-                                    uniquePath,
+                                    sLogContentFilePath,
                                 ]
                                   payload:kOnboardingPayload];
     XCTAssertTrue(started);
@@ -532,6 +533,10 @@ static BOOL sStackInitRan = NO;
 + (void)tearDown
 {
     // Global teardown, runs once
+    if (sLogContentFilePath != nil) {
+        [[NSFileManager defaultManager] removeItemAtPath:sLogContentFilePath error:nil];
+    }
+
     [self shutdownStack];
     [super tearDown];
 }


### PR DESCRIPTION
It should not be depending on a helper app started in a particular way; it should just start that helper app itself.
