### PR TITLE
TC-DA-1.2: Better error messages

### DIFF
--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -383,7 +383,12 @@ class TC_DA_1_2(MatterBaseTest, BasicCompositionTests):
             if '.der' not in filename:
                 continue
             with open(os.path.join(cd_cert_dir, filename), 'rb') as f:
-                cert = x509.load_der_x509_certificate(f.read())
+                logging.info(f'Parsing CD signing certificate file: {filename}')
+                try:
+                    cert = x509.load_der_x509_certificate(f.read())
+                except ValueError:
+                    logging.info(f'File is not a valid certificate, skipping')
+                    pass
                 pub = cert.public_key()
                 ski = x509.SubjectKeyIdentifier.from_public_key(pub).digest
                 certs[ski] = pub

--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -388,7 +388,7 @@ class TC_DA_1_2(MatterBaseTest, BasicCompositionTests):
                 try:
                     cert = x509.load_der_x509_certificate(f.read())
                 except ValueError:
-                    logging.info(f'File is not a valid certificate, skipping')
+                    logging.info(f'File {filename} is not a valid certificate, skipping')
                     pass
                 pub = cert.public_key()
                 ski = x509.SubjectKeyIdentifier.from_public_key(pub).digest

--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -27,6 +27,7 @@
 # test-runner-run/run1/script-args: --storage-path admin_storage.json --commissioning-method on-network --discriminator 1234 --passcode 20202021 --PICS src/app/tests/suites/certification/ci-pics-values --trace-to json:${TRACE_TEST_JSON}.json --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 # === END CI TEST ARGUMENTS ===
 
+import logging
 import os
 import random
 import re


### PR DESCRIPTION
Test: Added a bad der file in the cd-certs dir, saw failure on
      ToT, no failure with this fix.

