### PR TITLE
Remove a test-only method from base MTRDeviceController.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -449,18 +449,6 @@ using namespace chip::Tracing::DarwinFramework;
     }
 }
 
-#ifdef DEBUG
-- (NSDictionary<NSNumber *, NSNumber *> *)unitTestGetDeviceAttributeCounts
-{
-    std::lock_guard lock(*self.deviceMapLock);
-    NSMutableDictionary<NSNumber *, NSNumber *> * deviceAttributeCounts = [NSMutableDictionary dictionary];
-    for (NSNumber * nodeID in _nodeIDToDeviceMap) {
-        deviceAttributeCounts[nodeID] = @([[_nodeIDToDeviceMap objectForKey:nodeID] unitTestAttributeCount]);
-    }
-    return deviceAttributeCounts;
-}
-#endif
-
 - (BOOL)setOperationalCertificateIssuer:(nullable id<MTROperationalCertificateIssuer>)operationalCertificateIssuer
                                   queue:(nullable dispatch_queue_t)queue
 {

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1689,15 +1689,6 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     return nil;
 }
 
-#ifdef DEBUG
-+ (void)forceLocalhostAdvertisingOnly
-{
-    auto interfaceIndex = chip::Inet::InterfaceId::PlatformType(kDNSServiceInterfaceIndexLocalOnly);
-    auto interfaceId = chip::Inet::InterfaceId(interfaceIndex);
-    chip::app::DnssdServer::Instance().SetInterfaceId(interfaceId);
-}
-#endif // DEBUG
-
 @end
 
 /**


### PR DESCRIPTION
This is only used with concrete controllers from tests, and is already implemented by MTRDeviceController_Concrete.
    
Also removes a test-only class method from MTRDeviceController_Concrete that MTRDeviceController already implements (and has to keep implementing, since the tests use it on MTRDeviceController itself, not an instance).