### PR TITLE
Add Attribute and Command Conformance to ZAP Template XMLs

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
@@ -113,28 +113,57 @@ limitations under the License.
       <description>ACL</description>
       <access op="read" privilege="administer"/>
       <access op="write" privilege="administer"/>
+      <mandatoryConform/>
     </attribute>
 
     <attribute side="server" code="0x0001" define="EXTENSION" type="array" entryType="AccessControlExtensionStruct" writable="true" optional="true">
       <description>Extension</description>
       <access op="read" privilege="administer"/>
       <access op="write" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="EXTS"/>
+      </mandatoryConform>
     </attribute>
 
-    <attribute side="server" code="0x0002" define="SUBJECTS_PER_ACCESS_CONTROL_ENTRY" type="int16u" min="4" default="4">SubjectsPerAccessControlEntry</attribute>
-    <attribute side="server" code="0x0003" define="TARGETS_PER_ACCESS_CONTROL_ENTRY" type="int16u" min="3" default="3">TargetsPerAccessControlEntry</attribute>
-    <attribute side="server" code="0x0004" define="ACCESS_CONTROL_ENTRIES_PER_FABRIC" type="int16u" min="4" default="4">AccessControlEntriesPerFabric</attribute>
-    <attribute code="0x0005" side="server" define="COMMISSIONING_ARL" type="array" entryType="CommissioningAccessRestrictionEntryStruct" optional="true">CommissioningARL</attribute>
-    <attribute code="0x0006" side="server" define="ARL" type="array" entryType="AccessRestrictionEntryStruct" optional="true">ARL</attribute>
+    <attribute side="server" code="0x0002" define="SUBJECTS_PER_ACCESS_CONTROL_ENTRY" type="int16u" min="4" default="4">
+      <description>SubjectsPerAccessControlEntry</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="TARGETS_PER_ACCESS_CONTROL_ENTRY" type="int16u" min="3" default="3">
+      <description>TargetsPerAccessControlEntry</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="ACCESS_CONTROL_ENTRIES_PER_FABRIC" type="int16u" min="4" default="4">
+      <description>AccessControlEntriesPerFabric</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute code="0x0005" side="server" define="COMMISSIONING_ARL" type="array" entryType="CommissioningAccessRestrictionEntryStruct" optional="true">
+      <description>CommissioningARL</description>
+      <mandatoryConform>
+        <feature name="MNGD"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute code="0x0006" side="server" define="ARL" type="array" entryType="AccessRestrictionEntryStruct" optional="true">
+      <description>ARL</description>
+      <mandatoryConform>
+        <feature name="MNGD"/>
+      </mandatoryConform>
+    </attribute>
 
     <command code="0x00" source="client" name="ReviewFabricRestrictions" isFabricScoped="true" optional="true" response="ReviewFabricRestrictionsResponse">
       <description>This command signals to the service associated with the device vendor that the fabric administrator would like a review of the current restrictions on the accessing fabric.</description>
-       <access op="invoke" privilege="administer"/>
+      <access op="invoke" privilege="administer"/>
+      <mandatoryConform>
+        <feature name="MNGD"/>
+      </mandatoryConform>
       <arg id="0" name="ARL" array="true" type="CommissioningAccessRestrictionEntryStruct"/>
      </command>
 
     <command code="0x01" source="server" name="ReviewFabricRestrictionsResponse" optional="true" disableDefaultResponse="true">
       <description>Returns the review token for the request, which can be used to correlate with a FabricRestrictionReviewUpdate event.</description>
+      <mandatoryConform>
+        <feature name="MNGD"/>
+      </mandatoryConform>
       <arg id="0" name="Token" type="int64u"/>
     </command>
 

--- a/src/app/zap-templates/zcl/data-model/chip/account-login-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/account-login-cluster.xml
@@ -29,12 +29,14 @@ limitations under the License.
     <command source="client" code="0x00" name="GetSetupPIN" isFabricScoped="true" response="GetSetupPINResponse" mustUseTimedInvoke="true" optional="false">
       <description>Upon receipt, the Content App checks if the account associated with the client Temp Account Identifier Rotating ID is the same acount that is active on the given Content App. If the accounts are the same, then the Content App includes the Setup PIN in the GetSetupPIN Response.</description>
       <access op="invoke" role="administer" />
+      <mandatoryConform/>
       <arg name="TempAccountIdentifier" minLength="16" length="100" type="char_string"/>
     </command>
 
     <command source="client" code="0x02" name="Login" isFabricScoped="true" mustUseTimedInvoke="true" optional="false">
       <description>Upon receipt, the Content App checks if the account associated with the client’s Temp Account Identifier (Rotating ID) has a current active Setup PIN with the given value. If the Setup PIN is valid for the user account associated with the Temp Account Identifier, then the Content App MAY make that user account active.</description>
       <access op="invoke" role="administer" />
+      <mandatoryConform/>
       <arg name="TempAccountIdentifier" minLength="16" length="100" type="char_string"/>
       <arg name="SetupPIN" minLength="8" type="char_string"/>
       <arg name="Node" type="node_id" optional="true" />
@@ -42,11 +44,13 @@ limitations under the License.
 
     <command source="client" code="0x03" name="Logout" isFabricScoped="true" mustUseTimedInvoke="true" optional="false">
       <description>The purpose of this command is to instruct the Content App to clear the current user account. This command SHOULD be used by clients of a Content App to indicate the end of a user session.</description>
+      <mandatoryConform/>
       <arg name="Node" type="node_id" optional="true"/>
     </command>
 
     <command source="server" code="0x01" name="GetSetupPINResponse" optional="false" disableDefaultResponse="true">
       <description>This message is sent in response to the GetSetupPIN Request, and contains the Setup PIN code, or null when the accounts identified in the request does not match the active account of the running Content App.</description>
+      <mandatoryConform/>
       <arg name="SetupPIN" type="char_string"/>
     </command>
 

--- a/src/app/zap-templates/zcl/data-model/chip/actions-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/actions-cluster.xml
@@ -90,9 +90,18 @@ limitations under the License.
     <define>ACTIONS_CLUSTER</define>
     <description>This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.</description>
 
-    <attribute side="server" code="0x0000" define="ACTION_LIST" type="array" entryType="ActionStruct" length="256" writable="false" optional="false">ActionList</attribute>
-    <attribute side="server" code="0x0001" define="ENDPOINT_LIST" type="array" entryType="EndpointListStruct" length="256" writable="false" optional="false">EndpointLists</attribute>
-    <attribute side="server" code="0x0002" define="SETUP_URL" type="LONG_CHAR_STRING" length="512" writable="false" optional="true">SetupURL</attribute>
+    <attribute side="server" code="0x0000" define="ACTION_LIST" type="array" entryType="ActionStruct" length="256" writable="false" optional="false">
+      <description>ActionList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="ENDPOINT_LIST" type="array" entryType="EndpointListStruct" length="256" writable="false" optional="false">
+      <description>EndpointLists</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="SETUP_URL" type="LONG_CHAR_STRING" length="512" writable="false" optional="true">
+      <description>SetupURL</description>
+      <optionalConform/>
+    </attribute>
 
     <command source="client" code="0x00" name="InstantAction" optional="true">
       <description>This command triggers an action (state change) on the involved endpoints.</description>

--- a/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/administrator-commissioning-cluster.xml
@@ -43,12 +43,22 @@ limitations under the License.
         <optionalConform/>
       </feature>
     </features>
-    <attribute side="server" code="0x0000" define="WINDOW_STATUS" type="CommissioningWindowStatusEnum" writable="false" optional="false">WindowStatus</attribute>
-    <attribute side="server" code="0x0001" define="ADMIN_FABRIC_INDEX" type="fabric_idx" writable="false" isNullable="true" optional="false">AdminFabricIndex</attribute>
-    <attribute side="server" code="0x0002" define="ADMIN_VENDOR_ID" type="vendor_id" writable="false" isNullable="true" optional="false">AdminVendorId</attribute>
+    <attribute side="server" code="0x0000" define="WINDOW_STATUS" type="CommissioningWindowStatusEnum" writable="false" optional="false">
+      <description>WindowStatus</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="ADMIN_FABRIC_INDEX" type="fabric_idx" writable="false" isNullable="true" optional="false">
+      <description>AdminFabricIndex</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="ADMIN_VENDOR_ID" type="vendor_id" writable="false" isNullable="true" optional="false">
+      <description>AdminVendorId</description>
+      <mandatoryConform/>
+    </attribute>
 
     <command source="client" code="0x00" name="OpenCommissioningWindow" mustUseTimedInvoke="true" optional="false">
       <description>This command is used by a current Administrator to instruct a Node to go into commissioning mode using enhanced commissioning method.</description>
+      <mandatoryConform/>
       <arg name="CommissioningTimeout" type="int16u"/>
       <arg name="PAKEPasscodeVerifier" type="octet_string"/>
       <arg name="Discriminator" type="int16u"/>
@@ -59,12 +69,16 @@ limitations under the License.
 
     <command source="client" code="0x01" name="OpenBasicCommissioningWindow" mustUseTimedInvoke="true" optional="true">
       <description>This command is used by a current Administrator to instruct a Node to go into commissioning mode using basic commissioning method, if the node supports it.</description>
+      <mandatoryConform>
+        <feature name="BC"/>
+      </mandatoryConform>
       <arg name="CommissioningTimeout" type="int16u"/>
       <access op="invoke" privilege="administer"/>
     </command>
 
     <command source="client" code="0x02" name="RevokeCommissioning" mustUseTimedInvoke="true" optional="false">
       <description>This command is used by a current Administrator to instruct a Node to revoke any active Open Commissioning Window or Open Basic Commissioning Window command.</description>
+      <mandatoryConform/>
       <access op="invoke" privilege="administer"/>
     </command>
 

--- a/src/app/zap-templates/zcl/data-model/chip/air-quality-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/air-quality-cluster.xml
@@ -41,7 +41,10 @@ limitations under the License.
     </features>
 
     <!-- Attributes -->
-    <attribute side="server" code="0x0000" define="AIR_QUALITY" type="AirQualityEnum" min="0" max="6" writable="false" isNullable="false" default="0" optional="false">AirQuality</attribute>
+    <attribute side="server" code="0x0000" define="AIR_QUALITY" type="AirQualityEnum" min="0" max="6" writable="false" isNullable="false" default="0" optional="false">
+      <description>AirQuality</description>
+      <mandatoryConform/>
+    </attribute>
   </cluster>
 
   <!-- Cluster Data Types -->

--- a/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-basic-cluster.xml
@@ -24,16 +24,38 @@ limitations under the License.
     <client init="false" tick="false">true</client>
     <server init="false" tick="false">true</server>
     <description>This cluster provides information about an application running on a TV or media player device which is represented as an endpoint.</description>
