### PR TITLE
One more decouple from ember from src/app and ensure we can compile without `ember-compatibility-functions.cpp`

### DIFF
--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -65,7 +65,7 @@ jobs:
                         --target linux-arm64-chip-tool-nodeps-ipv6only \
                         --target linux-arm64-lock-clang \
                         --target linux-arm64-minmdns-clang \
-                        --target linux-arm64-light-rpc-ipv6only-clang \
+                        --target linux-arm64-light-data-model-enabled-rpc-ipv6only-clang \
                         --target linux-arm64-thermostat-no-ble-clang \
                         --target linux-arm64-lit-icd-no-ble-clang \
                         --target linux-arm64-fabric-admin-clang-rpc \

--- a/examples/common/pigweed/rpc_services/Attributes.h
+++ b/examples/common/pigweed/rpc_services/Attributes.h
@@ -21,6 +21,7 @@
 #include "attributes_service/attributes_service.rpc.pb.h"
 #include "pigweed/rpc_services/internal/StatusUtils.h"
 
+#include <app/AppConfig.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/AttributeReportIBs.h>
@@ -31,6 +32,13 @@
 #include <lib/core/TLVTags.h>
 #include <lib/core/TLVTypes.h>
 #include <platform/PlatformManager.h>
+
+#if CHIP_CONFIG_USE_DATA_MODEL_INTERFACE
+#include <app/data-model-provider/Provider.h>
+#include <app/AttributeValueEncoder.h>
+#include <app/data-model-provider/ActionReturnStatus.h>
+#include <app/data-model-provider/OperationTypes.h>
+#endif
 
 namespace chip {
 namespace rpc {
@@ -202,11 +210,40 @@ private:
         writer.Init(tlvBuffer);
         PW_TRY(ChipErrorToPwStatus(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outer)));
         PW_TRY(ChipErrorToPwStatus(attributeReports.Init(&writer, kReportContextTag)));
+
+#if CHIP_CONFIG_USE_DATA_MODEL_INTERFACE
+        // TODO: this assumes a singleton data model provider
+        app::DataModel::Provider *provider = app::InteractionModelEngine::GetInstance()->GetDataModelProvider();
+
+        app::DataModel::ReadAttributeRequest request;
+        request.path = path;
+        request.operationFlags.Set(app::DataModel::OperationFlags::kInternal);
+        request.subjectDescriptor = subjectDescriptor;
+
+        std::optional<app::DataModel::ClusterInfo> info = provider->GetClusterInfo(path);
+        if (!info.has_value()) {
+            return ::pw::Status::NotFound();
+        }
+
+        app::AttributeValueEncoder encoder(attributeReports, subjectDescriptor, path, info->dataVersion, false /* isFabricFiltered */, nullptr  /* attributeEncodingState */);
+        app::DataModel::ActionReturnStatus result = provider->ReadAttribute(request, encoder);
+
+        if (!result.IsSuccess()) 
+        {
+            app::DataModel::ActionReturnStatus::StringStorage storage;
+            ChipLogError(Support, "Failed to read data: %s", result.c_str(storage));
+            return ::pw::Status::Internal();
+        }
+
+#else
         PW_TRY(ChipErrorToPwStatus(app::ReadSingleClusterData(subjectDescriptor, false, path, attributeReports, nullptr)));
+#endif
+
         attributeReports.EndOfContainer();
         PW_TRY(ChipErrorToPwStatus(writer.EndContainer(outer)));
         PW_TRY(ChipErrorToPwStatus(writer.Finalize()));
         tlvBuffer.reduce_size(writer.GetLengthWritten());
+// FIXME: do not implement
 
         return ::pw::OkStatus();
     }

--- a/examples/common/pigweed/rpc_services/Attributes.h
+++ b/examples/common/pigweed/rpc_services/Attributes.h
@@ -245,7 +245,6 @@ private:
         PW_TRY(ChipErrorToPwStatus(writer.EndContainer(outer)));
         PW_TRY(ChipErrorToPwStatus(writer.Finalize()));
         tlvBuffer.reduce_size(writer.GetLengthWritten());
-        // FIXME: do not implement
 
         return ::pw::OkStatus();
     }

--- a/examples/common/pigweed/rpc_services/Attributes.h
+++ b/examples/common/pigweed/rpc_services/Attributes.h
@@ -21,8 +21,8 @@
 #include "attributes_service/attributes_service.rpc.pb.h"
 #include "pigweed/rpc_services/internal/StatusUtils.h"
 
-#include <app/AppConfig.h>
 #include <app-common/zap-generated/attribute-type.h>
+#include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/AttributeReportIBs.h>
 #include <app/util/attribute-storage.h>
