### PR TITLE
[Matter.framework] Clear all device controller delegates on controlle…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -313,7 +313,7 @@ using namespace chip::Tracing::DarwinFramework;
 
 - (void)shutdown
 {
-    // Subclass hook; nothing to do.
+    [self _clearDeviceControllerDelegates];
 }
 
 - (nullable NSNumber *)controllerNodeID
@@ -721,6 +721,14 @@ using namespace chip::Tracing::DarwinFramework;
         } else {
             MTR_LOG("%@ removeDeviceControllerDelegate: delegate %p not found in %lu", self, delegate, static_cast<unsigned long>(_delegates.count));
         }
+    }
+}
+
+- (void)_clearDeviceControllerDelegates
+{
+    @synchronized(self) {
+        _strongDelegateForSetDelegateAPI = nil;
+        [_delegates removeAllObjects];
     }
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -418,6 +418,7 @@ using namespace chip::Tracing::DarwinFramework;
         return;
     }
     [self finalShutdown];
+    [super shutdown];
 }
 
 - (void)finalShutdown


### PR DESCRIPTION
…r shutdown


#### Problem

When `darwin-framework-tool` sets the **pairing delegate** in [1], it leads to a memory leak. To resolve this, we could either clear the delegate in `darwin-framework-tool` or clear all delegates during controller shutdown. I chose the latter approach.

```
Process 44832: 12298 nodes malloced for 6406 KB
Process 44832: 15 leaks for 4624 total leaked bytes.

    15 (4.52K) ROOT CYCLE: <MTRDeviceController_Concrete 0x124817c00> [3584]
       2 (128 bytes) __strong _strongDelegateForSetDelegateAPI --> ROOT CYCLE: <CHIPToolDeviceControllerDelegate 0x600001f5b270> [48]
          __strong _commissioner --> CYCLE BACK TO <MTRDeviceController_Concrete 0x124817c00> [3584]
          1 (80 bytes) __strong _params --> <MTRCommissioningParameters 0x60000325a3a0> [80]
       3 (384 bytes) __strong _nodeIDToDeviceMap --> <NSMapTable 0x600003f5dd00> [128]
          1 (128 bytes) <NSMapTable (Key Storage) 0x600003f5dd80> [128]
          1 (128 bytes) <NSMapTable (Weak Value Storage) 0x600003f5de00> [128]
       4 (224 bytes) __strong _delegates --> <NSMutableArray 0x600001f5c930> [48]  item count: 1
          3 (176 bytes) <NSMutableArray (Storage) 0x60000135c470> [16]
             2 (160 bytes) <MTRDeviceControllerDelegateInfo 0x600001152740> [32]
                1 (128 bytes) __strong _queue --> <dispatch_queue_t (serial) 0x600003f48e80> [128]  "com.chip.pairing" (from darwin-framework-tool)
       1 (128 bytes) __strong _otaProviderDelegateQueue --> <dispatch_queue_t (serial) 0x600003f5cb80> [128]  "org.csa-iot.matter.framework.otaprovider.workqueue" (from Matter)
       2 (96 bytes) __strong _concurrentSubscriptionPool --> <MTRAsyncWorkQueue 0x600001f58a50> [48]
          1 (48 bytes) __strong _items --> <NSMutableArray 0x600001f58ab0> [48]  item count: 0
       1 (48 bytes) __strong _serverEndpoints --> <NSMutableArray 0x600001f58b70> [48]  item count: 0
       1 (32 bytes) __strong _uniqueIdentifier --> <NSUUID 0x60000115d980> [32]
```

[1] https://github.com/project-chip/connectedhomeip/blob/bcc1f1b3b8243326ec1818b0d1b84c37464bd0f6/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.mm#L87