### PR TITLE
Remove `event list attribute` support in the SDK

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -321,10 +321,6 @@ if (CONFIG_ENABLE_ESP_INSIGHTS_TRACE)
    target_include_directories(${COMPONENT_LIB} INTERFACE "${CHIP_ROOT}/src/tracing/esp32_trace/include")
 endif()
 
-if (CONFIG_ENABLE_MATTER_EVENT_LIST)
-    chip_gn_arg_append  ("enable_eventlist_attribute" "true")
-endif()
-
 set(args_gn_input "${CMAKE_CURRENT_BINARY_DIR}/args.gn.in")
 file(GENERATE OUTPUT "${args_gn_input}" CONTENT "${chip_gn_args}")
 

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -1298,15 +1298,6 @@ menu "CHIP Device Layer"
 
     endmenu
 
-    menu "Enable Matter Event List"
-        config ENABLE_MATTER_EVENT_LIST
-            bool "Enable Matter support Event List attribute"
-            default n
-            help
-                Enable Matter support Event List attribute.
-
-    endmenu
-
     menu "Enable BLE Extended Announcement"
         config ENABLE_BLE_EXT_ANNOUNCEMENT
             bool "Enable BLE Extended Announcement"

--- a/config/nxp/cmake/common.cmake
+++ b/config/nxp/cmake/common.cmake
@@ -47,7 +47,6 @@ matter_add_gn_arg_bool  ("chip_enable_wifi"                       CONFIG_CHIP_WI
 matter_add_gn_arg_bool  ("chip_enable_ethernet"                   CONFIG_CHIP_ETHERNET)
 matter_add_gn_arg_bool  ("chip_system_config_provide_statistics"  CONFIG_CHIP_STATISTICS)
 matter_add_gn_arg_bool  ("chip_enable_icd_server"                 CONFIG_CHIP_ENABLE_ICD_SUPPORT)
-matter_add_gn_arg_bool  ("enable_eventlist_attribute"             TRUE)
 matter_add_gn_arg_bool  ("chip_enable_ota_requestor"              CONFIG_CHIP_OTA_REQUESTOR)
 
 if(CONFIG_DEBUG)

--- a/src/app/AttributePathExpandIterator-DataModel.cpp
+++ b/src/app/AttributePathExpandIterator-DataModel.cpp
@@ -25,8 +25,8 @@ namespace app {
 
 AttributePathExpandIteratorDataModel::AttributePathExpandIteratorDataModel(
     DataModel::Provider * provider, SingleLinkedListNode<AttributePathParams> * attributePath) :
-    mDataModelProvider(provider), mpAttributePath(attributePath),
-    mOutputPath(kInvalidEndpointId, kInvalidClusterId, kInvalidAttributeId)
+    mDataModelProvider(provider),
+    mpAttributePath(attributePath), mOutputPath(kInvalidEndpointId, kInvalidClusterId, kInvalidAttributeId)
 
 {
     mOutputPath.mExpanded = true; // this is reset in 'next' if needed

--- a/src/app/AttributePathExpandIterator-DataModel.cpp
+++ b/src/app/AttributePathExpandIterator-DataModel.cpp
@@ -25,8 +25,8 @@ namespace app {
 
 AttributePathExpandIteratorDataModel::AttributePathExpandIteratorDataModel(
     DataModel::Provider * provider, SingleLinkedListNode<AttributePathParams> * attributePath) :
-    mDataModelProvider(provider),
-    mpAttributePath(attributePath), mOutputPath(kInvalidEndpointId, kInvalidClusterId, kInvalidAttributeId)
+    mDataModelProvider(provider), mpAttributePath(attributePath),
+    mOutputPath(kInvalidEndpointId, kInvalidClusterId, kInvalidAttributeId)
 
 {
     mOutputPath.mExpanded = true; // this is reset in 'next' if needed
@@ -42,9 +42,6 @@ bool AttributePathExpandIteratorDataModel::IsValidAttributeId(AttributeId attrib
     {
     case Clusters::Globals::Attributes::GeneratedCommandList::Id:
     case Clusters::Globals::Attributes::AcceptedCommandList::Id:
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-    case Clusters::Globals::Attributes::EventList::Id:
-#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     case Clusters::Globals::Attributes::AttributeList::Id:
         return true;
     default:

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -41,8 +41,6 @@ declare_args() {
   # By default, the resources used by each fabric is unlimited if they are allocated on heap. This flag is for checking the resource usage even when they are allocated on heap to increase code coverage in integration tests.
   chip_im_force_fabric_quota_check = false
 
-  enable_eventlist_attribute = false
-
   # Allow building ota-requestor-app with a non-spec-compliant floor
   # (i.e. smaller than 2 minutes) for action delays.
   non_spec_compliant_ota_action_delay_floor = -1
@@ -71,7 +69,6 @@ buildconfig_header("app_buildconfig") {
     "CHIP_CONFIG_ACCESS_CONTROL_POLICY_LOGGING_VERBOSITY=${chip_access_control_policy_logging_verbosity}",
     "CHIP_CONFIG_PERSIST_SUBSCRIPTIONS=${chip_persist_subscriptions}",
     "CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION=${chip_subscription_timeout_resumption}",
-    "CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE=${enable_eventlist_attribute}",
     "CHIP_CONFIG_ENABLE_READ_CLIENT=${chip_enable_read_client}",
     "CHIP_CONFIG_STATIC_GLOBAL_INTERACTION_MODEL_ENGINE=${chip_im_static_global_interaction_model_engine}",
     "TIME_SYNC_ENABLE_TSC_FEATURE=${time_sync_enable_tsc_feature}",

--- a/src/app/GlobalAttributes.h
+++ b/src/app/GlobalAttributes.h
@@ -32,9 +32,6 @@ namespace app {
 constexpr AttributeId GlobalAttributesNotInMetadata[] = {
     Clusters::Globals::Attributes::GeneratedCommandList::Id,
     Clusters::Globals::Attributes::AcceptedCommandList::Id,
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-    Clusters::Globals::Attributes::EventList::Id,
-#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     Clusters::Globals::Attributes::AttributeList::Id,
 };
 

--- a/src/app/tests/TestAttributePathExpandIterator.cpp
+++ b/src/app/tests/TestAttributePathExpandIterator.cpp
@@ -50,26 +50,17 @@ TEST(TestAttributePathExpandIterator, TestAllWildcard)
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint1, MockClusterId(2), MockAttributeId(1) },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -77,9 +68,6 @@ TEST(TestAttributePathExpandIterator, TestAllWildcard)
         { kMockEndpoint2, MockClusterId(2), MockAttributeId(2) },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -88,18 +76,12 @@ TEST(TestAttributePathExpandIterator, TestAllWildcard)
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(1), MockAttributeId(1) },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -109,25 +91,16 @@ TEST(TestAttributePathExpandIterator, TestAllWildcard)
         { kMockEndpoint3, MockClusterId(2), MockAttributeId(4) },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::AttributeList::Id },
     };
 
@@ -237,9 +210,6 @@ TEST(TestAttributePathExpandIterator, TestWildcardAttribute)
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
     };
 
@@ -314,26 +284,17 @@ TEST(TestAttributePathExpandIterator, TestMultipleClusInfo)
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint1, MockClusterId(2), MockAttributeId(1) },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint1, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint2, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -341,9 +302,6 @@ TEST(TestAttributePathExpandIterator, TestMultipleClusInfo)
         { kMockEndpoint2, MockClusterId(2), MockAttributeId(2) },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint2, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -352,18 +310,12 @@ TEST(TestAttributePathExpandIterator, TestMultipleClusInfo)
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(1), MockAttributeId(1) },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::FeatureMap::Id },
@@ -373,25 +325,16 @@ TEST(TestAttributePathExpandIterator, TestMultipleClusInfo)
         { kMockEndpoint3, MockClusterId(2), MockAttributeId(4) },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint3, MockClusterId(2), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint3, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::ClusterRevision::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::FeatureMap::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint3, MockClusterId(4), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
         { kMockEndpoint3, MockClusterId(1), Clusters::Globals::Attributes::ClusterRevision::Id },
@@ -405,9 +348,6 @@ TEST(TestAttributePathExpandIterator, TestMultipleClusInfo)
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::GeneratedCommandList::Id },
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AcceptedCommandList::Id },
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-        { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::EventList::Id },
-#endif
         { kMockEndpoint2, MockClusterId(3), Clusters::Globals::Attributes::AttributeList::Id },
         { kMockEndpoint2, MockClusterId(3), MockAttributeId(3) },
     };

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1247,7 +1247,8 @@ TEST_F(TestReadInteraction, TestSetDirtyBetweenChunks)
         public:
             DirtyingMockDelegate(AttributePathParams (&aReadPaths)[2], int & aNumAttributeResponsesWhenSetDirty,
                                  int & aNumArrayItemsWhenSetDirty) :