-    <attribute side="server" code="0x0000" define="APPLICATION_VENDOR_NAME"         type="char_string"                default=""     length="32"               writable="false" optional="true">VendorName</attribute>
-    <attribute side="server" code="0x0001" define="APPLICATION_VENDOR_ID"           type="vendor_id"                  default="0x0"  min="0x0000" max="0xFFFF" writable="false" optional="true">VendorID</attribute>
-    <attribute side="server" code="0x0002" define="APPLICATION_NAME"                type="long_char_string"           length="256"               writable="false" optional="false">ApplicationName</attribute>
-    <attribute side="server" code="0x0003" define="APPLICATION_PRODUCT_ID"          type="int16u"                     default="0x0"  min="0x0000" max="0xFFFF" writable="false" optional="true">ProductID</attribute>
-    <attribute side="server" code="0x0004" define="APPLICATION_APP"                 type="ApplicationStruct"                                                   writable="false" optional="false">Application</attribute>
-    <attribute side="server" code="0x0005" define="APPLICATION_STATUS"              type="ApplicationStatusEnum"      default="0x01" min="0x00"   max="0xFF"   writable="false" optional="false">Status</attribute>
-    <attribute side="server" code="0x0006" define="APPLICATION_VERSION"             type="char_string"                               length="32"               writable="false" optional="false">ApplicationVersion</attribute>
+    <attribute side="server" code="0x0000" define="APPLICATION_VENDOR_NAME"         type="char_string"                default=""     length="32"               writable="false" optional="true">
+      <description>VendorName</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="APPLICATION_VENDOR_ID"           type="vendor_id"                  default="0x0"  min="0x0000" max="0xFFFF" writable="false" optional="true">
+      <description>VendorID</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="APPLICATION_NAME"                type="long_char_string"           length="256"               writable="false" optional="false">
+      <description>ApplicationName</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0003" define="APPLICATION_PRODUCT_ID"          type="int16u"                     default="0x0"  min="0x0000" max="0xFFFF" writable="false" optional="true">
+      <description>ProductID</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="0x0004" define="APPLICATION_APP"                 type="ApplicationStruct"                                                   writable="false" optional="false">
+      <description>Application</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0005" define="APPLICATION_STATUS"              type="ApplicationStatusEnum"      default="0x01" min="0x00"   max="0xFF"   writable="false" optional="false">
+      <description>Status</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0006" define="APPLICATION_VERSION"             type="char_string"                               length="32"               writable="false" optional="false">
+      <description>ApplicationVersion</description>
+      <mandatoryConform/>
+    </attribute>
     <attribute side="server" code="0x0007" define="APPLICATION_ALLOWED_VENDOR_LIST" type="array" entryType="vendor_id"               length="32"               writable="false" optional="false">
         <description>AllowedVendorList</description>
         <access op="read" role="administer"/>
+        <mandatoryConform/>
     </attribute>
 
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/application-launcher-cluster.xml
@@ -31,27 +31,39 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="APPLICATION_LAUNCHER_LIST"        type="array" entryType="int16u" reportable="true"  writable="false" optional="true">CatalogList</attribute>
-    <attribute side="server" code="0x0001" define="APPLICATION_LAUNCHER_CURRENT_APP" type="ApplicationEPStruct"      isNullable="true" writable="false"  optional="true">CurrentApp</attribute>
+    <attribute side="server" code="0x0000" define="APPLICATION_LAUNCHER_LIST"        type="array" entryType="int16u" reportable="true"  writable="false" optional="true">
+      <description>CatalogList</description>
+      <mandatoryConform>
+        <feature name="AP"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="APPLICATION_LAUNCHER_CURRENT_APP" type="ApplicationEPStruct"      isNullable="true" writable="false"  optional="true">
+      <description>CurrentApp</description>
+      <optionalConform/>
+    </attribute>
 
     <command source="client" code="0x00" name="LaunchApp" response="LauncherResponse" optional="false">
       <description>Upon receipt, this SHALL launch the specified app with optional data. The TV Device SHALL launch and bring to foreground the identified application in the command if the application is not already launched and in foreground. The TV Device SHALL update state attribute on the Application Basic cluster of the Endpoint corresponding to the launched application. This command returns a Launch Response.</description>
+      <mandatoryConform/>
       <arg name="Application" type="ApplicationStruct" optional="true"/>
       <arg name="Data"  type="octet_string" optional="true"/>
     </command>
 
     <command source="client" code="0x01" name="StopApp" response="LauncherResponse" optional="false">
       <description>Upon receipt on a Video Player endpoint this SHALL stop the specified application if it is running.</description>
+      <mandatoryConform/>
       <arg name="Application" type="ApplicationStruct" optional="true"/>
     </command>
 
     <command source="client" code="0x02" name="HideApp" response="LauncherResponse" optional="false">
       <description>Upon receipt on a Video Player endpoint this SHALL hide the specified application if it is running and visible.</description>
+      <mandatoryConform/>
       <arg name="Application" type="ApplicationStruct" optional="true"/>
     </command>
 
     <command source="server" code="0x03" name="LauncherResponse" optional="false">
       <description>This command SHALL be generated in response to LaunchApp commands.</description>
+      <mandatoryConform/>
       <arg name="Status" type="StatusEnum"/>
       <arg name="Data" type="octet_string" optional="true"/>
     </command>

--- a/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/audio-output-cluster.xml
@@ -31,17 +31,27 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="AUDIO_OUTPUT_LIST"           type="array" entryType="OutputInfoStruct" length="254"          writable="false"  optional="false">OutputList</attribute>
-    <attribute side="server" code="0x0001" define="AUDIO_OUTPUT_CURRENT_OUTPUT" type="int8u" default="0x00"               min="0x00" max="0xFF" writable="false"  optional="false">CurrentOutput</attribute>
+    <attribute side="server" code="0x0000" define="AUDIO_OUTPUT_LIST"           type="array" entryType="OutputInfoStruct" length="254"          writable="false"  optional="false">
+      <description>OutputList</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="AUDIO_OUTPUT_CURRENT_OUTPUT" type="int8u" default="0x00"               min="0x00" max="0xFF" writable="false"  optional="false">
+      <description>CurrentOutput</description>
+      <mandatoryConform/>
+    </attribute>
 
     <command source="client" code="0x00" name="SelectOutput" optional="false">
       <description>Upon receipt, this SHALL change the output on the media device to the output at a specific index in the Output List.</description>
+      <mandatoryConform/>
       <arg name="Index" type="int8u"/>
     </command>
 
     <command source="client" code="0x01" name="RenameOutput" optional="true">
       <description>Upon receipt, this SHALL rename the output at a specific index in the Output List. Updates to the output name SHALL appear in the TV settings menus.</description>
       <access op="invoke" role="manage" />
+      <mandatoryConform>
+        <feature name="NU"/>
+      </mandatoryConform>
       <arg name="Index" type="int8u"/>
       <arg name="Name" type="char_string"/>
     </command>

--- a/src/app/zap-templates/zcl/data-model/chip/ballast-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/ballast-configuration-cluster.xml
@@ -41,53 +41,75 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="4"/>
 
     <!-- Ballast Configuration Attribute Set -->
-    <attribute side="server" code="0x0000" define="PHYSICAL_MIN_LEVEL" type="int8u" min="0x01" max="0xFE" writable="false" default="0x01" optional="false">PhysicalMinLevel</attribute>
-    <attribute side="server" code="0x0001" define="PHYSICAL_MAX_LEVEL" type="int8u" min="0x01" max="0xFE" writable="false" default="0xFE" optional="false">PhysicalMaxLevel</attribute>
-    <attribute side="server" code="0x0002" define="BALLAST_STATUS" type="BallastStatusBitmap" min="0x00" max="0x03" writable="false" default="0x00" optional="true">BallastStatus</attribute>
+    <attribute side="server" code="0x0000" define="PHYSICAL_MIN_LEVEL" type="int8u" min="0x01" max="0xFE" writable="false" default="0x01" optional="false">
+        <description>PhysicalMinLevel</description>
+        <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="PHYSICAL_MAX_LEVEL" type="int8u" min="0x01" max="0xFE" writable="false" default="0xFE" optional="false">
+        <description>PhysicalMaxLevel</description>
+        <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0002" define="BALLAST_STATUS" type="BallastStatusBitmap" min="0x00" max="0x03" writable="false" default="0x00" optional="true">
+        <description>BallastStatus</description>
+        <optionalConform/>
+    </attribute>
     <!-- Ballast Settings Attribute Set -->
     <attribute side="server" code="0x0010" define="MIN_LEVEL" type="int8u" min="0x01" max="0xFE" writable="true" default="0x01" optional="false">
         <description>MinLevel</description>
         <access op="write" privilege="manage"/>
+        <mandatoryConform/>
     </attribute>
     <attribute side="server" code="0x0011" define="MAX_LEVEL" type="int8u" min="0x01" max="0xFE" writable="true" default="0xFE" optional="false">
         <description>MaxLevel</description>
         <access op="write" privilege="manage"/>
+        <mandatoryConform/>
     </attribute>
     <!-- PowerOnLevel and PowerOnFadeTime are deprecated -->
     <attribute side="server" code="0x0014" define="INTRINSIC_BALLAST_FACTOR" type="int8u" writable="true" isNullable="true" optional="true">
         <description>IntrinsicBallastFactor</description>
         <access op="write" privilege="manage"/>
+        <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0015" define="BALLAST_FACTOR_ADJUSTMENT" type="int8u" min="0x64" writable="true" default="0xFF" isNullable="true" optional="true">
         <description>BallastFactorAdjustment</description>
         <access op="write" privilege="manage"/>
+        <optionalConform/>
     </attribute>
     <!-- Lamp Information Attribute Set -->
-    <attribute side="server" code="0x0020" define="LAMP_QUANTITY" type="int8u" writable="false" optional="false">LampQuantity</attribute>
+    <attribute side="server" code="0x0020" define="LAMP_QUANTITY" type="int8u" writable="false" optional="false">
+        <description>LampQuantity</description>
+        <mandatoryConform/>
+    </attribute>
     <!-- Lamp Settings Attribute Set -->
     <attribute side="server" code="0x0030" define="LAMP_TYPE" type="char_string" length="16" writable="true" optional="true">
         <description>LampType</description>
         <access op="write" privilege="manage"/>
+        <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0031" define="LAMP_MANUFACTURER" type="char_string" length="16" writable="true" optional="true">
         <description>LampManufacturer</description>
         <access op="write" privilege="manage"/>
+        <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0032" define="LAMP_RATED_HOURS" type="int24u" writable="true" default="0xFFFFFF" isNullable="true" optional="true">
         <description>LampRatedHours</description>
         <access op="write" privilege="manage"/>
+        <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0033" define="LAMP_BURN_HOURS" type="int24u" writable="true" default="0x000000" isNullable="true" optional="true">
         <description>LampBurnHours</description>
         <access op="write" privilege="manage"/>
+        <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0034" define="LAMP_ALARM_MODE" type="LampAlarmModeBitmap" min="0x00" max="0x01" writable="true" default="0x00" optional="true">
         <description>LampAlarmMode</description>
         <access op="write" privilege="manage"/>
+        <optionalConform/>
     </attribute>
     <attribute side="server" code="0x0035" define="LAMP_BURN_HOURS_TRIP_POINT" type="int24u" writable="true" default="0xFFFFFF" isNullable="true" optional="true">
         <description>LampBurnHoursTripPoint</description>
         <access op="write" privilege="manage"/>
+        <optionalConform/>
     </attribute>
   </cluster>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/basic-information-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/basic-information-cluster.xml
@@ -74,41 +74,103 @@ limitations under the License.
       which apply to the whole Node. Also allows setting user device information such as location.</description>
     <globalAttribute side="either" code="0xFFFD" value="3"/>
 
-    <attribute side="server" code="0"  define="DATA_MODEL_REVISION"       type="int16u"                                                                             >DataModelRevision</attribute>
-    <attribute side="server" code="1"  define="VENDOR_NAME"               type="char_string"               length="32"                                              >VendorName</attribute>
-    <attribute side="server" code="2"  define="VENDOR_ID"                 type="vendor_id"                                                                          >VendorID</attribute>
-    <attribute side="server" code="3"  define="PRODUCT_NAME"              type="char_string"               length="32"                                              >ProductName</attribute>
-    <attribute side="server" code="4"  define="PRODUCT_ID"                type="int16u"                                                                             >ProductID</attribute>
+    <attribute side="server" code="0"  define="DATA_MODEL_REVISION"       type="int16u"                                                                             >
+      <description>DataModelRevision</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="1"  define="VENDOR_NAME"               type="char_string"               length="32"                                              >
+      <description>VendorName</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="2"  define="VENDOR_ID"                 type="vendor_id"                                                                          >
+      <description>VendorID</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="3"  define="PRODUCT_NAME"              type="char_string"               length="32"                                              >
+      <description>ProductName</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="4"  define="PRODUCT_ID"                type="int16u"                                                                             >
+      <description>ProductID</description>
+    </attribute>
     <attribute side="server" code="5"  define="NODE_LABEL"                type="char_string"               length="32"  default=""   writable="true"                >
       <description>NodeLabel</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
     <attribute side="server" code="6"  define="LOCATION"                  type="char_string"               length="2"   default="XX" writable="true"                >
       <description>Location</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="administer"/>
