### PR TITLE
[Android]Fix android batch command test

### DIFF
--- a/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImExtendableInvokeCommand.kt
+++ b/examples/java-matter-controller/java/src/com/matter/controller/commands/pairing/PairOnNetworkLongImExtendableInvokeCommand.kt
@@ -75,6 +75,7 @@ class PairOnNetworkLongImExtendableInvokeCommand(
         ) {
           setFailure("invoke failure with incorrect status")
         }
+        responseCount++
       }
 
       if (clusterId == CLUSTER_ID_TEST && commandId == TEST_ADD_ARGUMENT_RSP_COMMAND) {
@@ -89,8 +90,8 @@ class PairOnNetworkLongImExtendableInvokeCommand(
         if (status != null) {
           setFailure("invoke failure with incorrect status")
         }
+        responseCount++
       }
-      responseCount++
     }
 
     override fun onNoResponse(noInvokeResponseData: NoInvokeResponseData) {
@@ -126,7 +127,7 @@ class PairOnNetworkLongImExtendableInvokeCommand(
 
     val element1: InvokeElement =
       InvokeElement.newInstance(
-        /* endpointId= */ 0,
+        /* endpointId= */ 1,
         CLUSTER_ID_IDENTIFY,
         IDENTIFY_COMMAND,
         tlvWriter1.getEncoded(),


### PR DESCRIPTION
The java PairOnNetworkLongImExtendableInvokeCommand.kt) CI test is returning unsupported cluster when handling identifying cluster, and not fail the CI as well, in order to fix these two issues.
a. Update the endpoint, since Identify cluster has been moved out from endpoint 0, and it is in endpoint 1 in all-cluster-app.
b. Update the counter for commands, if counter is not equal to expected one, we just fail the test when onDone is triggered. 
