### PR TITLE
VALCC: Remove top-level PICS

### DIFF
--- a/src/python_testing/TC_VALCC_2_1.py
+++ b/src/python_testing/TC_VALCC_2_1.py
@@ -28,7 +28,7 @@ import logging
 
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter_testing_support import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
 from mobly import asserts
 
 
@@ -58,16 +58,10 @@ class TC_VALCC_2_1(MatterBaseTest):
         ]
         return steps
 
-    def pics_TC_VALCC_2_1(self) -> list[str]:
-        pics = [
-            "VALCC.S",
-        ]
-        return pics
-
-    @async_test_body
+    @run_if_endpoint_matches(has_cluster(Clusters.ValveConfigurationAndControl))
     async def test_TC_VALCC_2_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.matter_test_config.endpoint
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_3_1.py
+++ b/src/python_testing/TC_VALCC_3_1.py
@@ -29,7 +29,7 @@ import time
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter_testing_support import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
 from mobly import asserts
 
 
@@ -53,16 +53,10 @@ class TC_VALCC_3_1(MatterBaseTest):
         ]
         return steps
 
-    def pics_TC_VALCC_3_1(self) -> list[str]:
-        pics = [
-            "VALCC.S",
-        ]
-        return pics
-
-    @async_test_body
+    @run_if_endpoint_matches(has_cluster(Clusters.ValveConfigurationAndControl))
     async def test_TC_VALCC_3_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.matter_test_config.endpoint
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_3_2.py
+++ b/src/python_testing/TC_VALCC_3_2.py
@@ -30,7 +30,7 @@ import time
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter_testing_support import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
 from mobly import asserts
 
 
@@ -55,92 +55,66 @@ class TC_VALCC_3_2(MatterBaseTest):
         ]
         return steps
 
-    def pics_TC_VALCC_3_2(self) -> list[str]:
-        pics = [
-            "VALCC.S",
-        ]
-        return pics
-
-    @async_test_body
+    @run_if_endpoint_matches(has_feature(Clusters.ValveConfigurationAndControl, Clusters.ValveConfigurationAndControl.Bitmaps.Feature.kLevel))
     async def test_TC_VALCC_3_2(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.matter_test_config.endpoint
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes
 
         self.step(2)
-        feature_map = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.FeatureMap)
-
-        is_lvl_feature_supported = feature_map & Clusters.ValveConfigurationAndControl.Bitmaps.Feature.kLevel
+        # Done as part of the test initialization
 
         self.step(3)
-        if is_lvl_feature_supported:
-            try:
-                await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Open(targetLevel=100), endpoint=endpoint)
-            except InteractionModelError as e:
-                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
-                pass
-        else:
-            logging.info("Test step skipped")
+        try:
+            await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Open(targetLevel=100), endpoint=endpoint)
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
 
         self.step(4)
-        if is_lvl_feature_supported:
-            target_level_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.TargetLevel)
+        target_level_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.TargetLevel)
 
-            asserts.assert_true(target_level_dut is not NullValue, "TargetLevel is null")
-            asserts.assert_equal(target_level_dut, 100, "TargetLevel is not the expected value")
-        else:
-            logging.info("Test step skipped")
+        asserts.assert_true(target_level_dut is not NullValue, "TargetLevel is null")
+        asserts.assert_equal(target_level_dut, 100, "TargetLevel is not the expected value")
 
         self.step(5)
-        if is_lvl_feature_supported:
+        current_level_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentLevel)
+        asserts.assert_true(current_level_dut is not NullValue, "CurrentLevel is null")
+
+        while current_level_dut != 100:
+            time.sleep(1)
+
             current_level_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentLevel)
             asserts.assert_true(current_level_dut is not NullValue, "CurrentLevel is null")
 
-            while current_level_dut != 100:
-                time.sleep(1)
-
-                current_level_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentLevel)
-                asserts.assert_true(current_level_dut is not NullValue, "CurrentLevel is null")
-
-            asserts.assert_equal(current_level_dut, 100, "CurrentLevel is not the expected value")
-        else:
-            logging.info("Test step skipped")
+        asserts.assert_equal(current_level_dut, 100, "CurrentLevel is not the expected value")
 
         self.step(6)