+      <mandatoryConform/>
     </attribute>
-    <attribute side="server" code="7"  define="HARDWARE_VERSION"          type="int16u"                                 default="0"                                 >HardwareVersion</attribute>
-    <attribute side="server" code="8"  define="HARDWARE_VERSION_STRING"   type="char_string" minLength="1" length="64"                                              >HardwareVersionString</attribute>
-    <attribute side="server" code="9"  define="SOFTWARE_VERSION"          type="int32u"                                 default="0"                                 >SoftwareVersion</attribute>
-    <attribute side="server" code="10" define="SOFTWARE_VERSION_STRING"   type="char_string" minLength="1" length="64"                                              >SoftwareVersionString</attribute>
-    <attribute side="server" code="11" define="MANUFACTURING_DATE"        type="char_string" minLength="8" length="16"                               optional="true">ManufacturingDate</attribute>
-    <attribute side="server" code="12" define="PART_NUMBER"               type="char_string"               length="32"                               optional="true">PartNumber</attribute>
-    <attribute side="server" code="13" define="PRODUCT_URL"               type="long_char_string"          length="256"                              optional="true">ProductURL</attribute>
-    <attribute side="server" code="14" define="PRODUCT_LABEL"             type="char_string"               length="64"                               optional="true">ProductLabel</attribute>
-    <attribute side="server" code="15" define="SERIAL_NUMBER"             type="char_string"               length="32"                               optional="true">SerialNumber</attribute>
+    <attribute side="server" code="7"  define="HARDWARE_VERSION"          type="int16u"                                 default="0"                                 >
+      <description>HardwareVersion</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="8"  define="HARDWARE_VERSION_STRING"   type="char_string" minLength="1" length="64"                                              >
+      <description>HardwareVersionString</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="9"  define="SOFTWARE_VERSION"          type="int32u"                                 default="0"                                 >
+      <description>SoftwareVersion</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="10" define="SOFTWARE_VERSION_STRING"   type="char_string" minLength="1" length="64"                                              >
+      <description>SoftwareVersionString</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="11" define="MANUFACTURING_DATE"        type="char_string" minLength="8" length="16"                               optional="true">
+      <description>ManufacturingDate</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="12" define="PART_NUMBER"               type="char_string"               length="32"                               optional="true">
+      <description>PartNumber</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="13" define="PRODUCT_URL"               type="long_char_string"          length="256"                              optional="true">
+      <description>ProductURL</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="14" define="PRODUCT_LABEL"             type="char_string"               length="64"                               optional="true">
+      <description>ProductLabel</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="15" define="SERIAL_NUMBER"             type="char_string"               length="32"                               optional="true">
+      <description>SerialNumber</description>
+      <optionalConform/>
+    </attribute>
     <attribute side="server" code="16" define="LOCAL_CONFIG_DISABLED"     type="boolean"                                default="0"  writable="true" optional="true">
       <description>LocalConfigDisabled</description>
       <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
+      <optionalConform/>
     </attribute>
-    <attribute side="server" code="17" define="REACHABLE"                 type="boolean"                                default="1"                  optional="true">Reachable</attribute>
-    <attribute side="server" code="18" define="UNIQUE_ID"                 type="char_string"               length="32"                               optional="false">UniqueID</attribute>
-    <attribute side="server" code="19" define="CAPABILITY_MINIMA"         type="CapabilityMinimaStruct"                              writable="false"               >CapabilityMinima</attribute>
-    <attribute side="server" code="20" define="PRODUCT_APPEARANCE"        type="ProductAppearanceStruct"                                             optional="true">ProductAppearance</attribute>
-    <attribute side="server" code="21" define="SPECIFICATION_VERSION"     type="int32u"                                                                             >SpecificationVersion</attribute>
-    <attribute side="server" code="22" define="MAX_PATHS_PER_INVOKE"      type="int16u"                                                                             >MaxPathsPerInvoke</attribute>
+    <attribute side="server" code="17" define="REACHABLE"                 type="boolean"                                default="1"                  optional="true">
+      <description>Reachable</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="18" define="UNIQUE_ID"                 type="char_string"               length="32"                               optional="false">
+      <description>UniqueID</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="19" define="CAPABILITY_MINIMA"         type="CapabilityMinimaStruct"                              writable="false"               >
+      <description>CapabilityMinima</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="20" define="PRODUCT_APPEARANCE"        type="ProductAppearanceStruct"                                             optional="true">
+      <description>ProductAppearance</description>
+      <optionalConform/>
+    </attribute>
+    <attribute side="server" code="21" define="SPECIFICATION_VERSION"     type="int32u"                                                                             >
+      <description>SpecificationVersion</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="22" define="MAX_PATHS_PER_INVOKE"      type="int16u"                                                                             >
+      <description>MaxPathsPerInvoke</description>
+      <mandatoryConform/>
+    </attribute>
 
     <event side="server" code="0x00" name="StartUp" priority="critical" optional="false">
       <description>The StartUp event SHALL be emitted by a Node as soon as reasonable after completing a boot or reboot process.</description>

--- a/src/app/zap-templates/zcl/data-model/chip/binding-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/binding-cluster.xml
@@ -34,6 +34,7 @@ limitations under the License.
     <attribute side="server" code="0x0000" define="BINDING_LIST" type="array" entryType="TargetStruct" writable="true" optional="false">
         <description>Binding</description>
         <access op="write" role="manage"/>
+        <mandatoryConform/>
     </attribute>
   </cluster>
 

--- a/src/app/zap-templates/zcl/data-model/chip/boolean-state-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/boolean-state-cluster.xml
@@ -26,7 +26,10 @@ limitations under the License.
     <client tick="false" init="false">true</client>
     <server tick="false" init="false">true</server>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
-    <attribute side="server" code="0x0000" define="STATE_VALUE" type="boolean" writable="false" reportable="true" optional="false">StateValue</attribute>
+    <attribute side="server" code="0x0000" define="STATE_VALUE" type="boolean" writable="false" reportable="true" optional="false">
+      <description>StateValue</description>
+      <mandatoryConform/>
+    </attribute>
 
     <event code="0x0000" name="StateChange" priority="info" side="server">
       <description>This event SHALL be generated when the StateValue attribute changes.</description>

--- a/src/app/zap-templates/zcl/data-model/chip/boolean-state-configuration-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/boolean-state-configuration-cluster.xml
@@ -58,22 +58,78 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="CURRENT_SENSITIVITY_LEVEL" type="int8u" isNullable="false" writable="true" optional="true">CurrentSensitivityLevel</attribute>
-    <attribute side="server" code="0x0001" define="SUPPORTED_SENSITIVITY_LEVELS" type="int8u" isNullable="false" min="2" max="10" writable="false" optional="true">SupportedSensitivityLevels</attribute>
-    <attribute side="server" code="0x0002" define="DEFAULT_SENSITIVITY_LEVEL" type="int8u" isNullable="false" writable="false" optional="true">DefaultSensitivityLevel</attribute>
-    <attribute side="server" code="0x0003" define="ALARMS_ACTIVE" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">AlarmsActive</attribute>
-    <attribute side="server" code="0x0004" define="ALARMS_SUPPRESSED" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">AlarmsSuppressed</attribute>
-    <attribute side="server" code="0x0005" define="ALARMS_ENABLED" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">AlarmsEnabled</attribute>
-    <attribute side="server" code="0x0006" define="ALARMS_SUPPORTED" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">AlarmsSupported</attribute>
-    <attribute side="server" code="0x0007" define="SENSOR_FAULT" type="SensorFaultBitmap" isNullable="false" writable="false" default="0" optional="true">SensorFault</attribute>
+    <attribute side="server" code="0x0000" define="CURRENT_SENSITIVITY_LEVEL" type="int8u" isNullable="false" writable="true" optional="true">
+      <description>CurrentSensitivityLevel</description>
+      <mandatoryConform>
+        <feature name="SENSLVL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="SUPPORTED_SENSITIVITY_LEVELS" type="int8u" isNullable="false" min="2" max="10" writable="false" optional="true">
+      <description>SupportedSensitivityLevels</description>
+      <mandatoryConform>
+        <feature name="SENSLVL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="DEFAULT_SENSITIVITY_LEVEL" type="int8u" isNullable="false" writable="false" optional="true">
+      <description>DefaultSensitivityLevel</description>
+      <optionalConform>
+        <feature name="SENSLVL"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="ALARMS_ACTIVE" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">
+      <description>AlarmsActive</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="VIS"/>
+          <feature name="AUD"/>
+        </orTerm>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="ALARMS_SUPPRESSED" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">
+      <description>AlarmsSuppressed</description>
+      <mandatoryConform>
+        <feature name="SPRS"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="ALARMS_ENABLED" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">
+      <description>AlarmsEnabled</description>
+      <optionalConform>
+        <orTerm>
+          <feature name="VIS"/>
+          <feature name="AUD"/>
+        </orTerm>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="ALARMS_SUPPORTED" type="AlarmModeBitmap" isNullable="false" writable="false" optional="true">
+      <description>AlarmsSupported</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="VIS"/>
+          <feature name="AUD"/>
+        </orTerm>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="SENSOR_FAULT" type="SensorFaultBitmap" isNullable="false" writable="false" default="0" optional="true">
+      <description>SensorFault</description>
+      <optionalConform/>
+    </attribute>
 
     <command source="client" code="0x00" name="SuppressAlarm" optional="true">
       <description>This command is used to suppress the specified alarm mode.</description>
+      <mandatoryConform>
+        <feature name="SPRS"/>
+      </mandatoryConform>
       <arg name="AlarmsToSuppress" type="AlarmModeBitmap"/>
     </command>
 
     <command source="client" code="0x01" name="EnableDisableAlarm" optional="true">
       <description>This command is used to enable or disable the specified alarm mode.</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="VIS"/>
+          <feature name="AUD"/>
+        </orTerm>
+      </mandatoryConform>
       <arg name="AlarmsToEnableDisable" type="AlarmModeBitmap"/>
     </command>
 

--- a/src/app/zap-templates/zcl/data-model/chip/bridged-device-basic-information.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/bridged-device-basic-information.xml
@@ -77,26 +77,76 @@ limitations under the License.
           </feature>
         </features>
 
-        <attribute side="server" code="1"  define="VENDOR_NAME"               type="char_string"               length="32"                              optional="true">VendorName</attribute>
-        <attribute side="server" code="2"  define="VENDOR_ID"                 type="vendor_id"                                                          optional="true">VendorID</attribute>
-        <attribute side="server" code="3"  define="PRODUCT_NAME"              type="char_string"               length="32"                              optional="true">ProductName</attribute>
+        <attribute side="server" code="1"  define="VENDOR_NAME"               type="char_string"               length="32"                              optional="true">
+            <description>VendorName</description>
+            <optionalConform/>
+        </attribute>
+        <attribute side="server" code="2"  define="VENDOR_ID"                 type="vendor_id"                                                          optional="true">
+            <description>VendorID</description>
+            <optionalConform/>
+        </attribute>
+        <attribute side="server" code="3"  define="PRODUCT_NAME"              type="char_string"               length="32"                              optional="true">
+            <description>ProductName</description>
+            <optionalConform/>
+        </attribute>
         <attribute side="server" code="4"  define="PRODUCT_ID"                type="int16u"  optional="true">ProductID</attribute>
