### PR TITLE
Darwin: Avoid autorelease handling around LoggerForModule

### DIFF
--- a/src/platform/Darwin/Logging.mm
+++ b/src/platform/Darwin/Logging.mm
@@ -30,7 +30,7 @@ namespace chip {
 namespace Logging {
     namespace Platform {
 
-        os_log_t LoggerForModule(chip::Logging::LogModule moduleID, char const * moduleName)
+        struct os_log_s * LoggerForModule(chip::Logging::LogModule moduleID, char const * moduleName)
         {
             if (moduleID <= kLogModule_NotSpecified || kLogModule_Max <= moduleID) {
                 moduleID = kLogModule_NotSpecified;
@@ -39,11 +39,11 @@ namespace Logging {
 
             static struct {
                 dispatch_once_t onceToken;
-                os_log_t logger;
+                struct os_log_s * logger;
             } cache[kLogModule_Max];
             auto & entry = cache[moduleID];
             dispatch_once(&entry.onceToken, ^{
-                entry.logger = os_log_create("com.csa.matter", moduleName);
+                entry.logger = (__bridge_retained struct os_log_s *) os_log_create("com.csa.matter", moduleName);
             });
             return entry.logger;
         }
@@ -51,15 +51,15 @@ namespace Logging {
         void LogByteSpan(
             chip::Logging::LogModule moduleId, char const * moduleName, os_log_type_t type, const chip::ByteSpan & span)
         {
-            os_log_t logger = LoggerForModule(moduleId, moduleName);
-            if (os_log_type_enabled(logger, type)) {
+            auto * logger = LoggerForModule(moduleId, moduleName);
+            if (os_log_type_enabled(ChipPlatformLogger(logger), type)) {
                 auto size = span.size();
                 auto data = span.data();
                 NSMutableString * string = [[NSMutableString alloc] initWithCapacity:(size * 6)]; // 6 characters per byte
                 for (size_t i = 0; i < size; i++) {
                     [string appendFormat:((i % 8 != 7) ? @"0x%02x, " : @"0x%02x,\n"), data[i]];
                 }
-                os_log_with_type(logger, type, "%@", string);
+                os_log_with_type(ChipPlatformLogger(logger), type, "%@", string);
             }
         }
 


### PR DESCRIPTION
We don't want the LoggerForModule() implementation to call retain/autorelease on the logger, because its unnecessary, and because LoggerForModule() can be called from a C++ context without an auto-release pool in place.

To avoid this, we can have LoggerForModule() return a raw pointer, and handle the bridge cast to os_log_t on the caller side. This also avoids unnecessary code on the caller side that would otherwise attempt to rescue the presumed-autoreleased logger object from the ARP.
