### PR TITLE
[AllClusters] If opened multiple times and something fails in Init, closing the app with Ctrl^C makes it crashes

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -89,6 +89,7 @@ CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeM
     VerifyOrReturnError(apExchangeMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(reportScheduler != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
+    mState                          = State::kInitializing;
     mpExchangeMgr                   = apExchangeMgr;
     mpFabricTable                   = apFabricTable;
     mpCASESessionMgr                = apCASESessionMgr;
@@ -111,11 +112,14 @@ CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeM
     ChipLogError(InteractionModel, "WARNING └────────────────────────────────────────────────────");
 #endif
 
+    mState = State::kInitialized;
     return CHIP_NO_ERROR;
 }
 
 void InteractionModelEngine::Shutdown()
 {
+    VerifyOrReturn(State::kUninitialized != mState);
+
     mpExchangeMgr->GetSessionManager()->SystemLayer()->CancelTimer(ResumeSubscriptionsTimerCallback, this);
 
     // TODO: individual object clears the entire command handler interface registry.
@@ -187,6 +191,8 @@ void InteractionModelEngine::Shutdown()
     //
     // mpFabricTable    = nullptr;
     // mpExchangeMgr    = nullptr;
+
+    mState = State::kUninitialized;
 }
 
 uint32_t InteractionModelEngine::GetNumActiveReadHandlers() const

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -713,6 +713,14 @@ private:
     DataModel::Provider * mDataModelProvider      = nullptr;
     Messaging::ExchangeContext * mCurrentExchange = nullptr;
 
+    enum class State : uint8_t
+    {
+        kUninitialized, // The object has not been initialized.
+        kInitializing,  // Initial setup is in progress (e.g. setting up mpExchangeMgr).
+        kInitialized    // The object has been fully initialized and is ready for use.
+    };
+    State mState = State::kUninitialized;
+
     // Changes the current exchange context of a InteractionModelEngine to a given context
     class CurrentExchangeValueScope
     {

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -111,6 +111,8 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
 
 void CommissioningWindowManager::Shutdown()
 {
+    VerifyOrReturn(nullptr != mServer);
+
     StopAdvertisement(/* aShuttingDown = */ true);
 
     ResetState();


### PR DESCRIPTION
#### Problem

Run:
```
# Shell 1
$ ./out/debug/standalone/chip-all-clusters-app

# shell 2
$ ./out/debug/standlone/chip-all-clusters-app
# See some error messages during init
# [1727702536.289] [13754:10343763] [IN] Failed to initialize TCP transport: src/inet/TCPEndPointImplSockets.cpp:133: OS # Error 0x02000030: Address already in use
# [1727702536.289] [13754:10343763] [SVR] ERROR setting up transport: src/inet/TCPEndPointImplSockets.cpp:133: OS # Error 0x02000030: Address already in use
# Ctrl^C
# Crash....
```

Basically, Init is failing, but most of our objects don’t provide a way for the caller to know whether they’ve been initialized.

In this case, the caller (`src/app/server/Server.cpp`) unconditionally calls the shutdown method. Since the shutdown method doesn’t perform any null checks, this results in crashes.

This PR adds null checks to prevent these crashes.

Other solutions I’ve considered are:
	•	Updating the caller to track which objects have been initialized using custom variables. However, this approach adds more complexity to the calling code and increases the likelihood of errors.
	•	Modifying the objects to have internal states, allowing the caller to check whether they’ve been initialized. The caller would then need to check these states before calling the shutdown method.