### PR TITLE
[darwin-framework-tool] Use DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_PO…

### DIFF
--- a/examples/darwin-framework-tool/commands/bdx/DownloadLogCommand.mm
+++ b/examples/darwin-framework-tool/commands/bdx/DownloadLogCommand.mm
@@ -31,7 +31,7 @@ CHIP_ERROR DownloadLogCommand::RunCommand()
     auto * device = [MTRDevice deviceWithNodeID:@(mNodeId) controller:commissioner];
 
     auto logType = static_cast<MTRDiagnosticLogType>(mLogType);
-    auto queue = dispatch_queue_create("com.chip.bdx.downloader", DISPATCH_QUEUE_SERIAL);
+    auto queue = dispatch_queue_create("com.chip.bdx.downloader", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 
     bool shouldWaitForDownload = !mIsAsyncCommand.ValueOr(false);
     mIsAsyncCommand.ClearValue();

--- a/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
@@ -71,7 +71,7 @@ public:
     {
         uint16_t repeatCount = mRepeatCount.ValueOr(1);
         uint16_t __block responsesNeeded = repeatCount;
-        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 
         while (repeatCount--) {
             [device invokeCommandWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]

--- a/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
@@ -52,7 +52,7 @@ public:
 
     CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endpointId) override
     {
-        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         MTRReadParams * params = [[MTRReadParams alloc] init];
         if (mFabricFiltered.HasValue()) {
             params.filterByFabric = mFabricFiltered.Value();
@@ -124,7 +124,7 @@ public:
 
     CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endpointId) override
     {
-        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 
         MTRSubscribeParams * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(mMinInterval) maxInterval:@(mMaxInterval)];
         if (mFabricFiltered.HasValue()) {
@@ -214,7 +214,7 @@ public:
 
     CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endpointId) override
     {
-        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 
         MTRSubscribeParams * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(mMinInterval) maxInterval:@(mMaxInterval)];
         if (mEventNumber.HasValue()) {
@@ -324,7 +324,7 @@ public:
 
     CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endpointId) override
     {
-        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         MTRReadParams * params = [[MTRReadParams alloc] init];
         if (mFabricFiltered.HasValue()) {
             params.filterByFabric = mFabricFiltered.Value();

--- a/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
@@ -72,7 +72,8 @@ public:
     CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endpointId, chip::ClusterId clusterId,
         chip::AttributeId attributeId, id _Nonnull value)
     {
-        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+
         [device
             writeAttributeWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
                                clusterID:[NSNumber numberWithUnsignedInteger:clusterId]

--- a/examples/darwin-framework-tool/commands/discover/DiscoverCommissionablesCommand.mm
+++ b/examples/darwin-framework-tool/commands/discover/DiscoverCommissionablesCommand.mm
@@ -18,7 +18,7 @@
 #include "DiscoverCommissionablesCommand.h"
 
 NSMutableArray * gDiscoveredDevices = [[NSMutableArray alloc] init];
-auto gDispatchQueue = dispatch_queue_create("com.chip.discover", DISPATCH_QUEUE_SERIAL);
+auto gDispatchQueue = dispatch_queue_create("com.chip.discover", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 
 @interface DeviceScannerDelegate : NSObject <MTRCommissionableBrowserDelegate>
 - (void)controller:(MTRDeviceController *)controller didFindCommissionableDevice:(MTRCommissionableBrowserResult *)device;

--- a/examples/darwin-framework-tool/commands/pairing/OpenCommissioningWindowCommand.mm
+++ b/examples/darwin-framework-tool/commands/pairing/OpenCommissioningWindowCommand.mm
@@ -23,7 +23,7 @@
 
 CHIP_ERROR OpenCommissioningWindowCommand::RunCommand()
 {
-    mWorkQueue = dispatch_queue_create("com.chip.open_commissioning_window", DISPATCH_QUEUE_SERIAL);
+    mWorkQueue = dispatch_queue_create("com.chip.open_commissioning_window", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
     auto * controller = CurrentCommissioner();
     auto * device = [MTRDevice deviceWithNodeID:mNodeId deviceController:controller];
 

--- a/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.mm
@@ -83,7 +83,7 @@ void PairingCommandBridge::SetUpDeviceControllerDelegate()
 
     MTRDeviceController * commissioner = CurrentCommissioner();
     [deviceControllerDelegate setCommissioner:commissioner];
-    dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.pairing", DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.pairing", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
     [commissioner setDeviceControllerDelegate:deviceControllerDelegate queue:callbackQueue];
 }
 
@@ -156,7 +156,7 @@ void PairingCommandBridge::PairWithPayload(NSError * __autoreleasing * error)
 
 void PairingCommandBridge::Unpair()
 {
-    dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip-tool.command", DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip-tool.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
     auto * device = BaseDeviceWithNodeId(mNodeId);
 
     ChipLogProgress(chipTool, "Attempting to unpair device %llu", mNodeId);

--- a/examples/darwin-framework-tool/templates/commands.zapt
+++ b/examples/darwin-framework-tool/templates/commands.zapt
@@ -65,7 +65,7 @@ public:
 
         ChipLogProgress(chipTool, "Sending cluster (0x%08" PRIX32 ") command (0x%08" PRIX32 ") on endpoint %u", clusterId, commandId, endpointId);
 
-        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         __auto_type * cluster = [[MTRBaseCluster{{asUpperCamelCase parent.name preserveAcronyms=true}} alloc] initWithDevice:device endpointID:@(endpointId) queue:callbackQueue];
         __auto_type * params = [[MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Params alloc] init];
         params.timedInvokeTimeoutMs = mTimedInteractionTimeoutMs.HasValue() ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()] : nil;
@@ -159,7 +159,7 @@ public:
 
         ChipLogProgress(chipTool, "Sending cluster (0x%08" PRIX32 ") ReadAttribute (0x%08" PRIX32 ") on endpoint %u", endpointId, clusterId, attributeId);
 
-        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         __auto_type * cluster = [[MTRBase{{>cluster}} alloc] initWithDevice:device endpointID:@(endpointId) queue:callbackQueue];
         {{#if_is_fabric_scoped_struct type}}
         __auto_type * params = [[MTRReadParams alloc] init];
@@ -217,7 +217,7 @@ public:
         constexpr chip::AttributeId attributeId = chip::app::Clusters::{{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::Id;
 
         ChipLogProgress(chipTool, "Sending cluster (0x%08" PRIX32 ") WriteAttribute (0x%08" PRIX32 ") on endpoint %u", clusterId, attributeId, endpointId);
-        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         __auto_type * cluster = [[MTRBase{{>cluster}} alloc] initWithDevice:device endpointID:@(endpointId) queue:callbackQueue];
         __auto_type * params = [[MTRWriteParams alloc] init];
         params.timedWriteTimeout = mTimedInteractionTimeoutMs.HasValue() ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()] : nil;
@@ -290,7 +290,7 @@ public:
         constexpr chip::CommandId attributeId = chip::app::Clusters::{{asUpperCamelCase parent.name}}::Attributes::{{asUpperCamelCase name}}::Id;
 
         ChipLogProgress(chipTool, "Sending cluster (0x%08" PRIX32 ") ReportAttribute (0x%08" PRIX32 ") on endpoint %u", clusterId, attributeId, endpointId);
-        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         __auto_type * cluster = [[MTRBase{{>cluster}} alloc] initWithDevice:device endpointID:@(endpointId) queue:callbackQueue];
         __auto_type * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(mMinInterval) maxInterval:@(mMaxInterval)];
         if (mKeepSubscriptions.HasValue()) {


### PR DESCRIPTION
…OL instead of DISPATCH_QUEUE_SERIAL

#### Problem

`darwin-framework-tool` uses mostly `DISPATCH_QUEUE_SERIAL` but some of the work happens to creates objects that have an hard time to be released without one.
This PR changes changes all the `DISPATCH_QUEUE_SERIAL` to `DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL`. 