-        <attribute side="server" code="5"  define="NODE_LABEL"                type="char_string"               length="32"  default=""  writable="true" optional="true">NodeLabel</attribute>
-        <attribute side="server" code="7"  define="HARDWARE_VERSION"          type="int16u"                                 default="0"                 optional="true">HardwareVersion</attribute>
-        <attribute side="server" code="8"  define="HARDWARE_VERSION_STRING"   type="char_string" minLength="1" length="64"                              optional="true">HardwareVersionString</attribute>
-        <attribute side="server" code="9"  define="SOFTWARE_VERSION"          type="int32u"                                 default="0"                 optional="true">SoftwareVersion</attribute>
-        <attribute side="server" code="10" define="SOFTWARE_VERSION_STRING"   type="char_string" minLength="1" length="64"                              optional="true">SoftwareVersionString</attribute>
-        <attribute side="server" code="11" define="MANUFACTURING_DATE"        type="char_string" minLength="8" length="16"                              optional="true">ManufacturingDate</attribute>
-        <attribute side="server" code="12" define="PART_NUMBER"               type="char_string"               length="32"                              optional="true">PartNumber</attribute>
-        <attribute side="server" code="13" define="PRODUCT_URL"               type="long_char_string"          length="256"                             optional="true">ProductURL</attribute>
-        <attribute side="server" code="14" define="PRODUCT_LABEL"             type="char_string"               length="64"                              optional="true">ProductLabel</attribute>
-        <attribute side="server" code="15" define="SERIAL_NUMBER"             type="char_string"               length="32"                              optional="true">SerialNumber</attribute>
-        <attribute side="server" code="17" define="REACHABLE"                 type="boolean"                                default="1"                 optional="false">Reachable</attribute>
-        <attribute side="server" code="18" define="UNIQUE_ID"                 type="char_string"               length="32"                              optional="false">UniqueID</attribute>
-        <attribute side="server" code="20" define="PRODUCT_APPEARANCE"        type="ProductAppearanceStruct"                                            optional="true">ProductAppearance</attribute>
+        <attribute side="server" code="5"  define="NODE_LABEL"                type="char_string"               length="32"  default=""  writable="true" optional="true">
+            <description>NodeLabel</description>
+        </attribute>
+        <attribute side="server" code="7"  define="HARDWARE_VERSION"          type="int16u"                                 default="0"                 optional="true">
+            <description>HardwareVersion</description>
+            <optionalConform/>
+        </attribute>
+        <attribute side="server" code="8"  define="HARDWARE_VERSION_STRING"   type="char_string" minLength="1" length="64"                              optional="true">
+            <description>HardwareVersionString</description>
+            <optionalConform/>
+        </attribute>
+        <attribute side="server" code="9"  define="SOFTWARE_VERSION"          type="int32u"                                 default="0"                 optional="true">
+            <description>SoftwareVersion</description>
+            <optionalConform/>
+        </attribute>
+        <attribute side="server" code="10" define="SOFTWARE_VERSION_STRING"   type="char_string" minLength="1" length="64"                              optional="true">
+            <description>SoftwareVersionString</description>
+            <optionalConform/>
+        </attribute>
+        <attribute side="server" code="11" define="MANUFACTURING_DATE"        type="char_string" minLength="8" length="16"                              optional="true">
+            <description>ManufacturingDate</description>
+            <optionalConform/>
+        </attribute>
+        <attribute side="server" code="12" define="PART_NUMBER"               type="char_string"               length="32"                              optional="true">
+            <description>PartNumber</description>
+            <optionalConform/>
+        </attribute>
+        <attribute side="server" code="13" define="PRODUCT_URL"               type="long_char_string"          length="256"                             optional="true">
+            <description>ProductURL</description>
+            <optionalConform/>
+        </attribute>
+        <attribute side="server" code="14" define="PRODUCT_LABEL"             type="char_string"               length="64"                              optional="true">
+            <description>ProductLabel</description>
+            <optionalConform/>
+        </attribute>
+        <attribute side="server" code="15" define="SERIAL_NUMBER"             type="char_string"               length="32"                              optional="true">
+            <description>SerialNumber</description>
+            <optionalConform/>
+        </attribute>
+        <attribute side="server" code="17" define="REACHABLE"                 type="boolean"                                default="1"                 optional="false">
+            <description>Reachable</description>
+            <mandatoryConform/>
+        </attribute>
+        <attribute side="server" code="18" define="UNIQUE_ID"                 type="char_string"               length="32"                              optional="false">
+            <description>UniqueID</description>
+            <mandatoryConform/>
+        </attribute>
+        <attribute side="server" code="20" define="PRODUCT_APPEARANCE"        type="ProductAppearanceStruct"                                            optional="true">
+            <description>ProductAppearance</description>
+            <optionalConform/>
+        </attribute>
 
         <command source="client" code="0x80" name="KeepActive" optional="true" apiMaturity="provisional">
           <description> The server SHALL attempt to keep the devices specified active for StayActiveDuration milliseconds when they are next active.</description>
+          <mandatoryConform>
+            <feature name="BIS"/>
+          </mandatoryConform>
           <arg id="0" name="StayActiveDuration" type="int32u"/>
           <arg id="1" name="TimeoutMs" type="int32u" min="30000" max="3600000"/>
         </command>

--- a/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/channel-cluster.xml
@@ -41,34 +41,64 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="CHANNEL_LIST"            type="array" entryType="ChannelInfoStruct" length="254"                    writable="false" optional="true">ChannelList</attribute>
-    <attribute side="server" code="0x0001" define="CHANNEL_LINEUP"          type="LineupInfoStruct"                    default="0x0" isNullable="true" writable="false" optional="true">Lineup</attribute>
-    <attribute side="server" code="0x0002" define="CHANNEL_CURRENT_CHANNEL" type="ChannelInfoStruct"                   default="0x0" isNullable="true" writable="false" optional="true">CurrentChannel</attribute>
+    <attribute side="server" code="0x0000" define="CHANNEL_LIST"            type="array" entryType="ChannelInfoStruct" length="254"                    writable="false" optional="true">
+      <description>ChannelList</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CHANNEL_LINEUP"          type="LineupInfoStruct"                    default="0x0" isNullable="true" writable="false" optional="true">
+      <description>Lineup</description>
+      <mandatoryConform>
+        <feature name="LI"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="CHANNEL_CURRENT_CHANNEL" type="ChannelInfoStruct"                   default="0x0" isNullable="true" writable="false" optional="true">
+      <description>CurrentChannel</description>
+      <optionalConform/>
+    </attribute>
 
     <command source="client" code="0x00" name="ChangeChannel" response="ChangeChannelResponse" optional="true">
       <description>Change the channel on the media player to the channel case-insensitive exact matching the value passed as an argument. </description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="CL"/>
+          <feature name="LI"/>
+        </orTerm>
+      </mandatoryConform>
       <arg name="Match" type="char_string"/>
     </command>
 
     <command source="client" code="0x02" name="ChangeChannelByNumber" optional="false">
       <description>Change the channel on the media plaeyer to the channel with the given Number in the ChannelList attribute.</description>
+      <mandatoryConform/>
       <arg name="MajorNumber" type="int16u"/>
       <arg name="MinorNumber" type="int16u"/>
     </command>
 
     <command source="client" code="0x03" name="SkipChannel" optional="false">
       <description>This command provides channel up and channel down functionality, but allows channel index jumps of size Count. When the value of the increase or decrease is larger than the number of channels remaining in the given direction, then the behavior SHALL be to return to the beginning (or end) of the channel list and continue. For example, if the current channel is at index 0 and count value of -1 is given, then the current channel should change to the last channel.</description>
+      <mandatoryConform/>
       <arg name="Count" type="int16s"/>
     </command>
 
     <command source="server" code="0x01" name="ChangeChannelResponse" optional="true">
       <description>Upon receipt, this SHALL display the active status of the input list on screen.</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="CL"/>
+          <feature name="LI"/>
+        </orTerm>
+      </mandatoryConform>
       <arg name="Status" type="StatusEnum"/>
       <arg name="Data"   type="char_string" optional="true"/>
     </command>
 
     <command source="client" code="0x04" name="GetProgramGuide" response="ProgramGuideResponse" optional="true">
       <description>This command retrieves the program guide. It accepts several filter parameters to return specific schedule and program information from a content app. The command shall receive in response a ProgramGuideResponse.</description>
+      <mandatoryConform>
+        <feature name="EG"/>
+      </mandatoryConform>
       <arg name="StartTime" type="epoch_s" optional="true"/>
       <arg name="EndTime" type="epoch_s" optional="true"/>
       <arg name="ChannelList" type="ChannelInfoStruct" array="true" optional="true"/>
@@ -80,12 +110,21 @@ limitations under the License.
 
     <command source="server" code="0x05" name="ProgramGuideResponse" optional="true" apiMaturity="provisional">
       <description>This command is a response to the GetProgramGuide command.</description>
+      <mandatoryConform>
+        <feature name="EG"/>
+      </mandatoryConform>
       <arg name="Paging" type="ChannelPagingStruct"/>
       <arg name="ProgramList" type="ProgramStruct" array="true"/>
     </command>
 
     <command source="client" code="0x06" name="RecordProgram" optional="true">
       <description>Record a specific program or series when it goes live. This functionality enables DVR recording features.</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="RP"/>
+          <feature name="EG"/>
+        </andTerm>
+      </mandatoryConform>
       <arg name="ProgramIdentifier" type="char_string"/>
       <arg name="ShouldRecordSeries" type="boolean"/>
       <arg name="ExternalIDList" type="AdditionalInfoStruct" array="true"/>
@@ -94,6 +133,12 @@ limitations under the License.
 
     <command source="client" code="0x07" name="CancelRecordProgram" optional="true">
       <description>Cancel recording for a specific program or series.</description>
+      <mandatoryConform>
+        <andTerm>
+          <feature name="RP"/>
+          <feature name="EG"/>
+        </andTerm>
+      </mandatoryConform>
       <arg name="ProgramIdentifier" type="char_string"/>
       <arg name="ShouldRecordSeries" type="boolean"/>
       <arg name="ExternalIDList" type="AdditionalInfoStruct" array="true"/>

--- a/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
@@ -46,6 +46,7 @@ limitations under the License.
         <server tick="false" init="false">true</server>
         <command source="client" code="0x00" name="QueryImage" response="QueryImageResponse" optional="false" cli="chip ota queryimage">
             <description>Determine availability of a new Software Image</description>
+            <mandatoryConform/>
             <arg name="VendorID" type="vendor_id"/>
             <arg name="ProductID" type="int16u"/>
             <arg name="SoftwareVersion" type="int32u"/>
@@ -57,6 +58,7 @@ limitations under the License.
         </command>
         <command source="server" code="0x01" name="QueryImageResponse" optional="false" cli="chip ota queryimageresponse">
             <description>Response to QueryImage command</description>
+            <mandatoryConform/>
             <arg name="Status" type="StatusEnum"/>
             <arg name="DelayedActionTime" type="int32u" optional="true"/>
             <arg name="ImageURI" type="char_string" length="256" optional="true"/>
@@ -68,16 +70,19 @@ limitations under the License.
         </command>
         <command source="client" code="0x02" name="ApplyUpdateRequest" response="ApplyUpdateResponse" optional="false" cli="chip ota applyupdaterequest">
             <description>Determine next action to take for a downloaded Software Image</description>
