### PR TITLE
Clean up asyncGetCommissionerOnMatterQueue on MTRDeviceController.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -43,7 +43,6 @@
 #import "MTRLogging_Internal.h"
 #import "MTRMetricKeys.h"
 #import "MTRMetricsCollector.h"
-#import "MTROperationalCredentialsDelegate.h"
 #import "MTRP256KeypairBridge.h"
 #import "MTRPersistentStorageDelegateBridge.h"
 #import "MTRServerEndpoint_Internal.h"
@@ -124,7 +123,6 @@ using namespace chip::Tracing::DarwinFramework;
     chip::Credentials::PartialDACVerifier * _partialDACVerifier;
     chip::Credentials::DefaultDACVerifier * _defaultDACVerifier;
     MTRDeviceControllerDelegateBridge * _deviceControllerDelegateBridge;
-    MTROperationalCredentialsDelegate * _operationalCredentialsDelegate;
     MTRDeviceAttestationDelegateBridge * _deviceAttestationDelegateBridge;
     os_unfair_lock _underlyingDeviceMapLock;
     MTRCommissionableBrowser * _commissionableBrowser;
@@ -592,27 +590,8 @@ using namespace chip::Tracing::DarwinFramework;
 - (void)asyncGetCommissionerOnMatterQueue:(void (^)(chip::Controller::DeviceCommissioner *))block
                              errorHandler:(nullable MTRDeviceErrorHandler)errorHandler
 {
-    {
-        NSError * error;
-        if (![self checkIsRunning:&error]) {
-            if (errorHandler != nil) {
-                errorHandler(error);
-            }
-            return;
-        }
-    }
-
-    dispatch_async(_chipWorkQueue, ^{
-        NSError * error;
-        if (![self checkIsRunning:&error]) {
-            if (errorHandler != nil) {
-                errorHandler(error);
-            }
-            return;
-        }
-
-        block(self->_cppCommissioner);
-    });
+    MTR_ABSTRACT_METHOD();
+    errorHandler([MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
 }
 
 - (void)asyncDispatchToMatterQueue:(dispatch_block_t)block errorHandler:(nullable MTRDeviceErrorHandler)errorHandler

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -49,7 +49,6 @@
 #import "MTRLogging_Internal.h"
 #import "MTRMetricKeys.h"
 #import "MTRMetricsCollector.h"
-#import "MTROperationalCredentialsDelegate.h"
 #import "MTRP256KeypairBridge.h"
 #import "MTRPersistentStorageDelegateBridge.h"
 #import "MTRServerEndpoint_Internal.h"

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
@@ -20,7 +20,7 @@
 #import <Foundation/Foundation.h>
 #import <Security/Security.h>
 
-#import "MTRDeviceController.h"
+#import "MTRDeviceController_Concrete.h"
 #import "MTRError_Internal.h"
 #import "MTRKeypair.h"
 #import "MTROperationalCertificateIssuer.h"
@@ -38,7 +38,7 @@ class MTROperationalCredentialsDelegate : public chip::Controller::OperationalCr
 public:
     using ChipP256KeypairPtr = chip::Crypto::P256Keypair *;
 
-    MTROperationalCredentialsDelegate(MTRDeviceController * deviceController);
+    MTROperationalCredentialsDelegate(MTRDeviceController_Concrete * deviceController);
     ~MTROperationalCredentialsDelegate() {}
 
     CHIP_ERROR Init(ChipP256KeypairPtr nocSigner, NSData * ipk, NSData * rootCert, NSData * _Nullable icaCert);
@@ -147,7 +147,7 @@ private:
     NSData * _Nullable mRootCert;
     NSData * _Nullable mIntermediateCert;
 
-    MTRDeviceController * __weak mWeakController;
+    MTRDeviceController_Concrete * __weak mWeakController;
     chip::Controller::DeviceCommissioner * _Nullable mCppCommissioner = nullptr;
     id<MTROperationalCertificateIssuer> _Nullable mOperationalCertificateIssuer;
     dispatch_queue_t _Nullable mOperationalCertificateIssuerQueue;

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
@@ -42,7 +42,7 @@ using namespace TLV;
 using namespace Credentials;
 using namespace Crypto;
 
-MTROperationalCredentialsDelegate::MTROperationalCredentialsDelegate(MTRDeviceController * deviceController)
+MTROperationalCredentialsDelegate::MTROperationalCredentialsDelegate(MTRDeviceController_Concrete * deviceController)
     : mWeakController(deviceController)
 {
 }
@@ -129,7 +129,7 @@ CHIP_ERROR MTROperationalCredentialsDelegate::ExternalGenerateNOCChain(const chi
 
     VerifyOrReturnError(mCppCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    MTRDeviceController * strongController = mWeakController;
+    MTRDeviceController_Concrete * strongController = mWeakController;
     VerifyOrReturnError(strongController != nil, CHIP_ERROR_INCORRECT_STATE);
 
     mOnNOCCompletionCallback = onCompletion;
@@ -168,14 +168,14 @@ CHIP_ERROR MTROperationalCredentialsDelegate::ExternalGenerateNOCChain(const chi
                          certificationDeclaration:AsData(certificationDeclarationSpan)
                                      firmwareInfo:firmwareInfo];
 
-    MTRDeviceController * __weak weakController = mWeakController;
+    MTRDeviceController_Concrete * __weak weakController = mWeakController;
     dispatch_async(mOperationalCertificateIssuerQueue, ^{
         [mOperationalCertificateIssuer
             issueOperationalCertificateForRequest:csrInfo
                                   attestationInfo:attestationInfo
                                        controller:strongController
                                        completion:^(MTROperationalCertificateChain * _Nullable chain, NSError * _Nullable error) {
-                                           MTRDeviceController * strongController = weakController;
+                                           MTRDeviceController_Concrete * strongController = weakController;
                                            if (strongController == nil || !strongController.isRunning) {
                                                // No longer safe to touch "this"
                                                return;


### PR DESCRIPTION
MTROperationalCredentialsDelegate always works with a concrete controller.  Make that explicit.

At that point, asyncGetCommissionerOnMatterQueue can only get called on an MTRDeviceController from and MTRBaseDevice that was created for an XPC controller.  Having that just fail out is perfectly reasonable.