-                mReadPaths(aReadPaths), mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
+                mReadPaths(aReadPaths),
+                mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
                 mNumArrayItemsWhenSetDirty(aNumArrayItemsWhenSetDirty)
             {}
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1247,8 +1247,7 @@ TEST_F(TestReadInteraction, TestSetDirtyBetweenChunks)
         public:
             DirtyingMockDelegate(AttributePathParams (&aReadPaths)[2], int & aNumAttributeResponsesWhenSetDirty,
                                  int & aNumArrayItemsWhenSetDirty) :
-                mReadPaths(aReadPaths),
-                mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
+                mReadPaths(aReadPaths), mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
                 mNumArrayItemsWhenSetDirty(aNumArrayItemsWhenSetDirty)
             {}
 
@@ -2429,7 +2428,6 @@ TEST_F(TestReadInteraction, TestSubscribeWildcard)
 
         EXPECT_TRUE(delegate.mGotReport);
 
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
         // Mock attribute storage that is reset and resides in src/app/util/mock/attribute-storage.cpp
         // has the following items:
         // - Endpoint 0xFFFE
@@ -2457,18 +2455,7 @@ TEST_F(TestReadInteraction, TestSubscribeWildcard)
         // 0xFFFC::0xFFF1'FC02::0xFFF1'0004 is chunked.  For each of the two instances of that attribute
         // in the response, there will be one AttributeDataIB for the start of the list (which will include
         // some number of 256-byte elements), then one AttributeDataIB for each of the remaining elements.
