### PR TITLE
Fixing exception with calling into a dead XPC object

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDefines_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDefines_Internal.h
@@ -67,41 +67,41 @@ typedef struct {} variable_hidden_by_mtr_hide;
 
 #pragma mark - XPC Defines
 
-#define MTR_SIMPLE_REMOTE_XPC_GETTER(XPC_CONNECTION, NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, PREFIX)        \
-                                                                                                            \
-    -(TYPE) NAME                                                                                            \
-    {                                                                                                       \
-        __block TYPE outValue = DEFAULT_VALUE;                                                              \
-                                                                                                            \
-        NSXPCConnection * xpcConnection = XPC_CONNECTION;                                                   \
-                                                                                                            \
-        @try {                                                                                              \
-            [[xpcConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {      \
-                MTR_LOG_ERROR("Error: %@", error);                                                          \
-            }] PREFIX                                                                                       \
-                GETTER_NAME:^(TYPE returnValue) {                                                           \
-                    outValue = returnValue;                                                                 \
-                }];                                                                                         \
-        } @catch (NSException *exception) {                                                                 \
-            MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                                 \
-            outValue = DEFAULT_VALUE;                                                                       \
-        }                                                                                                   \
-        return outValue;                                                                                    \
+#define MTR_SIMPLE_REMOTE_XPC_GETTER(XPC_CONNECTION, NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, PREFIX)   \
+                                                                                                       \
+    -(TYPE) NAME                                                                                       \
+    {                                                                                                  \
+        __block TYPE outValue = DEFAULT_VALUE;                                                         \
+                                                                                                       \
+        NSXPCConnection * xpcConnection = XPC_CONNECTION;                                              \
+                                                                                                       \
+        @try {                                                                                         \
+            [[xpcConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) { \
+                MTR_LOG_ERROR("Error: %@", error);                                                     \
+            }] PREFIX                                                                                  \
+                GETTER_NAME:^(TYPE returnValue) {                                                      \
+                    outValue = returnValue;                                                            \
+                }];                                                                                    \
+        } @catch (NSException * exception) {                                                           \
+            MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                            \
+            outValue = DEFAULT_VALUE;                                                                  \
+        }                                                                                              \
+        return outValue;                                                                               \
     }
 
-#define MTR_SIMPLE_REMOTE_XPC_COMMAND(XPC_CONNECTION, METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, PREFIX)       \
-                                                                                                            \
-    -(void) METHOD_SIGNATURE                                                                                \
-    {                                                                                                       \
-        NSXPCConnection * xpcConnection = XPC_CONNECTION;                                                   \
-                                                                                                            \
-        @try {                                                                                              \
-            [[xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {                 \
-                MTR_LOG_ERROR("Error: %@", error);                                                          \
-            }] PREFIX ADDITIONAL_ARGUMENTS];                                                                \
-        } @catch (NSException *exception) {                                                                 \
-            MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                                 \
-        }                                                                                                   \
+#define MTR_SIMPLE_REMOTE_XPC_COMMAND(XPC_CONNECTION, METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, PREFIX) \
+                                                                                                      \
+    -(void) METHOD_SIGNATURE                                                                          \
+    {                                                                                                 \
+        NSXPCConnection * xpcConnection = XPC_CONNECTION;                                             \
+                                                                                                      \
+        @try {                                                                                        \
+            [[xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {           \
+                MTR_LOG_ERROR("Error: %@", error);                                                    \
+            }] PREFIX ADDITIONAL_ARGUMENTS];                                                          \
+        } @catch (NSException * exception) {                                                          \
+            MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                           \
+        }                                                                                             \
     }
 
 #define MTR_COMPLEX_REMOTE_XPC_GETTER(XPC_CONNECTION, SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, PREFIX) \
@@ -117,7 +117,7 @@ typedef struct {} variable_hidden_by_mtr_hide;
             }] PREFIX ADDITIONAL_ARGUMENTS:^(TYPE returnValue) {                                                    \
                 outValue = returnValue;                                                                             \
             }];                                                                                                     \
-        } @catch (NSException *exception) {                                                                         \
+        } @catch (NSException * exception) {                                                                        \
             MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                                         \
             outValue = DEFAULT_VALUE;                                                                               \
         }                                                                                                           \

--- a/src/darwin/Framework/CHIP/MTRDefines_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDefines_Internal.h
@@ -84,7 +84,7 @@ typedef struct {} variable_hidden_by_mtr_hide;
                 }];                                                                                         \
         } @catch (NSException *exception) {                                                                 \
             MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                                 \
-            outValue = DEFAULT_VALUE;                                                                               \
+            outValue = DEFAULT_VALUE;                                                                       \
         }                                                                                                   \
         return outValue;                                                                                    \
     }

