### PR TITLE
Add missing feature map bit

### DIFF
--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -3222,7 +3222,7 @@ endpoint 2 {
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute attributeList;
-    ram      attribute featureMap default = 2;
+    ram      attribute featureMap default = 6;
     ram      attribute clusterRevision default = 2;
   }
 }

--- a/examples/light-switch-app/light-switch-common/light-switch-app.zap
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.zap
@@ -5587,7 +5587,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "2",
+              "defaultValue": "6",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,


### PR DESCRIPTION
#### Description
Light-Switch Data Model didn't have the correct feature map bits for what the apps would generate.
PR updates the ZAP configurations with the correct FeatureMap value.

Issue was found as part of the SVE testing for the Switch Cluster

#### Testing
Certification tests