-        //
-        // When EventList is enabled, for the first report for the list attribute we receive three
-        // of its items in the initial list, then the remaining items.  For the second report we
-        // receive 2 items in the initial list followed by the remaining items.
-        constexpr size_t kExpectedAttributeResponse = 29 * 2 + (kMockAttribute4ListLength - 3) + (kMockAttribute4ListLength - 2);
-#else
-        // When EventList is not enabled, the packet boundaries shift and for the first
-        // report for the list attribute we receive four of its items in the initial list,
-        // then additional items.  For the second report we receive 4 items in
-        // the initial list followed by additional items.
         constexpr size_t kExpectedAttributeResponse = 29 * 2 + (kMockAttribute4ListLength - 4) + (kMockAttribute4ListLength - 4);
-#endif
         EXPECT_EQ((unsigned) delegate.mNumAttributeResponse, kExpectedAttributeResponse);
         EXPECT_EQ(delegate.mNumArrayItems, 12);
         EXPECT_EQ(engine->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe), 1u);

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -806,20 +806,8 @@ Protocols::InteractionModel::Status CheckEventSupportStatus(const ConcreteEventP
         return Status::UnsupportedCluster;
     }
 
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-    for (size_t i = 0; i < cluster->eventCount; ++i)
-    {
-        if (cluster->eventList[i] == aPath.mEventId)
-        {
-            return Status::Success;
-        }
-    }
-
-    return Status::UnsupportedEvent;
-#else
     // No way to tell. Just claim supported.
     return Status::Success;
-#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
 }
 
 } // namespace app

