### PR TITLE
Fix null pointer issue in CHIPMemString

### DIFF
--- a/src/lib/support/CHIPMemString.h
+++ b/src/lib/support/CHIPMemString.h
@@ -121,12 +121,20 @@ inline void CopyString(char (&dest)[N], ByteSpan source)
  */
 inline void CopyString(char * dest, size_t destLength, CharSpan source)
 {
-    if (dest && destLength)
+    if ((dest == nullptr) || (destLength == 0))
     {
-        size_t maxChars = std::min(destLength - 1, source.size());
-        memcpy(dest, source.data(), maxChars);
-        dest[maxChars] = '\0';
+        return; // no space to copy anything, not even a null terminator
     }
+
+    if (source.empty())
+    {
+        *dest = '\0'; // just a null terminator, we are copying empty data
+        return;
+    }
+
+    size_t maxChars = std::min(destLength - 1, source.size());
+    memcpy(dest, source.data(), maxChars);
+    dest[maxChars] = '\0';
 }
 
 /**


### PR DESCRIPTION
### Description

`CHIPMemString.h:127:22: runtime error: null pointer passed as argument 2, which is declared to never be null`

- Fix passing null pointer issue in CHIPMemString.h:127:22 while running all-cluster-app with UndefinedBehavior Sanitizer
- This PR is similar to PR: [#35580](https://github.com/project-chip/connectedhomeip/pull/35580), but overloaded function did not have the necessary fix applied, which led to a null pointer being passed during the pairing process

### Changes

- Added null pointer checks to the overloaded function in `CHIPMemString`.

### Reproducing

- To reproduce the issue, attempt pairing using the chip-all-clusters-app with Undefined Behavior Sanitizer (UBsan) enabled.

```bash
./out/linux-x64-all-clusters-ubsan-clang/chip-all-clusters-app 

...

[1727661001.811740][5218:5218] CHIP:EM: Flushed pending ack for MessageCounter:263064390 on exchange 45711r
[1727661001.812225][5218:5218] CHIP:FP: Validating NOC chain
[1727661001.813018][5218:5218] CHIP:FP: NOC chain validation successful
../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/lib/support/CHIPMemString.h:127:22: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/lib/support/CHIPMemString.h:127:22 
[1727661001.813423][5218:5218] CHIP:FP: Added new fabric at index: 0x1
[1727661001.813438][5218:5218] CHIP:FP: Assigned compressed fabric ID: 0x653BF2694F51D787, node ID: 0x0000000000000001
[1727661001.813445][5218:5218] CHIP:TS: Last Known Good Time: 2023-10-14T01:16:48
```