### PR TITLE
[shell] Shedule factory reset in Server using Matter Shell command

### DIFF
--- a/src/lib/shell/commands/Device.cpp
+++ b/src/lib/shell/commands/Device.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <app/server/Server.h>
 #include <lib/shell/Commands.h>
 #include <lib/shell/Engine.h>
 #include <lib/shell/SubShellCommand.h>
@@ -27,7 +28,7 @@ namespace Shell {
 static CHIP_ERROR FactoryResetHandler(int argc, char ** argv)
 {
     streamer_printf(streamer_get(), "Performing factory reset ... \r\n");
-    DeviceLayer::ConfigurationMgr().InitiateFactoryReset();
+    chip::Server::GetInstance().ScheduleFactoryReset();
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
It is better to call the ScheduleFactoryReset method from the Server because it also removes all fabrics and emits the Leave event whereas calling InitiateFactoryReset() removes only the persistent storage entries.

