### PR TITLE
[Silabs]Fix efr32 test_driver non-docker build

### DIFF
--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -61,6 +61,16 @@ efr32_sdk("sdk") {
   ]
 }
 
+config("efr32_ldflags") {
+  _ldscript =
+      "${chip_root}/examples/platform/silabs/ldscripts/${silabs_family}.ld"
+
+  ldflags = [
+    "-T" + rebase_path(_ldscript, root_build_dir),
+    "-Wl,--no-warn-rwx-segment",
+  ]
+}
+
 # This is the test runner.  `pw_test` will dep this for each `silabs_executable` target.
 source_set("efr32_test_main") {
   defines = [ "PW_RPC_ENABLED" ]
@@ -103,6 +113,7 @@ source_set("efr32_test_main") {
   ]
 
   include_dirs = [ "${chip_root}/examples/common/pigweed/efr32" ]
+  public_configs = [ ":efr32_ldflags" ]
 }
 
 # This target is referred to by BuildRoot in scripts/build/builders/efr32.py, as well as the example in README.md.

--- a/src/test_driver/efr32/args.gni
+++ b/src/test_driver/efr32/args.gni
@@ -15,9 +15,7 @@
 import("//build_overrides/chip.gni")
 import("//build_overrides/pigweed.gni")
 import("${chip_root}/config/efr32/lib/pw_rpc/pw_rpc.gni")
-import("${chip_root}/examples/platform/silabs/args.gni")
 import("${chip_root}/src/platform/silabs/efr32/args.gni")
-import("${chip_root}/third_party/silabs/silabs_board.gni")  # silabs_family
 
 silabs_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
@@ -46,9 +44,3 @@ pw_unit_test_MAIN = "//:efr32_test_main"
 # Additional variables needed by silabs_executable that must be passed in to pw_test.
 test_executable_output_name = "matter-silabs-device_tests-"
 test_executable_output_name_suffix = ".out"
-_ldscript =
-    "${chip_root}/examples/platform/silabs/ldscripts/${silabs_family}.ld"
-test_executable_ldflags = [
-  "-T" + rebase_path(_ldscript, root_build_dir),
-  "-Wl,--no-warn-rwx-segment",
-]


### PR DESCRIPTION
**Issue**
PR https://github.com/project-chip/connectedhomeip/pull/35028 changed how the test driver is built and is trying to set 2 required ldfags, for silabs platform, through the new gn arg `test_executable_ldflags` which then sets ldflags in `template("chip_test_suite")`

However, `test_executable_ldflags` was set as a default_args, for the silabs test driver build, and was depending on configurable arguments. At the time when default_args are set, the declared arguments in command line are not yet applied leading to build failure on this assert (but also mis-configurations regardless of the assert)

```
if (silabs_board == "") {
  silabs_board = getenv("SILABS_BOARD")
}

assert(silabs_board != "", "silabs_board must be specified")
```
Using the docker image, the build didn't fail because the `SILABS_BOARD` env variable is defined (as BRD4187C) thus passing CI.

**Fix** 
Set the needed `ldflags` in the `source_set("efr32_test_main") ` through a public_config.

Tested by building the test driver locally using different target boards.