### PR TITLE
Fix formatting of unknown IDs in MTRClusterNames bits.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRClusterNames-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterNames-src.zapt
@@ -23,7 +23,7 @@ NSString * MTRClusterNameForID(MTRClusterIDType clusterID)
 {{/zcl_clusters}}
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown clusterID %d>", clusterID];
+            result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
             break;
     }
     
@@ -72,7 +72,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
 
 {{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
             default:
-                result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+                result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
                 break;
         }
         break;
@@ -80,7 +80,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
 
 {{/zcl_clusters}}
         default:
-           result = [NSString stringWithFormat:@"<Unknown clusterID %d>", clusterID];
+           result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
            break;
         }
 
@@ -119,7 +119,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
 {{> commandIDs clusterName=label}}
 
             default:
-                result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+                result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
                 break;
         }
         break;
@@ -127,7 +127,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
 
 {{/zcl_clusters}}
         default:
-           result = [NSString stringWithFormat:@"<Unknown clusterID %d>", clusterID];
+           result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
            break;
         }
 
@@ -183,7 +183,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
 
 {{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
             default:
-                result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+                result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
                 break;
         }
         break;
@@ -191,7 +191,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
 
 {{/zcl_clusters}}
         default:
-           result = [NSString stringWithFormat:@"<Unknown clusterID %d>", clusterID];
+           result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
            break;
         }
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterNames.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterNames.mm
@@ -389,7 +389,7 @@ NSString * MTRClusterNameForID(MTRClusterIDType clusterID)
         break;
 
     default:
-        result = [NSString stringWithFormat:@"<Unknown clusterID %d>", clusterID];
+        result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
         break;
     }
 
@@ -442,7 +442,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -481,7 +481,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -536,7 +536,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -627,7 +627,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -662,7 +662,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -717,7 +717,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -756,7 +756,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -819,7 +819,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -866,7 +866,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -993,7 +993,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1028,7 +1028,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1079,7 +1079,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1122,7 +1122,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1169,7 +1169,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1208,7 +1208,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1247,7 +1247,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1410,7 +1410,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1485,7 +1485,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1564,7 +1564,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1599,7 +1599,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1670,7 +1670,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -1721,7 +1721,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2008,7 +2008,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2095,7 +2095,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2166,7 +2166,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2253,7 +2253,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2356,7 +2356,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2403,7 +2403,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2450,7 +2450,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2509,7 +2509,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2560,7 +2560,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2599,7 +2599,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2638,7 +2638,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2677,7 +2677,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2752,7 +2752,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2799,7 +2799,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2858,7 +2858,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2909,7 +2909,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -2952,7 +2952,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3011,7 +3011,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3062,7 +3062,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3113,7 +3113,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3164,7 +3164,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3207,7 +3207,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3250,7 +3250,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3309,7 +3309,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3356,7 +3356,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3407,7 +3407,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3446,7 +3446,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3533,7 +3533,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3584,7 +3584,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3627,7 +3627,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3698,7 +3698,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3757,7 +3757,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3816,7 +3816,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3863,7 +3863,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3922,7 +3922,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -3981,7 +3981,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4048,7 +4048,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4127,7 +4127,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4238,7 +4238,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4297,7 +4297,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4356,7 +4356,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4423,7 +4423,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4466,7 +4466,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4533,7 +4533,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4660,7 +4660,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4715,7 +4715,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4758,7 +4758,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4809,7 +4809,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4860,7 +4860,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -4911,7 +4911,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -5126,7 +5126,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -5249,7 +5249,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -5308,7 +5308,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -5435,7 +5435,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -5710,7 +5710,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -5793,7 +5793,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -5840,7 +5840,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6083,7 +6083,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6174,7 +6174,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6229,7 +6229,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6280,7 +6280,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6351,7 +6351,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6402,7 +6402,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6453,7 +6453,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6544,7 +6544,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6623,7 +6623,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6702,7 +6702,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6781,7 +6781,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6860,7 +6860,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -6939,7 +6939,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7018,7 +7018,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7097,7 +7097,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7176,7 +7176,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7255,7 +7255,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7334,7 +7334,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7377,7 +7377,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7436,7 +7436,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7483,7 +7483,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7526,7 +7526,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7573,7 +7573,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7616,7 +7616,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7695,7 +7695,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7738,7 +7738,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7773,7 +7773,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7808,7 +7808,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7851,7 +7851,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7894,7 +7894,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -7937,7 +7937,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -8004,7 +8004,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -8039,7 +8039,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -8106,7 +8106,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -8141,7 +8141,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -8180,7 +8180,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -8227,7 +8227,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -8270,7 +8270,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -8309,7 +8309,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -8700,7 +8700,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
@@ -8739,13 +8739,13 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown attributeID %d>", attributeID];
+            result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
         break;
 
     default:
