### PR TITLE
Fix, for now, weird subclassing of MTRDevice and MTRDeviceController.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -295,6 +295,15 @@ using namespace chip::Tracing::DarwinFramework;
     return self;
 }
 
+// For now, implement an initWithNodeID in case some sub-class outside the
+// framework called it (by manually declaring it, even though it's not public
+// API).  Ideally we would not have this thing, since its signature does not
+// match the initWithNodeID signatures of our subclasses.
+- (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller
+{
+    return [self initForSubclassesWithNodeID:nodeID controller:controller];
+}
+
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:_systemTimeChangeObserverToken];

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -418,7 +418,11 @@ using namespace chip::Tracing::DarwinFramework;
 - (MTRDevice *)_setupDeviceForNodeID:(NSNumber *)nodeID prefetchedClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)prefetchedClusterData
 {
     MTR_ABSTRACT_METHOD();
-    return nil;
+    // We promise to not return nil from this API... return an MTRDevice
+    // instance, which will largely not be able to do anything useful.  This
+    // only matters when someone subclasses MTRDeviceController in a weird way,
+    // then tries to create an MTRDevice from their subclass.
+    return [[MTRDevice alloc] initForSubclassesWithNodeID:nodeID controller:self];
 }
 
 - (MTRDevice *)deviceForNodeID:(NSNumber *)nodeID


### PR DESCRIPTION
Some of our API consumers are apparently relying on implementation details. Stop breaking them for now, until they can fix that.
