### PR TITLE
Remove PASE verifier computation overrides from MTRDeviceController_Concrete.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1231,30 +1231,6 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     return [self syncRunOnWorkQueueWithBoolReturnValue:block error:nil];
 }
 
-+ (nullable NSData *)computePASEVerifierForSetupPasscode:(NSNumber *)setupPasscode
-                                              iterations:(NSNumber *)iterations
-                                                    salt:(NSData *)salt
-                                                   error:(NSError * __autoreleasing *)error
-{
-    chip::Crypto::Spake2pVerifier verifier;
-    CHIP_ERROR err = verifier.Generate(iterations.unsignedIntValue, AsByteSpan(salt), setupPasscode.unsignedIntValue);
-
-    MATTER_LOG_METRIC_SCOPE(kMetricPASEVerifierForSetupCode, err);
-
-    if ([MTRDeviceController_Concrete checkForError:err logMsg:kDeviceControllerErrorSpake2pVerifierGenerationFailed error:error]) {
-        return nil;
-    }
-
-    uint8_t serializedBuffer[chip::Crypto::kSpake2p_VerifierSerialized_Length];
-    chip::MutableByteSpan serializedBytes(serializedBuffer);
-    err = verifier.Serialize(serializedBytes);
-    if ([MTRDeviceController_Concrete checkForError:err logMsg:kDeviceControllerErrorSpake2pVerifierSerializationFailed error:error]) {
-        return nil;
-    }
-
-    return AsData(serializedBytes);
-}
-
 - (NSData * _Nullable)attestationChallengeForDeviceID:(NSNumber *)deviceID
 {
     auto block = ^NSData *
@@ -1984,11 +1960,6 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     };
 
     return [self syncRunOnWorkQueueWithReturnValue:block error:error];
-}
-
-- (nullable NSData *)computePaseVerifier:(uint32_t)setupPincode iterations:(uint32_t)iterations salt:(NSData *)salt
-{
-    return [MTRDeviceController computePASEVerifierForSetupPasscode:@(setupPincode) iterations:@(iterations) salt:salt error:nil];
 }
 
 - (void)setPairingDelegate:(id<MTRDevicePairingDelegate>)delegate queue:(dispatch_queue_t)queue

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -265,8 +265,6 @@ static NSString * const kDeviceControllerErrorKeyAllocation = @"Generating new o
 static NSString * const kDeviceControllerErrorCSRValidation = @"Extracting public key from CSR failed";
 static NSString * const kDeviceControllerErrorGetCommissionee = @"Failure obtaining device being commissioned";
 static NSString * const kDeviceControllerErrorGetAttestationChallenge = @"Failure getting attestation challenge";
-static NSString * const kDeviceControllerErrorSpake2pVerifierGenerationFailed = @"PASE verifier generation failed";
-static NSString * const kDeviceControllerErrorSpake2pVerifierSerializationFailed = @"PASE verifier serialization failed";
 static NSString * const kDeviceControllerErrorCDCertStoreInit = @"Init failure while initializing Certificate Declaration Signing Keys store";
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
The base class implements these selectors already, and its implementation is perfectly fine.