@@ -34,10 +34,10 @@
 #include <platform/PlatformManager.h>
 
 #if CHIP_CONFIG_USE_DATA_MODEL_INTERFACE
-#include <app/data-model-provider/Provider.h>
 #include <app/AttributeValueEncoder.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
 #include <app/data-model-provider/OperationTypes.h>
+#include <app/data-model-provider/Provider.h>
 #endif
 
 namespace chip {
@@ -213,7 +213,7 @@ private:
 
 #if CHIP_CONFIG_USE_DATA_MODEL_INTERFACE
         // TODO: this assumes a singleton data model provider
-        app::DataModel::Provider *provider = app::InteractionModelEngine::GetInstance()->GetDataModelProvider();
+        app::DataModel::Provider * provider = app::InteractionModelEngine::GetInstance()->GetDataModelProvider();
 
         app::DataModel::ReadAttributeRequest request;
         request.path = path;
@@ -221,14 +221,16 @@ private:
         request.subjectDescriptor = subjectDescriptor;
 
         std::optional<app::DataModel::ClusterInfo> info = provider->GetClusterInfo(path);
-        if (!info.has_value()) {
+        if (!info.has_value())
+        {
             return ::pw::Status::NotFound();
         }
 
-        app::AttributeValueEncoder encoder(attributeReports, subjectDescriptor, path, info->dataVersion, false /* isFabricFiltered */, nullptr  /* attributeEncodingState */);
+        app::AttributeValueEncoder encoder(attributeReports, subjectDescriptor, path, info->dataVersion,
+                                           false /* isFabricFiltered */, nullptr /* attributeEncodingState */);
         app::DataModel::ActionReturnStatus result = provider->ReadAttribute(request, encoder);
 
-        if (!result.IsSuccess()) 
+        if (!result.IsSuccess())
         {
             app::DataModel::ActionReturnStatus::StringStorage storage;
             ChipLogError(Support, "Failed to read data: %s", result.c_str(storage));
@@ -243,7 +245,7 @@ private:
         PW_TRY(ChipErrorToPwStatus(writer.EndContainer(outer)));
         PW_TRY(ChipErrorToPwStatus(writer.Finalize()));
         tlvBuffer.reduce_size(writer.GetLengthWritten());
-// FIXME: do not implement
+        // FIXME: do not implement
 
         return ::pw::OkStatus();
     }

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -80,7 +80,7 @@ void WriteHandler::Close()
     MoveToState(State::Uninitialized);
 }
 
-bool WriteHandler::IsAttributeList(const ConcreteAttributePath & path)
+bool WriteHandler::IsListAttributePath(const ConcreteAttributePath & path)
 {
 #if CHIP_CONFIG_USE_DATA_MODEL_INTERFACE
     VerifyOrReturnValue(mDataModelProvider != nullptr, false,
@@ -340,7 +340,7 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataIBs(TLV::TLVReader & aAttributeData
         err = element.GetData(&dataReader);
         SuccessOrExit(err);
 
-        if (!dataAttributePath.IsListOperation() && IsAttributeList(dataAttributePath))
+        if (!dataAttributePath.IsListOperation() && IsListAttributePath(dataAttributePath))
         {
             dataAttributePath.mListOp = ConcreteDataAttributePath::ListOperation::ReplaceAll;
         }
@@ -484,7 +484,7 @@ CHIP_ERROR WriteHandler::ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttribut
             {
                 needToCheckListOperation = false;
 
-                if (!dataAttributePath.IsListOperation() && IsAttributeList(dataAttributePath))
+                if (!dataAttributePath.IsListOperation() && IsListAttributePath(dataAttributePath))
                 {
                     dataAttributePath.mListOp = ConcreteDataAttributePath::ListOperation::ReplaceAll;
                 }

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -97,7 +97,7 @@ bool WriteHandler::IsAttributeList(const ConcreteAttributePath & path)
     return info->flags.Has(DataModel::AttributeQualityFlags::kListAttribute);
 #else
     constexpr uint8_t kListAttributeType = 0x48;
-    const auto attributeMetadata         = GetAttributeMetadata(dataAttributePath);
+    const auto attributeMetadata         = GetAttributeMetadata(path);
     return (attributeMetadata != nullptr && attributeMetadata->attributeType == kListAttributeType);
 #endif
 }

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -466,7 +466,6 @@ CHIP_ERROR WriteHandler::ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttribut
             mProcessingAttributePath, mStateFlags.Has(StateBits::kProcessingAttributeIsList), dataAttributePath);
         bool shouldReportListWriteBegin = false; // This will be set below.
 
-
         bool needToCheckListOperation = true;
 
         while (iterator->Next(mapping))

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -16,8 +16,6 @@
  *    limitations under the License.
  */
 
-#include "app/data-model-provider/MetadataTypes.h"
-#include "lib/support/logging/TextOnlyLogging.h"
 #include <app/AppConfig.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/AttributeValueDecoder.h>
@@ -26,6 +24,7 @@
 #include <app/MessageDef/StatusIB.h>
 #include <app/StatusResponse.h>
 #include <app/WriteHandler.h>
+#include <app/data-model-provider/MetadataTypes.h>
 #include <app/data-model-provider/OperationTypes.h>
 #include <app/reporting/Engine.h>
 #include <app/util/MatterCallbacks.h>
@@ -34,6 +33,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/TypeTraits.h>
+#include <lib/support/logging/TextOnlyLogging.h>
 #include <messaging/ExchangeContext.h>
 #include <protocols/interaction_model/StatusCode.h>
 

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -44,7 +44,6 @@ namespace app {
 
 using namespace Protocols::InteractionModel;
 using Status                         = Protocols::InteractionModel::Status;
-constexpr uint8_t kListAttributeType = 0x48;
 
 CHIP_ERROR WriteHandler::Init(DataModel::Provider * apProvider, WriteHandlerDelegate * apWriteHandlerDelegate)
 {
@@ -97,6 +96,7 @@ bool WriteHandler::IsAttributeList(const ConcreteAttributePath & path)
 
     return info->flags.Has(DataModel::AttributeQualityFlags::kListAttribute);
 #else
+    constexpr uint8_t kListAttributeType = 0x48;
     const auto attributeMetadata = GetAttributeMetadata(dataAttributePath);
     return (attributeMetadata != nullptr && attributeMetadata->attributeType == kListAttributeType);
 #endif

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -43,7 +43,7 @@ namespace chip {
 namespace app {
 
 using namespace Protocols::InteractionModel;
-using Status                         = Protocols::InteractionModel::Status;
+using Status = Protocols::InteractionModel::Status;
 
 CHIP_ERROR WriteHandler::Init(DataModel::Provider * apProvider, WriteHandlerDelegate * apWriteHandlerDelegate)
 {
@@ -97,7 +97,7 @@ bool WriteHandler::IsAttributeList(const ConcreteAttributePath & path)
     return info->flags.Has(DataModel::AttributeQualityFlags::kListAttribute);
 #else
     constexpr uint8_t kListAttributeType = 0x48;
-    const auto attributeMetadata = GetAttributeMetadata(dataAttributePath);
+    const auto attributeMetadata         = GetAttributeMetadata(dataAttributePath);
     return (attributeMetadata != nullptr && attributeMetadata->attributeType == kListAttributeType);
 #endif
 }

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -189,7 +189,7 @@ private:
     CHIP_ERROR WriteClusterData(const Access::SubjectDescriptor & aSubject, const ConcreteDataAttributePath & aPath,
                                 TLV::TLVReader & aData);
 
-    bool IsAttributeList(const ConcreteAttributePath &path);
+    bool IsAttributeList(const ConcreteAttributePath & path);
 
     Messaging::ExchangeHolder mExchangeCtx;
     WriteResponseMessage::Builder mWriteResponseBuilder;

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -189,7 +189,8 @@ private:
     CHIP_ERROR WriteClusterData(const Access::SubjectDescriptor & aSubject, const ConcreteDataAttributePath & aPath,
                                 TLV::TLVReader & aData);
 
-    bool IsAttributeList(const ConcreteAttributePath & path);
+    // Checks if the given path corresponds to a list attribute
+    bool IsListAttributePath(const ConcreteAttributePath & path);
 
     Messaging::ExchangeHolder mExchangeCtx;
     WriteResponseMessage::Builder mWriteResponseBuilder;

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -189,7 +189,7 @@ private:
     CHIP_ERROR WriteClusterData(const Access::SubjectDescriptor & aSubject, const ConcreteDataAttributePath & aPath,
                                 TLV::TLVReader & aData);
 
-    /// Checks if the given path corresponds to a list attribute
+    /// Checks whether the given path corresponds to a list attribute
     /// Return values:
     ///    true/false: valid attribute path, known if list or not
     ///    std::nulloptr - path not available/valid, unknown if attribute is a list or not

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -189,6 +189,8 @@ private:
     CHIP_ERROR WriteClusterData(const Access::SubjectDescriptor & aSubject, const ConcreteDataAttributePath & aPath,
                                 TLV::TLVReader & aData);
 
+    bool IsAttributeList(const ConcreteAttributePath &path);
+
     Messaging::ExchangeHolder mExchangeCtx;
     WriteResponseMessage::Builder mWriteResponseBuilder;
     Optional<ConcreteAttributePath> mProcessingAttributePath;

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -189,8 +189,11 @@ private:
     CHIP_ERROR WriteClusterData(const Access::SubjectDescriptor & aSubject, const ConcreteDataAttributePath & aPath,
                                 TLV::TLVReader & aData);
 
-    // Checks if the given path corresponds to a list attribute
-    bool IsListAttributePath(const ConcreteAttributePath & path);
+    /// Checks if the given path corresponds to a list attribute
+    /// Return values:
+    ///    true/false: valid attribute path, known if list or not
+    ///    std::nulloptr - path not available/valid, unknown if attribute is a list or not
+    std::optional<bool> IsListAttributePath(const ConcreteAttributePath & path);
 
     Messaging::ExchangeHolder mExchangeCtx;
     WriteResponseMessage::Builder mWriteResponseBuilder;

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -70,10 +70,15 @@ endfunction()
 #
 function(chip_configure_data_model APP_TARGET)
     set(SCOPE PRIVATE)
-    cmake_parse_arguments(ARG "" "SCOPE;ZAP_FILE;IDL" "EXTERNAL_CLUSTERS" ${ARGN})
+    set(ADD_EMBER_INTERFACE_FILES TRUE)
+    cmake_parse_arguments(ARG "SKIP_EMBER_INTERFACE" "SCOPE;ZAP_FILE;IDL" "EXTERNAL_CLUSTERS" ${ARGN})
 
     if(ARG_SCOPE)
         set(SCOPE ${ARG_SCOPE})
+    endif()
+
+    if(ARG_SKIP_EMBER_INTERFACE)
+        set(ADD_EMBER_INTERFACE_FILES FALSE)
     endif()
 
     # CMAKE data model auto-includes the server side implementation
@@ -159,7 +164,6 @@ function(chip_configure_data_model APP_TARGET)
         ${CHIP_APP_BASE_DIR}/util/attribute-table.cpp
         ${CHIP_APP_BASE_DIR}/util/binding-table.cpp
         ${CHIP_APP_BASE_DIR}/util/DataModelHandler.cpp
-        ${CHIP_APP_BASE_DIR}/util/ember-compatibility-functions.cpp
         ${CHIP_APP_BASE_DIR}/util/ember-global-attribute-access-interface.cpp
         ${CHIP_APP_BASE_DIR}/util/ember-io-storage.cpp
         ${CHIP_APP_BASE_DIR}/util/generic-callback-stubs.cpp
@@ -169,4 +173,10 @@ function(chip_configure_data_model APP_TARGET)
         ${APP_GEN_FILES}
         ${APP_TEMPLATES_GEN_FILES}
     )
+
+    if(ADD_EMBER_INTERFACE_FILES)
+        target_sources(${APP_TARGET} ${SCOPE}
+           ${CHIP_APP_BASE_DIR}/util/ember-compatibility-functions.cpp
+        )
+    endif()
 endfunction()

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -214,8 +214,7 @@ template("chip_data_model") {
         "${_app_root}/util/util.cpp",
       ]
 
-      if (chip_use_data_model_interface != "enabled")
-      {
+      if (chip_use_data_model_interface != "enabled") {
         # This applies to "check" or "disabled" (i.e. use ember-only or use ember for double-checking)
         sources += [ "${_app_root}/util/ember-compatibility-functions.cpp" ]
       }

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -209,11 +209,16 @@ template("chip_data_model") {
         "${_app_root}/util/DataModelHandler.cpp",
         "${_app_root}/util/attribute-storage.cpp",
         "${_app_root}/util/attribute-table.cpp",
-        "${_app_root}/util/ember-compatibility-functions.cpp",
         "${_app_root}/util/ember-global-attribute-access-interface.cpp",
         "${_app_root}/util/ember-io-storage.cpp",
         "${_app_root}/util/util.cpp",
       ]
+
+      if (chip_use_data_model_interface != "enabled")
+      {
+        # This applies to "check" or "disabled" (i.e. use ember-only or use ember for double-checking)
+        sources += [ "${_app_root}/util/ember-compatibility-functions.cpp" ]
+      }
     }
 
     if (defined(invoker.zap_file)) {


### PR DESCRIPTION
Final decouple step so that `ember-compatibility-functions.cpp` is not needed as part of data models.

### Changes

- Removed one more direct ember coupling from WriteHandler
- Updated GN code to not auto-compile ember-compatibility-functions.cpp in case data model is enabled (not in check mode)
- Ensure that we test that this mode compiles by making a build on arm64 build this version
- Update pw_rpc code to be able to use the data model interface for encoding attributes
- Also updated cmake to support this option, however cmake build options are more spread out so I did not use the option. Expect to still be ok because link-time we should remove unreferenced functions. The GN build should ensure no references (there is one more call in `pump-configuration-and-control-server.cpp` that we have to figure out for full support like all-clusters app, I will do that as a followup)