-        result = [NSString stringWithFormat:@"<Unknown clusterID %d>", clusterID];
+        result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
         break;
     }
 
@@ -8773,7 +8773,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -8807,7 +8807,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -8841,7 +8841,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -8887,7 +8887,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -8897,7 +8897,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -8907,7 +8907,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -8917,7 +8917,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -8931,7 +8931,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -8989,7 +8989,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -8999,7 +8999,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9021,7 +9021,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9035,7 +9035,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9045,7 +9045,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9055,7 +9055,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9065,7 +9065,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9075,7 +9075,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9085,7 +9085,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9111,7 +9111,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9149,7 +9149,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9163,7 +9163,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9185,7 +9185,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9199,7 +9199,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9213,7 +9213,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9227,7 +9227,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9241,7 +9241,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9271,7 +9271,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9285,7 +9285,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9295,7 +9295,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9317,7 +9317,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9359,7 +9359,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9385,7 +9385,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9395,7 +9395,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9405,7 +9405,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9415,7 +9415,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9437,7 +9437,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9463,7 +9463,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9489,7 +9489,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9503,7 +9503,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9513,7 +9513,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9527,7 +9527,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9541,7 +9541,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9555,7 +9555,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9565,7 +9565,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9579,7 +9579,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9593,7 +9593,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9607,7 +9607,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9617,7 +9617,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9631,7 +9631,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9641,7 +9641,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9655,7 +9655,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9673,7 +9673,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9683,7 +9683,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9701,7 +9701,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9727,7 +9727,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9749,7 +9749,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9791,7 +9791,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9805,7 +9805,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9819,7 +9819,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9837,7 +9837,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9855,7 +9855,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9865,7 +9865,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9875,7 +9875,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9893,7 +9893,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9923,7 +9923,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9941,7 +9941,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -9983,7 +9983,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10021,7 +10021,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10031,7 +10031,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10041,7 +10041,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10055,7 +10055,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10069,7 +10069,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10083,7 +10083,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10177,7 +10177,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10215,7 +10215,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10233,7 +10233,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10243,7 +10243,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10281,7 +10281,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10295,7 +10295,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10305,7 +10305,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10391,7 +10391,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10401,7 +10401,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10411,7 +10411,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10421,7 +10421,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10431,7 +10431,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10441,7 +10441,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10451,7 +10451,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10461,7 +10461,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10471,7 +10471,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10481,7 +10481,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10491,7 +10491,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10501,7 +10501,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10511,7 +10511,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10521,7 +10521,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10531,7 +10531,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10541,7 +10541,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10551,7 +10551,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10561,7 +10561,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10575,7 +10575,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10601,7 +10601,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10623,7 +10623,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10633,7 +10633,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10667,7 +10667,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10681,7 +10681,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10747,7 +10747,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10773,7 +10773,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10787,7 +10787,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10801,7 +10801,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10819,7 +10819,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10837,7 +10837,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10859,7 +10859,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10869,7 +10869,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10891,7 +10891,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10941,7 +10941,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10955,7 +10955,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10985,7 +10985,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -10999,7 +10999,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11009,7 +11009,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11027,7 +11027,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11145,7 +11145,7 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11163,13 +11163,13 @@ NSString * MTRRequestCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDTy
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
 
     default:
