### PR TITLE
Set python version to 3.10 for ruff checker

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -8,7 +8,7 @@ exclude = [
     "third_party",
     "examples/common/QRCode/",
 ]
-target-version = "py37"
+target-version = "py310"
 
 line-length = 132
 


### PR DESCRIPTION
We updated pigweed and that requires python 3.10 or higher. All our systems should pull that (we actually pull 3.11 for mac and have 3.12 on our CI runners)

