### PR TITLE
Remove provisional status of Fabric Sync bits to align with the spec

### DIFF
--- a/examples/fabric-bridge-app/fabric-bridge-common/fabric-bridge-app.matter
+++ b/examples/fabric-bridge-app/fabric-bridge-common/fabric-bridge-app.matter
@@ -1697,7 +1697,7 @@ cluster GroupKeyManagement = 63 {
 }
 
 /** Supports the ability for clients to request the commissioning of themselves or other nodes onto a fabric which the cluster server can commission onto. */
-provisional cluster CommissionerControl = 1873 {
+cluster CommissionerControl = 1873 {
   revision 1;
 
   bitmap SupportedDeviceCategoryBitmap : bitmap32 {

--- a/src/app/zap-templates/zcl/data-model/chip/bridged-device-basic-information.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/bridged-device-basic-information.xml
@@ -95,7 +95,7 @@ limitations under the License.
         <attribute side="server" code="18" define="UNIQUE_ID"                 type="char_string"               length="32"                              optional="false">UniqueID</attribute>
         <attribute side="server" code="20" define="PRODUCT_APPEARANCE"        type="ProductAppearanceStruct"                                            optional="true">ProductAppearance</attribute>
 
-        <command source="client" code="0x80" name="KeepActive" optional="true" apiMaturity="provisional">
+        <command source="client" code="0x80" name="KeepActive" optional="true">
           <description> The server SHALL attempt to keep the devices specified active for StayActiveDuration milliseconds when they are next active.</description>
           <arg id="0" name="StayActiveDuration" type="int32u"/>
           <arg id="1" name="TimeoutMs" type="int32u" min="30000" max="3600000"/>

--- a/src/app/zap-templates/zcl/data-model/chip/commissioner-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/commissioner-control-cluster.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <field name="FabricSynchronization" mask="0x1"/>
   </bitmap>
 
-  <cluster apiMaturity="provisional">
+  <cluster>
     <domain>General</domain>
     <name>Commissioner Control</name>
     <code>0x0751</code>

--- a/src/app/zap-templates/zcl/data-model/chip/ecosystem-information-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/ecosystem-information-cluster.xml
@@ -16,7 +16,7 @@ limitations under the License.
 -->
 <configurator>
   <domain name="CHIP"/>
-  <struct name="EcosystemDeviceStruct" isFabricScoped="true" apiMaturity="provisional">
+  <struct name="EcosystemDeviceStruct" isFabricScoped="true">
     <cluster code="0x0750"/>
     <item fieldId="0" name="DeviceName" type="char_string" optional="true" isFabricSensitive="true" length="64"/>
     <item fieldId="1" name="DeviceNameLastEdit" type="epoch_us" optional="true" isFabricSensitive="true" default="0"/>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -9590,7 +9590,7 @@ provisional cluster EcosystemInformation = 1872 {
 }
 
 /** Supports the ability for clients to request the commissioning of themselves or other nodes onto a fabric which the cluster server can commission onto. */
-provisional cluster CommissionerControl = 1873 {
+cluster CommissionerControl = 1873 {
   revision 1;
 
   bitmap SupportedDeviceCategoryBitmap : bitmap32 {


### PR DESCRIPTION
Fabric Sync bits are officially landed in Matter spec ToT by default, remove provisional status of Fabric Sync bits in SDK to align with the spec

