### PR TITLE
Make MTRBaseDevice be explicit about when it's assuming a concrete controller.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -232,6 +232,11 @@ static void LogStringAndReturnError(NSString * errorStr, MTRErrorCode errorCode,
 
 @end
 
+@interface MTRBaseDevice ()
+// Will return nil if our controller is not in fact a concrete controller.
+@property (nullable, nonatomic, strong, readonly) MTRDeviceController_Concrete * concreteController;
+@end
+
 @implementation MTRBaseDevice
 
 - (instancetype)initWithPASEDevice:(chip::DeviceProxy *)device controller:(MTRDeviceController *)controller
@@ -261,9 +266,23 @@ static void LogStringAndReturnError(NSString * errorStr, MTRErrorCode errorCode,
     return [controller baseDeviceForNodeID:nodeID];
 }
 
+- (nullable MTRDeviceController_Concrete *)concreteController
+{
+    auto * controller = self.deviceController;
+    if ([controller isKindOfClass:MTRDeviceController_Concrete.class]) {
+        return static_cast<MTRDeviceController_Concrete *>(controller);
+    }
+
+    return nil;
+}
+
 - (MTRTransportType)sessionTransportType
 {
-    return [self.deviceController sessionTransportTypeForDevice:self];
+    auto * concreteController = self.concreteController;
+    if (concreteController == nil) {
+        return MTRTransportTypeUndefined;
+    }
+    return [concreteController sessionTransportTypeForDevice:self];
 }
 
 - (void)invalidateCASESession
@@ -272,7 +291,13 @@ static void LogStringAndReturnError(NSString * errorStr, MTRErrorCode errorCode,
         return;
     }
 
-    [self.deviceController invalidateCASESessionForNode:self.nodeID];
+    auto * concreteController = self.concreteController;
+    if (concreteController == nil) {
+        // Nothing we can do here.
+        return;
+    }
+
+    [concreteController invalidateCASESessionForNode:@(self.nodeID)];
 }
 
 namespace {
@@ -311,121 +336,130 @@ public:
         return;
     }
 
