### PR TITLE
Fix Matter.framework path descriptions to be more readable.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -2302,6 +2302,45 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
 
 @end
 
+static NSString * FormatPossiblyWildcardEndpoint(NSNumber * _Nullable possiblyWildcardEndpoint)
+{
+    if (possiblyWildcardEndpoint == nil) {
+        return @"wildcard";
+    }
+
+    return [NSString stringWithFormat:@"%u", possiblyWildcardEndpoint.unsignedShortValue];
+}
+
+static NSString * FormatPossiblyWildcardCluster(NSNumber * _Nullable possiblyWildcardCluster)
+{
+    if (possiblyWildcardCluster == nil) {
+        return @"wildcard";
+    }
+
+    return [NSString stringWithFormat:@"0x%llx (%llu, %@)",
+                     possiblyWildcardCluster.unsignedLongLongValue,
+                     possiblyWildcardCluster.unsignedLongLongValue,
+                     MTRClusterNameForID(static_cast<MTRClusterIDType>(possiblyWildcardCluster.unsignedLongLongValue))];
+}
+
+static NSString * FormatPossiblyWildcardClusterElement(NSNumber * _Nullable possiblyWildcardCluster, NSNumber * _Nullable possiblyWildcardElement, NSString * (^nameGetter)(MTRClusterIDType clusterID, NSNumber * elementID))
+{
+    if (possiblyWildcardElement == nil) {
+        return @"wildcard";
+    }
+
+    if (possiblyWildcardCluster == nil) {
+        // We can't get a useful name for this, so just return the numeric
+        // value.
+        return [NSString stringWithFormat:@"0x%llx (%llu)", possiblyWildcardElement.unsignedLongLongValue, possiblyWildcardElement.unsignedLongLongValue];
+    }
+
+    return [NSString stringWithFormat:@"0x%llx (%llu, %@)",
+                     possiblyWildcardElement.unsignedLongLongValue,
+                     possiblyWildcardElement.unsignedLongLongValue,
+                     nameGetter(static_cast<MTRClusterIDType>(possiblyWildcardCluster.unsignedLongLongValue), possiblyWildcardElement)];
+}
+
 @implementation MTRAttributeRequestPath
 - (instancetype)initWithEndpointID:(NSNumber * _Nullable)endpointID
                          clusterID:(NSNumber * _Nullable)clusterID
@@ -2315,9 +2354,12 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<MTRAttributeRequestPath endpoint %u cluster 0x%llx (%llu) attribute 0x%llx (%llu)>",
-                     _endpoint.unsignedShortValue, _cluster.unsignedLongLongValue, _cluster.unsignedLongLongValue,
-                     _attribute.unsignedLongLongValue, _attribute.unsignedLongLongValue];
+    NSString * endpointStr = FormatPossiblyWildcardEndpoint(_endpoint);
+    NSString * clusterStr = FormatPossiblyWildcardCluster(_cluster);
+    NSString * attributeStr = FormatPossiblyWildcardClusterElement(_cluster, _attribute, ^(MTRClusterIDType clusterID, NSNumber * attributeID) {
+        return MTRAttributeNameForID(clusterID, static_cast<MTRAttributeIDType>(attributeID.unsignedLongLongValue));
+    });
+    return [NSString stringWithFormat:@"<MTRAttributeRequestPath endpoint %@ cluster %@ attribute %@>", endpointStr, clusterStr, attributeStr];
 }
 
 + (MTRAttributeRequestPath *)requestPathWithEndpointID:(NSNumber * _Nullable)endpointID
@@ -2439,9 +2481,12 @@ static NSString * const sAttributeIDKey = @"attributeIDKey";
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<MTREventRequestPath endpoint %u cluster 0x%llx (%llu) event 0x%llx (%llu)>",
-                     _endpoint.unsignedShortValue, _cluster.unsignedLongLongValue, _cluster.unsignedLongLongValue,
-                     _event.unsignedLongLongValue, _event.unsignedLongLongValue];
+    NSString * endpointStr = FormatPossiblyWildcardEndpoint(_endpoint);
+    NSString * clusterStr = FormatPossiblyWildcardCluster(_cluster);
+    NSString * eventStr = FormatPossiblyWildcardClusterElement(_cluster, _event, ^(MTRClusterIDType clusterID, NSNumber * eventID) {
+        return MTREventNameForID(clusterID, static_cast<MTREventIDType>(eventID.unsignedLongLongValue));
+    });
+    return [NSString stringWithFormat:@"<MTREventRequestPath endpoint %@ cluster %@ event %@>", endpointStr, clusterStr, eventStr];
 }
 
 + (MTREventRequestPath *)requestPathWithEndpointID:(NSNumber * _Nullable)endpointID