+            <mandatoryConform/>
             <arg name="UpdateToken" type="octet_string" length="32"/>
             <arg name="NewVersion" type="int32u"/>
         </command>
         <command source="server" code="0x03" name="ApplyUpdateResponse" optional="false" cli="chip ota applyupdateresponse">
             <description>Reponse to ApplyUpdateRequest command</description>
+            <mandatoryConform/>
             <arg name="Action" type="ApplyUpdateActionEnum"/>
             <arg name="DelayedActionTime" type="int32u"/>
         </command>
         <command source="client" code="0x04" name="NotifyUpdateApplied" optional="false" cli="chip ota notifyupdateapplied">
             <description>Notify OTA Provider that an update was applied</description>
+            <mandatoryConform/>
             <arg name="UpdateToken" type="octet_string" length="32"/>
             <arg name="SoftwareVersion" type="int32u"/>
         </command>

--- a/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/color-control-cluster.xml
@@ -127,141 +127,410 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="COLOR_CONTROL_CURRENT_HUE" type="int8u" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">CurrentHue</attribute>
+    <attribute side="server" code="0x0000" define="COLOR_CONTROL_CURRENT_HUE" type="int8u" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">
+      <description>CurrentHue</description>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
+    </attribute>
     <!-- CURRENT_HUE -->
-    <attribute side="server" code="0x0001" define="COLOR_CONTROL_CURRENT_SATURATION" type="int8u" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">CurrentSaturation</attribute>
+    <attribute side="server" code="0x0001" define="COLOR_CONTROL_CURRENT_SATURATION" type="int8u" min="0x00" max="0xFE" writable="false" reportable="true" default="0x00" optional="true">
+      <description>CurrentSaturation</description>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
+    </attribute>
     <!-- CURRENT_SATURATION -->
-    <attribute side="server" code="0x0002" define="COLOR_CONTROL_REMAINING_TIME" type="int16u" min="0x0000" max="0xFFFE" writable="false" default="0x0000" optional="true">RemainingTime</attribute>
+    <attribute side="server" code="0x0002" define="COLOR_CONTROL_REMAINING_TIME" type="int16u" min="0x0000" max="0xFFFE" writable="false" default="0x0000" optional="true">
+      <description>RemainingTime</description>
+      <optionalConform/>
+    </attribute>
     <!-- REMAINING_TIME -->
-    <attribute side="server" code="0x0003" define="COLOR_CONTROL_CURRENT_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x616B" optional="true">CurrentX</attribute>
+    <attribute side="server" code="0x0003" define="COLOR_CONTROL_CURRENT_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x616B" optional="true">
+      <description>CurrentX</description>
+      <mandatoryConform>
+        <feature name="XY"/>
+      </mandatoryConform>
+    </attribute>
     <!-- CURRENT_X -->
-    <attribute side="server" code="0x0004" define="COLOR_CONTROL_CURRENT_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x607D" optional="true">CurrentY</attribute>
+    <attribute side="server" code="0x0004" define="COLOR_CONTROL_CURRENT_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" reportable="true" default="0x607D" optional="true">
+      <description>CurrentY</description>
+      <mandatoryConform>
+        <feature name="XY"/>
+      </mandatoryConform>
+    </attribute>
     <!-- CURRENT_Y -->
-    <attribute side="server" code="0x0005" define="COLOR_CONTROL_DRIFT_COMPENSATION" type="DriftCompensationEnum" writable="false" optional="true">DriftCompensation</attribute>
+    <attribute side="server" code="0x0005" define="COLOR_CONTROL_DRIFT_COMPENSATION" type="DriftCompensationEnum" writable="false" optional="true">
+      <description>DriftCompensation</description>
+      <optionalConform/>
+    </attribute>
     <!-- DRIFT_COMPENSATION -->
-    <attribute side="server" code="0x0006" define="COLOR_CONTROL_COMPENSATION_TEXT" type="char_string" length="254" writable="false" optional="true">CompensationText</attribute>
+    <attribute side="server" code="0x0006" define="COLOR_CONTROL_COMPENSATION_TEXT" type="char_string" length="254" writable="false" optional="true">
+      <description>CompensationText</description>
+      <optionalConform/>
+    </attribute>
     <!-- COMPENSATION_TEXT -->
-    <attribute side="server" code="0x0007" define="COLOR_CONTROL_COLOR_TEMPERATURE" type="int16u" min="0x0001" max="0xFEFF" writable="false" reportable="true" default="0x00FA" optional="true">ColorTemperatureMireds</attribute>
+    <attribute side="server" code="0x0007" define="COLOR_CONTROL_COLOR_TEMPERATURE" type="int16u" min="0x0001" max="0xFEFF" writable="false" reportable="true" default="0x00FA" optional="true">
+      <description>ColorTemperatureMireds</description>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
+    </attribute>
     <!-- COLOR_TEMPERATURE -->
-    <attribute side="server" code="0x0008" define="COLOR_CONTROL_COLOR_MODE" type="ColorModeEnum" writable="false" default="0x01">ColorMode</attribute>
+    <attribute side="server" code="0x0008" define="COLOR_CONTROL_COLOR_MODE" type="ColorModeEnum" writable="false" default="0x01">
+      <description>ColorMode</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- COLOR_MODE -->
-    <attribute side="server" code="0x000F" define="COLOR_CONTROL_OPTIONS" type="OptionsBitmap" writable="true" default="0x00">Options</attribute>
+    <attribute side="server" code="0x000F" define="COLOR_CONTROL_OPTIONS" type="OptionsBitmap" writable="true" default="0x00">
+      <description>Options</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- COLOR_CONTROL_OPTIONS -->
-    <attribute side="server" code="0x0010" define="COLOR_CONTROL_NUMBER_OF_PRIMARIES" type="int8u" min="0x00" max="0x06" isNullable="true" writable="false">NumberOfPrimaries</attribute>
+    <attribute side="server" code="0x0010" define="COLOR_CONTROL_NUMBER_OF_PRIMARIES" type="int8u" min="0x00" max="0x06" isNullable="true" writable="false">
+      <description>NumberOfPrimaries</description>
+      <mandatoryConform/>
+    </attribute>
     <!-- NUMBER_OF_PRIMARIES -->
-    <attribute side="server" code="0x0011" define="COLOR_CONTROL_PRIMARY_1_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary1X</attribute>
+    <attribute side="server" code="0x0011" define="COLOR_CONTROL_PRIMARY_1_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary1X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="0"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_1_X -->
-    <attribute side="server" code="0x0012" define="COLOR_CONTROL_PRIMARY_1_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary1Y</attribute>
+    <attribute side="server" code="0x0012" define="COLOR_CONTROL_PRIMARY_1_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary1Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="0"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_1_Y -->
-    <attribute side="server" code="0x0013" define="COLOR_CONTROL_PRIMARY_1_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary1Intensity</attribute>
+    <attribute side="server" code="0x0013" define="COLOR_CONTROL_PRIMARY_1_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">
+      <description>Primary1Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="0"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_1_INTENSITY -->
-    <attribute side="server" code="0x0015" define="COLOR_CONTROL_PRIMARY_2_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary2X</attribute>
+    <attribute side="server" code="0x0015" define="COLOR_CONTROL_PRIMARY_2_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary2X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="1"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_2_X -->
-    <attribute side="server" code="0x0016" define="COLOR_CONTROL_PRIMARY_2_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary2Y</attribute>
+    <attribute side="server" code="0x0016" define="COLOR_CONTROL_PRIMARY_2_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary2Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="1"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_2_Y -->
-    <attribute side="server" code="0x0017" define="COLOR_CONTROL_PRIMARY_2_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary2Intensity</attribute>
+    <attribute side="server" code="0x0017" define="COLOR_CONTROL_PRIMARY_2_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">
+      <description>Primary2Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="1"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_2_INTENSITY -->
-    <attribute side="server" code="0x0019" define="COLOR_CONTROL_PRIMARY_3_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary3X</attribute>
+    <attribute side="server" code="0x0019" define="COLOR_CONTROL_PRIMARY_3_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary3X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="2"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_3_X -->
-    <attribute side="server" code="0x001A" define="COLOR_CONTROL_PRIMARY_3_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary3Y</attribute>
+    <attribute side="server" code="0x001A" define="COLOR_CONTROL_PRIMARY_3_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary3Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="2"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_3_Y -->
-    <attribute side="server" code="0x001B" define="COLOR_CONTROL_PRIMARY_3_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary3Intensity</attribute>
+    <attribute side="server" code="0x001B" define="COLOR_CONTROL_PRIMARY_3_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">
+      <description>Primary3Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="2"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_3_INTENSITY -->
-    <attribute side="server" code="0x0020" define="COLOR_CONTROL_PRIMARY_4_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary4X</attribute>
+    <attribute side="server" code="0x0020" define="COLOR_CONTROL_PRIMARY_4_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary4X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="3"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_4_X -->
-    <attribute side="server" code="0x0021" define="COLOR_CONTROL_PRIMARY_4_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary4Y</attribute>
+    <attribute side="server" code="0x0021" define="COLOR_CONTROL_PRIMARY_4_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary4Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="3"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_4_Y -->
-    <attribute side="server" code="0x0022" define="COLOR_CONTROL_PRIMARY_4_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary4Intensity</attribute>
+    <attribute side="server" code="0x0022" define="COLOR_CONTROL_PRIMARY_4_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">
+      <description>Primary4Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="3"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_4_INTENSITY -->
-    <attribute side="server" code="0x0024" define="COLOR_CONTROL_PRIMARY_5_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary5X</attribute>
+    <attribute side="server" code="0x0024" define="COLOR_CONTROL_PRIMARY_5_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary5X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="4"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_5_X -->
-    <attribute side="server" code="0x0025" define="COLOR_CONTROL_PRIMARY_5_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary5Y</attribute>
+    <attribute side="server" code="0x0025" define="COLOR_CONTROL_PRIMARY_5_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary5Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="4"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_5_Y -->
-    <attribute side="server" code="0x0026" define="COLOR_CONTROL_PRIMARY_5_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary5Intensity</attribute>
+    <attribute side="server" code="0x0026" define="COLOR_CONTROL_PRIMARY_5_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">
+      <description>Primary5Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="4"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_5_INTENSITY -->
-    <attribute side="server" code="0x0028" define="COLOR_CONTROL_PRIMARY_6_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary6X</attribute>
+    <attribute side="server" code="0x0028" define="COLOR_CONTROL_PRIMARY_6_X" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary6X</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="5"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_6_X -->
-    <attribute side="server" code="0x0029" define="COLOR_CONTROL_PRIMARY_6_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">Primary6Y</attribute>
+    <attribute side="server" code="0x0029" define="COLOR_CONTROL_PRIMARY_6_Y" type="int16u" min="0x0000" max="0xFEFF" writable="false" optional="true">
+      <description>Primary6Y</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="5"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_6_Y -->
-    <attribute side="server" code="0x002A" define="COLOR_CONTROL_PRIMARY_6_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">Primary6Intensity</attribute>
+    <attribute side="server" code="0x002A" define="COLOR_CONTROL_PRIMARY_6_INTENSITY" type="int8u" min="0x00" max="0xFF" isNullable="true" writable="false" optional="true">
+      <description>Primary6Intensity</description>
+      <otherwiseConform>
+        <mandatoryConform>
+          <greaterTerm>
+            <attribute name="NumberOfPrimaries"/>
+            <literal value="5"/>
+          </greaterTerm>
+        </mandatoryConform>
+        <optionalConform/>
+      </otherwiseConform>
+    </attribute>
     <!-- PRIMARY_6_INTENSITY -->
     <attribute side="server" code="0x0030" define="COLOR_CONTROL_WHITE_POINT_X" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>WhitePointX</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- WHITE_POINT_X -->
     <attribute side="server" code="0x0031" define="COLOR_CONTROL_WHITE_POINT_Y" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>WhitePointY</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- WHITE_POINT_Y -->
     <attribute side="server" code="0x0032" define="COLOR_CONTROL_COLOR_POINT_R_X" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointRX</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_R_X -->
     <attribute side="server" code="0x0033" define="COLOR_CONTROL_COLOR_POINT_R_Y" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointRY</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_R_Y -->
     <attribute side="server" code="0x0034" define="COLOR_CONTROL_COLOR_POINT_R_INTENSITY" type="int8u" isNullable="true" writable="true" optional="true">
       <description>ColorPointRIntensity</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_R_INTENSITY -->
     <attribute side="server" code="0x0036" define="COLOR_CONTROL_COLOR_POINT_G_X" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointGX</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_G_X -->
     <attribute side="server" code="0x0037" define="COLOR_CONTROL_COLOR_POINT_G_Y" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointGY</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_G_Y -->
     <attribute side="server" code="0x0038" define="COLOR_CONTROL_COLOR_POINT_G_INTENSITY" type="int8u" isNullable="true" writable="true" optional="true">
       <description>ColorPointGIntensity</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_G_INTENSITY -->
     <attribute side="server" code="0x003A" define="COLOR_CONTROL_COLOR_POINT_B_X" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointBX</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_B_X -->
     <attribute side="server" code="0x003B" define="COLOR_CONTROL_COLOR_POINT_B_Y" type="int16u" min="0x0000" max="0xFEFF" writable="true" optional="true">
       <description>ColorPointBY</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_B_Y -->
     <attribute side="server" code="0x003C" define="COLOR_CONTROL_COLOR_POINT_B_INTENSITY" type="int8u" isNullable="true" writable="true" optional="true">
       <description>ColorPointBIntensity</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <optionalConform/>
     </attribute>
     <!-- COLOR_POINT_B_INTENSITY -->
