### PR TITLE
Replace PIXIT with PICS in log statements

### DIFF
--- a/src/python_testing/TC_EWATERHTR_2_1.py
+++ b/src/python_testing/TC_EWATERHTR_2_1.py
@@ -99,14 +99,14 @@ class TC_EWATERHTR_2_1(MatterBaseTest, EWATERHTRBase):
         if em_supported:
             value = await self.read_whm_attribute_expect_success(attribute="TankVolume")
         else:
-            logging.info("Skipping step 4 as PIXIT.EWATERHTR.EM not supported")
+            logging.info("Skipping step 4 as PICS.EWATERHTR.EM not supported")
 
         self.step("6")
         if em_supported:
             value = await self.read_whm_attribute_expect_success(attribute="EstimatedHeatRequired")
             asserts.assert_greater_equal(value, 0, f"Unexpected EstimatedHeatRequired value - expected {value} >= 0")
         else:
-            logging.info("Skipping step 5 as PIXIT.EWATERHTR.EM not supported")
+            logging.info("Skipping step 5 as PICS.EWATERHTR.EM not supported")
 
         self.step("7")
         if tp_supported:
@@ -114,7 +114,7 @@ class TC_EWATERHTR_2_1(MatterBaseTest, EWATERHTRBase):
             asserts.assert_greater_equal(value, 0, f"Unexpected TankPercentage value - expected {value} >= 0")
             asserts.assert_less_equal(value, 100, f"Unexpected TankPercentage value - expected {value} <= 100")
         else:
-            logging.info("Skipping step 6 as PIXIT.EWATERHTR.TP not supported")
+            logging.info("Skipping step 6 as PICS.EWATERHTR.TP not supported")
 
         self.step("8")
         boost_state = await self.read_whm_attribute_expect_success(attribute="BoostState")

--- a/src/python_testing/TC_EWATERHTR_2_1.py
+++ b/src/python_testing/TC_EWATERHTR_2_1.py
@@ -99,14 +99,14 @@ class TC_EWATERHTR_2_1(MatterBaseTest, EWATERHTRBase):
         if em_supported:
             value = await self.read_whm_attribute_expect_success(attribute="TankVolume")
         else:
-            logging.info("Skipping step 4 as PICS.EWATERHTR.EM not supported")
+            logging.info("Skipping step 5 as PICS.EWATERHTR.F00(EnergyManagement) not supported")
 
         self.step("6")
         if em_supported:
             value = await self.read_whm_attribute_expect_success(attribute="EstimatedHeatRequired")
             asserts.assert_greater_equal(value, 0, f"Unexpected EstimatedHeatRequired value - expected {value} >= 0")
         else:
-            logging.info("Skipping step 5 as PICS.EWATERHTR.EM not supported")
+            logging.info("Skipping step 6 as PICS.EWATERHTR.F00(EnergyManagement) not supported")
 
         self.step("7")
         if tp_supported:
@@ -114,7 +114,7 @@ class TC_EWATERHTR_2_1(MatterBaseTest, EWATERHTRBase):
             asserts.assert_greater_equal(value, 0, f"Unexpected TankPercentage value - expected {value} >= 0")
             asserts.assert_less_equal(value, 100, f"Unexpected TankPercentage value - expected {value} <= 100")
         else:
-            logging.info("Skipping step 6 as PICS.EWATERHTR.TP not supported")
+            logging.info("Skipping step 7 as PICS.EWATERHTR.F01(TankPercenage) not supported")
 
         self.step("8")
         boost_state = await self.read_whm_attribute_expect_success(attribute="BoostState")


### PR DESCRIPTION
Replace PIXIT with PICS in the log messages.
Fixes #35356 