-        result = [NSString stringWithFormat:@"<Unknown clusterID %d>", clusterID];
+        result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
         break;
     }
 
@@ -11187,7 +11187,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11213,7 +11213,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11223,7 +11223,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11233,7 +11233,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11243,7 +11243,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11253,7 +11253,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11263,7 +11263,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11277,7 +11277,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11287,7 +11287,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11297,7 +11297,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11315,7 +11315,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11325,7 +11325,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11335,7 +11335,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11345,7 +11345,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11355,7 +11355,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11365,7 +11365,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11375,7 +11375,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11401,7 +11401,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11427,7 +11427,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11441,7 +11441,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11459,7 +11459,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11469,7 +11469,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11479,7 +11479,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11489,7 +11489,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11499,7 +11499,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11513,7 +11513,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11523,7 +11523,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11533,7 +11533,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11543,7 +11543,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11569,7 +11569,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11587,7 +11587,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11597,7 +11597,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11607,7 +11607,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11617,7 +11617,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11635,7 +11635,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11645,7 +11645,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11659,7 +11659,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11673,7 +11673,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11683,7 +11683,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11693,7 +11693,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11707,7 +11707,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11721,7 +11721,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11731,7 +11731,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11745,7 +11745,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11759,7 +11759,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11769,7 +11769,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11779,7 +11779,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11793,7 +11793,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11803,7 +11803,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11813,7 +11813,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11823,7 +11823,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11833,7 +11833,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11843,7 +11843,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11857,7 +11857,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11871,7 +11871,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11909,7 +11909,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11919,7 +11919,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11929,7 +11929,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11939,7 +11939,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11949,7 +11949,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11959,7 +11959,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11969,7 +11969,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11979,7 +11979,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11989,7 +11989,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -11999,7 +11999,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12009,7 +12009,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12023,7 +12023,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12033,7 +12033,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12043,7 +12043,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12057,7 +12057,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12071,7 +12071,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12085,7 +12085,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12119,7 +12119,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12129,7 +12129,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12147,7 +12147,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12157,7 +12157,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12175,7 +12175,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12185,7 +12185,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12195,7 +12195,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12205,7 +12205,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12215,7 +12215,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12225,7 +12225,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12235,7 +12235,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12245,7 +12245,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12255,7 +12255,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12265,7 +12265,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12275,7 +12275,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12285,7 +12285,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12295,7 +12295,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12305,7 +12305,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12315,7 +12315,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12325,7 +12325,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12335,7 +12335,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12345,7 +12345,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12355,7 +12355,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12365,7 +12365,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12375,7 +12375,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12389,7 +12389,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12403,7 +12403,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12417,7 +12417,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12427,7 +12427,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12445,7 +12445,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12459,7 +12459,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12473,7 +12473,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12483,7 +12483,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12493,7 +12493,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12507,7 +12507,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12521,7 +12521,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12531,7 +12531,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12545,7 +12545,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12555,7 +12555,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12569,7 +12569,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12583,7 +12583,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12597,7 +12597,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12615,7 +12615,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12625,7 +12625,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12635,7 +12635,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
         switch (commandID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12649,7 +12649,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12723,7 +12723,7 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
@@ -12737,13 +12737,13 @@ NSString * MTRResponseCommandNameForID(MTRClusterIDType clusterID, MTRCommandIDT
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown commandID %d>", commandID];
+            result = [NSString stringWithFormat:@"<Unknown commandID %u>", commandID];
             break;
         }
         break;
 
     default:
-        result = [NSString stringWithFormat:@"<Unknown clusterID %d>", clusterID];
+        result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
         break;
     }
 