-    <attribute side="server" code="0x400D" define="COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS" type="int16u" min="0x0000" max="0xFFFF" writable="false" optional="true">CoupleColorTempToLevelMinMireds</attribute>
+    <attribute side="server" code="0x400D" define="COLOR_CONTROL_TEMPERATURE_LEVEL_MIN_MIREDS" type="int16u" min="0x0000" max="0xFFFF" writable="false" optional="true">
+      <description>CoupleColorTempToLevelMinMireds</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="CT"/>
+          <attribute name="ColorTemperatureMireds"/>
+        </orTerm>
+      </mandatoryConform>
+    </attribute>
     <attribute side="server" code="0x4010" define="START_UP_COLOR_TEMPERATURE_MIREDS" type="int16u" min="0x0000" max="0xFEFF" writable="true" isNullable="true" optional="true">
       <description>StartUpColorTemperatureMireds</description>
       <access op="read" role="view"/>
       <access op="write" role="manage"/>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="CT"/>
+          <attribute name="ColorTemperatureMireds"/>
+        </orTerm>
+      </mandatoryConform>
     </attribute>
 
     <command source="client" code="0x00" name="MoveToHue" optional="true" cli="zcl color-control movetohue">
       <description>
         Move to specified hue.
       </description>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
       <arg name="Hue" type="int8u"/>
       <arg name="Direction" type="DirectionEnum"/>
       <arg name="TransitionTime" type="int16u"/>
@@ -273,6 +542,9 @@ limitations under the License.
       <description>
         Move hue up or down at specified rate.
       </description>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
       <arg name="MoveMode" type="MoveModeEnum"/>
       <arg name="Rate" type="int8u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
@@ -283,6 +555,9 @@ limitations under the License.
       <description>
         Step hue up or down by specified size at specified rate.
       </description>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
       <arg name="StepMode" type="StepModeEnum"/>
       <arg name="StepSize" type="int8u"/>
       <arg name="TransitionTime" type="int8u"/>
@@ -294,6 +569,9 @@ limitations under the License.
       <description>
         Move to specified saturation.
       </description>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
       <arg name="Saturation" type="int8u"/>
       <arg name="TransitionTime" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
@@ -304,6 +582,9 @@ limitations under the License.
       <description>
         Move saturation up or down at specified rate.
       </description>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
       <arg name="MoveMode" type="MoveModeEnum"/>
       <arg name="Rate" type="int8u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
@@ -314,6 +595,9 @@ limitations under the License.
       <description>
         Step saturation up or down by specified size at specified rate.
       </description>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
       <arg name="StepMode" type="StepModeEnum"/>
       <arg name="StepSize" type="int8u"/>
       <arg name="TransitionTime" type="int8u"/>
@@ -325,6 +609,9 @@ limitations under the License.
       <description>
         Move to hue and saturation.
       </description>
+      <mandatoryConform>
+        <feature name="HS"/>
+      </mandatoryConform>
       <arg name="Hue" type="int8u"/>
       <arg name="Saturation" type="int8u"/>
       <arg name="TransitionTime" type="int16u"/>
@@ -336,6 +623,9 @@ limitations under the License.
       <description>
         Move to specified color.
       </description>
+      <mandatoryConform>
+        <feature name="XY"/>
+      </mandatoryConform>
       <arg name="ColorX" type="int16u"/>
       <arg name="ColorY" type="int16u"/>
       <arg name="TransitionTime" type="int16u"/>
@@ -347,6 +637,9 @@ limitations under the License.
       <description>
         Moves the color.
       </description>
+      <mandatoryConform>
+        <feature name="XY"/>
+      </mandatoryConform>
       <arg name="RateX" type="int16s"/>
       <arg name="RateY" type="int16s"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
@@ -357,6 +650,9 @@ limitations under the License.
       <description>
         Steps the lighting to a specific color.
       </description>
+      <mandatoryConform>
+        <feature name="XY"/>
+      </mandatoryConform>
       <arg name="StepX" type="int16s"/>
       <arg name="StepY" type="int16s"/>
       <arg name="TransitionTime" type="int16u"/>
@@ -368,6 +664,9 @@ limitations under the License.
       <description>
         Move to a specific color temperature.
       </description>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
       <arg name="ColorTemperatureMireds" type="int16u"/>
       <arg name="TransitionTime" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
@@ -376,21 +675,70 @@ limitations under the License.
   </cluster>
 
   <clusterExtension code="0x0300">
-    <attribute side="server" code="0x4000" define="COLOR_CONTROL_ENHANCED_CURRENT_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">EnhancedCurrentHue</attribute>
-    <attribute side="server" code="0x4001" define="COLOR_CONTROL_ENHANCED_COLOR_MODE" type="EnhancedColorModeEnum" writable="false" default="0x01">EnhancedColorMode</attribute>
-    <attribute side="server" code="0x4002" define="COLOR_CONTROL_COLOR_LOOP_ACTIVE" type="int8u" min="0x00" max="0x01" writable="false" default="0x00" optional="true">ColorLoopActive</attribute>
-    <attribute side="server" code="0x4003" define="COLOR_CONTROL_COLOR_LOOP_DIRECTION" type="int8u" min="0x00" max="0x01" writable="false" default="0x00" optional="true">ColorLoopDirection</attribute>
-    <attribute side="server" code="0x4004" define="COLOR_CONTROL_COLOR_LOOP_TIME" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0019" optional="true">ColorLoopTime</attribute>
-    <attribute side="server" code="0x4005" define="COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x2300" optional="true">ColorLoopStartEnhancedHue</attribute>
-    <attribute side="server" code="0x4006" define="COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">ColorLoopStoredEnhancedHue</attribute>
-    <attribute side="server" code="0x400A" define="COLOR_CONTROL_COLOR_CAPABILITIES" type="ColorCapabilitiesBitmap" min="0x0000" max="0x001F" writable="false" default="0x0000">ColorCapabilities</attribute>
-    <attribute side="server" code="0x400B" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN" type="int16u" min="0x0001" max="0xFEFF" writable="false" default="0x0000" optional="true">ColorTempPhysicalMinMireds</attribute>
-    <attribute side="server" code="0x400C" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX" type="int16u" min="0x0000" max="0xFEFF" writable="false" default="0xFEFF" optional="true">ColorTempPhysicalMaxMireds</attribute>
+    <attribute side="server" code="0x4000" define="COLOR_CONTROL_ENHANCED_CURRENT_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">
+      <description>EnhancedCurrentHue</description>
+      <mandatoryConform>
+        <feature name="EHUE"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4001" define="COLOR_CONTROL_ENHANCED_COLOR_MODE" type="EnhancedColorModeEnum" writable="false" default="0x01">
+      <description>EnhancedColorMode</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x4002" define="COLOR_CONTROL_COLOR_LOOP_ACTIVE" type="int8u" min="0x00" max="0x01" writable="false" default="0x00" optional="true">
+      <description>ColorLoopActive</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4003" define="COLOR_CONTROL_COLOR_LOOP_DIRECTION" type="int8u" min="0x00" max="0x01" writable="false" default="0x00" optional="true">
+      <description>ColorLoopDirection</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4004" define="COLOR_CONTROL_COLOR_LOOP_TIME" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0019" optional="true">
+      <description>ColorLoopTime</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4005" define="COLOR_CONTROL_COLOR_LOOP_START_ENHANCED_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x2300" optional="true">
+      <description>ColorLoopStartEnhancedHue</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x4006" define="COLOR_CONTROL_COLOR_LOOP_STORED_ENHANCED_HUE" type="int16u" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">
+      <description>ColorLoopStoredEnhancedHue</description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x400A" define="COLOR_CONTROL_COLOR_CAPABILITIES" type="ColorCapabilitiesBitmap" min="0x0000" max="0x001F" writable="false" default="0x0000">
+      <description>ColorCapabilities</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x400B" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MIN" type="int16u" min="0x0001" max="0xFEFF" writable="false" default="0x0000" optional="true">
+      <description>ColorTempPhysicalMinMireds</description>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x400C" define="COLOR_CONTROL_COLOR_TEMP_PHYSICAL_MAX" type="int16u" min="0x0000" max="0xFEFF" writable="false" default="0xFEFF" optional="true">
+      <description>ColorTempPhysicalMaxMireds</description>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
+    </attribute>
 
     <command source="client" code="0x40" name="EnhancedMoveToHue" optional="true" noDefaultImplementation="true" cli="zcl color-control emovetohue">
       <description>
         Command description for EnhancedMoveToHue
       </description>
+      <mandatoryConform>
+        <feature name="EHUE"/>
+      </mandatoryConform>
       <arg name="EnhancedHue" type="int16u"/>
       <arg name="Direction" type="DirectionEnum"/>
       <arg name="TransitionTime" type="int16u"/>
@@ -402,6 +750,9 @@ limitations under the License.
       <description>
         Command description for EnhancedMoveHue
       </description>
+      <mandatoryConform>
+        <feature name="EHUE"/>
+      </mandatoryConform>
       <arg name="MoveMode" type="MoveModeEnum"/>
       <arg name="Rate" type="int16u"/>
       <arg name="OptionsMask" type="OptionsBitmap"/>
@@ -412,6 +763,9 @@ limitations under the License.
       <description>
         Command description for EnhancedStepHue
       </description>
+      <mandatoryConform>
+        <feature name="EHUE"/>
+      </mandatoryConform>
       <arg name="StepMode" type="StepModeEnum"/>
       <arg name="StepSize" type="int16u"/>
       <arg name="TransitionTime" type="int16u"/>
@@ -423,6 +777,9 @@ limitations under the License.
       <description>
         Command description for EnhancedMoveToHueAndSaturation
       </description>
+      <mandatoryConform>
+        <feature name="EHUE"/>
+      </mandatoryConform>
       <arg name="EnhancedHue" type="int16u"/>
       <arg name="Saturation" type="int8u"/>
       <arg name="TransitionTime" type="int16u"/>
