### PR TITLE
Documentation: Fix defaults on build_python.sh

### DIFF
--- a/docs/guides/python_chip_controller_building.md
+++ b/docs/guides/python_chip_controller_building.md
@@ -77,7 +77,8 @@ To build and run the Python CHIP controller:
 5. Build and install the Python CHIP controller:
 
     ```
-    scripts/build_python.sh -m platform -i separate
+    scripts/build_python.sh -m platform -i out/python_env
+    source out/python_env/bin/activate
     ```
 
     > Note: This builds the Python CHIP Controller along with the CHIP REPL as

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -587,7 +587,7 @@ Next build the python wheels and create / activate a venv (called `pyenv` here,
 but any name may be used)
 
 ```
-./scripts/build_python.sh -i pyenv
+./scripts/build_python.sh -i out/python_env
 source pyenv/bin/activate
 ```
 

--- a/docs/testing/yaml.md
+++ b/docs/testing/yaml.md
@@ -334,7 +334,7 @@ Next build the python wheels and create a venv (called `py` here, but any name
 may be used)
 
 ```
-./scripts/build_python.sh -i py
+./scripts/build_python.sh -i out/python_env
 source py/bin/activate
 ```
 

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -31,8 +31,8 @@
 # files, then add the extra dependencies. From the root:
 #
 # . scripts/activate.sh
-# ./scripts/build_python.sh -i py
-# source py/bin/activate
+# ./scripts/build_python.sh -i out/python_env
+# source out/python_env/bin/activate
 # pip install opencv-python requests click_option_group
 # python src/python_testing/post_certification_tests/production_device_checks.py
 


### PR DESCRIPTION
The default for the build environment shoudl be in the out dir since that's already excluded from git. Makes things easier for people following the documentation for the first time who won't necessarily change that directory to their preferred location.

