### PR TITLE
[TV Apps] Change the shutdown ordering to prevent some crashes when both commissioner and server are enabled

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -679,15 +679,15 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
 
     ApplicationShutdown();
 
-#if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-    ShutdownCommissioner();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-
 #if defined(ENABLE_CHIP_SHELL)
     shellThread.join();
 #endif
 
     Server::GetInstance().Shutdown();
+
+#if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+    ShutdownCommissioner();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
 #if ENABLE_TRACING
     tracing_setup.StopTracing();


### PR DESCRIPTION
…event shutdown crashes

#### Problem

Running `./out/debug/standalone/chip-tv-app` and then `Ctrl^C` results in some crashes.
Changing the ordering shutdown of `ChipLinuxAppMainLoop` 