+    auto * concreteController = self.concreteController;
+    if (concreteController == nil) {
+        // No subscriptions (or really any MTRBaseDevice use) with XPC controllers.
+        dispatch_async(queue, ^{
+            errorHandler([MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
+        });
+        return;
+    }
+
     // Copy params before going async.
     params = [params copy];
 
-    [self.deviceController getSessionForNode:self.nodeID
-                                  completion:^(ExchangeManager * _Nullable exchangeManager, const Optional<SessionHandle> & session,
-                                      NSError * _Nullable error, NSNumber * _Nullable retryDelay) {
-                                      if (error != nil) {
-                                          dispatch_async(queue, ^{
-                                              errorHandler(error);
-                                          });
-                                          return;
-                                      }
+    [concreteController getSessionForNode:self.nodeID
+                               completion:^(ExchangeManager * _Nullable exchangeManager, const Optional<SessionHandle> & session,
+                                   NSError * _Nullable error, NSNumber * _Nullable retryDelay) {
+                                   if (error != nil) {
+                                       dispatch_async(queue, ^{
+                                           errorHandler(error);
+                                       });
+                                       return;
+                                   }
 
-                                      // Wildcard endpoint, cluster, attribute, event.
-                                      auto attributePath = std::make_unique<AttributePathParams>();
-                                      auto eventPath = std::make_unique<EventPathParams>();
-                                      eventPath->mIsUrgentEvent = params.reportEventsUrgently;
-                                      ReadPrepareParams readParams(session.Value());
-                                      [params toReadPrepareParams:readParams];
-                                      readParams.mpAttributePathParamsList = attributePath.get();
-                                      readParams.mAttributePathParamsListSize = 1;
-                                      readParams.mpEventPathParamsList = eventPath.get();
-                                      readParams.mEventPathParamsListSize = 1;
+                                   // Wildcard endpoint, cluster, attribute, event.
+                                   auto attributePath = std::make_unique<AttributePathParams>();
+                                   auto eventPath = std::make_unique<EventPathParams>();
+                                   eventPath->mIsUrgentEvent = params.reportEventsUrgently;
+                                   ReadPrepareParams readParams(session.Value());
+                                   [params toReadPrepareParams:readParams];
+                                   readParams.mpAttributePathParamsList = attributePath.get();
+                                   readParams.mAttributePathParamsListSize = 1;
+                                   readParams.mpEventPathParamsList = eventPath.get();
+                                   readParams.mEventPathParamsListSize = 1;
 
-                                      std::unique_ptr<ClusterStateCache> clusterStateCache;
-                                      ReadClient::Callback * callbackForReadClient = nullptr;
-                                      OnDoneHandler onDoneHandler = nil;
+                                   std::unique_ptr<ClusterStateCache> clusterStateCache;
+                                   ReadClient::Callback * callbackForReadClient = nullptr;
+                                   OnDoneHandler onDoneHandler = nil;
 
-                                      if (clusterStateCacheContainer) {
-                                          __weak MTRClusterStateCacheContainer * weakPtr = clusterStateCacheContainer;
-                                          onDoneHandler = ^{
-                                              // This, like all manipulation of cppClusterStateCache, needs to run on the Matter
-                                              // queue.
-                                              MTRClusterStateCacheContainer * container = weakPtr;
-                                              if (container) {
-                                                  container.cppClusterStateCache = nullptr;
-                                                  container.baseDevice = nil;
-                                              }
-                                          };
-                                      }
+                                   if (clusterStateCacheContainer) {
+                                       __weak MTRClusterStateCacheContainer * weakPtr = clusterStateCacheContainer;
+                                       onDoneHandler = ^{
+                                           // This, like all manipulation of cppClusterStateCache, needs to run on the Matter
+                                           // queue.
+                                           MTRClusterStateCacheContainer * container = weakPtr;
+                                           if (container) {
+                                               container.cppClusterStateCache = nullptr;
+                                               container.baseDevice = nil;
+                                           }
+                                       };
+                                   }
 
-                                      auto callback = std::make_unique<SubscriptionCallback>(
-                                          ^(NSArray * value) {
-                                              dispatch_async(queue, ^{
-                                                  if (attributeReportHandler != nil) {
-                                                      attributeReportHandler(value);
-                                                  }
-                                              });
-                                          },
-                                          ^(NSArray * value) {
-                                              dispatch_async(queue, ^{
-                                                  if (eventReportHandler != nil) {
-                                                      eventReportHandler(value);
-                                                  }
-                                              });
-                                          },
-                                          ^(NSError * error) {
-                                              dispatch_async(queue, ^{
-                                                  errorHandler(error);
-                                              });
-                                          },
-                                          ^(NSError * error, NSNumber * resubscriptionDelay) {
-                                              dispatch_async(queue, ^{
-                                                  if (resubscriptionScheduled != nil) {
-                                                      resubscriptionScheduled(error, resubscriptionDelay);
-                                                  }
-                                              });
-                                          },
-                                          ^(void) {
-                                              dispatch_async(queue, ^{
-                                                  if (subscriptionEstablished != nil) {
-                                                      subscriptionEstablished();
-                                                  }
-                                              });
-                                          },
-                                          onDoneHandler);
+                                   auto callback = std::make_unique<SubscriptionCallback>(
+                                       ^(NSArray * value) {
+                                           dispatch_async(queue, ^{
+                                               if (attributeReportHandler != nil) {
+                                                   attributeReportHandler(value);
+                                               }
+                                           });
+                                       },
+                                       ^(NSArray * value) {
+                                           dispatch_async(queue, ^{
+                                               if (eventReportHandler != nil) {
+                                                   eventReportHandler(value);
+                                               }
+                                           });
+                                       },
+                                       ^(NSError * error) {
+                                           dispatch_async(queue, ^{
+                                               errorHandler(error);
+                                           });
+                                       },
+                                       ^(NSError * error, NSNumber * resubscriptionDelay) {
+                                           dispatch_async(queue, ^{
+                                               if (resubscriptionScheduled != nil) {
+                                                   resubscriptionScheduled(error, resubscriptionDelay);
+                                               }
+                                           });
+                                       },
+                                       ^(void) {
+                                           dispatch_async(queue, ^{
+                                               if (subscriptionEstablished != nil) {
+                                                   subscriptionEstablished();
+                                               }
+                                           });
+                                       },
+                                       onDoneHandler);
 
-                                      if (clusterStateCacheContainer) {
-                                          clusterStateCache = std::make_unique<ClusterStateCache>(*callback.get());
-                                          callbackForReadClient = &clusterStateCache->GetBufferedCallback();
-                                      } else {
-                                          callbackForReadClient = &callback->GetBufferedCallback();
-                                      }
+                                   if (clusterStateCacheContainer) {
+                                       clusterStateCache = std::make_unique<ClusterStateCache>(*callback.get());
+                                       callbackForReadClient = &clusterStateCache->GetBufferedCallback();
+                                   } else {
+                                       callbackForReadClient = &callback->GetBufferedCallback();
+                                   }
 
-                                      auto readClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(),
-                                          exchangeManager, *callbackForReadClient, ReadClient::InteractionType::Subscribe);
+                                   auto readClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(),
+                                       exchangeManager, *callbackForReadClient, ReadClient::InteractionType::Subscribe);
 
-                                      CHIP_ERROR err;
-                                      if (!params.resubscribeAutomatically) {
-                                          err = readClient->SendRequest(readParams);
-                                      } else {
-                                          // SendAutoResubscribeRequest cleans up the params, even on failure.
-                                          attributePath.release();
-                                          eventPath.release();
-                                          err = readClient->SendAutoResubscribeRequest(std::move(readParams));
-                                      }
+                                   CHIP_ERROR err;
+                                   if (!params.resubscribeAutomatically) {
+                                       err = readClient->SendRequest(readParams);
+                                   } else {
+                                       // SendAutoResubscribeRequest cleans up the params, even on failure.
+                                       attributePath.release();
+                                       eventPath.release();
+                                       err = readClient->SendAutoResubscribeRequest(std::move(readParams));
+                                   }
 
-                                      if (err != CHIP_NO_ERROR) {
-                                          dispatch_async(queue, ^{
-                                              errorHandler([MTRError errorForCHIPErrorCode:err]);
-                                          });
+                                   if (err != CHIP_NO_ERROR) {
+                                       dispatch_async(queue, ^{
+                                           errorHandler([MTRError errorForCHIPErrorCode:err]);
+                                       });
 
-                                          return;
-                                      }
+                                       return;
+                                   }
 
-                                      if (clusterStateCacheContainer) {
-                                          clusterStateCacheContainer.cppClusterStateCache = clusterStateCache.get();
-                                          // ClusterStateCache will be deleted when OnDone is called.
-                                          callback->AdoptClusterStateCache(std::move(clusterStateCache));
-                                          clusterStateCacheContainer.baseDevice = self;
-                                      }
-                                      // Callback and ReadClient will be deleted when OnDone is called.
-                                      callback->AdoptReadClient(std::move(readClient));
-                                      callback.release();
-                                  }];
+                                   if (clusterStateCacheContainer) {
+                                       clusterStateCacheContainer.cppClusterStateCache = clusterStateCache.get();
+                                       // ClusterStateCache will be deleted when OnDone is called.
+                                       callback->AdoptClusterStateCache(std::move(clusterStateCache));
+                                       clusterStateCacheContainer.baseDevice = self;
+                                   }
+                                   // Callback and ReadClient will be deleted when OnDone is called.
+                                   callback->AdoptReadClient(std::move(readClient));
+                                   callback.release();
+                               }];
 }
 
 static NSDictionary<NSString *, id> * _MakeDataValueDictionary(NSString * type, id _Nullable value, NSNumber * _Nullable dataVersion)
