### PR TITLE
Add --app-ready-pattern option to python test arguments

### DIFF
--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -669,10 +669,10 @@ for that run, e.g.:
 # test-runner-runs:
 #   run1:
 #     app: ${TYPE_OF_APP}
-#     factoryreset: <true|false>
-#     quiet: <true|false>
 #     app-args: <app_arguments>
 #     script-args: <script_arguments>
+#     factoryreset: <true|false>
+#     quiet: <true|false>
 # === END CI TEST ARGUMENTS ===
 ```
 
@@ -700,6 +700,14 @@ for that run, e.g.:
 
     -   Example:
         `--discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json`
+
+-   `app-ready-pattern`: Regular expression pattern to match against the output
+    of the application to determine when the application is ready. If this
+    parameter is specified, the test runner will not run the test script until
+    the pattern is found.
+
+    -   Example:
+        `"Manual pairing code: \\[\\d+\\]"`
 
 -   `script-args`: Specifies the arguments to be passed to the test script.
 

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -45,17 +45,24 @@ Python tests located in src/python_testing
 
 ### A simple test
 
-```
+```python
 # See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
 # for details about the block below.
 #
 # === BEGIN CI TEST ARGUMENTS ===
-# test-runner-runs: run1
-# test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
-# test-runner-run/run1/factoryreset: True
-# test-runner-run/run1/quiet: True
-# test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
-# test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factoryreset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 class TC_MYTEST_1_1(MatterBaseTest):

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -45,7 +45,7 @@ Python tests located in src/python_testing
 
 ### A simple test
 
-```python
+```
 # See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
 # for details about the block below.
 #

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -713,8 +713,7 @@ for that run, e.g.:
     parameter is specified, the test runner will not run the test script until
     the pattern is found.
 
-    -   Example:
-        `"Manual pairing code: \\[\\d+\\]"`
+    -   Example: `"Manual pairing code: \\[\\d+\\]"`
 
 -   `script-args`: Specifies the arguments to be passed to the test script.
 

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -714,14 +714,6 @@ for that run, e.g.:
     -   Example:
         `--storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto`
 
--   `script-start-delay`: Specifies the number of seconds to wait before
-    starting the test script. This parameter can be used to allow the
-    application to initialize itself properly before the test script will try to
-    commission it (e.g. in case if the application needs to be commissioned to
-    some other controller first). By default, the delay is 0 seconds.
-
-    -   Example: `10`
-
 This structured format ensures that all necessary configurations are clearly
 defined and easily understood, allowing for consistent and reliable test
 execution.

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -23,7 +23,6 @@ import os.path
 import pathlib
 import re
 import shlex
-import shutil
 import sys
 import time
 

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -87,8 +87,6 @@ def process_test_script_output(line, is_stderr):
                                                                              'mobile-device-test.py'), help='Test script to use.')
 @click.option("--script-args", type=str, default='',
               help='Script arguments, can use placeholders like {SCRIPT_BASE_NAME}.')
-@click.option("--script-start-delay", type=int, default=0,
-              help='Delay in seconds before starting the script.')
 @click.option("--script-gdb", is_flag=True,
               help='Run script through gdb')
 @click.option("--quiet", is_flag=True, help="Do not print output from passing tests. Use this flag in CI to keep github log sizes manageable.")
@@ -107,7 +105,6 @@ def main(app: str, factoryreset: bool, factoryreset_app_only: bool, app_args: st
                 app_args=app_args,
                 app_ready_pattern=app_ready_pattern,
                 script_args=script_args,
-                script_start_delay=script_start_delay,
                 factory_reset=factoryreset,
                 factory_reset_app_only=factoryreset_app_only,
                 script_gdb=script_gdb,
@@ -122,11 +119,11 @@ def main(app: str, factoryreset: bool, factoryreset_app_only: bool, app_args: st
     for run in runs:
         print(f"Executing {run.py_script_path.split('/')[-1]} {run.run}")
         main_impl(run.app, run.factory_reset, run.factory_reset_app_only, run.app_args or "",
-                  run.app_ready_pattern, run.py_script_path, run.script_args or "", run.script_start_delay, run.script_gdb, run.quiet)
+                  run.app_ready_pattern, run.py_script_path, run.script_args or "", run.script_gdb, run.quiet)
 
 
 def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_args: str,
-              app_ready_pattern: str, script: str, script_args: str, script_start_delay: int, script_gdb: bool, quiet: bool):
+              app_ready_pattern: str, script: str, script_args: str, script_gdb: bool, quiet: bool):
 
     app_args = app_args.replace('{SCRIPT_BASE_NAME}', os.path.splitext(os.path.basename(script))[0])
     script_args = script_args.replace('{SCRIPT_BASE_NAME}', os.path.splitext(os.path.basename(script))[0])
@@ -179,8 +176,6 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
         app_process.start(expected_output=app_ready_pattern, timeout=30)
         app_process.p.stdin.close()
         app_pid = app_process.p.pid
-
-    time.sleep(script_start_delay)
 
     script_command = [script, "--paa-trust-store-path", os.path.join(DEFAULT_CHIP_ROOT, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
                       '--log-format', '%(message)s', "--app-pid", str(app_pid)] + shlex.split(script_args)

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -20,6 +20,7 @@ import io
 import logging
 import os
 import os.path
+import pathlib
 import re
 import shlex
 import shutil
@@ -134,18 +135,18 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
     if factory_reset or factory_reset_app_only:
         # Remove native app config
         for path in glob.glob('/tmp/chip*') + glob.glob('/tmp/repl*'):
-            shutil.rmtree(path)
+            pathlib.Path(path).unlink(missing_ok=True)
 
         # Remove native app KVS if that was used
         if match := re.search(r"--KVS (?P<path>[^ ]+)", app_args):
             logging.info("Removing KVS path: %s" % match.group("path"))
-            shutil.rmtree(match.group("path"))
+            pathlib.Path(match.group("path")).unlink(missing_ok=True)
 
     if factory_reset:
         # Remove Python test admin storage if provided
         if match := re.search(r"--storage-path (?P<path>[^ ]+)", script_args):
             logging.info("Removing storage path: %s" % match.group("path"))
-            shutil.rmtree(match.group("path"))
+            pathlib.Path(match.group("path")).unlink(missing_ok=True)
 
     app_process = None
     app_exit_code = 0

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -23,12 +23,18 @@
 # for details about the block below.
 #
 # === BEGIN CI TEST ARGUMENTS ===
-# test-runner-runs: run1
-# test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
-# test-runner-run/run1/factoryreset: True
-# test-runner-run/run1/quiet: True
-# test-runner-run/run1/app-args: --trace-to json:${TRACE_APP}.json
-# test-runner-run/run1/script-args: --log-level INFO -t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --log-level INFO
+#       --timeout 3600
+#       --disable-test ClusterObjectTests.TestTimedRequestTimeout
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factoryreset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import asyncio

--- a/src/python_testing/TCP_Tests.py
+++ b/src/python_testing/TCP_Tests.py
@@ -15,12 +15,19 @@
 #    limitations under the License.
 #
 # === BEGIN CI TEST ARGUMENTS ===
-# test-runner-runs: run1
-# test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
-# test-runner-run/run1/factoryreset: True
-# test-runner-run/run1/quiet: True
-# test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
-# test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factoryreset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 #
 import chip.clusters as Clusters

--- a/src/python_testing/TC_ECOINFO_2_1.py
+++ b/src/python_testing/TC_ECOINFO_2_1.py
@@ -23,6 +23,7 @@
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
 #     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-ready-pattern: "Successfully opened pairing window on the device"
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -32,7 +33,6 @@
 #       --string-arg th_server_app_path:${ALL_CLUSTERS_APP} dut_fsa_stdin_pipe:dut-fsa-stdin
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#     script-start-delay: 5
 #     factoryreset: true
 #     quiet: false
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_ECOINFO_2_1.py
+++ b/src/python_testing/TC_ECOINFO_2_1.py
@@ -34,7 +34,7 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factoryreset: true
-#     quiet: false
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import asyncio

--- a/src/python_testing/TC_ECOINFO_2_2.py
+++ b/src/python_testing/TC_ECOINFO_2_2.py
@@ -23,6 +23,7 @@
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
 #     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-ready-pattern: "Successfully opened pairing window on the device"
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -32,7 +33,6 @@
 #       --string-arg th_server_app_path:${ALL_CLUSTERS_APP} dut_fsa_stdin_pipe:dut-fsa-stdin
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#     script-start-delay: 5
 #     factoryreset: true
 #     quiet: false
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_ECOINFO_2_2.py
+++ b/src/python_testing/TC_ECOINFO_2_2.py
@@ -34,7 +34,7 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factoryreset: true
-#     quiet: false
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import asyncio

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -25,6 +25,7 @@
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
 #     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-ready-pattern: "Successfully opened pairing window on the device"
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -34,7 +35,6 @@
 #       --string-arg th_server_app_path:${ALL_CLUSTERS_APP}
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#     script-start-delay: 5
 #     factoryreset: true
 #     quiet: false
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -36,7 +36,7 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factoryreset: true
-#     quiet: false
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -23,6 +23,7 @@
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
 #     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-ready-pattern: "Successfully opened pairing window on the device"
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -32,7 +33,6 @@
 #       --string-arg th_server_app_path:${ALL_CLUSTERS_APP} dut_fsa_stdin_pipe:dut-fsa-stdin
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#     script-start-delay: 5
 #     factoryreset: true
 #     quiet: false
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -34,7 +34,7 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factoryreset: true
-#     quiet: false
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import asyncio

--- a/src/python_testing/TC_MCORE_FS_1_3.py
+++ b/src/python_testing/TC_MCORE_FS_1_3.py
@@ -27,6 +27,7 @@
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
 #     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-ready-pattern: "Successfully opened pairing window on the device"
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -36,7 +37,6 @@
 #       --string-arg th_server_no_uid_app_path:${LIGHTING_APP_NO_UNIQUE_ID}
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#     script-start-delay: 5
 #     factoryreset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_MCORE_FS_1_4.py
+++ b/src/python_testing/TC_MCORE_FS_1_4.py
@@ -27,6 +27,7 @@
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
 #     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-ready-pattern: "Successfully opened pairing window on the device"
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -35,7 +36,6 @@
 #       --string-arg th_fsa_app_path:examples/fabric-admin/scripts/fabric-sync-app.py th_fsa_admin_path:${FABRIC_ADMIN_APP} th_fsa_bridge_path:${FABRIC_BRIDGE_APP} th_server_no_uid_app_path:${LIGHTING_APP_NO_UNIQUE_ID} dut_fsa_stdin_pipe:dut-fsa-stdin
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#     script-start-delay: 5
 #     factoryreset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -23,6 +23,7 @@
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
 #     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-ready-pattern: "Successfully opened pairing window on the device"
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json
@@ -32,7 +33,6 @@
 #       --string-arg th_server_app_path:${ALL_CLUSTERS_APP} dut_fsa_stdin_pipe:dut-fsa-stdin
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#     script-start-delay: 5
 #     factoryreset: true
 #     quiet: false
 # === END CI TEST ARGUMENTS ===

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -34,7 +34,7 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factoryreset: true
-#     quiet: false
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import asyncio

--- a/src/python_testing/TestBatchInvoke.py
+++ b/src/python_testing/TestBatchInvoke.py
@@ -19,12 +19,19 @@
 # for details about the block below.
 #
 # === BEGIN CI TEST ARGUMENTS ===
-# test-runner-runs: run1
-# test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
-# test-runner-run/run1/factoryreset: True
-# test-runner-run/run1/quiet: True
-# test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
-# test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factoryreset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/TestGroupTableReports.py
+++ b/src/python_testing/TestGroupTableReports.py
@@ -19,12 +19,19 @@
 # for details about the block below.
 #
 # === BEGIN CI TEST ARGUMENTS ===
-# test-runner-runs: run1
-# test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
-# test-runner-run/run1/factoryreset: True
-# test-runner-run/run1/quiet: True
-# test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
-# test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factoryreset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/TestUnitTestingErrorPath.py
+++ b/src/python_testing/TestUnitTestingErrorPath.py
@@ -19,12 +19,19 @@
 # for details about the block below.
 #
 # === BEGIN CI TEST ARGUMENTS ===
-# test-runner-runs: run1
-# test-runner-run/run1/app: ${ALL_CLUSTERS_APP}
-# test-runner-run/run1/factoryreset: True
-# test-runner-run/run1/quiet: True
-# test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
-# test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factoryreset: true
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/hello_test.py
+++ b/src/python_testing/hello_test.py
@@ -19,12 +19,19 @@
 # for details about the block below.
 #
 # === BEGIN CI TEST ARGUMENTS ===
-# test-runner-runs: run1
-# test-runner-run/run1/app: ${TYPE_OF_APP}
-# test-runner-run/run1/factoryreset: True
-# test-runner-run/run1/quiet: True
-# test-runner-run/run1/app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
-# test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# test-runner-runs:
+#    run1:
+#      app: ${TYPE_OF_APP}
+#      app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#      script-args: >
+#        --storage-path admin_storage.json
+#        --commissioning-method on-network
+#        --discriminator 1234
+#        --passcode 20202021
+#        --trace-to json:${TRACE_TEST_JSON}.json
+#        --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#      factoryreset: true
+#      quiet: true
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/metadata.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/metadata.py
@@ -16,7 +16,7 @@ import logging
 import re
 from dataclasses import dataclass
 from io import StringIO
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import yaml
 
@@ -33,54 +33,15 @@ def cast_to_bool(value: Any) -> bool:
 class Metadata:
     py_script_path: str
     run: str
-    app: str
-    app_args: str
-    script_args: str
+    app: str = ""
+    app_args: Optional[str] = None
+    app_ready_pattern: Optional[str] = None
+    script_args: Optional[str] = None
     script_start_delay: int = 0
-    factoryreset: bool = False
-    factoryreset_app_only: bool = False
+    factory_reset: bool = False
+    factory_reset_app_only: bool = False
     script_gdb: bool = False
     quiet: bool = True
-
-    def copy_from_dict(self, attr_dict: Dict[str, Any]) -> None:
-        """
-        Sets the value of the attributes from a dictionary.
-
-        Attributes:
-
-        attr_dict:
-         Dictionary that stores attributes value that should
-         be transferred to this class.
-        """
-        if "app" in attr_dict:
-            self.app = attr_dict["app"]
-
-        if "run" in attr_dict:
-            self.run = attr_dict["run"]
-
-        if "app-args" in attr_dict:
-            self.app_args = attr_dict["app-args"]
-
-        if "script-args" in attr_dict:
-            self.script_args = attr_dict["script-args"]
-
-        if "script-start-delay" in attr_dict:
-            self.script_start_delay = int(attr_dict["script-start-delay"])
-
-        if "py_script_path" in attr_dict:
-            self.py_script_path = attr_dict["py_script_path"]
-
-        if "factoryreset" in attr_dict:
-            self.factoryreset = cast_to_bool(attr_dict["factoryreset"])
-
-        if "factoryreset_app_only" in attr_dict:
-            self.factoryreset_app_only = cast_to_bool(attr_dict["factoryreset_app_only"])
-
-        if "script_gdb" in attr_dict:
-            self.script_gdb = cast_to_bool(attr_dict["script_gdb"])
-
-        if "quiet" in attr_dict:
-            self.quiet = cast_to_bool(attr_dict["quiet"])
 
 
 class NamedStringIO(StringIO):
@@ -89,7 +50,7 @@ class NamedStringIO(StringIO):
         self.name = name
 
 
-def extract_runs_arg_lines(py_script_path: str) -> Dict[str, Dict[str, str]]:
+def extract_runs_args(py_script_path: str) -> Dict[str, Dict[str, str]]:
     """Extract the run arguments from the CI test arguments blocks."""
 
     found_ci_args_section = False
@@ -135,7 +96,6 @@ def extract_runs_arg_lines(py_script_path: str) -> Dict[str, Dict[str, str]]:
                 for run in runs_match.group("run_id").strip().split():
                     runs_arg_lines[run] = {}
                     runs_arg_lines[run]['run'] = run
-                    runs_arg_lines[run]['py_script_path'] = py_script_path
 
             elif args_match:
                 runs_arg_lines[args_match.group("run_id")][args_match.group("arg_name")] = args_match.group("arg_val")
@@ -146,7 +106,6 @@ def extract_runs_arg_lines(py_script_path: str) -> Dict[str, Dict[str, str]]:
             for run, args in runs.get("test-runner-runs", {}).items():
                 runs_arg_lines[run] = {}
                 runs_arg_lines[run]['run'] = run
-                runs_arg_lines[run]['py_script_path'] = py_script_path
                 runs_arg_lines[run].update(args)
         except yaml.YAMLError as e:
             logging.error(f"Failed to parse CI arguments YAML: {e}")
@@ -213,24 +172,20 @@ class MetadataReader:
          the script file.
         """
         runs_metadata: List[Metadata] = []
-        runs_arg_lines = extract_runs_arg_lines(py_script_path)
+        runs_args = extract_runs_args(py_script_path)
 
-        for run, attr in runs_arg_lines.items():
+        for run, attr in runs_args.items():
             self.__resolve_env_vals__(attr)
-
-            metadata = Metadata(
-                py_script_path=attr.get("py_script_path", ""),
+            runs_metadata.append(Metadata(
+                py_script_path=py_script_path,
                 run=run,
                 app=attr.get("app", ""),
-                app_args=attr.get("app_args", ""),
-                script_args=attr.get("script_args", ""),
-                script_start_delay=int(attr.get("script_start_delay", 0)),
-                factoryreset=bool(attr.get("factoryreset", False)),
-                factoryreset_app_only=bool(attr.get("factoryreset_app_only", False)),
-                script_gdb=bool(attr.get("script_gdb", False)),
-                quiet=bool(attr.get("quiet", True))
-            )
-            metadata.copy_from_dict(attr)
-            runs_metadata.append(metadata)
+                app_args=attr.get("app-args"),
+                app_ready_pattern=attr.get("app-ready-pattern"),
+                script_args=attr.get("script-args"),
+                script_start_delay=attr.get("script-start-delay", 0),
+                factory_reset=cast_to_bool(attr.get("factoryreset", False)),
+                quiet=cast_to_bool(attr.get("quiet", True))
+            ))
 
         return runs_metadata

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/metadata.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/metadata.py
@@ -37,7 +37,6 @@ class Metadata:
     app_args: Optional[str] = None
     app_ready_pattern: Optional[str] = None
     script_args: Optional[str] = None
-    script_start_delay: int = 0
     factory_reset: bool = False
     factory_reset_app_only: bool = False
     script_gdb: bool = False
@@ -183,7 +182,6 @@ class MetadataReader:
                 app_args=attr.get("app-args"),
                 app_ready_pattern=attr.get("app-ready-pattern"),
                 script_args=attr.get("script-args"),
-                script_start_delay=attr.get("script-start-delay", 0),
                 factory_reset=cast_to_bool(attr.get("factoryreset", False)),
                 quiet=cast_to_bool(attr.get("quiet", True))
             ))

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/test_metadata.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/test_metadata.py
@@ -64,7 +64,7 @@ class TestMetadataReader(unittest.TestCase):
         app_args="--discriminator 1234 --trace-to json:out/trace_data/app-{SCRIPT_BASE_NAME}.json",
         run="run1",
         app="out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app",
-        factoryreset=True,
+        factory_reset=True,
         quiet=True
     )
 


### PR DESCRIPTION
### Problem

The option `--script-start-delay` relies on fixed time delay which might not be ideal for CI because of unknown CPU utilization. Instead of that we should wait for a specific trigger from the app.

### Changes

- Reuse `chip.testing.tasks.Subprocess` (which has the ability to wait for specified output line) in the `run_python_test.py` script
 - Add `--app-ready-pattern` option to `run_python_test.py`
 - Replace `script-start-delay` with `app-ready-pattern` and drop `--script-start-delay` support

### Testing

Tested locally but CI will verify as well.
