### PR TITLE
[Fabric-Sync] Fix compile warnings

### DIFF
--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -114,7 +114,7 @@ void DeviceManager::RemoveSyncedDevice(NodeId nodeId)
                     ChipLogValueX64(device->GetNodeId()), device->GetEndpointId());
 }
 
-void DeviceManager::OpenDeviceCommissioningWindow(NodeId nodeId, uint32_t commissioningTimeoutSec, uint32_t iterations,
+void DeviceManager::OpenDeviceCommissioningWindow(NodeId nodeId, uint32_t iterations, uint16_t commissioningTimeoutSec,
                                                   uint16_t discriminator, const ByteSpan & salt, const ByteSpan & verifier)
 {
     ChipLogProgress(NotSpecified, "Opening commissioning window for Node ID: " ChipLogFormatX64, ChipLogValueX64(nodeId));
@@ -422,7 +422,7 @@ void DeviceManager::HandleReverseOpenCommissioningWindow(TLV::TLVReader & data)
     ChipLogProgress(NotSpecified, "  PAKEPasscodeVerifier size: %lu", value.PAKEPasscodeVerifier.size());
     ChipLogProgress(NotSpecified, "  salt size: %lu", value.salt.size());
 
-    OpenDeviceCommissioningWindow(mLocalBridgeNodeId, value.commissioningTimeout, value.iterations, value.discriminator,
+    OpenDeviceCommissioningWindow(mLocalBridgeNodeId, value.iterations, value.commissioningTimeout, value.discriminator,
                                   ByteSpan(value.salt.data(), value.salt.size()),
                                   ByteSpan(value.PAKEPasscodeVerifier.data(), value.PAKEPasscodeVerifier.size()));
 }

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -94,17 +94,17 @@ public:
      * This function initiates the process to open the commissioning window for a device identified by the given node ID.
      *
      * @param nodeId               The ID of the node that should open the commissioning window.
-     * @param commissioningTimeoutSec The time in seconds before the commissioning window closes. This value determines
-     *                             how long the commissioning window remains open for incoming connections.
      * @param iterations           The number of PBKDF (Password-Based Key Derivation Function) iterations to use
      *                             for deriving the PAKE (Password Authenticated Key Exchange) verifier.
+     * @param commissioningTimeoutSec The time in seconds before the commissioning window closes. This value determines
+     *                             how long the commissioning window remains open for incoming connections.
      * @param discriminator        The device-specific discriminator, determined during commissioning, which helps
      *                             to uniquely identify the device among others.
      * @param salt                 The salt used in the cryptographic operations for commissioning.
      * @param verifier             The PAKE verifier used to authenticate the commissioning process.
      *
      */
-    void OpenDeviceCommissioningWindow(chip::NodeId nodeId, uint32_t commissioningTimeoutSec, uint32_t iterations,
+    void OpenDeviceCommissioningWindow(chip::NodeId nodeId, uint32_t iterations, uint16_t commissioningTimeoutSec,
                                        uint16_t discriminator, const chip::ByteSpan & salt, const chip::ByteSpan & verifier);
 
     /**

--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -101,9 +101,9 @@ public:
         // TODO(#35875): OpenDeviceCommissioningWindow uses the same controller every time and doesn't currently accept
         // FabricIndex. For now we are dropping fabric index from the scoped node id.
         NodeId nodeId                    = request.id.node_id;
-        uint32_t commissioningTimeoutSec = request.commissioning_timeout;
         uint32_t iterations              = request.iterations;
         uint16_t discriminator           = request.discriminator;
+        uint16_t commissioningTimeoutSec = static_cast<uint16_t>(request.commissioning_timeout);
 
         // Log the request details for debugging
         ChipLogProgress(NotSpecified,
@@ -111,7 +111,7 @@ public:
                         static_cast<unsigned long>(nodeId), commissioningTimeoutSec, iterations, discriminator);
 
         // Open the device commissioning window using raw binary data for salt and verifier
-        DeviceMgr().OpenDeviceCommissioningWindow(nodeId, commissioningTimeoutSec, iterations, discriminator,
+        DeviceMgr().OpenDeviceCommissioningWindow(nodeId, iterations, commissioningTimeoutSec, discriminator,
                                                   ByteSpan(request.salt.bytes, request.salt.size),
                                                   ByteSpan(request.verifier.bytes, request.verifier.size));
 

--- a/examples/fabric-bridge-app/linux/main.cpp
+++ b/examples/fabric-bridge-app/linux/main.cpp
@@ -81,10 +81,10 @@ bool HandleCustomOption(const char * aProgram, ArgParser::OptionSet * aOptions, 
     switch (aIdentifier)
     {
     case kOptionFabricAdminServerPortNumber:
-        gFabricAdminServerPort = atoi(aValue);
+        gFabricAdminServerPort = static_cast<uint16_t>(atoi(aValue));
         break;
     case kOptionLocalServerPortNumber:
-        gLocalServerPort = atoi(aValue);
+        gLocalServerPort = static_cast<uint16_t>(atoi(aValue));
         break;
     default:
         ArgParser::PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);


### PR DESCRIPTION
CommissioningTimeout is defined as  uint16 in spec, align its type with spec and fix compile warnings.

```
in-utils.DeviceManager.cpp.o
../../../examples/fabric-admin/device_manager/DeviceManager.cpp: In member function ‘void DeviceManager::OpenDeviceCommissioningWindow(chip::NodeId, uint32_t, uint32_t, uint16_t, const ByteSpan&, const ByteSpan&)’:
../../../examples/fabric-admin/device_manager/DeviceManager.cpp:123:98: error: conversion from ‘uint32_t’ {aka ‘unsigned int’} to ‘uint16_t’ {aka ‘short unsigned int’} may change value [-Werror=conversion]
  123 |     CHIP_ERROR err = PairingManager::Instance().OpenCommissioningWindow(nodeId, kRootEndpointId, commissioningTimeoutSec,
      |   
```                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~

```
../../../examples/fabric-bridge-app/linux/main.cpp: In function ‘bool {anonymous}::HandleCustomOption(const char*, chip::ArgParser::OptionSet*, int, const char*, const char*)’:
../../../examples/fabric-bridge-app/linux/main.cpp:84:38: error: conversion from ‘int’ to ‘uint16_t’ {aka ‘short unsigned int’} may change value [-Werror=conversion]
   84 |         gFabricAdminServerPort = atoi(aValue);
      |                                  ~~~~^~~~~~~~
../../../examples/fabric-bridge-app/linux/main.cpp:87:32: error: conversion from ‘int’ to ‘uint16_t’ {aka ‘short unsigned int’} may change value [-Werror=conversion]
   87 |         gLocalServerPort = atoi(aValue);
      |                            ~~~~^~~~~~~~
At global scope:
```