@@ -1616,6 +1650,15 @@ exit:
         return;
     }
 
+    auto * concreteController = self.concreteController;
+    if (concreteController == nil) {
+        // No subscriptions (or really any MTRBaseDevice use) with XPC controllers.
+        dispatch_async(queue, ^{
+            reportHandler(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
+        });
+        return;
+    }
+
     // Copy params before going async.
     NSArray<MTRAttributeRequestPath *> * attributes = nil;
     if (attributePaths != nil) {
@@ -1629,7 +1672,7 @@ exit:
 
     params = (params == nil) ? nil : [params copy];
 
-    [self.deviceController
+    [concreteController
         getSessionForNode:self.nodeID
                completion:^(ExchangeManager * _Nullable exchangeManager, const Optional<SessionHandle> & session,
                    NSError * _Nullable error, NSNumber * _Nullable retryDelay) {
@@ -1890,6 +1933,16 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
         return;
     }
 
+    auto * concreteController = self.concreteController;
+    if (concreteController == nil) {
+        MTR_LOG_ERROR("Can't open a commissioning window via MTRBaseDevice against an XPC Controller");
+        dispatch_async(queue, ^{
+            MATTER_LOG_METRIC_END(kMetricOpenPairingWindow, CHIP_ERROR_INCORRECT_STATE);
+            completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
+        });
+        return;
+    }
+
     unsigned long long durationVal = [duration unsignedLongLongValue];
     if (!CanCastTo<uint16_t>(durationVal)) {
         MTR_LOG_ERROR("Error: Duration %llu is too large.", durationVal);
@@ -1925,7 +1978,7 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
         passcode.Emplace(static_cast<uint32_t>(passcodeVal));
     }
 
-    [self.deviceController
+    [concreteController
         asyncGetCommissionerOnMatterQueue:^(Controller::DeviceCommissioner * commissioner) {
             auto resultCallback = ^(CHIP_ERROR status, const SetupPayload & payload) {
                 if (status != CHIP_NO_ERROR) {
@@ -2175,11 +2228,20 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
                     queue:(dispatch_queue_t)queue
                completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
 {
-    [_deviceController downloadLogFromNodeWithID:@(_nodeID)
-                                            type:type
-                                         timeout:timeout
-                                           queue:queue
-                                      completion:completion];
+    auto * concreteController = self.concreteController;
+    if (concreteController == nil) {
+        MTR_LOG_ERROR("Can't download logs via MTRBaseDevice against an XPC Controller");
+        dispatch_async(queue, ^{
+            completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
+        });
+        return;
+    }
+
+    [concreteController downloadLogFromNodeWithID:@(_nodeID)
+                                             type:type
+                                          timeout:timeout
+                                            queue:queue
+                                       completion:completion];
 }
 
 - (NSString *)description

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -280,6 +280,7 @@ static void LogStringAndReturnError(NSString * errorStr, MTRErrorCode errorCode,
 {
     auto * concreteController = self.concreteController;
     if (concreteController == nil) {
+        MTR_LOG_ERROR("Unable to determine session transport type for MTRBaseDevice created with an XPC controller");
         return MTRTransportTypeUndefined;
     }
     return [concreteController sessionTransportTypeForDevice:self];
@@ -294,6 +295,7 @@ static void LogStringAndReturnError(NSString * errorStr, MTRErrorCode errorCode,
     auto * concreteController = self.concreteController;
     if (concreteController == nil) {
         // Nothing we can do here.
+        MTR_LOG_ERROR("Unable invalidate CASE session for MTRBaseDevice created with an XPC controller");
         return;
     }
 
@@ -339,6 +341,7 @@ public:
     auto * concreteController = self.concreteController;
     if (concreteController == nil) {
         // No subscriptions (or really any MTRBaseDevice use) with XPC controllers.
+        MTR_LOG_ERROR("Unable to create subscription for MTRBaseDevice created with an XPC controller");
         dispatch_async(queue, ^{
             errorHandler([MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
         });
@@ -1653,6 +1656,7 @@ exit:
     auto * concreteController = self.concreteController;
     if (concreteController == nil) {
         // No subscriptions (or really any MTRBaseDevice use) with XPC controllers.
+        MTR_LOG_ERROR("Unable to create subscription for MTRBaseDevice created with an XPC controller");
         dispatch_async(queue, ^{
             reportHandler(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
         });
@@ -1935,7 +1939,7 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
 
     auto * concreteController = self.concreteController;
     if (concreteController == nil) {
-        MTR_LOG_ERROR("Can't open a commissioning window via MTRBaseDevice against an XPC Controller");
+        MTR_LOG_ERROR("Can't open a commissioning window via MTRBaseDevice created with an XPC controller");
         dispatch_async(queue, ^{
             MATTER_LOG_METRIC_END(kMetricOpenPairingWindow, CHIP_ERROR_INCORRECT_STATE);
             completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
@@ -2230,7 +2234,7 @@ MTREventPriority MTREventPriorityForValidPriorityLevel(chip::app::PriorityLevel 
 {
     auto * concreteController = self.concreteController;
     if (concreteController == nil) {
-        MTR_LOG_ERROR("Can't download logs via MTRBaseDevice against an XPC Controller");
+        MTR_LOG_ERROR("Can't download logs via MTRBaseDevice created with an XPC controller");
         dispatch_async(queue, ^{
             completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
         });

--- a/src/darwin/Framework/CHIP/MTRCallbackBridgeBase.h
+++ b/src/darwin/Framework/CHIP/MTRCallbackBridgeBase.h
@@ -81,6 +81,9 @@ protected:
     {
         LogRequestStart();
 
+        // TODO: Figure out whether we can usefully get an MTRDeviceController_Concrete in here, so
+        // we can move getSessionForCommissioneeDevice off of MTRDeviceController_Internal.  Ideally
+        // without bloating this inline method too much.
         [device.deviceController getSessionForCommissioneeDevice:device.nodeID
                                                       completion:^(chip::Messaging::ExchangeManager * exchangeManager,
                                                           const chip::Optional<chip::SessionHandle> & session, NSError * _Nullable error, NSNumber * _Nullable retryDelay) {
@@ -92,6 +95,8 @@ protected:
     {
         LogRequestStart();
 
+        // TODO: Figure out whether we can usefully get an MTRDeviceController_Concrete in here, so
+        // we can move getSessionForNode off of MTRDeviceController_Internal.
         [controller getSessionForNode:nodeID
                            completion:^(chip::Messaging::ExchangeManager * _Nullable exchangeManager,
                                const chip::Optional<chip::SessionHandle> & session, NSError * _Nullable error, NSNumber * _Nullable retryDelay) {

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -119,7 +119,6 @@ using namespace chip::Tracing::DarwinFramework;
 @end
 
 @implementation MTRDeviceController {
-    chip::Controller::DeviceCommissioner * _cppCommissioner;
     chip::Credentials::PartialDACVerifier * _partialDACVerifier;
     chip::Credentials::DefaultDACVerifier * _defaultDACVerifier;
     MTRDeviceControllerDelegateBridge * _deviceControllerDelegateBridge;
@@ -206,7 +205,8 @@ using namespace chip::Tracing::DarwinFramework;
 
 - (BOOL)isRunning
 {
-    return _cppCommissioner != nullptr;
+    MTR_ABSTRACT_METHOD();
+    return NO;
 }
 
 #pragma mark - Suspend/resume support
@@ -547,37 +547,9 @@ using namespace chip::Tracing::DarwinFramework;
     completion(nullptr, chip::NullOptional, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE], nil);
 }
 
-- (MTRTransportType)sessionTransportTypeForDevice:(MTRBaseDevice *)device
-{
-    VerifyOrReturnValue([self checkIsRunning], MTRTransportTypeUndefined);
-
-    __block MTRTransportType result = MTRTransportTypeUndefined;
-    dispatch_sync(_chipWorkQueue, ^{
-        VerifyOrReturn([self checkIsRunning]);
-
-        if (device.isPASEDevice) {
-            chip::CommissioneeDeviceProxy * deviceProxy;
-            VerifyOrReturn(CHIP_NO_ERROR == self->_cppCommissioner->GetDeviceBeingCommissioned(device.nodeID, &deviceProxy));
-            result = MTRMakeTransportType(deviceProxy->GetDeviceTransportType());
-        } else {
-            auto scopedNodeID = self->_cppCommissioner->GetPeerScopedId(device.nodeID);
-            auto sessionHandle = self->_cppCommissioner->SessionMgr()->FindSecureSessionForNode(scopedNodeID);
-            VerifyOrReturn(sessionHandle.HasValue());
-            result = MTRMakeTransportType(sessionHandle.Value()->AsSecureSession()->GetPeerAddress().GetTransportType());
-        }
-    });
-    return result;
-}
-
-- (void)asyncGetCommissionerOnMatterQueue:(void (^)(chip::Controller::DeviceCommissioner *))block
-                             errorHandler:(nullable MTRDeviceErrorHandler)errorHandler
-{
-    MTR_ABSTRACT_METHOD();
-    errorHandler([MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
-}
-
 - (void)asyncDispatchToMatterQueue:(dispatch_block_t)block errorHandler:(nullable MTRDeviceErrorHandler)errorHandler
 {
+    // TODO: Figure out how to get callsites to have an MTRDeviceController_Concrete.
     MTR_ABSTRACT_METHOD();
     errorHandler([MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
 }
@@ -625,31 +597,6 @@ using namespace chip::Tracing::DarwinFramework;
 {
     auto storedValue = _storedCompressedFabricID.load();
     return storedValue.has_value() ? @(storedValue.value()) : nil;
-}
-
-- (void)invalidateCASESessionForNode:(chip::NodeId)nodeID;
-{
-    auto block = ^{
-        auto sessionMgr = self->_cppCommissioner->SessionMgr();
-        VerifyOrDie(sessionMgr != nullptr);
-
-        sessionMgr->MarkSessionsAsDefunct(
-            self->_cppCommissioner->GetPeerScopedId(nodeID), chip::MakeOptional(chip::Transport::SecureSession::Type::kCASE));
-    };
-
-    [self syncRunOnWorkQueue:block error:nil];
-}
-
-- (void)downloadLogFromNodeWithID:(NSNumber *)nodeID
-                             type:(MTRDiagnosticLogType)type
-                          timeout:(NSTimeInterval)timeout
-                            queue:(dispatch_queue_t)queue
-                       completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
-{
-    MTR_ABSTRACT_METHOD();
-    dispatch_async(queue, ^{
-        completion(nil, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
-    });
 }
 
 #ifdef DEBUG

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -18,6 +18,7 @@
 #import <Foundation/Foundation.h>
 
 #import <Matter/MTRAccessGrant.h>
+#import <Matter/MTRBaseDevice.h>
 #import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceController.h>
 #import <Matter/MTRDeviceControllerFactory.h>
@@ -148,6 +149,43 @@ NS_ASSUME_NONNULL_BEGIN
  * Only called on the Matter queue.
  */
 - (nullable NSNumber *)neededReadPrivilegeForClusterID:(NSNumber *)clusterID attributeID:(NSNumber *)attributeID;
+
+/**
+ * Try to asynchronously dispatch the given block on the Matter queue.  If the
+ * controller is not running either at call time or when the block would be
+ * about to run, the provided error handler will be called with an error.  Note
+ * that this means the error handler might be called on an arbitrary queue, and
+ * might be called before this function returns or after it returns.
+ *
+ * The DeviceCommissioner pointer passed to the callback should only be used
+ * synchronously during the callback invocation.
+ *
+ * If the error handler is nil, failure to run the block will be silent.
+ */
+- (void)asyncGetCommissionerOnMatterQueue:(void (^)(chip::Controller::DeviceCommissioner *))block
+                             errorHandler:(nullable MTRDeviceErrorHandler)errorHandler;
+
+/**
+ * Returns the transport used by the current session with the given device,
+ * or `MTRTransportTypeUndefined` if no session is currently active.
+ */
+- (MTRTransportType)sessionTransportTypeForDevice:(MTRBaseDevice *)device;
+
+/**
+ * Invalidate the CASE session for the given node ID.  This is a temporary thing
+ * just to support MTRBaseDevice's invalidateCASESession.  Must not be called on
+ * the Matter event queue.
+ */
+- (void)invalidateCASESessionForNode:(NSNumber *)nodeID;
+
+/**
+ * Download log of the desired type from the device.
+ */
+- (void)downloadLogFromNodeWithID:(NSNumber *)nodeID
+                             type:(MTRDiagnosticLogType)type
+                          timeout:(NSTimeInterval)timeout
+                            queue:(dispatch_queue_t)queue
+                       completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1586,14 +1586,14 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     return CHIP_NO_ERROR;
 }
 
-- (void)invalidateCASESessionForNode:(chip::NodeId)nodeID;
+- (void)invalidateCASESessionForNode:(NSNumber *)nodeID;
 {
     auto block = ^{
         auto sessionMgr = self->_cppCommissioner->SessionMgr();
         VerifyOrDie(sessionMgr != nullptr);
 
         sessionMgr->MarkSessionsAsDefunct(
-            self->_cppCommissioner->GetPeerScopedId(nodeID), chip::MakeOptional(chip::Transport::SecureSession::Type::kCASE));
+            self->_cppCommissioner->GetPeerScopedId(nodeID.unsignedLongLongValue), chip::MakeOptional(chip::Transport::SecureSession::Type::kCASE));
     };
 
     [self syncRunOnWorkQueue:block error:nil];

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -155,34 +155,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)getSessionForCommissioneeDevice:(chip::NodeId)deviceID completion:(MTRInternalDeviceConnectionCallback)completion;
 
 /**
- * Returns the transport used by the current session with the given device,
- * or `MTRTransportTypeUndefined` if no session is currently active.
- */
-- (MTRTransportType)sessionTransportTypeForDevice:(MTRBaseDevice *)device;
-
-/**
- * Invalidate the CASE session for the given node ID.  This is a temporary thing
- * just to support MTRBaseDevice's invalidateCASESession.  Must not be called on
- * the Matter event queue.
- */
-- (void)invalidateCASESessionForNode:(chip::NodeId)nodeID;
-
-/**
- * Try to asynchronously dispatch the given block on the Matter queue.  If the
- * controller is not running either at call time or when the block would be
- * about to run, the provided error handler will be called with an error.  Note
- * that this means the error handler might be called on an arbitrary queue, and
- * might be called before this function returns or after it returns.
- *
- * The DeviceCommissioner pointer passed to the callback should only be used
- * synchronously during the callback invocation.
- *
- * If the error handler is nil, failure to run the block will be silent.
- */
-- (void)asyncGetCommissionerOnMatterQueue:(void (^)(chip::Controller::DeviceCommissioner *))block
-                             errorHandler:(nullable MTRDeviceErrorHandler)errorHandler;
-
-/**
  * Try to asynchronously dispatch the given block on the Matter queue.  If the
  * controller is not running either at call time or when the block would be
  * about to run, the provided error handler will be called with an error.  Note
@@ -199,15 +171,6 @@ NS_ASSUME_NONNULL_BEGIN
  * sort of MTRBaseDevice they return.
  */
 - (MTRBaseDevice *)baseDeviceForNodeID:(NSNumber *)nodeID;
-
-/**
- * Download log of the desired type from the device.
- */
-- (void)downloadLogFromNodeWithID:(NSNumber *)nodeID
-                             type:(MTRDiagnosticLogType)type
-                          timeout:(NSTimeInterval)timeout
-                            queue:(dispatch_queue_t)queue
-                       completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
 #pragma mark - Device-specific data and SDK access
 // DeviceController will act as a central repository for this opaque dictionary that MTRDevice manages


### PR DESCRIPTION
This allows us to move several selectors from MTRDeviceController_Internal to MTRDeviceController_Concrete, and get rid of the never-actually-set _cppCommissioner ivar on MTRDeviceController.

REVIEW NOTE: The whitespace-insensitive diff should be a lot easier to read.