@@ -12763,7 +12763,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12773,7 +12773,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12783,7 +12783,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12793,7 +12793,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12803,7 +12803,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12813,7 +12813,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12823,7 +12823,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12846,7 +12846,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12865,7 +12865,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12892,7 +12892,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12902,7 +12902,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12925,7 +12925,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12935,7 +12935,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12945,7 +12945,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12955,7 +12955,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12965,7 +12965,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12988,7 +12988,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -12998,7 +12998,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13008,7 +13008,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13018,7 +13018,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13045,7 +13045,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13060,7 +13060,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13079,7 +13079,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13102,7 +13102,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13112,7 +13112,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13143,7 +13143,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13174,7 +13174,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13213,7 +13213,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13223,7 +13223,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13233,7 +13233,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13243,7 +13243,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13253,7 +13253,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13263,7 +13263,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13278,7 +13278,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13288,7 +13288,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13298,7 +13298,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13317,7 +13317,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13327,7 +13327,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13337,7 +13337,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13347,7 +13347,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13357,7 +13357,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13367,7 +13367,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13377,7 +13377,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13387,7 +13387,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13397,7 +13397,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13407,7 +13407,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13422,7 +13422,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13432,7 +13432,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13442,7 +13442,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13497,7 +13497,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13512,7 +13512,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13522,7 +13522,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13532,7 +13532,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13551,7 +13551,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13570,7 +13570,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13580,7 +13580,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13590,7 +13590,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13600,7 +13600,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13619,7 +13619,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13638,7 +13638,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13653,7 +13653,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13672,7 +13672,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13691,7 +13691,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13706,7 +13706,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13729,7 +13729,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13756,7 +13756,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13791,7 +13791,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13801,7 +13801,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13811,7 +13811,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13821,7 +13821,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13831,7 +13831,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13841,7 +13841,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13872,7 +13872,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13882,7 +13882,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13892,7 +13892,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13971,7 +13971,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13981,7 +13981,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -13991,7 +13991,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14001,7 +14001,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14011,7 +14011,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14021,7 +14021,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14031,7 +14031,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14041,7 +14041,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14051,7 +14051,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14061,7 +14061,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14071,7 +14071,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14086,7 +14086,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14096,7 +14096,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14106,7 +14106,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14116,7 +14116,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14126,7 +14126,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14136,7 +14136,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14146,7 +14146,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14156,7 +14156,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14166,7 +14166,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14176,7 +14176,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14186,7 +14186,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14196,7 +14196,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14206,7 +14206,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14216,7 +14216,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14226,7 +14226,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14236,7 +14236,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14251,7 +14251,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14266,7 +14266,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14276,7 +14276,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14286,7 +14286,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14296,7 +14296,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14306,7 +14306,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14316,7 +14316,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14326,7 +14326,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14336,7 +14336,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14351,7 +14351,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14366,7 +14366,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14376,7 +14376,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14386,7 +14386,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14396,7 +14396,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14406,7 +14406,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
         switch (eventID) {
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14421,7 +14421,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14444,7 +14444,7 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
@@ -14459,13 +14459,13 @@ NSString * MTREventNameForID(MTRClusterIDType clusterID, MTREventIDType eventID)
             break;
 
         default:
-            result = [NSString stringWithFormat:@"<Unknown eventID %d>", eventID];
+            result = [NSString stringWithFormat:@"<Unknown eventID %u>", eventID];
             break;
         }
         break;
 
     default:
-        result = [NSString stringWithFormat:@"<Unknown clusterID %d>", clusterID];
+        result = [NSString stringWithFormat:@"<Unknown clusterID %u>", clusterID];
         break;
     }
 


### PR DESCRIPTION
IDs are unsigned; we should not be formatting them with %d, because for vendor-prefixed ones that might make them look negative.
