### PR TITLE
docs: Fix links, commands and QR code on first_example

### DIFF
--- a/docs/getting_started/first_example.md
+++ b/docs/getting_started/first_example.md
@@ -82,7 +82,7 @@ Scripts can be used to build both the lighting app and chip tool
 The first thing you need to do is to commission the device. First start up the
 lighting app in one terminal. By default it will start up with the default
 discriminator (3840) and passcode (20202021) and save its non-volatile information
-in a KVS in /temp/chip_kvs. You can change these, and multiple other options on
+in a key-value-store file ("KVS") in /tmp/chip_kvs. You can change this, and multiple other options on
 the command line. For a full description, use the `--help` command.
 
 Start the lighting app in one terminal using

--- a/docs/getting_started/first_example.md
+++ b/docs/getting_started/first_example.md
@@ -45,7 +45,7 @@ This quick start guide will walk you through
 ### Building the lighting app
 
 -   Install prerequisites from
-[docs/guides/BUILDING\.md](../guides/BUILDING.md#prerequisites)
+    [docs/guides/BUILDING\.md](../guides/BUILDING.md#prerequisites)
 -   Run bootstrap or activate to install all the required tools etc.
     -   `. scripts/bootstrap.sh` \- run this first\, or if builds fail
     -   `. scripts/activate.sh` \- faster\, use if you’ve already bootstrapped
@@ -81,9 +81,10 @@ Scripts can be used to build both the lighting app and chip tool
 
 The first thing you need to do is to commission the device. First start up the
 lighting app in one terminal. By default it will start up with the default
-discriminator (3840) and passcode (20202021) and save its non-volatile information
-in a key-value-store file ("KVS") in /tmp/chip_kvs. You can change this, and multiple other options on
-the command line. For a full description, use the `--help` command.
+discriminator (3840) and passcode (20202021) and save its non-volatile
+information in a key-value-store file ("KVS") in /tmp/chip_kvs. You can change
+this, and multiple other options on the command line. For a full description,
+use the `--help` command.
 
 Start the lighting app in one terminal using
 
@@ -98,8 +99,9 @@ Open a new terminal to use chip tool. Commission the device using:
 
 NOTE: pairing is the old name for commissioning. 0x12344321 is the node ID you
 want to assign to the node. 0x12344321 is the default for testing.
-MT:-24J0AFN00KA0648G00 is the QR code for a device with the default discriminator
-and passcode. If you have changed these, the code will be different.
+MT:-24J0AFN00KA0648G00 is the QR code for a device with the default
+discriminator and passcode. If you have changed these, the code will be
+different.
 
 #### Basic device interactions - Sending a command
 

--- a/docs/getting_started/first_example.md
+++ b/docs/getting_started/first_example.md
@@ -10,6 +10,8 @@ The example devices (occasionally referred to as "apps") are located in the
 directory. The examples often implement one particular device type. Some have
 implementations for various platforms.
 
+<!--- Relative path link to "examples" above doesn't work. See #35855 --->
+
 The linux platform examples are provided as examples, and are used in the CI.
 These can be used for preliminary testing.
 

--- a/docs/getting_started/first_example.md
+++ b/docs/getting_started/first_example.md
@@ -6,8 +6,9 @@ familiarize yourself with the SDK and the Matter ecosystem.
 ## Example Devices
 
 The example devices (occasionally referred to as "apps") are located in the
-[examples](../../examples/) directory. The examples often implement one
-particular device type. Some have implementations for various platforms.
+[examples](https://github.com/project-chip/connectedhomeip/tree/master/examples)
+directory. The examples often implement one particular device type. Some have
+implementations for various platforms.
 
 The linux platform examples are provided as examples, and are used in the CI.
 These can be used for preliminary testing.
@@ -43,7 +44,8 @@ This quick start guide will walk you through
 
 ### Building the lighting app
 
--   Install prerequisites from docs/guides/BUILDING\.md
+-   Install prerequisites from
+[docs/guides/BUILDING\.md](../guides/BUILDING.md#prerequisites)
 -   Run bootstrap or activate to install all the required tools etc.
     -   `. scripts/bootstrap.sh` \- run this first\, or if builds fail
     -   `. scripts/activate.sh` \- faster\, use if you’ve already bootstrapped
@@ -78,10 +80,10 @@ Scripts can be used to build both the lighting app and chip tool
 ### Building / Interacting with Matter Examples
 
 The first thing you need to do is to commission the device. First start up the
-app in one terminal. By default it will start up with the default discriminator
-(3840) and passcode (20202021) and save its non-volatile information in a KVS in
-/temp/chip_kvs. You can change these, and multiple other options on the command
-line. For a full description, use the `--help` command.
+lighting app in one terminal. By default it will start up with the default
+discriminator (3840) and passcode (20202021) and save its non-volatile information
+in a KVS in /temp/chip_kvs. You can change these, and multiple other options on
+the command line. For a full description, use the `--help` command.
 
 Start the lighting app in one terminal using
 
@@ -96,12 +98,12 @@ Open a new terminal to use chip tool. Commission the device using:
 
 NOTE: pairing is the old name for commissioning. 0x12344321 is the node ID you
 want to assign to the node. 0x12344321 is the default for testing.
-MT:-24J0AFN00KA0648G0 is the QR code for a device with the default discriminator
+MT:-24J0AFN00KA0648G00 is the QR code for a device with the default discriminator
 and passcode. If you have changed these, the code will be different.
 
 #### Basic device interactions - Sending a command
 
-`./chip-tool onoff on 0x12344321 1`
+`./out/linux-x64-chip-tool/chip-tool onoff on 0x12344321 1`
 
 where:
 
@@ -112,12 +114,12 @@ where:
 
 #### Basic device interactions - Reading an attribute
 
-`./chip-tool onoff read on-off 0x12344321 1`
+`./out/linux-x64-chip-tool/chip-tool onoff read on-off 0x12344321 1`
 
 where:
 
 -   onoff is the cluster name
 -   read is the desired action
--   on is the attribute name
+-   on-off is the attribute name
 -   0x12344321 is the node ID you used for commissioning
 -   1 is the endpoint


### PR DESCRIPTION
Changes:
* Add link to prerequisites
* Fix missing "0" on QR code "-24J0AFN00KA0648G00"
* Update path to chip-tool to "./out/linux-x64-chip-tool/chip-tool" to be consistent with the first examples and easier to copy/paste/run the commands.
* Fix broken link to examples (https://github.com/project-chip/connectedhomeip/blob/examples). I had to hard code the full path as it's been compiled without the branch in the link and I get a 404 when accessing it from "https://project-chip.github.io/connectedhomeip-doc/getting_started/first_example.html#an-sdk-example".