--- a/src/app/util/ember-global-attribute-access-interface.cpp
+++ b/src/app/util/ember-global-attribute-access-interface.cpp
@@ -36,15 +36,9 @@ CHIP_ERROR GlobalAttributeReader::Read(const ConcreteReadAttributePath & aPath, 
             {
                 AttributeId id              = mCluster->attributes[i].attributeId;
                 constexpr auto lastGlobalId = GlobalAttributesNotInMetadata[ArraySize(GlobalAttributesNotInMetadata) - 1];
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-                // The GlobalAttributesNotInMetadata shouldn't have any gaps in their ids here.
-                static_assert(lastGlobalId - GlobalAttributesNotInMetadata[0] == ArraySize(GlobalAttributesNotInMetadata) - 1,
-                              "Ids in GlobalAttributesNotInMetadata not consecutive");
-#else
                 // If EventList is not supported. The GlobalAttributesNotInMetadata is missing one id here.
                 static_assert(lastGlobalId - GlobalAttributesNotInMetadata[0] == ArraySize(GlobalAttributesNotInMetadata),
                               "Ids in GlobalAttributesNotInMetadata not consecutive (except EventList)");
-#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
                 if (!addedExtraGlobals && id > lastGlobalId)
                 {
                     for (const auto & globalId : GlobalAttributesNotInMetadata)
@@ -64,16 +58,6 @@ CHIP_ERROR GlobalAttributeReader::Read(const ConcreteReadAttributePath & aPath, 
             }
             return CHIP_NO_ERROR;
         });
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-    case EventList::Id:
-        return aEncoder.EncodeList([this](const auto & encoder) {
-            for (size_t i = 0; i < mCluster->eventCount; ++i)
-            {
-                ReturnErrorOnFailure(encoder.Encode(mCluster->eventList[i]));
-            }
-            return CHIP_NO_ERROR;
-        });
-#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     case AcceptedCommandList::Id:
         return EncodeCommandList(aPath, aEncoder, &CommandHandlerInterface::EnumerateAcceptedCommands,
                                  mCluster->acceptedCommandList);

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -179,12 +179,6 @@ void TestReadCallback::OnAttributeData(const app::ConcreteDataAttributePath & aP
         EXPECT_EQ(v.ComputeSize(&arraySize), CHIP_NO_ERROR);
         EXPECT_EQ(arraySize, 0u);
     }
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-    else if (aPath.mAttributeId == Globals::Attributes::EventList::Id)
-    {
-        // Nothing to check for this one; depends on the endpoint.
-    }
-#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     else if (aPath.mAttributeId == Globals::Attributes::AttributeList::Id)
     {
         // Nothing to check for this one; depends on the endpoint.

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -280,12 +280,6 @@ void TestReadCallback::OnAttributeData(const app::ConcreteDataAttributePath & aP
         EXPECT_EQ(v.ComputeSize(&arraySize), CHIP_NO_ERROR);
         EXPECT_EQ(arraySize, 0u);
     }
-#if CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
-    else if (aPath.mAttributeId == Globals::Attributes::EventList::Id)
-    {
-        // Nothing to check for this one; depends on the endpoint.
-    }
-#endif // CHIP_CONFIG_ENABLE_EVENTLIST_ATTRIBUTE
     else if (aPath.mAttributeId == Globals::Attributes::AttributeList::Id)
     {
         // Nothing to check for this one; depends on the endpoint.

--- a/src/platform/nxp/rt/rw61x/args.gni
+++ b/src/platform/nxp/rt/rw61x/args.gni
@@ -34,9 +34,6 @@ chip_ble_project_config_include = "<CHIPProjectConfig.h>"
 
 chip_build_tests = false
 
-#This enables the EventList global attribute
-enable_eventlist_attribute = true
-
 declare_args() {
   spinel_interface_rpmsg = true
 


### PR DESCRIPTION
Specification marks it as deprecated (conformance `D`) and we have not actually supported it in previous releases.

For now remove all defines from implementing it. Client clusters still claim supported, so that may need further iteration.