--- a/src/darwin/Framework/CHIP/MTRDefines_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDefines_Internal.h
@@ -67,33 +67,41 @@ typedef struct {} variable_hidden_by_mtr_hide;
 
 #pragma mark - XPC Defines
 
-#define MTR_SIMPLE_REMOTE_XPC_GETTER(XPC_CONNECTION, NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, PREFIX) \
-                                                                                                     \
-    -(TYPE) NAME                                                                                     \
-    {                                                                                                \
-        __block TYPE outValue = DEFAULT_VALUE;                                                       \
-                                                                                                     \
-        NSXPCConnection * xpcConnection = XPC_CONNECTION;                                            \
-                                                                                                     \
-        [[xpcConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {   \
-            MTR_LOG_ERROR("Error: %@", error);                                                       \
-        }] PREFIX                                                                                    \
-            GETTER_NAME:^(TYPE returnValue) {                                                        \
-                outValue = returnValue;                                                              \
-            }];                                                                                      \
-                                                                                                     \
-        return outValue;                                                                             \
+#define MTR_SIMPLE_REMOTE_XPC_GETTER(XPC_CONNECTION, NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, PREFIX)        \
+                                                                                                            \
+    -(TYPE) NAME                                                                                            \
+    {                                                                                                       \
+        __block TYPE outValue = DEFAULT_VALUE;                                                              \
+                                                                                                            \
+        NSXPCConnection * xpcConnection = XPC_CONNECTION;                                                   \
+                                                                                                            \
+        @try {                                                                                              \
+            [[xpcConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {      \
+                MTR_LOG_ERROR("Error: %@", error);                                                          \
+            }] PREFIX                                                                                       \
+                GETTER_NAME:^(TYPE returnValue) {                                                           \
+                    outValue = returnValue;                                                                 \
+                }];                                                                                         \
+        } @catch (NSException *exception) {                                                                 \
+            MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                                 \
+            outValue = DEFAULT_VALUE;                                                                               \
+        }                                                                                                   \
+        return outValue;                                                                                    \
     }
 
-#define MTR_SIMPLE_REMOTE_XPC_COMMAND(XPC_CONNECTION, METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, PREFIX) \
-                                                                                                      \
-    -(void) METHOD_SIGNATURE                                                                          \
-    {                                                                                                 \
-        NSXPCConnection * xpcConnection = XPC_CONNECTION;                                             \
-                                                                                                      \
-        [[xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {               \
-            MTR_LOG_ERROR("Error: %@", error);                                                        \
-        }] PREFIX ADDITIONAL_ARGUMENTS];                                                              \
+#define MTR_SIMPLE_REMOTE_XPC_COMMAND(XPC_CONNECTION, METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, PREFIX)       \
+                                                                                                            \
+    -(void) METHOD_SIGNATURE                                                                                \
+    {                                                                                                       \
+        NSXPCConnection * xpcConnection = XPC_CONNECTION;                                                   \
+                                                                                                            \
+        @try {                                                                                              \
+            [[xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {                 \
+                MTR_LOG_ERROR("Error: %@", error);                                                          \
+            }] PREFIX ADDITIONAL_ARGUMENTS];                                                                \
+        } @catch (NSException *exception) {                                                                 \
+            MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                                 \
+        }                                                                                                   \
     }
 
 #define MTR_COMPLEX_REMOTE_XPC_GETTER(XPC_CONNECTION, SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, PREFIX) \
@@ -103,11 +111,16 @@ typedef struct {} variable_hidden_by_mtr_hide;
                                                                                                                     \
         NSXPCConnection * xpcConnection = XPC_CONNECTION;                                                           \
                                                                                                                     \
-        [[xpcConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {                  \
-            MTR_LOG_ERROR("Error: %@", error);                                                                      \
-        }] PREFIX ADDITIONAL_ARGUMENTS:^(TYPE returnValue) {                                                        \
-            outValue = returnValue;                                                                                 \
-        }];                                                                                                         \
+        @try {                                                                                                      \
+            [[xpcConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {              \
+                MTR_LOG_ERROR("Error: %@", error);                                                                  \
+            }] PREFIX ADDITIONAL_ARGUMENTS:^(TYPE returnValue) {                                                    \
+                outValue = returnValue;                                                                             \
+            }];                                                                                                     \
+        } @catch (NSException *exception) {                                                                         \
+            MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                                         \
+            outValue = DEFAULT_VALUE;                                                                               \
+        }                                                                                                           \
                                                                                                                     \
         return outValue;                                                                                            \
     }

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -46,40 +46,41 @@
 
 #pragma mark - Device Node ID Commands
 
-- (void)_registerNodeID:(NSNumber *)nodeID {
+- (void)_registerNodeID:(NSNumber *)nodeID
+{
     @try {
         [[self.xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
             MTR_LOG_ERROR("Register node error: %@   nodeID: %@", error, nodeID);
-        }] deviceController:self.uniqueIdentifier registerNodeID: nodeID];
-    } @catch (NSException *exception) {
+        }] deviceController:self.uniqueIdentifier registerNodeID:nodeID];
+    } @catch (NSException * exception) {
         MTR_LOG_ERROR("Exception registering nodeID: %@", exception);
     }
 }
 