@@ -434,6 +791,9 @@ limitations under the License.
       <description>
         Command description for ColorLoopSet
       </description>
+      <mandatoryConform>
+        <feature name="CL"/>
+      </mandatoryConform>
       <arg name="UpdateFlags" type="UpdateFlagsBitmap"/>
       <arg name="Action" type="ColorLoopActionEnum"/>
       <arg name="Direction" type="ColorLoopDirectionEnum"/>
@@ -447,6 +807,13 @@ limitations under the License.
       <description>
         Command description for StopMoveStep
       </description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="HS"/>
+          <feature name="XY"/>
+          <feature name="CT"/>
+        </orTerm>
+      </mandatoryConform>
       <arg name="OptionsMask" type="OptionsBitmap"/>
       <arg name="OptionsOverride" type="OptionsBitmap"/>
     </command>
@@ -455,6 +822,9 @@ limitations under the License.
       <description>
         Command description for MoveColorTemperature
       </description>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
       <arg name="MoveMode" type="MoveModeEnum"/>
       <arg name="Rate" type="int16u"/>
       <arg name="ColorTemperatureMinimumMireds" type="int16u"/>
@@ -467,6 +837,9 @@ limitations under the License.
       <description>
         Command description for StepColorTemperature
       </description>
+      <mandatoryConform>
+        <feature name="CT"/>
+      </mandatoryConform>
       <arg name="StepMode" type="StepModeEnum"/>
       <arg name="StepSize" type="int16u"/>
       <arg name="TransitionTime" type="int16u"/>

--- a/src/app/zap-templates/zcl/data-model/chip/commissioner-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/commissioner-control-cluster.xml
@@ -35,10 +35,12 @@ limitations under the License.
     <attribute side="server" code="0x0000" define="SUPPORTED_DEVICE_CATEGORIES" type="SupportedDeviceCategoryBitmap" default="0" min="0x00000000" max="0x00000001">
       <description>SupportedDeviceCategories</description>
       <access op="read" privilege="manage"/>
+      <mandatoryConform/>
     </attribute>
 
     <command source="client" code="0x00" name="RequestCommissioningApproval" optional="false">
       <description>This command is sent by a client to request approval for a future CommissionNode call.</description>
+      <mandatoryConform/>
       <arg id="0" name="RequestID" type="int64u"/>
       <arg id="1" name="VendorID" type="vendor_id"/>
       <arg id="2" name="ProductID" type="int16u"/>
@@ -48,6 +50,7 @@ limitations under the License.
 
     <command source="client" code="0x01" name="CommissionNode" response="ReverseOpenCommissioningWindow" optional="false">
       <description>This command is sent by a client to request that the server begins commissioning a previously approved request.</description>
+      <mandatoryConform/>
       <arg id="0" name="RequestID" type="int64u"/>
       <arg id="1" name="ResponseTimeoutSeconds" type="int16u" min="30" max="120" default="30"/>
       <access op="invoke" privilege="manage"/>
@@ -55,6 +58,7 @@ limitations under the License.
 
     <command source="server" code="0x02" name="ReverseOpenCommissioningWindow" optional="false" disableDefaultResponse="true">
       <description>When received within the timeout specified by CommissionNode, the client SHALL open a commissioning window on to the node which the client called RequestCommissioningApproval to have commissioned.</description>
+      <mandatoryConform/>
       <arg id="0" name="CommissioningTimeout" type="int16u"/>
       <arg id="1" name="PAKEPasscodeVerifier" type="octet_string"/>
       <arg id="2" name="Discriminator" type="int16u" min="0" max="4095"/>

--- a/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/concentration-measurement-cluster.xml
@@ -58,17 +58,70 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -113,17 +166,70 @@ limitations under the License.
      </features>
 
     <!-- Attributes -->
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -167,17 +273,70 @@ limitations under the License.
        </feature>
      </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -221,17 +380,70 @@ limitations under the License.
        </feature>
      </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -275,17 +487,70 @@ limitations under the License.
        </feature>
      </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -329,17 +594,70 @@ limitations under the License.
        </feature>
      </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -383,17 +701,70 @@ limitations under the License.
        </feature>
      </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -437,17 +808,70 @@ limitations under the License.
        </feature>
      </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -491,17 +915,70 @@ limitations under the License.
        </feature>
      </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <cluster>
@@ -545,17 +1022,70 @@ limitations under the License.
        </feature>
      </features>
 
-    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MeasuredValue</attribute>
-    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MinMeasuredValue</attribute>
-    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">MaxMeasuredValue</attribute>
-    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">PeakMeasuredValue</attribute>
-    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">PeakMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">AverageMeasuredValue</attribute>
-    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">AverageMeasuredValueWindow</attribute>
-    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">Uncertainty</attribute>
-    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">MeasurementUnit</attribute>
-    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">MeasurementMedium</attribute>
-    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">LevelValue</attribute>
+    <attribute side="server" code="0x0000" define="MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="MIN_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MinMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="MAX_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>MaxMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="PEAK_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>PeakMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="PEAK_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>PeakMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="PEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="AVG_MEASURED_VALUE" type="single" writable="false" isNullable="true" optional="true">
+      <description>AverageMeasuredValue</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="AVG_MEASURED_VALUE_WINDOW" type="elapsed_s" min="0" max="604800" writable="false" default="1" optional="true">
+      <description>AverageMeasuredValueWindow</description>
+      <mandatoryConform>
+        <feature name="AVG"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="UNCERTAINTY" type="single" writable="false" default="0" optional="true">
+      <description>Uncertainty</description>
+      <optionalConform>
+        <feature name="MEA"/>
+      </optionalConform>
+    </attribute>
+    <attribute side="server" code="0x0008" define="MEASUREMENT_UNIT" type="MeasurementUnitEnum" min="0" max="7" writable="false" default="0" optional="true">
+      <description>MeasurementUnit</description>
+      <mandatoryConform>
+        <feature name="MEA"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0009" define="MEASUREMENT_MEDIUM" type="MeasurementMediumEnum" min="0" max="2" writable="false" default="0" optional="true">
+      <description>MeasurementMedium</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x000a" define="LEVEL_VALUE" type="LevelValueEnum" min="0" max="4" writable="false" default="0" optional="true">
+      <description>LevelValue</description>
+      <mandatoryConform>
+        <feature name="LEV"/>
+      </mandatoryConform>
+    </attribute>
   </cluster>
 
   <!-- Cluster Data Types -->

--- a/src/app/zap-templates/zcl/data-model/chip/content-app-observer-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-app-observer-cluster.xml
@@ -27,12 +27,14 @@ limitations under the License.
 
     <command source="client" code="0x00" name="ContentAppMessage" response="ContentAppMessageResponse" optional="false">
       <description>Upon receipt, the data field MAY be parsed and interpreted. Message encoding is specific to the Content App. A Content App MAY when possible read attributes from the Basic Information Cluster on the Observer and use this to determine the Message encoding.</description>
+      <mandatoryConform/>
       <arg name="Data" type="char_string" optional="true"/>
       <arg name="EncodingHint" type="char_string" optional="false"/>
     </command>
 
     <command source="server" code="0x01" name="ContentAppMessageResponse" optional="false" apiMaturity="provisional">
       <description>This command SHALL be generated in response to ContentAppMessage command.</description>
+      <mandatoryConform/>
       <arg name="Status" type="StatusEnum" optional="false"/>
       <arg name="Data" type="char_string" optional="true"/>
       <arg name="EncodingHint" type="char_string" optional="true"/>

--- a/src/app/zap-templates/zcl/data-model/chip/content-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-control-cluster.xml
@@ -43,64 +43,131 @@ limitations under the License.
       </feature>
     </features>
 
-    <attribute side="server" code="0x0000" define="ENABLED" type="boolean" writable="false" optional="false">Enabled</attribute>
-    <attribute side="server" code="0x0001" define="ON_DEMAND_RATINGS" type="ARRAY" entryType="RatingNameStruct" writable="false" optional="true">OnDemandRatings</attribute>
-    <attribute side="server" code="0x0002" define="ON_DEMAND_THRESHOLD" type="char_string" length="8" writable="false" optional="true">OnDemandRatingThreshold</attribute>
-    <attribute side="server" code="0x0003" define="SCHEDULED_CONTENT_RATINGS" type="ARRAY" entryType="RatingNameStruct" writable="false" optional="true">ScheduledContentRatings</attribute>
-    <attribute side="server" code="0x0004" define="SCHEDULED_CONTENT_RATING_THRESHOLD" type="char_string" length="8" writable="false" optional="true">ScheduledContentRatingThreshold</attribute>
-    <attribute side="server" code="0x0005" define="SCREEN_DAILY_TIME" type="elapsed_s" length="86400" writable="false" optional="true">ScreenDailyTime</attribute>
-    <attribute side="server" code="0x0006" define="REMAINING_SCREEN_TIME" type="elapsed_s" length="86400" writable="false" optional="true">RemainingScreenTime</attribute>
-    <attribute side="server" code="0x0007" define="ENABLED" type="boolean" writable="false" optional="false">BlockUnrated</attribute>
+    <attribute side="server" code="0x0000" define="ENABLED" type="boolean" writable="false" optional="false">
+      <description>Enabled</description>
+      <mandatoryConform/>
+    </attribute>
+    <attribute side="server" code="0x0001" define="ON_DEMAND_RATINGS" type="ARRAY" entryType="RatingNameStruct" writable="false" optional="true">
+      <description>OnDemandRatings</description>
+      <mandatoryConform>
+        <feature name="OCR"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0002" define="ON_DEMAND_THRESHOLD" type="char_string" length="8" writable="false" optional="true">
+      <description>OnDemandRatingThreshold</description>
+      <mandatoryConform>
+        <feature name="OCR"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0003" define="SCHEDULED_CONTENT_RATINGS" type="ARRAY" entryType="RatingNameStruct" writable="false" optional="true">
+      <description>ScheduledContentRatings</description>
+      <mandatoryConform>
+        <feature name="SCR"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0004" define="SCHEDULED_CONTENT_RATING_THRESHOLD" type="char_string" length="8" writable="false" optional="true">
+      <description>ScheduledContentRatingThreshold</description>
+      <mandatoryConform>
+        <feature name="SCR"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0005" define="SCREEN_DAILY_TIME" type="elapsed_s" length="86400" writable="false" optional="true">
+      <description>ScreenDailyTime</description>
+      <mandatoryConform>
+        <feature name="ST"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0006" define="REMAINING_SCREEN_TIME" type="elapsed_s" length="86400" writable="false" optional="true">
+      <description>RemainingScreenTime</description>
+      <mandatoryConform>
+        <feature name="ST"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0007" define="ENABLED" type="boolean" writable="false" optional="false">
+      <description>BlockUnrated</description>
+      <mandatoryConform>
+        <feature name="BU"/>
+      </mandatoryConform>
+    </attribute>
 
     <command source="client" code="0x00" name="UpdatePIN" optional="true">
       <description>The purpose of this command is to update the PIN used for protecting configuration of the content control settings. Upon success, the old PIN SHALL no longer work. The PIN is used to ensure that only the Node (or User) with the PIN code can make changes to the Content Control settings, for example, turn off Content Controls or modify the ScreenDailyTime. The PIN is composed of a numeric string of up to 6 human readable characters (displayable) . Upon receipt of this command, the media device SHALL check if the OldPIN field of this command is the same as the current PIN. If the PINs are the same, then the PIN code SHALL be set to NewPIN. Otherwise a response with InvalidPINCode error status SHALL be returned. The media device MAY provide a default PIN to the User via an out of band mechanism. For security reasons, it is recommended that a client encourage the user to update the PIN from its default value when performing configuration of the Content Control settings exposed by this cluster. The ResetPIN command can also be used to obtain the default PIN.</description>
