### PR TITLE
Fix data type check in MTRDevice's invokeCommandWithEndpointID.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -1059,7 +1059,7 @@ using namespace chip::Tracing::DarwinFramework;
     }
 
     MTRDeviceDataValueDictionary fieldsDataValue = commandFields;
-    if (fieldsDataValue[MTRTypeKey] != MTRStructureValueType) {
+    if (![MTRStructureValueType isEqual:fieldsDataValue[MTRTypeKey]]) {
         MTR_LOG_ERROR("%@ invokeCommandWithEndpointID passed a commandFields (%@) that is not a structure-typed data-value object",
             self, commandFields);
         completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_ARGUMENT]);


### PR DESCRIPTION
We were checking two NSStrings for pointer-equality, when we should be testing for logical equality.
