### PR TITLE
Fix empty report feedback loop edge-case

### DIFF
--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -150,6 +150,7 @@ public:
                      IsEngineRunScheduled()));
         }
 
+        bool CanStartReporting() const { return mReadHandler->CanStartReporting(); }
         bool IsChunkedReport() const { return mReadHandler->IsChunkedReport(); }
         bool IsEngineRunScheduled() const { return mFlags.Has(ReadHandlerNodeFlags::EngineRunScheduled); }
         void SetEngineRunScheduled(bool aEngineRunScheduled)

--- a/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
+++ b/src/app/reporting/SynchronizedReportSchedulerImpl.cpp
@@ -183,7 +183,7 @@ void SynchronizedReportSchedulerImpl::TimerFired()
     VerifyOrReturn(mNodesPool.Allocated());
 
     mNodesPool.ForEachActiveObject([now, &firedEarly](ReadHandlerNode * node) {
-        if (node->GetMinTimestamp() <= now)
+        if (node->GetMinTimestamp() <= now && node->CanStartReporting())
         {
             // Since this handler can now report whenever it wants to, mark it as allowed to report if any other handler is
             // reporting using the CanBeSynced flag.


### PR DESCRIPTION
#### Description

When using the Synchronized report scheduler, it was possible to hit an edge-case where the device would fall into a feedback loop sending reports if it has more than two subscriptions.

The edge-case can happen (how the bug was found) when the publisher has 2 or more subscriptions.

![image](https://github.com/user-attachments/assets/d239d567-b9de-498b-acd9-48784162e7d1)

Fundemental issue is a ReadHandler was being marked as CanBeSynced (line#190) when it is already waiting for a response.
Since it is already waiting for a response, it is already synced and does not need to be synced once again.

#### Testing
Manual testing

Due to the nature of the "multi-task" trigger that needs to happen back to back to trigger the bug, i was not able to unit test this exact scenario. The bug was triggered when a seperate task from the chip task was causing the attributes of the subscriptions to be marked dirty.