-        if is_lvl_feature_supported:
-            try:
-                await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Close(), endpoint=endpoint)
-            except InteractionModelError as e:
-                asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
-                pass
-        else:
-            logging.info("Test step skipped")
+        try:
+            await self.send_single_cmd(cmd=Clusters.Objects.ValveConfigurationAndControl.Commands.Close(), endpoint=endpoint)
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
 
         self.step(7)
-        if is_lvl_feature_supported:
-            target_level_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.TargetLevel)
+        target_level_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.TargetLevel)
 
-            asserts.assert_true(target_level_dut is not NullValue, "TargetLevel is null")
-            asserts.assert_equal(target_level_dut, 0, "TargetLevel is not the expected value")
-        else:
-            logging.info("Test step skipped")
+        asserts.assert_true(target_level_dut is not NullValue, "TargetLevel is null")
+        asserts.assert_equal(target_level_dut, 0, "TargetLevel is not the expected value")
 
         self.step(8)
-        if is_lvl_feature_supported:
+        current_level_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentLevel)
+        asserts.assert_true(current_level_dut is not NullValue, "CurrentLevel is null")
+
+        while current_level_dut is Clusters.Objects.ValveConfigurationAndControl.Enums.ValveStateEnum.kTransitioning:
+            time.sleep(1)
+
             current_level_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentLevel)
             asserts.assert_true(current_level_dut is not NullValue, "CurrentLevel is null")
 
-            while current_level_dut is Clusters.Objects.ValveConfigurationAndControl.Enums.ValveStateEnum.kTransitioning:
-                time.sleep(1)
-
-                current_level_dut = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentLevel)
-                asserts.assert_true(current_level_dut is not NullValue, "CurrentLevel is null")
-
-            asserts.assert_equal(current_level_dut, 0, "CurrentLevel is not the expected value")
-        else:
-            logging.info("Test step skipped")
+        asserts.assert_equal(current_level_dut, 0, "CurrentLevel is not the expected value")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_VALCC_3_4.py
+++ b/src/python_testing/TC_VALCC_3_4.py
@@ -28,7 +28,7 @@ import logging
 
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter_testing_support import MatterBaseTest, TestStep, default_matter_test_main, has_attribute, run_if_endpoint_matches
 from mobly import asserts
 
 
@@ -51,36 +51,17 @@ class TC_VALCC_3_4(MatterBaseTest):
         ]
         return steps
 
-    def pics_TC_VALCC_3_4(self) -> list[str]:
-        pics = [
-            "VALCC.S",
-        ]
-        return pics
-
-    @async_test_body
+    @run_if_endpoint_matches(has_attribute(Clusters.ValveConfigurationAndControl.Attributes.LevelStep))
     async def test_TC_VALCC_3_4(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.matter_test_config.endpoint
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes
 
         self.step(2)
-        attribute_list = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.AttributeList)
-
         self.step(3)
-        if attributes.LevelStep.attribute_id not in attribute_list:
-            logging.info("LevelStep not supported skipping test case")
-
-            # Skipping all remainig steps
-            for step in self.get_test_steps(self.current_test_info.name)[self.current_step_index:]:
-                self.step(step.test_plan_number)
-                logging.info("Test step skipped")
-
-            return
-
-        else:
-            logging.info("Test step skipped")
+        # Steps 2 and three are handled by the decorator
 
         self.step(4)
         levelStep = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.LevelStep)

--- a/src/python_testing/TC_VALCC_4_1.py
+++ b/src/python_testing/TC_VALCC_4_1.py
@@ -29,7 +29,7 @@ import time
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter_testing_support import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
 from mobly import asserts
 
 
@@ -55,16 +55,10 @@ class TC_VALCC_4_1(MatterBaseTest):
         ]
         return steps
 