-
-- (void)_unregisterNodeID:(NSNumber *)nodeID {
+- (void)_unregisterNodeID:(NSNumber *)nodeID
+{
     @try {
         [[self.xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
             MTR_LOG_ERROR("Unregister node error: %@   nodeID: %@", error, nodeID);
-        }] deviceController:self.uniqueIdentifier unregisterNodeID: nodeID];
-    } @catch (NSException *exception) {
+        }] deviceController:self.uniqueIdentifier unregisterNodeID:nodeID];
+    } @catch (NSException * exception) {
         MTR_LOG_ERROR("Exception registering nodeID: %@", exception);
     }
 }
 
-
-- (void)_checkinWithContext:(NSDictionary *)context {
+- (void)_checkinWithContext:(NSDictionary *)context
+{
     @try {
-        if ( !context ) context = [NSDictionary dictionary];
+        if (!context)
+            context = [NSDictionary dictionary];
 
         [[self.xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
             MTR_LOG_ERROR("Checkin error: %@", error);
         }] deviceController:self.uniqueIdentifier checkInWithContext:context];
-    } @catch (NSException *exception) {
+    } @catch (NSException * exception) {
         MTR_LOG_ERROR("Exception registering nodeID: %@", exception);
     }
 }
-
 
 #pragma mark - XPC
 + (NSMutableSet *)_allowedClasses
@@ -240,7 +241,7 @@
         MTR_LOG("%@ Activating new XPC connection", self);
         [self.xpcConnection activate];
 
-        [self _checkinWithContext: [NSDictionary dictionary]];
+        [self _checkinWithContext:[NSDictionary dictionary]];
 
         // FIXME: Trying to kick all the MTRDevices attached to this controller to re-establish connections
         //        This state needs to be stored properly and re-established at connnection time
@@ -248,7 +249,7 @@
         MTR_LOG("%@ Starting existing NodeID Registration", self);
         for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
             MTR_LOG("%@ => Registering nodeID: %@", self, nodeID);
-            [self _registerNodeID: nodeID];
+            [self _registerNodeID:nodeID];
         }
 
         MTR_LOG("%@ Done existing NodeID Registration", self);
@@ -339,7 +340,7 @@
     [self.nodeIDToDeviceMap setObject:deviceToReturn forKey:nodeID];
     MTR_LOG("%s: returning XPC device for node id %@", __PRETTY_FUNCTION__, nodeID);
 
-    [self _registerNodeID: nodeID];
+    [self _registerNodeID:nodeID];
 
     return deviceToReturn;
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -44,6 +44,44 @@
 
 @implementation MTRDeviceController_XPC
 