@@ -2561,8 +2606,9 @@ static NSString * const sEventAttributeIDKey = @"attributeIDKey";
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<MTRClusterPath endpoint %u cluster 0x%llx (%llu)>", _endpoint.unsignedShortValue,
-                     _cluster.unsignedLongLongValue, _cluster.unsignedLongLongValue];
+    return [NSString stringWithFormat:@"<MTRClusterPath endpoint %u cluster 0x%llx (%llu, %@)>", _endpoint.unsignedShortValue,
+                     _cluster.unsignedLongLongValue, _cluster.unsignedLongLongValue,
+                     MTRClusterNameForID(static_cast<MTRClusterIDType>(_cluster.unsignedLongLongValue))];
 }
 
 + (MTRClusterPath *)clusterPathWithEndpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID
@@ -2646,9 +2692,11 @@ static NSString * const sClusterKey = @"clusterKey";
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<MTRAttributePath endpoint %u cluster 0x%llx (%llu) attribute 0x%llx (%llu)>",
-                     self.endpoint.unsignedShortValue, self.cluster.unsignedLongLongValue, self.cluster.unsignedLongLongValue,
-                     _attribute.unsignedLongLongValue, _attribute.unsignedLongLongValue];
+    return [NSString stringWithFormat:@"<MTRAttributePath endpoint %u cluster 0x%llx (%llu, %@) 0x%llx (%llu, %@)>",
+                     self.endpoint.unsignedShortValue,
+                     self.cluster.unsignedLongLongValue, self.cluster.unsignedLongLongValue, MTRClusterNameForID(static_cast<MTRClusterIDType>(self.cluster.unsignedLongLongValue)),
+                     _attribute.unsignedLongLongValue, _attribute.unsignedLongLongValue,
+                     MTRAttributeNameForID(static_cast<MTRClusterIDType>(self.cluster.unsignedLongLongValue), static_cast<MTRAttributeIDType>(_attribute.unsignedLongLongValue))];
 }
 
 + (MTRAttributePath *)attributePathWithEndpointID:(NSNumber *)endpointID
@@ -2743,8 +2791,11 @@ static NSString * const sAttributeKey = @"attributeKey";
 - (NSString *)description
 {
     return
-        [NSString stringWithFormat:@"<MTREventPath endpoint %u cluster 0x%llx (%llu) event 0x%llx (%llu)>", self.endpoint.unsignedShortValue,
-                  self.cluster.unsignedLongLongValue, self.cluster.unsignedLongLongValue, _event.unsignedLongLongValue, _event.unsignedLongLongValue];
+        [NSString stringWithFormat:@"<MTREventPath endpoint %u cluster 0x%llx (%llu, %@) event 0x%llx (%llu, %@)>",
+                  self.endpoint.unsignedShortValue,
+                  self.cluster.unsignedLongLongValue, self.cluster.unsignedLongLongValue, MTRClusterNameForID(static_cast<MTRClusterIDType>(self.cluster.unsignedLongLongValue)),
+                  _event.unsignedLongLongValue, _event.unsignedLongLongValue,
+                  MTREventNameForID(static_cast<MTRClusterIDType>(self.cluster.unsignedLongLongValue), static_cast<MTREventIDType>(_event.unsignedLongLongValue))];
 }
 
 + (MTREventPath *)eventPathWithEndpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID eventID:(NSNumber *)eventID


### PR DESCRIPTION
1) For request paths, clearly mark wildcards instead of logging 0.

2) For all paths except command paths, when we have a value (cluster id,
   attribute id, event id) that we can find a string representation for,
   log that string representation.

Command paths are a bit complicated because we have to know whether this is a request or a response and we don't have that information in MTRCommandPath at the moment.  Will be done in a followup.