-    def pics_TC_VALCC_4_1(self) -> list[str]:
-        pics = [
-            "VALCC.S",
-        ]
-        return pics
-
-    @async_test_body
+    @run_if_endpoint_matches(has_cluster(Clusters.ValveConfigurationAndControl))
     async def test_TC_VALCC_4_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.matter_test_config.endpoint
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_4_2.py
+++ b/src/python_testing/TC_VALCC_4_2.py
@@ -30,7 +30,7 @@ import time
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter_testing_support import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
 from mobly import asserts
 
 
@@ -58,16 +58,10 @@ class TC_VALCC_4_2(MatterBaseTest):
         ]
         return steps
 
-    def pics_TC_VALCC_4_2(self) -> list[str]:
-        pics = [
-            "VALCC.S",
-        ]
-        return pics
-
-    @async_test_body
+    @run_if_endpoint_matches(has_cluster(Clusters.ValveConfigurationAndControl))
     async def test_TC_VALCC_4_2(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.matter_test_config.endpoint
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_4_3.py
+++ b/src/python_testing/TC_VALCC_4_3.py
@@ -29,7 +29,7 @@ import logging
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter_testing_support import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
 from mobly import asserts
 
 
@@ -55,38 +55,17 @@ class TC_VALCC_4_3(MatterBaseTest):
         ]
         return steps
 
-    def pics_TC_VALCC_4_3(self) -> list[str]:
-        pics = [
-            "VALCC.S",
-        ]
-        return pics
-
-    @async_test_body
+    @run_if_endpoint_matches(has_feature(Clusters.ValveConfigurationAndControl, Clusters.ValveConfigurationAndControl.Bitmaps.Feature.kTimeSync))
     async def test_TC_VALCC_4_3(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.matter_test_config.endpoint
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes
 
         self.step("2a")
-        feature_map = await self.read_valcc_attribute_expect_success(endpoint=endpoint, attribute=attributes.FeatureMap)
-
-        is_ts_feature_supported = feature_map & Clusters.ValveConfigurationAndControl.Bitmaps.Feature.kTimeSync
-
         self.step("2b")
-        if not is_ts_feature_supported:
-            logging.info("TimeSync feature not supported skipping test case")
-
-            # Skipping all remainig steps
-            for step in self.get_test_steps(self.current_test_info.name)[self.current_step_index:]:
-                self.step(step.test_plan_number)
-                logging.info("Test step skipped")
-
-            return
-
-        else:
-            logging.info("Test step skipped")
+        # steps 2a and 2b are handled by the decorator
 
         self.step("3a")
         utcTime = await self.read_single_attribute_check_success(endpoint=0, cluster=Clusters.Objects.TimeSynchronization, attribute=Clusters.TimeSynchronization.Attributes.UTCTime)
@@ -95,15 +74,9 @@ class TC_VALCC_4_3(MatterBaseTest):
         if utcTime is not NullValue:
             logging.info("UTCTime is not null, skipping test case")
 
-            # Skipping all remainig steps
-            for step in self.get_test_steps(self.current_test_info.name)[self.current_step_index:]:
-                self.step(step.test_plan_number)
-                logging.info("Test step skipped")
-
+            # Skipping all remaining steps
+            self.skip_all_remaining_steps(4)
             return
-
-        else:
-            logging.info("Test step skipped")
 
         self.step(4)
         try:

--- a/src/python_testing/TC_VALCC_4_5.py
+++ b/src/python_testing/TC_VALCC_4_5.py
@@ -29,7 +29,7 @@ import time
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
-from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from matter_testing_support import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
 from mobly import asserts
 
 
@@ -55,16 +55,10 @@ class TC_VALCC_4_5(MatterBaseTest):
         ]
         return steps
 
-    def pics_TC_VALCC_4_5(self) -> list[str]:
-        pics = [
-            "VALCC.S",
-        ]
-        return pics
-
-    @async_test_body
+    @run_if_endpoint_matches(has_cluster(Clusters.ValveConfigurationAndControl))
     async def test_TC_VALCC_4_5(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.matter_test_config.endpoint
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes


### PR DESCRIPTION
Self-select the valve tests off the device information rather than the PICS. This makes it easier to run the tests since you can just run them all unconditionally and they will run if required.