### PR TITLE
Move some Matter.framework server APIs used only with concrete controllers to the concrete controller class.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -691,43 +691,6 @@ using namespace chip::Tracing::DarwinFramework;
     });
 }
 
-- (NSArray<MTRAccessGrant *> *)accessGrantsForClusterPath:(MTRClusterPath *)clusterPath
-{
-    assertChipStackLockedByCurrentThread();
-
-    for (MTRServerEndpoint * endpoint in _serverEndpoints) {
-        if ([clusterPath.endpoint isEqual:endpoint.endpointID]) {
-            return [endpoint matterAccessGrantsForCluster:clusterPath.cluster];
-        }
-    }
-
-    // Nothing matched, no grants.
-    return @[];
-}
-
-- (nullable NSNumber *)neededReadPrivilegeForClusterID:(NSNumber *)clusterID attributeID:(NSNumber *)attributeID
-{
-    assertChipStackLockedByCurrentThread();
-
-    for (MTRServerEndpoint * endpoint in _serverEndpoints) {
-        for (MTRServerCluster * cluster in endpoint.serverClusters) {
-            if (![cluster.clusterID isEqual:clusterID]) {
-                continue;
-            }
-
-            for (MTRServerAttribute * attr in cluster.attributes) {
-                if (![attr.attributeID isEqual:attributeID]) {
-                    continue;
-                }
-
-                return @(attr.requiredReadPrivilege);
-            }
-        }
-    }
-
-    return nil;
-}
-
 #ifdef DEBUG
 + (void)forceLocalhostAdvertisingOnly
 {

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -17,6 +17,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import <Matter/MTRAccessGrant.h>
 #import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceController.h>
 #import <Matter/MTRDeviceControllerFactory.h>
@@ -130,6 +131,23 @@ NS_ASSUME_NONNULL_BEGIN
  * and a compressed fabric id that matches this controller has been observed.
  */
 - (void)operationalInstanceAdded:(NSNumber *)nodeID;
+
+/**
+ * Get the access grants that apply for the given cluster path.
+ */
+- (NSArray<MTRAccessGrant *> *)accessGrantsForClusterPath:(MTRClusterPath *)clusterPath;
+
+/**
+ * Get the privilege level needed to read the given attribute.  There's no
+ * endpoint provided because the expectation is that this information is the
+ * same for all cluster instances.
+ *
+ * Returns nil if we have no such attribute defined on any endpoint, otherwise
+ * one of MTRAccessControlEntry* constants wrapped in NSNumber.
+ *
+ * Only called on the Matter queue.
+ */
+- (nullable NSNumber *)neededReadPrivilegeForClusterID:(NSNumber *)clusterID attributeID:(NSNumber *)attributeID;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -20,7 +20,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <Matter/MTRAccessGrant.h>
 #import <Matter/MTRBaseDevice.h> // for MTRClusterPath
 
 #import "MTRDeviceConnectionBridge.h" // For MTRInternalDeviceConnectionCallback
@@ -209,23 +208,6 @@ NS_ASSUME_NONNULL_BEGIN
                           timeout:(NSTimeInterval)timeout
                             queue:(dispatch_queue_t)queue
                        completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
-
-/**
- * Get the access grants that apply for the given cluster path.
- */
-- (NSArray<MTRAccessGrant *> *)accessGrantsForClusterPath:(MTRClusterPath *)clusterPath;
-
-/**
- * Get the privilege level needed to read the given attribute.  There's no
- * endpoint provided because the expectation is that this information is the
- * same for all cluster instances.
- *
- * Returns nil if we have no such attribute defined on any endpoint, otherwise
- * one of MTRAccessControlEntry* constants wrapped in NSNumber.
- *
- * Only called on the Matter queue.
- */
-- (nullable NSNumber *)neededReadPrivilegeForClusterID:(NSNumber *)clusterID attributeID:(NSNumber *)attributeID;
 
 #pragma mark - Device-specific data and SDK access
 // DeviceController will act as a central repository for this opaque dictionary that MTRDevice manages


### PR DESCRIPTION
These APIs are never used for XPC controllers, and the base class implementation does not really make sense.
