### PR TITLE
[Java]Fix errorcode in GetConnectedDeviceCallbackForTestJni

### DIFF
--- a/src/controller/java/AndroidCallbacks-ForTestJNI.cpp
+++ b/src/controller/java/AndroidCallbacks-ForTestJNI.cpp
@@ -43,7 +43,7 @@ JNI_METHOD(void, GetConnectedDeviceCallbackForTestJni, onDeviceConnected)
 }
 
 JNI_METHOD(void, GetConnectedDeviceCallbackForTestJni, onDeviceConnectionFailure)
-(JNIEnv * env, jobject self, jlong callbackHandle, jint errorCode)
+(JNIEnv * env, jobject self, jlong callbackHandle, jlong errorCode)
 {
     GetConnectedDeviceCallback * connectedDeviceCallback = reinterpret_cast<GetConnectedDeviceCallback *>(callbackHandle);
     VerifyOrReturn(connectedDeviceCallback != nullptr, ChipLogError(Controller, "GetConnectedDeviceCallbackJni handle is nullptr"));

--- a/src/controller/java/src/chip/devicecontroller/GetConnectedDeviceCallbackForTestJni.java
+++ b/src/controller/java/src/chip/devicecontroller/GetConnectedDeviceCallbackForTestJni.java
@@ -37,9 +37,9 @@ public final class GetConnectedDeviceCallbackForTestJni {
 
   private native void onDeviceConnected(long callbackHandle, long messagingContextHandle);
 
-  public void onDeviceConnectionFailure(GetConnectedDeviceCallbackJni callback, int errorCode) {
+  public void onDeviceConnectionFailure(GetConnectedDeviceCallbackJni callback, long errorCode) {
     onDeviceConnectionFailure(callback.getCallbackHandle(), errorCode);
   }
 
-  private native void onDeviceConnectionFailure(long callbackHandle, int errorCode);
+  private native void onDeviceConnectionFailure(long callbackHandle, long errorCode);
 }


### PR DESCRIPTION
errorCode in GetConnectedDeviceCallbackForTestJni should be handled by long instead of int