### PR TITLE
[Matter.framework] Wrap the MatterControllerFactory shutdown code tha…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -73,8 +73,12 @@ using namespace chip::Tracing::DarwinFramework;
 static bool sExitHandlerRegistered = false;
 static void ShutdownOnExit()
 {
-    MTR_LOG("ShutdownOnExit invoked on exit");
-    [[MTRDeviceControllerFactory sharedInstance] stopControllerFactory];
+    // Depending on the structure of the software, this code might execute *after* the main autorelease pool has exited.
+    // Therefore, it needs to be enclosed in its own autorelease pool.
+    @autoreleasepool {
+        MTR_LOG("ShutdownOnExit invoked on exit");
+        [[MTRDeviceControllerFactory sharedInstance] stopControllerFactory];
+    }
 }
 
 @interface MTRDeviceControllerFactoryParams ()


### PR DESCRIPTION
…t is runned with atexit into its own autorelease pool

#### Problem

The `MTRDeviceControllerFactory` install some code to be runned on shutdown. But this code escapes our root `autoreleasepool` that is set up in `examples/darwin-framework-tool/main.mm`.

This PR adds an `autoreleasepool` for this specific code block.