+      <mandatoryConform>
+        <feature name="PM"/>
+      </mandatoryConform>
       <arg name="OldPIN" type="char_string" max="6" optional="true"/>
       <arg name="NewPIN" type="char_string" max="6" optional="false"/>
     </command>
 
     <command source="client" code="0x01" name="ResetPIN" response="ResetPINResponse" optional="true">
       <description>The purpose of this command is to reset the PIN. If this command is executed successfully, a ResetPINResponse command with a new PIN SHALL be returned.</description>
+      <mandatoryConform>
+        <feature name="PM"/>
+      </mandatoryConform>
     </command>
 
     <command source="server" code="0x02" name="ResetPINResponse" optional="true">
       <description>This command SHALL be generated in response to a ResetPIN command. The data for this command SHALL be as follows:</description>
+      <mandatoryConform>
+        <feature name="PM"/>
+      </mandatoryConform>
       <arg name="PINCode" type="char_string" max="6" optional="false"/>
     </command>
 
     <command source="client" code="0x03" name="Enable" optional="true">
       <description>The purpose of this command is to turn on the Content Control feature on a media device. On receipt of the Enable command, the media device SHALL set the Enabled attribute to TRUE.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x04" name="Disable" optional="true">
       <description>The purpose of this command is to turn off the Content Control feature on a media device. On receipt of the Disable command, the media device SHALL set the Enabled attribute to FALSE.</description>
+      <mandatoryConform/>
     </command>
 
     <command source="client" code="0x05" name="AddBonusTime" optional="true">
       <description>The purpose of this command is to add the extra screen time for the user. If a client with Operate privilege invokes this command, the media device SHALL check whether the PINCode passed in the command matches the current PINCode value. If these match, then the RemainingScreenTime attribute SHALL be increased by the specified BonusTime value. If the PINs do not match, then a response with InvalidPINCode error status SHALL be returned, and no changes SHALL be made to RemainingScreenTime. If a client with Manage privilege or greater invokes this command, the media device SHALL ignore the PINCode field and directly increase the RemainingScreenTime attribute by the specified BonusTime value. A server that does not support the PM feature SHALL respond with InvalidPINCode to clients that only have Operate privilege unless: It has been provided with the PIN value to expect via an out of band mechanism, and The client has provided a PINCode that matches the expected PIN value.</description>
+      <mandatoryConform>
+        <feature name="ST"/>
+      </mandatoryConform>
       <arg name="PINCode" type="char_string" max="6" optional="true"/>
       <arg name="BonusTime" type="elapsed_s" optional="true"/>
     </command>
 
     <command source="client" code="0x06" name="SetScreenDailyTime" optional="true">
       <description>The purpose of this command is to set the ScreenDailyTime attribute. On receipt of the SetScreenDailyTime command, the media device SHALL set the ScreenDailyTime attribute to the ScreenTime value.</description>
+      <mandatoryConform>
+        <feature name="ST"/>
+      </mandatoryConform>
       <arg name="ScreenTime" type="elapsed_s" optional="false"/>
     </command>
 
     <command source="client" code="0x07" name="BlockUnratedContent" optional="true">
       <description>The purpose of this command is to specify whether programs with no Content rating must be blocked by this media device. On receipt of the BlockUnratedContent command, the media device SHALL set the BlockUnrated attribute to TRUE.</description>
+      <mandatoryConform>
+        <feature name="BU"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x08" name="UnblockUnratedContent" optional="true">
       <description>The purpose of this command is to specify whether programs with no Content rating must be blocked by this media device. On receipt of the UnblockUnratedContent command, the media device SHALL set the BlockUnrated attribute to FALSE.</description>
+      <mandatoryConform>
+        <feature name="BU"/>
+      </mandatoryConform>
     </command>
 
     <command source="client" code="0x09" name="SetOnDemandRatingThreshold" optional="true">
       <description>The purpose of this command is to set the OnDemandRatingThreshold attribute. On receipt of the SetOnDemandRatingThreshold command, the media device SHALL check if the Rating field is one of values present in the OnDemandRatings attribute. If not, then a response with InvalidRating error status SHALL be returned.</description>
+      <mandatoryConform>
+        <feature name="OCR"/>
+      </mandatoryConform>
       <arg name="Rating" type="char_string" max="8" optional="false"/>
     </command>
 
     <command source="client" code="0x0A" name="SetScheduledContentRatingThreshold" optional="true">
       <description>The purpose of this command is to set ScheduledContentRatingThreshold attribute. On receipt of the SetScheduledContentRatingThreshold command, the media device SHALL check if the Rating field is one of values present in the ScheduledContentRatings attribute. If not, then a response with InvalidRating error status SHALL be returned.</description>
+      <mandatoryConform>
+        <feature name="SCR"/>
+      </mandatoryConform>
       <arg name="Rating" type="char_string" max="8" optional="false"/>
     </command>
 

--- a/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/content-launch-cluster.xml
@@ -26,11 +26,42 @@ limitations under the License.
     <description>This cluster provides an interface for launching content on a media player device such as a TV or Speaker.</description>
     <globalAttribute side="either" code="0xFFFD" value="1"/>
 
-    <attribute side="server" code="0x0000" define="CONTENT_LAUNCHER_ACCEPT_HEADER"                 type="array" entryType="char_string" length="254" writable="false" optional="true">AcceptHeader</attribute>
-    <attribute side="server" code="0x0001" define="CONTENT_LAUNCHER_SUPPORTED_STREAMING_PROTOCOLS" type="SupportedProtocolsBitmap" default="0"                       writable="false"  optional="true">SupportedStreamingProtocols</attribute>
+    <features>
+      <feature bit="0" code="CS" name="ContentSearch" summary="Device supports content search (non-app specific)">
+        <optionalConform/>
+      </feature>
+      <feature bit="1" code="UP" name="URLPlayback" summary="Device supports basic URL-based file playback">
+        <optionalConform/>
+      </feature>
+      <feature bit="2" code="AS" name="AdvancedSeek" summary="Enables clients to implement more advanced media seeking behavior in their user interface, such as for example a &quot;seek bar&quot;.">
+        <optionalConform/>
+      </feature>
+      <feature bit="3" code="TT" name="TextTracks" summary="Device or app supports Text Tracks.">
+        <optionalConform/>
+      </feature>
+      <feature bit="4" code="AT" name="AudioTracks" summary="Device or app supports Audio Tracks.">
+        <optionalConform/>
+      </feature>
+    </features>
+
+    <attribute side="server" code="0x0000" define="CONTENT_LAUNCHER_ACCEPT_HEADER"                 type="array" entryType="char_string" length="254" writable="false" optional="true">
+      <description>AcceptHeader</description>
+      <mandatoryConform>
+        <feature name="UP"/>
+      </mandatoryConform>
+    </attribute>
+    <attribute side="server" code="0x0001" define="CONTENT_LAUNCHER_SUPPORTED_STREAMING_PROTOCOLS" type="SupportedProtocolsBitmap" default="0"                       writable="false"  optional="true">
+      <description>SupportedStreamingProtocols</description>
+      <mandatoryConform>
+        <feature name="UP"/>
+      </mandatoryConform>
+    </attribute>
 
     <command source="client" code="0x00" name="LaunchContent" response="LauncherResponse" optional="true">
       <description>Upon receipt, this SHALL launch the specified content with optional search criteria.</description>
+      <mandatoryConform>
+        <feature name="CS"/>
+      </mandatoryConform>
       <arg name="Search" type="ContentSearchStruct"/>
       <arg name="AutoPlay" type="boolean"/>
       <arg name="Data" type="char_string" optional="true"/>
@@ -40,6 +71,9 @@ limitations under the License.
 
     <command source="client" code="0x01" name="LaunchURL" response="LauncherResponse" optional="true">
       <description>Upon receipt, this SHALL launch content from the specified URL.</description>
+      <mandatoryConform>
+        <feature name="UP"/>
+      </mandatoryConform>
       <arg name="ContentURL" type="char_string"/>
       <arg name="DisplayString" type="char_string" optional="true"/>
       <arg name="BrandingInformation" type="BrandingInformationStruct" optional="true"/>
@@ -47,6 +81,12 @@ limitations under the License.
 
     <command source="server" code="0x02" name="LauncherResponse" optional="true" disableDefaultResponse="true">
       <description>This command SHALL be generated in response to LaunchContent command.</description>
+      <mandatoryConform>
+        <orTerm>
+          <feature name="CS"/>
+          <feature name="UP"/>
+        </orTerm>
+      </mandatoryConform>
       <arg name="Status" type="StatusEnum"/>
       <arg name="Data" type="char_string" optional="true"/>
     </command>
@@ -175,14 +215,5 @@ limitations under the License.
     <field name="DASH" mask="0x1"/>
     <field name="HLS" mask="0x2"/>
   </bitmap>
-
-  <bitmap name="Feature" type="bitmap32">
-     <cluster code="0x050a"/>
-     <field name="ContentSearch" mask="0x1"/>
-     <field name="URLPlayback" mask="0x2"/>
-     <field name="AdvancedSeek" mask="0x3"/>
-     <field name="TextTracks" mask="0x4"/>
-     <field name="AudioTracks" mask="0x5"/>
-   </bitmap>
 
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2153,7 +2153,7 @@ limitations under the License.
             <include cluster="Temperature Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Dishwasher Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
-                    <feature code="OO" name="OnOff">
+                    <feature code="DEPONOFF" name="OnOff">
                     <disallowConform/>
                     </feature>
                 </features>
@@ -2220,7 +2220,7 @@ limitations under the License.
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
-                    <feature code="OO" name="OnOff">
+                    <feature code="DEPONOFF" name="OnOff">
                     <disallowConform/>
                     </feature>
                 </features>
@@ -2248,7 +2248,7 @@ limitations under the License.
             </include>
             <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
-                    <feature code="OO" name="OnOff">
+                    <feature code="DEPONOFF" name="OnOff">
                     <disallowConform/>
                     </feature>
                 </features>
@@ -2278,7 +2278,7 @@ limitations under the License.
             </include>
             <include cluster="Laundry Washer Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
-                    <feature code="" name="OnOff">
+                    <feature code="DEPONOFF" name="OnOff">
                     <disallowConform/>
                     </feature>
                 </features>
@@ -2348,14 +2348,14 @@ limitations under the License.
             <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Refrigerator And Temperature Controlled Cabinet Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
-                    <feature code="OO" name="OnOff">
+                    <feature code="DEPONOFF" name="OnOff">
                     <disallowConform/>
                     </feature>
                 </features>
             </include>
             <include cluster="Oven Mode" client="false" server="false" clientLocked="true" serverLocked="false">
                 <features>
-                    <feature code="OO" name="OnOff">
+                    <feature code="DEPONOFF" name="OnOff">
                     <disallowConform/>
                     </feature>
                 </features>


### PR DESCRIPTION
- Added conformance details for attributes and commands in ZAP template XMLs from the new XML version. The added XML data is necessary for the functionality of the [Feature Page project](https://github.com/project-chip/zap/issues/1380).

- This commit only updates XMLs with initials from A to C to ease the review process. Remaining XML changes will be addressed in subsequent PRs.

- Removed the Feature bitmap in content-launch-cluster.xml and replaced it with features represented by the `<Feature>` tag. The value in original Feature bitmap is wrong: the feature masks should be `0x01, 0x02, 0x04, 0x08, 0x10`, but in the XML it was `0x01, 0x02, 0x03, 0x04, 0x05`. Consequently, after the update, the CI job would fail but the change is actually correct. Should consider correcting this bitmap checking in CI. [See job failure details](https://github.com/project-chip/connectedhomeip/actions/runs/11133255934/job/30938932982?pr=35865#step:10:16)

- Corrected the OnOff feature code in matter-devices.xml

