### PR TITLE
Fix handling of controllerNodeID on non-concrete controllers.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -318,16 +318,10 @@ using namespace chip::Tracing::DarwinFramework;
     // Subclass hook; nothing to do.
 }
 
-- (NSNumber *)controllerNodeID
+- (nullable NSNumber *)controllerNodeID
 {
-    auto block = ^NSNumber * { return @(self->_cppCommissioner->GetNodeId()); };
-
-    NSNumber * nodeID = [self syncRunOnWorkQueueWithReturnValue:block error:nil];
-    if (!nodeID) {
-        MTR_LOG_ERROR("%@ A controller has no node id if it has not been started", self);
-    }
-
-    return nodeID;
+    MTR_ABSTRACT_METHOD();
+    return nil;
 }
 
 - (BOOL)setupCommissioningSessionWithPayload:(MTRSetupPayload *)payload

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -141,6 +141,7 @@ using namespace chip::Tracing::DarwinFramework;
 @synthesize commissionableBrowser = _commissionableBrowser;
 @synthesize concurrentSubscriptionPool = _concurrentSubscriptionPool;
 @synthesize storageBehaviorConfiguration = _storageBehaviorConfiguration;
+@synthesize controllerNodeID = _controllerNodeID;
 
 - (nullable instancetype)initWithParameters:(MTRDeviceControllerAbstractParameters *)parameters
                                       error:(NSError * __autoreleasing *)error
@@ -729,6 +730,7 @@ using namespace chip::Tracing::DarwinFramework;
 
         self->_storedFabricIndex = fabricIdx;
         self->_storedCompressedFabricID = _cppCommissioner->GetCompressedFabricId();
+        self->_controllerNodeID = @(_cppCommissioner->GetNodeId());
 
         chip::Crypto::P256PublicKey rootPublicKey;
         if (_cppCommissioner->GetRootPublicKey(rootPublicKey) == CHIP_NO_ERROR) {
@@ -791,18 +793,6 @@ using namespace chip::Tracing::DarwinFramework;
     MTR_LOG("%@ startup: %@", NSStringFromClass(self.class), self);
 
     return YES;
-}
-
-- (NSNumber *)controllerNodeID
-{
-    auto block = ^NSNumber * { return @(self->_cppCommissioner->GetNodeId()); };
-
-    NSNumber * nodeID = [self syncRunOnWorkQueueWithReturnValue:block error:nil];
-    if (!nodeID) {
-        MTR_LOG_ERROR("%@ A controller has no node id if it has not been started", self);
-    }
-
-    return nodeID;
 }
 
 static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
@@ -1735,11 +1725,6 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 @end
 
 @implementation MTRDeviceController_Concrete (Deprecated)
-
-- (NSNumber *)controllerNodeId
-{
-    return self.controllerNodeID;
-}
 
 - (nullable NSData *)fetchAttestationChallengeForDeviceId:(uint64_t)deviceId
 {


### PR DESCRIPTION
There isn't actually a _cppCommissioner on the base controller, so that implementation made no sense.  In practice, the XPC and concrete controller just have different implementations here, and the base should not try to implement anything.

Also fixes the concrete implementation to avoid a sync dispatch by caching the value (which should be immutable) during startup and removes the unnecessary controllerNodeId override from the concrete controller: the base class handles that backwards compat shim already.
