### PR TITLE
[macOS standalone apps] Add missing autoreleasepool for logging when …

### DIFF
--- a/src/platform/Darwin/Logging.h
+++ b/src/platform/Darwin/Logging.h
@@ -28,11 +28,12 @@
 #define ChipPlatformLog(MOD, CAT, MSG, ...)                                                                                        \
     do                                                                                                                             \
     {                                                                                                                              \
-        ChipPlatformValidateLogFormat(MSG, ##__VA_ARGS__); /* validate once and ignore warnings from os_log() / Log() */           \
+        ChipPlatformValidateLogFormat(MSG, ##__VA_ARGS__); /* validate once and ignore warnings from Log() */                      \
+        chip::Logging::Platform::LogAny(chip::Logging::kLogModule_##MOD, #MOD,                                                     \
+                                        static_cast<os_log_type_t>(chip::Logging::Platform::kOSLogCategory_##CAT), MSG,            \
+                                        ##__VA_ARGS__);                                                                            \
         _Pragma("clang diagnostic push");                                                                                          \
         _Pragma("clang diagnostic ignored \"-Wformat\"");                                                                          \
-        os_log_with_type(chip::Logging::Platform::LoggerForModule(chip::Logging::kLogModule_##MOD, #MOD),                          \
-                         static_cast<os_log_type_t>(chip::Logging::Platform::kOSLogCategory_##CAT), MSG, ##__VA_ARGS__);           \
         ChipInternalLogImpl(MOD, CHIP_LOG_CATEGORY_##CAT, MSG, ##__VA_ARGS__);                                                     \
         _Pragma("clang diagnostic pop");                                                                                           \
     } while (0)
@@ -66,6 +67,7 @@ enum OSLogCategory
 
 os_log_t LoggerForModule(chip::Logging::LogModule moduleId, char const * moduleName);
 void LogByteSpan(chip::Logging::LogModule moduleId, char const * moduleName, os_log_type_t type, const chip::ByteSpan & span);
+void LogAny(chip::Logging::LogModule moduleId, char const * moduleName, os_log_type_t type, const char * msg, ...);
 
 // Helper constructs for compile-time validation of format strings for C++ / ObjC++ contexts.
 // Note that ObjC++ contexts are restricted to NSString style specifiers. Supporting os_log()

--- a/src/platform/Darwin/Logging.mm
+++ b/src/platform/Darwin/Logging.mm
@@ -51,15 +51,36 @@ namespace Logging {
         void LogByteSpan(
             chip::Logging::LogModule moduleId, char const * moduleName, os_log_type_t type, const chip::ByteSpan & span)
         {
-            os_log_t logger = LoggerForModule(moduleId, moduleName);
-            if (os_log_type_enabled(logger, type)) {
-                auto size = span.size();
-                auto data = span.data();
-                NSMutableString * string = [[NSMutableString alloc] initWithCapacity:(size * 6)]; // 6 characters per byte
-                for (size_t i = 0; i < size; i++) {
-                    [string appendFormat:((i % 8 != 7) ? @"0x%02x, " : @"0x%02x,\n"), data[i]];
+            @autoreleasepool {
+                os_log_t logger = LoggerForModule(moduleId, moduleName);
+                if (os_log_type_enabled(logger, type)) {
+                    auto size = span.size();
+                    auto data = span.data();
+                    NSMutableString * string = [[NSMutableString alloc] initWithCapacity:(size * 6)]; // 6 characters per byte
+                    for (size_t i = 0; i < size; i++) {
+                        [string appendFormat:((i % 8 != 7) ? @"0x%02x, " : @"0x%02x,\n"), data[i]];
+                    }
+                    os_log_with_type(logger, type, "%@", string);
                 }
-                os_log_with_type(logger, type, "%@", string);
+            }
+        }
+
+        void LogAny(
+            chip::Logging::LogModule moduleId, char const * moduleName, os_log_type_t type, const char * msg, ...)
+        {
+            @autoreleasepool {
+                os_log_t logger = LoggerForModule(moduleId, moduleName);
+                if (os_log_type_enabled(logger, type)) {
+                    va_list v;
+                    va_start(v, msg);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+                    NSString * string = [[NSString alloc] initWithFormat:@(msg) arguments:v];
+#pragma clang diagnostic pop
+                    va_end(v);
+
+                    os_log_with_type(logger, type, "%@", string);
+                }
             }
         }
 


### PR DESCRIPTION
…standalone apps are runned on macOS

#### Problem

When standalone apps (`chip-tool`, `all-clusters-app`, ..) are runned on macOS, there is no top level `autoreleasepool` objects can be pushed to. But the logging code uses `NSString` objects. This PR add an `autoreleasepool` for those.