### PR TITLE
Improve DataVersion filter list logging when subscribing.

### DIFF
--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -626,15 +626,7 @@ CHIP_ERROR ClusterStateCacheT<CanEnableDataCaching>::OnUpdateDataVersionFilterLi
             continue;
         }
 
-        DataVersionFilterIB::Builder & filterIB = aDataVersionFilterIBsBuilder.CreateDataVersionFilter();
-        SuccessOrExit(err = aDataVersionFilterIBsBuilder.GetError());
-        ClusterPathIB::Builder & filterPath = filterIB.CreatePath();
-        SuccessOrExit(err = filterIB.GetError());
-        SuccessOrExit(err = filterPath.Endpoint(filter.first.mEndpointId).Cluster(filter.first.mClusterId).EndOfClusterPathIB());
-        SuccessOrExit(err = filterIB.DataVersion(filter.first.mDataVersion.Value()).EndOfDataVersionFilterIB());
-        ChipLogProgress(DataManagement, "Update DataVersionFilter: Endpoint=%u Cluster=" ChipLogFormatMEI " Version=%" PRIu32,
-                        filter.first.mEndpointId, ChipLogValueMEI(filter.first.mClusterId), filter.first.mDataVersion.Value());
-
+        SuccessOrExit(err = aDataVersionFilterIBsBuilder.EncodeDataVersionFilterIB(filter.first));
         aEncodedDataVersionList = true;
     }
 

--- a/src/app/MessageDef/DataVersionFilterIBs.cpp
+++ b/src/app/MessageDef/DataVersionFilterIBs.cpp
@@ -69,6 +69,21 @@ DataVersionFilterIB::Builder & DataVersionFilterIBs::Builder::CreateDataVersionF
     return mDataVersionFilter;
 }
 
+CHIP_ERROR DataVersionFilterIBs::Builder::EncodeDataVersionFilterIB(const DataVersionFilter & aFilter)
+{
+    DataVersionFilterIB::Builder & filterIB = CreateDataVersionFilter();
+    ReturnErrorOnFailure(GetError());
+    ClusterPathIB::Builder & path = filterIB.CreatePath();
+    ReturnErrorOnFailure(filterIB.GetError());
+    ReturnErrorOnFailure(path.Endpoint(aFilter.mEndpointId).Cluster(aFilter.mClusterId).EndOfClusterPathIB());
+    ReturnErrorOnFailure(filterIB.DataVersion(aFilter.mDataVersion.Value()).EndOfDataVersionFilterIB());
+
+    ChipLogProgress(DataManagement, "Encoded DataVersionFilter: Endpoint=%u Cluster=" ChipLogFormatMEI " Version=%" PRIu32,
+                    aFilter.mEndpointId, ChipLogValueMEI(aFilter.mClusterId), aFilter.mDataVersion.Value());
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR DataVersionFilterIBs::Builder::EndOfDataVersionFilterIBs()
 {
     EndOfContainer();

--- a/src/app/MessageDef/DataVersionFilterIBs.h
+++ b/src/app/MessageDef/DataVersionFilterIBs.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app/AppConfig.h>
+#include <app/DataVersionFilter.h>
 #include <app/util/basic-types.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/TLV.h>
@@ -53,6 +54,16 @@ public:
      *  @return A reference to DataVersionFilterIB::Builder
      */
     DataVersionFilterIB::Builder & GetDataVersionFilter() { return mDataVersionFilter; };
+
+    /**
+     * Add a DataVersionFilter to the list.  This is a convenience method
+     * that will handle calling CreateDataVersionFilter() and then using the
+     * result to encode the provided DataVersionFilter.
+     *
+     * The passed-in DataVersionFilter is assumed to pass the
+     * IsValidDataVersionFilter() test.
+     */
+    CHIP_ERROR EncodeDataVersionFilterIB(const DataVersionFilter & aFilter);
 
     /**
      *  @brief Mark the end of this DataVersionFilterIBs

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -433,7 +433,7 @@ CHIP_ERROR ReadClient::BuildDataVersionFilterList(DataVersionFilterIBs::Builder 
 
         TLV::TLVWriter backup;
         aDataVersionFilterIBsBuilder.Checkpoint(backup);
-        CHIP_ERROR err = EncodeDataVersionFilter(aDataVersionFilterIBsBuilder, filter);
+        CHIP_ERROR err = aDataVersionFilterIBsBuilder.EncodeDataVersionFilterIB(filter);
         if (err == CHIP_NO_ERROR)
         {
 #if CHIP_PROGRESS_LOGGING
@@ -461,19 +461,6 @@ CHIP_ERROR ReadClient::BuildDataVersionFilterList(DataVersionFilterIBs::Builder 
                     "%lu data version filters provided, %lu not relevant, %lu encoded, %lu skipped due to lack of space",
                     static_cast<unsigned long>(aDataVersionFilters.size()), static_cast<unsigned long>(irrelevantFilterCount),
                     static_cast<unsigned long>(encodedFilterCount), static_cast<unsigned long>(skippedFilterCount));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR ReadClient::EncodeDataVersionFilter(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
-                                               DataVersionFilter const & aFilter)
-{
-    // Caller has checked aFilter.IsValidDataVersionFilter()
-    DataVersionFilterIB::Builder & filterIB = aDataVersionFilterIBsBuilder.CreateDataVersionFilter();
-    ReturnErrorOnFailure(aDataVersionFilterIBsBuilder.GetError());
-    ClusterPathIB::Builder & path = filterIB.CreatePath();
-    ReturnErrorOnFailure(filterIB.GetError());
-    ReturnErrorOnFailure(path.Endpoint(aFilter.mEndpointId).Cluster(aFilter.mClusterId).EndOfClusterPathIB());
-    ReturnErrorOnFailure(filterIB.DataVersion(aFilter.mDataVersion.Value()).EndOfDataVersionFilterIB());
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -562,8 +562,6 @@ private:
     CHIP_ERROR BuildDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
                                           const Span<AttributePathParams> & aAttributePaths,
                                           const Span<DataVersionFilter> & aDataVersionFilters, bool & aEncodedDataVersionList);
-    CHIP_ERROR EncodeDataVersionFilter(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
-                                       DataVersionFilter const & aFilter);
     CHIP_ERROR ReadICDOperatingModeFromAttributeDataIB(TLV::TLVReader && aReader, PeerType & aType);
     CHIP_ERROR ProcessAttributeReportIBs(TLV::TLVReader & aAttributeDataIBsReader);
     CHIP_ERROR ProcessEventReportIBs(TLV::TLVReader & aEventReportIBsReader);

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -3322,6 +3322,8 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
             _clusterDataToPersist = [NSMutableDictionary dictionary];
         }
         _clusterDataToPersist[clusterPath] = clusterData;
+
+        MTR_LOG("%@ updated DataVersion for %@ to %@", self, clusterPath, dataVersion);
     }
 }
 


### PR DESCRIPTION
We logged the encoded filters when doing a re-subscribe with a ClusterStateCache, but not when doing an initial subscribe.  This moves the logging into the encoding of the filter list, so it's logged consistently.

Also logs the DataVersion that we get back in MTRDevice_Concrete.