+#pragma mark - Device Node ID Commands
+
+- (void)_registerNodeID:(NSNumber *)nodeID {
+    @try {
+        [[self.xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
+            MTR_LOG_ERROR("Register node error: %@   nodeID: %@", error, nodeID);
+        }] deviceController:self.uniqueIdentifier registerNodeID: nodeID];
+    } @catch (NSException *exception) {
+        MTR_LOG_ERROR("Exception registering nodeID: %@", exception);
+    }
+}
+
+
+- (void)_unregisterNodeID:(NSNumber *)nodeID {
+    @try {
+        [[self.xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
+            MTR_LOG_ERROR("Unregister node error: %@   nodeID: %@", error, nodeID);
+        }] deviceController:self.uniqueIdentifier unregisterNodeID: nodeID];
+    } @catch (NSException *exception) {
+        MTR_LOG_ERROR("Exception registering nodeID: %@", exception);
+    }
+}
+
+
+- (void)_checkinWithContext:(NSDictionary *)context {
+    @try {
+        if ( !context ) context = [NSDictionary dictionary];
+        
+        [[self.xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
+            MTR_LOG_ERROR("Checkin error: %@", error);
+        }] deviceController:self.uniqueIdentifier checkInWithContext:context];
+    } @catch (NSException *exception) {
+        MTR_LOG_ERROR("Exception registering nodeID: %@", exception);
+    }
+}
+
+
+#pragma mark - XPC
 + (NSMutableSet *)_allowedClasses
 {
     static NSArray * sBaseAllowedClasses = @[
@@ -202,9 +240,7 @@
         MTR_LOG("%@ Activating new XPC connection", self);
         [self.xpcConnection activate];
 
-        [[self.xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
-            MTR_LOG_ERROR("Checkin error: %@", error);
-        }] deviceController:self.uniqueIdentifier checkInWithContext:[NSDictionary dictionary]];
+        [self _checkinWithContext: [NSDictionary dictionary]];
 
         // FIXME: Trying to kick all the MTRDevices attached to this controller to re-establish connections
         //        This state needs to be stored properly and re-established at connnection time
@@ -212,12 +248,7 @@
         MTR_LOG("%@ Starting existing NodeID Registration", self);
         for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
             MTR_LOG("%@ => Registering nodeID: %@", self, nodeID);
-            mtr_weakify(self);
-
-            [[self.xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
-                mtr_strongify(self);
-                MTR_LOG_ERROR("%@ Registration error for device nodeID: %@ : %@", self, nodeID, error);
-            }] deviceController:self.uniqueIdentifier registerNodeID:nodeID];
+            [self _registerNodeID: nodeID];
         }
 
         MTR_LOG("%@ Done existing NodeID Registration", self);
@@ -308,11 +339,7 @@
     [self.nodeIDToDeviceMap setObject:deviceToReturn forKey:nodeID];
     MTR_LOG("%s: returning XPC device for node id %@", __PRETTY_FUNCTION__, nodeID);
 
-    mtr_weakify(self);
-    [[self.xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
-        mtr_strongify(self);
-        MTR_LOG_ERROR("%@ Registration error for device nodeID: %@ : %@", self, nodeID, error);
-    }] deviceController:self.uniqueIdentifier registerNodeID:nodeID];
+    [self _registerNodeID: nodeID];
 
     return deviceToReturn;
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -71,7 +71,7 @@
 - (void)_checkinWithContext:(NSDictionary *)context {
     @try {
         if ( !context ) context = [NSDictionary dictionary];
-        
+
         [[self.xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
             MTR_LOG_ERROR("Checkin error: %@", error);
         }] deviceController:self.uniqueIdentifier checkInWithContext:context];

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -249,19 +249,23 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
 {
     NSXPCConnection * xpcConnection = [(MTRDeviceController_XPC *) [self deviceController] xpcConnection];
 
-    [[xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
-        MTR_LOG_ERROR("Error: %@", error);
-    }] deviceController:[[self deviceController] uniqueIdentifier]
-                             nodeID:[self nodeID]
-        invokeCommandWithEndpointID:endpointID
-                          clusterID:clusterID
-                          commandID:commandID
-                      commandFields:commandFields
-                     expectedValues:expectedValues
-              expectedValueInterval:expectedValueInterval
-                 timedInvokeTimeout:timeout
-        serverSideProcessingTimeout:serverSideProcessingTimeout
-                         completion:completion];
+    @try {
+        [[xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
+            MTR_LOG_ERROR("Error: %@", error);
+        }] deviceController:[[self deviceController] uniqueIdentifier]
+                                 nodeID:[self nodeID]
+            invokeCommandWithEndpointID:endpointID
+                              clusterID:clusterID
+                              commandID:commandID
+                          commandFields:commandFields
+                         expectedValues:expectedValues
+                  expectedValueInterval:expectedValueInterval
+                     timedInvokeTimeout:timeout
+            serverSideProcessingTimeout:serverSideProcessingTimeout
+                             completion:completion];
+    } @catch (NSException *exception) {
+        MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);
+    }
 }
 
 // Not Supported via XPC

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -263,7 +263,7 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
                      timedInvokeTimeout:timeout
             serverSideProcessingTimeout:serverSideProcessingTimeout
                              completion:completion];
-    } @catch (NSException *exception) {
+    } @catch (NSException * exception) {
         MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);
     }
 }


### PR DESCRIPTION
When we call into an XPC object, it might throw an exception, so we should catch it!